### PR TITLE
Record GitHub repo and branch model in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,9 +12,8 @@ Machine **dev1**, `~/devel/forestshop/forestshop_app`. Sibling of
 `forestshop/parovanie_produktov` — a separate repo; never edit one from the
 other's session.
 
-New directory: no code, no git history, no GitHub remote yet. Until that
-changes, the statusline `Issues` counter, Discord run-cards and the `gh`-driven
-watchdog jobs stay silent — they resolve the project from `git remote`.
+Repo: `zbynekdrlik/forestshop-app` (private). Two-branch flow — `main`
+(production) + `dev` (work). No application code yet.
 
 ## Playbook router
 


### PR DESCRIPTION
Records the actual repo name and the two-branch model in the project's CLAUDE.md, replacing the placeholder text written before the GitHub repo existed.

Global rules stay inherited from `~/.claude/CLAUDE.md` (managed by airuleset); this file carries only project-specific facts.
