### PR TITLE
Bring apps/api/tests/ under tsc -b + serialize local integration-test DB isolation

### DIFF
--- a/.claude/rules/catalog.md
+++ b/.claude/rules/catalog.md
@@ -125,8 +125,11 @@ paths:
   len tenký alias.** Kanonická implementácia žije v `apps/api/src/cli/
   catalog-prune-raw.ts` (súčasť `apps/api`'s vlastného `tsc -b`), skompiluje sa
   do `apps/api/dist/cli/catalog-prune-raw.js` a BEŽÍ V PRODUKCII (`.claude/rules/
-  deploy.md`) — `docker compose exec app node apps/api/dist/cli/
-  catalog-prune-raw.js`. Dôvod: dev2 má `scripts/` len ako `rsync`-nutú kópiu BEZ
+  deploy.md`) — `docker compose -f docker-compose.prod.yml exec app node
+  apps/api/dist/cli/catalog-prune-raw.js` (bez `-f docker-compose.prod.yml` by
+  compose na dev2 siahol po vývojovom `docker-compose.yml`). Overené naživo na
+  dev2 2026-07-29 po nasadení v0.2.0: `Zmazaných surových súborov: 0 (staršie
+  než 30 dní).` + `{"removed":0}`. Dôvod: dev2 má `scripts/` len ako `rsync`-nutú kópiu BEZ
   `node_modules` (final-wave-b, položka 2), takže `tsx scripts/catalog-prune-raw.ts`
   tam nemá ako bežať — bez skompilovanej verzie v obraze retencia v produkcii
   nemala žiadny spôsob spustenia a `catalog-raw` zväzok rástol donekonečna.

--- a/apps/api/tests/db-isolation-lock.integration.test.ts
+++ b/apps/api/tests/db-isolation-lock.integration.test.ts
@@ -1,0 +1,55 @@
+import pg from "pg";
+import { afterEach, expect, it } from "vitest";
+import { TEST_DB_ISOLATION_LOCK_KEY, withCleanDb } from "./helpers/db.js";
+
+// issue #7 — withCleanDb() musí držať session advisory zámok od TRUNCATE po
+// close(), aby dva súbežné procesy (dva terminály/agent session bežiace
+// `pnpm test:integration` proti tej istej lokálnej Postgres, port 5433)
+// nikdy neprekrývali TRUNCATE jedného s ešte prebiehajúcim testom druhého.
+//
+// Skutočná TRUNCATE-vs-insert kolízia je časovo nedeterministická (presne to
+// varovanie v .claude/rules/testing.md), takže to dokazujeme
+// DETERMINISTICKY: `pg_try_advisory_lock` (neblokujúci) z DRUHÉHO, nezávislého
+// pripojenia musí zlyhať, kým je `withCleanDb()`-ov kontext otvorený, a uspieť
+// hneď po `close()`.
+
+let checker: pg.Client | undefined;
+
+afterEach(async () => {
+  await checker?.end();
+  checker = undefined;
+});
+
+async function tryLockFromSeparateConnection(): Promise<boolean> {
+  const databaseUrl = process.env["DATABASE_URL"];
+  if (databaseUrl === undefined || databaseUrl === "") {
+    throw new Error("Integračné testy potrebujú DATABASE_URL");
+  }
+  checker = new pg.Client({ connectionString: databaseUrl });
+  await checker.connect();
+  const result = await checker.query<{ pg_try_advisory_lock: boolean }>(
+    "select pg_try_advisory_lock($1)",
+    [TEST_DB_ISOLATION_LOCK_KEY],
+  );
+  const acquired = result.rows[0]?.pg_try_advisory_lock ?? false;
+  if (acquired) {
+    await checker.query("select pg_advisory_unlock($1)", [TEST_DB_ISOLATION_LOCK_KEY]);
+  }
+  await checker.end();
+  checker = undefined;
+  return acquired;
+}
+
+it("withCleanDb() drží advisory zámok od otvorenia po close(), takže súbežný withCleanDb() naň musí čakať", async () => {
+  const ctx = await withCleanDb();
+
+  // Kým je ctx otvorený, iné pripojenie nesmie ten istý zámok získať —
+  // dnes (bez zámku vo withCleanDb()) by toto zlyhalo, lebo nikto zámok
+  // vôbec neberie.
+  expect(await tryLockFromSeparateConnection()).toBe(false);
+
+  await ctx.close();
+
+  // Po close() musí byť zámok voľný.
+  expect(await tryLockFromSeparateConnection()).toBe(true);
+});

--- a/apps/api/tests/helpers/db.ts
+++ b/apps/api/tests/helpers/db.ts
@@ -1,6 +1,15 @@
 import { sql } from "drizzle-orm";
 import { createDb, type Database } from "../../src/db/client.js";
 
+/**
+ * Distinct advisory-lock key for serializing `withCleanDb()` across
+ * concurrent OS processes sharing the same local dev Postgres (issue #7) —
+ * pg_advisory_lock/pg_advisory_xact_lock share ONE keyspace regardless of
+ * which function takes it (see catalog-ingest-lock.integration.test.ts), so
+ * this must never collide with INGEST_ADVISORY_LOCK_KEY (787_878_001).
+ */
+export const TEST_DB_ISOLATION_LOCK_KEY = 787_878_100;
+
 export async function withCleanDb(): Promise<{ db: Database; close: () => Promise<void> }> {
   const url = process.env["DATABASE_URL"];
   if (url === undefined || url === "") {

--- a/apps/api/tests/helpers/db.ts
+++ b/apps/api/tests/helpers/db.ts
@@ -1,4 +1,5 @@
 import { sql } from "drizzle-orm";
+import pg from "pg";
 import { createDb, type Database } from "../../src/db/client.js";
 
 /**
@@ -15,6 +16,17 @@ export async function withCleanDb(): Promise<{ db: Database; close: () => Promis
   if (url === undefined || url === "") {
     throw new Error("Integračné testy potrebujú DATABASE_URL na testovaciu databázu");
   }
+
+  // pg_advisory_lock is per-SESSION (per backend connection), so it must be
+  // taken on its own dedicated connection, not through the pool `db` below
+  // shares across queries — held from here until close() releases it, so a
+  // second, concurrent withCleanDb() (another agent/terminal running
+  // `pnpm test:integration` against the same DATABASE_URL) blocks until this
+  // test's whole TRUNCATE-and-use span is done, instead of interleaving.
+  const lock = new pg.Client({ connectionString: url });
+  await lock.connect();
+  await lock.query("select pg_advisory_lock($1)", [TEST_DB_ISOLATION_LOCK_KEY]);
+
   const { db, pool } = createDb(url);
   try {
     await db.execute(
@@ -22,7 +34,17 @@ export async function withCleanDb(): Promise<{ db: Database; close: () => Promis
     );
   } catch (err) {
     await pool.end();
+    await lock.query("select pg_advisory_unlock($1)", [TEST_DB_ISOLATION_LOCK_KEY]);
+    await lock.end();
     throw err;
   }
-  return { db, close: () => pool.end() };
+
+  return {
+    db,
+    close: async () => {
+      await pool.end();
+      await lock.query("select pg_advisory_unlock($1)", [TEST_DB_ISOLATION_LOCK_KEY]);
+      await lock.end();
+    },
+  };
 }

--- a/apps/api/tests/helpers/db.ts
+++ b/apps/api/tests/helpers/db.ts
@@ -33,18 +33,28 @@ export async function withCleanDb(): Promise<{ db: Database; close: () => Promis
       sql`TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, audit_events, sessions, users RESTART IDENTITY CASCADE`,
     );
   } catch (err) {
-    await pool.end();
-    await lock.query("select pg_advisory_unlock($1)", [TEST_DB_ISOLATION_LOCK_KEY]);
-    await lock.end();
+    try {
+      await pool.end();
+    } finally {
+      await lock.query("select pg_advisory_unlock($1)", [TEST_DB_ISOLATION_LOCK_KEY]);
+      await lock.end();
+    }
     throw err;
   }
 
   return {
     db,
     close: async () => {
-      await pool.end();
-      await lock.query("select pg_advisory_unlock($1)", [TEST_DB_ISOLATION_LOCK_KEY]);
-      await lock.end();
+      try {
+        await pool.end();
+      } finally {
+        // Release the lock even if pool.end() throws — otherwise the
+        // dedicated lock connection (and the lock itself) would leak until
+        // the test process exits, blocking every other concurrent
+        // withCleanDb() for no good reason.
+        await lock.query("select pg_advisory_unlock($1)", [TEST_DB_ISOLATION_LOCK_KEY]);
+        await lock.end();
+      }
     },
   };
 }

--- a/apps/api/tests/tsconfig.json
+++ b/apps/api/tests/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["**/*.ts"]
+}

--- a/apps/api/tsconfig.eslint.json
+++ b/apps/api/tsconfig.eslint.json
@@ -4,5 +4,5 @@
     "noEmit": true,
     "types": ["node"]
   },
-  "include": ["src", "tests", "*.config.ts"]
+  "include": ["src", "*.config.ts"]
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,8 +11,6 @@ export default tseslint.config(
         projectService: {
           allowDefaultProject: [
             "apps/api/*.config.ts",
-            "apps/api/tests/*.ts",
-            "apps/api/tests/helpers/*.ts",
             "apps/web/*.config.ts",
             "apps/web/tests/e2e/*.ts",
             // "scripts/*.ts" REMOVED (final-wave-b, item 1/issue #4) — scripts/
@@ -20,6 +18,10 @@ export default tseslint.config(
             // `pnpm typecheck`), so typescript-eslint's project service finds it
             // on its own; leaving the glob here errors ("was included by
             // allowDefaultProject but also was found in the project service").
+            //
+            // "apps/api/tests/*.ts" + "apps/api/tests/helpers/*.ts" REMOVED
+            // (issue #4, remaining half) — same reason: apps/api/tests/ now has
+            // its own real tsconfig.json, wired into `pnpm typecheck`.
           ],
           defaultProject: "apps/api/tsconfig.eslint.json",
           // The monorepo now has two packages, each with a handful of standalone

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.2.0",
+  "version": "0.3.0-dev.1",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": ">=24"
   },
   "scripts": {
-    "typecheck": "tsc -b && tsc -p scripts/tsconfig.json",
+    "typecheck": "tsc -b && tsc -p scripts/tsconfig.json && tsc -p apps/api/tests/tsconfig.json",
     "lint": "eslint .",
     "test": "pnpm -r test",
     "test:integration": "pnpm --filter @forestshop/api test:integration",


### PR DESCRIPTION
## Summary

- **#4 (rescoped remainder):** `apps/api/tests/*.ts` + `apps/api/tests/helpers/*.ts` now get real `tsc -b` strict type checking via a new `apps/api/tests/tsconfig.json`, mirroring the `scripts/` pattern from `87ab34a`. Removed from ESLint's `allowDefaultProject` fallback; dropped the now-dead `"tests"` entry from `apps/api/tsconfig.eslint.json`.
- **#7:** `withCleanDb()` now takes a session-level `pg_advisory_lock` (dedicated connection) around its TRUNCATE-and-use span, so two concurrent local `pnpm test:integration` runs against the shared dev Postgres (port 5433) can no longer interleave and corrupt each other's data. RED regression test added first, proving the gap, then the fix.

## Verification

- `pnpm typecheck` — clean (now includes `apps/api/tests/tsconfig.json`)
- `pnpm lint` — clean
- `pnpm test` (unit) — 182 + 35 passed
- `pnpm --filter @forestshop/api test:integration` — 72/72 passed (11 files), incl. new `db-isolation-lock.integration.test.ts` and the existing `catalog-ingest-lock.integration.test.ts`
- `apps/api` docker build (`tsc -b --force`) — `dist/` output unchanged, no test files leaked into it

Closes #4
Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)
