### PR TITLE
chore: bump 0.3.0-dev.2 + playbook review (#4/#7 follow-up)

### DIFF
--- a/.claude/rules/local-dev.md
+++ b/.claude/rules/local-dev.md
@@ -5,6 +5,10 @@ paths:
   - ".nvmrc"
   - ".npmrc"
   - "docker-compose.yml"
+  - "tsconfig.json"
+  - "tsconfig.base.json"
+  - "scripts/tsconfig.json"
+  - "apps/api/tests/tsconfig.json"
 ---
 
 # Local development environment
@@ -27,3 +31,17 @@ paths:
 - Bežný lokálny cyklus: `docker compose up -d postgres` (port 5433) →
   `pnpm --filter @forestshop/api db:migrate` → `pnpm test` /
   `pnpm test:integration` / `pnpm --filter @forestshop/web e2e`.
+- **Vzor pre "priečinok mimo hlavného `tsc -b` composite grafu, ale chcem naň
+  plnú prísnu kontrolu typov"** (najprv `scripts/`, potom `apps/api/tests/`
+  — issue #4): nový SAMOSTATNÝ, nekompozitný tsconfig (`extends` spoločný
+  `tsconfig.base.json`, `composite: false`, `declaration: false`,
+  `noEmit: true`, vlastný `include`), pridaný do root `package.json`'s
+  `typecheck` ako ĎALŠIE `&& tsc -p <priečinok>/tsconfig.json` (NIE ako
+  `references` v `tsc -b`'s grafe). Dôvod: `apps/api/tsconfig.json` má
+  `outDir: dist`, ktorý ide priamo do produkčného Docker image — pridanie
+  ďalšieho priečinka do TOHO istého kompozitného projektu by riskovalo únik
+  (test/skript) súborov do `dist`; samostatný `noEmit` projekt to riziko úplne
+  vylučuje. Pri tomto vzore VŽDY zároveň odstráň dotknuté globy z
+  `eslint.config.js`'s `allowDefaultProject` — necháš ich tam, ESLint padne
+  na "was included by allowDefaultProject but also was found in the project
+  service" (project service si nový reálny `tsconfig.json` nájde sám).

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -56,17 +56,26 @@ paths:
   DVOCH súčasne prihlásených používateľov (napr. rôzne role), použi JEDEN
   spoločný `withCleanDb()`/`createApp()` a prihlás sa POD KAŽDÝM
   používateľom zvlášť, nie dva samostatné `boot()` volania.
-- **Lokálne integračné testy sa navzájom rušia, keď bežia SÚBEŽNE proti tej
-  istej zdieľanej lokálnej Postgres inštancii** (viac agentov/terminálov
-  naraz) — `withCleanDb()`'s `TRUNCATE` z jedného procesu môže zasiahnuť
-  rozbehnutý test druhého procesu (`duplicate key value violates unique
-  constraint "users_email_unique"`, `insert or update on table "sessions"
-  violates foreign key constraint`). Nie je to chyba v testovanej appke ani
-  v konkrétnom teste — over si to spustením TOHO ISTÉHO súboru izolovane
-  (žiadny iný `vitest`/`test:integration` beh naraz) skôr, než začneš
-  ladiť. CI je bezpečné (každý job má vlastný efemérny Postgres kontajner).
-  Sledované ako issue #7 (cross-cutting oprava — per-proces izolácia DB —
-  zatiaľ neriešená).
+- **Lokálne integračné testy sa už NErušia, keď bežia SÚBEŽNE proti tej istej
+  zdieľanej lokálnej Postgres inštancii** (viac agentov/terminálov naraz) —
+  vyriešené v issue #7. `withCleanDb()` (`tests/helpers/db.ts`) berie session
+  `pg_advisory_lock` na VLASTNOM, samostatnom `pg.Client` pripojení (zámok je
+  per-backend-session, nie per-pool — zdieľaný `drizzle` pool by ho mohol
+  vziať na jednom pripojení a odomykať volanie poslať na inom) hneď na
+  začiatku, pred TRUNCATE, a uvoľní ho až v `close()` — takže druhý súbežný
+  proces na tej istej `DATABASE_URL` počká, kým prvý celý test doskončí,
+  namiesto toho, aby sa jeho TRUNCATE prekryl s bežiacim testom. Kľúč
+  (`TEST_DB_ISOLATION_LOCK_KEY = 787_878_100`, exportovaný z `db.ts`) je
+  ZÁMERNE odlišný od `INGEST_ADVISORY_LOCK_KEY` (787_878_001,
+  `ingest.ts`) — `pg_advisory_lock`/`pg_advisory_xact_lock` zdieľajú JEDEN
+  priestor kľúčov bez ohľadu na to, ktorá funkcia zámok vzala, takže KAŽDÝ
+  ĎALŠÍ advisory zámok pridaný do tohto repa musí dostať svoj vlastný,
+  nekolidujúci literál — over oba existujúce kľúče, než pridáš tretí. Beh
+  `withCleanDb()` sa preto navzájom SERIALIZUJE (nie paralelizuje) naprieč
+  procesmi — v CI to nič nemení (každý job má vlastný efemérny Postgres
+  kontajner, zámok tam nikdy nesúperí). Regresný test:
+  `tests/db-isolation-lock.integration.test.ts` (deterministicky cez
+  `pg_try_advisory_lock`, nie časovaním skutočnej TRUNCATE-kolízie).
 - **`insertTestSnapshot`'s (`tests/helpers/catalog.ts`) predvolený `fetchedAt`
   je pre KAŽDÉ volanie ten istý literál**, ak ho neprepíšeš — dva snapshoty
   vložené bez explicitného `fetchedAt` majú teda ZHODNÝ čas, a dopyt, ktorý

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.1",
+  "version": "0.3.0-dev.2",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Playbook-review housekeeping after PR #13 (#4/#7): the stale testing.md note about issue #7 being unresolved is replaced with the actual fix description (advisory-lock shared keyspace — future locks must pick a distinct key), and local-dev.md gets a short entry documenting the "standalone non-composite tsc project outside the main tsc -b graph" pattern used twice now (scripts/, apps/api/tests/).

Version bump to 0.3.0-dev.2 (mandatory since main == dev after PR #13 merged).

No functional/behavioral change — docs + version only.