### PR TITLE
chore: playbook review + version bump for F2 scheduler cycle

### DIFF
--- a/.claude/rules/deploy.md
+++ b/.claude/rules/deploy.md
@@ -145,3 +145,31 @@ paths:
   beží aj cez tlačidlo na webe (`POST /api/catalog/ingest`, priamo v bežiacom
   procese appky), takže `scripts/catalog-ingest.ts` zostáva len pohodlný LOKÁLNY/CI
   vstupný bod, nie produkčná nutnosť.
+
+- **`deploy` job (self-hosted dev2) môže raz za čas zlyhať na `failed to
+  extract layer ... link ... no such file or directory` počas `docker
+  compose pull app`** (pozorované 2026-07-29, PR #16 — žiadna zmena
+  závislostí v tom PR, čiže nešlo o obsah image, ale o lokálny
+  containerd/overlayfs stav na dev2). Cesta z chyby ukazuje na hardlink
+  VNÚTRI runtime obrazovej vrstvy — `runtime` štádium (`Dockerfile`) inštaluje
+  produkčné závislosti ČERSTVO (`RUN pnpm install --filter @forestshop/api
+  --prod`), čo napečie pnpm-ov hardlinkovaný content-addressable store
+  (`/root/.local/share/pnpm/store/v10/...`) do TEJ ISTEJ vrstvy ako
+  `node_modules` — ak sa pri sťahovaní/extrakcii na dev2 poškodí/vynechá
+  jeden blob v containerd content-store, hardlink naň zlyhá.
+  **Diagnostika (bez zásahu do bežiacich kontajnerov iných projektov na
+  zdieľanom dev2):**
+  ```bash
+  ssh newlevel@dev2 "sudo ctr --address /run/containerd/containerd.sock -n moby snapshots ls | grep <snapshot-id z chybovej hlášky>"
+  ssh newlevel@dev2 "sudo ctr --address /run/containerd/containerd.sock -n moby content ls | grep <chýbajúci sha256 prefix z chybovej hlášky>"
+  ```
+  (`ctr` bez `--address`/`-n moby` sa pripája na iný — prázdny — namespace a
+  nič neukáže; docker's vlastný containerd socket je `/run/containerd/
+  containerd.sock`, nie `/var/run/docker/containerd/containerd.sock`.)
+  Ak zlyhaný snapshot aj chýbajúci blob už nie sú v zozname, docker/containerd
+  si to už samo vyčistilo (rollback po zlyhanej extrakcii) — nie je čo mazať,
+  `docker system prune -f` nepomôže (0B reclaimed, korupcia nie je na úrovni
+  bežných "unused images"). V tomto prípade stačí `gh run rerun <run-id>
+  --failed` — čerstvý pull znova stiahne vrstvu od nuly. Ak sa to isté zopakuje
+  DRUHÝKRÁT za sebou, už to nie je transientný jav — over `docker system df`
+  (miesto na disku) a zváž reštart `containerd`/`docker` služby na dev2.

--- a/.claude/rules/scheduler.md
+++ b/.claude/rules/scheduler.md
@@ -1,0 +1,52 @@
+---
+paths:
+  - "apps/api/src/modules/scheduler/**"
+  - "apps/api/src/db/schema-scheduler.ts"
+  - "apps/api/src/http/scheduler-routes.ts"
+  - "apps/web/src/schedulerApi.ts"
+  - "apps/web/src/components/SchedulerSection.tsx"
+---
+
+# Plánovač úloh (F2)
+
+- **Pridanie ŠTVRTEJ naplánovanej úlohy = jedna nová `ScheduledJob` v
+  `modules/scheduler/jobs.ts` + jeden riadok v `index.ts`'s
+  `startScheduler(db, [...])` zozname.** Job's `run(db, now)` MUSÍ volať
+  existujúcu, už otestovanú business-logickú funkciu (rovnaký vzor ako
+  `catalogImportJob`/`pruneRawExportsJob`/`sessionCleanupJob`) — scheduler
+  sám žiadnu doménovú logiku nemá a nemá ju ani získať. `run()` nikdy
+  nezachytáva vlastné výnimky — necháva ich prejsť, `scheduler.ts`'s
+  `executeJob` ich odchytí a zapíše ako `job_run.status = "failure"`.
+- **Rozvrh je len denná hodina:minúta v UTC (`DailySchedule`), žiadny cron
+  výraz.** `isDue()` (`scheduler.ts`) je čistá funkcia — nová úloha dostáva
+  vlastný `{ hourUtc, minuteUtc }`; zvoľ ho aspoň 15 min od existujúcich
+  troch (01:00 import, 01:15 prune, 01:30 session-cleanup), aby sa
+  neprekrývali zbytočne (nie je to tvrdá závislosť, len aby operátor v
+  logoch/`job_run` vedel odlíšiť poradie).
+- **Nová advisory zámok kľúč VŽDY over proti existujúcim, nikdy nehádaj.**
+  `pg_advisory_lock`/`pg_advisory_xact_lock` zdieľajú JEDEN priestor kľúčov
+  bez ohľadu na funkciu (rovnaké upozornenie ako `testing.md`). Dnes
+  obsadené: `787_878_001` (`INGEST_ADVISORY_LOCK_KEY`, `ingest.ts`),
+  `787_878_002` (`SCHEDULER_ADVISORY_LOCK_KEY`, `scheduler.ts`),
+  `787_878_100` (`TEST_DB_ISOLATION_LOCK_KEY`, `tests/helpers/db.ts`).
+- **`tick()`'s zámok chráni LEN kontrolu splatnosti + vloženie "running"
+  riadku, NIE celý beh úlohy.** `job.run()` beží AŽ PO commite transakcie so
+  zámkom, mimo neho — dlho bežiaci job (napr. 54 MB import katalógu) tak
+  zámok nedrží počas celého behu. Splatnosť sa odvodzuje VÝLUČNE z
+  perzistovaného `job_run` (posledný riadok danej úlohy podľa
+  `started_at`), nikdy z pamäte procesu — to je čo robí scheduler odolný
+  voči reštartu kontajnera aj druhej replike appky bez akejkoľvek
+  distribuovanej koordinácie navyše.
+- **`job_run` musí byť v TRUNCATE zozname oboch test-setup miest** —
+  `apps/api/tests/helpers/db.ts` (integration testy) AJ
+  `scripts/e2e-setup.ts` (e2e) — inak sa staré riadky naťahujú medzi behmi
+  (žiadny FK problém, tabuľka na nič neukazuje, len poradie v TRUNCATE
+  zozname je nutné udržiavať ručne).
+- **Typ zdieľaný medzi `http/` a `modules/scheduler/` patrí do `modules/`,
+  nikdy do `http/`.** `RunIngest` pôvodne žil v `http/catalog-routes.ts`;
+  `modules/scheduler/jobs.ts` ho potrebovalo tiež, čo by vytvorilo
+  `modules → http` závislosť opačným smerom, než je v repe bežné (`http`
+  závisí od `modules`, nikdy naopak). Presunuté do `modules/catalog/
+  ingest.ts` vedľa `CatalogIngestResult`, `catalog-routes.ts` ho odtiaľ
+  len re-exportuje. Rovnaký test pri KAŽDOM ďalšom type zdieľanom medzi
+  vrstvami: ktorá vrstva ho logicky vlastní?

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,3 +27,4 @@ Per-area rules live in `.claude/rules/<area>.md` with `paths:` frontmatter.
 - deployment on dev2 → `.claude/rules/deploy.md`
 - backups / restore → `.claude/rules/backups.md`
 - katalóg zo Shoptetu (import, snapshoty, dostupnosť) → `.claude/rules/catalog.md`
+- plánovač úloh (F2 — nočné joby, job_run, advisory zámok) → `.claude/rules/scheduler.md`

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -32,3 +32,69 @@ RED→GREEN test names, key decisions, and the shared PR.
   note. Version bumped to 0.3.0-dev.2 (main had caught up to dev's
   0.3.0-dev.1 after #13's merge). Deployed + verified (v0.3.0-dev.2 in DOM
   footer, zero console errors).
+
+## 2026-07-29 — #12 (F2 job scheduler) + #3 (session cleanup job)
+
+- Version bumped `bf44462`→`6464971` (0.3.0-dev.3 → 0.3.0-dev.4) as the first
+  commit, before any feature code.
+- Design posted BEFORE the implementation commit: root cause (no
+  scheduler/cron infra exists; #8 punted the "how does it run periodically"
+  decision here), chosen approach (own `job_run` table + tiny in-process
+  tick loop, due-ness derived from the persisted table so it survives a
+  restart, `pg_advisory_xact_lock` reusing `ingest.ts`'s exact pattern with a
+  new distinct key `787_878_002` so a second replica never double-runs a
+  job), rejected alternatives (host cron/systemd timer — #8 explicitly ruled
+  it out; a scheduling library — 3 simple daily jobs don't need one).
+  Posted to #12 (`issuecomment-5121249995`) and #3
+  (`issuecomment-5121448774`, pointing back to #12's rationale since #3 is
+  explicitly one of the three jobs on this same infra).
+- No RED/GREEN commit split — both tickets are new capability (scheduler
+  infra + a job that never existed before), not a regression fix to
+  existing behavior, so this followed the "features: tests mandatory, order
+  flexible" path (`tdd-workflow.md`) rather than `regression-test-first.md`.
+  Full test coverage landed in the same commit: `isDue` unit tests
+  (`apps/api/src/modules/scheduler/scheduler.test.ts`), a deterministic
+  advisory-lock mutual-exclusion integration test (same pattern as
+  `catalog-ingest-lock.integration.test.ts`), full wiring tests for all
+  three jobs + the new `GET /api/scheduler/runs` route (role gating, empty
+  state), a dedicated `cleanupExpiredSessions` integration test (boundary
+  parity with `resolveSession`'s `gt`), web unit tests for the new
+  `SchedulerSection` component, and an extension of the existing
+  `login.spec.ts` e2e test asserting the "Plánovač" section's empty state
+  with a clean console.
+- Commit `a3b2568` (both jobs + scheduler infra + HTTP route + UI + e2e
+  extension + `docs/stara-appka-inventar.md`, `Closes #12` + `Closes #3`),
+  self-review follow-up `bc9249d` (fixed a layering violation found before
+  merge: `modules/scheduler/jobs.ts` was importing the `RunIngest` type from
+  `http/catalog-routes.ts` — inverted the repo's usual http→modules
+  dependency direction; moved the type to `modules/catalog/ingest.ts` next
+  to `CatalogIngestResult`, `catalog-routes.ts` now re-exports it).
+- Shared PR: **#16** (`dev` → `main`), merged `3c2b46c7`. CI: all 5 jobs
+  green (check, integration, e2e, docker-build, version-check) on both the
+  push-triggered and PR-triggered runs.
+- **Deploy hit a transient dev2 runner infra failure, unrelated to this
+  PR's code** (no dependency changes at all in this PR): `docker compose
+  pull app` failed extracting a layer — `link ... no such file or
+  directory` from `/var/lib/containerd/io.containerd.snapshotter.v1.
+  overlayfs/...` to a path inside `/root/.local/share/pnpm/store/v10/files/
+  ...` — a corrupted/incomplete containerd content-store blob referenced by
+  a hardlink inside the runtime image's own `pnpm install --prod` layer
+  (Dockerfile installs prod deps fresh in the runtime stage, which bakes
+  pnpm's hardlinked content-store into that same layer). Verified via `ctr
+  --address /run/containerd/containerd.sock -n moby` that the failed
+  snapshot (36721) and the missing blob were already cleaned up by
+  docker/containerd's own rollback — nothing manual to remove, no
+  disk-space issue (100G free). Reran the failed `deploy` job
+  (`gh run rerun --failed`) and it succeeded cleanly on retry — a one-off
+  transient extraction glitch, not a recurring pattern (grepped this repo's
+  issues + `docs/autopilot-log.md` for prior "overlayfs"/"containerd"
+  occurrences — none).
+- Deployed + verified on https://forestshop-novy.newlevel.media (v0.3.0-dev.4
+  in DOM footer + `/api/version`; live authenticated session already showed
+  the new "Plánovač" section rendering its empty state — no scheduler tick
+  has fired yet, next window is 01:00–01:30 UTC; `GET /api/scheduler/runs`
+  called from within the live authenticated page returned `200 {"items":
+  []}`; zero console errors/warnings; container logs clean, no scheduler
+  errors).
+- Two per-ticket Discord cards fired (`notify --run-card`, one per issue,
+  both confirmed delivered).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.4",
+  "version": "0.3.0-dev.5",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Follow-up to #16: playbook review captured the scheduler conventions, the http-vs-modules layering test, and the transient dev2 containerd/overlayfs deploy gotcha. Version bump (0.3.0-dev.4 → 0.3.0-dev.5) since main caught up to dev after #16 merged. No feature code changed.