### PR TITLE
Add self-service change-password screen and endpoint (#10)

### DIFF
--- a/apps/api/src/http/app.ts
+++ b/apps/api/src/http/app.ts
@@ -4,6 +4,8 @@ import { deleteCookie, getCookie, setCookie } from "hono/cookie";
 import { z } from "zod";
 import type { Database } from "../db/client.js";
 import { log } from "../logger.js";
+import { changePassword } from "../modules/auth/change-password.js";
+import { MIN_NEW_PASSWORD_LENGTH } from "../modules/auth/passwords.js";
 import { login, logout } from "../modules/auth/service.js";
 import { appVersion } from "../version.js";
 import { registerCatalogRoutes, type RunIngest } from "./catalog-routes.js";
@@ -15,6 +17,11 @@ import { registerSchedulerRoutes } from "./scheduler-routes.js";
 const loginSchema = z.object({
   email: z.string().email(),
   password: z.string().min(1),
+});
+
+const changePasswordSchema = z.object({
+  oldPassword: z.string().min(1),
+  newPassword: z.string().min(MIN_NEW_PASSWORD_LENGTH),
 });
 
 export function createApp(
@@ -70,6 +77,42 @@ export function createApp(
   });
 
   app.get("/api/me", requireUser(db), (c) => c.json(c.get("user")));
+
+  app.post(
+    "/api/me/password",
+    // Rovnaká CSRF disciplína ako `/api/logout` a import katalógu
+    // (`origin-check.ts`) — ide o stavovo-meniacu požiadavku nad
+    // autentifikovaným cookie session-om.
+    requireSameOrigin(),
+    requireUser(db),
+    zValidator("json", changePasswordSchema),
+    async (c) => {
+      const body = c.req.valid("json");
+      const user = c.get("user");
+      const now = new Date();
+      const result = await changePassword(db, {
+        userId: user.userId,
+        oldPassword: body.oldPassword,
+        newPassword: body.newPassword,
+        currentSessionToken: getCookie(c, SESSION_COOKIE) ?? "",
+        now,
+      });
+      // Zámerne 200 aj pre "zlé staré heslo" — je to bežný, očakávaný
+      // DOMÉNOVÝ výsledok (rovnaká rodina rozhodnutí ako `/api/catalog/ingest`
+      // vraciace 200 `{status: "busy"}`/"rejected" pre iný nechybový výsledok
+      // importu), nie chyba na úrovni HTTP. Chromium loguje "Failed to load
+      // resource" do konzoly pre KAŽDÝ fetch s 4xx/5xx bez ohľadu na to, či ho
+      // JS odchytí — pri 4xx by to pri zlom starom hesle (bežná, očakávaná
+      // používateľská chyba, nie výnimočný stav) porušilo pravidlo čistej
+      // konzoly (`testing.md` zakazuje rozširovať jedinú dnes povolenú
+      // výnimku o ďalšie cesty/kódy). 401 zostáva vyhradené pre skutočnú
+      // stratu relácie (`requireUser` vyššie v reťazci), 403 pre CSRF.
+      if (result === "wrong_old_password") {
+        return c.json({ ok: false, error: "Nesprávne staré heslo" });
+      }
+      return c.json({ ok: true });
+    },
+  );
 
   registerCatalogRoutes(app, db, options.runIngest);
   registerSchedulerRoutes(app, db);

--- a/apps/api/src/modules/audit/service.ts
+++ b/apps/api/src/modules/audit/service.ts
@@ -1,6 +1,14 @@
 import type { Database } from "../../db/client.js";
 import { auditEvents } from "../../db/schema.js";
 
+// `Pick<Database, "insert">` (not the full `Database`) so this also accepts a
+// `db.transaction(async (tx) => ...)` callback's `tx` — a `PgTransaction`
+// extends the same base class as `NodePgDatabase` and structurally has an
+// `insert` of the same shape, but is missing `Database`'s own `$client`
+// property (#10, `changePassword` writes its audit row inside the same
+// transaction as the password/session updates it's paired with).
+export type AuditExecutor = Pick<Database, "insert">;
+
 export interface AuditEventInput {
   readonly actorUserId?: string | undefined;
   readonly action: string;
@@ -13,7 +21,7 @@ export interface AuditEventInput {
   readonly at: Date;
 }
 
-export async function record(db: Database, event: AuditEventInput): Promise<void> {
+export async function record(db: AuditExecutor, event: AuditEventInput): Promise<void> {
   await db.insert(auditEvents).values({
     at: event.at,
     actorUserId: event.actorUserId ?? null,

--- a/apps/api/src/modules/auth/change-password.ts
+++ b/apps/api/src/modules/auth/change-password.ts
@@ -1,0 +1,67 @@
+import { and, eq, ne } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { sessions, users } from "../../db/schema.js";
+import { record } from "../audit/service.js";
+import { hashPassword, verifyPassword } from "./passwords.js";
+import { hashToken } from "./sessions.js";
+
+export type ChangePasswordResult = "ok" | "wrong_old_password";
+
+export interface ChangePasswordInput {
+  readonly userId: string;
+  readonly oldPassword: string;
+  readonly newPassword: string;
+  // Token (not hash) of the session making this request — kept alive while every
+  // OTHER session of this user is invalidated (#10's "old session stops working"
+  // requirement only applies to sessions other than the one performing the change).
+  readonly currentSessionToken: string;
+  readonly now: Date;
+}
+
+// Celý zápis beží v JEDNEJ transakcii (rovnaký vzor ako `catalog/ingest.ts` a
+// `scheduler/scheduler.ts`) — pád procesu medzi UPDATE hesla a zrušením
+// ostatných relácií by inak mohol nechať nové heslo platné, ale staré
+// (ukradnuté?) relácie stále živé, alebo naopak zapísať audit bez toho, aby sa
+// heslo skutočne zmenilo.
+export async function changePassword(
+  db: Database,
+  input: ChangePasswordInput,
+): Promise<ChangePasswordResult> {
+  return db.transaction(async (tx) => {
+    const [user] = await tx.select().from(users).where(eq(users.id, input.userId)).limit(1);
+    // `userId` prichádza z už vyriešenej relácie (`requireUser`) — chýbajúci
+    // používateľ by znamenal databázovú nekonzistenciu, nie bežný vstup od
+    // klienta. Zaobchádzame s ním rovnako ako so zlým starým heslom (žiadny
+    // zápis, žiadny audit s neexistujúcim actorUserId), namiesto vyhodenia.
+    if (user === undefined) return "wrong_old_password";
+
+    const oldPasswordOk = await verifyPassword(user.passwordHash, input.oldPassword);
+    if (!oldPasswordOk) {
+      await record(tx, {
+        actorUserId: user.id,
+        action: "password.change.failed",
+        entity: "user",
+        entityId: user.id,
+        at: input.now,
+      });
+      return "wrong_old_password";
+    }
+
+    const newPasswordHash = await hashPassword(input.newPassword);
+    await tx.update(users).set({ passwordHash: newPasswordHash }).where(eq(users.id, user.id));
+
+    const currentTokenHash = hashToken(input.currentSessionToken);
+    await tx
+      .delete(sessions)
+      .where(and(eq(sessions.userId, user.id), ne(sessions.tokenHash, currentTokenHash)));
+
+    await record(tx, {
+      actorUserId: user.id,
+      action: "password.change.ok",
+      entity: "user",
+      entityId: user.id,
+      at: input.now,
+    });
+    return "ok";
+  });
+}

--- a/apps/api/src/modules/auth/passwords.ts
+++ b/apps/api/src/modules/auth/passwords.ts
@@ -2,6 +2,12 @@ import { hash, verify } from "@node-rs/argon2";
 
 const OPTIONS = { memoryCost: 19_456, timeCost: 2, parallelism: 1 } as const;
 
+// Neexistoval nikde v repe skutočný spodný limit dĺžky hesla — loginova
+// `z.string().min(1)` kontroluje len neprázdnosť. Toto je prvé miesto, kde
+// heslo VOLÍ používateľ sám (#10, zmena vlastného hesla), takže potrebuje
+// vlastné, zmysluplné minimum.
+export const MIN_NEW_PASSWORD_LENGTH = 8;
+
 export function hashPassword(plain: string): Promise<string> {
   return hash(plain, OPTIONS);
 }

--- a/apps/api/tests/change-password.integration.test.ts
+++ b/apps/api/tests/change-password.integration.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, expect, it } from "vitest";
+import { changePassword } from "../src/modules/auth/change-password.js";
+import { login, resolveSession } from "../src/modules/auth/service.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import { auditEvents, users } from "../src/db/schema.js";
+import { withCleanDb } from "./helpers/db.js";
+
+let close: (() => Promise<void>) | undefined;
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+});
+
+const NOW = new Date("2026-07-29T10:00:00Z");
+const NESKOR = new Date("2026-07-29T10:05:00Z");
+const STARE_HESLO = "test-heslo-abc"; // testovacie údaje, nie tajomstvo
+const ZLE_STARE_HESLO = "nespravne-stare-heslo";
+const NOVE_HESLO = "nove-tajne-heslo-123";
+
+async function seed(db: Awaited<ReturnType<typeof withCleanDb>>["db"]): Promise<string> {
+  const [user] = await db
+    .insert(users)
+    .values({
+      email: "manazer@forestshop.sk",
+      passwordHash: await hashPassword(STARE_HESLO),
+      displayName: "Manažér",
+      role: "manazer",
+    })
+    .returning({ id: users.id });
+  if (user === undefined) throw new Error("testovací používateľ sa nepodarilo vložiť");
+  return user.id;
+}
+
+it("úspešná zmena hesla: staré heslo prestane fungovať, nové zaberie, zápis v audite", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const userId = await seed(ctx.db);
+  const session = await login(ctx.db, { email: "manazer@forestshop.sk", password: STARE_HESLO, now: NOW });
+  if (session === null) throw new Error("prihlásenie zlyhalo");
+
+  const result = await changePassword(ctx.db, {
+    userId,
+    oldPassword: STARE_HESLO,
+    newPassword: NOVE_HESLO,
+    currentSessionToken: session.token,
+    now: NESKOR,
+  });
+  expect(result).toBe("ok");
+
+  await expect(
+    login(ctx.db, { email: "manazer@forestshop.sk", password: STARE_HESLO, now: NESKOR }),
+  ).resolves.toBeNull();
+  await expect(
+    login(ctx.db, { email: "manazer@forestshop.sk", password: NOVE_HESLO, now: NESKOR }),
+  ).resolves.not.toBeNull();
+
+  const events = await ctx.db.select().from(auditEvents);
+  expect(events.map((e) => e.action)).toContain("password.change.ok");
+});
+
+it("zlé staré heslo: zmena sa odmietne, heslo aj relácie ostanú netknuté, zápis v audite", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const userId = await seed(ctx.db);
+  const session = await login(ctx.db, { email: "manazer@forestshop.sk", password: STARE_HESLO, now: NOW });
+  if (session === null) throw new Error("prihlásenie zlyhalo");
+
+  const result = await changePassword(ctx.db, {
+    userId,
+    oldPassword: ZLE_STARE_HESLO,
+    newPassword: NOVE_HESLO,
+    currentSessionToken: session.token,
+    now: NESKOR,
+  });
+  expect(result).toBe("wrong_old_password");
+
+  // pôvodné heslo stále platí
+  await expect(
+    login(ctx.db, { email: "manazer@forestshop.sk", password: STARE_HESLO, now: NESKOR }),
+  ).resolves.not.toBeNull();
+  // relácia zostala platná (nič sa nezrušilo)
+  await expect(resolveSession(ctx.db, session.token, NESKOR)).resolves.not.toBeNull();
+
+  const events = await ctx.db.select().from(auditEvents);
+  expect(events.map((e) => e.action)).toContain("password.change.failed");
+});
+
+it("po zmene hesla PRESTANE platiť INÁ (staršia) relácia toho istého používateľa, aktuálna relácia ostáva platná", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const userId = await seed(ctx.db);
+
+  const stara = await login(ctx.db, { email: "manazer@forestshop.sk", password: STARE_HESLO, now: NOW });
+  const aktualna = await login(ctx.db, {
+    email: "manazer@forestshop.sk",
+    password: STARE_HESLO,
+    now: NOW,
+  });
+  if (stara === null || aktualna === null) throw new Error("prihlásenie zlyhalo");
+
+  const result = await changePassword(ctx.db, {
+    userId,
+    oldPassword: STARE_HESLO,
+    newPassword: NOVE_HESLO,
+    currentSessionToken: aktualna.token,
+    now: NESKOR,
+  });
+  expect(result).toBe("ok");
+
+  await expect(resolveSession(ctx.db, stara.token, NESKOR)).resolves.toBeNull();
+  await expect(resolveSession(ctx.db, aktualna.token, NESKOR)).resolves.not.toBeNull();
+});

--- a/apps/api/tests/http.integration.test.ts
+++ b/apps/api/tests/http.integration.test.ts
@@ -14,6 +14,7 @@ afterEach(async () => {
 
 const HESLO = "test-heslo-abc";     // testovacie údaje, nie tajomstvo
 const ZLE_HESLO = "nespravne";
+const NOVE_HESLO = ["nove", "tajne", "heslo", "xyz"].join("-"); // testovacie údaje, nie tajomstvo
 
 async function boot() {
   const ctx = await withCleanDb();
@@ -135,6 +136,116 @@ it("sprejovanie mnohých rôznych e-mailov z JEDNEJ IP narazí na samostatný IP
   // iná IP nie je ovplyvnená sprejovaním na prvej
   const inaIp = await attempt("203.0.113.10", "neznamy-0@forestshop.sk");
   expect(inaIp.status).toBe(401);
+});
+
+it("POST /api/me/password zmení heslo prihláseného používateľa (#10)", async () => {
+  const app = await boot();
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "manazer@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+
+  const zmena = await app.request("/api/me/password", {
+    method: "POST",
+    headers: { "content-type": "application/json", cookie },
+    body: JSON.stringify({ oldPassword: HESLO, newPassword: NOVE_HESLO }),
+  });
+  expect(zmena.status).toBe(200);
+
+  const staryPrihlasenie = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "manazer@forestshop.sk", password: HESLO }),
+  });
+  expect(staryPrihlasenie.status).toBe(401);
+
+  const novyPrihlasenie = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "manazer@forestshop.sk", password: NOVE_HESLO }),
+  });
+  expect(novyPrihlasenie.status).toBe(200);
+});
+
+it("POST /api/me/password so zlým starým heslom vráti 200 s ok:false a heslo nezmení", async () => {
+  const app = await boot();
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "manazer@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+
+  const zmena = await app.request("/api/me/password", {
+    method: "POST",
+    headers: { "content-type": "application/json", cookie },
+    body: JSON.stringify({ oldPassword: ZLE_HESLO, newPassword: NOVE_HESLO }),
+  });
+  // Zámerne 200 aj tu (nie 4xx) — pozri komentár pri trase v `http/app.ts`:
+  // "zlé staré heslo" je bežný domény výsledok, nie HTTP chyba, a 4xx by
+  // Chromiu prinútilo zalogovať "Failed to load resource" do konzoly, čo by
+  // v e2e teste porušilo jedinú dnes povolenú (a rozširovanie zakazujúcu)
+  // výnimku (`testing.md`).
+  expect(zmena.status).toBe(200);
+  expect(await zmena.json()).toEqual({ ok: false, error: "Nesprávne staré heslo" });
+
+  const staryPrihlasenie = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "manazer@forestshop.sk", password: HESLO }),
+  });
+  expect(staryPrihlasenie.status).toBe(200);
+});
+
+it("POST /api/me/password s príliš krátkym novým heslom vráti 400", async () => {
+  const app = await boot();
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "manazer@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+
+  const zmena = await app.request("/api/me/password", {
+    method: "POST",
+    headers: { "content-type": "application/json", cookie },
+    body: JSON.stringify({ oldPassword: HESLO, newPassword: "krat" }),
+  });
+  expect(zmena.status).toBe(400);
+});
+
+it("POST /api/me/password bez prihlásenia vráti 401", async () => {
+  const app = await boot();
+  const res = await app.request("/api/me/password", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ oldPassword: HESLO, newPassword: NOVE_HESLO }),
+  });
+  expect(res.status).toBe(401);
+});
+
+it("POST /api/me/password s cudzím Origin je odmietnuté (403)", async () => {
+  const app = await boot();
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "manazer@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+
+  const res = await app.request("/api/me/password", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      cookie,
+      origin: "https://utocnik.example",
+      host: "forestshop.example",
+    },
+    body: JSON.stringify({ oldPassword: HESLO, newPassword: NOVE_HESLO }),
+  });
+  expect(res.status).toBe(403);
 });
 
 it("odhlásenie s cudzím Origin je odmietnuté (403), rovnaký pôvod prejde", async () => {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState, type JSX } from "react";
 import { fetchMe, postLogout, type Me } from "./api.js";
 import { CatalogPage } from "./components/CatalogPage.js";
+import { ChangePasswordForm } from "./components/ChangePasswordForm.js";
 import { Footer } from "./components/Footer.js";
 import { LoginForm } from "./components/LoginForm.js";
 import { SchedulerSection } from "./components/SchedulerSection.js";
@@ -75,6 +76,7 @@ export function App(): JSX.Element {
       {logoutError !== "" && <p role="alert">{logoutError}</p>}
       <CatalogPage role={me.role} onSessionExpired={reload} />
       <SchedulerSection role={me.role} onSessionExpired={reload} />
+      <ChangePasswordForm onSessionExpired={reload} />
       <Footer />
     </main>
   );

--- a/apps/web/src/components/ChangePasswordForm.test.tsx
+++ b/apps/web/src/components/ChangePasswordForm.test.tsx
@@ -1,0 +1,106 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { ChangePasswordForm } from "./ChangePasswordForm.js";
+
+const { postChangePassword, PasswordChangeUnauthorizedError } = vi.hoisted(() => {
+  class PasswordChangeUnauthorizedError extends Error {}
+  return { postChangePassword: vi.fn(), PasswordChangeUnauthorizedError };
+});
+vi.mock("../passwordApi.js", () => ({ postChangePassword, PasswordChangeUnauthorizedError }));
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+function vyplnIba(polia: { stareHeslo?: string; noveHeslo?: string; potvrdenie?: string }): void {
+  if (polia.stareHeslo !== undefined) {
+    fireEvent.change(screen.getByLabelText("Staré heslo"), { target: { value: polia.stareHeslo } });
+  }
+  if (polia.noveHeslo !== undefined) {
+    fireEvent.change(screen.getByLabelText("Nové heslo"), { target: { value: polia.noveHeslo } });
+  }
+  if (polia.potvrdenie !== undefined) {
+    fireEvent.change(screen.getByLabelText("Nové heslo znova"), { target: { value: polia.potvrdenie } });
+  }
+}
+
+function odosli(): void {
+  fireEvent.click(screen.getByRole("button", { name: "Zmeniť heslo" }));
+}
+
+it("nezhodujúce sa potvrdenie nového hesla ukáže chybu a nezavolá server", () => {
+  render(<ChangePasswordForm onSessionExpired={() => {}} />);
+  vyplnIba({ stareHeslo: "stare-heslo", noveHeslo: "nove-heslo-123", potvrdenie: "ine-heslo-456" });
+  odosli();
+
+  expect(screen.getByRole("alert").textContent).toBe("Nové heslo a jeho potvrdenie sa nezhodujú");
+  expect(postChangePassword).not.toHaveBeenCalled();
+});
+
+it("príliš krátke nové heslo ukáže chybu a nezavolá server", () => {
+  render(<ChangePasswordForm onSessionExpired={() => {}} />);
+  vyplnIba({ stareHeslo: "stare-heslo", noveHeslo: "krat", potvrdenie: "krat" });
+  odosli();
+
+  expect(screen.getByRole("alert").textContent).toBe("Nové heslo musí mať aspoň 8 znakov");
+  expect(postChangePassword).not.toHaveBeenCalled();
+});
+
+it("úspešná zmena ukáže potvrdenie a vyprázdni polia", async () => {
+  postChangePassword.mockResolvedValue({ ok: true });
+  render(<ChangePasswordForm onSessionExpired={() => {}} />);
+  vyplnIba({ stareHeslo: "stare-heslo", noveHeslo: "nove-heslo-123", potvrdenie: "nove-heslo-123" });
+  odosli();
+
+  await screen.findByTestId("password-change-success");
+  expect(postChangePassword).toHaveBeenCalledWith("stare-heslo", "nove-heslo-123");
+  expect(screen.getByLabelText<HTMLInputElement>("Staré heslo").value).toBe("");
+  expect(screen.getByLabelText<HTMLInputElement>("Nové heslo").value).toBe("");
+});
+
+it("zlé staré heslo zo servera ukáže chybovú hlášku servera", async () => {
+  postChangePassword.mockResolvedValue({ ok: false, error: "Nesprávne staré heslo" });
+  render(<ChangePasswordForm onSessionExpired={() => {}} />);
+  vyplnIba({ stareHeslo: "zle-heslo", noveHeslo: "nove-heslo-123", potvrdenie: "nove-heslo-123" });
+  odosli();
+
+  const alert = await screen.findByRole("alert");
+  expect(alert.textContent).toBe("Nesprávne staré heslo");
+});
+
+it("keď relácia medzitým vypršala, zavolá onSessionExpired", async () => {
+  postChangePassword.mockRejectedValue(new PasswordChangeUnauthorizedError());
+  const onSessionExpired = vi.fn();
+  render(<ChangePasswordForm onSessionExpired={onSessionExpired} />);
+  vyplnIba({ stareHeslo: "stare-heslo", noveHeslo: "nove-heslo-123", potvrdenie: "nove-heslo-123" });
+  odosli();
+
+  await waitFor(() => { expect(onSessionExpired).toHaveBeenCalledTimes(1); });
+});
+
+it("tlačidlo sa počas prebiehajúcej požiadavky vypne a druhý klik nevyšle ďalšiu požiadavku", async () => {
+  let resolvePost: (result: { ok: true }) => void = () => {
+    throw new Error("resolvePost nebol nastavený");
+  };
+  postChangePassword.mockImplementation(
+    () =>
+      new Promise((resolve) => {
+        resolvePost = resolve;
+      }),
+  );
+
+  render(<ChangePasswordForm onSessionExpired={() => {}} />);
+  vyplnIba({ stareHeslo: "stare-heslo", noveHeslo: "nove-heslo-123", potvrdenie: "nove-heslo-123" });
+  odosli();
+
+  const tlacidlo = await screen.findByRole("button", { name: "Zmeniť heslo" });
+  await waitFor(() => { expect(tlacidlo.hasAttribute("disabled")).toBe(true); });
+
+  fireEvent.click(tlacidlo);
+  expect(postChangePassword).toHaveBeenCalledTimes(1);
+
+  resolvePost({ ok: true });
+  await waitFor(() => { expect(tlacidlo.hasAttribute("disabled")).toBe(false); });
+  expect(postChangePassword).toHaveBeenCalledTimes(1);
+});

--- a/apps/web/src/components/ChangePasswordForm.tsx
+++ b/apps/web/src/components/ChangePasswordForm.tsx
@@ -1,0 +1,92 @@
+import { useState, type SyntheticEvent, type JSX } from "react";
+import { PasswordChangeUnauthorizedError, postChangePassword } from "../passwordApi.js";
+
+// Musí zodpovedať `MIN_NEW_PASSWORD_LENGTH` v `apps/api/src/modules/auth/passwords.ts`
+// (server je autoritatívny zdroj — toto len šetrí zbytočnú okružnú cestu na
+// server pri zjavne krátkom hesle).
+const MIN_NEW_PASSWORD_LENGTH = 8;
+
+export function ChangePasswordForm({
+  onSessionExpired,
+}: {
+  readonly onSessionExpired: () => void;
+}): JSX.Element {
+  const [oldPassword, setOldPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [newPasswordConfirm, setNewPasswordConfirm] = useState("");
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function submit(e: SyntheticEvent): Promise<void> {
+    e.preventDefault();
+    if (submitting) return; // dvojklik/opakovaný Enter počas prebiehajúcej požiadavky
+    setSuccess(false);
+    setError("");
+
+    if (newPassword !== newPasswordConfirm) {
+      setError("Nové heslo a jeho potvrdenie sa nezhodujú");
+      return;
+    }
+    if (newPassword.length < MIN_NEW_PASSWORD_LENGTH) {
+      setError(`Nové heslo musí mať aspoň ${String(MIN_NEW_PASSWORD_LENGTH)} znakov`);
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const result = await postChangePassword(oldPassword, newPassword);
+      if (result.ok) {
+        setSuccess(true);
+        setOldPassword("");
+        setNewPassword("");
+        setNewPasswordConfirm("");
+      } else {
+        setError(result.error);
+      }
+    } catch (err) {
+      if (err instanceof PasswordChangeUnauthorizedError) {
+        onSessionExpired();
+        return;
+      }
+      setError("Zmena hesla zlyhala — server neodpovedal");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <section>
+      <h2>Zmena hesla</h2>
+      <form onSubmit={(e) => { void submit(e); }}>
+        <label htmlFor="old-password">Staré heslo</label>
+        <input
+          id="old-password"
+          type="password"
+          value={oldPassword}
+          onChange={(e) => { setOldPassword(e.target.value); }}
+          required
+        />
+        <label htmlFor="new-password">Nové heslo</label>
+        <input
+          id="new-password"
+          type="password"
+          value={newPassword}
+          onChange={(e) => { setNewPassword(e.target.value); }}
+          required
+        />
+        <label htmlFor="new-password-confirm">Nové heslo znova</label>
+        <input
+          id="new-password-confirm"
+          type="password"
+          value={newPasswordConfirm}
+          onChange={(e) => { setNewPasswordConfirm(e.target.value); }}
+          required
+        />
+        <button type="submit" disabled={submitting}>Zmeniť heslo</button>
+        {error !== "" && <p role="alert">{error}</p>}
+        {success && <p data-testid="password-change-success">Heslo bolo úspešne zmenené</p>}
+      </form>
+    </section>
+  );
+}

--- a/apps/web/src/passwordApi.test.ts
+++ b/apps/web/src/passwordApi.test.ts
@@ -1,0 +1,38 @@
+import { expect, it, vi } from "vitest";
+import { PasswordChangeUnauthorizedError, postChangePassword } from "./passwordApi.js";
+
+it("vráti ok pri úspechu (telo { ok: true })", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 })),
+  );
+  await expect(postChangePassword("stare", "nove-heslo-123")).resolves.toEqual({ ok: true });
+});
+
+it("zlé staré heslo (200, telo { ok: false, error }) vráti chybovú hlášku zo servera", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: false, error: "Nesprávne staré heslo" }), { status: 200 }),
+    ),
+  );
+  await expect(postChangePassword("zle", "nove-heslo-123")).resolves.toEqual({
+    ok: false,
+    error: "Nesprávne staré heslo",
+  });
+});
+
+it("pri nerozpoznateľnom tvare tela vráti všeobecnú hlášku", async () => {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 400 })));
+  await expect(postChangePassword("zle", "krat")).resolves.toEqual({
+    ok: false,
+    error: "Zmena hesla zlyhala",
+  });
+});
+
+it("pri 401 vyhodí PasswordChangeUnauthorizedError", async () => {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 401 })));
+  await expect(postChangePassword("stare", "nove-heslo-123")).rejects.toBeInstanceOf(
+    PasswordChangeUnauthorizedError,
+  );
+});

--- a/apps/web/src/passwordApi.ts
+++ b/apps/web/src/passwordApi.ts
@@ -1,0 +1,32 @@
+/** Relácia medzitým vypršala (401) — rovnaký rozdiel ako `CatalogUnauthorizedError`/`SchedulerUnauthorizedError`. */
+export class PasswordChangeUnauthorizedError extends Error {
+  constructor() {
+    super("Neprihlásený");
+  }
+}
+
+export type ChangePasswordResult = { readonly ok: true } | { readonly ok: false; readonly error: string };
+
+export async function postChangePassword(
+  oldPassword: string,
+  newPassword: string,
+): Promise<ChangePasswordResult> {
+  const res = await fetch("/api/me/password", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ oldPassword, newPassword }),
+  });
+  if (res.status === 401) throw new PasswordChangeUnauthorizedError();
+  // Server posiela `{ ok: true }` alebo `{ ok: false, error: "..." }` — vždy s
+  // 200 (aj pre "zlé staré heslo", zámerne, pozri komentár pri trase v
+  // `http/app.ts`). Iný tvar tela (napr. zod validačná chyba pri obídení
+  // klientskej kontroly dĺžky, alebo CSRF 403) padne na všeobecnú hlášku —
+  // nikdy sa nezobrazí surová/technická chybová štruktúra používateľovi.
+  const body: unknown = await res.json().catch(() => null);
+  if (typeof body === "object" && body !== null && "ok" in body) {
+    if (body.ok === true) return { ok: true };
+    const error = "error" in body && typeof body.error === "string" ? body.error : "Zmena hesla zlyhala";
+    return { ok: false, error };
+  }
+  return { ok: false, error: "Zmena hesla zlyhala" };
+}

--- a/apps/web/tests/e2e/login.spec.ts
+++ b/apps/web/tests/e2e/login.spec.ts
@@ -44,3 +44,86 @@ test("zlé heslo ukáže slovenskú hlášku a nepustí ďalej", async ({ page }
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
   await expect(page.getByRole("alert")).toHaveText("Nesprávny e-mail alebo heslo");
 });
+
+// (#10) Zmena vlastného hesla. Používa DVE prihlásené "zariadenia" (dva
+// samostatné browser contexty so ZDIEĽANÝM e2e používateľom) na overenie, že
+// zmena hesla zruší tú DRUHÚ, staršiu reláciu, ale tú, ktorá zmenu vykonala,
+// necháva bežať ďalej — presne požiadavka ticketu ("stará relácia prestane
+// platiť"). Na konci sa heslo vráti na pôvodné, aby test ostal opakovateľný
+// bez ohľadu na poradie behu (žiadny reset DB medzi testami v tomto súbore).
+test("zmena hesla: zlé staré heslo/nezhoda odmietnuté, úspešná zmena zruší INÚ reláciu, aktuálna ostáva prihlásená", async ({
+  page,
+  browser,
+}) => {
+  const NOVE_HESLO = "e2e-nove-heslo-xyz";
+  const jeOcakavane = (m: ConsoleMessage): boolean =>
+    m.location().url.includes("/api/me") && m.text().includes("401");
+  const chyby: string[] = [];
+  const sledujKonzolu = (p: typeof page): void => {
+    p.on("console", (m) => {
+      if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+    });
+    p.on("pageerror", (e) => { chyby.push(e.message); });
+  };
+  sledujKonzolu(page);
+
+  await page.goto("/");
+  await page.getByLabel("E-mail").fill("e2e@forestshop.sk");
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await expect(page.getByTestId("greeting")).toContainText("E2E Manažér");
+
+  // Druhé, nezávislé "zariadenie" — prihlásené TEN ISTÝ používateľ, PRED
+  // zmenou hesla — aby sme mali reláciu, ktorá zmenu hesla nevykoná.
+  const context2 = await browser.newContext();
+  const page2 = await context2.newPage();
+  sledujKonzolu(page2);
+  await page2.goto("/");
+  await page2.getByLabel("E-mail").fill("e2e@forestshop.sk");
+  await page2.getByLabel("Heslo").fill(E2E_HESLO);
+  await page2.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await expect(page2.getByTestId("greeting")).toContainText("E2E Manažér");
+
+  // Zlé staré heslo — odmietnuté, nič sa nezmení.
+  await page.getByLabel("Staré heslo").fill(ZLE_HESLO);
+  await page.getByLabel("Nové heslo", { exact: true }).fill(NOVE_HESLO);
+  await page.getByLabel("Nové heslo znova").fill(NOVE_HESLO);
+  await page.getByRole("button", { name: "Zmeniť heslo" }).click();
+  await expect(page.getByRole("alert")).toHaveText("Nesprávne staré heslo");
+
+  // Nezhodujúce sa potvrdenie nového hesla — odmietnuté klientom, server sa
+  // vôbec nevolá.
+  await page.getByLabel("Staré heslo").fill(E2E_HESLO);
+  await page.getByLabel("Nové heslo", { exact: true }).fill(NOVE_HESLO);
+  await page.getByLabel("Nové heslo znova").fill("ine-heslo-nez-vyssie");
+  await page.getByRole("button", { name: "Zmeniť heslo" }).click();
+  await expect(page.getByRole("alert")).toHaveText("Nové heslo a jeho potvrdenie sa nezhodujú");
+
+  // Úspešná zmena.
+  await page.getByLabel("Staré heslo").fill(E2E_HESLO);
+  await page.getByLabel("Nové heslo", { exact: true }).fill(NOVE_HESLO);
+  await page.getByLabel("Nové heslo znova").fill(NOVE_HESLO);
+  await page.getByRole("button", { name: "Zmeniť heslo" }).click();
+  await expect(page.getByTestId("password-change-success")).toBeVisible();
+
+  // Druhé zariadenie malo v tom čase ešte OTVORENÚ reláciu — po obnovení
+  // stránky zistí, že jeho relácia je zrušená, a appka ho vráti na
+  // prihlasovaciu obrazovku (skutočné správanie, ktoré uvidí používateľ).
+  await page2.reload();
+  await expect(page2.getByRole("heading", { name: "Prihlásenie" })).toBeVisible();
+
+  // Prvé zariadenie (to, čo zmenu vykonalo) ostáva prihlásené aj po obnovení.
+  await page.reload();
+  await expect(page.getByTestId("greeting")).toContainText("E2E Manažér");
+
+  // Vrátenie hesla na pôvodné — aby test ostal opakovateľný bez ohľadu na
+  // poradie/opakovanie behu (žiaden reset DB medzi testami tohto súboru).
+  await page.getByLabel("Staré heslo").fill(NOVE_HESLO);
+  await page.getByLabel("Nové heslo", { exact: true }).fill(E2E_HESLO);
+  await page.getByLabel("Nové heslo znova").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Zmeniť heslo" }).click();
+  await expect(page.getByTestId("password-change-success")).toBeVisible();
+
+  await context2.close();
+  expect(chyby).toEqual([]);
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.5",
+  "version": "0.3.0-dev.6",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Summary

Adds a self-service "change my password" screen and endpoint — until now
the only way to change a password was a manual `UPDATE users SET
password_hash = ...` on dev2 (heslá sú uložené nevratne cez argon2, takže
sa dajú len prepísať, nie prečítať).

- `POST /api/me/password` (`http/app.ts`, next to the other small auth
  routes `/api/login`/`/api/logout`/`/api/me`): `requireSameOrigin()` →
  `requireUser(db)` → zod (`newPassword` min 8 chars, `MIN_NEW_PASSWORD_LENGTH`,
  new — nothing in the repo defined a real minimum before).
- `changePassword()` (`modules/auth/change-password.ts`): verifies the old
  password, writes the new hash, deletes every OTHER session of that user
  (keeps the session performing the change alive), and records
  `password.change.ok`/`password.change.failed` in the audit log — all
  inside one `db.transaction` (same pattern as `catalog/ingest.ts` and
  `scheduler/scheduler.ts`).
- Web: `ChangePasswordForm` (old password + new password twice, client-side
  match check) rendered for every logged-in role in `App.tsx`.
- `record()` (`modules/audit/service.ts`) now takes `Pick<Database,
  "insert">` instead of the full `Database` type, so it can be called with
  a `db.transaction()` callback's `tx` too.

**Wrong old password → 200 `{ok:false, error}`, not a 4xx** — deliberate:
it's a normal domain outcome (same family as `/api/catalog/ingest`'s 200
`{status:"busy"}`), and returning a 4xx here makes Chromium log a "Failed
to load resource" console entry, which would have broken the project's
single documented e2e console exception (unauthenticated `/api/me` 401) —
`testing.md` explicitly forbids widening that exception to more
paths/codes.

Design rationale posted to the issue BEFORE the implementation commit:
https://github.com/zbynekdrlik/forestshop-app/issues/10#issuecomment-5121796661

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` (unit, no DB) — 188 (api) + 55 (web) passed
- [x] `pnpm --filter @forestshop/api test:integration` — 98 tests passed,
      incl. `change-password.integration.test.ts` (successful change, wrong
      old password, old session invalidated / current session survives)
      and new HTTP-level cases in `http.integration.test.ts` (too-short new
      password → 400, wrong Origin → 403, unauthenticated → 401)
- [x] `pnpm --filter @forestshop/web e2e` — extended `login.spec.ts` with a
      real two-browser-context test: wrong old password, mismatched
      confirmation, successful change, the OTHER (already logged-in)
      session gets kicked back to the login screen on reload, the session
      performing the change stays logged in, console stays clean
      throughout, password restored to the original at the end

Closes #10
