### PR TITLE
Add order/order_line DB schema for F3 (#20)

### DIFF
--- a/apps/api/drizzle/0006_goofy_strong_guy.sql
+++ b/apps/api/drizzle/0006_goofy_strong_guy.sql
@@ -1,0 +1,27 @@
+CREATE TYPE "public"."order_line_state" AS ENUM('objednane', 'caka_sa', 'skladom', 'nedostupne');--> statement-breakpoint
+CREATE TABLE "order_line" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"order_id" uuid NOT NULL,
+	"variant_code" text NOT NULL,
+	"quantity" integer NOT NULL,
+	"state" "order_line_state" DEFAULT 'objednane' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "order_line_quantity_positive_ck" CHECK ("order_line"."quantity" > 0)
+);
+--> statement-breakpoint
+CREATE TABLE "order" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"external_order_id" text NOT NULL,
+	"customer_name" text NOT NULL,
+	"comment" text,
+	"placed_at" timestamp with time zone NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "order_external_order_id_unique" UNIQUE("external_order_id")
+);
+--> statement-breakpoint
+ALTER TABLE "order_line" ADD CONSTRAINT "order_line_order_id_order_id_fk" FOREIGN KEY ("order_id") REFERENCES "public"."order"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "order_line" ADD CONSTRAINT "order_line_variant_code_variant_code_fk" FOREIGN KEY ("variant_code") REFERENCES "public"."variant"("code") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "order_line_order_idx" ON "order_line" USING btree ("order_id");--> statement-breakpoint
+CREATE INDEX "order_line_variant_idx" ON "order_line" USING btree ("variant_code");--> statement-breakpoint
+CREATE INDEX "order_line_state_idx" ON "order_line" USING btree ("state");--> statement-breakpoint
+CREATE INDEX "order_placed_at_idx" ON "order" USING btree ("placed_at");

--- a/apps/api/drizzle/meta/0006_snapshot.json
+++ b/apps/api/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,1134 @@
+{
+  "id": "5a461738-2db2-4354-9fd2-1844a2e2671d",
+  "prevId": "518dccc3-524b-4d82-be26-7f336f6aa41e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1785345851423,
       "tag": "0005_jittery_gideon",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1785360575937,
+      "tag": "0006_goofy_strong_guy",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema-orders.ts
+++ b/apps/api/src/db/schema-orders.ts
@@ -1,0 +1,64 @@
+import { sql } from "drizzle-orm";
+import { check, index, integer, pgEnum, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { variants } from "./schema-catalog.js";
+
+// Stav riadku objednávky ako automat (návrh, kap. 4): objednané → čaká sa →
+// skladom → nedostupné. Zámerne PROSTÝ enum na `order_line.state`, nie
+// samostatná (konfigurovateľná) tabuľka — EN spresnenie v #20 explicitne žiada
+// "proper enum"; konfigurovateľnosť stavov (stará appka) by bez API na jej
+// zmenu (mimo scope, #21+) bola špekulatívna zložitosť navyše. Hodnoty bez
+// diakritiky, rovnaký vzor ako `user_role` (`manazer`, `sef`, `citanie`).
+export const orderLineState = pgEnum("order_line_state", [
+  "objednane",
+  "caka_sa",
+  "skladom",
+  "nedostupne",
+]);
+
+// Identita objednávky je Shoptet-ovo číslo objednávky (`externalOrderId`) —
+// budúci importer (#21) ho potrebuje na idempotentné párovanie, rovnaký vzor
+// ako `catalog_snapshot.content_sha256` unique. Cena/mena na riadku sa
+// ZÁMERNE nepridáva teraz (viď komentár k `orderLines` nižšie) — pozri
+// zamietnutú alternatívu #2 v návrhovom komentári na tickete.
+export const orders = pgTable(
+  "order",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    externalOrderId: text("external_order_id").notNull().unique(),
+    customerName: text("customer_name").notNull(),
+    // Manažérov voľný komentár k objednávke (stará appka, obrazovka "Na
+    // objednanie" — potvrdené v docs/stara-appka-inventar.md, bod 1).
+    comment: text("comment"),
+    placedAt: timestamp("placed_at", { withTimezone: true }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [index("order_placed_at_idx").on(t.placedAt)],
+);
+
+export const orderLines = pgTable(
+  "order_line",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    orderId: uuid("order_id")
+      .notNull()
+      .references(() => orders.id, { onDelete: "cascade" }),
+    // FK na existujúcu katalógovú tabuľku `variant.code` (identita variantu je
+    // kód, viď schema-catalog.ts). Bez `onDelete` — varianty sa nikdy
+    // nemažú (len `missingSince`), rovnaký vzor ako
+    // `products.last_seen_snapshot_id`. Zoskupenie podľa dodávateľa pre
+    // obrazovku "Na objednanie" ide cez `variant.product_key → product.supplier`,
+    // netreba duplicitné pole na riadku.
+    variantCode: text("variant_code")
+      .notNull()
+      .references(() => variants.code),
+    quantity: integer("quantity").notNull(),
+    state: orderLineState("state").notNull().default("objednane"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    index("order_line_order_idx").on(t.orderId),
+    index("order_line_variant_idx").on(t.variantCode),
+    index("order_line_state_idx").on(t.state),
+    check("order_line_quantity_positive_ck", sql`${t.quantity} > 0`),
+  ],
+);

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -45,3 +45,4 @@ export const usersRelations = relations(users, ({ many }) => ({
 
 export * from "./schema-catalog.js";
 export * from "./schema-scheduler.js";
+export * from "./schema-orders.js";

--- a/apps/api/tests/helpers/db.ts
+++ b/apps/api/tests/helpers/db.ts
@@ -29,8 +29,13 @@ export async function withCleanDb(): Promise<{ db: Database; close: () => Promis
 
   const { db, pool } = createDb(url);
   try {
+    // "order_line"/"order" (order.ts) added explicitly, not left to CASCADE —
+    // order_line references variant (CASCADE from variant would clear it), but
+    // "order" itself has no FK into any of the other listed tables, so CASCADE
+    // never reaches it: without listing it here, rows would silently survive
+    // across tests. "order" is a reserved SQL keyword and must be quoted.
     await db.execute(
-      sql`TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users RESTART IDENTITY CASCADE`,
+      sql`TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order" RESTART IDENTITY CASCADE`,
     );
   } catch (err) {
     try {

--- a/apps/api/tests/order-schema.integration.test.ts
+++ b/apps/api/tests/order-schema.integration.test.ts
@@ -1,0 +1,206 @@
+import { eq, sql } from "drizzle-orm";
+import { afterEach, expect, it } from "vitest";
+import { orderLines, orders, products, variants } from "../src/db/schema.js";
+import { insertTestSnapshot } from "./helpers/catalog.js";
+import { withCleanDb } from "./helpers/db.js";
+import type { Database } from "../src/db/client.js";
+
+let close: (() => Promise<void>) | undefined;
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+});
+
+const NOW = new Date("2026-07-29T10:00:00Z");
+
+/** Vloží presne jeden produkt + variant, na ktoré sa dá referencovať z order_line. */
+async function insertTestVariant(db: Database, code: string): Promise<void> {
+  const snapshotId = await insertTestSnapshot(db);
+  await db.insert(products).values({
+    key: code,
+    name: "Nohavice FOREST 1003",
+    supplier: "Test dodávateľ",
+    firstSeenAt: NOW,
+    lastSeenAt: NOW,
+    lastSeenSnapshotId: snapshotId,
+  });
+  await db.insert(variants).values({
+    code,
+    productKey: code,
+    guid: code,
+    sizeLabel: "XL",
+    pairCode: "1",
+    name: "Nohavice FOREST 1003",
+    currency: "EUR",
+    price: "62.76",
+    standardPrice: "66.08",
+    purchasePrice: null,
+    actionPrice: null,
+    actionFrom: null,
+    actionUntil: null,
+    percentVat: "23.00",
+    includingVat: true,
+    stock: 5,
+    availabilityInStockText: "Skladom",
+    availabilityOutOfStockText: "Není skladem",
+    availabilityText: "Skladom",
+    productVisibility: "visible",
+    state: "sellable",
+    firstSeenAt: NOW,
+    lastSeenAt: NOW,
+    lastSeenSnapshotId: snapshotId,
+    missingSince: null,
+  });
+}
+
+it("uloží objednávku a riadok a prečíta ich späť, s predvoleným stavom 'objednane'", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await insertTestVariant(ctx.db, "40237/XL");
+
+  const [order] = await ctx.db
+    .insert(orders)
+    .values({
+      externalOrderId: "SHOPTET-1001",
+      customerName: "Ján Novák",
+      comment: "Zavolať pred doručením",
+      placedAt: NOW,
+    })
+    .returning();
+  if (order === undefined) throw new Error("insert order zlyhal");
+
+  await ctx.db.insert(orderLines).values({
+    orderId: order.id,
+    variantCode: "40237/XL",
+    quantity: 2,
+  });
+
+  const lines = await ctx.db.select().from(orderLines).where(eq(orderLines.orderId, order.id));
+  expect(lines).toHaveLength(1);
+  expect(lines[0]?.quantity).toBe(2);
+  expect(lines[0]?.state).toBe("objednane");
+  expect(lines[0]?.variantCode).toBe("40237/XL");
+
+  const readOrder = await ctx.db.select().from(orders).where(eq(orders.id, order.id));
+  expect(readOrder[0]?.externalOrderId).toBe("SHOPTET-1001");
+  expect(readOrder[0]?.comment).toBe("Zavolať pred doručením");
+});
+
+it("umožní prechod riadku medzi všetkými štyrmi stavmi automatu", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await insertTestVariant(ctx.db, "40238/M");
+  const [order] = await ctx.db
+    .insert(orders)
+    .values({ externalOrderId: "SHOPTET-1002", customerName: "Eva Malá", placedAt: NOW })
+    .returning();
+  if (order === undefined) throw new Error("insert order zlyhal");
+  const [line] = await ctx.db
+    .insert(orderLines)
+    .values({ orderId: order.id, variantCode: "40238/M", quantity: 1 })
+    .returning();
+  if (line === undefined) throw new Error("insert order_line zlyhal");
+
+  for (const state of ["caka_sa", "skladom", "nedostupne"] as const) {
+    await ctx.db.update(orderLines).set({ state }).where(eq(orderLines.id, line.id));
+    const rows = await ctx.db.select().from(orderLines).where(eq(orderLines.id, line.id));
+    expect(rows[0]?.state).toBe(state);
+  }
+});
+
+it("odmietne riadok s neexistujúcim variantom (FK)", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const [order] = await ctx.db
+    .insert(orders)
+    .values({ externalOrderId: "SHOPTET-1003", customerName: "Peter Suchý", placedAt: NOW })
+    .returning();
+  if (order === undefined) throw new Error("insert order zlyhal");
+
+  await expect(
+    ctx.db.insert(orderLines).values({ orderId: order.id, variantCode: "neexistujuci-kod", quantity: 1 }),
+  ).rejects.toThrow(/order_line_variant_code_variant_code_fk/);
+});
+
+it("odmietne nekladné množstvo (CHECK)", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await insertTestVariant(ctx.db, "40239/S");
+  const [order] = await ctx.db
+    .insert(orders)
+    .values({ externalOrderId: "SHOPTET-1004", customerName: "Zuzana Krátka", placedAt: NOW })
+    .returning();
+  if (order === undefined) throw new Error("insert order zlyhal");
+
+  await expect(
+    ctx.db.insert(orderLines).values({ orderId: order.id, variantCode: "40239/S", quantity: 0 }),
+  ).rejects.toThrow(/order_line_quantity_positive_ck/);
+  await expect(
+    ctx.db.insert(orderLines).values({ orderId: order.id, variantCode: "40239/S", quantity: -3 }),
+  ).rejects.toThrow(/order_line_quantity_positive_ck/);
+});
+
+it("odmietne stav mimo automatu (enum)", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await insertTestVariant(ctx.db, "40240/L");
+  const [order] = await ctx.db
+    .insert(orders)
+    .values({ externalOrderId: "SHOPTET-1005", customerName: "Milan Veľký", placedAt: NOW })
+    .returning();
+  if (order === undefined) throw new Error("insert order zlyhal");
+
+  await expect(
+    ctx.db.execute(sql`
+      INSERT INTO order_line (order_id, variant_code, quantity, state)
+      VALUES (${order.id}, '40240/L', 1, 'zrusene')
+    `),
+  ).rejects.toThrow(/invalid input value for enum order_line_state/);
+});
+
+it("odmietne druhú objednávku s rovnakým external_order_id (UNIQUE)", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await ctx.db
+    .insert(orders)
+    .values({ externalOrderId: "SHOPTET-1006", customerName: "Prvá zákazníčka", placedAt: NOW });
+
+  await expect(
+    ctx.db
+      .insert(orders)
+      .values({ externalOrderId: "SHOPTET-1006", customerName: "Druhý zákazník", placedAt: NOW }),
+  ).rejects.toThrow(/order_external_order_id_unique/);
+});
+
+it("zmaže riadky objednávky, keď sa zmaže objednávka (CASCADE)", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await insertTestVariant(ctx.db, "40241/2XL");
+  const [order] = await ctx.db
+    .insert(orders)
+    .values({ externalOrderId: "SHOPTET-1007", customerName: "Katarína Nízka", placedAt: NOW })
+    .returning();
+  if (order === undefined) throw new Error("insert order zlyhal");
+  await ctx.db.insert(orderLines).values({ orderId: order.id, variantCode: "40241/2XL", quantity: 1 });
+
+  await ctx.db.delete(orders).where(eq(orders.id, order.id));
+
+  const remaining = await ctx.db.select().from(orderLines).where(eq(orderLines.orderId, order.id));
+  expect(remaining).toHaveLength(0);
+});
+
+it("NEzmaže objednávku, keď sa zmaže referencovaný variant (bez onDelete = RESTRICT)", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await insertTestVariant(ctx.db, "40242/M");
+  const [order] = await ctx.db
+    .insert(orders)
+    .values({ externalOrderId: "SHOPTET-1008", customerName: "Tomáš Dlhý", placedAt: NOW })
+    .returning();
+  if (order === undefined) throw new Error("insert order zlyhal");
+  await ctx.db.insert(orderLines).values({ orderId: order.id, variantCode: "40242/M", quantity: 1 });
+
+  await expect(ctx.db.delete(variants).where(eq(variants.code, "40242/M"))).rejects.toThrow(
+    /order_line_variant_code_variant_code_fk/,
+  );
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.7",
+  "version": "0.3.0-dev.8",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Summary

Database layer for F3 "Na objednanie" — schema only, per issue scope.

- New `apps/api/src/db/schema-orders.ts`: `order`, `order_line` tables, FK to
  existing `product`/`variant`, order-line state as a `pgEnum`
  (`objednane` / `caka_sa` / `skladom` / `nedostupne`), re-exported from
  `schema.ts`.
- Incremental drizzle migration `0006_goofy_strong_guy.sql`.
- `withCleanDb()` TRUNCATE list extended with `order_line`/`"order"` — CASCADE
  from `variant` reaches `order_line` (it references `variant`) but never
  reaches `order` itself, since nothing about `order` references any of the
  already-listed tables.
- Design rationale (root cause, chosen approach, rejected alternatives) posted
  to the issue before the first commit: https://github.com/zbynekdrlik/forestshop-app/issues/20#issuecomment-5123555063

No HTTP routes, no importer, no UI — that's #21 onward.

Closes #20

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` (unit, no DB) — 188+55 passed
- [x] `pnpm test:integration` — 17 files / 106 tests passed, incl. new
      `tests/order-schema.integration.test.ts` (8 tests: default state,
      state-machine transitions, FK violation, CHECK on quantity, invalid
      enum value, UNIQUE on external_order_id, CASCADE delete order→lines,
      RESTRICT delete variant while referenced)
