### PR TITLE
F3: orders scheduler, raw-export retention, read HTTP API (#22, #28, #23)

### DIFF
--- a/.claude/rules/orders.md
+++ b/.claude/rules/orders.md
@@ -55,12 +55,28 @@ paths:
   (víkendy, sezónnosť) než počet produktov v katalógu.
 - **Advisory zámok kľúč `787_878_003`** (`INGEST_ORDERS_ADVISORY_LOCK_KEY`)
   — ďalší v registri `.claude/rules/scheduler.md`, nikdy nehádaj nový.
-- **Žiadna HTTP trasa ani plánovač zatiaľ neexistuje** (#22/#23 sú
-  samostatné tickety) — jediný spôsob, ako import spustiť, je
-  `pnpm orders:ingest` (lokálne/CI) alebo `node apps/api/dist/cli/
-  orders-ingest.js` (produkcia, rovnaký vzor ako `catalog-prune-raw`,
-  pozri `.claude/rules/deploy.md`) — `SHOPTET_ORDERS_URL`/`DATABASE_URL`
-  musia byť nastavené v prostredí.
+- **Nočný beh + retencia + HTTP rozhranie existujú (#22/#28/#23).**
+  `ordersImportJob` (01:45 UTC) + `pruneRawOrdersJob` (02:00 UTC) sú
+  registrované v scheduleri (`index.ts`) vedľa katalógových jobov — registrácia
+  advisory zámkov aj časov je v `.claude/rules/scheduler.md`. Čítanie/ručný
+  refresh ide cez `GET /api/orders/open`, `GET /api/orders/:id`,
+  `POST /api/orders/ingest` (`http/orders-routes.ts` + `modules/orders/
+  queries.ts`) — rovnaký štýl ako katalógové trasy. CLI (`pnpm orders:ingest`
+  / `node apps/api/dist/cli/orders-ingest.js`) zostáva ako lokálny/CI vstupný
+  bod aj núdzové produkčné tlačidlo, keď appka bežiaci proces z nejakého
+  dôvodu nemá zmysel reštartovať.
+- **`product.supplier` je NEPOVINNÝ stĺpec** (`text("supplier")`, bez
+  `.notNull()`, `schema-catalog.ts`) — Shoptet export niekedy nesie prázdnu
+  hodnotu (`map-row.ts`'s `textOrNull`). `modules/orders/queries.ts`'s
+  zoskupenie "Na objednanie" podľa dodávateľa preto mapuje `null` na
+  čitateľný zástupný kľúč (`"(bez dodávateľa)"`), nikdy netriedi/nezoskupuje
+  priamo podľa `null`.
+- **Retencia surových exportov objednávok (`pruneRawOrders`,
+  `modules/orders/raw-prune.ts`) je ČISTO súborová (mtime), nie DB-riadená**
+  ako katalógova `pruneRawSnapshots` — objednávky nemajú snapshotovú tabuľku
+  (pozri vyššie), takže neexistuje DB riadok, cez ktorý by sa dala pohnať. Na
+  rozdiel od katalógu preto NEEXISTUJE výnimka "posledný prijatý sa nikdy
+  nemaže" — každý súbor sa posudzuje rovnako, len podľa veku.
 - **Fixtúra (`fixtures/orders-sample.csv`) je ručne vyrobená z reálnej
   67-stĺpcovej hlavičky** (nie výrez reálneho exportu ako katalóg — export
   objednávok nesie mená a e-maily zákazníkov, tie sa nekomitujú), cp1250

--- a/.claude/rules/scheduler.md
+++ b/.claude/rules/scheduler.md
@@ -19,10 +19,18 @@ paths:
   `executeJob` ich odchytí a zapíše ako `job_run.status = "failure"`.
 - **Rozvrh je len denná hodina:minúta v UTC (`DailySchedule`), žiadny cron
   výraz.** `isDue()` (`scheduler.ts`) je čistá funkcia — nová úloha dostáva
-  vlastný `{ hourUtc, minuteUtc }`; zvoľ ho aspoň 15 min od existujúcich
-  troch (01:00 import, 01:15 prune, 01:30 session-cleanup), aby sa
-  neprekrývali zbytočne (nie je to tvrdá závislosť, len aby operátor v
-  logoch/`job_run` vedel odlíšiť poradie).
+  vlastný `{ hourUtc, minuteUtc }`; zvoľ ho aspoň 15 min od existujúcich, aby
+  sa neprekrývali zbytočne (nie je to tvrdá závislosť, len aby operátor v
+  logoch/`job_run` vedel odlíšiť poradie). Dnes zaregistrované: 01:00 import
+  katalógu, 01:15 mazanie surových exportov katalógu, 01:30 mazanie relácií,
+  01:45 import objednávok (`ordersImportJob`, #22), 02:00 mazanie surových
+  exportov objednávok (`pruneRawOrdersJob`, #28).
+- **Job NEPOTREBUJE vlastný advisory zámok, keď buď (a) volaná business
+  funkcia už berie svoj vlastný vnútri seba** (`catalogImportJob`/
+  `ordersImportJob` → `ingestCatalog`/`ingestOrders`), **alebo (b) sa vôbec
+  nedotýka databázy** (`pruneRawOrdersJob` → čisto súborová `pruneRawOrders`,
+  #28) — `tick()`'s `SCHEDULER_ADVISORY_LOCK_KEY` už serializuje samotné
+  vloženie "running" riadku, viac netreba.
 - **Nová advisory zámok kľúč VŽDY over proti existujúcim, nikdy nehádaj.**
   `pg_advisory_lock`/`pg_advisory_xact_lock` zdieľajú JEDEN priestor kľúčov
   bez ohľadu na funkciu (rovnaké upozornenie ako `testing.md`). Dnes
@@ -30,6 +38,8 @@ paths:
   `787_878_002` (`SCHEDULER_ADVISORY_LOCK_KEY`, `scheduler.ts`),
   `787_878_003` (`INGEST_ORDERS_ADVISORY_LOCK_KEY`, `orders/ingest.ts`, #21),
   `787_878_100` (`TEST_DB_ISOLATION_LOCK_KEY`, `tests/helpers/db.ts`).
+  `ordersImportJob`/`pruneRawOrdersJob` (#22/#28) nepridali žiadny nový kľúč
+  (pozri bod vyššie).
 - **`tick()`'s zámok chráni LEN kontrolu splatnosti + vloženie "running"
   riadku, NIE celý beh úlohy.** `job.run()` beží AŽ PO commite transakcie so
   zámkom, mimo neho — dlho bežiaci job (napr. 54 MB import katalógu) tak

--- a/apps/api/src/cli/orders-ingest.ts
+++ b/apps/api/src/cli/orders-ingest.ts
@@ -17,9 +17,11 @@
 import { createDb } from "../db/client.js";
 import { loadEnv } from "../env.js";
 import { computeImportWindow, createHttpOrdersExportFetcher } from "../modules/orders/fetcher.js";
-import { ingestOrders, type OrdersIngestResult } from "../modules/orders/ingest.js";
-
-const WINDOW_DAYS = 90;
+import {
+  DEFAULT_ORDERS_IMPORT_WINDOW_DAYS,
+  ingestOrders,
+  type OrdersIngestResult,
+} from "../modules/orders/ingest.js";
 
 function popis(result: OrdersIngestResult): string {
   switch (result.status) {
@@ -41,7 +43,7 @@ if (env.SHOPTET_ORDERS_URL === undefined) {
 }
 
 const now = new Date();
-const { dateFrom, dateUntil } = computeImportWindow(now, WINDOW_DAYS);
+const { dateFrom, dateUntil } = computeImportWindow(now, DEFAULT_ORDERS_IMPORT_WINDOW_DAYS);
 
 const { db, pool } = createDb(env.DATABASE_URL);
 let result: OrdersIngestResult;

--- a/apps/api/src/db/schema-orders.ts
+++ b/apps/api/src/db/schema-orders.ts
@@ -25,6 +25,11 @@ export const orderLineState = pgEnum("order_line_state", [
   "nedostupne",
 ]);
 
+// Odvodené priamo z `enumValues`, nie ručne prepísaná duplicitná únia — nová
+// hodnota pridaná do `orderLineState` vyššie sa tak prejaví aj tu bez rizika
+// rozídenia (#23, `modules/orders/queries.ts` + `http/orders-routes.ts`).
+export type OrderLineState = (typeof orderLineState.enumValues)[number];
+
 // Identita objednávky je Shoptet-ovo číslo objednávky (`externalOrderId`) —
 // budúci importer (#21) ho potrebuje na idempotentné párovanie, rovnaký vzor
 // ako `catalog_snapshot.content_sha256` unique. Cena/mena na riadku sa

--- a/apps/api/src/http/app.ts
+++ b/apps/api/src/http/app.ts
@@ -11,6 +11,7 @@ import { appVersion } from "../version.js";
 import { registerCatalogRoutes, type RunIngest } from "./catalog-routes.js";
 import { checkLoginRateLimit, clientIp } from "./login-rate-limit.js";
 import { SESSION_COOKIE, requireUser, type AppBindings } from "./middleware.js";
+import { registerOrdersRoutes, type RunOrdersIngest } from "./orders-routes.js";
 import { requireSameOrigin } from "./origin-check.js";
 import { registerSchedulerRoutes } from "./scheduler-routes.js";
 
@@ -26,7 +27,11 @@ const changePasswordSchema = z.object({
 
 export function createApp(
   db: Database,
-  options: { readonly cookieSecure: boolean; readonly runIngest?: RunIngest },
+  options: {
+    readonly cookieSecure: boolean;
+    readonly runIngest?: RunIngest;
+    readonly runOrdersIngest?: RunOrdersIngest;
+  },
 ): Hono<AppBindings> {
   const app = new Hono<AppBindings>();
 
@@ -115,6 +120,7 @@ export function createApp(
   );
 
   registerCatalogRoutes(app, db, options.runIngest);
+  registerOrdersRoutes(app, db, options.runOrdersIngest);
   registerSchedulerRoutes(app, db);
 
   // Musí byť registrovaný AŽ PO všetkých skutočných /api/* trasách vyššie — Hono

--- a/apps/api/src/http/orders-routes.ts
+++ b/apps/api/src/http/orders-routes.ts
@@ -1,0 +1,102 @@
+import { zValidator } from "@hono/zod-validator";
+import type { Hono } from "hono";
+import { z } from "zod";
+import type { Database } from "../db/client.js";
+import { log } from "../logger.js";
+import { record } from "../modules/audit/service.js";
+import { ORDERS_EXPORT_URL_NOT_CONFIGURED, type OrdersIngestResult, type RunOrdersIngest } from "../modules/orders/ingest.js";
+import { getOrderDetail, listOpenOrderLinesBySupplier } from "../modules/orders/queries.js";
+import { requireRole, requireUser, type AppBindings } from "./middleware.js";
+import { requireSameOrigin } from "./origin-check.js";
+
+const orderParam = z.object({ id: z.string().uuid() });
+
+// Re-exportované, aby `http/app.ts` nemusel meniť svoj import — kanonická
+// definícia žije v `modules/orders/ingest.ts` (rovnaký vzor ako katalógov
+// `RunIngest` re-export v `catalog-routes.ts`).
+export type { RunOrdersIngest };
+
+export function registerOrdersRoutes(
+  app: Hono<AppBindings>,
+  db: Database,
+  runOrdersIngest: RunOrdersIngest | undefined,
+): void {
+  // Čítacie trasy — rovnaké oprávnenie ako katalógové čítanie
+  // (`requireUser`, žiadne obmedzenie roly): každý prihlásený používateľ smie
+  // vidieť otvorené objednávky, len SPÚŠŤANIE importu (nižšie) je vyhradené.
+  app.get("/api/orders/open", requireUser(db), async (c) =>
+    c.json({ suppliers: await listOpenOrderLinesBySupplier(db) }),
+  );
+
+  app.get("/api/orders/:id", requireUser(db), zValidator("param", orderParam), async (c) => {
+    const detail = await getOrderDetail(db, c.req.valid("param").id);
+    if (detail === null) return c.json({ error: "Objednávka sa nenašla" }, 404);
+    return c.json(detail);
+  });
+
+  // JEDEN import naraz — rovnaký in-flight guard ako `/api/catalog/ingest`
+  // (uzáver na inštanciu aplikácie, `createApp`/`registerOrdersRoutes` sa
+  // volá raz za proces).
+  let ingestInFlight = false;
+
+  app.post(
+    "/api/orders/ingest",
+    // Rovnaká CSRF disciplína ako `/api/catalog/ingest` — stavovo-meniaca
+    // požiadavka nad autentifikovaným cookie session-om.
+    requireSameOrigin(),
+    requireUser(db),
+    requireRole("admin", "manazer"),
+    async (c) => {
+      if (runOrdersIngest === undefined) {
+        return c.json({ error: ORDERS_EXPORT_URL_NOT_CONFIGURED }, 503);
+      }
+      if (ingestInFlight) {
+        return c.json({ status: "busy" as const });
+      }
+      ingestInFlight = true;
+      try {
+        const now = new Date();
+        const user = c.get("user");
+        let result: OrdersIngestResult;
+        try {
+          result = await runOrdersIngest(now);
+        } catch (error) {
+          // Stiahnutie exportu zlyhalo úplne — rovnaká disciplína ako
+          // katalógov ekvivalent (`catalog-routes.ts`): surová chyba sa
+          // loguje samostatne, nikdy sa neinterpoluje do hlášky pre
+          // operátora ani do auditového záznamu.
+          const rawErrorMessage = error instanceof Error ? error.message : String(error);
+          log.error(
+            { actorUserId: user.userId, rawErrorMessage },
+            "stiahnutie exportu objednávok zlyhalo",
+          );
+          await record(db, {
+            at: now,
+            actorUserId: user.userId,
+            action: "orders.ingest.trigger",
+            entity: "order",
+            data: { status: "fetch_failed" },
+          });
+          return c.json(
+            { error: "Export objednávok zo Shoptetu sa nepodarilo stiahnuť. Skúste import o chvíľu zopakovať." },
+            502,
+          );
+        }
+        // Audit sa zapisuje PO dobehnutí importu, nie pred ním — nesie tak
+        // skutočný výsledok, nielen úmysel ho spustiť (rovnaký vzor ako
+        // katalóg).
+        await record(db, {
+          at: now,
+          actorUserId: user.userId,
+          action: "orders.ingest.trigger",
+          entity: "order",
+          data: result,
+        });
+        log.info({ actorUserId: user.userId, status: result.status }, "ručný import objednávok");
+        return c.json(result);
+      } finally {
+        ingestInFlight = false;
+      }
+    },
+  );
+}

--- a/apps/api/src/http/orders-routes.ts
+++ b/apps/api/src/http/orders-routes.ts
@@ -84,13 +84,18 @@ export function registerOrdersRoutes(
         }
         // Audit sa zapisuje PO dobehnutí importu, nie pred ním — nesie tak
         // skutočný výsledok, nielen úmysel ho spustiť (rovnaký vzor ako
-        // katalóg).
+        // katalóg). Dáta sú ZÚŽENÉ (nie celý `result`) — rovnaká disciplína
+        // ako katalógov `{ status, snapshotId }`: `rawPath` je cesta na
+        // serverovom disku, do audit záznamu (čitateľného cez API) nepatrí.
         await record(db, {
           at: now,
           actorUserId: user.userId,
           action: "orders.ingest.trigger",
           entity: "order",
-          data: result,
+          data:
+            result.status === "accepted"
+              ? { status: result.status, orderCount: result.orderCount, lineCount: result.lineCount }
+              : { status: result.status, reason: result.reason },
         });
         log.info({ actorUserId: user.userId, status: result.status }, "ručný import objednávok");
         return c.json(result);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -9,7 +9,15 @@ import { createApp } from "./http/app.js";
 import { log } from "./logger.js";
 import { createHttpExportFetcher } from "./modules/catalog/fetcher.js";
 import { ingestCatalog } from "./modules/catalog/ingest.js";
-import { catalogImportJob, pruneRawExportsJob, sessionCleanupJob } from "./modules/scheduler/jobs.js";
+import { computeImportWindow, createHttpOrdersExportFetcher } from "./modules/orders/fetcher.js";
+import { DEFAULT_ORDERS_IMPORT_WINDOW_DAYS, ingestOrders, type RunOrdersIngest } from "./modules/orders/ingest.js";
+import {
+  catalogImportJob,
+  ordersImportJob,
+  pruneRawExportsJob,
+  pruneRawOrdersJob,
+  sessionCleanupJob,
+} from "./modules/scheduler/jobs.js";
 import { startScheduler } from "./modules/scheduler/scheduler.js";
 import { appVersion } from "./version.js";
 
@@ -39,19 +47,46 @@ const runIngest =
           rawDir: env.CATALOG_RAW_DIR,
         });
 
-const app = createApp(
-  db,
-  runIngest === undefined
-    ? { cookieSecure: env.SESSION_COOKIE_SECURE }
-    : { cookieSecure: env.SESSION_COOKIE_SECURE, runIngest },
-);
+// Rovnaká úvaha ako katalógov `runIngest` vyššie: `SHOPTET_ORDERS_URL` je
+// nepovinná (env.ts) — bez nej appka beží ďalej, len ručný/nočný import
+// objednávok vráti/zaloguje "nenakonfigurované". Okno sa počíta AŽ VNÚTRI
+// closure (z `now`, ktoré dostane až v čase behu), nikdy vopred — rovnaká
+// disciplína ako `cli/orders-ingest.ts`.
+const ordersUrl = env.SHOPTET_ORDERS_URL;
+const runOrdersIngest: RunOrdersIngest | undefined =
+  ordersUrl === undefined
+    ? undefined
+    : (now: Date) => {
+        const { dateFrom, dateUntil } = computeImportWindow(now, DEFAULT_ORDERS_IMPORT_WINDOW_DAYS);
+        return ingestOrders(db, {
+          fetchExport: createHttpOrdersExportFetcher({ url: ordersUrl, dateFrom, dateUntil }),
+          now,
+          rawDir: env.ORDERS_RAW_DIR,
+          windowStart: dateFrom,
+          windowEnd: dateUntil,
+        });
+      };
 
-// F2 (#12/#3): nočný import katalógu, mazanie starých surových exportov a
-// mazanie expirovaných relácií — dnes len ručne spúšťané. `catalogImportJob`
-// dostáva `runIngest` (môže byť `undefined`, keď SHOPTET_EXPORT_URL nie je
-// nastavené — job to zaznamená ako "failure" s vysvetlením, nikdy sa
+const app = createApp(db, {
+  cookieSecure: env.SESSION_COOKIE_SECURE,
+  ...(runIngest === undefined ? {} : { runIngest }),
+  ...(runOrdersIngest === undefined ? {} : { runOrdersIngest }),
+});
+
+// F2 (#12/#3) + F3 (#22/#28): nočný import katalógu/objednávok, mazanie
+// starých surových exportov (katalóg aj objednávky) a mazanie expirovaných
+// relácií — dnes len ručne spúšťané pre objednávky mimo tohto nočného behu
+// cez `POST /api/orders/ingest` (#23). `catalogImportJob`/`ordersImportJob`
+// dostávajú svoj `run*Ingest` (môže byť `undefined`, keď zodpovedajúca URL
+// nie je nastavená — job to zaznamená ako "failure" s vysvetlením, nikdy sa
 // nepreskočí ticho).
-startScheduler(db, [catalogImportJob(runIngest), pruneRawExportsJob(), sessionCleanupJob()]);
+startScheduler(db, [
+  catalogImportJob(runIngest),
+  pruneRawExportsJob(),
+  sessionCleanupJob(),
+  ordersImportJob(runOrdersIngest),
+  pruneRawOrdersJob(env.ORDERS_RAW_DIR),
+]);
 
 // `@hono/node-server`'s `serveStatic` prints its OWN `console.error` on every
 // call whose `root` doesn't exist — unconditionally, once per process start.

--- a/apps/api/src/modules/orders/ingest.ts
+++ b/apps/api/src/modules/orders/ingest.ts
@@ -94,6 +94,23 @@ export type OrdersIngestResult =
     }
   | { readonly status: "rejected"; readonly reason: string; readonly rawPath: string | null };
 
+// Zdieľaný typ medzi `index.ts` (postaví closure z env premennej), `modules/
+// scheduler/jobs.ts` (#22) a `http/orders-routes.ts` (#23, ručné tlačidlo
+// "stiahnuť teraz") — patrí do `modules/`, nikdy do `http/` (rovnaký dôvod
+// ako katalógov `RunIngest`, `.claude/rules/scheduler.md`).
+export type RunOrdersIngest = (now: Date) => Promise<OrdersIngestResult>;
+
+// Rovnaká hláška, akú `catalog-routes.ts`/`scheduler/jobs.ts` používajú pre
+// chýbajúce `SHOPTET_EXPORT_URL` — zdieľaná JEDNA konštanta (nie kopírovaný
+// literál na dvoch miestach), aby sa hláška v `jobs.ts` aj `orders-routes.ts`
+// nikdy nerozišla.
+export const ORDERS_EXPORT_URL_NOT_CONFIGURED = "Import objednávok nie je nakonfigurovaný (chýba SHOPTET_ORDERS_URL)";
+
+// Posúvajúce sa 90-dňové okno (`fetcher.ts`'s `computeImportWindow`) — jedna
+// zdieľaná konštanta namiesto lokálnej `WINDOW_DAYS` duplikovanej v
+// `cli/orders-ingest.ts` aj v budúcom scheduler/HTTP volaní (#22/#23).
+export const DEFAULT_ORDERS_IMPORT_WINDOW_DAYS = 90;
+
 function chunk<T>(items: readonly T[], size: number): T[][] {
   const out: T[][] = [];
   for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));

--- a/apps/api/src/modules/orders/queries.ts
+++ b/apps/api/src/modules/orders/queries.ts
@@ -1,0 +1,140 @@
+import { asc, desc, eq } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { orderLines, orders, products, variants, type OrderLineState } from "../../db/schema.js";
+
+export interface OpenOrderLine {
+  readonly lineId: string;
+  readonly orderId: string;
+  readonly externalOrderId: string;
+  readonly customerName: string;
+  readonly comment: string | null;
+  readonly placedAt: string;
+  readonly variantCode: string;
+  readonly variantName: string;
+  readonly sizeLabel: string | null;
+  readonly quantity: number;
+  readonly state: OrderLineState;
+}
+
+export interface SupplierOpenOrders {
+  readonly supplier: string;
+  readonly lines: readonly OpenOrderLine[];
+}
+
+// `product.supplier` je v schéme nepovinné (`text("supplier")`, bez
+// `.notNull()`) — Shoptet export niekedy nesie prázdnu hodnotu (`map-row.ts`'s
+// `textOrNull`). Zoskupenie takých riadkov dostáva čitateľný zástupný kľúč
+// namiesto toho, aby zmizli/spadli na `null` kľúč v Mape.
+const NEZNAMY_DODAVATEL = "(bez dodávateľa)";
+
+// Zoskupenie je na ÚROVNI RIADKA objednávky, nie na úrovni objednávky —
+// jedna objednávka môže obsahovať položky od VIACERÝCH dodávateľov
+// (`docs/stara-appka-inventar.md` bod 1: "Otvorené objednávky zoskupené
+// podľa dodávateľa"). "Otvorená" v v1 znamená VŠETKY riadky objednávok —
+// `order_line.state` (objednane/caka_sa/skladom/nedostupne) zatiaľ nemá
+// žiadny "hotový/zatvorený" stav (ten príde až s #25), takže nič dnes riadok
+// z tohto zoznamu neodstráni.
+export async function listOpenOrderLinesBySupplier(db: Database): Promise<readonly SupplierOpenOrders[]> {
+  const rows = await db
+    .select({
+      lineId: orderLines.id,
+      orderId: orders.id,
+      externalOrderId: orders.externalOrderId,
+      customerName: orders.customerName,
+      comment: orders.comment,
+      placedAt: orders.placedAt,
+      variantCode: orderLines.variantCode,
+      variantName: variants.name,
+      sizeLabel: variants.sizeLabel,
+      quantity: orderLines.quantity,
+      state: orderLines.state,
+      supplier: products.supplier,
+    })
+    .from(orderLines)
+    .innerJoin(orders, eq(orders.id, orderLines.orderId))
+    .innerJoin(variants, eq(variants.code, orderLines.variantCode))
+    .innerJoin(products, eq(products.key, variants.productKey))
+    // Sekundárne triedenie podľa najnovšej objednávky ako prvej v rámci
+    // dodávateľa — rovnaký zámer ako katalógov `desc(fetchedAt), desc(id)`
+    // tie-break, len tu na `placedAt`/`lineId`, aby poradie bolo stabilné aj
+    // pri zhodnom čase.
+    .orderBy(asc(products.supplier), desc(orders.placedAt), desc(orderLines.id));
+
+  const bySupplier = new Map<string, OpenOrderLine[]>();
+  for (const row of rows) {
+    const line: OpenOrderLine = {
+      lineId: row.lineId,
+      orderId: row.orderId,
+      externalOrderId: row.externalOrderId,
+      customerName: row.customerName,
+      comment: row.comment,
+      placedAt: row.placedAt.toISOString(),
+      variantCode: row.variantCode,
+      variantName: row.variantName,
+      sizeLabel: row.sizeLabel,
+      quantity: row.quantity,
+      state: row.state,
+    };
+    const supplierKey = row.supplier ?? NEZNAMY_DODAVATEL;
+    let lines = bySupplier.get(supplierKey);
+    if (lines === undefined) {
+      lines = [];
+      bySupplier.set(supplierKey, lines);
+    }
+    lines.push(line);
+  }
+
+  // `Map` uchováva poradie prvého vloženia kľúča — keďže hlavný dopyt už
+  // triedi `asc(products.supplier)`, výsledné poradie skupín je abecedné bez
+  // ďalšieho triedenia tu.
+  return [...bySupplier.entries()].map(([supplier, lines]) => ({ supplier, lines }));
+}
+
+export interface OrderDetailLine {
+  readonly lineId: string;
+  readonly variantCode: string;
+  readonly variantName: string;
+  readonly sizeLabel: string | null;
+  readonly supplier: string;
+  readonly quantity: number;
+  readonly state: OrderLineState;
+}
+
+export interface OrderDetail {
+  readonly id: string;
+  readonly externalOrderId: string;
+  readonly customerName: string;
+  readonly comment: string | null;
+  readonly placedAt: string;
+  readonly lines: readonly OrderDetailLine[];
+}
+
+export async function getOrderDetail(db: Database, id: string): Promise<OrderDetail | null> {
+  const [order] = await db.select().from(orders).where(eq(orders.id, id)).limit(1);
+  if (order === undefined) return null;
+
+  const lineRows = await db
+    .select({
+      lineId: orderLines.id,
+      variantCode: orderLines.variantCode,
+      variantName: variants.name,
+      sizeLabel: variants.sizeLabel,
+      supplier: products.supplier,
+      quantity: orderLines.quantity,
+      state: orderLines.state,
+    })
+    .from(orderLines)
+    .innerJoin(variants, eq(variants.code, orderLines.variantCode))
+    .innerJoin(products, eq(products.key, variants.productKey))
+    .where(eq(orderLines.orderId, id))
+    .orderBy(asc(products.supplier), asc(variants.code));
+
+  return {
+    id: order.id,
+    externalOrderId: order.externalOrderId,
+    customerName: order.customerName,
+    comment: order.comment,
+    placedAt: order.placedAt.toISOString(),
+    lines: lineRows.map((row) => ({ ...row, supplier: row.supplier ?? NEZNAMY_DODAVATEL })),
+  };
+}

--- a/apps/api/src/modules/orders/raw-prune.test.ts
+++ b/apps/api/src/modules/orders/raw-prune.test.ts
@@ -1,7 +1,21 @@
 import { access, mkdir, mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, expect, it } from "vitest";
+import { afterEach, expect, it, vi } from "vitest";
+
+// Čiastočný mock — `stat` je jediná exportovaná funkcia, ktorú tento súbor
+// potrebuje ovládať (simulácia rasovej podmienky "súbor zmizol MEDZI
+// readdir a stat"). Priamy `vi.spyOn(fsPromises, "stat")` na natívnom ESM
+// module zlyhá ("Module namespace is not configurable in ESM") — `vi.mock`
+// s `importOriginal` je jediný spôsob, ako v ESM prostredí nahradiť JEDEN
+// export a ostatné (`readdir`/`rm`) nechať skutočné.
+const { stat: mockedStat } = vi.hoisted(() => ({ stat: vi.fn() }));
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  mockedStat.mockImplementation(actual.stat);
+  return { ...actual, stat: mockedStat };
+});
+
 import { pruneRawOrders } from "./raw-prune.js";
 
 const NOW = new Date("2026-07-30T10:00:00Z");
@@ -56,6 +70,30 @@ it("prejde adresár rekurzívne — súbory v podadresároch YYYY/MM (storeRawSn
 it("chýbajúci adresár (žiadny import ešte nebežal) sa berie ako 'nič na zmazanie', nie chyba", async () => {
   const neexistujuci = join(tmpdir(), `forestshop-orders-prune-neexistuje-${String(Date.now())}`);
   await expect(pruneRawOrders(neexistujuci, { keepDays: 30, now: NOW })).resolves.toEqual({ removed: 0 });
+});
+
+it("súbor, ktorý zmizne MEDZI readdir a stat (súbežné mazanie mimo appky), sa ticho preskočí — nepadne celý beh (review finding)", async () => {
+  dir = await mkdtemp(join(tmpdir(), "forestshop-orders-prune-"));
+  const prvy = join(dir, "prvy.csv.gz");
+  const druhy = join(dir, "druhy.csv.gz");
+  await writeFile(prvy, "a");
+  await writeFile(druhy, "b");
+  await utimes(prvy, DAVNO, DAVNO);
+  await utimes(druhy, DAVNO, DAVNO);
+
+  const enoent = new Error("ENOENT") as NodeJS.ErrnoException;
+  enoent.code = "ENOENT";
+  // `mockImplementationOnce` zasiahne PRVÉ volanie `stat` bez ohľadu na to, v
+  // akom poradí `readdir` súbory vráti (POSIX to negarantuje) — test je preto
+  // zámerne nezávislý od toho, ktorý z dvoch súborov "zmizne".
+  mockedStat.mockImplementationOnce(() => Promise.reject(enoent));
+
+  const result = await pruneRawOrders(dir, { keepDays: 30, now: NOW });
+  // Presne JEDEN súbor sa naozaj zmazal (ten, čo prešiel `stat` normálne) —
+  // beh nesmie spadnúť na tom, ktorý "zmizol", ani ho omylom nepočítať.
+  expect(result).toEqual({ removed: 1 });
+  const presneJedenOstal = (await existuje(prvy)) !== (await existuje(druhy));
+  expect(presneJedenOstal).toBe(true);
 });
 
 it("súbor presne na hranici keepDays (mtime rovný cutoffu) sa nezmaže — hranica je ostro 'starší než', nie 'starý alebo rovný'", async () => {

--- a/apps/api/src/modules/orders/raw-prune.test.ts
+++ b/apps/api/src/modules/orders/raw-prune.test.ts
@@ -1,0 +1,72 @@
+import { access, mkdir, mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, expect, it } from "vitest";
+import { pruneRawOrders } from "./raw-prune.js";
+
+const NOW = new Date("2026-07-30T10:00:00Z");
+const DAVNO = new Date("2026-05-01T10:00:00Z");
+const VCERA = new Date("2026-07-29T10:00:00Z");
+
+let dir: string | undefined;
+afterEach(async () => {
+  if (dir !== undefined) await rm(dir, { recursive: true, force: true });
+  dir = undefined;
+});
+
+async function existuje(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+it("zmaže len súbory staršie než keepDays (podľa mtime), nedávne nechá", async () => {
+  dir = await mkdtemp(join(tmpdir(), "forestshop-orders-prune-"));
+  const stary = join(dir, "stary.csv.gz");
+  const novy = join(dir, "novy.csv.gz");
+  await writeFile(stary, "a");
+  await writeFile(novy, "b");
+  await utimes(stary, DAVNO, DAVNO);
+  await utimes(novy, VCERA, VCERA);
+
+  const result = await pruneRawOrders(dir, { keepDays: 30, now: NOW });
+
+  expect(result).toEqual({ removed: 1 });
+  expect(await existuje(stary)).toBe(false);
+  expect(await existuje(novy)).toBe(true);
+});
+
+it("prejde adresár rekurzívne — súbory v podadresároch YYYY/MM (storeRawSnapshot) sa tiež posúdia", async () => {
+  dir = await mkdtemp(join(tmpdir(), "forestshop-orders-prune-"));
+  const subdir = join(dir, "2026", "05");
+  await mkdir(subdir, { recursive: true });
+  const staryVHlbke = join(subdir, "stary.csv.gz");
+  await writeFile(staryVHlbke, "a");
+  await utimes(staryVHlbke, DAVNO, DAVNO);
+
+  const result = await pruneRawOrders(dir, { keepDays: 30, now: NOW });
+
+  expect(result).toEqual({ removed: 1 });
+  expect(await existuje(staryVHlbke)).toBe(false);
+});
+
+it("chýbajúci adresár (žiadny import ešte nebežal) sa berie ako 'nič na zmazanie', nie chyba", async () => {
+  const neexistujuci = join(tmpdir(), `forestshop-orders-prune-neexistuje-${String(Date.now())}`);
+  await expect(pruneRawOrders(neexistujuci, { keepDays: 30, now: NOW })).resolves.toEqual({ removed: 0 });
+});
+
+it("súbor presne na hranici keepDays (mtime rovný cutoffu) sa nezmaže — hranica je ostro 'starší než', nie 'starý alebo rovný'", async () => {
+  dir = await mkdtemp(join(tmpdir(), "forestshop-orders-prune-"));
+  const naHranici = join(dir, "na-hranici.csv.gz");
+  await writeFile(naHranici, "a");
+  const cutoff = new Date(NOW.getTime() - 30 * 24 * 60 * 60 * 1000);
+  await utimes(naHranici, cutoff, cutoff);
+
+  const result = await pruneRawOrders(dir, { keepDays: 30, now: NOW });
+
+  expect(result).toEqual({ removed: 0 });
+  expect(await existuje(naHranici)).toBe(true);
+});

--- a/apps/api/src/modules/orders/raw-prune.ts
+++ b/apps/api/src/modules/orders/raw-prune.ts
@@ -1,0 +1,60 @@
+import { readdir, rm, stat } from "node:fs/promises";
+import { join } from "node:path";
+
+export interface PruneRawOrdersOptions {
+  readonly keepDays: number;
+  readonly now: Date;
+}
+
+/**
+ * Objednávky (na rozdiel od katalógu) ZÁMERNE nemajú snapshotovú tabuľku
+ * (`.claude/rules/orders.md`), takže neexistuje žiadny DB riadok, cez ktorý
+ * by sa dala pohnať retencia v štýle katalógovej `pruneRawSnapshots`
+ * (`raw-store.ts`) — tá prechádza riadky `catalog_snapshot`, nikdy adresár na
+ * disku. Retencia surových exportov objednávok je preto ČISTO súborová:
+ * prejde `ORDERS_RAW_DIR` rekurzívne (súbory ležia v `dir/YYYY/MM/*.csv.gz`,
+ * `storeRawSnapshot`, zdieľané s katalógom) a zmaže súbory, ktorých mtime je
+ * staršie než `keepDays`. Bez sprievodnej DB tabuľky niet ani "posledný
+ * prijatý sa nemaže nikdy" výnimky, akú má katalóg — každý súbor sa posudzuje
+ * rovnako, len podľa veku.
+ */
+async function walkFiles(dir: string): Promise<string[]> {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch (error) {
+    // Adresár ešte neexistuje (žiadny import ešte nebežal) — to je "nič na
+    // zmazanie", nie chyba. Rovnaká disciplína ako katalógov
+    // `rm(..., { force: true })`, ktorý ticho prežije aj chýbajúci súbor.
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw error;
+  }
+  const files: string[] = [];
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await walkFiles(full)));
+    } else if (entry.isFile()) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+export async function pruneRawOrders(
+  dir: string,
+  options: PruneRawOrdersOptions,
+): Promise<{ readonly removed: number }> {
+  const cutoff = options.now.getTime() - options.keepDays * 24 * 60 * 60 * 1000;
+  const files = await walkFiles(dir);
+
+  let removed = 0;
+  for (const file of files) {
+    const info = await stat(file);
+    if (info.mtime.getTime() < cutoff) {
+      await rm(file, { force: true });
+      removed += 1;
+    }
+  }
+  return { removed };
+}

--- a/apps/api/src/modules/orders/raw-prune.ts
+++ b/apps/api/src/modules/orders/raw-prune.ts
@@ -50,7 +50,18 @@ export async function pruneRawOrders(
 
   let removed = 0;
   for (const file of files) {
-    const info = await stat(file);
+    let info;
+    try {
+      info = await stat(file);
+    } catch (error) {
+      // Súbor zmizol MEDZI `readdir` a `stat` (napr. súbežné ručné upratanie
+      // na disku) — rovnaká "už je preč, netreba nič robiť" disciplína ako
+      // `rm(..., { force: true })` nižšie. Bez tohto by táto rasová podmienka
+      // zhodila celý nočný beh na `job_run.status = "failure"` namiesto toho,
+      // aby jeden zmiznutý súbor jednoducho preskočila.
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+      throw error;
+    }
     if (info.mtime.getTime() < cutoff) {
       await rm(file, { force: true });
       removed += 1;

--- a/apps/api/src/modules/scheduler/jobs.ts
+++ b/apps/api/src/modules/scheduler/jobs.ts
@@ -1,11 +1,15 @@
 import { cleanupExpiredSessions } from "../auth/sessions.js";
 import type { RunIngest } from "../catalog/ingest.js";
 import { pruneRawSnapshots } from "../catalog/raw-store.js";
+import { ORDERS_EXPORT_URL_NOT_CONFIGURED, type RunOrdersIngest } from "../orders/ingest.js";
+import { pruneRawOrders } from "../orders/raw-prune.js";
 import type { ScheduledJob } from "./types.js";
 
 export const CATALOG_IMPORT_JOB_NAME = "catalog-import";
 export const PRUNE_RAW_EXPORTS_JOB_NAME = "prune-raw-exports";
 export const SESSION_CLEANUP_JOB_NAME = "session-cleanup";
+export const ORDERS_IMPORT_JOB_NAME = "orders-import";
+export const PRUNE_RAW_ORDERS_JOB_NAME = "prune-raw-orders";
 
 // Rovnaká hláška ako `catalog-routes.ts`'s 503 pri ručnom importe bez
 // nakonfigurovaného SHOPTET_EXPORT_URL — operátor vidí to isté vysvetlenie na
@@ -53,6 +57,48 @@ export function sessionCleanupJob(): ScheduledJob {
     schedule: { hourUtc: 1, minuteUtc: 30 },
     async run(db, now) {
       const result = await cleanupExpiredSessions(db, now);
+      return { detail: result };
+    },
+  };
+}
+
+/**
+ * Nočný import objednávok (#22) — rovnaký vzor ako `catalogImportJob`, volá
+ * EXISTUJÚCI `ingestOrders` (cez `runOrdersIngest` closure z `index.ts`),
+ * nič sa nereimplementuje. Žiadny nový advisory lock na tejto úrovni —
+ * `ingestOrders` (`orders/ingest.ts`) už berie svoj vlastný
+ * (`INGEST_ORDERS_ADVISORY_LOCK_KEY`) vnútri seba, presne ako
+ * `catalogImportJob` nepridáva zámok navyše. Keď `SHOPTET_ORDERS_URL` nie je
+ * nakonfigurované, job VYHODÍ — `scheduler.ts` to zapíše ako "failure" s
+ * touto správou, namiesto toho, aby beh ticho preskočil bez záznamu.
+ */
+export function ordersImportJob(runOrdersIngest: RunOrdersIngest | undefined): ScheduledJob {
+  return {
+    name: ORDERS_IMPORT_JOB_NAME,
+    // Ďalší voľný 15-minútový slot v registri (01:00 import katalógu, 01:15
+    // mazanie surových exportov katalógu, 01:30 mazanie relácií).
+    schedule: { hourUtc: 1, minuteUtc: 45 },
+    async run(_db, now) {
+      if (runOrdersIngest === undefined) throw new Error(ORDERS_EXPORT_URL_NOT_CONFIGURED);
+      const result = await runOrdersIngest(now);
+      return { detail: result };
+    },
+  };
+}
+
+/**
+ * Mazanie surových exportov objednávok starších než `keepDays` (#28) — volá
+ * existujúci `pruneRawOrders` (čisto súborová retencia, objednávky nemajú
+ * snapshotovú tabuľku, na rozdiel od katalógu). Žiadny DB prístup, teda ani
+ * žiadny advisory lock.
+ */
+export function pruneRawOrdersJob(rawDir: string, keepDays = 30): ScheduledJob {
+  return {
+    name: PRUNE_RAW_ORDERS_JOB_NAME,
+    // Ďalší voľný slot po `ordersImportJob` (01:45).
+    schedule: { hourUtc: 2, minuteUtc: 0 },
+    async run(_db, now) {
+      const result = await pruneRawOrders(rawDir, { keepDays, now });
       return { detail: result };
     },
   };

--- a/apps/api/tests/helpers/orders.ts
+++ b/apps/api/tests/helpers/orders.ts
@@ -6,14 +6,21 @@ import { insertTestSnapshot } from "./catalog.js";
  * Vloží presne jeden produkt + variant, na ktoré sa dá referencovať z
  * `order_line` — orders-ingest testy potrebujú aspoň jeden ZNÁMY variant, aby
  * import mohol skutočne zapísať riadok (neznáme varianty sa inak ticho
- * preskočia, `orders/ingest.ts`'s `knownVariantCodes` kontrola).
+ * preskočia, `orders/ingest.ts`'s `knownVariantCodes` kontrola). Nepovinný
+ * `supplier` (#23) — testy zoskupenia "Na objednanie" podľa dodávateľa
+ * potrebujú aspoň dvoch RÔZNYCH dodávateľov, predvolená hodnota zostáva
+ * rovnaká ako doteraz, takže existujúce volania sa nemenia.
  */
-export async function insertTestVariant(db: Database, code: string): Promise<void> {
+export async function insertTestVariant(
+  db: Database,
+  code: string,
+  supplier = "Test dodávateľ",
+): Promise<void> {
   const snapshotId = await insertTestSnapshot(db);
   await db.insert(products).values({
     key: code,
     name: `Test produkt ${code}`,
-    supplier: "Test dodávateľ",
+    supplier,
     firstSeenAt: new Date("2026-01-01T00:00:00Z"),
     lastSeenAt: new Date("2026-01-01T00:00:00Z"),
     lastSeenSnapshotId: snapshotId,

--- a/apps/api/tests/helpers/orders.ts
+++ b/apps/api/tests/helpers/orders.ts
@@ -9,12 +9,15 @@ import { insertTestSnapshot } from "./catalog.js";
  * preskočia, `orders/ingest.ts`'s `knownVariantCodes` kontrola). Nepovinný
  * `supplier` (#23) — testy zoskupenia "Na objednanie" podľa dodávateľa
  * potrebujú aspoň dvoch RÔZNYCH dodávateľov, predvolená hodnota zostáva
- * rovnaká ako doteraz, takže existujúce volania sa nemenia.
+ * rovnaká ako doteraz, takže existujúce volania sa nemenia. `null` je
+ * explicitne povolené (nie len string) — `product.supplier` je v schéme
+ * nepovinný stĺpec (`.claude/rules/orders.md`) a `queries.ts`'s zoskupenie
+ * musí zvládnuť aj tento prípad.
  */
 export async function insertTestVariant(
   db: Database,
   code: string,
-  supplier = "Test dodávateľ",
+  supplier: string | null = "Test dodávateľ",
 ): Promise<void> {
   const snapshotId = await insertTestSnapshot(db);
   await db.insert(products).values({

--- a/apps/api/tests/orders-http.integration.test.ts
+++ b/apps/api/tests/orders-http.integration.test.ts
@@ -1,0 +1,268 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { auditEvents, orderLines, orders, users } from "../src/db/schema.js";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import type { UserRole } from "../src/modules/auth/service.js";
+import type { OrdersIngestResult, RunOrdersIngest } from "../src/modules/orders/ingest.js";
+import { insertTestVariant } from "./helpers/orders.js";
+import { withCleanDb } from "./helpers/db.js";
+
+const HESLO = "test-heslo-abc"; // testovacie údaje, nie tajomstvo
+
+let close: (() => Promise<void>) | undefined;
+
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  resetLoginRateLimit();
+});
+
+async function boot(role: UserRole, runOrdersIngest?: RunOrdersIngest) {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const [pouzivatel] = await ctx.db
+    .insert(users)
+    .values({
+      email: "manazer@forestshop.sk",
+      passwordHash: await hashPassword(HESLO),
+      displayName: "Manažér",
+      role,
+    })
+    .returning({ id: users.id });
+  if (pouzivatel === undefined) throw new Error("testovací používateľ sa nepodarilo vložiť");
+
+  const app = createApp(ctx.db, {
+    cookieSecure: false,
+    ...(runOrdersIngest === undefined ? {} : { runOrdersIngest }),
+  });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "manazer@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie, db: ctx.db, userId: pouzivatel.id };
+}
+
+it("bez prihlásenia vráti 401 na všetkých troch trasách objednávok", async () => {
+  const { app } = await boot("manazer");
+  const trasy: { readonly path: string; readonly method: "GET" | "POST" }[] = [
+    { path: "/api/orders/open", method: "GET" },
+    { path: "/api/orders/11111111-1111-1111-1111-111111111111", method: "GET" },
+    { path: "/api/orders/ingest", method: "POST" },
+  ];
+  for (const trasa of trasy) {
+    const res = await app.request(trasa.path, { method: trasa.method });
+    expect(res.status).toBe(401);
+  }
+});
+
+it("vráti otvorené objednávky zoskupené podľa dodávateľa, riadky zostupne podľa dátumu objednávky", async () => {
+  const { app, cookie, db } = await boot("citanie"); // čítanie smie vidieť otvorené objednávky
+  await insertTestVariant(db, "A-1", "Dodávateľ Alfa");
+  await insertTestVariant(db, "B-1", "Dodávateľ Beta");
+
+  const [staraObjednavka] = await db
+    .insert(orders)
+    .values({ externalOrderId: "1001", customerName: "Zákazník 1", placedAt: new Date("2026-07-01T00:00:00Z") })
+    .returning();
+  const [novaObjednavka] = await db
+    .insert(orders)
+    .values({ externalOrderId: "1002", customerName: "Zákazník 2", placedAt: new Date("2026-07-15T00:00:00Z") })
+    .returning();
+  if (staraObjednavka === undefined || novaObjednavka === undefined) throw new Error("insert zlyhal");
+
+  // Jedna objednávka (1002) obsahuje položky OD DVOCH dodávateľov — zoskupenie
+  // preto beží na úrovni RIADKA, nie objednávky.
+  await db.insert(orderLines).values([
+    { orderId: staraObjednavka.id, variantCode: "A-1", quantity: 2 },
+    { orderId: novaObjednavka.id, variantCode: "A-1", quantity: 1 },
+    { orderId: novaObjednavka.id, variantCode: "B-1", quantity: 5 },
+  ]);
+
+  const res = await app.request("/api/orders/open", { headers: { cookie } });
+  expect(res.status).toBe(200);
+  const telo = (await res.json()) as {
+    suppliers: { supplier: string; lines: { externalOrderId: string; variantCode: string; quantity: number }[] }[];
+  };
+
+  expect(telo.suppliers.map((s) => s.supplier)).toEqual(["Dodávateľ Alfa", "Dodávateľ Beta"]);
+
+  const alfa = telo.suppliers.find((s) => s.supplier === "Dodávateľ Alfa");
+  // Novšia objednávka (1002) prvá — zostupné triedenie podľa placedAt.
+  expect(alfa?.lines.map((l) => l.externalOrderId)).toEqual(["1002", "1001"]);
+  expect(alfa?.lines.map((l) => l.quantity)).toEqual([1, 2]);
+
+  const beta = telo.suppliers.find((s) => s.supplier === "Dodávateľ Beta");
+  expect(beta?.lines).toHaveLength(1);
+  expect(beta?.lines[0]).toMatchObject({ externalOrderId: "1002", variantCode: "B-1", quantity: 5 });
+});
+
+it("vráti detail objednávky so všetkými riadkami, 404 pre neznáme id, 400 pre neplatné id", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await insertTestVariant(db, "A-1", "Dodávateľ Alfa");
+  const [objednavka] = await db
+    .insert(orders)
+    .values({
+      externalOrderId: "2001",
+      customerName: "Zákazník",
+      comment: "Zavolať pred doručením",
+      placedAt: new Date("2026-07-10T00:00:00Z"),
+    })
+    .returning();
+  if (objednavka === undefined) throw new Error("insert zlyhal");
+  await db.insert(orderLines).values({ orderId: objednavka.id, variantCode: "A-1", quantity: 3 });
+
+  const detailRes = await app.request(`/api/orders/${objednavka.id}`, { headers: { cookie } });
+  expect(detailRes.status).toBe(200);
+  expect(await detailRes.json()).toMatchObject({
+    externalOrderId: "2001",
+    customerName: "Zákazník",
+    comment: "Zavolať pred doručením",
+    lines: [{ variantCode: "A-1", supplier: "Dodávateľ Alfa", quantity: 3, state: "objednane" }],
+  });
+
+  const neznameRes = await app.request("/api/orders/11111111-1111-1111-1111-111111111111", { headers: { cookie } });
+  expect(neznameRes.status).toBe(404);
+
+  const neplatneRes = await app.request("/api/orders/nie-je-to-uuid", { headers: { cookie } });
+  expect(neplatneRes.status).toBe(400);
+});
+
+// `insertTestVariant`/o dôvod, prečo je každá rola SAMOSTATNÝM `it()` a nie
+// tromi po sebe idúcimi `boot()` volaniami v jednom teste: `withCleanDb()`
+// berie exkluzívny session-scoped zámok a druhé volanie TRUNCATE-uje tie isté
+// zdieľané tabuľky (`.claude/rules/testing.md`) — samostatné testy sú tu
+// jednoduchšie než zdieľať jeden `boot()`/prihlásiť sa pod tromi rolami.
+const fakeAcceptedResult: OrdersIngestResult = {
+  status: "accepted",
+  orderCount: 0,
+  lineCount: 0,
+  skippedItemCount: 0,
+  pseudoItemCount: 0,
+  issueCount: 0,
+  rawPath: "/tmp/fake.csv.gz",
+};
+
+it("rola citanie nesmie spustiť import objednávok", async () => {
+  const { app, cookie } = await boot("citanie", () => Promise.resolve(fakeAcceptedResult));
+  expect((await app.request("/api/orders/ingest", { method: "POST", headers: { cookie } })).status).toBe(403);
+});
+
+it("rola sef tiež nesmie spustiť import objednávok — obe neprivilegované role sú overené, nielen jedna", async () => {
+  const { app, cookie } = await boot("sef", () => Promise.resolve(fakeAcceptedResult));
+  expect((await app.request("/api/orders/ingest", { method: "POST", headers: { cookie } })).status).toBe(403);
+});
+
+it("rola manazer smie spustiť import objednávok", async () => {
+  const { app, cookie } = await boot("manazer", () => Promise.resolve(fakeAcceptedResult));
+  expect((await app.request("/api/orders/ingest", { method: "POST", headers: { cookie } })).status).toBe(200);
+});
+
+it("import objednávok s cudzím Origin je odmietnutý (403), rovnaký pôvod prejde", async () => {
+  const runOrdersIngest: RunOrdersIngest = () =>
+    Promise.resolve({
+      status: "accepted",
+      orderCount: 0,
+      lineCount: 0,
+      skippedItemCount: 0,
+      pseudoItemCount: 0,
+      issueCount: 0,
+      rawPath: "/tmp/fake.csv.gz",
+    });
+  const { app, cookie } = await boot("manazer", runOrdersIngest);
+
+  const cudzi = await app.request("/api/orders/ingest", {
+    method: "POST",
+    headers: { cookie, origin: "https://utocnik.example", host: "forestshop.example" },
+  });
+  expect(cudzi.status).toBe(403);
+
+  const rovnaky = await app.request("/api/orders/ingest", {
+    method: "POST",
+    headers: { cookie, origin: "https://forestshop.example", host: "forestshop.example" },
+  });
+  expect(rovnaky.status).toBe(200);
+});
+
+it("bez nakonfigurovanej SHOPTET_ORDERS_URL vráti import 503", async () => {
+  const { app, cookie } = await boot("manazer");
+  const res = await app.request("/api/orders/ingest", { method: "POST", headers: { cookie } });
+  expect(res.status).toBe(503);
+});
+
+it("keď sa export nedá vôbec stiahnuť, vráti sa jasná hláška (nie 500) a zapíše sa dôkaz o pokuse", async () => {
+  const runOrdersIngest: RunOrdersIngest = () => Promise.reject(new Error("fetch failed: connect ECONNREFUSED"));
+  const { app, cookie, db, userId } = await boot("manazer", runOrdersIngest);
+
+  const res = await app.request("/api/orders/ingest", { method: "POST", headers: { cookie } });
+  expect(res.status).toBe(502);
+  const telo = (await res.json()) as { error: string };
+  expect(telo.error).toMatch(/stiahnuť/);
+  expect(telo.error).not.toContain("ECONNREFUSED");
+
+  const udalosti = await db.select().from(auditEvents);
+  const udalost = udalosti.find((e) => e.action === "orders.ingest.trigger");
+  expect(udalost).toBeDefined();
+  expect(udalost?.actorUserId).toBe(userId);
+  expect(udalost?.data).toMatchObject({ status: "fetch_failed" });
+});
+
+it("ručný import spustí manažér a zapíše sa do auditu so skutočným výsledkom", async () => {
+  const fakeResult: OrdersIngestResult = {
+    status: "accepted",
+    orderCount: 1,
+    lineCount: 1,
+    skippedItemCount: 0,
+    pseudoItemCount: 0,
+    issueCount: 0,
+    rawPath: "/tmp/fake.csv.gz",
+  };
+  const runOrdersIngest: RunOrdersIngest = () => Promise.resolve(fakeResult);
+  const { app, cookie, db, userId } = await boot("manazer", runOrdersIngest);
+
+  const res = await app.request("/api/orders/ingest", { method: "POST", headers: { cookie } });
+  expect(res.status).toBe(200);
+  expect(await res.json()).toMatchObject({ status: "accepted", orderCount: 1, lineCount: 1 });
+
+  const udalosti = await db.select().from(auditEvents);
+  const udalost = udalosti.find((e) => e.action === "orders.ingest.trigger");
+  expect(udalost).toBeDefined();
+  expect(udalost?.actorUserId).toBe(userId);
+  expect(udalost?.data).toMatchObject({ status: "accepted" });
+});
+
+it("druhé súbežné spustenie importu vráti busy namiesto paralelného behu", async () => {
+  let volani = 0;
+  let dokonci: ((result: OrdersIngestResult) => void) | undefined;
+  const runOrdersIngest: RunOrdersIngest = () => {
+    volani += 1;
+    return new Promise((resolve) => {
+      dokonci = resolve;
+    });
+  };
+  const { app, cookie } = await boot("manazer", runOrdersIngest);
+
+  const prvyPromise = app.request("/api/orders/ingest", { method: "POST", headers: { cookie } });
+  await vi.waitFor(() => {
+    if (volani < 1) throw new Error("runOrdersIngest ešte nebolo zavolané");
+  });
+
+  const druhy = await app.request("/api/orders/ingest", { method: "POST", headers: { cookie } });
+  expect(druhy.status).toBe(200);
+  expect((await druhy.json()) as { status: string }).toEqual({ status: "busy" });
+
+  dokonci?.({
+    status: "accepted",
+    orderCount: 0,
+    lineCount: 0,
+    skippedItemCount: 0,
+    pseudoItemCount: 0,
+    issueCount: 0,
+    rawPath: "/tmp/fake.csv.gz",
+  });
+  const prvy = await prvyPromise;
+  expect(prvy.status).toBe(200);
+  expect((await prvy.json()) as { status: string }).toMatchObject({ status: "accepted" });
+});

--- a/apps/api/tests/orders-http.integration.test.ts
+++ b/apps/api/tests/orders-http.integration.test.ts
@@ -99,6 +99,32 @@ it("vráti otvorené objednávky zoskupené podľa dodávateľa, riadky zostupne
   expect(beta?.lines[0]).toMatchObject({ externalOrderId: "1002", variantCode: "B-1", quantity: 5 });
 });
 
+// Review finding: `product.supplier` je nepovinný stĺpec (Shoptet export
+// niekedy nesie prázdnu hodnotu, `map-row.ts`'s `textOrNull`) — bez tohto
+// testu by regresia zlomeného `?? NEZNAMY_DODAVATEL` fallbacku (napr.
+// omylom pridané non-null tvrdenie) prešla ticho.
+it("riadok bez dodávateľa (product.supplier je null) sa zoskupí pod čitateľný zástupný kľúč, nielen na 'null'", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await insertTestVariant(db, "N-1", null);
+
+  const [objednavka] = await db
+    .insert(orders)
+    .values({ externalOrderId: "3001", customerName: "Zákazník bez dodávateľa", placedAt: new Date("2026-07-05T00:00:00Z") })
+    .returning();
+  if (objednavka === undefined) throw new Error("insert zlyhal");
+  await db.insert(orderLines).values({ orderId: objednavka.id, variantCode: "N-1", quantity: 1 });
+
+  const openRes = await app.request("/api/orders/open", { headers: { cookie } });
+  const openTelo = (await openRes.json()) as { suppliers: { supplier: string; lines: unknown[] }[] };
+  const bezDodavatela = openTelo.suppliers.find((s) => s.supplier === "(bez dodávateľa)");
+  expect(bezDodavatela).toBeDefined();
+  expect(bezDodavatela?.lines).toHaveLength(1);
+
+  const detailRes = await app.request(`/api/orders/${objednavka.id}`, { headers: { cookie } });
+  const detailTelo = (await detailRes.json()) as { lines: { supplier: string }[] };
+  expect(detailTelo.lines[0]?.supplier).toBe("(bez dodávateľa)");
+});
+
 it("vráti detail objednávky so všetkými riadkami, 404 pre neznáme id, 400 pre neplatné id", async () => {
   const { app, cookie, db } = await boot("manazer");
   await insertTestVariant(db, "A-1", "Dodávateľ Alfa");

--- a/apps/api/tests/scheduler-jobs.integration.test.ts
+++ b/apps/api/tests/scheduler-jobs.integration.test.ts
@@ -1,16 +1,21 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, expect, it } from "vitest";
 import { sessions, users } from "../src/db/schema.js";
 import { hashPassword } from "../src/modules/auth/passwords.js";
 import type { CatalogIngestResult } from "../src/modules/catalog/ingest.js";
+import { ORDERS_EXPORT_URL_NOT_CONFIGURED, type OrdersIngestResult } from "../src/modules/orders/ingest.js";
 import {
   CATALOG_IMPORT_JOB_NAME,
+  ORDERS_IMPORT_JOB_NAME,
   PRUNE_RAW_EXPORTS_JOB_NAME,
+  PRUNE_RAW_ORDERS_JOB_NAME,
   SESSION_CLEANUP_JOB_NAME,
   catalogImportJob,
+  ordersImportJob,
   pruneRawExportsJob,
+  pruneRawOrdersJob,
   sessionCleanupJob,
 } from "../src/modules/scheduler/jobs.js";
 import { insertTestSnapshot } from "./helpers/catalog.js";
@@ -103,4 +108,46 @@ it("sessionCleanupJob deleguje na cleanupExpiredSessions — zmaže expirovanú,
 
   const zostavajuce = await ctx.db.select({ tokenHash: sessions.tokenHash }).from(sessions);
   expect(zostavajuce).toEqual([{ tokenHash: "platna" }]);
+});
+
+it("ordersImportJob bez nakonfigurovaného runOrdersIngest VYHODÍ (zachytí ho scheduler.ts, zapíše ako failure)", async () => {
+  const job = ordersImportJob(undefined);
+  expect(job.name).toBe(ORDERS_IMPORT_JOB_NAME);
+  await expect(job.run({} as never, NOW)).rejects.toThrow(ORDERS_EXPORT_URL_NOT_CONFIGURED);
+});
+
+it("ordersImportJob s nakonfigurovaným runOrdersIngest naň deleguje a vráti jeho výsledok ako detail", async () => {
+  const fakeResult: OrdersIngestResult = {
+    status: "accepted",
+    orderCount: 2,
+    lineCount: 3,
+    skippedItemCount: 0,
+    pseudoItemCount: 0,
+    issueCount: 0,
+    rawPath: "/tmp/fake.csv.gz",
+  };
+  let receivedNow: Date | undefined;
+  const job = ordersImportJob((now) => {
+    receivedNow = now;
+    return Promise.resolve(fakeResult);
+  });
+
+  const outcome = await job.run({} as never, NOW);
+  expect(outcome).toEqual({ detail: fakeResult });
+  expect(receivedNow).toBe(NOW);
+});
+
+it("pruneRawOrdersJob deleguje na existujúci pruneRawOrders — starý surový súbor objednávok sa naozaj zmaže", async () => {
+  dir = await mkdtemp(join(tmpdir(), "forestshop-scheduler-orders-"));
+  const staryPath = join(dir, "stary.csv.gz");
+  const novyPath = join(dir, "novy.csv.gz");
+  await writeFile(staryPath, "stary");
+  await writeFile(novyPath, "novy");
+  await utimes(staryPath, DAVNO, DAVNO);
+  await utimes(novyPath, NOW, NOW);
+
+  const job = pruneRawOrdersJob(dir, 30);
+  expect(job.name).toBe(PRUNE_RAW_ORDERS_JOB_NAME);
+  const outcome = await job.run({} as never, NOW);
+  expect(outcome).toEqual({ detail: { removed: 1 } });
 });

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -161,3 +161,36 @@ RED→GREEN test names, key decisions, and the shared PR.
   already-documented `/api/me`/`/api/login` 401 patterns (expected,
   deliberate test actions), no genuine errors.
 - Per-ticket Discord card fired (`notify --run-card`, confirmed delivered).
+
+## #21 — Import objednávok zo Shoptetu (F3)
+
+- Version bump `39a2436` (0.3.0-dev.8 → 0.3.0-dev.9), design comment posted
+  BEFORE first code commit (https://github.com/zbynekdrlik/forestshop-app/issues/21#issuecomment-5123773711).
+- Feature commit `4bc570e`: `modules/orders/{fetcher,parser,ingest}.ts` +
+  unit tests (`parser.test.ts` 24, `fetcher.test.ts` 9) + integration tests
+  (`orders-ingest.integration.test.ts` 8, `orders-ingest-lock.integration.test.ts`
+  1), migration `0007_groovy_alice.sql` (unique index `order_line_order_variant_uq`),
+  `cli/orders-ingest.ts` + `scripts/orders-ingest.ts`, `env.ts`/
+  `docker-compose.prod.yml`/`Dockerfile` for `SHOPTET_ORDERS_URL`/`ORDERS_RAW_DIR`.
+- Playbook commit `f95863d`: new `.claude/rules/orders.md` (pseudo-item
+  filtering, duplicate-line summing, DST-aware datetime parsing, comment/
+  state preservation, no-snapshot-table acceptance gate).
+- Fix commit `3421bb2`: an adversarial review fork caught a literal NUL
+  byte (0x00) that had landed in a template-literal Map key instead of a
+  space — harmless functionally but made `git diff`/`gh pr diff` render the
+  whole file as binary, defeating review. Fixed + hardened by switching to
+  a Map-nested-in-Map key (no string-concatenation separator at all).
+- Shared PR: **#27** (`dev` → `main`), merged `5228c8e`. CI: all jobs green
+  (check, integration, e2e, docker-build, version-check) on push and PR
+  runs, both before and after the NUL-byte fix.
+- Deployed + verified on https://forestshop-novy.newlevel.media
+  (v0.3.0-dev.9 in DOM footer, `/api/version` commit matches `5228c8e7`):
+  zero console errors. Installed `SHOPTET_ORDERS_URL` in `/srv/forestshop/.env`
+  (mode 600), restarted the app container, ran
+  `docker compose exec app node apps/api/dist/cli/orders-ingest.js` against
+  the REAL Shoptet export — 524 orders / 864 order_line rows written
+  (51 unknown-variant items skipped, 1046 shipping/billing/discount pseudo
+  items ignored), confirmed via `psql` row counts. Re-ran the same import a
+  second time — counts stayed identical (idempotent upsert confirmed on
+  real production data).
+- Per-ticket Discord card fired (`notify --run-card`, confirmed delivered).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.10",
+  "version": "0.3.0-dev.11",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.9",
+  "version": "0.3.0-dev.10",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Bundled batch: nočný beh importu objednávok + retencia surových exportov +
čítacie HTTP rozhranie pre objednávky (F3).

- ordersImportJob (01:45 UTC) + pruneRawOrdersJob (02:00 UTC) registrované v
  scheduleri, rovnaký vzor ako katalógové joby.
- Čisto súborová retencia ORDERS_RAW_DIR (žiadna snapshotová tabuľka pre
  objednávky, na rozdiel od katalógu).
- GET /api/orders/open (zoskupené podľa dodávateľa), GET /api/orders/:id,
  POST /api/orders/ingest (ručné tlačidlo "stiahnuť teraz").

Design rationale posted on each ticket before the first code commit (root
cause / chosen approach / rejected alternative):
- #22: https://github.com/zbynekdrlik/forestshop-app/issues/22#issuecomment-5124103095
- #28: https://github.com/zbynekdrlik/forestshop-app/issues/28#issuecomment-5124103303
- #23: https://github.com/zbynekdrlik/forestshop-app/issues/23#issuecomment-5124103512

Closes #22
Closes #28
Closes #23
