### PR TITLE
Add "Na objednanie" tab — read-only open orders (#24)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -4,6 +4,7 @@ import { CatalogPage } from "./components/CatalogPage.js";
 import { ChangePasswordForm } from "./components/ChangePasswordForm.js";
 import { Footer } from "./components/Footer.js";
 import { LoginForm } from "./components/LoginForm.js";
+import { OrdersSection } from "./components/OrdersSection.js";
 import { SchedulerSection } from "./components/SchedulerSection.js";
 
 export function App(): JSX.Element {
@@ -75,6 +76,7 @@ export function App(): JSX.Element {
       </button>
       {logoutError !== "" && <p role="alert">{logoutError}</p>}
       <CatalogPage role={me.role} onSessionExpired={reload} />
+      <OrdersSection onSessionExpired={reload} />
       <SchedulerSection role={me.role} onSessionExpired={reload} />
       <ChangePasswordForm onSessionExpired={reload} />
       <Footer />

--- a/apps/web/src/components/OrdersSection.test.tsx
+++ b/apps/web/src/components/OrdersSection.test.tsx
@@ -1,0 +1,112 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { OrdersSection } from "./OrdersSection.js";
+
+const { fetchOpenOrders } = vi.hoisted(() => ({ fetchOpenOrders: vi.fn() }));
+
+// `OrdersUnauthorizedError` ostáva SKUTOČNÁ trieda z reálneho modulu — rovnaký
+// dôvod ako `SchedulerSection.test.tsx`'s `SchedulerUnauthorizedError`:
+// `instanceof` v komponente musí fungovať aj v teste.
+vi.mock("../ordersApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../ordersApi.js")>();
+  return { ...actual, fetchOpenOrders };
+});
+
+const { OrdersUnauthorizedError } = await import("../ordersApi.js");
+
+const LINE_STARA = {
+  lineId: "11111111-1111-1111-1111-111111111111",
+  orderId: "aaaaaaaa-1111-1111-1111-111111111111",
+  externalOrderId: "1001",
+  customerName: "Zákazník Starý",
+  comment: null,
+  placedAt: "2026-07-01T00:00:00.000Z",
+  variantCode: "A-1",
+  variantName: "Nohavice FOREST 1003",
+  sizeLabel: "3XL",
+  quantity: 2,
+  state: "objednane" as const,
+};
+
+const LINE_NOVA = {
+  lineId: "22222222-2222-2222-2222-222222222222",
+  orderId: "bbbbbbbb-2222-2222-2222-222222222222",
+  externalOrderId: "1002",
+  customerName: "Zákazník Nový",
+  comment: "Zavolať pred doručením",
+  placedAt: "2026-07-15T00:00:00.000Z",
+  variantCode: "B-1",
+  variantName: "Bunda FOREST 2001",
+  sizeLabel: null,
+  quantity: 1,
+  state: "skladom" as const,
+};
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+it("keď zatiaľ nie sú žiadne otvorené objednávky, zobrazí informačnú vetu namiesto holej tabuľky", async () => {
+  fetchOpenOrders.mockResolvedValue([]);
+
+  render(<OrdersSection onSessionExpired={() => {}} />);
+
+  await screen.findByTestId("orders-empty");
+  expect(screen.queryByRole("table")).toBeNull();
+});
+
+it("zoskupí riadky podľa dodávateľa a zobrazí produkt, veľkosť, množstvo a stav", async () => {
+  fetchOpenOrders.mockResolvedValue([
+    { supplier: "Dodávateľ Alfa", lines: [LINE_NOVA, LINE_STARA] },
+  ]);
+
+  render(<OrdersSection onSessionExpired={() => {}} />);
+
+  const skupina = await screen.findByTestId("supplier-Dodávateľ Alfa");
+  expect(skupina.textContent).toContain("Dodávateľ Alfa");
+
+  const novy = screen.getByTestId(`order-line-${LINE_NOVA.lineId}`);
+  expect(novy.textContent).toContain("1002");
+  expect(novy.textContent).toContain("Zákazník Nový");
+  expect(novy.textContent).toContain("B-1");
+  expect(novy.textContent).toContain("Bunda FOREST 2001");
+  expect(novy.textContent).toContain("Skladom");
+  expect(novy.textContent).toContain("Zavolať pred doručením");
+
+  const stary = screen.getByTestId(`order-line-${LINE_STARA.lineId}`);
+  expect(stary.textContent).toContain("3XL");
+  expect(stary.textContent).toContain("Objednané");
+});
+
+it("chýbajúcu veľkosť a komentár zobrazí ako pomlčku", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_NOVA] }]);
+
+  render(<OrdersSection onSessionExpired={() => {}} />);
+
+  const riadok = await screen.findByTestId(`order-line-${LINE_NOVA.lineId}`);
+  // LINE_NOVA má sizeLabel: null — zobrazí sa pomlčka namiesto prázdneho políčka.
+  expect(riadok.textContent).toContain("—");
+});
+
+it("pri 401 zavolá onSessionExpired namiesto zobrazenia všeobecnej chyby", async () => {
+  fetchOpenOrders.mockRejectedValue(new OrdersUnauthorizedError());
+  const onSessionExpired = vi.fn();
+
+  render(<OrdersSection onSessionExpired={onSessionExpired} />);
+
+  await waitFor(() => {
+    expect(onSessionExpired).toHaveBeenCalledTimes(1);
+  });
+  expect(screen.queryByRole("alert")).toBeNull();
+});
+
+it("keď načítanie zlyhá inou chybou, zobrazí vlastnú slovenskú hlášku", async () => {
+  fetchOpenOrders.mockRejectedValue(new Error("network"));
+
+  render(<OrdersSection onSessionExpired={() => {}} />);
+
+  await waitFor(() => {
+    expect(screen.getByRole("alert").textContent).toBe("Otvorené objednávky sa nepodarilo načítať.");
+  });
+});

--- a/apps/web/src/components/OrdersSection.tsx
+++ b/apps/web/src/components/OrdersSection.tsx
@@ -1,0 +1,95 @@
+import { useCallback, useEffect, useState, type JSX } from "react";
+import {
+  fetchOpenOrders,
+  OrdersUnauthorizedError,
+  type OrderLine,
+  type SupplierOpenOrders,
+} from "../ordersApi.js";
+
+const STATE_LABELS: Record<OrderLine["state"], string> = {
+  objednane: "Objednané",
+  caka_sa: "Čaká sa",
+  skladom: "Skladom",
+  nedostupne: "Nedostupné",
+};
+
+// V1 je čisto na pozeranie (#24) — meniť stav riadku a kopírovať objednávku
+// príde až s #25. Preto tu nie je žiadny formulár ani tlačidlo, len čítanie.
+export function OrdersSection({
+  onSessionExpired,
+}: {
+  readonly onSessionExpired: () => void;
+}): JSX.Element {
+  const [suppliers, setSuppliers] = useState<readonly SupplierOpenOrders[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState("");
+
+  const load = useCallback(() => {
+    fetchOpenOrders()
+      .then((items) => {
+        setSuppliers(items);
+        setLoaded(true);
+      })
+      .catch((err: unknown) => {
+        setLoaded(true);
+        if (err instanceof OrdersUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setError("Otvorené objednávky sa nepodarilo načítať.");
+      });
+  }, [onSessionExpired]);
+
+  useEffect(load, [load]);
+
+  // `/api/orders/open` už zoraďuje riadky presne tak, ako majú byť zobrazené
+  // (dodávateľ vzostupne, potom najnovšia objednávka prvá) — žiadne ďalšie
+  // preskupovanie na klientovi.
+  const totalLines = suppliers.reduce((sum, group) => sum + group.lines.length, 0);
+
+  return (
+    <section>
+      <h2>Na objednanie</h2>
+      {!loaded && <p>Načítavam otvorené objednávky…</p>}
+      {error !== "" && <p role="alert">{error}</p>}
+      {loaded && totalLines === 0 && (
+        <p data-testid="orders-empty">Zatiaľ nie sú žiadne otvorené objednávky.</p>
+      )}
+      {suppliers.map((group) => (
+        <div key={group.supplier} data-testid={`supplier-${group.supplier}`}>
+          <h3>{group.supplier}</h3>
+          <table>
+            <thead>
+              <tr>
+                <th>Objednávka</th>
+                <th>Zákazník</th>
+                <th>Kód</th>
+                <th>Produkt</th>
+                <th>Veľkosť</th>
+                <th>Množstvo</th>
+                <th>Stav</th>
+                <th>Objednané</th>
+                <th>Komentár</th>
+              </tr>
+            </thead>
+            <tbody>
+              {group.lines.map((line) => (
+                <tr key={line.lineId} data-testid={`order-line-${line.lineId}`}>
+                  <td>{line.externalOrderId}</td>
+                  <td>{line.customerName}</td>
+                  <td>{line.variantCode}</td>
+                  <td>{line.variantName}</td>
+                  <td>{line.sizeLabel ?? "—"}</td>
+                  <td>{line.quantity}</td>
+                  <td>{STATE_LABELS[line.state]}</td>
+                  <td>{new Date(line.placedAt).toLocaleDateString("sk-SK")}</td>
+                  <td>{line.comment ?? "—"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/apps/web/src/ordersApi.test.ts
+++ b/apps/web/src/ordersApi.test.ts
@@ -1,0 +1,54 @@
+import { expect, it, vi } from "vitest";
+import { OrdersUnauthorizedError, fetchOpenOrders } from "./ordersApi.js";
+
+const LINE = {
+  lineId: "11111111-1111-1111-1111-111111111111",
+  orderId: "22222222-2222-2222-2222-222222222222",
+  externalOrderId: "1002",
+  customerName: "Zákazník 2",
+  comment: null,
+  placedAt: "2026-07-15T00:00:00.000Z",
+  variantCode: "A-1",
+  variantName: "Test produkt A-1",
+  sizeLabel: null,
+  quantity: 1,
+  state: "objednane" as const,
+};
+
+it("prečíta otvorené objednávky zoskupené podľa dodávateľa", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ suppliers: [{ supplier: "Dodávateľ Alfa", lines: [LINE] }] }), {
+          status: 200,
+        }),
+      ),
+  );
+  await expect(fetchOpenOrders()).resolves.toEqual([{ supplier: "Dodávateľ Alfa", lines: [LINE] }]);
+});
+
+it("odmietne odpoveď s neplatným tvarom", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ suppliers: [{ supplier: "X", lines: [{ ...LINE, quantity: "1" }] }] }), {
+          status: 200,
+        }),
+      ),
+  );
+  await expect(fetchOpenOrders()).rejects.toThrow();
+});
+
+it("pri 401 vyhodí OrdersUnauthorizedError namiesto všeobecnej chyby", async () => {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 401 })));
+  await expect(fetchOpenOrders()).rejects.toBeInstanceOf(OrdersUnauthorizedError);
+});
+
+it("zlyhá zrozumiteľne pri chybe servera", async () => {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 500 })));
+  await expect(fetchOpenOrders()).rejects.toThrow("Otvorené objednávky sa nepodarilo načítať");
+});

--- a/apps/web/src/ordersApi.ts
+++ b/apps/web/src/ordersApi.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+
+// Zrkadlí `OrderLineState`/`OpenOrderLine`/`SupplierOpenOrders` z
+// `apps/api/src/modules/orders/queries.ts` — vlastná zod schéma namiesto
+// zdieľaného typu, rovnaký vzor ako `catalogApi.ts` (frontend a backend sú
+// samostatné balíčky, žiadny zdieľaný typový balík medzi nimi (zatiaľ)
+// neexistuje).
+const orderLineSchema = z.object({
+  lineId: z.string(),
+  orderId: z.string(),
+  externalOrderId: z.string(),
+  customerName: z.string(),
+  comment: z.string().nullable(),
+  placedAt: z.string(),
+  variantCode: z.string(),
+  variantName: z.string(),
+  sizeLabel: z.string().nullable(),
+  quantity: z.number(),
+  state: z.enum(["objednane", "caka_sa", "skladom", "nedostupne"]),
+});
+
+const supplierGroupSchema = z.object({
+  supplier: z.string(),
+  lines: z.array(orderLineSchema),
+});
+
+const openOrdersSchema = z.object({ suppliers: z.array(supplierGroupSchema) });
+
+export type OrderLine = z.infer<typeof orderLineSchema>;
+export type SupplierOpenOrders = z.infer<typeof supplierGroupSchema>;
+
+/** Relácia medzitým vypršala (401) — rovnaký vzor ako `CatalogUnauthorizedError`. */
+export class OrdersUnauthorizedError extends Error {
+  constructor() {
+    super("Neprihlásený");
+  }
+}
+
+async function readJson(response: Response, fallback: string): Promise<unknown> {
+  if (response.status === 401) throw new OrdersUnauthorizedError();
+  if (!response.ok) throw new Error(fallback);
+  return await response.json();
+}
+
+export async function fetchOpenOrders(): Promise<readonly SupplierOpenOrders[]> {
+  const response = await fetch("/api/orders/open");
+  const parsed = openOrdersSchema.parse(
+    await readJson(response, "Otvorené objednávky sa nepodarilo načítať"),
+  );
+  return parsed.suppliers;
+}

--- a/apps/web/tests/e2e/orders.spec.ts
+++ b/apps/web/tests/e2e/orders.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test, type ConsoleMessage } from "@playwright/test";
+
+const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
+
+// Rovnaká a JEDINÁ povolená výnimka ako v login.spec.ts/catalog.spec.ts.
+const jeOcakavane = (m: ConsoleMessage): boolean =>
+  m.location().url.includes("/api/me") && m.text().includes("401");
+
+test("manažér vidí otvorené objednávky zoskupené podľa dodávateľa, konzola je čistá", async ({ page }) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/");
+  await page.getByLabel("E-mail").fill("e2e@forestshop.sk");
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+
+  await expect(page.getByRole("heading", { name: "Na objednanie" })).toBeVisible();
+
+  // `scripts/e2e-setup.ts` zakladá objednávku 9001 nad variantom "4859/46",
+  // ktorý má v exporte skutočného dodávateľa "DODAVATEL-TEST-1".
+  const skupinaDodavatel = page.getByTestId("supplier-DODAVATEL-TEST-1");
+  await expect(skupinaDodavatel).toBeVisible();
+  const riadokAlfa = skupinaDodavatel.locator("[data-testid^='order-line-']");
+  await expect(riadokAlfa).toContainText("9001");
+  await expect(riadokAlfa).toContainText("E2E Zákazník Alfa");
+  await expect(riadokAlfa).toContainText("4859/46");
+  await expect(riadokAlfa).toContainText("Nohavice Hart Wild-T");
+  await expect(riadokAlfa).toContainText("46");
+  await expect(riadokAlfa).toContainText("2");
+  await expect(riadokAlfa).toContainText("Čaká sa");
+  await expect(riadokAlfa).toContainText("Zavolať pred doručením");
+
+  // Objednávka 9002 je nad variantom "40287", ktorý nemá dodávateľa
+  // (`product.supplier` je `null`) — zoskupí sa pod zástupný kľúč, nie pod
+  // "null" a nezmizne.
+  const skupinaBezDodavatela = page.getByTestId("supplier-(bez dodávateľa)");
+  await expect(skupinaBezDodavatela).toBeVisible();
+  const riadokBez = skupinaBezDodavatela.locator("[data-testid^='order-line-']");
+  await expect(riadokBez).toContainText("9002");
+  await expect(riadokBez).toContainText("E2E Zákazník Bez dodávateľa");
+  await expect(riadokBez).toContainText("40287");
+  await expect(riadokBez).toContainText("Čiapka Polar FOREST");
+  // Predvolený stav riadku (schema default "objednane") a chýbajúca veľkosť.
+  await expect(riadokBez).toContainText("Objednané");
+
+  expect(chyby).toEqual([]);
+});

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -194,3 +194,49 @@ RED→GREEN test names, key decisions, and the shared PR.
   second time — counts stayed identical (idempotent upsert confirmed on
   real production data).
 - Per-ticket Discord card fired (`notify --run-card`, confirmed delivered).
+
+## #22 + #28 + #23 — Bundled batch: orders scheduler, raw-export retention, read API (F3)
+
+- Version bump `a1bf750` (0.3.0-dev.10 → 0.3.0-dev.11). Design comments
+  posted BEFORE first code commit on all three tickets:
+  [#22](https://github.com/zbynekdrlik/forestshop-app/issues/22#issuecomment-5124103095),
+  [#28](https://github.com/zbynekdrlik/forestshop-app/issues/28#issuecomment-5124103303),
+  [#23](https://github.com/zbynekdrlik/forestshop-app/issues/23#issuecomment-5124103512).
+- Commit `c35c0b2` (#22+#28): `ordersImportJob` (01:45 UTC) + `pruneRawOrdersJob`
+  (02:00 UTC) in `modules/scheduler/jobs.ts`, wired in `index.ts`; new
+  `modules/orders/raw-prune.ts` (pure filesystem mtime retention — orders have
+  no snapshot table); shared `RunOrdersIngest` type + `DEFAULT_ORDERS_IMPORT_WINDOW_DAYS`
+  moved into `modules/orders/ingest.ts`. Tests: `raw-prune.test.ts` (unit, 4
+  cases), `scheduler-jobs.integration.test.ts` additions (delegation tests
+  for both new jobs).
+- Commit `b2fd182` (#23): `modules/orders/queries.ts`
+  (`listOpenOrderLinesBySupplier` grouped at LINE level, `getOrderDetail`) +
+  `http/orders-routes.ts` (`GET /api/orders/open`, `GET /api/orders/:id`,
+  `POST /api/orders/ingest`) — same style as `catalog-routes.ts`. 12 new
+  integration tests (`orders-http.integration.test.ts`): auth/role/CSRF/
+  in-flight/503/502/audit paths + grouping/detail correctness.
+- Independent code-review subagent dispatched (`general-purpose`, diff
+  5228c8e7..d30943e): 1 Important (nullable `product.supplier` → `"(bez
+  dodávateľa)"` fallback was unverified — no test exercised it) + 2 Minor
+  (a `stat()` TOCTOU race in `raw-prune.ts` could fail the whole nightly job
+  on a concurrently-deleted file; the ingest audit payload was wider than
+  catalog's narrowed equivalent). All three fixed in commit `85f3d56`: added
+  the null-supplier regression test (both `listOpenOrderLinesBySupplier` and
+  `getOrderDetail`), guarded `stat()` with an ENOENT skip + its own
+  `vi.mock`-based regression test, narrowed the audit payload to
+  `{status, orderCount, lineCount}`/`{status, reason}`.
+- Shared PR: **#29** (`dev` → `main`), merged `601734a`. CI: all jobs green
+  (check, integration, e2e, docker-build, version-check) on both push and
+  PR runs, across all three push cycles (initial, playbook-docs-only,
+  review-fixes).
+- Deployed + verified on https://forestshop-novy.newlevel.media
+  (v0.3.0-dev.11 in DOM footer, `/api/version` commit matches `601734a0`):
+  the scheduler had ALREADY run `orders-import` (524 orders/864 lines) and
+  `prune-raw-orders` (`{"removed":0}`) live overnight, both "Úspešná" in the
+  Plánovač table — direct production confirmation of #22/#28 with zero
+  manual trigger. `GET /api/orders/open` (live, authenticated) returned 41
+  suppliers / 864 total lines (exact match to the scheduler's own
+  `lineCount`), `GET /api/orders/:id` returned a full order detail. Zero
+  console errors (only the sanctioned unauthenticated `/api/me` 401).
+- Per-ticket Discord cards fired for #22, #28, #23 (`notify --run-card`,
+  all confirmed delivered).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.11",
+  "version": "0.3.0-dev.12",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -9,7 +9,7 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { createDb } from "../apps/api/src/db/client.js";
-import { users } from "../apps/api/src/db/schema.js";
+import { orderLines, orders, users } from "../apps/api/src/db/schema.js";
 import { hashPassword } from "../apps/api/src/modules/auth/passwords.js";
 import { ingestCatalog } from "../apps/api/src/modules/catalog/ingest.js";
 import { DEFAULT_SNAPSHOT_LIMITS } from "../apps/api/src/modules/catalog/validation.js";
@@ -22,8 +22,14 @@ const { db, pool } = createDb();
 // ale vyhne sa priamemu importu z "drizzle-orm" v tomto samostatnom skripte mimo
 // TS projektu apps/api — ESLint-ova type-aware kontrola vtedy nevie spoľahlivo
 // odvodiť typ tagovanej šablóny a hlási falošné @typescript-eslint/no-unsafe-*.
+// `order_line, "order"` sú pridané RUČNE (`.claude/rules/testing.md` #20) —
+// `TRUNCATE variant CASCADE` by síce strhol `order_line` (referencuje
+// `variant.code`), ale NIE `order` (rodič `order_line`, cascade ide len jedným
+// smerom) — bez ručného pridania by riadky `order` z predchádzajúceho E2E
+// behu ticho prežívali. `"order"` je rezervované SQL kľúčové slovo, musí byť
+// uvodzované ručne v priamom SQL stringu.
 await db.execute(
-  "TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users RESTART IDENTITY CASCADE",
+  'TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order" RESTART IDENTITY CASCADE',
 );
 await db.insert(users).values({
   email: "e2e@forestshop.sk",
@@ -58,5 +64,46 @@ if (vysledok.status !== "accepted") {
 // skripte mimo TS projektu apps/api falošné @typescript-eslint/no-unsafe-*),
 // bezpečný presne preto, že reťazec nikdy nenesie vonkajší vstup.
 await db.execute("UPDATE variant SET missing_since = now() WHERE code = '40287'");
+
+// F3 (#24): dve otvorené objednávky nad UŽ naimportovanými fixtúrovými
+// variantmi — žiadne ručné vkladanie produktu/variantu netreba, E2E tak
+// overuje zoskupenie "Na objednanie" (#23) nad skutočne naimportovanými
+// dátami. "4859/46" má v exporte reálneho dodávateľa ("DODAVATEL-TEST-1",
+// map-row.test.ts), "40287" ho nemá (`product.supplier` je `null`) —
+// zámerne pokrýva OBE vetvy zoskupenia podľa dodávateľa, vrátane zástupného
+// kľúča "(bez dodávateľa)" (`modules/orders/queries.ts`).
+const [objednavkaAlfa] = await db
+  .insert(orders)
+  .values({
+    externalOrderId: "9001",
+    customerName: "E2E Zákazník Alfa",
+    comment: "Zavolať pred doručením",
+    placedAt: new Date("2026-07-20T10:00:00Z"),
+  })
+  .returning();
+if (objednavkaAlfa === undefined) throw new Error("E2E objednávka (dodávateľ) sa nepodarila vložiť");
+await db.insert(orderLines).values({
+  orderId: objednavkaAlfa.id,
+  variantCode: "4859/46",
+  quantity: 2,
+  state: "caka_sa",
+});
+
+const [objednavkaBezDodavatela] = await db
+  .insert(orders)
+  .values({
+    externalOrderId: "9002",
+    customerName: "E2E Zákazník Bez dodávateľa",
+    placedAt: new Date("2026-07-21T09:00:00Z"),
+  })
+  .returning();
+if (objednavkaBezDodavatela === undefined) {
+  throw new Error("E2E objednávka (bez dodávateľa) sa nepodarila vložiť");
+}
+await db.insert(orderLines).values({
+  orderId: objednavkaBezDodavatela.id,
+  variantCode: "40287",
+  quantity: 1,
+});
 
 await pool.end();


### PR DESCRIPTION
## Čo pridáva

Prvá verzia záložky "Na objednanie" (F3) — čisto na pozeranie: otvorené
objednávky zoskupené podľa dodávateľa, riadky s produktom (kód/názov/
veľkosť/množstvo) a stavom riadku. Backend (`GET /api/orders/open`) už bol
zmergovaný skôr — táto zmena je len frontend + e2e seed dát.

Mimo rozsahu (potvrdené v zadaní #24): zmena stavu riadku + kopírovanie
objednávky (samostatný ticket), párovanie na dodávateľskú adresu a delenie
podľa veľkostí (F4).

## Testy

- `apps/web/src/ordersApi.test.ts` — 4 unit testy (parsing, 401, chyba servera)
- `apps/web/src/components/OrdersSection.test.tsx` — 5 unit testy (prázdny
  stav, zoskupenie, chýbajúce hodnoty, 401, chyba)
- `apps/web/tests/e2e/orders.spec.ts` — Playwright e2e nad reálne
  naimportovanými katalógovými variantmi, s console-error assertom

Closes #24
