### PR TITLE
Add order line state change with audit history (#25)

### DIFF
--- a/.claude/rules/orders.md
+++ b/.claude/rules/orders.md
@@ -77,6 +77,24 @@ paths:
   (pozri vyššie), takže neexistuje DB riadok, cez ktorý by sa dala pohnať. Na
   rozdiel od katalógu preto NEEXISTUJE výnimka "posledný prijatý sa nikdy
   nemaže" — každý súbor sa posudzuje rovnako, len podľa veku.
+- **`scripts/e2e-setup.ts` má VLASTNÝ, SAMOSTATNÝ `TRUNCATE` zoznam od
+  `apps/api/tests/helpers/db.ts`** (#24) — pridanie novej "koreňovej"
+  tabuľky (`.claude/rules/testing.md`'s `order`/`order_line` pravidlo,
+  #20) treba urobiť na OBOCH miestach, nie len v integračných testoch.
+  E2E-setup pôvodne `order`/`order_line` vôbec netruncatoval (objednávky
+  vtedy ešte neexistovali) — pri prvom pridaní objednávkových dát do E2E
+  (#24) to bolo treba doplniť ručne, rovnakým vzorom (`order_line,
+  "order"` s ručne uvodzovaným rezervovaným slovom).
+- **E2E objednávkové dáta (#24) sedia na UŽ naimportovaných katalógových
+  fixtúrových variantoch, nie na ručne vloženom produkte/variante** —
+  žiadne volanie `insertTestVariant`-ekvivalentu netreba. Dva variantné kódy
+  z `apps/api/src/modules/catalog/fixtures/shoptet-sample.csv` majú známe,
+  overené hodnoty užitočné pre ďalšie objednávkové E2E testy: `"4859/46"`
+  (`product.supplier = "DODAVATEL-TEST-1"`, názov "Nohavice Hart Wild-T",
+  `sizeLabel = "46"`) a `"40287"` (`supplier = null` → zoskupí sa pod
+  "(bez dodávateľa)", názov "Čiapka Polar FOREST", `sizeLabel = null`,
+  jednovariantný). Over cez `map-row.test.ts`, ak fixtúra niekedy zmení
+  obsah.
 - **Fixtúra (`fixtures/orders-sample.csv`) je ručne vyrobená z reálnej
   67-stĺpcovej hlavičky** (nie výrez reálneho exportu ako katalóg — export
   objednávok nesie mená a e-maily zákazníkov, tie sa nekomitujú), cp1250

--- a/apps/api/src/http/orders-routes.ts
+++ b/apps/api/src/http/orders-routes.ts
@@ -2,14 +2,21 @@ import { zValidator } from "@hono/zod-validator";
 import type { Hono } from "hono";
 import { z } from "zod";
 import type { Database } from "../db/client.js";
+import { orderLineState } from "../db/schema.js";
 import { log } from "../logger.js";
 import { record } from "../modules/audit/service.js";
 import { ORDERS_EXPORT_URL_NOT_CONFIGURED, type OrdersIngestResult, type RunOrdersIngest } from "../modules/orders/ingest.js";
 import { getOrderDetail, listOpenOrderLinesBySupplier } from "../modules/orders/queries.js";
+import { setOrderLineState } from "../modules/orders/state.js";
 import { requireRole, requireUser, type AppBindings } from "./middleware.js";
 import { requireSameOrigin } from "./origin-check.js";
 
 const orderParam = z.object({ id: z.string().uuid() });
+const orderLineParam = z.object({ lineId: z.string().uuid() });
+// Čerpané priamo z `orderLineState.enumValues` (zdieľaný zdroj pravdy so
+// schémou, `schema-orders.ts`) — nikdy ručne prepísaná únia, ktorá by sa mohla
+// rozísť pri pridaní ďalšieho stavu.
+const orderLineStateBody = z.object({ state: z.enum(orderLineState.enumValues) });
 
 // Re-exportované, aby `http/app.ts` nemusel meniť svoj import — kanonická
 // definícia žije v `modules/orders/ingest.ts` (rovnaký vzor ako katalógov
@@ -33,6 +40,36 @@ export function registerOrdersRoutes(
     if (detail === null) return c.json({ error: "Objednávka sa nenašla" }, 404);
     return c.json(detail);
   });
+
+  // Zmena stavu riadku objednávky (#25) — rovnaké oprávnenie ako spustenie
+  // importu (`requireRole("admin", "manazer")`): manažér stavy mení, `citanie`/
+  // `sef` len čítajú.
+  app.post(
+    "/api/orders/lines/:lineId/state",
+    requireSameOrigin(),
+    requireUser(db),
+    requireRole("admin", "manazer"),
+    zValidator("param", orderLineParam),
+    zValidator("json", orderLineStateBody),
+    async (c) => {
+      const { lineId } = c.req.valid("param");
+      const { state } = c.req.valid("json");
+      const user = c.get("user");
+      const now = new Date();
+
+      const result = await setOrderLineState(db, {
+        lineId,
+        newState: state,
+        actorUserId: user.userId,
+        now,
+      });
+      if (result === "not_found") {
+        return c.json({ error: "Riadok objednávky sa nenašiel" }, 404);
+      }
+      log.info({ actorUserId: user.userId, lineId, state }, "zmena stavu riadku objednávky");
+      return c.json({ ok: true as const, state });
+    },
+  );
 
   // JEDEN import naraz — rovnaký in-flight guard ako `/api/catalog/ingest`
   // (uzáver na inštanciu aplikácie, `createApp`/`registerOrdersRoutes` sa

--- a/apps/api/src/modules/orders/state.ts
+++ b/apps/api/src/modules/orders/state.ts
@@ -1,0 +1,49 @@
+import { eq } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { orderLines, type OrderLineState } from "../../db/schema.js";
+import { record } from "../audit/service.js";
+
+export type SetOrderLineStateResult = "ok" | "not_found";
+
+export interface SetOrderLineStateInput {
+  readonly lineId: string;
+  readonly newState: OrderLineState;
+  readonly actorUserId: string;
+  readonly now: Date;
+}
+
+// Celý zápis beží v JEDNEJ transakcii (rovnaký vzor ako `auth/change-password.ts`
+// a `catalog/ingest.ts`) — zápis nového stavu bez auditového záznamu (alebo
+// naopak) by nechal históriu ("kto to spravil") nekonzistentnú so skutočným
+// stavom riadku.
+export async function setOrderLineState(
+  db: Database,
+  input: SetOrderLineStateInput,
+): Promise<SetOrderLineStateResult> {
+  return db.transaction(async (tx) => {
+    const [line] = await tx
+      .select({ orderId: orderLines.orderId, variantCode: orderLines.variantCode, state: orderLines.state })
+      .from(orderLines)
+      .where(eq(orderLines.id, input.lineId))
+      .limit(1);
+    if (line === undefined) return "not_found";
+
+    await tx.update(orderLines).set({ state: input.newState }).where(eq(orderLines.id, input.lineId));
+
+    await record(tx, {
+      at: input.now,
+      actorUserId: input.actorUserId,
+      action: "order_line.state.changed",
+      entity: "order_line",
+      entityId: input.lineId,
+      data: {
+        orderId: line.orderId,
+        variantCode: line.variantCode,
+        from: line.state,
+        to: input.newState,
+      },
+    });
+
+    return "ok";
+  });
+}

--- a/apps/api/tests/orders-http.integration.test.ts
+++ b/apps/api/tests/orders-http.integration.test.ts
@@ -1,3 +1,4 @@
+import { eq } from "drizzle-orm";
 import { afterEach, expect, it, vi } from "vitest";
 import { auditEvents, orderLines, orders, users } from "../src/db/schema.js";
 import { createApp } from "../src/http/app.js";
@@ -45,12 +46,13 @@ async function boot(role: UserRole, runOrdersIngest?: RunOrdersIngest) {
   return { app, cookie, db: ctx.db, userId: pouzivatel.id };
 }
 
-it("bez prihlásenia vráti 401 na všetkých troch trasách objednávok", async () => {
+it("bez prihlásenia vráti 401 na všetkých štyroch trasách objednávok", async () => {
   const { app } = await boot("manazer");
   const trasy: { readonly path: string; readonly method: "GET" | "POST" }[] = [
     { path: "/api/orders/open", method: "GET" },
     { path: "/api/orders/11111111-1111-1111-1111-111111111111", method: "GET" },
     { path: "/api/orders/ingest", method: "POST" },
+    { path: "/api/orders/lines/11111111-1111-1111-1111-111111111111/state", method: "POST" },
   ];
   for (const trasa of trasy) {
     const res = await app.request(trasa.path, { method: trasa.method });
@@ -291,4 +293,126 @@ it("druhé súbežné spustenie importu vráti busy namiesto paralelného behu",
   const prvy = await prvyPromise;
   expect(prvy.status).toBe(200);
   expect((await prvy.json()) as { status: string }).toMatchObject({ status: "accepted" });
+});
+
+// #25: zmena stavu riadku objednávky + audit.
+// `poradie` robí variant/objednávku UNIKÁTNU pri viacerých volaniach v tom
+// istom teste — `insertTestVariant` vkladá `product`/`variant` s daným kódom
+// ako primárnym kľúčom, druhé volanie s tým istým kódom by zhodilo unique
+// constraint.
+let poradieVlozenia = 0;
+async function vlozRiadok(db: Awaited<ReturnType<typeof boot>>["db"]): Promise<{ orderId: string; lineId: string }> {
+  poradieVlozenia += 1;
+  const kod = `A-${String(poradieVlozenia)}`;
+  await insertTestVariant(db, kod, "Dodávateľ Alfa");
+  const [objednavka] = await db
+    .insert(orders)
+    .values({
+      externalOrderId: `400${String(poradieVlozenia)}`,
+      customerName: "Zákazník",
+      placedAt: new Date("2026-07-20T00:00:00Z"),
+    })
+    .returning();
+  if (objednavka === undefined) throw new Error("insert objednávky zlyhal");
+  const [riadok] = await db
+    .insert(orderLines)
+    .values({ orderId: objednavka.id, variantCode: kod, quantity: 1 })
+    .returning();
+  if (riadok === undefined) throw new Error("insert riadku zlyhal");
+  return { orderId: objednavka.id, lineId: riadok.id };
+}
+
+it("manažér zmení stav riadku objednávky, zápis sa uloží aj do auditu s tým, kto ho spravil", async () => {
+  const { app, cookie, db, userId } = await boot("manazer");
+  const { orderId, lineId } = await vlozRiadok(db);
+
+  const res = await app.request(`/api/orders/lines/${lineId}/state`, {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ state: "skladom" }),
+  });
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ ok: true, state: "skladom" });
+
+  const [riadok] = await db.select().from(orderLines).where(eq(orderLines.id, lineId));
+  expect(riadok?.state).toBe("skladom");
+
+  const udalosti = await db.select().from(auditEvents);
+  const udalost = udalosti.find((e) => e.action === "order_line.state.changed");
+  expect(udalost).toBeDefined();
+  expect(udalost?.actorUserId).toBe(userId);
+  expect(udalost?.entity).toBe("order_line");
+  expect(udalost?.entityId).toBe(lineId);
+  expect(udalost?.data).toMatchObject({ orderId, from: "objednane", to: "skladom" });
+});
+
+it("rola citanie nesmie zmeniť stav riadku objednávky", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const { lineId } = await vlozRiadok(db);
+  const res = await app.request(`/api/orders/lines/${lineId}/state`, {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ state: "skladom" }),
+  });
+  expect(res.status).toBe(403);
+});
+
+it("rola sef tiež nesmie zmeniť stav riadku objednávky", async () => {
+  const { app, cookie, db } = await boot("sef");
+  const { lineId } = await vlozRiadok(db);
+  const res = await app.request(`/api/orders/lines/${lineId}/state`, {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ state: "skladom" }),
+  });
+  expect(res.status).toBe(403);
+});
+
+it("neznámy riadok vráti 404, neplatná hodnota stavu vráti 400", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await vlozRiadok(db);
+
+  const neznamy = await app.request("/api/orders/lines/11111111-1111-1111-1111-111111111111/state", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ state: "skladom" }),
+  });
+  expect(neznamy.status).toBe(404);
+
+  const { lineId } = await vlozRiadok(db);
+  const neplatny = await app.request(`/api/orders/lines/${lineId}/state`, {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ state: "zrusene" }),
+  });
+  expect(neplatny.status).toBe(400);
+});
+
+it("zmena stavu s cudzím Origin je odmietnutá (403), rovnaký pôvod prejde", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  const { lineId } = await vlozRiadok(db);
+
+  const cudzi = await app.request(`/api/orders/lines/${lineId}/state`, {
+    method: "POST",
+    headers: {
+      cookie,
+      "content-type": "application/json",
+      origin: "https://utocnik.example",
+      host: "forestshop.example",
+    },
+    body: JSON.stringify({ state: "skladom" }),
+  });
+  expect(cudzi.status).toBe(403);
+
+  const rovnaky = await app.request(`/api/orders/lines/${lineId}/state`, {
+    method: "POST",
+    headers: {
+      cookie,
+      "content-type": "application/json",
+      origin: "https://forestshop.example",
+      host: "forestshop.example",
+    },
+    body: JSON.stringify({ state: "skladom" }),
+  });
+  expect(rovnaky.status).toBe(200);
 });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -76,7 +76,7 @@ export function App(): JSX.Element {
       </button>
       {logoutError !== "" && <p role="alert">{logoutError}</p>}
       <CatalogPage role={me.role} onSessionExpired={reload} />
-      <OrdersSection onSessionExpired={reload} />
+      <OrdersSection role={me.role} onSessionExpired={reload} />
       <SchedulerSection role={me.role} onSessionExpired={reload} />
       <ChangePasswordForm onSessionExpired={reload} />
       <Footer />

--- a/apps/web/src/components/OrdersSection.test.tsx
+++ b/apps/web/src/components/OrdersSection.test.tsx
@@ -2,14 +2,17 @@ import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, expect, it, vi } from "vitest";
 import { OrdersSection } from "./OrdersSection.js";
 
-const { fetchOpenOrders } = vi.hoisted(() => ({ fetchOpenOrders: vi.fn() }));
+const { fetchOpenOrders, updateOrderLineState } = vi.hoisted(() => ({
+  fetchOpenOrders: vi.fn(),
+  updateOrderLineState: vi.fn(),
+}));
 
 // `OrdersUnauthorizedError` ostáva SKUTOČNÁ trieda z reálneho modulu — rovnaký
 // dôvod ako `SchedulerSection.test.tsx`'s `SchedulerUnauthorizedError`:
 // `instanceof` v komponente musí fungovať aj v teste.
 vi.mock("../ordersApi.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../ordersApi.js")>();
-  return { ...actual, fetchOpenOrders };
+  return { ...actual, fetchOpenOrders, updateOrderLineState };
 });
 
 const { OrdersUnauthorizedError } = await import("../ordersApi.js");
@@ -50,7 +53,7 @@ afterEach(() => {
 it("keď zatiaľ nie sú žiadne otvorené objednávky, zobrazí informačnú vetu namiesto holej tabuľky", async () => {
   fetchOpenOrders.mockResolvedValue([]);
 
-  render(<OrdersSection onSessionExpired={() => {}} />);
+  render(<OrdersSection role="citanie" onSessionExpired={() => {}} />);
 
   await screen.findByTestId("orders-empty");
   expect(screen.queryByRole("table")).toBeNull();
@@ -61,7 +64,7 @@ it("zoskupí riadky podľa dodávateľa a zobrazí produkt, veľkosť, množstvo
     { supplier: "Dodávateľ Alfa", lines: [LINE_NOVA, LINE_STARA] },
   ]);
 
-  render(<OrdersSection onSessionExpired={() => {}} />);
+  render(<OrdersSection role="citanie" onSessionExpired={() => {}} />);
 
   const skupina = await screen.findByTestId("supplier-Dodávateľ Alfa");
   expect(skupina.textContent).toContain("Dodávateľ Alfa");
@@ -82,7 +85,7 @@ it("zoskupí riadky podľa dodávateľa a zobrazí produkt, veľkosť, množstvo
 it("chýbajúcu veľkosť a komentár zobrazí ako pomlčku", async () => {
   fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_NOVA] }]);
 
-  render(<OrdersSection onSessionExpired={() => {}} />);
+  render(<OrdersSection role="citanie" onSessionExpired={() => {}} />);
 
   const riadok = await screen.findByTestId(`order-line-${LINE_NOVA.lineId}`);
   // LINE_NOVA má sizeLabel: null — zobrazí sa pomlčka namiesto prázdneho políčka.
@@ -93,7 +96,7 @@ it("pri 401 zavolá onSessionExpired namiesto zobrazenia všeobecnej chyby", asy
   fetchOpenOrders.mockRejectedValue(new OrdersUnauthorizedError());
   const onSessionExpired = vi.fn();
 
-  render(<OrdersSection onSessionExpired={onSessionExpired} />);
+  render(<OrdersSection role="citanie" onSessionExpired={onSessionExpired} />);
 
   await waitFor(() => {
     expect(onSessionExpired).toHaveBeenCalledTimes(1);
@@ -104,9 +107,77 @@ it("pri 401 zavolá onSessionExpired namiesto zobrazenia všeobecnej chyby", asy
 it("keď načítanie zlyhá inou chybou, zobrazí vlastnú slovenskú hlášku", async () => {
   fetchOpenOrders.mockRejectedValue(new Error("network"));
 
-  render(<OrdersSection onSessionExpired={() => {}} />);
+  render(<OrdersSection role="citanie" onSessionExpired={() => {}} />);
 
   await waitFor(() => {
     expect(screen.getByRole("alert").textContent).toBe("Otvorené objednávky sa nepodarilo načítať.");
   });
+});
+
+// #25: zmena stavu riadku — rola "sef" ostáva na čistom texte, presne ako
+// "citanie" vyššie (rovnaká brána ako server, žiadny select pre neprivilegovanú rolu).
+it("rola sef nevidí select na zmenu stavu, len text", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_STARA] }]);
+
+  render(<OrdersSection role="sef" onSessionExpired={() => {}} />);
+
+  await screen.findByTestId(`order-line-${LINE_STARA.lineId}`);
+  expect(screen.queryByTestId(`state-select-${LINE_STARA.lineId}`)).toBeNull();
+});
+
+it("rola manazer vidí select a zmena stavu sa prejaví lokálne bez nového načítania", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_STARA] }]);
+  updateOrderLineState.mockResolvedValue(undefined);
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const select = await screen.findByTestId<HTMLSelectElement>(`state-select-${LINE_STARA.lineId}`);
+  expect(select.value).toBe("objednane");
+
+  select.value = "skladom";
+  select.dispatchEvent(new Event("change", { bubbles: true }));
+
+  await waitFor(() => {
+    expect(updateOrderLineState).toHaveBeenCalledWith(LINE_STARA.lineId, "skladom");
+  });
+  await waitFor(() => {
+    expect(screen.getByTestId<HTMLSelectElement>(`state-select-${LINE_STARA.lineId}`).value).toBe("skladom");
+  });
+  // Presne JEDNO volanie fetchOpenOrders (počiatočné načítanie) — úspešná
+  // zmena aktualizuje lokálny stav, netreba refetch.
+  expect(fetchOpenOrders).toHaveBeenCalledTimes(1);
+  expect(screen.queryByRole("alert")).toBeNull();
+});
+
+it("zlyhaná zmena stavu zobrazí slovenskú hlášku zo servera a stav sa nezmení", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_STARA] }]);
+  updateOrderLineState.mockRejectedValue(new Error("Riadok objednávky sa nenašiel"));
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const select = await screen.findByTestId<HTMLSelectElement>(`state-select-${LINE_STARA.lineId}`);
+  select.value = "skladom";
+  select.dispatchEvent(new Event("change", { bubbles: true }));
+
+  await waitFor(() => {
+    expect(screen.getByRole("alert").textContent).toBe("Riadok objednávky sa nenašiel");
+  });
+  expect(screen.getByTestId<HTMLSelectElement>(`state-select-${LINE_STARA.lineId}`).value).toBe("objednane");
+});
+
+it("zmena stavu pri 401 zavolá onSessionExpired namiesto zobrazenia chyby", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_STARA] }]);
+  updateOrderLineState.mockRejectedValue(new OrdersUnauthorizedError());
+  const onSessionExpired = vi.fn();
+
+  render(<OrdersSection role="manazer" onSessionExpired={onSessionExpired} />);
+
+  const select = await screen.findByTestId<HTMLSelectElement>(`state-select-${LINE_STARA.lineId}`);
+  select.value = "skladom";
+  select.dispatchEvent(new Event("change", { bubbles: true }));
+
+  await waitFor(() => {
+    expect(onSessionExpired).toHaveBeenCalledTimes(1);
+  });
+  expect(screen.queryByRole("alert")).toBeNull();
 });

--- a/apps/web/src/components/OrdersSection.tsx
+++ b/apps/web/src/components/OrdersSection.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useState, type JSX } from "react";
+import type { Me } from "../api.js";
 import {
   fetchOpenOrders,
   OrdersUnauthorizedError,
+  updateOrderLineState,
   type OrderLine,
   type SupplierOpenOrders,
 } from "../ordersApi.js";
@@ -13,16 +15,29 @@ const STATE_LABELS: Record<OrderLine["state"], string> = {
   nedostupne: "Nedostupné",
 };
 
-// V1 je čisto na pozeranie (#24) — meniť stav riadku a kopírovať objednávku
-// príde až s #25. Preto tu nie je žiadny formulár ani tlačidlo, len čítanie.
+// Rovnaké dve role, ktoré server vyžaduje pre
+// `POST /api/orders/lines/:lineId/state` (`requireRole("admin", "manazer")`,
+// `orders-routes.ts`) — server ostáva skutočnou bránou, toto len skrýva
+// ovládací prvok pre role, ktoré by aj tak dostali 403 (rovnaký vzor ako
+// `CatalogPage`'s `IMPORT_ROLES`/`SchedulerSection`'s `SCHEDULER_ROLES`).
+const CAN_CHANGE_STATE_ROLES: ReadonlySet<Me["role"]> = new Set(["admin", "manazer"]);
+
+// #25: kopírovanie objednávky presunuté do #31 (otvorená otázka pre
+// majiteľa — presný výstup nie je definovaný), preto tu stále nie je žiadne
+// tlačidlo "kopírovať".
 export function OrdersSection({
+  role,
   onSessionExpired,
 }: {
+  readonly role: Me["role"];
   readonly onSessionExpired: () => void;
 }): JSX.Element {
   const [suppliers, setSuppliers] = useState<readonly SupplierOpenOrders[]>([]);
   const [loaded, setLoaded] = useState(false);
   const [error, setError] = useState("");
+  const [stateError, setStateError] = useState("");
+  const [busyLineId, setBusyLineId] = useState<string | null>(null);
+  const canChangeState = CAN_CHANGE_STATE_ROLES.has(role);
 
   const load = useCallback(() => {
     fetchOpenOrders()
@@ -42,6 +57,35 @@ export function OrdersSection({
 
   useEffect(load, [load]);
 
+  const changeState = useCallback(
+    (lineId: string, newState: OrderLine["state"]) => {
+      setStateError("");
+      setBusyLineId(lineId);
+      updateOrderLineState(lineId, newState)
+        .then(() => {
+          // Lokálna aktualizácia namiesto plného refetchu — server už
+          // potvrdil zápis (aj audit), netreba znova ťahať celý zoznam.
+          setSuppliers((current) =>
+            current.map((group) => ({
+              ...group,
+              lines: group.lines.map((line) => (line.lineId === lineId ? { ...line, state: newState } : line)),
+            })),
+          );
+        })
+        .catch((err: unknown) => {
+          if (err instanceof OrdersUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setStateError(err instanceof Error ? err.message : "Zmena stavu sa nepodarila.");
+        })
+        .finally(() => {
+          setBusyLineId(null);
+        });
+    },
+    [onSessionExpired],
+  );
+
   // `/api/orders/open` už zoraďuje riadky presne tak, ako majú byť zobrazené
   // (dodávateľ vzostupne, potom najnovšia objednávka prvá) — žiadne ďalšie
   // preskupovanie na klientovi.
@@ -52,6 +96,7 @@ export function OrdersSection({
       <h2>Na objednanie</h2>
       {!loaded && <p>Načítavam otvorené objednávky…</p>}
       {error !== "" && <p role="alert">{error}</p>}
+      {stateError !== "" && <p role="alert">{stateError}</p>}
       {loaded && totalLines === 0 && (
         <p data-testid="orders-empty">Zatiaľ nie sú žiadne otvorené objednávky.</p>
       )}
@@ -81,7 +126,33 @@ export function OrdersSection({
                   <td>{line.variantName}</td>
                   <td>{line.sizeLabel ?? "—"}</td>
                   <td>{line.quantity}</td>
-                  <td>{STATE_LABELS[line.state]}</td>
+                  <td>
+                    {canChangeState ? (
+                      <select
+                        // Zámerne BEZ slova "stav" — Playwright's `getByLabel`
+                        // robí substring zhodu bez ohľadu na veľkosť písmen, takže
+                        // by kolidovalo s katalógovým `<label>Stav</label>`
+                        // (`CatalogPage.tsx`, `getByLabel("Stav")` v
+                        // `catalog.spec.ts`) a e2e test by dostal "strict mode
+                        // violation" (viacero zhôd).
+                        aria-label={`Riadok objednávky ${line.externalOrderId} / ${line.variantCode}`}
+                        data-testid={`state-select-${line.lineId}`}
+                        value={line.state}
+                        disabled={busyLineId === line.lineId}
+                        onChange={(e) => {
+                          changeState(line.lineId, e.target.value as OrderLine["state"]);
+                        }}
+                      >
+                        {(Object.keys(STATE_LABELS) as OrderLine["state"][]).map((s) => (
+                          <option key={s} value={s}>
+                            {STATE_LABELS[s]}
+                          </option>
+                        ))}
+                      </select>
+                    ) : (
+                      STATE_LABELS[line.state]
+                    )}
+                  </td>
                   <td>{new Date(line.placedAt).toLocaleDateString("sk-SK")}</td>
                   <td>{line.comment ?? "—"}</td>
                 </tr>

--- a/apps/web/src/ordersApi.test.ts
+++ b/apps/web/src/ordersApi.test.ts
@@ -1,5 +1,5 @@
 import { expect, it, vi } from "vitest";
-import { OrdersUnauthorizedError, fetchOpenOrders } from "./ordersApi.js";
+import { OrdersUnauthorizedError, fetchOpenOrders, updateOrderLineState } from "./ordersApi.js";
 
 const LINE = {
   lineId: "11111111-1111-1111-1111-111111111111",
@@ -51,4 +51,45 @@ it("pri 401 vyhodí OrdersUnauthorizedError namiesto všeobecnej chyby", async (
 it("zlyhá zrozumiteľne pri chybe servera", async () => {
   vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 500 })));
   await expect(fetchOpenOrders()).rejects.toThrow("Otvorené objednávky sa nepodarilo načítať");
+});
+
+// #25: zmena stavu riadku objednávky.
+it("updateOrderLineState pošle POST na správnu trasu s telom { state }", async () => {
+  const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true, state: "skladom" }), { status: 200 }));
+  vi.stubGlobal("fetch", fetchMock);
+
+  await updateOrderLineState("11111111-1111-1111-1111-111111111111", "skladom");
+
+  expect(fetchMock).toHaveBeenCalledWith(
+    "/api/orders/lines/11111111-1111-1111-1111-111111111111/state",
+    expect.objectContaining({
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ state: "skladom" }),
+    }),
+  );
+});
+
+it("updateOrderLineState pri 401 vyhodí OrdersUnauthorizedError", async () => {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 401 })));
+  await expect(updateOrderLineState("11111111-1111-1111-1111-111111111111", "skladom")).rejects.toBeInstanceOf(
+    OrdersUnauthorizedError,
+  );
+});
+
+it("updateOrderLineState pri chybe servera vráti slovenskú hlášku z tela odpovede", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue(new Response(JSON.stringify({ error: "Riadok objednávky sa nenašiel" }), { status: 404 })),
+  );
+  await expect(updateOrderLineState("11111111-1111-1111-1111-111111111111", "skladom")).rejects.toThrow(
+    "Riadok objednávky sa nenašiel",
+  );
+});
+
+it("updateOrderLineState bez tela odpovede použije všeobecnú hlášku", async () => {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 500 })));
+  await expect(updateOrderLineState("11111111-1111-1111-1111-111111111111", "skladom")).rejects.toThrow(
+    "Zmena stavu sa nepodarila",
+  );
 });

--- a/apps/web/src/ordersApi.ts
+++ b/apps/web/src/ordersApi.ts
@@ -36,9 +36,24 @@ export class OrdersUnauthorizedError extends Error {
   }
 }
 
+const errorBodySchema = z.object({ error: z.string() });
+
+// Rovnaký vzor ako `catalogApi.ts`'s `serverErrorMessage` — server posiela
+// `{error: "..."}` telo so slovenskou hláškou (napr. neznámy riadok, neplatný
+// stav), ktorú treba zobraziť namiesto všeobecného fallbacku.
+async function serverErrorMessage(response: Response, fallback: string): Promise<string> {
+  try {
+    const parsed = errorBodySchema.safeParse(await response.json());
+    if (parsed.success) return parsed.data.error;
+  } catch {
+    // Telo nie je platný JSON (alebo chýba) — použi všeobecnú hlášku.
+  }
+  return fallback;
+}
+
 async function readJson(response: Response, fallback: string): Promise<unknown> {
   if (response.status === 401) throw new OrdersUnauthorizedError();
-  if (!response.ok) throw new Error(fallback);
+  if (!response.ok) throw new Error(await serverErrorMessage(response, fallback));
   return await response.json();
 }
 
@@ -48,4 +63,18 @@ export async function fetchOpenOrders(): Promise<readonly SupplierOpenOrders[]> 
     await readJson(response, "Otvorené objednávky sa nepodarilo načítať"),
   );
   return parsed.suppliers;
+}
+
+// #25: zmena stavu riadku objednávky — `lineId` je globálne unikátne (UUID
+// primárny kľúč `order_line.id`), netreba aj `orderId`.
+export async function updateOrderLineState(
+  lineId: string,
+  state: OrderLine["state"],
+): Promise<void> {
+  const response = await fetch(`/api/orders/lines/${lineId}/state`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ state }),
+  });
+  await readJson(response, "Zmena stavu sa nepodarila");
 }

--- a/apps/web/tests/e2e/orders.spec.ts
+++ b/apps/web/tests/e2e/orders.spec.ts
@@ -51,3 +51,43 @@ test("manažér vidí otvorené objednávky zoskupené podľa dodávateľa, konz
 
   expect(chyby).toEqual([]);
 });
+
+// #25: manažér prepne stav riadku cez select v UI a zmena PRETRVÁ po obnovení
+// stránky. Zápis stavu a audit bežia v JEDNEJ transakcii (`modules/orders/
+// state.ts`) — pretrvanie po reloade je teda dôkazom, že transakcia skutočne
+// commitla (audit zápis neyhodil výnimku, ktorá by ju bola vrátila späť).
+// Samotný obsah auditového riadku (kto, kedy, z akého stavu do akého) overuje
+// integračný test (`apps/api/tests/orders-http.integration.test.ts`) priamo
+// nad databázou — tam patrí kontrola stĺpcov DB riadku, nie do e2e.
+test("manažér prepne stav riadku cez select, zmena pretrvá po obnovení stránky, konzola je čistá", async ({ page }) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/");
+  await page.getByLabel("E-mail").fill("e2e@forestshop.sk");
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await expect(page.getByRole("heading", { name: "Na objednanie" })).toBeVisible();
+
+  // Objednávka 9001 (dodávateľ "DODAVATEL-TEST-1") má riadok so stavom
+  // "caka_sa" (`scripts/e2e-setup.ts`).
+  const riadok = page.getByTestId("supplier-DODAVATEL-TEST-1").locator("[data-testid^='order-line-']");
+  const select = riadok.locator("select");
+  await expect(select).toHaveValue("caka_sa");
+
+  await select.selectOption("skladom");
+  await expect(riadok).toContainText("Skladom");
+  await expect(page.getByRole("alert")).toHaveCount(0);
+
+  await page.reload();
+  await expect(page.getByRole("heading", { name: "Na objednanie" })).toBeVisible();
+  const riadokPoReloade = page.getByTestId("supplier-DODAVATEL-TEST-1").locator("[data-testid^='order-line-']");
+  await expect(riadokPoReloade.locator("select")).toHaveValue("skladom");
+
+  expect(chyby).toEqual([]);
+});

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -240,3 +240,47 @@ RED→GREEN test names, key decisions, and the shared PR.
   console errors (only the sanctioned unauthenticated `/api/me` 401).
 - Per-ticket Discord cards fired for #22, #28, #23 (`notify --run-card`,
   all confirmed delivered).
+
+## #24 — "Na objednanie" tab (F3, read-only v1)
+
+- Design comment posted BEFORE first code commit:
+  [#24](https://github.com/zbynekdrlik/forestshop-app/issues/24#issuecomment-5124541486)
+  (root cause: manager needs the old app's daily "Na objednanie" screen;
+  chosen approach: flat per-supplier table straight off the already-live
+  `GET /api/orders/open`, no client reshaping; rejected alternative:
+  per-order `GET /api/orders/:id` fetch + nested tree, since `/open` already
+  carries every field this ticket needs on the line itself). No version
+  bump needed — dev (`0.3.0-dev.12`) was already ahead of main
+  (`0.3.0-dev.11`) from the previous cycle's bump.
+- Commit `9e8d156`: new `apps/web/src/ordersApi.ts` + `apps/web/src/
+  components/OrdersSection.tsx` (mirrors `schedulerApi.ts`/
+  `SchedulerSection.tsx` conventions — zod schema, `OrdersUnauthorizedError`,
+  session-expiry handling), wired into `App.tsx`. No role gate on visibility
+  (the read route has none, unlike scheduler). `scripts/e2e-setup.ts` now
+  seeds two open orders over already-imported fixture variants (one with a
+  real supplier, one with `null` → exercises the "(bez dodávateľa)"
+  fallback) so `orders.spec.ts` runs against real ingested data, not
+  hand-inserted rows. Also added `order_line, "order"` to the e2e TRUNCATE
+  list (`.claude/rules/testing.md` #20 pattern — `order` doesn't cascade
+  from `variant`). Feature ticket, no RED/GREEN regression pair (not a bug
+  fix) — tests added same-commit per `tdd-workflow.md`'s feature path:
+  4 unit tests (`ordersApi.test.ts`), 5 unit tests (`OrdersSection.test.tsx`),
+  1 Playwright e2e (`orders.spec.ts`) with the standard console-zero-errors
+  assertion.
+- Independent code-review subagent dispatched (`general-purpose`, diff
+  `601734a..9e8d156`): 0 Critical, 0 Warning. 2 Suggestions — this
+  autopilot-log entry (addressed here) and a note that neither
+  `OrdersSection` nor `SchedulerSection` offers a manual refresh/retry after
+  a transient load error (pre-existing pattern, not introduced by this
+  change, no action taken). Overall assessment: ready to merge.
+- PR: **#30** (`dev` → `main`), merged `2d8c4e7`. CI: all jobs green (check,
+  integration, e2e, docker-build; version-check skipped on main as
+  expected) on both push and PR runs.
+- Deployed + verified on https://forestshop-novy.newlevel.media
+  (v0.3.0-dev.12 in DOM footer, `/api/version` commit matches `2d8c4e7a`):
+  logged-in session showed the "Na objednanie" heading with 41 real
+  supplier groups and real order lines (e.g. BETALOV group, order 20261259,
+  product "Poľovnícke kraťasy HART GOROSTA-SH") — matches the issue's
+  "41 supplier groups, 864 lines" production figures. Zero console
+  errors/warnings.
+- Per-ticket Discord card fired (`notify --run-card`, confirmed delivered).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.12",
+  "version": "0.3.0-dev.13",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Summary
- Manager can switch each open order line's state (objednané / čaká sa / skladom / nedostupné) via a role-gated select in the "Na objednanie" table
- Every state change writes an `audit_events` row (who, when, from/to) in the same transaction as the state write
- `POST /api/orders/lines/:lineId/state` — `requireSameOrigin()` + `requireUser` + `requireRole("admin","manazer")`, same gate as `/api/orders/ingest`
- Copying an order (originally part of #25) is split into a new follow-up issue — the exact output format is an open owner decision

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` (unit, apps/api + apps/web) — all green
- [x] `pnpm test:integration` — all green, incl. new role-gate/404/400/CSRF tests for the state-change route
- [x] `pnpm --filter @forestshop/web e2e` — manager changes a line's state through the real UI and it persists after reload
- [x] CI green (check, integration, e2e, docker-build, version-check)

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)
