### PR TITLE
Fix order-line state-change concurrency + select accessibility (#25)

### DIFF
--- a/.claude/rules/deploy.md
+++ b/.claude/rules/deploy.md
@@ -173,3 +173,12 @@ paths:
   --failed` — čerstvý pull znova stiahne vrstvu od nuly. Ak sa to isté zopakuje
   DRUHÝKRÁT za sebou, už to nie je transientný jav — over `docker system df`
   (miesto na disku) a zváž reštart `containerd`/`docker` služby na dev2.
+- **DRUHÝ pozorovaný transientný symptom TEJ ISTEJ triedy (#25, 2026-07-30):
+  `docker compose up -d` zlyhá na `Error response from daemon: No such
+  container: <hash>_forestshop-app-1` počas kroku "Recreate"** — opäť žiadna
+  zmena závislostí v danom PR, teda opäť lokálny containerd/docker stav na
+  dev2, nie obsah image. Rovnaká liečba ako vyššie: `gh run rerun <run-id>
+  --failed` (jeden rerun stačil, prešiel hneď). Ak sa PRI DEPLOJI objaví
+  INÁ hláška než "failed to extract layer", nepredpokladaj automaticky inú
+  príčinu — over najprv jednoduchým rerunom, až pri DRUHOM zlyhaní za sebou
+  rieš ako skutočný problém.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -132,3 +132,24 @@ paths:
   `change-password.integration.test.ts`/`login.spec.ts`'s dvoj-kontextový
   e2e test — presne takto sa to odhalilo (e2e test napísaný najprv na 4xx
   zlyhal na tomto pravidle).
+- **Playwright's `getByLabel`/`getByText` robia SUBSTRING zhodu (case-
+  insensitive), nie presnú, pokiaľ nedáš `{ exact: true }`** — nové
+  `aria-label` pridané do jednej sekcie môže tichým spôsobom kolidovať s
+  `getByLabel(...)` v INOM e2e súbore, ktorý beží na tej istej stránke
+  (celá appka je JEDNA stránka, `App.tsx` renderuje `CatalogPage` +
+  `OrdersSection` + `SchedulerSection` naraz). Zistené #25: nový
+  `aria-label={"Stav riadku " + ...}` na stavovom selecte v
+  `OrdersSection.tsx` kolidoval s `catalog.spec.ts`'s
+  `getByLabel("Stav")` (katalógov filter) — "strict mode violation:
+  resolved to 3 elements". Odhalilo sa AŽ pri behu CELÉHO e2e balíka
+  (`pnpm --filter @forestshop/web e2e`), nie len nového spec súboru — pri
+  pridávaní `aria-label`/`getByLabel` VŽDY spusti celý balík, nikdy len
+  novo pridaný test.
+- **Playwright s viacerými workermi (predvolený počet, ako aj CI runner)
+  môže byť nestály — všetky e2e spec súbory zdieľajú JEDEN bežiaci API
+  server aj JEDNU lokálnu Postgres inštanciu.** Sledované #25/#32:
+  `orders.spec.ts`'s prvý test niekedy zlyhá na chýbajúcom "Na
+  objednanie" nadpise (5s timeout) pri `--workers=2`, spoľahlivo prejde
+  pri `--workers=1`. Potvrdené ako PRE-EXISTING (reprodukované aj na
+  čistom `origin/dev` bez akejkoľvek súvisiacej zmeny) — sledované ako
+  samostatný issue **#32**, nie vec jedného konkrétneho spec súboru.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -144,6 +144,13 @@ paths:
   resolved to 3 elements". Odhalilo sa AŽ pri behu CELÉHO e2e balíka
   (`pnpm --filter @forestshop/web e2e`), nie len nového spec súboru — pri
   pridávaní `aria-label`/`getByLabel` VŽDY spusti celý balík, nikdy len
+  nový spec súbor. **Oprav to na strane KOLÍDUJÚCEHO (existujúceho, užšieho)
+  labelu, nie obetovaním prístupnosti nového prvku** — code review na #25
+  upozornil, že prvá oprava (odstránenie slova "stav" z nového
+  `aria-label`u) by čítačke obrazovky vôbec neoznámila, čo nový select robí.
+  Skutočná oprava: existujúci `catalog.spec.ts` dostal
+  `getByLabel("Stav", { exact: true })`, nový select v `OrdersSection.tsx`
+  si ponechal plnohodnotný popis (`"Zmeniť stav riadku objednávky ..."`).
   novo pridaný test.
 - **Playwright s viacerými workermi (predvolený počet, ako aj CI runner)
   môže byť nestály — všetky e2e spec súbory zdieľajú JEDEN bežiaci API

--- a/apps/api/src/modules/orders/state.ts
+++ b/apps/api/src/modules/orders/state.ts
@@ -21,10 +21,19 @@ export async function setOrderLineState(
   input: SetOrderLineStateInput,
 ): Promise<SetOrderLineStateResult> {
   return db.transaction(async (tx) => {
+    // `.for("update")` — bez tohto by dve súbežné zmeny stavu TOHO ISTÉHO
+    // riadku mohli zapísať audit s neplatným `from` (druhá transakcia by
+    // prečítala stav PRED tým, než prvá commitla svoj UPDATE, nie tesne pred
+    // vlastným zápisom). Výsledný stĺpec `state` by bol aj tak správny
+    // (posledný zápis vyhráva), ale história ("z akého stavu do akého") by
+    // klamala. Zámok drží riadok len do konca TEJTO transakcie (rovnako
+    // krátko ako `changePassword`), druhá súbežná požiadavka počká na
+    // COMMIT prvej a prečíta si už aktuálny stav (code review finding, #25).
     const [line] = await tx
       .select({ orderId: orderLines.orderId, variantCode: orderLines.variantCode, state: orderLines.state })
       .from(orderLines)
       .where(eq(orderLines.id, input.lineId))
+      .for("update")
       .limit(1);
     if (line === undefined) return "not_found";
 

--- a/apps/api/tests/orders-state-lock.integration.test.ts
+++ b/apps/api/tests/orders-state-lock.integration.test.ts
@@ -1,0 +1,100 @@
+import pg from "pg";
+import { afterEach, expect, it } from "vitest";
+import { auditEvents, orderLines, orders, users } from "../src/db/schema.js";
+import { setOrderLineState } from "../src/modules/orders/state.js";
+import { insertTestVariant } from "./helpers/orders.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// Code-review finding on #25: `setOrderLineState`'s SELECT (ktorý číta
+// pôvodný stav pre auditový `from`) pôvodne nebol chránený riadkovým zámkom
+// — dve súbežné zmeny stavu TOHO ISTÉHO riadku mohli zapísať audit s
+// nesprávnym `from` (druhá transakcia by prečítala stav SPRED prvej zmeny,
+// nie tesne pred vlastným zápisom), hoci samotný stĺpec `state` by aj tak
+// skončil správne (posledný zápis vyhráva). Test to dokazuje
+// DETERMINISTICKY: druhé pripojenie podrží `SELECT ... FOR UPDATE` na tom
+// istom riadku v otvorenej (necommitnutej) transakcii — `setOrderLineState`
+// sa musí na svojom vlastnom `.for("update")` zaseknúť presne na tomto
+// mieste, kým druhé pripojenie neskôr riadok zmení a commitne. Bez zámku
+// (pôvodná chyba) by obyčajný SELECT nebol blokovaný vôbec (v Postgrese
+// obyčajné čítanie nikdy nečaká na riadkový zámok inej transakcie) a
+// videl by ZASTARANÝ stav spred zmeny.
+
+let close: (() => Promise<void>) | undefined;
+
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+});
+
+it("súbežná zmena stavu čaká na riadkový zámok — audit 'from' odráža ČERSTVÝ stav, nie zastaraný", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const db = ctx.db;
+
+  await insertTestVariant(db, "A-1", "Dodávateľ Alfa");
+  const [pouzivatel] = await db
+    .insert(users)
+    .values({
+      email: "manazer-lock-test@forestshop.sk",
+      passwordHash: "x", // FK potrebuje existujúci riadok, heslo sa v tomto teste nikdy neoveruje
+      displayName: "Manažér",
+      role: "manazer",
+    })
+    .returning({ id: users.id });
+  if (pouzivatel === undefined) throw new Error("insert používateľa zlyhal");
+
+  const [objednavka] = await db
+    .insert(orders)
+    .values({ externalOrderId: "5001", customerName: "Zákazník", placedAt: new Date("2026-07-20T00:00:00Z") })
+    .returning();
+  if (objednavka === undefined) throw new Error("insert objednávky zlyhal");
+  const [riadok] = await db
+    .insert(orderLines)
+    .values({ orderId: objednavka.id, variantCode: "A-1", quantity: 1 }) // default state: "objednane"
+    .returning();
+  if (riadok === undefined) throw new Error("insert riadku zlyhal");
+
+  const databaseUrl = process.env["DATABASE_URL"];
+  if (databaseUrl === undefined || databaseUrl === "") {
+    throw new Error("Integračné testy potrebujú DATABASE_URL");
+  }
+  const rawClient = new pg.Client({ connectionString: databaseUrl });
+  await rawClient.connect();
+  await rawClient.query("BEGIN");
+  // Podrží riadkový zámok presne na tom istom riadku, aký `setOrderLineState`
+  // sám žiada cez `.for("update")`.
+  await rawClient.query('SELECT state FROM order_line WHERE id = $1 FOR UPDATE', [riadok.id]);
+
+  try {
+    const concurrentChange = setOrderLineState(db, {
+      lineId: riadok.id,
+      newState: "skladom",
+      actorUserId: pouzivatel.id,
+      now: new Date("2026-07-30T10:00:00Z"),
+    });
+
+    // Dá `concurrentChange`'s vlastnému `.for("update")` selectu dosť času
+    // dôjsť k riadkovému zámku a zaseknúť sa naň — zámok drží `rawClient`,
+    // takže "príliš neskoro" tu nehrozí, len čakáme, kým sa naň naozaj zasekne.
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    // Simuluje "prvú" súbežnú zmenu, ktorá stihla commitnúť MEDZITÝM — priamo,
+    // mimo `setOrderLineState`, presne v momente, keď je druhá zaseknutá na
+    // zámku.
+    await rawClient.query('UPDATE order_line SET state = $1 WHERE id = $2', ["caka_sa", riadok.id]);
+    await rawClient.query("COMMIT");
+
+    const result = await concurrentChange;
+    expect(result).toBe("ok");
+
+    const udalosti = await db.select().from(auditEvents);
+    const udalost = udalosti.find((e) => e.action === "order_line.state.changed" && e.entityId === riadok.id);
+    expect(udalost).toBeDefined();
+    // Dôkaz opravy: `from` je "caka_sa" (stav COMMITNUTÝ tesne pred týmto
+    // zápisom), NIE "objednane" (pôvodný, zastaraný stav spred súbežnej
+    // zmeny) — presne to, čo `.for("update")` zaručuje.
+    expect(udalost?.data).toMatchObject({ from: "caka_sa", to: "skladom" });
+  } finally {
+    await rawClient.end();
+  }
+});

--- a/apps/web/src/components/OrdersSection.tsx
+++ b/apps/web/src/components/OrdersSection.tsx
@@ -129,13 +129,15 @@ export function OrdersSection({
                   <td>
                     {canChangeState ? (
                       <select
-                        // Zámerne BEZ slova "stav" — Playwright's `getByLabel`
-                        // robí substring zhodu bez ohľadu na veľkosť písmen, takže
-                        // by kolidovalo s katalógovým `<label>Stav</label>`
-                        // (`CatalogPage.tsx`, `getByLabel("Stav")` v
-                        // `catalog.spec.ts`) a e2e test by dostal "strict mode
-                        // violation" (viacero zhôd).
-                        aria-label={`Riadok objednávky ${line.externalOrderId} / ${line.variantCode}`}
+                        // Code review finding (#25): pôvodne bez slova "stav"
+                        // v aria-labeli (obchádzka Playwright's substring
+                        // `getByLabel("Stav")` kolízie s katalógovým filtrom),
+                        // čo by čítačke obrazovky neoznámilo, čo tento prvok
+                        // robí. Skutočná oprava patrí na stranu KOLÍDUJÚCEHO
+                        // testu (`catalog.spec.ts` teraz používa
+                        // `{ exact: true }`), nie na obetovanie prístupnosti
+                        // tu — tento select smie mať plnohodnotný popis.
+                        aria-label={`Zmeniť stav riadku objednávky ${line.externalOrderId} / ${line.variantCode}`}
                         data-testid={`state-select-${line.lineId}`}
                         value={line.state}
                         disabled={busyLineId === line.lineId}

--- a/apps/web/tests/e2e/catalog.spec.ts
+++ b/apps/web/tests/e2e/catalog.spec.ts
@@ -46,7 +46,7 @@ test("filter podľa stavu zúži zoznam na predajné varianty", async ({ page })
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
   await expect(page.getByTestId("total")).toHaveText("Nájdených: 35");
-  await page.getByLabel("Stav").selectOption("sellable");
+  await page.getByLabel("Stav", { exact: true }).selectOption("sellable");
   await page.getByRole("button", { name: "Hľadať" }).click();
 
   await expect(page.getByTestId("total")).toHaveText("Nájdených: 6");
@@ -62,7 +62,7 @@ test("filter 'Chýbajúce' nájde presne označený variant a riadok ukazuje, od
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
   await expect(page.getByTestId("total")).toHaveText("Nájdených: 35");
-  await page.getByLabel("Stav").selectOption("missing");
+  await page.getByLabel("Stav", { exact: true }).selectOption("missing");
   await page.getByRole("button", { name: "Hľadať" }).click();
 
   await expect(page.getByTestId("total")).toHaveText("Nájdených: 1");

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -284,3 +284,64 @@ RED→GREEN test names, key decisions, and the shared PR.
   "41 supplier groups, 864 lines" production figures. Zero console
   errors/warnings.
 - Per-ticket Discord card fired (`notify --run-card`, confirmed delivered).
+
+## #25 — Order line state change + audit history (F3)
+
+- Ticket was deliberately split at intake (owner comment recorded
+  2026-07-30): state-change is scoped/clear, "copy order" has no defined
+  output format. Copy-order moved to a new follow-up issue **#31**
+  (`Scope-gate: needs-user-decision`, label `needs-decision`); #25's body
+  rewritten to cover state-change only.
+- Design comments posted BEFORE first code commit:
+  [#25 (main rationale)](https://github.com/zbynekdrlik/forestshop-app/issues/25#issuecomment-5124750130),
+  [#25 (classifier-keyword supplement)](https://github.com/zbynekdrlik/forestshop-app/issues/25#issuecomment-5124899513)
+  — root cause: `order_line.state` (since #21) was READ-only, no write path
+  existed; chosen approach: narrow `POST /api/orders/lines/:lineId/state`
+  (same `requireSameOrigin()+requireUser+requireRole("admin","manazer")`
+  gate as `/api/orders/ingest`) backed by `modules/orders/state.ts`'s
+  `setOrderLineState()` — one transaction (update + `record()` audit,
+  same pattern as `changePassword`); rejected alternative: a general
+  `PATCH /api/orders/lines/:lineId` accepting arbitrary fields, rejected
+  because `quantity`/`variantCode` are importer-owned
+  (`.claude/rules/orders.md`) and a wide endpoint would let a manager
+  accidentally clobber them. No version bump needed — dev
+  (`0.3.0-dev.13`) was already ahead of main (`0.3.0-dev.12`).
+- Commit `7183ade`: new `apps/api/src/modules/orders/state.ts`, new route
+  in `orders-routes.ts`, `OrdersSection.tsx` gets a role-gated `<select>`
+  (admin/manazer, same `CAN_CHANGE_STATE_ROLES` pattern as `CatalogPage`'s
+  `IMPORT_ROLES`) with local-state update on success (no full refetch),
+  `ordersApi.ts`'s `updateOrderLineState()`. Select's `aria-label`
+  deliberately avoids the substring "stav" — it collided with
+  `catalog.spec.ts`'s `getByLabel("Stav")` (Playwright's default substring
+  match), caught by running the FULL e2e suite, not just the new spec.
+  Tests: 5 new integration tests (role gates, 404/400, CSRF) in
+  `orders-http.integration.test.ts`, 4 unit tests in `ordersApi.test.ts`,
+  4 unit tests in `OrdersSection.test.tsx`, 1 new Playwright e2e proving
+  the manager changes a line's state through the real UI and it persists
+  after reload (audit row content itself is asserted at the integration
+  level, per `.claude/rules/testing.md`'s two-tier split).
+- Filed **#32**: `tests/e2e/orders.spec.ts`'s FIRST test intermittently
+  fails under 2-worker Playwright runs (confirmed pre-existing —
+  reproduced on `origin/dev` `917242c` with none of this PR's changes,
+  disappears at `--workers=1`); likely all e2e specs racing the same
+  shared backend/Postgres. Out of scope for #25, left for investigation.
+- PR: **#33** (`dev` → `main`), merged `d49aaf5`. CI: all jobs green
+  (check, integration, e2e, docker-build, version-check) on both push and
+  PR runs.
+- Main-branch Deploy workflow run `30503448643` failed on its first
+  attempt (`docker compose up -d`: "No such container:
+  ..._forestshop-app-1" during container recreate — the same class of
+  transient dev2 containerd race documented in `.claude/rules/deploy.md`,
+  unrelated to this PR's content). `gh run rerun --failed` succeeded
+  immediately (one rerun, per `ci-monitoring.md`'s "one rerun acceptable
+  to rule out a transient").
+- Deployed + verified on https://forestshop-novy.newlevel.media
+  (v0.3.0-dev.13 in DOM footer, `/api/version` commit matches `d49aaf54`):
+  logged in as the real owner account (role `admin`), changed order
+  20261259's line (product "Poľovnícke kraťasy HART GOROSTA-SH") from
+  "Objednané" to "Čaká sa" via the live select, confirmed the DOM showed
+  the new value, reloaded the page and confirmed it PERSISTED (proves the
+  write+audit transaction committed), then restored it back to
+  "Objednané" (real production data, real customer order). Zero console
+  errors beyond the sanctioned unauthenticated `/api/me` 401.
+- Per-ticket Discord card fired (`notify --run-card`, confirmed delivered).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.13",
+  "version": "0.3.0-dev.14",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Summary
- Independent code review of #25 (order line state change), run after merge since the ticket adds a new authenticated write endpoint, found a 🟡 concurrency gap and a 🔵 accessibility regression — both fixed here
- `setOrderLineState()`'s read of the prior state is now row-locked (`.for("update")`), preventing a stale `from` value in the audit trail under concurrent state changes on the same line
- The state-change `<select>`'s `aria-label` is restored to a full description; the pre-existing `catalog.spec.ts` test that collided with it now uses `getByLabel("Stav", { exact: true })` instead

## Test plan
- [x] New deterministic regression test (`orders-state-lock.integration.test.ts`) — verified RED without the fix (records stale `from`), GREEN with it
- [x] `pnpm typecheck` / `pnpm lint` — clean
- [x] `pnpm test` + `pnpm test:integration` — all green (136 integration tests)
- [x] `pnpm --filter @forestshop/web e2e` — full suite green
- [x] CI green (check, integration, e2e, docker-build, version-check)

Addresses #25 (already closed by #33; this is a follow-up review-finding fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
