### PR TITLE
Fix intermittent e2e flake: isolate password-change test's e2e user (#32)

### DIFF
--- a/apps/api/tests/e2e-setup-user-isolation.integration.test.ts
+++ b/apps/api/tests/e2e-setup-user-isolation.integration.test.ts
@@ -1,0 +1,122 @@
+// #32: `apps/web/tests/e2e/orders.spec.ts`'s prvý test niekedy zlyhával pri
+// súbežnom Playwright behu (`--workers=2`) — koreňová príčina bola, že
+// `login.spec.ts`'s test zmeny hesla DOČASNE menil skutočné heslo ZDIEĽANÉHO
+// e2e účtu (`e2e@forestshop.sk`), ktorý súčasne používajú aj
+// `catalog.spec.ts`/`orders.spec.ts` v inom, súbežne bežiacom workeri — súbežné
+// `POST /api/login` s naprogramovaným pôvodným heslom potom spadlo presne do
+// okna medzi zmenou a vrátením hesla a dostalo skutočný 401. Reprodukované a
+// zdokumentované na tickete (5× `pnpm --filter @forestshop/web e2e --workers=2`,
+// 4× zlyhalo, koreláciou timestampov potvrdené presne toto).
+//
+// Oprava: `login.spec.ts`'s test zmeny hesla dostal VLASTNÝ, IZOLOVANÝ účet
+// (`E2E_HESLO_ZMENA_EMAIL` v `scripts/e2e-setup.ts`) — jediný, ktorého heslo sa
+// kedy mení. Tento test to dokazuje SPUSTENÍM SKUTOČNÉHO `scripts/e2e-setup.ts`
+// ako podproces (rovnaký vzor ako `catalog-ingest-script.integration.test.ts` —
+// nie preimplementovaná kópia, aby chytil aj budúcu regresiu priamo v skripte),
+// a potom priamym volaním `login()`/`changePassword()` (mimo HTTP, teda mimo
+// `login-rate-limit.ts`'s modulového singletonu — ten NIE je táto chyba, pozri
+// komentár na #32) overí: zmena hesla DEDIKOVANÉHO účtu nikdy neovplyvní
+// prihlásenie ZDIEĽANÉHO účtu, aj keď sa oba spočiatku delia o rovnaké heslo.
+//
+// RED pred opravou #32: skript seedoval JEDNÉHO e2e používateľa
+// (`e2e@forestshop.sk`) — dedikovaný `E2E_HESLO_ZMENA_EMAIL` účet v DB vôbec
+// neexistoval, takže druhé `login()` nižšie vráti `null` namiesto session a
+// test zlyhá skôr, než sa dostane k samotnému dôkazu izolácie.
+import { spawn } from "node:child_process";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { eq } from "drizzle-orm";
+import { afterEach, expect, it } from "vitest";
+import { changePassword } from "../src/modules/auth/change-password.js";
+import { login } from "../src/modules/auth/service.js";
+import { users } from "../src/db/schema.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// `tests/` je `apps/api/tests/` — tri úrovne hore je koreň repozitára, kde žije
+// `scripts/e2e-setup.ts` aj `node_modules/.bin/tsx` (rovnaký vzor ako
+// `catalog-ingest-script.integration.test.ts`).
+const REPO_ROOT = fileURLToPath(new URL("../../../", import.meta.url));
+const TSX_BIN = join(REPO_ROOT, "node_modules/.bin/tsx");
+const SCRIPT_PATH = join(REPO_ROOT, "scripts/e2e-setup.ts");
+
+// Musia sa zhodovať so `scripts/e2e-setup.ts` a `apps/web/tests/e2e/login.spec.ts`.
+const ZDIELANY_EMAIL = "e2e@forestshop.sk";
+const ZMENA_EMAIL = "e2e-heslo@forestshop.sk";
+const PUVODNE_HESLO = "e2e-test-heslo";
+const NOVE_HESLO_LEN_PRE_TEST = "iny-e2e-izolacny-test-heslo-xyz";
+
+let close: (() => Promise<void>) | undefined;
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+});
+
+function runSetupScript(databaseUrl: string): Promise<{ exitCode: number | null; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(TSX_BIN, [SCRIPT_PATH], {
+      cwd: REPO_ROOT,
+      env: { ...process.env, DATABASE_URL: databaseUrl },
+    });
+    let stderr = "";
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+    child.on("error", reject);
+    child.on("close", (exitCode) => {
+      resolve({ exitCode, stderr });
+    });
+  });
+}
+
+it(
+  "#32: zmena hesla dedikovaného e2e účtu nikdy neovplyvní prihlásenie zdieľaného e2e účtu",
+  async () => {
+    const ctx = await withCleanDb();
+    close = ctx.close;
+    const databaseUrl = process.env["DATABASE_URL"];
+    if (databaseUrl === undefined || databaseUrl === "") {
+      throw new Error("Integračné testy potrebujú DATABASE_URL na testovaciu databázu");
+    }
+
+    const result = await runSetupScript(databaseUrl);
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+
+    const now = new Date("2026-07-30T10:00:00Z");
+
+    // Sanity: oba účty existujú a spočiatku majú ROVNAKÉ heslo — presne to, čo
+    // `scripts/e2e-setup.ts` seeduje.
+    const zdielanaSession = await login(ctx.db, { email: ZDIELANY_EMAIL, password: PUVODNE_HESLO, now });
+    if (zdielanaSession === null) throw new Error("zdieľaný e2e účet sa neprihlásil pôvodným heslom");
+    const zmenaSession = await login(ctx.db, { email: ZMENA_EMAIL, password: PUVODNE_HESLO, now });
+    if (zmenaSession === null) throw new Error("dedikovaný e2e účet sa neprihlásil pôvodným heslom");
+
+    const [zmenaUser] = await ctx.db.select({ id: users.id }).from(users).where(eq(users.email, ZMENA_EMAIL));
+    if (zmenaUser === undefined) throw new Error("dedikovaný e2e účet nebol po behu skriptu nájdený");
+
+    const zmenaVysledok = await changePassword(ctx.db, {
+      userId: zmenaUser.id,
+      oldPassword: PUVODNE_HESLO,
+      newPassword: NOVE_HESLO_LEN_PRE_TEST,
+      currentSessionToken: zmenaSession.token,
+      now,
+    });
+    expect(zmenaVysledok).toBe("ok");
+
+    // Sanity: dedikovaný účet teraz pôvodné heslo skutočne odmieta — dôkaz, že
+    // zmena reálne prebehla, nie len že volanie vrátilo "ok".
+    await expect(
+      login(ctx.db, { email: ZMENA_EMAIL, password: PUVODNE_HESLO, now }),
+    ).resolves.toBeNull();
+
+    // Samotný dôkaz izolácie (#32): ZDIEĽANÝ účet, ktorého heslo nikto nemenil,
+    // sa PRESNE V TEJTO CHVÍLI — keď je heslo DEDIKOVANÉHO účtu už zmenené — stále
+    // prihlási svojím pôvodným, nezmeneným heslom. Ak by oba e-maily mierili na
+    // TEN ISTÝ riadok (alebo ak by dedikovaný účet vôbec neexistoval a test by
+    // padol vyššie), toto by zlyhalo presne tak, ako #32 zlyhával v Playwrighte.
+    await expect(
+      login(ctx.db, { email: ZDIELANY_EMAIL, password: PUVODNE_HESLO, now }),
+    ).resolves.not.toBeNull();
+  },
+  20_000,
+);

--- a/apps/web/tests/e2e/login.spec.ts
+++ b/apps/web/tests/e2e/login.spec.ts
@@ -2,6 +2,15 @@ import { expect, test, type ConsoleMessage } from "@playwright/test";
 
 const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
 const ZLE_HESLO = "nespravne";
+// #32: samostatný, IZOLOVANÝ účet len pre test zmeny hesla nižšie — musí sa
+// zhodovať s `E2E_HESLO_ZMENA_EMAIL` v `scripts/e2e-setup.ts`. Ten test
+// DOČASNE mení skutočné heslo prihláseného účtu v DB; keby sa prihlasoval pod
+// zdieľaným `e2e@forestshop.sk` (ako zvyšné testy tu aj `catalog.spec.ts`/
+// `orders.spec.ts`), súbežný `POST /api/login` z INÉHO spec súboru (Playwright
+// pri `--workers=2` beží spec súbory súbežne proti JEDNÉMU API serveru + DB)
+// by mohol spadnúť do okna medzi zmenou a vrátením hesla a dostať skutočný
+// 401 — presne mechanizmus, ktorý spôsoboval #32.
+const E2E_HESLO_ZMENA_EMAIL = "e2e-heslo@forestshop.sk";
 
 test("manažér sa prihlási, vidí svoje meno a verziu, konzola je čistá", async ({ page }) => {
   const chyby: string[] = [];
@@ -68,7 +77,7 @@ test("zmena hesla: zlé staré heslo/nezhoda odmietnuté, úspešná zmena zruš
   sledujKonzolu(page);
 
   await page.goto("/");
-  await page.getByLabel("E-mail").fill("e2e@forestshop.sk");
+  await page.getByLabel("E-mail").fill(E2E_HESLO_ZMENA_EMAIL);
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
   await expect(page.getByTestId("greeting")).toContainText("E2E Manažér");
@@ -79,7 +88,7 @@ test("zmena hesla: zlé staré heslo/nezhoda odmietnuté, úspešná zmena zruš
   const page2 = await context2.newPage();
   sledujKonzolu(page2);
   await page2.goto("/");
-  await page2.getByLabel("E-mail").fill("e2e@forestshop.sk");
+  await page2.getByLabel("E-mail").fill(E2E_HESLO_ZMENA_EMAIL);
   await page2.getByLabel("Heslo").fill(E2E_HESLO);
   await page2.getByRole("button", { name: "Prihlásiť sa" }).click();
   await expect(page2.getByTestId("greeting")).toContainText("E2E Manažér");

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -345,3 +345,26 @@ RED→GREEN test names, key decisions, and the shared PR.
   "Objednané" (real production data, real customer order). Zero console
   errors beyond the sanctioned unauthenticated `/api/me` 401.
 - Per-ticket Discord card fired (`notify --run-card`, confirmed delivered).
+- **Follow-up fix cycle (same ticket, after merge):** dispatched an
+  independent code-review subagent against the merged diff (`917242c
+  ..7183ade`) as extra due diligence since #25 adds a new authenticated
+  write endpoint. Found 🟡 `setOrderLineState`'s SELECT wasn't row-locked
+  (audit `from` could go stale under two concurrent state changes on the
+  same line — the `state` column itself still ended up correct,
+  last-write-wins) and 🔵 the state select's `aria-label` had been
+  stripped of the word "stav" to dodge a Playwright substring collision,
+  silently sacrificing accessibility. Design rationale posted on #25
+  ([comment](https://github.com/zbynekdrlik/forestshop-app/issues/25#issuecomment-5125171329))
+  before the fix commit `eb0703d`: added `.for("update")` + a new
+  deterministic regression test `orders-state-lock.integration.test.ts`
+  (verified RED without the lock, GREEN with it — same pattern as
+  `catalog-ingest-lock.integration.test.ts`); restored a full `aria-label`
+  and instead made the COLLIDING existing test
+  (`catalog.spec.ts`) use `getByLabel("Stav", { exact: true })`. PR **#34**
+  (`dev` → `main`), merged `e736aab`. CI all green on both push and PR
+  runs. Deployed + verified: https://forestshop-novy.newlevel.media shows
+  `v0.3.0-dev.14` in the DOM footer, `/api/version` commit matches
+  `e736aaba`, the new accessible `aria-label` ("Zmeniť stav riadku
+  objednávky …") is live in the DOM, order 20261259's line still correctly
+  shows "Objednané" (the earlier manual test restore held), zero console
+  errors.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.14",
+  "version": "0.3.0-dev.15",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -1,7 +1,7 @@
-// Pripraví databázu pre E2E beh: vymaže všetky riadky a založí presne jedného
-// testovacieho používateľa. Beží pred štartom API servera (viď
+// Pripraví databázu pre E2E beh: vymaže všetky riadky a založí testovacích
+// používateľov. Beží pred štartom API servera (viď
 // apps/web/playwright.config.ts) a je idempotentný — opakované spustenie
-// necháva presne jedného používateľa vďaka TRUNCATE pred insertom.
+// necháva rovnaký počet používateľov vďaka TRUNCATE pred insertom.
 //
 // POZOR: mieri na tú istú lokálnu databázu ako integračné testy (DATABASE_URL
 // z prostredia). To je v poriadku LEN preto, že tabuľky vždy najprv vyprázdni
@@ -14,7 +14,20 @@ import { hashPassword } from "../apps/api/src/modules/auth/passwords.js";
 import { ingestCatalog } from "../apps/api/src/modules/catalog/ingest.js";
 import { DEFAULT_SNAPSHOT_LIMITS } from "../apps/api/src/modules/catalog/validation.js";
 
-const E2E_HESLO = "e2e-test-heslo"; // musí sa zhodovať s hodnotou v login.spec.ts
+const E2E_HESLO = "e2e-test-heslo"; // musí sa zhodovať s hodnotou v login.spec.ts/catalog.spec.ts/orders.spec.ts
+
+// #32: vlastný, IZOLOVANÝ účet len pre `login.spec.ts`'s test zmeny hesla.
+// Ten test DOČASNE mení SKUTOČNÉ heslo prihláseného účtu v DB (staré → nové →
+// späť) — keby sa prihlasoval pod ZDIEĽANÝM `e2e@forestshop.sk` (ako
+// `catalog.spec.ts`/`orders.spec.ts`/zvyšné testy v `login.spec.ts`), Playwright
+// pri `--workers=2` (CI default) plánuje spec SÚBORY na súbežné workery proti
+// JEDNÉMU zdieľanému API serveru + JEDNEJ DB — súbežný `POST /api/login` z INÉHO
+// súboru, spadnutý presne do okna medzi zmenou a vrátením hesla, by dostal
+// skutočný 401 (heslo v DB v tej chvíli nesedí s naprogramovaným literálom).
+// Reprodukované a potvrdené #32 (5× `--workers=2`, 4× zlyhalo presne takto —
+// pozri komentár na tickete pred touto zmenou). Účet tu nižšie zostáva jediný,
+// ktorého heslo sa kedy mení — nikto iný sa pod ním neprihlasuje.
+const E2E_HESLO_ZMENA_EMAIL = "e2e-heslo@forestshop.sk"; // musí sa zhodovať s hodnotou v login.spec.ts
 
 const { db, pool } = createDb();
 // Konštantný literál bez interpolácie — obyčajný reťazec je tu rovnako bezpečný
@@ -33,6 +46,15 @@ await db.execute(
 );
 await db.insert(users).values({
   email: "e2e@forestshop.sk",
+  passwordHash: await hashPassword(E2E_HESLO),
+  displayName: "E2E Manažér",
+  role: "manazer",
+});
+// Rovnaké počiatočné heslo a zobrazované meno ako vyššie (žiadny test naň
+// nespolieha ako na odlišujúci znak) — jediný rozdiel je e-mail, ktorý ho robí
+// SAMOSTATNÝM riadkom v `users`, izolovaným od zdieľaného účtu vyššie.
+await db.insert(users).values({
+  email: E2E_HESLO_ZMENA_EMAIL,
   passwordHash: await hashPassword(E2E_HESLO),
   displayName: "E2E Manažér",
   role: "manazer",


### PR DESCRIPTION
Closes #32

## Root cause

`scripts/e2e-setup.ts` seeded exactly ONE e2e user (`e2e@forestshop.sk`), shared
by `login.spec.ts`, `catalog.spec.ts`, and `orders.spec.ts`. `login.spec.ts`'s
password-change test temporarily mutates that shared account's real password
in the DB. With Playwright's default `--workers=2` (matching CI), spec FILES
run concurrently against one shared API server + Postgres — a concurrent
`POST /api/login` from another spec file, using the hard-coded original
password, could land inside the mutation window and get a genuine 401,
so the dashboard never renders and the 5s assertion times out.

Reproduced directly: 5x `pnpm --filter @forestshop/web e2e --workers=2`,
4/5 failed. Server-side debug logs correlated the exact timing across all
4 failures. Confirmed NOT the rate limiter (9 total `/api/login` calls per
run, well under `MAX_ATTEMPTS=10`, zero 429s) and NOT Postgres pool
exhaustion (all requests 60-160ms). Full evidence + rejected alternative
posted to the issue before any code: https://github.com/zbynekdrlik/forestshop-app/issues/32#issuecomment-5125363114

## Fix

`login.spec.ts`'s password-change test now uses its OWN dedicated,
isolated e2e account (`e2e-heslo@forestshop.sk`, seeded in
`scripts/e2e-setup.ts`) instead of the shared one — its password mutation
can never again race a concurrent login from another spec file.

## Verification

- New regression test `apps/api/tests/e2e-setup-user-isolation.integration.test.ts`
  runs the REAL `scripts/e2e-setup.ts` as a subprocess and proves the
  isolation via `login()`/`changePassword()` directly. RED before the fix
  (dedicated account didn't exist), GREEN after.
- `pnpm --filter @forestshop/web e2e --workers=2`: 8/8 clean runs after the
  fix (previously 4/5 failed).
- Full local gate green: typecheck, lint, unit, integration (137 tests).
