### PR TITLE
docs: capture #32 root cause in playbook + version bump

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -154,9 +154,33 @@ paths:
   novo pridaný test.
 - **Playwright s viacerými workermi (predvolený počet, ako aj CI runner)
   môže byť nestály — všetky e2e spec súbory zdieľajú JEDEN bežiaci API
-  server aj JEDNU lokálnu Postgres inštanciu.** Sledované #25/#32:
-  `orders.spec.ts`'s prvý test niekedy zlyhá na chýbajúcom "Na
-  objednanie" nadpise (5s timeout) pri `--workers=2`, spoľahlivo prejde
-  pri `--workers=1`. Potvrdené ako PRE-EXISTING (reprodukované aj na
-  čistom `origin/dev` bez akejkoľvek súvisiacej zmeny) — sledované ako
-  samostatný issue **#32**, nie vec jedného konkrétneho spec súboru.
+  server aj JEDNU lokálnu Postgres inštanciu.** #32 (vyriešené): koreňová
+  príčina NEBOLA rate limiter ani Postgres pool exhaustion (vylúčené
+  priamym dôkazom — 9 volaní `/api/login` na celý beh, ďaleko pod
+  `MAX_ATTEMPTS=10`, žiadna `429`; všetky requesty 60-160ms), ale
+  `login.spec.ts`'s test zmeny hesla, ktorý DOČASNE mení SKUTOČNÉ heslo
+  ZDIEĽANÉHO e2e účtu (`e2e@forestshop.sk`) priamo v DB — súbežný
+  `POST /api/login` z iného spec súboru (`catalog.spec.ts`/
+  `orders.spec.ts`), bežiaci v inom workeri s naprogramovaným pôvodným
+  heslom, mohol spadnúť presne do okna medzi zmenou a vrátením hesla a
+  dostal skutočný `401`. **Všeobecné pravidlo:** ktorýkoľvek e2e test, čo
+  MUTUJE zdieľaný fixture (heslo, rolu, akékoľvek pole zdieľaného riadku),
+  ktorý ČÍTAJÚ aj iné súbežne bežiace spec súbory, potrebuje VLASTNÝ
+  izolovaný fixture riadok — nie zdieľať účet a spoliehať sa na časovanie.
+  Fix: `scripts/e2e-setup.ts` teraz seeduje DRUHÉHO, dedikovaného
+  používateľa (`e2e-heslo@forestshop.sk`) len pre `login.spec.ts`'s test
+  zmeny hesla — nikto iný sa pod ním neprihlasuje. Vynútenie sériového
+  behu (`--workers=1`/`describe.serial`) bolo zámerne zamietnuté ako
+  band-aid, ktorý by nechal presne túto mínu pre AKÝKOĽVEK budúci súbežný
+  test. Regresný dôkaz:
+  `apps/api/tests/e2e-setup-user-isolation.integration.test.ts` (spúšťa
+  SKUTOČNÝ `scripts/e2e-setup.ts` ako podproces, overuje izoláciu priamo
+  cez `login()`/`changePassword()`, mimo HTTP/rate-limitera).
+  **Debug technika pre budúci podobný flake:** `pino` logger tu má default
+  level `debug` (`logger.ts`), ale Playwright svojím `webServer`'s stdout
+  bežne nezobrazuje — spusti lokálnu reprodukciu s
+  `DEBUG=pw:webserver npx playwright test --workers=2`, aby sa JSON logy
+  API servera (vrátane `requestId`/`path`/`status`/`elapsedMs` pre KAŽDÝ
+  request) prepísali do vlastného výstupu; korelácia timestampov medzi
+  zlyhaním a týmito logmi je rýchlejšia cesta k skutočnej príčine než
+  hádanie z popisu symptómu.

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -368,3 +368,31 @@ RED→GREEN test names, key decisions, and the shared PR.
   objednávky …") is live in the DOM, order 20261259's line still correctly
   shows "Objednané" (the earlier manual test restore held), zero console
   errors.
+
+## Issue #32: Playwright e2e s viacerými workermi bol občas nestály (orders.spec.ts prvý test)
+
+Root cause reprodukovaný priamo (5× `pnpm --filter @forestshop/web e2e --workers=2`,
+4/5 zlyhalo) a potvrdený koreláciou timestampov v pino debug logoch API servera:
+`scripts/e2e-setup.ts` seedoval JEDNÉHO zdieľaného e2e používateľa
+(`e2e@forestshop.sk`), pod ktorým sa prihlasovali VŠETKY tri spec súbory.
+`login.spec.ts`'s test zmeny hesla dočasne mení skutočné heslo tohto zdieľaného
+účtu v DB — súbežný `POST /api/login` z INÉHO spec súboru, bežiaceho v inom
+workeri, ktorý spadol presne do okna medzi zmenou a vrátením hesla, dostal
+skutočný 401 (nie 429 — rate limiter aj Postgres pool exhaustion boli vylúčené
+priamym dôkazom z logov: 9 volaní `/api/login` na beh, žiadna 429, latencie
+60-160ms). Design rationale posted on #32
+([comment](https://github.com/zbynekdrlik/forestshop-app/issues/32#issuecomment-5125363114))
+pred prvým kódovým commitom: `[red]` commit `293eba8` pridal regresný
+integračný test (`e2e-setup-user-isolation.integration.test.ts`, spúšťa SKUTOČNÝ
+`scripts/e2e-setup.ts` ako podproces + priamo overuje `login()`/`changePassword()`
+izoláciu — RED pred opravou), `[green]` commit `0ef14dd` dal `login.spec.ts`'s
+testu zmeny hesla VLASTNÝ izolovaný e2e účet (`e2e-heslo@forestshop.sk` v
+`scripts/e2e-setup.ts`). Zamietnutá alternatíva: vynútenie sériového behu
+(`--workers=1`/`describe.serial`) — band-aid, ktorý by nechal mínu pre
+akýkoľvek budúci súbežný test. Overené: 8/8 čistých behov `--workers=2` po
+oprave. PR **#35** (`dev` → `main`), merged `fdb5c0b`. CI all green (push aj
+pull_request run). Deployed + verified: https://forestshop-novy.newlevel.media
+`/api/version` vracia `{"version":"0.3.0-dev.15","commit":"fdb5c0b6..."}`,
+DOM footer ukazuje `v0.3.0-dev.15`, prihlásenie vlastníkovým účtom funguje,
+dashboard "Na objednanie" sa vykresľuje so skutočnými produkčnými dátami,
+konzola čistá (len povolený `/api/me` 401).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.15",
+  "version": "0.3.0-dev.16",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Follow-up to #35 (Fix intermittent e2e flake #32): docs/playbook capture only,
no behavior change.

- Bumps version 0.3.0-dev.15 -> 0.3.0-dev.16 (required after PR #35's merge
  made dev==main).
- `.claude/rules/testing.md`: updates the e2e-flakiness entry with the
  now-resolved #32 root cause and the `DEBUG=pw:webserver` debug technique
  used to find it.
- `docs/autopilot-log.md`: cycle entry for #32.
