### PR TITLE
Implement supplier order-mail sending with editable contact email (#31)

### DIFF
--- a/apps/api/drizzle/0008_jittery_thaddeus_ross.sql
+++ b/apps/api/drizzle/0008_jittery_thaddeus_ross.sql
@@ -1,0 +1,5 @@
+CREATE TABLE "supplier_contact" (
+	"supplier" text PRIMARY KEY NOT NULL,
+	"email" text,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/apps/api/drizzle/meta/0008_snapshot.json
+++ b/apps/api/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,1187 @@
+{
+  "id": "857b5a63-4cc9-4e15-8183-c4763524d0c1",
+  "prevId": "af04d3e5-8f62-4713-8ccd-e255f9fbefe6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1785362232703,
       "tag": "0007_groovy_alice",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1785396136527,
+      "tag": "0008_jittery_thaddeus_ross",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,12 +17,14 @@
     "@node-rs/argon2": "^2.0.0",
     "drizzle-orm": "^0.38.0",
     "hono": "^4.6.0",
+    "nodemailer": "^9.0.3",
     "pg": "^8.13.0",
     "pino": "^9.5.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",
+    "@types/nodemailer": "^8.0.1",
     "@types/pg": "^8.11.0",
     "drizzle-kit": "^0.31.0",
     "vitest": "^3.0.0"

--- a/apps/api/src/db/schema-orders.ts
+++ b/apps/api/src/db/schema-orders.ts
@@ -50,6 +50,19 @@ export const orders = pgTable(
   (t) => [index("order_placed_at_idx").on(t.placedAt)],
 );
 
+// E-mailový kontakt na dodávateľa (#31) — nová dátová položka, ktorá v
+// starej appke nikdy neexistovala (dodávateľ tam bol len názov, viď komentár
+// na tickete). Kľúčovaný PRESNE tým istým reťazcom, aký `queries.ts`'s
+// zoskupenie "Na objednanie" už dnes zobrazuje ako `supplier` (vrátane
+// zástupného "(bez dodávateľa)"), nie priamo na `product.supplier` (to je
+// `null` pre zástupnú skupinu, nie ten čitateľný reťazec) — manažér tak vie
+// nastaviť kontakt aj pre skupinu bez dodávateľa, keby to niekedy potreboval.
+export const supplierContacts = pgTable("supplier_contact", {
+  supplier: text("supplier").primaryKey(),
+  email: text("email"),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+});
+
 export const orderLines = pgTable(
   "order_line",
   {

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -16,6 +16,16 @@ const envSchema = z.object({
   // nej appka beží ďalej, len CLI import objednávok zlyhá nahlas hneď na štarte.
   SHOPTET_ORDERS_URL: z.string().url().optional(),
   ORDERS_RAW_DIR: z.string().min(1).default("./data/orders-raw"),
+  // Odosielanie objednávky dodávateľovi mailom (#31) — rovnaký mechanizmus ako
+  // stará appka (SMTP, env premenné). Nepovinné ako `SHOPTET_EXPORT_URL`
+  // vyššie: bez `MAIL_HOST` appka beží ďalej, len odoslanie mailom vráti 503
+  // (heslo/prihlasovacie údaje sú tiež nepovinné — niektoré SMTP relaye
+  // nevyžadujú autentifikáciu).
+  MAIL_HOST: z.string().min(1).optional(),
+  MAIL_PORT: z.coerce.number().int().positive().default(587),
+  MAIL_USER: z.string().optional(),
+  MAIL_PASS: z.string().optional(),
+  MAIL_FROM: z.string().optional(),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/apps/api/src/http/app.ts
+++ b/apps/api/src/http/app.ts
@@ -7,6 +7,7 @@ import { log } from "../logger.js";
 import { changePassword } from "../modules/auth/change-password.js";
 import { MIN_NEW_PASSWORD_LENGTH } from "../modules/auth/passwords.js";
 import { login, logout } from "../modules/auth/service.js";
+import type { MailTransport } from "../modules/mail/transport.js";
 import { appVersion } from "../version.js";
 import { registerCatalogRoutes, type RunIngest } from "./catalog-routes.js";
 import { checkLoginRateLimit, clientIp } from "./login-rate-limit.js";
@@ -14,6 +15,7 @@ import { SESSION_COOKIE, requireUser, type AppBindings } from "./middleware.js";
 import { registerOrdersRoutes, type RunOrdersIngest } from "./orders-routes.js";
 import { requireSameOrigin } from "./origin-check.js";
 import { registerSchedulerRoutes } from "./scheduler-routes.js";
+import { registerSupplierRoutes } from "./supplier-routes.js";
 
 const loginSchema = z.object({
   email: z.string().email(),
@@ -31,6 +33,7 @@ export function createApp(
     readonly cookieSecure: boolean;
     readonly runIngest?: RunIngest;
     readonly runOrdersIngest?: RunOrdersIngest;
+    readonly sendSupplierMail?: MailTransport;
   },
 ): Hono<AppBindings> {
   const app = new Hono<AppBindings>();
@@ -122,6 +125,7 @@ export function createApp(
   registerCatalogRoutes(app, db, options.runIngest);
   registerOrdersRoutes(app, db, options.runOrdersIngest);
   registerSchedulerRoutes(app, db);
+  registerSupplierRoutes(app, db, options.sendSupplierMail);
 
   // Musí byť registrovaný AŽ PO všetkých skutočných /api/* trasách vyššie — Hono
   // vyberá presnejšiu zhodu, takže tie majú prednosť a sem sa dostane len to, čo

--- a/apps/api/src/http/supplier-routes.ts
+++ b/apps/api/src/http/supplier-routes.ts
@@ -1,0 +1,109 @@
+import { zValidator } from "@hono/zod-validator";
+import type { Hono } from "hono";
+import { z } from "zod";
+import type { Database } from "../db/client.js";
+import { log } from "../logger.js";
+import { record } from "../modules/audit/service.js";
+import type { MailTransport } from "../modules/mail/transport.js";
+import { buildSupplierOrderMailContent, sendSupplierOrderMail } from "../modules/orders/mail.js";
+import { setSupplierContactEmail } from "../modules/orders/supplier-contact.js";
+import { requireRole, requireUser, type AppBindings } from "./middleware.js";
+import { requireSameOrigin } from "./origin-check.js";
+
+const supplierParam = z.object({ supplier: z.string().min(1) });
+
+// Prázdny reťazec (formulár vyčistený) sa berie ako "žiadny e-mail", nie ako
+// neplatná hodnota — inak by manažér nemal ako kontakt zmazať.
+const setSupplierEmailBody = z.object({
+  email: z.preprocess((value) => (value === "" ? null : value), z.string().email().nullable()),
+});
+
+export function registerSupplierRoutes(app: Hono<AppBindings>, db: Database, sendMail: MailTransport | undefined): void {
+  // E-mailový kontakt dodávateľa (#31) — rovnaké oprávnenie ako zmena stavu
+  // riadku objednávky (`requireRole("admin", "manazer")`): manažér kontakty
+  // spravuje, `citanie`/`sef` len čítajú (kontakt je súčasťou
+  // `GET /api/orders/open`, žiadna samostatná čítacia trasa netreba).
+  app.put(
+    "/api/suppliers/:supplier/email",
+    requireSameOrigin(),
+    requireUser(db),
+    requireRole("admin", "manazer"),
+    zValidator("param", supplierParam),
+    zValidator("json", setSupplierEmailBody),
+    async (c) => {
+      const { supplier } = c.req.valid("param");
+      const { email } = c.req.valid("json");
+      const user = c.get("user");
+      const now = new Date();
+      await setSupplierContactEmail(db, { supplier, email, actorUserId: user.userId, now });
+      log.info({ actorUserId: user.userId, supplier, hasEmail: email !== null }, "zmena e-mailu dodávateľa");
+      return c.json({ ok: true as const, email });
+    },
+  );
+
+  // Náhľad mailu — čisto čítacia trasa (žiadny vedľajší efekt), preto len
+  // `requireUser` (rovnaké oprávnenie ako `/api/orders/open`), nie
+  // `requireRole`: prezrieť si, čo by sa poslalo, nie je citlivejšie ako
+  // vidieť samotné otvorené objednávky.
+  app.get(
+    "/api/suppliers/:supplier/order-mail",
+    requireUser(db),
+    zValidator("param", supplierParam),
+    async (c) => {
+      const { supplier } = c.req.valid("param");
+      const content = await buildSupplierOrderMailContent(db, supplier);
+      return c.json(content);
+    },
+  );
+
+  // Odoslanie — rovnaké oprávnenie + CSRF disciplína ako zmena stavu riadku
+  // objednávky. Server VŽDY prepočíta obsah zo skutočného aktuálneho stavu DB
+  // (`sendSupplierOrderMail` → `buildSupplierOrderMailContent`), nikdy
+  // nedôveruje telu z náhľadu. "no_email"/"no_items" sú BEŽNÉ, OČAKÁVANÉ
+  // doménové výsledky (klientské tlačidlo je za rovnakých podmienok
+  // disabled, toto je len obranná záloha) — rovnaký vzor ako
+  // `/api/me/password`'s "zlé staré heslo": 200 s telom, nie 4xx (testing.md
+  // zakazuje rozšíriť jedinú povolenú console-error výnimku). Skutočné
+  // zlyhanie SMTP odoslania (502) a nenakonfigurovaný mailer (503) zostávajú
+  // HTTP-úrovňové chyby, rovnaký vzor ako `/api/orders/ingest`.
+  app.post(
+    "/api/suppliers/:supplier/order-mail/send",
+    requireSameOrigin(),
+    requireUser(db),
+    requireRole("admin", "manazer"),
+    zValidator("param", supplierParam),
+    async (c) => {
+      if (sendMail === undefined) {
+        return c.json({ error: "Odosielanie e-mailov nie je nakonfigurované (chýba MAIL_HOST)." }, 503);
+      }
+      const { supplier } = c.req.valid("param");
+      const user = c.get("user");
+      const now = new Date();
+
+      const result = await sendSupplierOrderMail(db, sendMail, supplier);
+      await record(db, {
+        at: now,
+        actorUserId: user.userId,
+        action: "orders.mail.send",
+        entity: "supplier_contact",
+        entityId: supplier,
+        data:
+          result.status === "sent"
+            ? { supplier, status: result.status, recipient: result.to, itemCount: result.itemCount }
+            : { supplier, status: result.status },
+      });
+      log.info({ actorUserId: user.userId, supplier, status: result.status }, "odoslanie objednávky dodávateľovi mailom");
+
+      switch (result.status) {
+        case "sent":
+          return c.json({ ok: true as const, to: result.to, itemCount: result.itemCount });
+        case "no_email":
+          return c.json({ ok: false as const, error: "Pre tohto dodávateľa nie je nastavený e-mail." });
+        case "no_items":
+          return c.json({ ok: false as const, error: "Nie sú žiadne položky na objednanie pre tohto dodávateľa." });
+        case "send_failed":
+          return c.json({ error: "Odoslanie e-mailu zlyhalo. Skúste to znova o chvíľu." }, 502);
+      }
+    },
+  );
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -9,6 +9,7 @@ import { createApp } from "./http/app.js";
 import { log } from "./logger.js";
 import { createHttpExportFetcher } from "./modules/catalog/fetcher.js";
 import { ingestCatalog } from "./modules/catalog/ingest.js";
+import { createSmtpMailTransport } from "./modules/mail/transport.js";
 import { computeImportWindow, createHttpOrdersExportFetcher } from "./modules/orders/fetcher.js";
 import { DEFAULT_ORDERS_IMPORT_WINDOW_DAYS, ingestOrders, type RunOrdersIngest } from "./modules/orders/ingest.js";
 import {
@@ -67,10 +68,27 @@ const runOrdersIngest: RunOrdersIngest | undefined =
         });
       };
 
+// Odosielanie objednávky dodávateľovi mailom (#31) — rovnaká úvaha ako
+// `runIngest`/`runOrdersIngest` vyššie: `MAIL_HOST` je nepovinná (`env.ts`),
+// bez nej appka beží ďalej, len odoslanie mailom vráti 503
+// (`http/supplier-routes.ts`).
+const mailHost = env.MAIL_HOST;
+const sendSupplierMail =
+  mailHost === undefined
+    ? undefined
+    : createSmtpMailTransport({
+        host: mailHost,
+        port: env.MAIL_PORT,
+        user: env.MAIL_USER,
+        pass: env.MAIL_PASS,
+        from: env.MAIL_FROM,
+      });
+
 const app = createApp(db, {
   cookieSecure: env.SESSION_COOKIE_SECURE,
   ...(runIngest === undefined ? {} : { runIngest }),
   ...(runOrdersIngest === undefined ? {} : { runOrdersIngest }),
+  ...(sendSupplierMail === undefined ? {} : { sendSupplierMail }),
 });
 
 // F2 (#12/#3) + F3 (#22/#28): nočný import katalógu/objednávok, mazanie

--- a/apps/api/src/modules/mail/transport.ts
+++ b/apps/api/src/modules/mail/transport.ts
@@ -1,0 +1,49 @@
+import nodemailer from "nodemailer";
+
+// Rovnaký MECHANIZMUS ako stará appka (`parovanie_produktov`'s
+// `webreview/app.py:1193-1350`, `smtplib`) — obyčajný SMTP, konfigurácia
+// výhradne z premenných prostredia, žiadny secret v repe (#31). `nodemailer`
+// je Node ekvivalent Pythonovho `smtplib` (investigate-existing-first: SMTP
+// protokol sa tu nemá zmysel písať ručne).
+export interface MailMessage {
+  readonly to: string;
+  readonly subject: string;
+  readonly text: string;
+}
+
+export type MailTransport = (message: MailMessage) => Promise<void>;
+
+export interface SmtpMailConfig {
+  readonly host: string;
+  readonly port: number;
+  readonly user?: string | undefined;
+  readonly pass?: string | undefined;
+  readonly from?: string | undefined;
+}
+
+// Odosielateľ: explicitný `MAIL_FROM`, inak SMTP účet (`user`), inak
+// samotný host — appka nikdy nepošle mail bez hlavičky `From`.
+export function createSmtpMailTransport(config: SmtpMailConfig): MailTransport {
+  const transporter = nodemailer.createTransport({
+    host: config.host,
+    port: config.port,
+    // Port 465 = implicitné TLS od začiatku spojenia (SMTPS), inak STARTTLS
+    // (nodemailer si STARTTLS rieši sám, keď `secure: false`) — rovnaká
+    // vetva ako stará appka's `_smtp_deliver` (`port == 465` → `SMTP_SSL`).
+    secure: config.port === 465,
+    auth:
+      config.user !== undefined && config.user !== ""
+        ? { user: config.user, pass: config.pass ?? "" }
+        : undefined,
+  });
+  const from = config.from ?? config.user ?? config.host;
+
+  return async (message: MailMessage): Promise<void> => {
+    await transporter.sendMail({
+      from,
+      to: message.to,
+      subject: message.subject,
+      text: message.text,
+    });
+  };
+}

--- a/apps/api/src/modules/orders/mail.test.ts
+++ b/apps/api/src/modules/orders/mail.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { formatSupplierOrderMailText, type SupplierOrderMailLine } from "./mail.js";
+
+// Čisté funkcie (žiadna DB) — presné hranice slovenského skloňovania
+// (0, 1, 2, 4, 5) a zloženie riadku, ktoré `formatSupplierOrderMailText`
+// zdieľa medzi náhľadom aj odoslaním (`supplier-routes.ts`).
+describe("formatSupplierOrderMailText", () => {
+  it("predmet aj prvý riadok tela sú zhodné, jednotné číslo pre presne 1 položku", () => {
+    const lines: SupplierOrderMailLine[] = [{ variantCode: "40287", sizeLabel: null, quantity: 1 }];
+    const { subject, body } = formatSupplierOrderMailText("DODAVATEL-TEST-1", lines);
+    expect(subject).toBe("Objednávka — DODAVATEL-TEST-1 (1 položka)");
+    expect(body.split("\n")[0]).toBe(subject);
+  });
+
+  it.each([
+    [0, "položiek"],
+    [1, "položka"],
+    [2, "položky"],
+    [4, "položky"],
+    [5, "položiek"],
+    [11, "položiek"],
+  ])("skloňovanie pre %i položiek je '%s'", (count, expectedWord) => {
+    const lines: SupplierOrderMailLine[] = Array.from({ length: count }, (_, i) => ({
+      variantCode: `KOD-${String(i)}`,
+      sizeLabel: null,
+      quantity: 1,
+    }));
+    const { subject } = formatSupplierOrderMailText("Dodávateľ", lines);
+    expect(subject).toBe(`Objednávka — Dodávateľ (${String(count)} ${expectedWord})`);
+  });
+
+  it("riadok s veľkosťou skladá kód | veľkosť | N ks", () => {
+    const lines: SupplierOrderMailLine[] = [{ variantCode: "4859/46", sizeLabel: "46", quantity: 3 }];
+    const { body } = formatSupplierOrderMailText("DODAVATEL-TEST-1", lines);
+    expect(body.split("\n")[1]).toBe("4859/46 | 46 | 3 ks");
+  });
+
+  it("riadok bez veľkosti (jednovariantný produkt) vynechá prázdnu časť, nepridá prázdny stĺpec", () => {
+    const lines: SupplierOrderMailLine[] = [{ variantCode: "40287", sizeLabel: null, quantity: 2 }];
+    const { body } = formatSupplierOrderMailText("Dodávateľ", lines);
+    expect(body.split("\n")[1]).toBe("40287 | 2 ks");
+  });
+
+  it("žiadne položky vyprodukuje predmet '0 položiek' a telo len s hlavičkou", () => {
+    const { subject, body } = formatSupplierOrderMailText("Prázdny dodávateľ", []);
+    expect(subject).toBe("Objednávka — Prázdny dodávateľ (0 položiek)");
+    expect(body).toBe(subject);
+  });
+});

--- a/apps/api/src/modules/orders/mail.ts
+++ b/apps/api/src/modules/orders/mail.ts
@@ -1,0 +1,127 @@
+import { and, asc, eq, isNull } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { orderLines, orders, products, supplierContacts, variants } from "../../db/schema.js";
+import { log } from "../../logger.js";
+import type { MailTransport } from "../mail/transport.js";
+import { NEZNAMY_DODAVATEL } from "./queries.js";
+import { itemsWord } from "./pluralize.js";
+
+// Jeden agregovaný riadok objednávky pre daného dodávateľa — súčet
+// množstva podľa `variant.code` naprieč VŠETKÝMI otvorenými objednávkami
+// toho dodávateľa (veľkosť je súčasťou kódu variantu, netreba samostatný
+// agregačný kľúč ako stará appka's `code + size`, viď komentár na tickete).
+export interface SupplierOrderMailLine {
+  readonly variantCode: string;
+  readonly sizeLabel: string | null;
+  readonly quantity: number;
+}
+
+export interface SupplierOrderMailContent {
+  readonly supplier: string;
+  readonly to: string | null;
+  readonly subject: string;
+  readonly body: string;
+  readonly itemCount: number;
+}
+
+// Jeden riadok textu = `[kód, veľkosť, "N ks"].filter(Boolean).join(' | ')` —
+// rovnaká `.filter(Boolean).join(' | ')` kostra ako stará appka's
+// `orderCopyLines` (`app.js:2076-2142`), len BEZ jej dvoch ďalších polí
+// (per-dodávateľské "grube id", URL produktu) — nová dátová schéma tohoto
+// projektu tieto dva zdroje štruktúrovo nemá (žiadny per-dodávateľský kód
+// položky, žiadna URL v `variant`/`product`), takže v tom istom
+// `filter(Boolean)` mechanizme vždy vypadnú, presne ako by vypadlo prázdne
+// pole u ktoréhokoľvek iného dodávateľa v starej appke.
+function formatSupplierOrderMailLine(line: SupplierOrderMailLine): string {
+  return [line.variantCode, line.sizeLabel ?? "", `${String(line.quantity)} ks`]
+    .filter((part) => part !== "")
+    .join(" | ");
+}
+
+// Čistá funkcia (žiadna DB) — ľahko testovateľná na hraniciach skloňovania
+// (0, 1, 2, 4, 5) bez behu integračných testov.
+export function formatSupplierOrderMailText(
+  supplier: string,
+  lines: readonly SupplierOrderMailLine[],
+): { readonly subject: string; readonly body: string } {
+  const subject = `Objednávka — ${supplier} (${String(lines.length)} ${itemsWord(lines.length)})`;
+  const body = [subject, ...lines.map(formatSupplierOrderMailLine)].join("\n");
+  return { subject, body };
+}
+
+// Len riadky v stave "objednane" (ešte neposlané/nevybavené dodávateľovi) —
+// rovnaký zámer ako stará appka's `outstandingOf`/`!isHandled`: mail má niesť
+// NOVÉ položky na objednanie, nie tie, čo manažér už predtým ručne posunul
+// ďalej (čaká sa/skladom/nedostupné). Poradie riadkov je deterministické
+// (vzostupne podľa kódu variantu) — stará appka triedila podľa poradia
+// zobrazenia v tabe, čo tu nemá priamy ekvivalent; abecedné poradie je
+// stabilné a ľahko overiteľné, nie hádanie chýbajúceho zdroja dát.
+async function loadOutstandingLines(db: Database, supplier: string): Promise<SupplierOrderMailLine[]> {
+  const supplierCondition = supplier === NEZNAMY_DODAVATEL ? isNull(products.supplier) : eq(products.supplier, supplier);
+  const rows = await db
+    .select({
+      variantCode: orderLines.variantCode,
+      sizeLabel: variants.sizeLabel,
+      quantity: orderLines.quantity,
+    })
+    .from(orderLines)
+    .innerJoin(orders, eq(orders.id, orderLines.orderId))
+    .innerJoin(variants, eq(variants.code, orderLines.variantCode))
+    .innerJoin(products, eq(products.key, variants.productKey))
+    .where(and(supplierCondition, eq(orderLines.state, "objednane")))
+    .orderBy(asc(orderLines.variantCode));
+
+  const byCode = new Map<string, SupplierOrderMailLine>();
+  for (const row of rows) {
+    const existing = byCode.get(row.variantCode);
+    if (existing === undefined) {
+      byCode.set(row.variantCode, { variantCode: row.variantCode, sizeLabel: row.sizeLabel, quantity: row.quantity });
+    } else {
+      byCode.set(row.variantCode, { ...existing, quantity: existing.quantity + row.quantity });
+    }
+  }
+  return [...byCode.values()];
+}
+
+// Náhľad aj odoslanie počítajú obsah TOU ISTOU cestou — server vždy prepočíta
+// zo skutočného aktuálneho stavu DB, nikdy nedôveruje telu, ktoré by poslal
+// klient (obrana proti pretekaniu/manipulácii medzi náhľadom a odoslaním).
+export async function buildSupplierOrderMailContent(db: Database, supplier: string): Promise<SupplierOrderMailContent> {
+  const lines = await loadOutstandingLines(db, supplier);
+  const [contact] = await db
+    .select({ email: supplierContacts.email })
+    .from(supplierContacts)
+    .where(eq(supplierContacts.supplier, supplier))
+    .limit(1);
+  const { subject, body } = formatSupplierOrderMailText(supplier, lines);
+  return { supplier, to: contact?.email ?? null, subject, body, itemCount: lines.length };
+}
+
+export type SendSupplierOrderMailResult =
+  | { readonly status: "sent"; readonly to: string; readonly itemCount: number }
+  | { readonly status: "no_email" }
+  | { readonly status: "no_items" }
+  | { readonly status: "send_failed" };
+
+// Odoslanie NEMENÍ stav žiadneho riadku objednávky (#31, návrhový komentár
+// na tickete) — manažér stav ("čaká sa" a ďalej) prepína ručne cez existujúci
+// select, presne ako doteraz. Automatická zmena stavu by pridala správanie,
+// ktoré zadanie nežiada.
+export async function sendSupplierOrderMail(
+  db: Database,
+  transport: MailTransport,
+  supplier: string,
+): Promise<SendSupplierOrderMailResult> {
+  const content = await buildSupplierOrderMailContent(db, supplier);
+  if (content.to === null) return { status: "no_email" };
+  if (content.itemCount === 0) return { status: "no_items" };
+
+  try {
+    await transport({ to: content.to, subject: content.subject, text: content.body });
+  } catch (error) {
+    const rawErrorMessage = error instanceof Error ? error.message : String(error);
+    log.error({ supplier, rawErrorMessage }, "odoslanie objednávky dodávateľovi zlyhalo (SMTP)");
+    return { status: "send_failed" };
+  }
+  return { status: "sent", to: content.to, itemCount: content.itemCount };
+}

--- a/apps/api/src/modules/orders/pluralize.ts
+++ b/apps/api/src/modules/orders/pluralize.ts
@@ -1,0 +1,12 @@
+// Slovenské skloňovanie počtu — presná zhoda so starou appkou
+// (`parovanie_produktov/webreview/static/app.js:1972-1979`, `pluralWord`/
+// `itemsWord`), reprodukovaná verne pre mailový predmet/telo (#31): 1 →
+// jednotné číslo, 2-4 → "málo" tvar, 0 aj 5+ → "veľa" tvar.
+export function pluralWord(n: number, one: string, few: string, many: string): string {
+  if (n === 1) return one;
+  return n >= 2 && n <= 4 ? few : many;
+}
+
+export function itemsWord(n: number): string {
+  return pluralWord(n, "položka", "položky", "položiek");
+}

--- a/apps/api/src/modules/orders/queries.ts
+++ b/apps/api/src/modules/orders/queries.ts
@@ -1,6 +1,6 @@
 import { asc, desc, eq } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
-import { orderLines, orders, products, variants, type OrderLineState } from "../../db/schema.js";
+import { orderLines, orders, products, supplierContacts, variants, type OrderLineState } from "../../db/schema.js";
 
 export interface OpenOrderLine {
   readonly lineId: string;
@@ -19,13 +19,25 @@ export interface OpenOrderLine {
 export interface SupplierOpenOrders {
   readonly supplier: string;
   readonly lines: readonly OpenOrderLine[];
+  // E-mailový kontakt dodávateľa (#31), `null` keď zatiaľ nenastavený —
+  // `supplier_contact` je samostatná tabuľka (manažér ju edituje nezávisle
+  // od importu objednávok), preto sa dopytuje osobitne od hlavného
+  // zoskupovacieho dopytu nižšie, nie cez JOIN naň (zástupný kľúč
+  // "(bez dodávateľa)" nemá zodpovedajúci `product.supplier`, na ktorý by sa
+  // dalo joinovať — kontakt sa priraďuje AŽ PO zoskupení, podľa rovnakého
+  // zobrazovaného kľúča).
+  readonly email: string | null;
 }
 
 // `product.supplier` je v schéme nepovinné (`text("supplier")`, bez
 // `.notNull()`) — Shoptet export niekedy nesie prázdnu hodnotu (`map-row.ts`'s
 // `textOrNull`). Zoskupenie takých riadkov dostáva čitateľný zástupný kľúč
 // namiesto toho, aby zmizli/spadli na `null` kľúč v Mape.
-const NEZNAMY_DODAVATEL = "(bez dodávateľa)";
+// Exportované (nie len modulová konštanta) — `modules/orders/mail.ts` (#31)
+// potrebuje TEN ISTÝ reťazec pri hľadaní kontaktu/agregovaní outstanding
+// riadkov pre zástupnú skupinu, nikdy vlastnú duplicitnú definíciu, ktorá by
+// sa mohla rozísť.
+export const NEZNAMY_DODAVATEL = "(bez dodávateľa)";
 
 // Zoskupenie je na ÚROVNI RIADKA objednávky, nie na úrovni objednávky —
 // jedna objednávka môže obsahovať položky od VIACERÝCH dodávateľov
@@ -84,10 +96,19 @@ export async function listOpenOrderLinesBySupplier(db: Database): Promise<readon
     lines.push(line);
   }
 
+  const contactRows = await db
+    .select({ supplier: supplierContacts.supplier, email: supplierContacts.email })
+    .from(supplierContacts);
+  const emailBySupplier = new Map(contactRows.map((row) => [row.supplier, row.email]));
+
   // `Map` uchováva poradie prvého vloženia kľúča — keďže hlavný dopyt už
   // triedi `asc(products.supplier)`, výsledné poradie skupín je abecedné bez
   // ďalšieho triedenia tu.
-  return [...bySupplier.entries()].map(([supplier, lines]) => ({ supplier, lines }));
+  return [...bySupplier.entries()].map(([supplier, lines]) => ({
+    supplier,
+    lines,
+    email: emailBySupplier.get(supplier) ?? null,
+  }));
 }
 
 export interface OrderDetailLine {

--- a/apps/api/src/modules/orders/supplier-contact.ts
+++ b/apps/api/src/modules/orders/supplier-contact.ts
@@ -1,0 +1,35 @@
+import type { Database } from "../../db/client.js";
+import { supplierContacts } from "../../db/schema.js";
+import { record } from "../audit/service.js";
+
+export interface SetSupplierContactEmailInput {
+  readonly supplier: string;
+  readonly email: string | null;
+  readonly actorUserId: string;
+  readonly now: Date;
+}
+
+// Rovnaký vzor ako `orders/state.ts`'s `setOrderLineState` — zápis novej
+// hodnoty a auditový záznam v JEDNEJ transakcii (#31), aby história "kto
+// nastavil e-mail dodávateľa" nikdy nezostala nekonzistentná so skutočnou
+// hodnotou stĺpca.
+export async function setSupplierContactEmail(db: Database, input: SetSupplierContactEmailInput): Promise<void> {
+  await db.transaction(async (tx) => {
+    await tx
+      .insert(supplierContacts)
+      .values({ supplier: input.supplier, email: input.email, updatedAt: input.now })
+      .onConflictDoUpdate({
+        target: supplierContacts.supplier,
+        set: { email: input.email, updatedAt: input.now },
+      });
+
+    await record(tx, {
+      at: input.now,
+      actorUserId: input.actorUserId,
+      action: "supplier_contact.email.changed",
+      entity: "supplier_contact",
+      entityId: input.supplier,
+      data: { supplier: input.supplier, email: input.email },
+    });
+  });
+}

--- a/apps/api/tests/helpers/db.ts
+++ b/apps/api/tests/helpers/db.ts
@@ -34,8 +34,12 @@ export async function withCleanDb(): Promise<{ db: Database; close: () => Promis
     // "order" itself has no FK into any of the other listed tables, so CASCADE
     // never reaches it: without listing it here, rows would silently survive
     // across tests. "order" is a reserved SQL keyword and must be quoted.
+    // "supplier_contact" (#31) has NO foreign key at all (keyed on the
+    // supplier NAME string, not an id) — CASCADE never reaches it from any
+    // direction, so it must be listed explicitly too, same reasoning as
+    // "order" above.
     await db.execute(
-      sql`TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order" RESTART IDENTITY CASCADE`,
+      sql`TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact RESTART IDENTITY CASCADE`,
     );
   } catch (err) {
     try {

--- a/apps/api/tests/supplier-mail.integration.test.ts
+++ b/apps/api/tests/supplier-mail.integration.test.ts
@@ -1,0 +1,357 @@
+import { eq } from "drizzle-orm";
+import { afterEach, expect, it } from "vitest";
+import { auditEvents, orderLines, orders, supplierContacts, users } from "../src/db/schema.js";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import type { MailMessage, MailTransport } from "../src/modules/mail/transport.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import type { UserRole } from "../src/modules/auth/service.js";
+import { insertTestVariant } from "./helpers/orders.js";
+import { withCleanDb } from "./helpers/db.js";
+
+const HESLO = "test-heslo-abc"; // testovacie údaje, nie tajomstvo
+
+let close: (() => Promise<void>) | undefined;
+
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  resetLoginRateLimit();
+});
+
+// Fake transport (externá služba — SMTP — je jediné, čo `test-strictness.md`
+// dovoľuje mockovať; nič INTERNÉ tu nie je mockované, `sendSupplierOrderMail`/
+// `buildSupplierOrderMailContent` bežia naozaj nad reálnou DB).
+function fakeTransport(): { readonly transport: MailTransport; readonly sent: MailMessage[] } {
+  const sent: MailMessage[] = [];
+  const transport: MailTransport = (message) => {
+    sent.push(message);
+    return Promise.resolve();
+  };
+  return { transport, sent };
+}
+
+function failingTransport(): MailTransport {
+  return () => Promise.reject(new Error("SMTP spojenie zlyhalo: connect ECONNREFUSED"));
+}
+
+async function boot(role: UserRole, sendSupplierMail?: MailTransport) {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const [pouzivatel] = await ctx.db
+    .insert(users)
+    .values({
+      email: "manazer@forestshop.sk",
+      passwordHash: await hashPassword(HESLO),
+      displayName: "Manažér",
+      role,
+    })
+    .returning({ id: users.id });
+  if (pouzivatel === undefined) throw new Error("testovací používateľ sa nepodarilo vložiť");
+
+  const app = createApp(ctx.db, {
+    cookieSecure: false,
+    ...(sendSupplierMail === undefined ? {} : { sendSupplierMail }),
+  });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "manazer@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie, db: ctx.db, userId: pouzivatel.id };
+}
+
+// --- PUT /api/suppliers/:supplier/email -------------------------------------
+
+it("manažér nastaví e-mail dodávateľa, zápis sa objaví v /api/orders/open aj v audite", async () => {
+  const { app, cookie, db, userId } = await boot("manazer");
+  await insertTestVariant(db, "A-1", "Dodávateľ Alfa");
+  await db
+    .insert(orders)
+    .values({ externalOrderId: "5001", customerName: "Zákazník", placedAt: new Date("2026-07-01T00:00:00Z") })
+    .returning()
+    .then(async ([o]) => {
+      if (o === undefined) throw new Error("insert zlyhal");
+      await db.insert(orderLines).values({ orderId: o.id, variantCode: "A-1", quantity: 1 });
+    });
+
+  const res = await app.request(`/api/suppliers/${encodeURIComponent("Dodávateľ Alfa")}/email`, {
+    method: "PUT",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ email: "alfa@dodavatel.example" }),
+  });
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ ok: true, email: "alfa@dodavatel.example" });
+
+  const openRes = await app.request("/api/orders/open", { headers: { cookie } });
+  const openTelo = (await openRes.json()) as { suppliers: { supplier: string; email: string | null }[] };
+  const alfa = openTelo.suppliers.find((s) => s.supplier === "Dodávateľ Alfa");
+  expect(alfa?.email).toBe("alfa@dodavatel.example");
+
+  const udalosti = await db.select().from(auditEvents);
+  const udalost = udalosti.find((e) => e.action === "supplier_contact.email.changed");
+  expect(udalost).toBeDefined();
+  expect(udalost?.actorUserId).toBe(userId);
+  expect(udalost?.entityId).toBe("Dodávateľ Alfa");
+  expect(udalost?.data).toMatchObject({ supplier: "Dodávateľ Alfa", email: "alfa@dodavatel.example" });
+});
+
+it("prázdny reťazec vymaže e-mail dodávateľa (nastaví na null)", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await db.insert(supplierContacts).values({ supplier: "Dodávateľ Alfa", email: "stary@dodavatel.example" });
+
+  const res = await app.request(`/api/suppliers/${encodeURIComponent("Dodávateľ Alfa")}/email`, {
+    method: "PUT",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ email: "" }),
+  });
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ ok: true, email: null });
+
+  const [riadok] = await db.select().from(supplierContacts).where(eq(supplierContacts.supplier, "Dodávateľ Alfa"));
+  expect(riadok?.email).toBeNull();
+});
+
+it("rola citanie nesmie nastaviť e-mail dodávateľa (403)", async () => {
+  const { app, cookie } = await boot("citanie");
+  const res = await app.request(`/api/suppliers/${encodeURIComponent("Dodávateľ Alfa")}/email`, {
+    method: "PUT",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ email: "x@example.com" }),
+  });
+  expect(res.status).toBe(403);
+});
+
+it("nastavenie e-mailu s cudzím Origin je odmietnuté (403)", async () => {
+  const { app, cookie } = await boot("manazer");
+  const res = await app.request(`/api/suppliers/${encodeURIComponent("Dodávateľ Alfa")}/email`, {
+    method: "PUT",
+    headers: {
+      cookie,
+      "content-type": "application/json",
+      origin: "https://utocnik.example",
+      host: "forestshop.example",
+    },
+    body: JSON.stringify({ email: "x@example.com" }),
+  });
+  expect(res.status).toBe(403);
+});
+
+it("neplatný formát e-mailu vráti 400", async () => {
+  const { app, cookie } = await boot("manazer");
+  const res = await app.request(`/api/suppliers/${encodeURIComponent("Dodávateľ Alfa")}/email`, {
+    method: "PUT",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ email: "nie-je-to-mail" }),
+  });
+  expect(res.status).toBe(400);
+});
+
+// --- GET /api/suppliers/:supplier/order-mail (náhľad) -----------------------
+
+it("náhľad agreguje množstvo podľa kódu variantu naprieč objednávkami, vynecháva už vybavené riadky", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await insertTestVariant(db, "4859/46", "Dodávateľ Alfa");
+
+  const [obj1] = await db
+    .insert(orders)
+    .values({ externalOrderId: "6001", customerName: "Zákazník 1", placedAt: new Date("2026-07-01T00:00:00Z") })
+    .returning();
+  const [obj2] = await db
+    .insert(orders)
+    .values({ externalOrderId: "6002", customerName: "Zákazník 2", placedAt: new Date("2026-07-02T00:00:00Z") })
+    .returning();
+  if (obj1 === undefined || obj2 === undefined) throw new Error("insert zlyhal");
+
+  // Dve objednávky rovnakého variantu vo východiskovom stave "objednane" —
+  // majú sa SČÍTAŤ (2 + 3 = 5). Tretia objednávka toho istého variantu je už
+  // "skladom" (vybavená) — nemá sa objaviť v maile vôbec.
+  await db.insert(orderLines).values({ orderId: obj1.id, variantCode: "4859/46", quantity: 2 });
+  await db.insert(orderLines).values({ orderId: obj2.id, variantCode: "4859/46", quantity: 3 });
+
+  await insertTestVariant(db, "9999/S", "Dodávateľ Alfa");
+  const [obj3] = await db
+    .insert(orders)
+    .values({ externalOrderId: "6003", customerName: "Zákazník 3", placedAt: new Date("2026-07-03T00:00:00Z") })
+    .returning();
+  if (obj3 === undefined) throw new Error("insert zlyhal");
+  await db.insert(orderLines).values({ orderId: obj3.id, variantCode: "9999/S", quantity: 7, state: "skladom" });
+
+  await db.insert(supplierContacts).values({ supplier: "Dodávateľ Alfa", email: "alfa@dodavatel.example" });
+
+  const res = await app.request(`/api/suppliers/${encodeURIComponent("Dodávateľ Alfa")}/order-mail`, {
+    headers: { cookie },
+  });
+  expect(res.status).toBe(200);
+  const telo = (await res.json()) as { to: string | null; subject: string; body: string; itemCount: number };
+  expect(telo.to).toBe("alfa@dodavatel.example");
+  expect(telo.itemCount).toBe(1);
+  expect(telo.subject).toBe("Objednávka — Dodávateľ Alfa (1 položka)");
+  expect(telo.body).toBe("Objednávka — Dodávateľ Alfa (1 položka)\n4859/46 | 5 ks");
+});
+
+it("náhľad pre dodávateľa bez e-mailu vráti to: null", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await insertTestVariant(db, "Z-1", "Dodávateľ Zeta");
+  const [obj] = await db
+    .insert(orders)
+    .values({ externalOrderId: "7001", customerName: "Zákazník", placedAt: new Date("2026-07-01T00:00:00Z") })
+    .returning();
+  if (obj === undefined) throw new Error("insert zlyhal");
+  await db.insert(orderLines).values({ orderId: obj.id, variantCode: "Z-1", quantity: 1 });
+
+  const res = await app.request(`/api/suppliers/${encodeURIComponent("Dodávateľ Zeta")}/order-mail`, {
+    headers: { cookie },
+  });
+  expect((await res.json()) as { to: string | null }).toMatchObject({ to: null });
+});
+
+// --- POST /api/suppliers/:supplier/order-mail/send --------------------------
+
+it("manažér odošle objednávku mailom, audit nesie príjemcu a počet položiek", async () => {
+  const { transport, sent } = fakeTransport();
+  const { app, cookie, db, userId } = await boot("manazer", transport);
+  await insertTestVariant(db, "4859/46", "Dodávateľ Alfa");
+  const [obj] = await db
+    .insert(orders)
+    .values({ externalOrderId: "8001", customerName: "Zákazník", placedAt: new Date("2026-07-01T00:00:00Z") })
+    .returning();
+  if (obj === undefined) throw new Error("insert zlyhal");
+  await db.insert(orderLines).values({ orderId: obj.id, variantCode: "4859/46", quantity: 4 });
+  await db.insert(supplierContacts).values({ supplier: "Dodávateľ Alfa", email: "alfa@dodavatel.example" });
+
+  const res = await app.request(`/api/suppliers/${encodeURIComponent("Dodávateľ Alfa")}/order-mail/send`, {
+    method: "POST",
+    headers: { cookie },
+  });
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ ok: true, to: "alfa@dodavatel.example", itemCount: 1 });
+
+  expect(sent).toHaveLength(1);
+  expect(sent[0]).toMatchObject({
+    to: "alfa@dodavatel.example",
+    subject: "Objednávka — Dodávateľ Alfa (1 položka)",
+    text: "Objednávka — Dodávateľ Alfa (1 položka)\n4859/46 | 4 ks",
+  });
+
+  const udalosti = await db.select().from(auditEvents);
+  const udalost = udalosti.find((e) => e.action === "orders.mail.send");
+  expect(udalost).toBeDefined();
+  expect(udalost?.actorUserId).toBe(userId);
+  expect(udalost?.data).toMatchObject({
+    supplier: "Dodávateľ Alfa",
+    status: "sent",
+    recipient: "alfa@dodavatel.example",
+    itemCount: 1,
+  });
+
+  // Odoslanie NEMENÍ stav riadku (návrhové rozhodnutie na tickete #31) —
+  // zostáva vo východiskovom stave "objednane".
+  const [riadok] = await db.select().from(orderLines).where(eq(orderLines.orderId, obj.id));
+  expect(riadok?.state).toBe("objednane");
+});
+
+it("odoslanie bez nastaveného e-mailu vráti ok:false (200), nič sa neodošle", async () => {
+  const { transport, sent } = fakeTransport();
+  const { app, cookie, db } = await boot("manazer", transport);
+  await insertTestVariant(db, "N-1", "Dodávateľ Bez mailu");
+  const [obj] = await db
+    .insert(orders)
+    .values({ externalOrderId: "8002", customerName: "Zákazník", placedAt: new Date("2026-07-01T00:00:00Z") })
+    .returning();
+  if (obj === undefined) throw new Error("insert zlyhal");
+  await db.insert(orderLines).values({ orderId: obj.id, variantCode: "N-1", quantity: 1 });
+
+  const res = await app.request(`/api/suppliers/${encodeURIComponent("Dodávateľ Bez mailu")}/order-mail/send`, {
+    method: "POST",
+    headers: { cookie },
+  });
+  expect(res.status).toBe(200);
+  expect(await res.json()).toMatchObject({ ok: false });
+  expect(sent).toHaveLength(0);
+});
+
+it("odoslanie bez outstanding položiek vráti ok:false (200), nič sa neodošle", async () => {
+  const { transport, sent } = fakeTransport();
+  const { app, cookie, db } = await boot("manazer", transport);
+  await insertTestVariant(db, "V-1", "Dodávateľ Vybavený");
+  const [obj] = await db
+    .insert(orders)
+    .values({ externalOrderId: "8003", customerName: "Zákazník", placedAt: new Date("2026-07-01T00:00:00Z") })
+    .returning();
+  if (obj === undefined) throw new Error("insert zlyhal");
+  await db.insert(orderLines).values({ orderId: obj.id, variantCode: "V-1", quantity: 1, state: "skladom" });
+  await db.insert(supplierContacts).values({ supplier: "Dodávateľ Vybavený", email: "vybaveny@example.com" });
+
+  const res = await app.request(`/api/suppliers/${encodeURIComponent("Dodávateľ Vybavený")}/order-mail/send`, {
+    method: "POST",
+    headers: { cookie },
+  });
+  expect(res.status).toBe(200);
+  expect(await res.json()).toMatchObject({ ok: false });
+  expect(sent).toHaveLength(0);
+});
+
+it("zlyhanie SMTP odoslania vráti 502 (nie 200/500), audit nesie status send_failed", async () => {
+  const { app, cookie, db, userId } = await boot("manazer", failingTransport());
+  await insertTestVariant(db, "F-1", "Dodávateľ Padne");
+  const [obj] = await db
+    .insert(orders)
+    .values({ externalOrderId: "8004", customerName: "Zákazník", placedAt: new Date("2026-07-01T00:00:00Z") })
+    .returning();
+  if (obj === undefined) throw new Error("insert zlyhal");
+  await db.insert(orderLines).values({ orderId: obj.id, variantCode: "F-1", quantity: 1 });
+  await db.insert(supplierContacts).values({ supplier: "Dodávateľ Padne", email: "padne@example.com" });
+
+  const res = await app.request(`/api/suppliers/${encodeURIComponent("Dodávateľ Padne")}/order-mail/send`, {
+    method: "POST",
+    headers: { cookie },
+  });
+  expect(res.status).toBe(502);
+  const telo = (await res.json()) as { error: string };
+  expect(telo.error).not.toContain("ECONNREFUSED");
+
+  const udalosti = await db.select().from(auditEvents);
+  const udalost = udalosti.find((e) => e.action === "orders.mail.send");
+  expect(udalost?.actorUserId).toBe(userId);
+  expect(udalost?.data).toMatchObject({ supplier: "Dodávateľ Padne", status: "send_failed" });
+});
+
+it("bez nakonfigurovaného MAIL_HOST vráti odoslanie 503", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await insertTestVariant(db, "C-1", "Dodávateľ Chýba mailer");
+  const [obj] = await db
+    .insert(orders)
+    .values({ externalOrderId: "8005", customerName: "Zákazník", placedAt: new Date("2026-07-01T00:00:00Z") })
+    .returning();
+  if (obj === undefined) throw new Error("insert zlyhal");
+  await db.insert(orderLines).values({ orderId: obj.id, variantCode: "C-1", quantity: 1 });
+  await db.insert(supplierContacts).values({ supplier: "Dodávateľ Chýba mailer", email: "x@example.com" });
+
+  const res = await app.request(`/api/suppliers/${encodeURIComponent("Dodávateľ Chýba mailer")}/order-mail/send`, {
+    method: "POST",
+    headers: { cookie },
+  });
+  expect(res.status).toBe(503);
+});
+
+it("rola citanie nesmie odoslať objednávku mailom (403)", async () => {
+  const { transport } = fakeTransport();
+  const { app, cookie } = await boot("citanie", transport);
+  const res = await app.request(`/api/suppliers/${encodeURIComponent("Dodávateľ Alfa")}/order-mail/send`, {
+    method: "POST",
+    headers: { cookie },
+  });
+  expect(res.status).toBe(403);
+});
+
+it("odoslanie s cudzím Origin je odmietnuté (403)", async () => {
+  const { transport } = fakeTransport();
+  const { app, cookie } = await boot("manazer", transport);
+  const res = await app.request(`/api/suppliers/${encodeURIComponent("Dodávateľ Alfa")}/order-mail/send`, {
+    method: "POST",
+    headers: { cookie, origin: "https://utocnik.example", host: "forestshop.example" },
+  });
+  expect(res.status).toBe(403);
+});

--- a/apps/web/src/components/OrdersSection.test.tsx
+++ b/apps/web/src/components/OrdersSection.test.tsx
@@ -1,18 +1,29 @@
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, expect, it, vi } from "vitest";
 import { OrdersSection } from "./OrdersSection.js";
 
-const { fetchOpenOrders, updateOrderLineState } = vi.hoisted(() => ({
-  fetchOpenOrders: vi.fn(),
-  updateOrderLineState: vi.fn(),
-}));
+const { fetchOpenOrders, updateOrderLineState, setSupplierEmail, fetchSupplierOrderMailPreview, sendSupplierOrderMail } =
+  vi.hoisted(() => ({
+    fetchOpenOrders: vi.fn(),
+    updateOrderLineState: vi.fn(),
+    setSupplierEmail: vi.fn(),
+    fetchSupplierOrderMailPreview: vi.fn(),
+    sendSupplierOrderMail: vi.fn(),
+  }));
 
 // `OrdersUnauthorizedError` ostáva SKUTOČNÁ trieda z reálneho modulu — rovnaký
 // dôvod ako `SchedulerSection.test.tsx`'s `SchedulerUnauthorizedError`:
 // `instanceof` v komponente musí fungovať aj v teste.
 vi.mock("../ordersApi.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../ordersApi.js")>();
-  return { ...actual, fetchOpenOrders, updateOrderLineState };
+  return {
+    ...actual,
+    fetchOpenOrders,
+    updateOrderLineState,
+    setSupplierEmail,
+    fetchSupplierOrderMailPreview,
+    sendSupplierOrderMail,
+  };
 });
 
 const { OrdersUnauthorizedError } = await import("../ordersApi.js");
@@ -61,7 +72,7 @@ it("keď zatiaľ nie sú žiadne otvorené objednávky, zobrazí informačnú ve
 
 it("zoskupí riadky podľa dodávateľa a zobrazí produkt, veľkosť, množstvo a stav", async () => {
   fetchOpenOrders.mockResolvedValue([
-    { supplier: "Dodávateľ Alfa", lines: [LINE_NOVA, LINE_STARA] },
+    { supplier: "Dodávateľ Alfa", lines: [LINE_NOVA, LINE_STARA], email: null },
   ]);
 
   render(<OrdersSection role="citanie" onSessionExpired={() => {}} />);
@@ -83,7 +94,7 @@ it("zoskupí riadky podľa dodávateľa a zobrazí produkt, veľkosť, množstvo
 });
 
 it("chýbajúcu veľkosť a komentár zobrazí ako pomlčku", async () => {
-  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_NOVA] }]);
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_NOVA], email: null }]);
 
   render(<OrdersSection role="citanie" onSessionExpired={() => {}} />);
 
@@ -117,7 +128,7 @@ it("keď načítanie zlyhá inou chybou, zobrazí vlastnú slovenskú hlášku",
 // #25: zmena stavu riadku — rola "sef" ostáva na čistom texte, presne ako
 // "citanie" vyššie (rovnaká brána ako server, žiadny select pre neprivilegovanú rolu).
 it("rola sef nevidí select na zmenu stavu, len text", async () => {
-  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_STARA] }]);
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_STARA], email: null }]);
 
   render(<OrdersSection role="sef" onSessionExpired={() => {}} />);
 
@@ -126,7 +137,7 @@ it("rola sef nevidí select na zmenu stavu, len text", async () => {
 });
 
 it("rola manazer vidí select a zmena stavu sa prejaví lokálne bez nového načítania", async () => {
-  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_STARA] }]);
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_STARA], email: null }]);
   updateOrderLineState.mockResolvedValue(undefined);
 
   render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
@@ -150,7 +161,7 @@ it("rola manazer vidí select a zmena stavu sa prejaví lokálne bez nového na�
 });
 
 it("zlyhaná zmena stavu zobrazí slovenskú hlášku zo servera a stav sa nezmení", async () => {
-  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_STARA] }]);
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_STARA], email: null }]);
   updateOrderLineState.mockRejectedValue(new Error("Riadok objednávky sa nenašiel"));
 
   render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
@@ -166,7 +177,7 @@ it("zlyhaná zmena stavu zobrazí slovenskú hlášku zo servera a stav sa nezme
 });
 
 it("zmena stavu pri 401 zavolá onSessionExpired namiesto zobrazenia chyby", async () => {
-  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_STARA] }]);
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_STARA], email: null }]);
   updateOrderLineState.mockRejectedValue(new OrdersUnauthorizedError());
   const onSessionExpired = vi.fn();
 
@@ -180,4 +191,115 @@ it("zmena stavu pri 401 zavolá onSessionExpired namiesto zobrazenia chyby", asy
     expect(onSessionExpired).toHaveBeenCalledTimes(1);
   });
   expect(screen.queryByRole("alert")).toBeNull();
+});
+
+// #31: e-mailový kontakt dodávateľa + odoslanie objednávky mailom.
+
+it("rola citanie nevidí tlačidlá na úpravu e-mailu ani odoslanie mailom, len text", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_STARA], email: null }]);
+
+  render(<OrdersSection role="citanie" onSessionExpired={() => {}} />);
+
+  await screen.findByTestId(`order-line-${LINE_STARA.lineId}`);
+  expect(screen.queryByRole("button", { name: "Upraviť e-mail" })).toBeNull();
+  expect(screen.queryByRole("button", { name: "✉️ Poslať objednávku e-mailom" })).toBeNull();
+  expect(screen.queryByRole("button", { name: "📋 Kopírovať objednávku" })).toBeNull();
+});
+
+it("manažér nastaví e-mail dodávateľa cez formulár, zobrazenie sa aktualizuje bez refetchu", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_STARA], email: null }]);
+  setSupplierEmail.mockResolvedValue(undefined);
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  await screen.findByTestId(`order-line-${LINE_STARA.lineId}`);
+  expect(screen.getByText("E-mail dodávateľa: nenastavený")).toBeTruthy();
+
+  fireEvent.click(screen.getByRole("button", { name: "Upraviť e-mail" }));
+  fireEvent.change(screen.getByLabelText("E-mail dodávateľa Dodávateľ Alfa"), {
+    target: { value: "alfa@dodavatel.example" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: "Uložiť" }));
+
+  await waitFor(() => {
+    expect(setSupplierEmail).toHaveBeenCalledWith("Dodávateľ Alfa", "alfa@dodavatel.example");
+  });
+  await waitFor(() => {
+    expect(screen.getByText("E-mail dodávateľa: alfa@dodavatel.example")).toBeTruthy();
+  });
+  expect(fetchOpenOrders).toHaveBeenCalledTimes(1);
+});
+
+it("bez e-mailu je tlačidlo na odoslanie mailom disabled s vysvetlením", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_STARA], email: null }]);
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const tlacidlo = await screen.findByRole("button", { name: "✉️ Poslať objednávku e-mailom" });
+  expect(tlacidlo.hasAttribute("disabled")).toBe(true);
+  expect(screen.getByText("Pre odoslanie mailom treba najprv nastaviť e-mail dodávateľa.")).toBeTruthy();
+});
+
+it("s e-mailom a otvorenou položkou manažér otvorí náhľad, potvrdí a mail sa odošle", async () => {
+  fetchOpenOrders.mockResolvedValue([
+    { supplier: "Dodávateľ Alfa", lines: [LINE_STARA], email: "alfa@dodavatel.example" },
+  ]);
+  fetchSupplierOrderMailPreview.mockResolvedValue({
+    supplier: "Dodávateľ Alfa",
+    to: "alfa@dodavatel.example",
+    subject: "Objednávka — Dodávateľ Alfa (1 položka)",
+    body: "Objednávka — Dodávateľ Alfa (1 položka)\nA-1 | 3XL | 2 ks",
+    itemCount: 1,
+  });
+  sendSupplierOrderMail.mockResolvedValue({ ok: true });
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const posluTlacidlo = await screen.findByRole("button", { name: "✉️ Poslať objednávku e-mailom" });
+  expect(posluTlacidlo.hasAttribute("disabled")).toBe(false);
+  fireEvent.click(posluTlacidlo);
+
+  await waitFor(() => {
+    expect(fetchSupplierOrderMailPreview).toHaveBeenCalledWith("Dodávateľ Alfa");
+  });
+  const nahlad = await screen.findByTestId("mail-preview-Dodávateľ Alfa");
+  expect(nahlad.textContent).toContain("alfa@dodavatel.example");
+  expect(nahlad.textContent).toContain("Objednávka — Dodávateľ Alfa (1 položka)");
+
+  fireEvent.click(screen.getByRole("button", { name: "Odoslať" }));
+
+  await waitFor(() => {
+    expect(sendSupplierOrderMail).toHaveBeenCalledWith("Dodávateľ Alfa");
+  });
+  await waitFor(() => {
+    expect(screen.getByRole("status").textContent).toContain("odoslaná");
+  });
+  expect(screen.queryByTestId("mail-preview-Dodávateľ Alfa")).toBeNull();
+});
+
+it("kopírovanie objednávky do schránky použije text náhľadu", async () => {
+  fetchOpenOrders.mockResolvedValue([
+    { supplier: "Dodávateľ Alfa", lines: [LINE_STARA], email: "alfa@dodavatel.example" },
+  ]);
+  fetchSupplierOrderMailPreview.mockResolvedValue({
+    supplier: "Dodávateľ Alfa",
+    to: "alfa@dodavatel.example",
+    subject: "Objednávka — Dodávateľ Alfa (1 položka)",
+    body: "Objednávka — Dodávateľ Alfa (1 položka)\nA-1 | 3XL | 2 ks",
+    itemCount: 1,
+  });
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  Object.assign(navigator, { clipboard: { writeText } });
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const kopirovat = await screen.findByRole("button", { name: "📋 Kopírovať objednávku" });
+  fireEvent.click(kopirovat);
+
+  await waitFor(() => {
+    expect(writeText).toHaveBeenCalledWith("Objednávka — Dodávateľ Alfa (1 položka)\nA-1 | 3XL | 2 ks");
+  });
+  await waitFor(() => {
+    expect(screen.getByRole("status").textContent).toContain("schránky");
+  });
 });

--- a/apps/web/src/components/OrdersSection.tsx
+++ b/apps/web/src/components/OrdersSection.tsx
@@ -2,9 +2,13 @@ import { useCallback, useEffect, useState, type JSX } from "react";
 import type { Me } from "../api.js";
 import {
   fetchOpenOrders,
+  fetchSupplierOrderMailPreview,
   OrdersUnauthorizedError,
+  sendSupplierOrderMail,
+  setSupplierEmail,
   updateOrderLineState,
   type OrderLine,
+  type OrderMailPreview,
   type SupplierOpenOrders,
 } from "../ordersApi.js";
 
@@ -22,9 +26,11 @@ const STATE_LABELS: Record<OrderLine["state"], string> = {
 // `CatalogPage`'s `IMPORT_ROLES`/`SchedulerSection`'s `SCHEDULER_ROLES`).
 const CAN_CHANGE_STATE_ROLES: ReadonlySet<Me["role"]> = new Set(["admin", "manazer"]);
 
-// #25: kopírovanie objednávky presunuté do #31 (otvorená otázka pre
-// majiteľa — presný výstup nie je definovaný), preto tu stále nie je žiadne
-// tlačidlo "kopírovať".
+// Riadky, ktoré ešte treba objednať u dodávateľa (rovnaký zámer ako stará
+// appka's `outstandingOf`/`!isHandled`, #31) — východiskový stav pred tým,
+// než manažér čokoľvek ručne posunie ďalej.
+const OUTSTANDING_STATE: OrderLine["state"] = "objednane";
+
 export function OrdersSection({
   role,
   onSessionExpired,
@@ -38,6 +44,19 @@ export function OrdersSection({
   const [stateError, setStateError] = useState("");
   const [busyLineId, setBusyLineId] = useState<string | null>(null);
   const canChangeState = CAN_CHANGE_STATE_ROLES.has(role);
+
+  // #31: e-mailový kontakt dodávateľa (editovateľný priamo v zozname).
+  const [editingEmailSupplier, setEditingEmailSupplier] = useState<string | null>(null);
+  const [emailDraft, setEmailDraft] = useState("");
+  const [emailBusy, setEmailBusy] = useState(false);
+  const [emailError, setEmailError] = useState("");
+
+  // #31: náhľad + potvrdenie pred odoslaním objednávky mailom.
+  const [previewSupplier, setPreviewSupplier] = useState<string | null>(null);
+  const [preview, setPreview] = useState<OrderMailPreview | null>(null);
+  const [previewError, setPreviewError] = useState("");
+  const [sendBusy, setSendBusy] = useState(false);
+  const [sendResult, setSendResult] = useState<{ readonly supplier: string; readonly message: string } | null>(null);
 
   const load = useCallback(() => {
     fetchOpenOrders()
@@ -86,6 +105,129 @@ export function OrdersSection({
     [onSessionExpired],
   );
 
+  // #31: úprava e-mailu dodávateľa.
+  const startEditEmail = useCallback((group: SupplierOpenOrders) => {
+    setEditingEmailSupplier(group.supplier);
+    setEmailDraft(group.email ?? "");
+    setEmailError("");
+  }, []);
+
+  const cancelEditEmail = useCallback(() => {
+    setEditingEmailSupplier(null);
+    setEmailError("");
+  }, []);
+
+  const saveEmail = useCallback(
+    (supplier: string) => {
+      setEmailBusy(true);
+      setEmailError("");
+      const novyEmail = emailDraft.trim() === "" ? null : emailDraft.trim();
+      setSupplierEmail(supplier, novyEmail)
+        .then(() => {
+          setSuppliers((current) =>
+            current.map((group) => (group.supplier === supplier ? { ...group, email: novyEmail } : group)),
+          );
+          setEditingEmailSupplier(null);
+        })
+        .catch((err: unknown) => {
+          if (err instanceof OrdersUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setEmailError(err instanceof Error ? err.message : "Nastavenie e-mailu sa nepodarilo.");
+        })
+        .finally(() => {
+          setEmailBusy(false);
+        });
+    },
+    [emailDraft, onSessionExpired],
+  );
+
+  // #31: náhľad pred odoslaním — server prepočíta predmet/telo/adresáta zo
+  // skutočného aktuálneho stavu (nikdy sa nedôveruje tomu, čo je práve
+  // zobrazené na klientovi).
+  const openPreview = useCallback(
+    (supplier: string) => {
+      setPreviewSupplier(supplier);
+      setPreview(null);
+      setPreviewError("");
+      setSendResult(null);
+      fetchSupplierOrderMailPreview(supplier)
+        .then((p) => {
+          setPreview(p);
+        })
+        .catch((err: unknown) => {
+          if (err instanceof OrdersUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setPreviewError(err instanceof Error ? err.message : "Náhľad mailu sa nepodarilo načítať.");
+        });
+    },
+    [onSessionExpired],
+  );
+
+  const closePreview = useCallback(() => {
+    setPreviewSupplier(null);
+    setPreview(null);
+    setPreviewError("");
+  }, []);
+
+  const confirmSend = useCallback(
+    (supplier: string) => {
+      setSendBusy(true);
+      sendSupplierOrderMail(supplier)
+        .then((result) => {
+          setSendResult({
+            supplier,
+            message: result.ok
+              ? `Objednávka bola odoslaná na ${preview?.to ?? "e-mail dodávateľa"}.`
+              : (result.error ?? "Odoslanie sa nepodarilo."),
+          });
+          if (result.ok) {
+            setPreviewSupplier(null);
+            setPreview(null);
+          }
+        })
+        .catch((err: unknown) => {
+          if (err instanceof OrdersUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setSendResult({ supplier, message: err instanceof Error ? err.message : "Odoslanie sa nepodarilo." });
+        })
+        .finally(() => {
+          setSendBusy(false);
+        });
+    },
+    [onSessionExpired, preview],
+  );
+
+  const copyOrderToClipboard = useCallback(
+    (supplier: string) => {
+      fetchSupplierOrderMailPreview(supplier)
+        .then(async (p) => {
+          try {
+            await navigator.clipboard.writeText(p.body);
+            setSendResult({ supplier, message: "Text objednávky skopírovaný do schránky." });
+          } catch {
+            setSendResult({ supplier, message: "Kopírovanie do schránky sa nepodarilo." });
+          }
+        })
+        .catch((err: unknown) => {
+          if (err instanceof OrdersUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setSendResult({
+            supplier,
+            message: err instanceof Error ? err.message : "Text objednávky sa nepodarilo pripraviť.",
+          });
+        });
+    },
+    [onSessionExpired],
+  );
+
   // `/api/orders/open` už zoraďuje riadky presne tak, ako majú byť zobrazené
   // (dodávateľ vzostupne, potom najnovšia objednávka prvá) — žiadne ďalšie
   // preskupovanie na klientovi.
@@ -103,6 +245,76 @@ export function OrdersSection({
       {suppliers.map((group) => (
         <div key={group.supplier} data-testid={`supplier-${group.supplier}`}>
           <h3>{group.supplier}</h3>
+          <div data-testid={`supplier-contact-${group.supplier}`}>
+            {editingEmailSupplier === group.supplier ? (
+              <>
+                <input
+                  aria-label={`E-mail dodávateľa ${group.supplier}`}
+                  type="email"
+                  value={emailDraft}
+                  disabled={emailBusy}
+                  onChange={(e) => {
+                    setEmailDraft(e.target.value);
+                  }}
+                />
+                <button type="button" disabled={emailBusy} onClick={() => { saveEmail(group.supplier); }}>
+                  Uložiť
+                </button>
+                <button type="button" disabled={emailBusy} onClick={cancelEditEmail}>
+                  Zrušiť
+                </button>
+                {emailError !== "" && <p role="alert">{emailError}</p>}
+              </>
+            ) : (
+              <>
+                <span>E-mail dodávateľa: {group.email ?? "nenastavený"}</span>
+                {canChangeState && (
+                  <button type="button" onClick={() => { startEditEmail(group); }}>
+                    Upraviť e-mail
+                  </button>
+                )}
+              </>
+            )}
+          </div>
+          {canChangeState && (
+            <div>
+              <button type="button" onClick={() => { copyOrderToClipboard(group.supplier); }}>
+                📋 Kopírovať objednávku
+              </button>
+              <button
+                type="button"
+                disabled={group.email === null || !group.lines.some((l) => l.state === OUTSTANDING_STATE)}
+                title={
+                  group.email === null
+                    ? "Pre odoslanie mailom treba najprv nastaviť e-mail dodávateľa."
+                    : undefined
+                }
+                onClick={() => { openPreview(group.supplier); }}
+              >
+                ✉️ Poslať objednávku e-mailom
+              </button>
+              {group.email === null && <p>Pre odoslanie mailom treba najprv nastaviť e-mail dodávateľa.</p>}
+              {sendResult?.supplier === group.supplier && <p role="status">{sendResult.message}</p>}
+              {previewSupplier === group.supplier && (
+                <div data-testid={`mail-preview-${group.supplier}`}>
+                  {previewError !== "" && <p role="alert">{previewError}</p>}
+                  {preview !== null && (
+                    <>
+                      <p>Komu: {preview.to ?? "—"}</p>
+                      <p>Predmet: {preview.subject}</p>
+                      <pre>{preview.body}</pre>
+                      <button type="button" disabled={sendBusy} onClick={() => { confirmSend(group.supplier); }}>
+                        Odoslať
+                      </button>
+                      <button type="button" disabled={sendBusy} onClick={closePreview}>
+                        Zrušiť
+                      </button>
+                    </>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
           <table>
             <thead>
               <tr>

--- a/apps/web/src/ordersApi.test.ts
+++ b/apps/web/src/ordersApi.test.ts
@@ -1,5 +1,12 @@
 import { expect, it, vi } from "vitest";
-import { OrdersUnauthorizedError, fetchOpenOrders, updateOrderLineState } from "./ordersApi.js";
+import {
+  OrdersUnauthorizedError,
+  fetchOpenOrders,
+  fetchSupplierOrderMailPreview,
+  sendSupplierOrderMail,
+  setSupplierEmail,
+  updateOrderLineState,
+} from "./ordersApi.js";
 
 const LINE = {
   lineId: "11111111-1111-1111-1111-111111111111",
@@ -15,18 +22,21 @@ const LINE = {
   state: "objednane" as const,
 };
 
-it("prečíta otvorené objednávky zoskupené podľa dodávateľa", async () => {
+it("prečíta otvorené objednávky zoskupené podľa dodávateľa, vrátane e-mailu dodávateľa", async () => {
   vi.stubGlobal(
     "fetch",
     vi
       .fn()
       .mockResolvedValue(
-        new Response(JSON.stringify({ suppliers: [{ supplier: "Dodávateľ Alfa", lines: [LINE] }] }), {
-          status: 200,
-        }),
+        new Response(
+          JSON.stringify({ suppliers: [{ supplier: "Dodávateľ Alfa", lines: [LINE], email: "alfa@example.com" }] }),
+          { status: 200 },
+        ),
       ),
   );
-  await expect(fetchOpenOrders()).resolves.toEqual([{ supplier: "Dodávateľ Alfa", lines: [LINE] }]);
+  await expect(fetchOpenOrders()).resolves.toEqual([
+    { supplier: "Dodávateľ Alfa", lines: [LINE], email: "alfa@example.com" },
+  ]);
 });
 
 it("odmietne odpoveď s neplatným tvarom", async () => {
@@ -35,9 +45,10 @@ it("odmietne odpoveď s neplatným tvarom", async () => {
     vi
       .fn()
       .mockResolvedValue(
-        new Response(JSON.stringify({ suppliers: [{ supplier: "X", lines: [{ ...LINE, quantity: "1" }] }] }), {
-          status: 200,
-        }),
+        new Response(
+          JSON.stringify({ suppliers: [{ supplier: "X", lines: [{ ...LINE, quantity: "1" }], email: null }] }),
+          { status: 200 },
+        ),
       ),
   );
   await expect(fetchOpenOrders()).rejects.toThrow();
@@ -92,4 +103,77 @@ it("updateOrderLineState bez tela odpovede použije všeobecnú hlášku", async
   await expect(updateOrderLineState("11111111-1111-1111-1111-111111111111", "skladom")).rejects.toThrow(
     "Zmena stavu sa nepodarila",
   );
+});
+
+// #31: e-mailový kontakt dodávateľa + odoslanie objednávky mailom.
+
+it("setSupplierEmail pošle PUT s URL-enkódovaným menom dodávateľa a telom { email }", async () => {
+  const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true, email: "a@b.sk" }), { status: 200 }));
+  vi.stubGlobal("fetch", fetchMock);
+
+  await setSupplierEmail("Dodávateľ Alfa", "a@b.sk");
+
+  expect(fetchMock).toHaveBeenCalledWith(
+    "/api/suppliers/Dod%C3%A1vate%C4%BE%20Alfa/email",
+    expect.objectContaining({ method: "PUT", body: JSON.stringify({ email: "a@b.sk" }) }),
+  );
+});
+
+it("setSupplierEmail s null pošle prázdny reťazec (zmazanie kontaktu)", async () => {
+  const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true, email: null }), { status: 200 }));
+  vi.stubGlobal("fetch", fetchMock);
+
+  await setSupplierEmail("Dodávateľ Alfa", null);
+
+  expect(fetchMock).toHaveBeenCalledWith(
+    expect.any(String),
+    expect.objectContaining({ body: JSON.stringify({ email: "" }) }),
+  );
+});
+
+it("fetchSupplierOrderMailPreview prečíta náhľad predmetu/tela/adresáta", async () => {
+  const preview = { supplier: "Dodávateľ Alfa", to: "a@b.sk", subject: "Objednávka — Dodávateľ Alfa (1 položka)", body: "...", itemCount: 1 };
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify(preview), { status: 200 })));
+  await expect(fetchSupplierOrderMailPreview("Dodávateľ Alfa")).resolves.toEqual(preview);
+});
+
+it("sendSupplierOrderMail vráti ok:true po úspešnom odoslaní", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true, to: "a@b.sk", itemCount: 2 }), { status: 200 })),
+  );
+  await expect(sendSupplierOrderMail("Dodávateľ Alfa")).resolves.toEqual({ ok: true });
+});
+
+it("sendSupplierOrderMail vráti ok:false s hláškou, keď server odpovie ok:false (200)", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ ok: false, error: "Pre tohto dodávateľa nie je nastavený e-mail." }), { status: 200 }),
+      ),
+  );
+  await expect(sendSupplierOrderMail("Dodávateľ Alfa")).resolves.toEqual({
+    ok: false,
+    error: "Pre tohto dodávateľa nie je nastavený e-mail.",
+  });
+});
+
+it("sendSupplierOrderMail pri 502 (zlyhané SMTP) vráti ok:false namiesto vyhodenia výnimky", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ error: "Odoslanie e-mailu zlyhalo. Skúste to znova o chvíľu." }), { status: 502 })),
+  );
+  await expect(sendSupplierOrderMail("Dodávateľ Alfa")).resolves.toEqual({
+    ok: false,
+    error: "Odoslanie e-mailu zlyhalo. Skúste to znova o chvíľu.",
+  });
+});
+
+it("sendSupplierOrderMail pri 401 vyhodí OrdersUnauthorizedError", async () => {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 401 })));
+  await expect(sendSupplierOrderMail("Dodávateľ Alfa")).rejects.toBeInstanceOf(OrdersUnauthorizedError);
 });

--- a/apps/web/src/ordersApi.ts
+++ b/apps/web/src/ordersApi.ts
@@ -22,6 +22,8 @@ const orderLineSchema = z.object({
 const supplierGroupSchema = z.object({
   supplier: z.string(),
   lines: z.array(orderLineSchema),
+  // E-mailový kontakt dodávateľa (#31), `null` keď zatiaľ nenastavený.
+  email: z.string().nullable(),
 });
 
 const openOrdersSchema = z.object({ suppliers: z.array(supplierGroupSchema) });
@@ -77,4 +79,53 @@ export async function updateOrderLineState(
     body: JSON.stringify({ state }),
   });
   await readJson(response, "Zmena stavu sa nepodarila");
+}
+
+// #31: e-mailový kontakt dodávateľa + odoslanie objednávky mailom.
+export async function setSupplierEmail(supplier: string, email: string | null): Promise<void> {
+  const response = await fetch(`/api/suppliers/${encodeURIComponent(supplier)}/email`, {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: email ?? "" }),
+  });
+  await readJson(response, "Nastavenie e-mailu sa nepodarilo");
+}
+
+const orderMailPreviewSchema = z.object({
+  supplier: z.string(),
+  to: z.string().nullable(),
+  subject: z.string(),
+  body: z.string(),
+  itemCount: z.number(),
+});
+
+export type OrderMailPreview = z.infer<typeof orderMailPreviewSchema>;
+
+export async function fetchSupplierOrderMailPreview(supplier: string): Promise<OrderMailPreview> {
+  const response = await fetch(`/api/suppliers/${encodeURIComponent(supplier)}/order-mail`);
+  return orderMailPreviewSchema.parse(await readJson(response, "Náhľad mailu sa nepodarilo načítať"));
+}
+
+const sendOrderMailResultSchema = z.object({
+  ok: z.boolean(),
+  error: z.string().optional(),
+});
+
+/**
+ * Odoslanie prebehlo — `ok` hovorí, či mail reálne odišiel. Na rozdiel od
+ * `readJson` NEhádže na 502/503 (nenakonfigurovaný mailer/zlyhané SMTP) —
+ * tie sú tu rovnocenné "no_email"/"no_items" doménovým výsledkom (odlišné len
+ * HTTP kódom, `http/supplier-routes.ts`), UI ich zobrazuje rovnako ako chybu
+ * poslania, nie ako neočakávanú výnimku.
+ */
+export async function sendSupplierOrderMail(supplier: string): Promise<{ ok: boolean; error?: string }> {
+  const response = await fetch(`/api/suppliers/${encodeURIComponent(supplier)}/order-mail/send`, {
+    method: "POST",
+  });
+  if (response.status === 401) throw new OrdersUnauthorizedError();
+  if (!response.ok) {
+    return { ok: false, error: await serverErrorMessage(response, "Odoslanie objednávky mailom sa nepodarilo") };
+  }
+  const telo = sendOrderMailResultSchema.parse(await response.json());
+  return { ok: telo.ok, ...(telo.error === undefined ? {} : { error: telo.error }) };
 }

--- a/apps/web/tests/e2e/orders.spec.ts
+++ b/apps/web/tests/e2e/orders.spec.ts
@@ -91,3 +91,73 @@ test("manažér prepne stav riadku cez select, zmena pretrvá po obnovení strá
 
   expect(chyby).toEqual([]);
 });
+
+// #31: e-mailový kontakt dodávateľa + náhľad objednávky mailom, cez skutočný
+// prehliadač nad reálne naimportovanými fixtúrovými dátami (`scripts/
+// e2e-setup.ts`). Skutočné ODOSLANIE (SMTP) sa tu zámerne NEKLIKÁ — MAIL_HOST
+// nie je v e2e prostredí nakonfigurovaný (`playwright.config.ts`), takže
+// server by na "Odoslať" vrátil 503, čo by (rovnako ako akýkoľvek iný
+// 4xx/5xx fetch) zalogovalo console error a porušilo jedinú povolenú
+// výnimku (`.claude/rules/testing.md`) — samotné odoslanie je overené
+// integračne (`apps/api/tests/supplier-mail.integration.test.ts`) s falošným
+// transportom. E2E overuje SKUTOČNÝ prehliadačový workflow: nastavenie
+// e-mailu (perzistuje po reloade) a náhľad so správne agregovaným obsahom.
+test("manažér nastaví e-mail dodávateľa a uvidí náhľad mailu so správne agregovaným obsahom, konzola je čistá", async ({ page }) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/");
+  await page.getByLabel("E-mail").fill("e2e@forestshop.sk");
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await expect(page.getByRole("heading", { name: "Na objednanie" })).toBeVisible();
+
+  // Objednávka 9001 (dodávateľ "DODAVATEL-TEST-1") má JEDINÝ riadok vo stave
+  // "caka_sa" (`scripts/e2e-setup.ts`) — teda ŽIADNU otvorenú položku na
+  // objednanie. Tlačidlo odoslania preto musí byť disabled, aj keď sa
+  // e-mail dodávateľa nastaví — overuje, že disabled stav sleduje SKUTOČNÝ
+  // stav riadkov, nie len prítomnosť e-mailu.
+  const skupinaTest1 = page.getByTestId("supplier-DODAVATEL-TEST-1");
+  await skupinaTest1.getByRole("button", { name: "Upraviť e-mail" }).click();
+  await skupinaTest1.getByLabel("E-mail dodávateľa DODAVATEL-TEST-1").fill("test1@dodavatel.example");
+  await skupinaTest1.getByRole("button", { name: "Uložiť" }).click();
+  await expect(skupinaTest1.getByText("E-mail dodávateľa: test1@dodavatel.example")).toBeVisible();
+  await expect(skupinaTest1.getByRole("button", { name: "✉️ Poslať objednávku e-mailom" })).toBeDisabled();
+
+  await page.reload();
+  await expect(page.getByRole("heading", { name: "Na objednanie" })).toBeVisible();
+  await expect(
+    page.getByTestId("supplier-DODAVATEL-TEST-1").getByText("E-mail dodávateľa: test1@dodavatel.example"),
+  ).toBeVisible();
+
+  // Objednávka 9002 (zástupný dodávateľ "(bez dodávateľa)") má riadok vo
+  // východiskovom stave "objednane" — TÁ skupina má odoslanie povolené,
+  // hneď ako dostane e-mail.
+  const skupinaBezDodavatela = page.getByTestId("supplier-(bez dodávateľa)");
+  await skupinaBezDodavatela.getByRole("button", { name: "Upraviť e-mail" }).click();
+  await skupinaBezDodavatela.getByLabel("E-mail dodávateľa (bez dodávateľa)").fill("nezaradene@example.com");
+  await skupinaBezDodavatela.getByRole("button", { name: "Uložiť" }).click();
+  const poslatTlacidlo = skupinaBezDodavatela.getByRole("button", { name: "✉️ Poslať objednávku e-mailom" });
+  await expect(poslatTlacidlo).toBeEnabled();
+  await poslatTlacidlo.click();
+
+  const nahlad = skupinaBezDodavatela.getByTestId("mail-preview-(bez dodávateľa)");
+  await expect(nahlad).toBeVisible();
+  await expect(nahlad).toContainText("nezaradene@example.com");
+  // "40287" je jednovariantný produkt (žiadna veľkosť) s množstvom 1
+  // (`scripts/e2e-setup.ts`) — presný, server-vypočítaný tvar riadku.
+  await expect(nahlad).toContainText("Objednávka — (bez dodávateľa) (1 položka)");
+  await expect(nahlad.locator("pre")).toHaveText("Objednávka — (bez dodávateľa) (1 položka)\n40287 | 1 ks");
+
+  // Zrušenie náhľadu — v tomto teste sa zámerne NEODOSIELA (viď komentár
+  // vyššie).
+  await nahlad.getByRole("button", { name: "Zrušiť" }).click();
+  await expect(nahlad).not.toBeVisible();
+
+  expect(chyby).toEqual([]);
+});

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -47,6 +47,15 @@ services:
       # (#21), bare kľúč preberá `/srv/forestshop/.env`, keď tam je.
       SHOPTET_ORDERS_URL:
       ORDERS_RAW_DIR: /data/orders-raw
+      # Odosielanie objednávky dodávateľovi mailom (#31) — rovnaká úvaha ako
+      # SHOPTET_EXPORT_URL vyššie: `.optional()` v `env.ts`, bare kľúč
+      # preberá `/srv/forestshop/.env`, keď tam je; keď nie je, appka beží
+      # ďalej, len odoslanie mailom vráti 503.
+      MAIL_HOST:
+      MAIL_PORT:
+      MAIL_USER:
+      MAIL_PASS:
+      MAIL_FROM:
     volumes:
       - catalog-raw:/data/catalog-raw
       - orders-raw:/data/orders-raw

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.16",
+  "version": "0.3.0-dev.17",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       hono:
         specifier: ^4.6.0
         version: 4.12.32
+      nodemailer:
+        specifier: ^9.0.3
+        version: 9.0.3
       pg:
         specifier: ^8.13.0
         version: 8.22.0
@@ -60,6 +63,9 @@ importers:
       '@types/node':
         specifier: ^24.0.0
         version: 24.13.3
+      '@types/nodemailer':
+        specifier: ^8.0.1
+        version: 8.0.1
       '@types/pg':
         specifier: ^8.11.0
         version: 8.20.0
@@ -1084,6 +1090,9 @@ packages:
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
 
+  '@types/nodemailer@8.0.1':
+    resolution: {integrity: sha512-PxpaInm8V1JQDd4j0ds5HfvWQk8JupS1C0Picb96QJsrrRDjBH+DlK7L4ZdNSqNULhiZRQHc40nLVShaGxXAMw==}
+
   '@types/pg@8.20.0':
     resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
 
@@ -1710,6 +1719,10 @@ packages:
   node-releases@2.0.51:
     resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
     engines: {node: '>=18'}
+
+  nodemailer@9.0.3:
+    resolution: {integrity: sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==}
+    engines: {node: '>=6.0.0'}
 
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
@@ -2923,6 +2936,10 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
+  '@types/nodemailer@8.0.1':
+    dependencies:
+      '@types/node': 24.13.3
+
   '@types/pg@8.20.0':
     dependencies:
       '@types/node': 24.13.3
@@ -3553,6 +3570,8 @@ snapshots:
   natural-compare@1.4.0: {}
 
   node-releases@2.0.51: {}
+
+  nodemailer@9.0.3: {}
 
   on-exit-leak-free@2.1.2: {}
 

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -41,8 +41,11 @@ const { db, pool } = createDb();
 // smerom) — bez ručného pridania by riadky `order` z predchádzajúceho E2E
 // behu ticho prežívali. `"order"` je rezervované SQL kľúčové slovo, musí byť
 // uvodzované ručne v priamom SQL stringu.
+// "supplier_contact" (#31) pridané rovnakým dôvodom ako "order_line, \"order\""
+// vyššie — nemá žiadny FK (kľúčovaný reťazcom dodávateľa, nie id), CASCADE ho
+// preto nikdy nestrhne.
 await db.execute(
-  'TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order" RESTART IDENTITY CASCADE',
+  'TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact RESTART IDENTITY CASCADE',
 );
 await db.insert(users).values({
   email: "e2e@forestshop.sk",


### PR DESCRIPTION
## Súhrn

Objednávku dodávateľovi je teraz možné poslať priamo mailom z appky (rovnaký
mechanizmus ako stará appka — SMTP, env premenné), s presne rovnakým
formátom predmetu/tela ako doteraz používala stará appka na kopírovanie do
schránky. Pridáva editovateľný e-mailový kontakt dodávateľa (nová dátová
položka, tá predtým nikde neexistovala), náhľad pred odoslaním, audit
každého pokusu a ponecháva kopírovanie do schránky ako záložnú možnosť.

Design komentár (root cause / zvolený prístup / zamietnutá alternatíva) je
na tickete PRED prvým commitom.

Closes #31

## Test plan

- [x] `pnpm test` (unit, bez DB) — 236 + 84 testov zelené
- [x] `pnpm test:integration` — 151 testov zelené (vrátane 14 nových v
      `supplier-mail.integration.test.ts`)
- [x] `pnpm --filter @forestshop/web e2e` — 9/9 zelené (nový test:
      nastavenie e-mailu dodávateľa + náhľad mailu, konzola čistá)
- [x] `pnpm typecheck`, `pnpm lint` — čisté
