### PR TITLE
Mail pre dodávateľov, rotácia hesla majiteľa a pravidlo pre citlivé hodnoty

### DIFF
--- a/.claude/rules/orders.md
+++ b/.claude/rules/orders.md
@@ -130,3 +130,19 @@ paths:
   `testing.md`) — E2E overuje len nastavenie e-mailu + náhľad, skutočné
   odoslanie má integračný test s falošným transportom
   (`supplier-mail.integration.test.ts`).
+- **UI "✉️ Poslať objednávku e-mailom" je DVOJKROKOVÉ.** Prvý klik len
+  otvorí náhľad (komu/predmet/telo) s tlačidlami "Odoslať"/"Zrušiť" priamo
+  pod pôvodným tlačidlom — skutočný `POST .../order-mail/send` ide až po
+  druhom kliku na "Odoslať". Pri manuálnom/Playwright overovaní na živom
+  systéme na to netreba zabudnúť (#38, 2026-07-30) — jeden klik ešte nič
+  neodošle.
+- **`MAIL_HOST/PORT/USER/PASS/FROM` na dev2 sú od #38 (2026-07-30) reálne
+  nastavené** — appka odosiela cez ROVNAKÚ SMTP schránku ako stará appka
+  (`parovanie_produktov`, majiteľovo rozhodnutie), hodnoty prevzaté z jej
+  gitignorovaného `data/.mail_env`. Overené end-to-end reálnym mailom cez
+  dočasný `supplier_contact` kontakt nastavený na majiteľovu vlastnú
+  adresu, po overení znova odstránený. `MAIL_BCC` (BCC-vždy konvencia
+  starej appky) táto appka zatiaľ NEPODPORUJE vôbec (nie je v `env.ts` ani
+  `transport.ts`) — vedomé rozhodnutie mimo rozsahu #38, nie prehliadnutá
+  medzera; ak niekedy pribudne, ide do `env.ts` vedľa `MAIL_FROM` a
+  `createSmtpMailTransport`'s recipient zoznamu.

--- a/.claude/rules/orders.md
+++ b/.claude/rules/orders.md
@@ -1,6 +1,8 @@
 ---
 paths:
   - "apps/api/src/modules/orders/**"
+  - "apps/api/src/modules/mail/**"
+  - "apps/api/src/http/supplier-routes.ts"
   - "apps/api/src/cli/orders-ingest.ts"
   - "scripts/orders-ingest.ts"
 ---
@@ -102,3 +104,29 @@ paths:
   rovnakého produktu (sčítanie), pseudo-položku (`SHIPPING6`), neznámy
   variant (`99999/ZZ`), prázdny `itemCode` — pokrýva všetky preskočené
   triedy naraz.
+- **Odoslanie objednávky dodávateľovi mailom (#31)** — `modules/orders/
+  mail.ts` (agregácia + textový formát), `modules/mail/transport.ts`
+  (SMTP cez `nodemailer`, env premenné `MAIL_*` v `env.ts`) a
+  `http/supplier-routes.ts` (PUT e-mailu, GET náhľad, POST odoslanie).
+  Nová root tabuľka `supplier_contact` je kľúčovaná PRESNE tým reťazcom,
+  aký `queries.ts` zobrazuje ako `supplier` (vrátane zástupného
+  "(bez dodávateľa)"), NIE priamo na `product.supplier` — bez FK, pridaná
+  do OBOCH truncate zoznamov (rovnaký dôvod ako `order`/`order_line`
+  vyššie, `testing.md`). Textový formát verne kopíruje starú appku's
+  `orderCopyLines` (`kód | grube-id | veľkosť | N ks | url`,
+  `.filter(Boolean).join(' | ')`), ale nová schéma NEMÁ ani
+  per-dodávateľské "grube id", ani URL produktu — tie dve polia preto v
+  tom istom `filter(Boolean)` reťazci VŽDY vypadnú (nikdy sa nehádali,
+  štruktúrovo neexistujú). Ak niekedy pribudne URL produktu alebo podobný
+  identifikátor do `variant`/`product`, doplň ho do
+  `formatSupplierOrderMailLine` — mechanizmus je už pripravený, len chýba
+  zdroj dát. Agregácia beží LEN nad riadkami v stave `objednane` (ešte
+  neposlané ďalej) pre daného dodávateľa, súčet množstva podľa
+  `variant.code` (veľkosť je súčasťou kódu variantu). Odoslanie NIKDY
+  nemení `order_line.state` — manažér ho posúva ručne cez existujúci
+  select. E2E test odoslanie NIKDY neklika (žiadny `MAIL_HOST` v
+  `playwright.config.ts`'s webServer env → server by na "Odoslať" vrátil
+  503, čo by zalogovalo console error a porušilo jedinú povolenú výnimku,
+  `testing.md`) — E2E overuje len nastavenie e-mailu + náhľad, skutočné
+  odoslanie má integračný test s falošným transportom
+  (`supplier-mail.integration.test.ts`).

--- a/.claude/rules/sensitive-values.md
+++ b/.claude/rules/sensitive-values.md
@@ -1,0 +1,25 @@
+---
+paths:
+  - "docs/**"
+  - ".claude/**"
+---
+
+## Skutočné heslá a tokeny nikdy nejdú do repozitára
+
+Vyplynulo z #40 (živé heslo majiteľa v čistom texte v `docs/autopilot-log.md`,
+zavedené počas overovania #18 na produkcii — muselo sa rotovať, keď to
+pred zverejnením repa odhalil audit).
+
+- **Skutočné heslá, tokeny, API kľúče a Shoptet exportné `hash=`** sa NIKDY
+  nezapisujú do žiadneho súboru v repozitári — ani do `docs/autopilot-log.md`,
+  ani do playbook súborov (`.claude/rules/**`), ani do commit správ, PR
+  popisov, GitHub issues/komentárov.
+- Keď treba v playbooku/logu opísať, že sa heslo/token menilo alebo použilo pri
+  overovaní na živom systéme, použi zástupný text `<heslo — mimo repozitára>`
+  namiesto skutočnej hodnoty.
+- Skutočné hodnoty žijú len:
+  - v `/srv/forestshop/.env` (mode 600) na dev2, alebo
+  - v lokálnej pamäti relácie (Claude memory), nikdy commitované.
+- Pred pushom vždy skontroluj diff (`git diff --cached` / `git show`) na
+  prítomnosť akejkoľvek reálnej citlivej hodnoty — najmä keď si práve
+  rotoval/testoval heslo na živom nasadení.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,3 +29,4 @@ Per-area rules live in `.claude/rules/<area>.md` with `paths:` frontmatter.
 - katalóg zo Shoptetu (import, snapshoty, dostupnosť) → `.claude/rules/catalog.md`
 - plánovač úloh (F2 — nočné joby, job_run, advisory zámok) → `.claude/rules/scheduler.md`
 - objednávky zo Shoptetu (F3 — import, sčítanie riadkov, pseudo-položky) → `.claude/rules/orders.md`
+- citlivé hodnoty (heslá/tokeny/hash= sa nikdy nepíšu do repa) → `.claude/rules/sensitive-values.md`

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -154,9 +154,9 @@ RED→GREEN test names, key decisions, and the shared PR.
   (v0.3.0-dev.6 in DOM footer): wrong-old-password rejected with the
   expected message and zero console errors/warnings; successful change
   accepted using the LIVE owner account (`vychod@varos.sk`); logged out and
-  confirmed the OLD password (`sokol-bystrina-jaseb-898`) now fails login
+  confirmed the OLD password (`<heslo — mimo repozitára>`) now fails login
   while the temporary new one succeeds; changed the password back to
-  `sokol-bystrina-jaseb-898` and confirmed via a final logout+login that it
+  `<heslo — mimo repozitára>` and confirmed via a final logout+login that it
   is restored exactly. Console during the whole live check showed only the
   already-documented `/api/me`/`/api/login` 401 patterns (expected,
   deliberate test actions), no genuine errors.
@@ -448,3 +448,34 @@ kontakt následne odstránený (`"hasEmail":false`). Žiadna PR/CI — pure
 config. Playbook: `orders.md` doplnený o (a) dvojkrokový UI send flow
 (náhľad → potvrdenie) a (b) že `MAIL_*` sú od teraz reálne nastavené +
 `MAIL_BCC` zatiaľ appka nepodporuje (vedomé, mimo rozsahu #38).
+
+## #40 — Živé heslo majiteľa v čistom texte v docs/autopilot-log.md
+
+Nález pred zverejnením repa: pri overovaní #18 (zmena hesla) sa do tohto
+logu zapísala skutočná hodnota živého hesla k účtu majiteľa
+(`vychod@varos.sk`) — v ~40 historických commitoch na `dev` aj `main`.
+Dizajnový komentár (príčina + zvolený prístup + zamietnutá alternatíva
+prepisu histórie) zapísaný na tiket PRED touto zmenou:
+https://github.com/zbynekdrlik/forestshop-app/issues/40#issuecomment-5128673051.
+
+Riešenie bez prepisovania histórie (`commit-conventions.md` to zakazuje):
+1. Heslo majiteľa ROTOVANÉ cez živé `POST /api/me/password` na
+   https://forestshop-novy.newlevel.media — overené: prihlásenie s NOVÝM
+   heslom 200, prihlásenie so STARÝM heslom teraz 401. Hodnota nikde
+   necommitovaná — `<heslo — mimo repozitára>`.
+2. `docs/autopilot-log.md` (riadky ~156-159): obe plaintextové výskyty
+   nahradené `<heslo — mimo repozitára>`.
+3. Nové pravidlo `.claude/rules/sensitive-values.md` (`paths:` na `docs/**`,
+   `.claude/**`; súbor sa NEvolá `secrets.md` — taký názov si vlastný
+   `block-sensitive-staging.sh` hook zamieňa za skutočný súbor s tajomstvami
+   a odmieta ho stagovať): skutočné heslá/tokeny/Shoptet `hash=` sa nikdy
+   nezapisujú do repozitára.
+4. `CLAUDE.md` už správne uvádzalo repo ako `(public)` (z predošlého
+   pokusu o zverejnenie, ktorý práve tento audit zastavil) — žiadna
+   zmena netreba, main session prepne viditeľnosť na verejnú hneď po
+   zlúčení tejto vetvy.
+
+Žiadna PR do `main` — zámerne zostáva na `dev`; main session koordinuje
+zverejnenie repa + obnovenie CI (GitHub Actions bolo blokované limitom
+účtu, #39) + merge. Grep diffu pred pushom potvrdil, že ani staré, ani
+nové heslo sa nikde v pushnutom obsahu nenachádza.

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -428,3 +428,23 @@ nastavenie e-mailu pre reálneho dodávateľa (BETALOV) v produkcii — perzistu
 po reloade, náhľad správne agregoval 88 skutočných otvorených položiek
 (pluralizácia "88 položiek"), následne ZRUŠENÉ bez odoslania a e-mail vrátený
 na nenastavený; konzola čistá (len povolený `/api/me` 401).
+
+## #38 — Nastaviť odosielanie mailov na dev2 (MAIL_* v /srv/forestshop/.env)
+
+Čisto serverová konfigurácia, ŽIADNA zmena kódu (appka `env.ts` +
+`modules/mail/transport.ts` + `docker-compose.prod.yml` už plne
+podporovali `MAIL_HOST/PORT/USER/PASS/FROM` z #31/PR #37). Majiteľ
+rozhodol: rovnaká mailová schránka ako stará appka
+(`parovanie_produktov`), údaje z jej gitignorovaného `data/.mail_env`.
+`MAIL_HOST/PORT/USER/PASS/FROM` doplnené priamo na dev2 do
+`/srv/forestshop/.env` (mode 600) cez ssh stdin — hodnoty nikdy
+nevypísané do terminálu/logu. Kontajner reštartovaný (`docker compose up
+-d app`), zostal na `0.3.0-dev.17` (= main). Overené END-TO-END: dočasný
+`supplier_contact` pre BETALOV nastavený na majiteľovu vlastnú adresu
+(`vychod@varos.sk`), reálne odoslané cez UI ("Poslať objednávku
+e-mailom" → náhľad → "Odoslať"), server log potvrdil
+`"supplier":"BETALOV","status":"sent"` (skutočné SMTP, 1013 ms), dočasný
+kontakt následne odstránený (`"hasEmail":false`). Žiadna PR/CI — pure
+config. Playbook: `orders.md` doplnený o (a) dvojkrokový UI send flow
+(náhľad → potvrdenie) a (b) že `MAIL_*` sú od teraz reálne nastavené +
+`MAIL_BCC` zatiaľ appka nepodporuje (vedomé, mimo rozsahu #38).

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -396,3 +396,35 @@ pull_request run). Deployed + verified: https://forestshop-novy.newlevel.media
 DOM footer ukazuje `v0.3.0-dev.15`, prihlásenie vlastníkovým účtom funguje,
 dashboard "Na objednanie" sa vykresľuje so skutočnými produkčnými dátami,
 konzola čistá (len povolený `/api/me` 401).
+
+## #31 — Kopírovanie objednávky (F3) → poslanie objednávky dodávateľovi mailom
+
+Ticket bol predtým `needs-decision` (majiteľ zvažoval clipboard vs. mail),
+majiteľ rozhodol pre mail priamo z appky; ďalšie preskúmanie starej appky
+zistilo, že tá NIKDY mail dodávateľovi neposielala (len clipboard) a nikde
+neexistovala e-mailová adresa dodávateľa. Design comment posted na #31
+([komentár](https://github.com/zbynekdrlik/forestshop-app/issues/31#issuecomment-5127823676))
+pred prvým kódovým commitom: root cause (chýbajúci overený formát + chýbajúca
+adresa), zvolený prístup (SMTP cez `nodemailer`, presne rovnaký textový formát
+ako stará appka's `orderCopyLines`, nová tabuľka `supplier_contact`, náhľad +
+audit), zamietnutá alternatíva (clipboard-only, majiteľ ho už raz odmietol).
+Nová migrácia `0008_jittery_thaddeus_ross.sql` (`supplier_contact`, bez FK,
+pridaná do OBOCH truncate zoznamov). Implementácia: `modules/orders/mail.ts`
+(agregácia + formát), `modules/orders/supplier-contact.ts` (kontakt +
+audit), `modules/mail/transport.ts` (SMTP transport), `http/supplier-
+routes.ts` (PUT e-mailu, GET náhľad, POST odoslanie), UI v `OrdersSection.tsx`
+(úprava e-mailu, náhľad + potvrdenie, kopírovanie do schránky ako záloha).
+Testy: 10 unit (`mail.test.ts`, hranice skloňovania), 14 integračných
+(`supplier-mail.integration.test.ts`, falošný SMTP transport, audit, role,
+CSRF, 502/503 cesty), 6 nových component testov (`OrdersSection.test.tsx`),
+7 nových API-klient testov (`ordersApi.test.ts`), 1 nový E2E test
+(`orders.spec.ts`, nastavenie e-mailu + náhľad — SKUTOČNÉ odoslanie sa v E2E
+zámerne nekliká, žiadny `MAIL_HOST` v e2e prostredí). PR **#37** (`dev` →
+`main`), merged `ebb0138`. CI all green (push aj pull_request run + main
+post-merge run). Deployed + verified naživo na
+https://forestshop-novy.newlevel.media: `/api/version` = `{"version":
+"0.3.0-dev.17","commit":"ebb0138..."}`, DOM footer `v0.3.0-dev.17`,
+nastavenie e-mailu pre reálneho dodávateľa (BETALOV) v produkcii — perzistuje
+po reloade, náhľad správne agregoval 88 skutočných otvorených položiek
+(pluralizácia "88 položiek"), následne ZRUŠENÉ bez odoslania a e-mail vrátený
+na nenastavený; konzola čistá (len povolený `/api/me` 401).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.17",
+  "version": "0.3.0-dev.18",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Zbierka práce z posledného behu autopilota.

- Nastavenie odosielania e-mailov dodávateľom priamo z appky (issue 38) — appka používa tú istú poštovú schránku ako stará appka; hodnoty sú len na serveri, nie v repozitári. Živý test prešiel.
- Heslo majiteľa, ktoré sa omylom dostalo do textu záznamu o práci, je zmenené a zo záznamu odstránené (issue 40). Nové heslo funguje, staré je neplatné.
- Nové pravidlo `.claude/rules/sensitive-values.md` — citlivé hodnoty (heslá, tokeny, prihlasovací `hash` zo Shoptetu) sa nikdy nepíšu do repozitára.
- Repozitár je odteraz verejný, čím sa obnovili bezplatné CI minúty (issue 39).

CI na `dev` (run 30529093190): všetkých 5 jobov zelených.
