### PR TITLE
fix(deploy): provision buildx builder before pushing to ghcr.io

### DIFF
--- a/.claude/rules/deploy.md
+++ b/.claude/rules/deploy.md
@@ -182,3 +182,17 @@ paths:
   INÁ hláška než "failed to extract layer", nepredpokladaj automaticky inú
   príčinu — over najprv jednoduchým rerunom, až pri DRUHOM zlyhaní za sebou
   rieš ako skutočný problém.
+
+- **`build` job (GitHub-hosted, nahráva do ghcr.io) potrebuje explicitný
+  `docker/setup-buildx-action@v3` PRED `docker/build-push-action@v6`** —
+  bez neho buildx použije predvolený builder s driverom `docker` (naviazaný
+  na lokálny daemon runnera), ktorý nevie `push: true` počas zostavovania
+  cez natívny BuildKit exportér; namiesto toho obraz najprv uloží do
+  daemona a až potom spustí samostatný `docker push`. Tento dvojkrokový
+  spôsob bol príčinou `ERROR: failed to build: unknown blob` pri nahrávaní
+  viacerých tagov naraz (`:0.3.0-dev.18` + `:latest`) na ghcr.io (run
+  30529745338, issue #42) — desiatky predchádzajúcich behov s tým istým
+  chýbajúcim krokom prešli, takže ide o latentnú krehkosť builderu bez
+  `docker-container` drivera, nie o vždy-zlyhá chybu. Fix je jeden riadok
+  (`uses: docker/setup-buildx-action@v3`), nie retry/`continue-on-error`
+  okolo push kroku.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,16 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - id: meta
         run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+      # Bez tohto kroku buildx použije predvolený builder s driverom `docker`
+      # (naviazaný na lokálny daemon runnera), ktorý nevie nahrať obraz do
+      # registra PRIAMO počas zostavovania — najprv ho uloží do daemona a až
+      # potom spustí samostatný `docker push`. Tento dvojkrokový spôsob je
+      # zdokumentovane menej spoľahlivý pri viacvrstvových obrazoch a viacerých
+      # tagoch naraz a bol príčinou `ERROR: failed to build: unknown blob` pri
+      # nahrávaní na ghcr.io (run 30529745338, issue #42). Vlastný builder s
+      # driverom `docker-container` nahráva natívnym BuildKit exportérom
+      # jedným krokom (push=true priamo v build kroku).
+      - uses: docker/setup-buildx-action@v3
       - uses: docker/build-push-action@v6
         with:
           context: .

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.18",
+  "version": "0.3.0-dev.19",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Opravuje pád nasadenia na server: `Deploy` workflow spadol pri nahrávaní Docker balíka do registra (`ERROR: failed to build: unknown blob`). Príčina a zvolené riešenie sú zaznamenané na tickete.

Closes #42
