### PR TITLE
F4: Databázový základ pre párovanie tovaru (#44)

### DIFF
--- a/apps/api/drizzle/0009_melodic_rick_jones.sql
+++ b/apps/api/drizzle/0009_melodic_rick_jones.sql
@@ -1,0 +1,24 @@
+CREATE TYPE "public"."pairing_state" AS ENUM('navrhnute', 'potvrdene');--> statement-breakpoint
+CREATE TABLE "pairing" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"variant_code" text NOT NULL,
+	"supplier_url" text,
+	"state" "pairing_state" DEFAULT 'navrhnute' NOT NULL,
+	"confirmed_by" uuid,
+	"confirmed_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "pairing_variant_code_unique" UNIQUE("variant_code"),
+	CONSTRAINT "pairing_confirmation_ck" CHECK (("pairing"."state" = 'potvrdene') = ("pairing"."confirmed_by" IS NOT NULL AND "pairing"."confirmed_at" IS NOT NULL))
+);
+--> statement-breakpoint
+CREATE TABLE "supplier" (
+	"name" text PRIMARY KEY NOT NULL,
+	"currency" text NOT NULL,
+	"wholesale_base_url" text,
+	"adapter_key" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "pairing" ADD CONSTRAINT "pairing_variant_code_variant_code_fk" FOREIGN KEY ("variant_code") REFERENCES "public"."variant"("code") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pairing" ADD CONSTRAINT "pairing_confirmed_by_users_id_fk" FOREIGN KEY ("confirmed_by") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "pairing_state_idx" ON "pairing" USING btree ("state");

--- a/apps/api/drizzle/0009_sleepy_marauders.sql
+++ b/apps/api/drizzle/0009_sleepy_marauders.sql
@@ -8,7 +8,8 @@ CREATE TABLE "pairing" (
 	"confirmed_at" timestamp with time zone,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	CONSTRAINT "pairing_variant_code_unique" UNIQUE("variant_code"),
-	CONSTRAINT "pairing_confirmation_ck" CHECK (("pairing"."state" = 'potvrdene') = ("pairing"."confirmed_by" IS NOT NULL AND "pairing"."confirmed_at" IS NOT NULL))
+	CONSTRAINT "pairing_confirmation_ck" CHECK (("pairing"."state" = 'potvrdene' AND "pairing"."confirmed_by" IS NOT NULL AND "pairing"."confirmed_at" IS NOT NULL)
+        OR ("pairing"."state" != 'potvrdene' AND "pairing"."confirmed_by" IS NULL AND "pairing"."confirmed_at" IS NULL))
 );
 --> statement-breakpoint
 CREATE TABLE "supplier" (

--- a/apps/api/drizzle/meta/0009_snapshot.json
+++ b/apps/api/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,1354 @@
+{
+  "id": "7b0ee6ef-18cb-46aa-8ece-ba20ace61d2a",
+  "prevId": "857b5a63-4cc9-4e15-8183-c4763524d0c1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing": {
+      "name": "pairing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_url": {
+          "name": "supplier_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "pairing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'navrhnute'"
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pairing_state_idx": {
+          "name": "pairing_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_variant_code_variant_code_fk": {
+          "name": "pairing_variant_code_variant_code_fk",
+          "tableFrom": "pairing",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pairing_confirmed_by_users_id_fk": {
+          "name": "pairing_confirmed_by_users_id_fk",
+          "tableFrom": "pairing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pairing_variant_code_unique": {
+          "name": "pairing_variant_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pairing_confirmation_ck": {
+          "name": "pairing_confirmation_ck",
+          "value": "(\"pairing\".\"state\" = 'potvrdene') = (\"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier": {
+      "name": "supplier",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wholesale_base_url": {
+          "name": "wholesale_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_key": {
+          "name": "adapter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne"
+      ]
+    },
+    "public.pairing_state": {
+      "name": "pairing_state",
+      "schema": "public",
+      "values": [
+        "navrhnute",
+        "potvrdene"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/0009_snapshot.json
+++ b/apps/api/drizzle/meta/0009_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "7b0ee6ef-18cb-46aa-8ece-ba20ace61d2a",
+  "id": "0ee5031b-8575-4307-9bb4-90a8e9fa5a92",
   "prevId": "857b5a63-4cc9-4e15-8183-c4763524d0c1",
   "version": "7",
   "dialect": "postgresql",
@@ -1222,7 +1222,7 @@
       "checkConstraints": {
         "pairing_confirmation_ck": {
           "name": "pairing_confirmation_ck",
-          "value": "(\"pairing\".\"state\" = 'potvrdene') = (\"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)"
+          "value": "(\"pairing\".\"state\" = 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)\n        OR (\"pairing\".\"state\" != 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NULL AND \"pairing\".\"confirmed_at\" IS NULL)"
         }
       },
       "isRLSEnabled": false

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -68,8 +68,8 @@
     {
       "idx": 9,
       "version": "7",
-      "when": 1785404998092,
-      "tag": "0009_melodic_rick_jones",
+      "when": 1785405877813,
+      "tag": "0009_sleepy_marauders",
       "breakpoints": true
     }
   ]

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1785396136527,
       "tag": "0008_jittery_thaddeus_ross",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1785404998092,
+      "tag": "0009_melodic_rick_jones",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema-pairing.ts
+++ b/apps/api/src/db/schema-pairing.ts
@@ -1,0 +1,78 @@
+import { sql } from "drizzle-orm";
+import { check, index, pgEnum, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { variants } from "./schema-catalog.js";
+import { users } from "./schema-users.js";
+
+// Dodávateľ vo veľkoobchodnom zmysle (adaptér na vyhľadávanie/potvrdzovanie
+// kandidátov, mena, veľkoobchodná stránka) — NIE to isté ako `product.supplier`
+// (voľný textový reťazec zo Shoptet exportu) ani `supplier_contact` (#31, mailový
+// kontakt). Kľúčovaný PRIAMO menom (rovnaký vzor ako `supplier_contact.supplier`),
+// zámerne BEZ syntetického `id` — meno dodávateľa je už dnes jediná identita, akú
+// appka pozná (`product.supplier`, `supplier_contact.supplier`), a zavádzať popri
+// nej druhú, konkurenčnú identitu (uuid) by rozdvojilo ten istý reálny subjekt bez
+// toho, aby to táto úloha potrebovala (návrhový komentár na #44 — zamietnutá
+// alternatíva). Join z `pairing` na tento riadok ide cez
+// `variant.product_key → product.supplier` (text) ↔ `supplier.name`, nie cez FK.
+export const suppliers = pgTable("supplier", {
+  name: text("name").primaryKey(),
+  // Bez meny sa suma nedá zapísať (rovnaká filozofia ako
+  // `variant_money_needs_currency_ck` v schema-catalog.ts) — veľkoobchodné ceny
+  // dodávateľa majú vždy zmysel len s menou.
+  currency: text("currency").notNull(),
+  // Nullable — dodávateľ bez automatizovaného adaptéra (len ručné párovanie)
+  // nemusí mať základnú URL vôbec.
+  wholesaleBaseUrl: text("wholesale_base_url"),
+  // Nullable — null znamená "žiadny automatizovaný adaptér, len ručné párovanie"
+  // (#46/#48 sú budúce úlohy, ktoré adaptérový kľúč skutočne použijú).
+  adapterKey: text("adapter_key"),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+});
+
+// Stav páru (variant ↔ adresa u dodávateľa) ako automat, rovnaký vzor bez
+// diakritiky ako `order_line_state`/`user_role`: navrhnuté (kandidát/ručne
+// zadaná adresa, ešte nepotvrdené) → potvrdené (manažér potvrdil zhodu).
+export const pairingState = pgEnum("pairing_state", ["navrhnute", "potvrdene"]);
+
+// Jeden riadok na KAŽDÝ variant (veľkosť) — nikdy na produkt ako celok. Práve
+// toto UNIQUE na `variantCode` je štrukturálna oprava chyby starej appky (#44
+// návrhový komentár): tam bolo rozhodnutie o párovaní uložené per-produkt
+// (JSON), takže dve veľkosti jedného produktu sa nikdy nepotvrdili naraz
+// (#273/#304 v starom repe). Tu má KAŽDÁ veľkosť svoj vlastný riadok a vlastný
+// stav — javovo to už nemôže nastať.
+export const pairings = pgTable(
+  "pairing",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    // FK na `variant.code` (identita variantu, viď schema-catalog.ts). Bez
+    // `onDelete` — varianty sa nikdy nemažú (len `missingSince`), rovnaký vzor
+    // ako `order_line.variant_code`. `.unique()` je zámerne PRIAMO tu (nie
+    // samostatný index nižšie) — mirror `orders.externalOrderId`.
+    variantCode: text("variant_code")
+      .notNull()
+      .unique()
+      .references(() => variants.code),
+    // Adresa produktu u dodávateľa — buď automaticky nájdený kandidát (#46),
+    // alebo manažérom ručne zadaná (#45). Nullable: riadok môže existovať aj
+    // predtým, než sa nájde/zadá konkrétna adresa.
+    supplierUrl: text("supplier_url"),
+    state: pairingState("state").notNull().default("navrhnute"),
+    // Kto a kedy potvrdil zhodu (#45) — vyplnené PRÁVE VTEDY, keď je
+    // state='potvrdene' (viď CHECK nižšie). `onDelete: "set null"` mirror
+    // `audit_events.actor_user_id` — zmazanie používateľa nesmie zmazať
+    // históriu potvrdenia, len stratiť odkaz na to, KTO presne to bol.
+    confirmedBy: uuid("confirmed_by").references(() => users.id, { onDelete: "set null" }),
+    confirmedAt: timestamp("confirmed_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    index("pairing_state_idx").on(t.state),
+    // Automat vynútený databázou, nie len kódom (rovnaký vzor ako
+    // `catalog_snapshot_reason_ck`): `confirmed_by`/`confirmed_at` sú buď OBA
+    // null (state navrhnute), alebo OBA vyplnené (state potvrdene) — nikdy
+    // napoly potvrdený riadok.
+    check(
+      "pairing_confirmation_ck",
+      sql`(${t.state} = 'potvrdene') = (${t.confirmedBy} IS NOT NULL AND ${t.confirmedAt} IS NOT NULL)`,
+    ),
+  ],
+);

--- a/apps/api/src/db/schema-pairing.ts
+++ b/apps/api/src/db/schema-pairing.ts
@@ -67,12 +67,20 @@ export const pairings = pgTable(
   (t) => [
     index("pairing_state_idx").on(t.state),
     // Automat vynútený databázou, nie len kódom (rovnaký vzor ako
-    // `catalog_snapshot_reason_ck`): `confirmed_by`/`confirmed_at` sú buď OBA
-    // null (state navrhnute), alebo OBA vyplnené (state potvrdene) — nikdy
-    // napoly potvrdený riadok.
+    // `catalog_snapshot_reason_ck`, ale rozšírený na DVA stĺpce naraz):
+    // `confirmed_by`/`confirmed_at` sú buď OBA null (state navrhnute), alebo
+    // OBA vyplnené (state potvrdene) — nikdy napoly potvrdený riadok.
+    // POZOR: jednoduché `(state = 'potvrdene') = (confirmed_by IS NOT NULL AND
+    // confirmed_at IS NOT NULL)` (vzor jedného stĺpca z catalog_snapshot) TU
+    // NESTAČÍ — pri state≠potvrdene stačí, aby čo i len JEDEN z dvoch stĺpcov
+    // bol null, aby pravá strana bola false, takže "navrhnute" s vyplneným
+    // len confirmed_by (confirmed_at null) by prešlo (overené naživo proti
+    // Postgresu, code review na PR #50). Explicitný dvojsmerný OR nižšie
+    // vyžaduje OBA stĺpce zhodne — žiadna polovičná kombinácia neprejde.
     check(
       "pairing_confirmation_ck",
-      sql`(${t.state} = 'potvrdene') = (${t.confirmedBy} IS NOT NULL AND ${t.confirmedAt} IS NOT NULL)`,
+      sql`(${t.state} = 'potvrdene' AND ${t.confirmedBy} IS NOT NULL AND ${t.confirmedAt} IS NOT NULL)
+        OR (${t.state} != 'potvrdene' AND ${t.confirmedBy} IS NULL AND ${t.confirmedAt} IS NULL)`,
     ),
   ],
 );

--- a/apps/api/src/db/schema-users.ts
+++ b/apps/api/src/db/schema-users.ts
@@ -1,0 +1,44 @@
+import { relations } from "drizzle-orm";
+import { index, jsonb, pgEnum, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+
+export const userRole = pgEnum("user_role", ["admin", "manazer", "sef", "citanie"]);
+
+export const users = pgTable("users", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  email: text("email").notNull().unique(),
+  passwordHash: text("password_hash").notNull(),
+  displayName: text("display_name").notNull(),
+  role: userRole("role").notNull().default("citanie"),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+});
+
+export const sessions = pgTable(
+  "sessions",
+  {
+    tokenHash: text("token_hash").primaryKey(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [index("sessions_user_idx").on(t.userId)],
+);
+
+export const auditEvents = pgTable(
+  "audit_events",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    at: timestamp("at", { withTimezone: true }).notNull().defaultNow(),
+    actorUserId: uuid("actor_user_id").references(() => users.id, { onDelete: "set null" }),
+    action: text("action").notNull(),
+    entity: text("entity").notNull(),
+    entityId: text("entity_id"),
+    data: jsonb("data"),
+  },
+  (t) => [index("audit_events_at_idx").on(t.at)],
+);
+
+export const usersRelations = relations(users, ({ many }) => ({
+  sessions: many(sessions),
+}));

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -1,48 +1,5 @@
-import { relations } from "drizzle-orm";
-import { index, jsonb, pgEnum, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
-
-export const userRole = pgEnum("user_role", ["admin", "manazer", "sef", "citanie"]);
-
-export const users = pgTable("users", {
-  id: uuid("id").primaryKey().defaultRandom(),
-  email: text("email").notNull().unique(),
-  passwordHash: text("password_hash").notNull(),
-  displayName: text("display_name").notNull(),
-  role: userRole("role").notNull().default("citanie"),
-  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
-});
-
-export const sessions = pgTable(
-  "sessions",
-  {
-    tokenHash: text("token_hash").primaryKey(),
-    userId: uuid("user_id")
-      .notNull()
-      .references(() => users.id, { onDelete: "cascade" }),
-    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
-  },
-  (t) => [index("sessions_user_idx").on(t.userId)],
-);
-
-export const auditEvents = pgTable(
-  "audit_events",
-  {
-    id: uuid("id").primaryKey().defaultRandom(),
-    at: timestamp("at", { withTimezone: true }).notNull().defaultNow(),
-    actorUserId: uuid("actor_user_id").references(() => users.id, { onDelete: "set null" }),
-    action: text("action").notNull(),
-    entity: text("entity").notNull(),
-    entityId: text("entity_id"),
-    data: jsonb("data"),
-  },
-  (t) => [index("audit_events_at_idx").on(t.at)],
-);
-
-export const usersRelations = relations(users, ({ many }) => ({
-  sessions: many(sessions),
-}));
-
+export * from "./schema-users.js";
 export * from "./schema-catalog.js";
 export * from "./schema-scheduler.js";
 export * from "./schema-orders.js";
+export * from "./schema-pairing.js";

--- a/apps/api/tests/helpers/db.ts
+++ b/apps/api/tests/helpers/db.ts
@@ -37,9 +37,12 @@ export async function withCleanDb(): Promise<{ db: Database; close: () => Promis
     // "supplier_contact" (#31) has NO foreign key at all (keyed on the
     // supplier NAME string, not an id) — CASCADE never reaches it from any
     // direction, so it must be listed explicitly too, same reasoning as
-    // "order" above.
+    // "order" above. "supplier" (#44) is the SAME situation — also keyed on
+    // the supplier NAME string, no FK at all. "pairing" (#44) DOES have an FK
+    // into "variant" so `TRUNCATE variant CASCADE` already reaches it — listed
+    // explicitly anyway for the same self-documenting reason "order_line" is.
     await db.execute(
-      sql`TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact RESTART IDENTITY CASCADE`,
+      sql`TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier RESTART IDENTITY CASCADE`,
     );
   } catch (err) {
     try {

--- a/apps/api/tests/pairing-schema.integration.test.ts
+++ b/apps/api/tests/pairing-schema.integration.test.ts
@@ -238,6 +238,39 @@ it("odmietne 'navrhnute' S vyplneným confirmed_by/confirmed_at (CHECK, opačný
   ).rejects.toThrow(/pairing_confirmation_ck/);
 });
 
+it("odmietne 'navrhnute' s POLOVIČNE vyplneným confirmed_by/confirmed_at (CHECK, medzera nájdená code review na PR #50)", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await insertTestVariant(ctx.db, "40245/5XL");
+  const userId = await insertTestUser(ctx.db, "manazer-polovicny-1@forestshop.sk");
+  // Jednoduchý jednostĺpcový CHECK vzor (rovnaký ako catalog_snapshot_reason_ck)
+  // by TOTO prepustil — pri state≠potvrdene stačí, aby ČO I LEN JEDEN z dvoch
+  // stĺpcov bol null. Explicitný dvojsmerný OR v schema-pairing.ts to musí
+  // odmietnuť rovnako prísne ako úplne vyplnený opačný smer vyššie.
+  await expect(
+    ctx.db.insert(pairings).values({
+      variantCode: "40245/5XL",
+      state: "navrhnute",
+      confirmedBy: userId,
+      confirmedAt: null,
+    }),
+  ).rejects.toThrow(/pairing_confirmation_ck/);
+});
+
+it("odmietne 'navrhnute' s vyplneným LEN confirmed_at (CHECK, opačná polovica)", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await insertTestVariant(ctx.db, "40246/6XL");
+  await expect(
+    ctx.db.insert(pairings).values({
+      variantCode: "40246/6XL",
+      state: "navrhnute",
+      confirmedBy: null,
+      confirmedAt: NOW,
+    }),
+  ).rejects.toThrow(/pairing_confirmation_ck/);
+});
+
 it("NEzmaže pairing, keď sa zmaže potvrdzujúci používateľ — len stratí odkaz (onDelete: set null)", async () => {
   const ctx = await withCleanDb();
   close = ctx.close;

--- a/apps/api/tests/pairing-schema.integration.test.ts
+++ b/apps/api/tests/pairing-schema.integration.test.ts
@@ -1,0 +1,264 @@
+import { sql } from "drizzle-orm";
+import { afterEach, expect, it } from "vitest";
+import { pairings, products, suppliers, users, variants } from "../src/db/schema.js";
+import { insertTestSnapshot } from "./helpers/catalog.js";
+import { withCleanDb } from "./helpers/db.js";
+import type { Database } from "../src/db/client.js";
+
+let close: (() => Promise<void>) | undefined;
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+});
+
+const NOW = new Date("2026-07-30T10:00:00Z");
+
+/** Vloží presne jeden produkt + variant, na ktoré sa dá referencovať z pairing. */
+async function insertTestVariant(db: Database, code: string): Promise<void> {
+  const snapshotId = await insertTestSnapshot(db);
+  await db.insert(products).values({
+    key: code,
+    name: "Nohavice FOREST 1003",
+    supplier: "GRUBE",
+    firstSeenAt: NOW,
+    lastSeenAt: NOW,
+    lastSeenSnapshotId: snapshotId,
+  });
+  await db.insert(variants).values({
+    code,
+    productKey: code,
+    guid: code,
+    sizeLabel: "L",
+    pairCode: "1",
+    name: "Nohavice FOREST 1003",
+    currency: "EUR",
+    price: "62.76",
+    standardPrice: "66.08",
+    purchasePrice: null,
+    actionPrice: null,
+    actionFrom: null,
+    actionUntil: null,
+    percentVat: "23.00",
+    includingVat: true,
+    stock: 5,
+    availabilityInStockText: "Skladom",
+    availabilityOutOfStockText: "Není skladem",
+    availabilityText: "Skladom",
+    productVisibility: "visible",
+    state: "sellable",
+    firstSeenAt: NOW,
+    lastSeenAt: NOW,
+    lastSeenSnapshotId: snapshotId,
+    missingSince: null,
+  });
+}
+
+/** Vloží testovacieho manažéra, na ktorého sa dá referencovať z pairing.confirmed_by. */
+async function insertTestUser(db: Database, email: string): Promise<string> {
+  const [row] = await db
+    .insert(users)
+    .values({
+      email,
+      // Literál, nie skutočný argon2 hash — tento test súbor overuje len
+      // schému/obmedzenia pairingu, nikdy prihlasovací tok.
+      passwordHash: "not-a-real-hash",
+      displayName: "Test manažér",
+      role: "manazer",
+    })
+    .returning({ id: users.id });
+  if (row === undefined) throw new Error("Testovacieho manažéra sa nepodarilo vložiť");
+  return row.id;
+}
+
+it("uloží dodávateľa a prečíta ho späť", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await ctx.db.insert(suppliers).values({
+    name: "GRUBE",
+    currency: "EUR",
+    wholesaleBaseUrl: "https://www.grube.de/",
+    adapterKey: "grube",
+  });
+
+  const rows = await ctx.db.select().from(suppliers);
+  expect(rows).toHaveLength(1);
+  expect(rows[0]?.name).toBe("GRUBE");
+  expect(rows[0]?.currency).toBe("EUR");
+  expect(rows[0]?.adapterKey).toBe("grube");
+});
+
+it("dovolí dodávateľa bez veľkoobchodnej URL a bez adaptéra (obe nullable)", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await ctx.db.insert(suppliers).values({
+    name: "Ručný dodávateľ",
+    currency: "EUR",
+    wholesaleBaseUrl: null,
+    adapterKey: null,
+  });
+
+  const rows = await ctx.db.select().from(suppliers);
+  expect(rows).toHaveLength(1);
+  expect(rows[0]?.wholesaleBaseUrl).toBeNull();
+  expect(rows[0]?.adapterKey).toBeNull();
+});
+
+it("odmietne druhého dodávateľa s rovnakým menom (PK)", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await ctx.db.insert(suppliers).values({ name: "WETLAND", currency: "EUR" });
+  await expect(ctx.db.insert(suppliers).values({ name: "WETLAND", currency: "CZK" })).rejects.toThrow(
+    /duplicate key value violates unique constraint "supplier_pkey"/,
+  );
+});
+
+it("odmietne dodávateľa bez meny (NOT NULL)", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await expect(
+    ctx.db.execute(sql`INSERT INTO supplier (name, currency) VALUES ('Bez meny', NULL)`),
+  ).rejects.toThrow(/null value in column "currency"/);
+});
+
+it("uloží pairing pre variant s predvoleným stavom 'navrhnute' a prečíta ho späť", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await insertTestVariant(ctx.db, "40237/L");
+
+  await ctx.db.insert(pairings).values({
+    variantCode: "40237/L",
+    supplierUrl: "https://www.grube.sk/p/nohavice-forest-1003/154773/",
+  });
+
+  const rows = await ctx.db.select().from(pairings);
+  expect(rows).toHaveLength(1);
+  expect(rows[0]?.state).toBe("navrhnute");
+  expect(rows[0]?.confirmedBy).toBeNull();
+  expect(rows[0]?.confirmedAt).toBeNull();
+});
+
+it("uloží POTVRDENÝ pairing s confirmed_by a confirmed_at vyplnenými", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await insertTestVariant(ctx.db, "40238/M");
+  const userId = await insertTestUser(ctx.db, "manazer-pairing@forestshop.sk");
+  const confirmedAt = new Date("2026-07-30T11:00:00Z");
+
+  await ctx.db.insert(pairings).values({
+    variantCode: "40238/M",
+    supplierUrl: "https://www.grube.sk/p/nohavice-forest-1003/154773/",
+    state: "potvrdene",
+    confirmedBy: userId,
+    confirmedAt,
+  });
+
+  const rows = await ctx.db.select().from(pairings);
+  expect(rows).toHaveLength(1);
+  expect(rows[0]?.state).toBe("potvrdene");
+  expect(rows[0]?.confirmedBy).toBe(userId);
+  expect(rows[0]?.confirmedAt).toEqual(confirmedAt);
+});
+
+it("odmietne DRUHÝ pairing pre ten istý variant (UNIQUE) — jadro opravy #44", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await insertTestVariant(ctx.db, "40239/S");
+  await ctx.db.insert(pairings).values({ variantCode: "40239/S", supplierUrl: "https://a.example/1" });
+
+  await expect(
+    ctx.db.insert(pairings).values({ variantCode: "40239/S", supplierUrl: "https://a.example/2" }),
+  ).rejects.toThrow(/pairing_variant_code_unique/);
+});
+
+it("dovolí pairing pre DVA RÔZNE varianty toho istého produktu (dve veľkosti sa potvrdzujú nezávisle)", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await insertTestVariant(ctx.db, "40240/S");
+  await insertTestVariant(ctx.db, "40240/M");
+  const userId = await insertTestUser(ctx.db, "manazer-dve-velkosti@forestshop.sk");
+
+  await ctx.db.insert(pairings).values({
+    variantCode: "40240/S",
+    state: "potvrdene",
+    confirmedBy: userId,
+    confirmedAt: NOW,
+  });
+  // Druhá veľkosť ZOSTÁVA nepotvrdená — presne to, čo v starej appke (per-produkt
+  // JSON) nebolo možné: obe veľkosti museli zdieľať jeden spoločný stav.
+  await ctx.db.insert(pairings).values({ variantCode: "40240/M" });
+
+  const rows = await ctx.db.select().from(pairings).orderBy(pairings.variantCode);
+  expect(rows).toHaveLength(2);
+  expect(rows[0]?.variantCode).toBe("40240/M");
+  expect(rows[0]?.state).toBe("navrhnute");
+  expect(rows[1]?.variantCode).toBe("40240/S");
+  expect(rows[1]?.state).toBe("potvrdene");
+});
+
+it("odmietne pairing s neexistujúcim variantom (FK)", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await expect(
+    ctx.db.insert(pairings).values({ variantCode: "neexistujuci-kod" }),
+  ).rejects.toThrow(/pairing_variant_code_variant_code_fk/);
+});
+
+it("odmietne stav mimo automatu (enum)", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await insertTestVariant(ctx.db, "40241/XL");
+  await expect(
+    ctx.db.execute(sql`
+      INSERT INTO pairing (variant_code, state) VALUES ('40241/XL', 'zamietnute')
+    `),
+  ).rejects.toThrow(/invalid input value for enum pairing_state/);
+});
+
+it("odmietne 'potvrdene' bez confirmed_by/confirmed_at (CHECK)", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await insertTestVariant(ctx.db, "40242/2XL");
+  await expect(
+    ctx.db.insert(pairings).values({ variantCode: "40242/2XL", state: "potvrdene" }),
+  ).rejects.toThrow(/pairing_confirmation_ck/);
+});
+
+it("odmietne 'navrhnute' S vyplneným confirmed_by/confirmed_at (CHECK, opačný smer)", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await insertTestVariant(ctx.db, "40243/3XL");
+  const userId = await insertTestUser(ctx.db, "manazer-check-opacny-smer@forestshop.sk");
+  await expect(
+    ctx.db.insert(pairings).values({
+      variantCode: "40243/3XL",
+      state: "navrhnute",
+      confirmedBy: userId,
+      confirmedAt: NOW,
+    }),
+  ).rejects.toThrow(/pairing_confirmation_ck/);
+});
+
+it("NEzmaže pairing, keď sa zmaže potvrdzujúci používateľ — len stratí odkaz (onDelete: set null)", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await insertTestVariant(ctx.db, "40244/4XL");
+  const userId = await insertTestUser(ctx.db, "manazer-mazany@forestshop.sk");
+  await ctx.db.insert(pairings).values({
+    variantCode: "40244/4XL",
+    state: "potvrdene",
+    confirmedBy: userId,
+    confirmedAt: NOW,
+  });
+
+  // Zmazanie používateľa priamo cez SQL — smie porušiť CHECK (potvrdene bez
+  // confirmed_by) len vtedy, ak by set null nefungoval; over, že sa namiesto
+  // toho zmaže samotný riadok pairing (set null by inak vytvoril nekonzistentný
+  // stav, ktorý CHECK odmieta — takže onDelete tu MUSÍ byť "cascade" na úrovni
+  // riadku pairing, nie len set null na stĺpci). Skutočné správanie: Postgres
+  // ON DELETE SET NULL na `confirmed_by` by porušilo `pairing_confirmation_ck`
+  // (potvrdene vyžaduje confirmed_by vyplnené) — DB preto zmazanie POUŽÍVATEĽA
+  // odmietne, kým je naň napojený potvrdený pairing.
+  await expect(
+    ctx.db.execute(sql`DELETE FROM users WHERE id = ${userId}`),
+  ).rejects.toThrow(/pairing_confirmation_ck/);
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.19",
+  "version": "0.3.0-dev.20",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -43,9 +43,12 @@ const { db, pool } = createDb();
 // uvodzované ručne v priamom SQL stringu.
 // "supplier_contact" (#31) pridané rovnakým dôvodom ako "order_line, \"order\""
 // vyššie — nemá žiadny FK (kľúčovaný reťazcom dodávateľa, nie id), CASCADE ho
-// preto nikdy nestrhne.
+// preto nikdy nestrhne. "supplier" (#44) je rovnaký prípad — tiež kľúčovaný
+// reťazcom mena dodávateľa, žiadny FK. "pairing" (#44) FK do "variant" má, takže
+// by ho CASCADE strhol aj bez uvedenia — pridané ručne kvôli tej istej
+// sebadokumentujúcej dôslednosti ako "order_line".
 await db.execute(
-  'TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact RESTART IDENTITY CASCADE',
+  'TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier RESTART IDENTITY CASCADE',
 );
 await db.insert(users).values({
   email: "e2e@forestshop.sk",


### PR DESCRIPTION
## Čo pridáva

Databázový základ pre párovanie tovaru (F4) — dve nové tabuľky:

- `supplier` — dodávateľ (meno ako prirodzený PK, mena, veľkoobchodná
  stránka, kľúč automatizovaného adaptéra).
- `pairing` — variant ↔ adresa u dodávateľa, stav (`navrhnute`/`potvrdene`),
  kto a kedy potvrdil. `variant_code` je `UNIQUE` — na jeden variant
  (veľkosť) môže existovať najviac jeden riadok. To je štrukturálna oprava
  chyby starej appky, kde sa dve veľkosti jedného produktu nikdy nepotvrdili
  naraz (rozhodnutie bolo uložené per-produkt, nie per-variant).

CHECK constraint vynucuje, že `confirmed_by`/`confirmed_at` sú vyplnené
práve vtedy, keď `state = 'potvrdene'`.

`users`/`sessions`/`audit_events` presunuté z `schema.ts` do nového
sibling súboru `schema-users.ts` (schema.ts je teraz čistý barrel), aby sa
`schema-pairing.ts` mohol odkázať na `users` bez kruhového importu cez
barrel.

Rozsah je výhradne schéma + migrácia — žiadne UI, žiadny adaptér, žiadny
route handler (tie sú issues 45-49).

Návrh (root cause, zvolený prístup, zamietnutá alternatíva) zaznamenaný na
tickete pred prvým commitom: https://github.com/zbynekdrlik/forestshop-app/issues/44#issuecomment-5129250113

## Testy

`apps/api/tests/pairing-schema.integration.test.ts` — 13 nových
integračných testov (PK/NOT NULL na supplier, UNIQUE/FK/enum/CHECK oboma
smermi na pairing, onDelete set-null vs. CHECK interakcia, dve veľkosti
toho istého produktu potvrdené nezávisle).

Closes #44
