### PR TITLE
docs(playbook): onDelete-vs-CHECK gotcha + version bump

### DIFF
--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -91,3 +91,15 @@ paths:
   POLOVIČNÚ kombináciu (jeden stĺpec vyplnený, druhý null), nielen pre "oba
   vyplnené v zlom stave" a "oba prázdne v zlom stave" — presne tá tretia
   kombinácia je to, čo bare rovnosť tichο prepúšťa.
+- **`onDelete: "set null"` na FK stĺpci, ktorý je súčasťou CHECKu viažuceho
+  ho na `state` (vzor vyššie), NEMUSÍ reálne nikdy nastať** — ak CHECK
+  vyžaduje ten stĺpec NOT NULL práve vtedy, keď je `state` v danom stave, set
+  null vždy poruší CHECK skôr, než sa uplatní, takže Postgres delete odmietne
+  s CHECK-violation namiesto FK-violation. Zistené code review na PR #50
+  (`pairing.confirmed_by`, deklarované "set null" ako mirror
+  `audit_events.actor_user_id`, ale `pairing_confirmation_ck` to nikdy
+  nedovolí) — oprava bola zmeniť FK na `onDelete: "restrict"` (skutočné
+  správanie sa nezmenilo, len sa zosúladil deklarovaný zámer s realitou).
+  Test na KAŽDÚ ďalšiu takúto FK+CHECK kombináciu: over, či `onDelete` reálne
+  vie nastať v STAVE, kde CHECK vyžaduje ten stĺpec vyplnený — ak nie,
+  `restrict` je pravdivejší popis než `set null`/`cascade`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.22",
+  "version": "0.3.0-dev.23",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Docs-only follow-up to PR 52: captures the onDelete/CHECK interaction gotcha in .claude/rules/database.md per the playbook-review mandate, plus the version bump needed because dev and main matched right after PR 52 merged.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>