### PR TITLE
F4: Kontrola párovania — potvrdenie/oprava adresy u dodávateľa (issue 45)

### DIFF
--- a/apps/api/src/http/app.ts
+++ b/apps/api/src/http/app.ts
@@ -14,6 +14,7 @@ import { checkLoginRateLimit, clientIp } from "./login-rate-limit.js";
 import { SESSION_COOKIE, requireUser, type AppBindings } from "./middleware.js";
 import { registerOrdersRoutes, type RunOrdersIngest } from "./orders-routes.js";
 import { requireSameOrigin } from "./origin-check.js";
+import { registerPairingRoutes } from "./pairing-routes.js";
 import { registerSchedulerRoutes } from "./scheduler-routes.js";
 import { registerSupplierRoutes } from "./supplier-routes.js";
 
@@ -126,6 +127,7 @@ export function createApp(
   registerOrdersRoutes(app, db, options.runOrdersIngest);
   registerSchedulerRoutes(app, db);
   registerSupplierRoutes(app, db, options.sendSupplierMail);
+  registerPairingRoutes(app, db);
 
   // Musí byť registrovaný AŽ PO všetkých skutočných /api/* trasách vyššie — Hono
   // vyberá presnejšiu zhodu, takže tie majú prednosť a sem sa dostane len to, čo

--- a/apps/api/src/http/pairing-routes.ts
+++ b/apps/api/src/http/pairing-routes.ts
@@ -1,0 +1,78 @@
+import { zValidator } from "@hono/zod-validator";
+import type { Hono } from "hono";
+import { z } from "zod";
+import type { Database } from "../db/client.js";
+import { log } from "../logger.js";
+import { listPairings } from "../modules/pairing/queries.js";
+import { confirmPairing } from "../modules/pairing/state.js";
+import { requireRole, requireUser, type AppBindings } from "./middleware.js";
+import { requireSameOrigin } from "./origin-check.js";
+
+// Prázdna hodnota (`page=`) sa má správať ako neprítomný parameter, rovnaký
+// vzor ako `catalog-routes.ts`'s `pageParam` — inak `Number("") === 0` padne
+// na `min(1)` a vráti 400 namiesto predvolenej prvej strany.
+const pageParam = z.preprocess(
+  (value) => (value === "" ? undefined : value),
+  z.coerce.number().int().min(1).max(100_000).default(1),
+);
+
+const pairingQuery = z.object({
+  q: z.string().max(200).default(""),
+  state: z.enum(["all", "navrhnute", "potvrdene"]).default("all"),
+  page: pageParam,
+  pageSize: z.coerce.number().int().min(1).max(200).default(50),
+});
+
+// `variantCode` ide v TELE, nie v ceste — kódy variantov nesú lomku
+// (napr. "40237/3XL"), ktorá by ako cestový segment bola prinajlepšom
+// krehká (viď návrhový komentár na issue 45). `supplierUrl` je voliteľné:
+// prítomné → ručne zadaná/opravená adresa (prepíše uloženú a rovno potvrdí);
+// chýbajúce → potvrdenie AKTUÁLNE uloženej/navrhnutej adresy.
+const confirmPairingBody = z.object({
+  variantCode: z.string().min(1).max(100),
+  supplierUrl: z.string().trim().min(1).max(2000).url().optional(),
+});
+
+export function registerPairingRoutes(app: Hono<AppBindings>, db: Database): void {
+  // Čítanie — rovnaké oprávnenie ako katalóg/objednávky (`requireUser`, žiadne
+  // obmedzenie roly): každý prihlásený smie vidieť stav párovania, len
+  // POTVRDZOVANIE (nižšie) je vyhradené.
+  app.get("/api/pairing", requireUser(db), zValidator("query", pairingQuery), async (c) =>
+    c.json(await listPairings(db, c.req.valid("query"))),
+  );
+
+  // Potvrdenie páru (jedným klikom, s alebo bez ručne zadanej novej adresy) —
+  // rovnaké oprávnenie ako zmena stavu riadku objednávky
+  // (`requireRole("admin", "manazer")`): manažér páruje, `citanie`/`sef` len
+  // čítajú.
+  app.post(
+    "/api/pairing/confirm",
+    requireSameOrigin(),
+    requireUser(db),
+    requireRole("admin", "manazer"),
+    zValidator("json", confirmPairingBody),
+    async (c) => {
+      const body = c.req.valid("json");
+      const user = c.get("user");
+      const now = new Date();
+
+      const result = await confirmPairing(db, {
+        variantCode: body.variantCode,
+        supplierUrl: body.supplierUrl,
+        actorUserId: user.userId,
+        now,
+      });
+      if (result === "not_found") {
+        return c.json({ error: "Variant sa nenašiel" }, 404);
+      }
+      if (result === "missing_url") {
+        return c.json({ error: "Chýba adresa produktu u dodávateľa" }, 400);
+      }
+      log.info(
+        { actorUserId: user.userId, variantCode: body.variantCode, manualOverride: body.supplierUrl !== undefined },
+        "potvrdenie párovania variantu",
+      );
+      return c.json({ ok: true as const });
+    },
+  );
+}

--- a/apps/api/src/modules/catalog/queries.ts
+++ b/apps/api/src/modules/catalog/queries.ts
@@ -122,7 +122,10 @@ export async function listSnapshots(db: Database, limit: number): Promise<readon
 // task-6-fix-1). Postgres berie spätnú lomku ako escape znak pre LIKE/ILIKE bez
 // ďalšej konfigurácie — preto sa escapuje aj ona sama, a to PRVÁ, inak by
 // escapovanie znaku escapovalo escape.
-function escapeLikePattern(value: string): string {
+// Exportované — `modules/pairing/queries.ts` (issue 45) potrebuje PRESNE tú
+// istú escapovaciu logiku pre svoje vlastné ILIKE hľadanie nad `variant.code`/
+// `variant.name`, nikdy vlastnú duplicitnú kópiu, ktorá by sa mohla rozísť.
+export function escapeLikePattern(value: string): string {
   return value.replace(/[\\%_]/g, (ch) => `\\${ch}`);
 }
 

--- a/apps/api/src/modules/pairing/queries.ts
+++ b/apps/api/src/modules/pairing/queries.ts
@@ -1,0 +1,121 @@
+import { and, asc, eq, or, sql, type SQL } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { pairings, products, users, variants } from "../../db/schema.js";
+import { escapeLikePattern } from "../catalog/queries.js";
+
+// Zrkadlí `PairingState` zo schémy (`schema-pairing.ts`'s `pairingState`
+// enum), ale drží sa aj bez importu typu odtiaľ — jednoduchý reťazcový
+// literál je tu čitateľnejší než ďalší cyklus importov.
+export type PairingDisplayState = "navrhnute" | "potvrdene";
+
+export interface PairingListItem {
+  readonly variantCode: string;
+  readonly variantName: string;
+  readonly sizeLabel: string | null;
+  // `product.supplier` — INFORMATÍVNY reťazec zo Shoptet exportu (kto nám
+  // produkt oficiálne dodáva), NIE cieľ párovania. Cieľ párovania je
+  // `supplierUrl` nižšie (konkrétna adresa produktu u veľkoobchodného
+  // dodávateľa, viď `schema-pairing.ts`).
+  readonly productSupplier: string | null;
+  readonly supplierUrl: string | null;
+  // Chýbajúci `pairing` riadok (žiadny kandidát zatiaľ nebol navrhnutý ani
+  // ručne zadaný — #46 automatické hľadanie kandidátov ešte neexistuje) sa
+  // zobrazuje ako "navrhnute" s `supplierUrl: null` — presne zodpovedá
+  // počiatočnému stavu DB automatu (`pairing_confirmation_ck`), len bez
+  // toho, že by preň musel existovať riadok.
+  readonly state: PairingDisplayState;
+  readonly confirmedByName: string | null;
+  readonly confirmedAt: string | null;
+}
+
+export interface PairingSearchInput {
+  readonly q: string;
+  readonly state: "all" | PairingDisplayState;
+  readonly page: number;
+  readonly pageSize: number;
+}
+
+export interface PairingSearchResult {
+  readonly total: number;
+  readonly items: readonly PairingListItem[];
+}
+
+const listColumns = {
+  variantCode: variants.code,
+  variantName: variants.name,
+  sizeLabel: variants.sizeLabel,
+  productSupplier: products.supplier,
+  supplierUrl: pairings.supplierUrl,
+  pairingState: pairings.state,
+  confirmedByName: users.displayName,
+  confirmedAt: pairings.confirmedAt,
+};
+
+type ListRow = {
+  readonly variantCode: string;
+  readonly variantName: string;
+  readonly sizeLabel: string | null;
+  readonly productSupplier: string | null;
+  readonly supplierUrl: string | null;
+  readonly pairingState: PairingDisplayState | null;
+  readonly confirmedByName: string | null;
+  readonly confirmedAt: Date | null;
+};
+
+function toItem(row: ListRow): PairingListItem {
+  return {
+    variantCode: row.variantCode,
+    variantName: row.variantName,
+    sizeLabel: row.sizeLabel,
+    productSupplier: row.productSupplier,
+    supplierUrl: row.supplierUrl,
+    // Chýbajúci riadok (LEFT JOIN nenašiel zhodu) → `pairingState` je `null`
+    // → zobrazí sa ako "navrhnute" (viď komentár pri `PairingListItem.state`).
+    state: row.pairingState ?? "navrhnute",
+    confirmedByName: row.confirmedByName,
+    confirmedAt: row.confirmedAt?.toISOString() ?? null,
+  };
+}
+
+// LEFT JOIN na `pairing` aj `users` (nie INNER) — zámerné, viď návrhový
+// komentár na issue 45: `pairing` dnes nemá ANI JEDEN riadok (#46 automatické
+// hľadanie kandidátov ešte neexistuje), INNER JOIN by preto vrátil vždy
+// prázdny zoznam. `users` LEFT JOIN zo symetrického dôvodu — nepotvrdený
+// pairing nemá `confirmed_by` vôbec.
+export async function listPairings(db: Database, input: PairingSearchInput): Promise<PairingSearchResult> {
+  const filters: SQL[] = [];
+  if (input.q !== "") {
+    // ILIKE nad `code` aj `name`, rovnaký zámer ako katalógové vyhľadávanie —
+    // manažér hľadá raz kód variantu, raz slovo z názvu produktu.
+    const pattern = `%${escapeLikePattern(input.q)}%`;
+    const byCodeOrName = or(sql`${variants.code} ILIKE ${pattern}`, sql`${variants.name} ILIKE ${pattern}`);
+    if (byCodeOrName !== undefined) filters.push(byCodeOrName);
+  }
+  if (input.state !== "all") {
+    // `coalesce` — chýbajúci riadok sa pri filtrovaní musí správať PRESNE
+    // tak, ako sa zobrazuje (viď `toItem` vyššie), inak by filter "navrhnute"
+    // ticho vynechával práve tie varianty, ktoré ho najviac potrebujú.
+    filters.push(sql`coalesce(${pairings.state}, 'navrhnute') = ${input.state}`);
+  }
+  const where = filters.length === 0 ? undefined : and(...filters);
+
+  const [totals] = await db
+    .select({ total: sql<number>`count(*)`.mapWith(Number) })
+    .from(variants)
+    .innerJoin(products, eq(products.key, variants.productKey))
+    .leftJoin(pairings, eq(pairings.variantCode, variants.code))
+    .where(where);
+
+  const rows = await db
+    .select(listColumns)
+    .from(variants)
+    .innerJoin(products, eq(products.key, variants.productKey))
+    .leftJoin(pairings, eq(pairings.variantCode, variants.code))
+    .leftJoin(users, eq(users.id, pairings.confirmedBy))
+    .where(where)
+    .orderBy(asc(variants.code))
+    .limit(input.pageSize)
+    .offset((input.page - 1) * input.pageSize);
+
+  return { total: totals?.total ?? 0, items: rows.map(toItem) };
+}

--- a/apps/api/src/modules/pairing/state.ts
+++ b/apps/api/src/modules/pairing/state.ts
@@ -1,0 +1,84 @@
+import { eq } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { pairings, variants } from "../../db/schema.js";
+import { record } from "../audit/service.js";
+
+export type ConfirmPairingResult = "ok" | "not_found" | "missing_url";
+
+export interface ConfirmPairingInput {
+  readonly variantCode: string;
+  // Voliteľné — keď je prítomné, PREPÍŠE navrhnutú/uloženú adresu pred
+  // potvrdením (stará appka's "zamietni a zadaj inú adresu ručne"). Keď
+  // chýba, potvrdí sa AKTUÁLNE uložená adresa (stará appka's "✓ jedným
+  // klikom") — viď návrhový komentár na issue 45.
+  readonly supplierUrl?: string | undefined;
+  readonly actorUserId: string;
+  readonly now: Date;
+}
+
+// Celý zápis beží v JEDNEJ transakcii (rovnaký vzor ako `orders/state.ts`'s
+// `setOrderLineState` a `orders/supplier-contact.ts`'s
+// `setSupplierContactEmail`) — nový stav bez auditového záznamu (alebo
+// naopak) by nechal históriu ("kto a kedy potvrdil párovanie") nekonzistentnú
+// so skutočným obsahom riadku.
+export async function confirmPairing(db: Database, input: ConfirmPairingInput): Promise<ConfirmPairingResult> {
+  return db.transaction(async (tx) => {
+    const [variant] = await tx
+      .select({ code: variants.code })
+      .from(variants)
+      .where(eq(variants.code, input.variantCode))
+      .limit(1);
+    if (variant === undefined) return "not_found";
+
+    // `.for("update")` na existujúcom `pairing` riadku (ak existuje) —
+    // rovnaký dôvod ako `setOrderLineState`'s zámok (nález review na #25 v
+    // tomto repe): bez neho by dve súbežné potvrdenia TOHO ISTÉHO variantu
+    // mohli obe prečítať tú istú (čoskoro zastaranú) uloženú adresu pred
+    // tým, než druhá transakcia commitne svoj UPSERT. Zámok drží riadok len
+    // do konca TEJTO transakcie.
+    const [existing] = await tx
+      .select({ supplierUrl: pairings.supplierUrl })
+      .from(pairings)
+      .where(eq(pairings.variantCode, input.variantCode))
+      .for("update")
+      .limit(1);
+
+    const manualOverride = input.supplierUrl !== undefined;
+    const finalUrl = manualOverride ? input.supplierUrl : (existing?.supplierUrl ?? null);
+    if (finalUrl === null || finalUrl === "") return "missing_url";
+
+    // Upsert — funguje rovnako, či `pairing` riadok pre tento variant už
+    // existuje (typicky po #46 auto-návrhu), alebo ešte vôbec neexistuje
+    // (dnešný bežný prípad, kým #46 nepristane) — `variant_code` UNIQUE
+    // (schema-pairing.ts) robí z tohto bezpečný atomický upsert.
+    await tx
+      .insert(pairings)
+      .values({
+        variantCode: input.variantCode,
+        supplierUrl: finalUrl,
+        state: "potvrdene",
+        confirmedBy: input.actorUserId,
+        confirmedAt: input.now,
+      })
+      .onConflictDoUpdate({
+        target: pairings.variantCode,
+        set: {
+          supplierUrl: finalUrl,
+          state: "potvrdene",
+          confirmedBy: input.actorUserId,
+          confirmedAt: input.now,
+        },
+      });
+
+    await record(tx, {
+      at: input.now,
+      actorUserId: input.actorUserId,
+      action: "pairing.confirm",
+      entity: "pairing",
+      entityId: input.variantCode,
+      data: { variantCode: input.variantCode, supplierUrl: finalUrl, manualOverride },
+    });
+
+    return "ok";
+  });
+}

--- a/apps/api/tests/pairing-http.integration.test.ts
+++ b/apps/api/tests/pairing-http.integration.test.ts
@@ -1,0 +1,329 @@
+import { eq } from "drizzle-orm";
+import { afterEach, expect, it } from "vitest";
+import { auditEvents, pairings, users } from "../src/db/schema.js";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import type { UserRole } from "../src/modules/auth/service.js";
+import { withCleanDb } from "./helpers/db.js";
+import { insertTestVariant } from "./helpers/orders.js";
+
+const HESLO = "test-heslo-abc"; // testovacie údaje, nie tajomstvo
+
+let close: (() => Promise<void>) | undefined;
+
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  resetLoginRateLimit();
+});
+
+async function boot(role: UserRole) {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const [pouzivatel] = await ctx.db
+    .insert(users)
+    .values({
+      email: "manazer@forestshop.sk",
+      passwordHash: await hashPassword(HESLO),
+      displayName: "Manažér",
+      role,
+    })
+    .returning({ id: users.id });
+  if (pouzivatel === undefined) throw new Error("testovací používateľ sa nepodarilo vložiť");
+
+  const app = createApp(ctx.db, { cookieSecure: false });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "manazer@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie, db: ctx.db, userId: pouzivatel.id };
+}
+
+it("bez prihlásenia vráti 401 na oboch trasách párovania", async () => {
+  const { app } = await boot("manazer");
+  expect((await app.request("/api/pairing")).status).toBe(401);
+  expect(
+    (
+      await app.request("/api/pairing/confirm", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ variantCode: "A-1" }),
+      })
+    ).status,
+  ).toBe(401);
+});
+
+it("variant bez pairing riadku sa zobrazí ako 'navrhnute' s prázdnou adresou (LEFT JOIN, nie INNER)", async () => {
+  const { app, cookie, db } = await boot("citanie"); // čítanie smie vidieť stav párovania
+  await insertTestVariant(db, "40237/3XL", "GRUBE");
+
+  const res = await app.request("/api/pairing", { headers: { cookie } });
+  expect(res.status).toBe(200);
+  const telo = (await res.json()) as { total: number; items: unknown[] };
+  expect(telo.total).toBe(1);
+  expect(telo.items[0]).toMatchObject({
+    variantCode: "40237/3XL",
+    productSupplier: "GRUBE",
+    supplierUrl: null,
+    state: "navrhnute",
+    confirmedByName: null,
+    confirmedAt: null,
+  });
+});
+
+it("potvrdený pairing nesie meno a čas potvrdenia", async () => {
+  const { app, cookie, db, userId } = await boot("manazer");
+  await insertTestVariant(db, "40238/M", "GRUBE");
+  await db.insert(pairings).values({
+    variantCode: "40238/M",
+    supplierUrl: "https://www.grube.sk/p/1",
+    state: "potvrdene",
+    confirmedBy: userId,
+    confirmedAt: new Date("2026-07-30T11:00:00Z"),
+  });
+
+  const res = await app.request("/api/pairing", { headers: { cookie } });
+  const telo = (await res.json()) as {
+    items: { variantCode: string; state: string; confirmedByName: string | null; confirmedAt: string | null }[];
+  };
+  expect(telo.items[0]).toMatchObject({
+    variantCode: "40238/M",
+    state: "potvrdene",
+    confirmedByName: "Manažér",
+  });
+  expect(telo.items[0]?.confirmedAt).not.toBeNull();
+});
+
+it("filter podľa stavu vráti len navrhnuté / len potvrdené", async () => {
+  const { app, cookie, db, userId } = await boot("manazer");
+  await insertTestVariant(db, "40239/S", "GRUBE");
+  await insertTestVariant(db, "40239/M", "GRUBE");
+  await db.insert(pairings).values({
+    variantCode: "40239/M",
+    supplierUrl: "https://www.grube.sk/p/2",
+    state: "potvrdene",
+    confirmedBy: userId,
+    confirmedAt: new Date("2026-07-30T11:00:00Z"),
+  });
+
+  const navrhnute = (await (
+    await app.request("/api/pairing?state=navrhnute", { headers: { cookie } })
+  ).json()) as { items: { variantCode: string }[] };
+  expect(navrhnute.items.map((i) => i.variantCode)).toEqual(["40239/S"]);
+
+  const potvrdene = (await (
+    await app.request("/api/pairing?state=potvrdene", { headers: { cookie } })
+  ).json()) as { items: { variantCode: string }[] };
+  expect(potvrdene.items.map((i) => i.variantCode)).toEqual(["40239/M"]);
+});
+
+it("fulltext hľadanie podľa kódu aj názvu", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await insertTestVariant(db, "60055/L", "GRUBE");
+
+  const podlaKodu = (await (
+    await app.request("/api/pairing?q=60055", { headers: { cookie } })
+  ).json()) as { items: { variantCode: string }[] };
+  expect(podlaKodu.items.map((i) => i.variantCode)).toEqual(["60055/L"]);
+
+  const podlaNazvu = (await (
+    await app.request(`/api/pairing?q=${encodeURIComponent("Test produkt 60055/L")}`, { headers: { cookie } })
+  ).json()) as { items: { variantCode: string }[] };
+  expect(podlaNazvu.items.map((i) => i.variantCode)).toEqual(["60055/L"]);
+
+  const ziadnaZhoda = (await (
+    await app.request("/api/pairing?q=neexistuje-vobec", { headers: { cookie } })
+  ).json()) as { items: unknown[]; total: number };
+  expect(ziadnaZhoda.total).toBe(0);
+});
+
+it("potvrdenie BEZ tela použije uloženú/navrhnutú adresu (jedným klikom)", async () => {
+  const { app, cookie, db, userId } = await boot("manazer");
+  await insertTestVariant(db, "40240/S", "GRUBE");
+  await db.insert(pairings).values({ variantCode: "40240/S", supplierUrl: "https://www.grube.sk/p/3" });
+
+  const res = await app.request("/api/pairing/confirm", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ variantCode: "40240/S" }),
+  });
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ ok: true });
+
+  const [riadok] = await db.select().from(pairings).where(eq(pairings.variantCode, "40240/S"));
+  expect(riadok).toMatchObject({
+    supplierUrl: "https://www.grube.sk/p/3",
+    state: "potvrdene",
+    confirmedBy: userId,
+  });
+  expect(riadok?.confirmedAt).not.toBeNull();
+
+  const udalosti = await db.select().from(auditEvents);
+  const udalost = udalosti.find((e) => e.action === "pairing.confirm");
+  expect(udalost).toMatchObject({
+    actorUserId: userId,
+    entity: "pairing",
+    entityId: "40240/S",
+    data: { variantCode: "40240/S", supplierUrl: "https://www.grube.sk/p/3", manualOverride: false },
+  });
+});
+
+it("potvrdenie BEZ tela a bez uloženej adresy vráti 400 (nie je čo potvrdiť)", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await insertTestVariant(db, "40241/XL", "GRUBE");
+
+  const res = await app.request("/api/pairing/confirm", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ variantCode: "40241/XL" }),
+  });
+  expect(res.status).toBe(400);
+  const telo = (await res.json()) as { error: string };
+  expect(telo.error).toMatch(/adresa/);
+
+  const [riadok] = await db.select().from(pairings);
+  expect(riadok).toBeUndefined();
+});
+
+it("ručne zadaná adresa (zamietnutie pôvodného kandidáta) PREPÍŠE uloženú adresu a rovno potvrdí", async () => {
+  const { app, cookie, db, userId } = await boot("manazer");
+  await insertTestVariant(db, "40242/2XL", "GRUBE");
+  // Pôvodne navrhnutá (nesprávna) adresa — manažér ju "zamietne" tým, že
+  // pošle inú v tele požiadavky.
+  await db.insert(pairings).values({ variantCode: "40242/2XL", supplierUrl: "https://www.grube.sk/spatna-adresa" });
+
+  const res = await app.request("/api/pairing/confirm", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ variantCode: "40242/2XL", supplierUrl: "https://www.grube.sk/p/spravna-adresa" }),
+  });
+  expect(res.status).toBe(200);
+
+  const [riadok] = await db.select().from(pairings).where(eq(pairings.variantCode, "40242/2XL"));
+  expect(riadok).toMatchObject({
+    supplierUrl: "https://www.grube.sk/p/spravna-adresa",
+    state: "potvrdene",
+    confirmedBy: userId,
+  });
+
+  const udalosti = await db.select().from(auditEvents);
+  const udalost = udalosti.find((e) => e.action === "pairing.confirm");
+  expect(udalost?.data).toMatchObject({ manualOverride: true });
+});
+
+it("ručne zadaná adresa funguje aj keď ešte VÔBEC neexistuje pairing riadok (prvé párovanie variantu)", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await insertTestVariant(db, "40243/3XL", "GRUBE");
+
+  const res = await app.request("/api/pairing/confirm", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ variantCode: "40243/3XL", supplierUrl: "https://www.grube.sk/p/nove" }),
+  });
+  expect(res.status).toBe(200);
+
+  const [riadok] = await db.select().from(pairings).where(eq(pairings.variantCode, "40243/3XL"));
+  expect(riadok).toMatchObject({ supplierUrl: "https://www.grube.sk/p/nove", state: "potvrdene" });
+});
+
+it("neplatná (nie-URL) ručne zadaná adresa vráti 400 pred akýmkoľvek zápisom", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await insertTestVariant(db, "40244/4XL", "GRUBE");
+
+  const res = await app.request("/api/pairing/confirm", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ variantCode: "40244/4XL", supplierUrl: "nie je to url" }),
+  });
+  expect(res.status).toBe(400);
+
+  const [riadok] = await db.select().from(pairings);
+  expect(riadok).toBeUndefined();
+});
+
+it("neznámy variant vráti 404, nič sa nezapíše", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  const res = await app.request("/api/pairing/confirm", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ variantCode: "neexistujuci-kod", supplierUrl: "https://a.example/1" }),
+  });
+  expect(res.status).toBe(404);
+
+  const [riadok] = await db.select().from(pairings);
+  expect(riadok).toBeUndefined();
+});
+
+it("rola citanie nesmie potvrdiť párovanie", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  await insertTestVariant(db, "40245/5XL", "GRUBE");
+  const res = await app.request("/api/pairing/confirm", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ variantCode: "40245/5XL", supplierUrl: "https://a.example/1" }),
+  });
+  expect(res.status).toBe(403);
+});
+
+it("rola sef tiež nesmie potvrdiť párovanie", async () => {
+  const { app, cookie, db } = await boot("sef");
+  await insertTestVariant(db, "40246/6XL", "GRUBE");
+  const res = await app.request("/api/pairing/confirm", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ variantCode: "40246/6XL", supplierUrl: "https://a.example/1" }),
+  });
+  expect(res.status).toBe(403);
+});
+
+it("potvrdenie s cudzím Origin je odmietnuté (403), rovnaký pôvod prejde", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await insertTestVariant(db, "40247/7XL", "GRUBE");
+
+  const cudzi = await app.request("/api/pairing/confirm", {
+    method: "POST",
+    headers: {
+      cookie,
+      "content-type": "application/json",
+      origin: "https://utocnik.example",
+      host: "forestshop.example",
+    },
+    body: JSON.stringify({ variantCode: "40247/7XL", supplierUrl: "https://a.example/1" }),
+  });
+  expect(cudzi.status).toBe(403);
+
+  const rovnaky = await app.request("/api/pairing/confirm", {
+    method: "POST",
+    headers: {
+      cookie,
+      "content-type": "application/json",
+      origin: "https://forestshop.example",
+      host: "forestshop.example",
+    },
+    body: JSON.stringify({ variantCode: "40247/7XL", supplierUrl: "https://a.example/1" }),
+  });
+  expect(rovnaky.status).toBe(200);
+});
+
+it("dva variantné kódy toho istého produktu sa páruju NEZÁVISLE (unique na variant_code, nie na produkt)", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await insertTestVariant(db, "40248/S", "GRUBE");
+  await insertTestVariant(db, "40248/M", "GRUBE");
+
+  await app.request("/api/pairing/confirm", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ variantCode: "40248/S", supplierUrl: "https://a.example/velkost-s" }),
+  });
+
+  const zoznam = (await (await app.request("/api/pairing", { headers: { cookie } })).json()) as {
+    items: { variantCode: string; state: string }[];
+  };
+  const s = zoznam.items.find((i) => i.variantCode === "40248/S");
+  const m = zoznam.items.find((i) => i.variantCode === "40248/M");
+  expect(s?.state).toBe("potvrdene");
+  expect(m?.state).toBe("navrhnute"); // druhá veľkosť zostáva nedotknutá
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5,6 +5,7 @@ import { ChangePasswordForm } from "./components/ChangePasswordForm.js";
 import { Footer } from "./components/Footer.js";
 import { LoginForm } from "./components/LoginForm.js";
 import { OrdersSection } from "./components/OrdersSection.js";
+import { PairingSection } from "./components/PairingSection.js";
 import { SchedulerSection } from "./components/SchedulerSection.js";
 
 export function App(): JSX.Element {
@@ -77,6 +78,7 @@ export function App(): JSX.Element {
       {logoutError !== "" && <p role="alert">{logoutError}</p>}
       <CatalogPage role={me.role} onSessionExpired={reload} />
       <OrdersSection role={me.role} onSessionExpired={reload} />
+      <PairingSection role={me.role} onSessionExpired={reload} />
       <SchedulerSection role={me.role} onSessionExpired={reload} />
       <ChangePasswordForm onSessionExpired={reload} />
       <Footer />

--- a/apps/web/src/components/PairingSection.test.tsx
+++ b/apps/web/src/components/PairingSection.test.tsx
@@ -1,0 +1,196 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { PairingSection } from "./PairingSection.js";
+
+const { searchPairings, confirmPairing } = vi.hoisted(() => ({
+  searchPairings: vi.fn(),
+  confirmPairing: vi.fn(),
+}));
+
+// `PairingUnauthorizedError` ostáva SKUTOČNÁ trieda z reálneho modulu — rovnaký
+// dôvod ako `OrdersSection.test.tsx`'s `OrdersUnauthorizedError`: `instanceof`
+// v komponente musí fungovať aj v teste.
+vi.mock("../pairingApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../pairingApi.js")>();
+  return { ...actual, searchPairings, confirmPairing };
+});
+
+const { PairingUnauthorizedError } = await import("../pairingApi.js");
+
+const NAVRHNUTY = {
+  variantCode: "40237/3XL",
+  variantName: "Nohavice FOREST 1003",
+  sizeLabel: "3XL",
+  productSupplier: "GRUBE",
+  supplierUrl: "https://www.grube.sk/p/1",
+  state: "navrhnute" as const,
+  confirmedByName: null,
+  confirmedAt: null,
+};
+
+const POTVRDENY = {
+  variantCode: "40238/M",
+  variantName: "Nohavice FOREST 1003",
+  sizeLabel: "M",
+  productSupplier: "GRUBE",
+  supplierUrl: "https://www.grube.sk/p/2",
+  state: "potvrdene" as const,
+  confirmedByName: "Manažér",
+  confirmedAt: "2026-07-30T11:00:00.000Z",
+};
+
+const BEZ_ADRESY = {
+  variantCode: "40239/S",
+  variantName: "Čiapka Polar FOREST",
+  sizeLabel: null,
+  productSupplier: null,
+  supplierUrl: null,
+  state: "navrhnute" as const,
+  confirmedByName: null,
+  confirmedAt: null,
+};
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+it("keď zoznam nezodpovedá žiadnemu variantu, zobrazí informačnú vetu namiesto holej tabuľky", async () => {
+  searchPairings.mockResolvedValue({ total: 0, items: [] });
+
+  render(<PairingSection role="citanie" onSessionExpired={() => {}} />);
+
+  await screen.findByTestId("pairing-empty");
+  expect(screen.queryByRole("table")).toBeNull();
+});
+
+it("zobrazí kód, produkt, veľkosť, dodávateľa, adresu a stav", async () => {
+  searchPairings.mockResolvedValue({ total: 2, items: [NAVRHNUTY, POTVRDENY] });
+
+  render(<PairingSection role="citanie" onSessionExpired={() => {}} />);
+
+  const navrhnuty = await screen.findByTestId("pairing-40237/3XL");
+  expect(navrhnuty.textContent).toContain("Nohavice FOREST 1003");
+  expect(navrhnuty.textContent).toContain("3XL");
+  expect(navrhnuty.textContent).toContain("GRUBE");
+  expect(navrhnuty.textContent).toContain("Navrhnuté");
+
+  const potvrdeny = screen.getByTestId("pairing-40238/M");
+  expect(potvrdeny.textContent).toContain("Potvrdené");
+  expect(potvrdeny.textContent).toContain("Manažér");
+});
+
+it("chýbajúcu veľkosť a dodávateľa zobrazí ako pomlčku, chýbajúcu adresu tiež", async () => {
+  searchPairings.mockResolvedValue({ total: 1, items: [BEZ_ADRESY] });
+
+  render(<PairingSection role="citanie" onSessionExpired={() => {}} />);
+
+  const riadok = await screen.findByTestId("pairing-40239/S");
+  const bunky = riadok.querySelectorAll("td");
+  expect(bunky[2]?.textContent).toContain("—"); // veľkosť
+  expect(bunky[3]?.textContent).toContain("—"); // dodávateľ
+  expect(bunky[4]?.textContent).toContain("—"); // adresa
+});
+
+it("pri 401 zavolá onSessionExpired namiesto zobrazenia všeobecnej chyby", async () => {
+  searchPairings.mockRejectedValue(new PairingUnauthorizedError());
+  const onSessionExpired = vi.fn();
+
+  render(<PairingSection role="citanie" onSessionExpired={onSessionExpired} />);
+
+  await waitFor(() => {
+    expect(onSessionExpired).toHaveBeenCalledTimes(1);
+  });
+});
+
+it("rola citanie nevidí stĺpec Akcie", async () => {
+  searchPairings.mockResolvedValue({ total: 1, items: [NAVRHNUTY] });
+
+  render(<PairingSection role="citanie" onSessionExpired={() => {}} />);
+
+  await screen.findByTestId("pairing-40237/3XL");
+  expect(screen.queryByTestId("confirm-40237/3XL")).toBeNull();
+  expect(screen.queryByTestId("reject-40237/3XL")).toBeNull();
+});
+
+it("rola manazer potvrdí navrhnutú adresu jedným klikom, obrazovka sa po potvrdení znova načíta (confirmedByName/At sú AUTORITATÍVNE zo servera)", async () => {
+  const POTVRDENY_PO_KLIKU = { ...NAVRHNUTY, state: "potvrdene" as const, confirmedByName: "Manažér", confirmedAt: "2026-07-30T12:00:00.000Z" };
+  searchPairings.mockResolvedValueOnce({ total: 1, items: [NAVRHNUTY] });
+  searchPairings.mockResolvedValueOnce({ total: 1, items: [POTVRDENY_PO_KLIKU] });
+  confirmPairing.mockResolvedValue(undefined);
+
+  render(<PairingSection role="manazer" onSessionExpired={() => {}} />);
+
+  const tlacidlo = await screen.findByTestId("confirm-40237/3XL");
+  fireEvent.click(tlacidlo);
+
+  await waitFor(() => {
+    expect(confirmPairing).toHaveBeenCalledWith("40237/3XL");
+  });
+  await waitFor(() => {
+    expect(screen.getByTestId("pairing-40237/3XL").textContent).toContain("Manažér");
+  });
+  expect(searchPairings).toHaveBeenCalledTimes(2); // druhé volanie po potvrdení, aby sa zobrazilo AUTORITATÍVNE meno/čas potvrdenia
+});
+
+it("tlačidlo ✓ Potvrdiť je disabled, keď variant nemá žiadnu navrhnutú adresu", async () => {
+  searchPairings.mockResolvedValue({ total: 1, items: [BEZ_ADRESY] });
+
+  render(<PairingSection role="manazer" onSessionExpired={() => {}} />);
+
+  const tlacidlo = await screen.findByTestId("confirm-40239/S");
+  expect((tlacidlo as HTMLButtonElement).disabled).toBe(true);
+});
+
+it("✗ Zadať inú adresu otvorí formulár, uloženie pošle novú adresu a potvrdí", async () => {
+  const POTVRDENY_S_NOVOU_ADRESOU = {
+    ...BEZ_ADRESY,
+    supplierUrl: "https://www.grube.sk/p/nova",
+    state: "potvrdene" as const,
+    confirmedByName: "Manažér",
+    confirmedAt: "2026-07-30T12:00:00.000Z",
+  };
+  searchPairings.mockResolvedValueOnce({ total: 1, items: [BEZ_ADRESY] });
+  searchPairings.mockResolvedValueOnce({ total: 1, items: [POTVRDENY_S_NOVOU_ADRESOU] });
+  confirmPairing.mockResolvedValue(undefined);
+
+  render(<PairingSection role="manazer" onSessionExpired={() => {}} />);
+
+  fireEvent.click(await screen.findByTestId("reject-40239/S"));
+  const vstup = screen.getByLabelText("Adresa u dodávateľa pre 40239/S");
+  fireEvent.change(vstup, { target: { value: "https://www.grube.sk/p/nova" } });
+  fireEvent.click(screen.getByRole("button", { name: "Potvrdiť" }));
+
+  await waitFor(() => {
+    expect(confirmPairing).toHaveBeenCalledWith("40239/S", "https://www.grube.sk/p/nova");
+  });
+  await waitFor(() => {
+    expect(screen.getByTestId("pairing-40239/S").textContent).toContain("Potvrdené");
+  });
+});
+
+it("zlyhané potvrdenie zobrazí slovenskú hlášku zo servera a stav sa nezmení", async () => {
+  searchPairings.mockResolvedValue({ total: 1, items: [NAVRHNUTY] });
+  confirmPairing.mockRejectedValue(new Error("Chýba adresa produktu u dodávateľa"));
+
+  render(<PairingSection role="manazer" onSessionExpired={() => {}} />);
+
+  fireEvent.click(await screen.findByTestId("confirm-40237/3XL"));
+
+  await screen.findByText("Chýba adresa produktu u dodávateľa");
+  expect(screen.getByTestId("pairing-40237/3XL").textContent).toContain("Navrhnuté");
+});
+
+it("potvrdenie pri 401 zavolá onSessionExpired namiesto zobrazenia chyby", async () => {
+  searchPairings.mockResolvedValue({ total: 1, items: [NAVRHNUTY] });
+  confirmPairing.mockRejectedValue(new PairingUnauthorizedError());
+  const onSessionExpired = vi.fn();
+
+  render(<PairingSection role="manazer" onSessionExpired={onSessionExpired} />);
+
+  fireEvent.click(await screen.findByTestId("confirm-40237/3XL"));
+
+  await waitFor(() => {
+    expect(onSessionExpired).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/PairingSection.tsx
+++ b/apps/web/src/components/PairingSection.tsx
@@ -1,0 +1,313 @@
+import { useCallback, useEffect, useRef, useState, type SyntheticEvent, type JSX } from "react";
+import type { Me } from "../api.js";
+import {
+  confirmPairing,
+  searchPairings,
+  PairingUnauthorizedError,
+  type PairingItem,
+  type PairingState,
+} from "../pairingApi.js";
+
+const STATE_LABELS: Record<PairingItem["state"], string> = {
+  navrhnute: "Navrhnuté",
+  potvrdene: "Potvrdené",
+};
+
+// Rovnaké dve role, ktoré server vyžaduje pre `POST /api/pairing/confirm`
+// (`requireRole("admin", "manazer")`, `pairing-routes.ts`) — server ostáva
+// skutočnou bránou, toto len skrýva ovládacie prvky pre role, ktoré by aj tak
+// dostali 403 (rovnaký vzor ako `OrdersSection`'s `CAN_CHANGE_STATE_ROLES`).
+const CAN_CONFIRM_ROLES: ReadonlySet<Me["role"]> = new Set(["admin", "manazer"]);
+
+export function PairingSection({
+  role,
+  onSessionExpired,
+}: {
+  readonly role: Me["role"];
+  readonly onSessionExpired: () => void;
+}): JSX.Element {
+  const [items, setItems] = useState<readonly PairingItem[]>([]);
+  const [total, setTotal] = useState(0);
+  const [searchLoaded, setSearchLoaded] = useState(false);
+  const [query, setQuery] = useState("");
+  const [state, setState] = useState<PairingState>("all");
+  const [searchError, setSearchError] = useState("");
+  const canConfirm = CAN_CONFIRM_ROLES.has(role);
+
+  // Ručné zadanie/oprava adresy pre PRÁVE JEDEN riadok naraz (rovnaký vzor
+  // ako `OrdersSection`'s e-mailová úprava dodávateľa).
+  const [editingCode, setEditingCode] = useState<string | null>(null);
+  const [urlDraft, setUrlDraft] = useState("");
+  const [busyCode, setBusyCode] = useState<string | null>(null);
+  const [actionError, setActionError] = useState("");
+
+  // Len najnovšia požiadavka smie zapísať výsledok — rovnaký dôvod ako
+  // `CatalogPage`'s `searchSeq` (neindexovaný ILIKE nad celým katalógom môže
+  // staršiu, širšiu odpoveď doručiť neskôr než novšiu, užšiu).
+  const searchSeq = useRef(0);
+
+  const search = useCallback(
+    (q: string, s: PairingState) => {
+      const seq = (searchSeq.current += 1);
+      setSearchError("");
+      searchPairings({ q, state: s, page: 1 })
+        .then((result) => {
+          if (seq !== searchSeq.current) return; // medzitým prišla novšia požiadavka
+          setItems(result.items);
+          setTotal(result.total);
+          setSearchLoaded(true);
+        })
+        .catch((err: unknown) => {
+          if (seq !== searchSeq.current) return;
+          setSearchLoaded(true);
+          if (err instanceof PairingUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setItems([]);
+          setTotal(0);
+          setSearchError("Zoznam párovania sa nepodarilo načítať.");
+        });
+    },
+    [onSessionExpired],
+  );
+
+  useEffect(() => {
+    search("", "all");
+  }, [search]);
+
+  function submit(event: SyntheticEvent): void {
+    event.preventDefault();
+    search(query, state);
+  }
+
+  // Na rozdiel od `OrdersSection`'s lokálnej aktualizácie stavu (tá si vystačí
+  // s hodnotou, ktorú si klient sám poslal) táto tabuľka zobrazuje AJ
+  // `confirmedByName`/`confirmedAt` — údaje, ktoré klient nepozná vopred (server
+  // ich odvodí z prihlásenej relácie a aktuálneho času). Preto sa po úspešnom
+  // potvrdení znova NAČÍTA aktuálna stránka výsledkov, rovnaký vzor ako
+  // `CatalogPage`'s `runIngest` (`loadStats(); search(query, state);`) — jediný
+  // spôsob, ako zobraziť AUTORITATÍVNu hodnotu bez toho, aby si klient
+  // "hádal" meno/čas.
+  const refetch = useCallback(() => {
+    search(query, state);
+  }, [search, query, state]);
+
+  // "✓ jedným klikom" — potvrdí aktuálne uloženú/navrhnutú adresu bez zmeny.
+  const confirmAsIs = useCallback(
+    (item: PairingItem) => {
+      if (item.supplierUrl === null) return; // tlačidlo je aj tak disabled, obranná záloha
+      setActionError("");
+      setBusyCode(item.variantCode);
+      confirmPairing(item.variantCode)
+        .then(() => {
+          refetch();
+        })
+        .catch((err: unknown) => {
+          if (err instanceof PairingUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setActionError(err instanceof Error ? err.message : "Potvrdenie sa nepodarilo.");
+        })
+        .finally(() => {
+          setBusyCode(null);
+        });
+    },
+    [refetch, onSessionExpired],
+  );
+
+  const startEdit = useCallback((item: PairingItem) => {
+    setEditingCode(item.variantCode);
+    setUrlDraft(item.supplierUrl ?? "");
+    setActionError("");
+  }, []);
+
+  const cancelEdit = useCallback(() => {
+    setEditingCode(null);
+    setActionError("");
+  }, []);
+
+  // "zamietni a zadaj inú adresu ručne" — server prepíše uloženú adresu touto
+  // novou a rovno ju potvrdí (viď návrhový komentár na issue 45).
+  const saveManualUrl = useCallback(
+    (variantCode: string) => {
+      setActionError("");
+      setBusyCode(variantCode);
+      confirmPairing(variantCode, urlDraft.trim())
+        .then(() => {
+          setEditingCode(null);
+          refetch();
+        })
+        .catch((err: unknown) => {
+          if (err instanceof PairingUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setActionError(err instanceof Error ? err.message : "Uloženie adresy sa nepodarilo.");
+        })
+        .finally(() => {
+          setBusyCode(null);
+        });
+    },
+    [refetch, onSessionExpired, urlDraft],
+  );
+
+  const showingAll = total === 0 || items.length >= total;
+
+  return (
+    <section>
+      <h2>Kontrola párovania</h2>
+      <p>
+        Náš produkt oproti navrhnutej/zadanej adrese u dodávateľa — jedným klikom potvrďte zhodu,
+        alebo zadajte inú adresu ručne.
+      </p>
+
+      <form onSubmit={submit}>
+        {/* NIE "Kód alebo názov" — `CatalogPage.tsx` má PRESNE tento label text
+            pre svoje vlastné hľadanie na tej istej stránke; `catalog.spec.ts`'s
+            bare (nie exact) `getByLabel("Kód alebo názov")` by inak zrazu videl
+            DVE zhody. Rovnaký gotcha ako pri "Stav" nižšie. */}
+        <label htmlFor="pairing-q">Kód variantu alebo produktu</label>
+        <input
+          id="pairing-q"
+          type="search"
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+          }}
+        />
+        {/* NIE holé "Stav" — `CatalogPage.tsx` má PRESNE ten istý label text pre
+            svoj vlastný stavový filter na tej istej stránke (`App.tsx` renderuje
+            obe naraz); `getByLabel("Stav", { exact: true })` (catalog.spec.ts,
+            #25 vzor) by inak zrazu videl DVE zhody. Rovnaký gotcha ako
+            `.claude/rules/testing.md`'s zdokumentovaná Stav/aria-label kolízia
+            — rieš na strane NOVÉHO prvku (jedinečnejší label), nikdy
+            obetovaním existujúceho testu. */}
+        <label htmlFor="pairing-state">Stav párovania</label>
+        <select
+          id="pairing-state"
+          value={state}
+          onChange={(e) => {
+            setState(e.target.value as PairingState);
+          }}
+        >
+          <option value="all">Všetky</option>
+          <option value="navrhnute">Navrhnuté</option>
+          <option value="potvrdene">Potvrdené</option>
+        </select>
+        {/* NIE "Hľadať" — `CatalogPage.tsx` má PRESNE toto tlačidlo (rovnaký text)
+            na tej istej stránke; `catalog.spec.ts`'s bare (nie exact)
+            `getByRole("button", { name: "Hľadať" })` by inak zrazu videl DVE
+            zhody (Playwright's name matching je substring, takže samotné
+            pridanie ďalšieho slova okolo "Hľadať" by kolíziu NEVYRIEŠILO —
+            treba úplne odlišné slovo). */}
+        <button type="submit">Filtrovať</button>
+      </form>
+
+      {searchError !== "" && <p role="alert">{searchError}</p>}
+      {actionError !== "" && <p role="alert">{actionError}</p>}
+      <p data-testid="pairing-total">
+        {showingAll
+          ? `Nájdených: ${String(total)}`
+          : `Nájdených: ${String(total)} (zobrazených prvých ${String(items.length)})`}
+      </p>
+
+      {searchLoaded && total === 0 ? (
+        <p data-testid="pairing-empty">Hľadaniu nezodpovedá žiadny variant.</p>
+      ) : (
+        <table>
+          <thead>
+            <tr>
+              <th>Kód</th>
+              <th>Produkt</th>
+              <th>Veľkosť</th>
+              <th>Dodávateľ</th>
+              <th>Adresa u dodávateľa</th>
+              <th>Stav</th>
+              <th>Potvrdil</th>
+              {canConfirm && <th>Akcie</th>}
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((item) => (
+              <tr key={item.variantCode} data-testid={`pairing-${item.variantCode}`}>
+                <td>{item.variantCode}</td>
+                <td>{item.variantName}</td>
+                <td>{item.sizeLabel ?? "—"}</td>
+                <td>{item.productSupplier ?? "—"}</td>
+                <td>
+                  {editingCode === item.variantCode ? (
+                    <>
+                      <input
+                        aria-label={`Adresa u dodávateľa pre ${item.variantCode}`}
+                        type="url"
+                        value={urlDraft}
+                        disabled={busyCode === item.variantCode}
+                        onChange={(e) => {
+                          setUrlDraft(e.target.value);
+                        }}
+                      />
+                      <button
+                        type="button"
+                        disabled={busyCode === item.variantCode || urlDraft.trim() === ""}
+                        onClick={() => {
+                          saveManualUrl(item.variantCode);
+                        }}
+                      >
+                        Potvrdiť
+                      </button>
+                      <button type="button" disabled={busyCode === item.variantCode} onClick={cancelEdit}>
+                        Zrušiť
+                      </button>
+                    </>
+                  ) : item.supplierUrl === null ? (
+                    "—"
+                  ) : (
+                    <a href={item.supplierUrl} target="_blank" rel="noreferrer">
+                      {item.supplierUrl}
+                    </a>
+                  )}
+                </td>
+                <td>{STATE_LABELS[item.state]}</td>
+                <td>
+                  {item.confirmedByName === null
+                    ? "—"
+                    : `${item.confirmedByName} (${new Date(item.confirmedAt ?? "").toLocaleDateString("sk-SK")})`}
+                </td>
+                {canConfirm && (
+                  <td>
+                    {editingCode !== item.variantCode && (
+                      <>
+                        <button
+                          type="button"
+                          data-testid={`confirm-${item.variantCode}`}
+                          disabled={item.supplierUrl === null || busyCode === item.variantCode}
+                          onClick={() => {
+                            confirmAsIs(item);
+                          }}
+                        >
+                          ✓ Potvrdiť
+                        </button>
+                        <button
+                          type="button"
+                          data-testid={`reject-${item.variantCode}`}
+                          disabled={busyCode === item.variantCode}
+                          onClick={() => {
+                            startEdit(item);
+                          }}
+                        >
+                          ✗ Zadať inú adresu
+                        </button>
+                      </>
+                    )}
+                  </td>
+                )}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/pairingApi.test.ts
+++ b/apps/web/src/pairingApi.test.ts
@@ -1,0 +1,87 @@
+import { expect, it, vi } from "vitest";
+import { PairingUnauthorizedError, confirmPairing, searchPairings } from "./pairingApi.js";
+
+it("zloží dopyt na hľadanie z parametrov", async () => {
+  const spy = vi
+    .fn()
+    .mockResolvedValue(new Response(JSON.stringify({ total: 0, items: [] }), { status: 200 }));
+  vi.stubGlobal("fetch", spy);
+
+  await searchPairings({ q: "40237/3XL", state: "navrhnute", page: 2 });
+
+  expect(spy).toHaveBeenCalledWith("/api/pairing?q=40237%2F3XL&state=navrhnute&page=2&pageSize=50");
+});
+
+it("prečíta zoznam párovania", async () => {
+  const telo = {
+    total: 1,
+    items: [
+      {
+        variantCode: "40237/3XL",
+        variantName: "Nohavice FOREST 1003",
+        sizeLabel: "3XL",
+        productSupplier: "GRUBE",
+        supplierUrl: null,
+        state: "navrhnute" as const,
+        confirmedByName: null,
+        confirmedAt: null,
+      },
+    ],
+  };
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify(telo), { status: 200 })));
+  await expect(searchPairings({ q: "", state: "all", page: 1 })).resolves.toEqual(telo);
+});
+
+it("odmietne odpoveď s neplatným tvarom", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue(new Response(JSON.stringify({ total: "veľa", items: [] }), { status: 200 })),
+  );
+  await expect(searchPairings({ q: "", state: "all", page: 1 })).rejects.toThrow();
+});
+
+it("pri 401 vyhodí PairingUnauthorizedError namiesto všeobecnej chyby", async () => {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 401 })));
+  await expect(searchPairings({ q: "", state: "all", page: 1 })).rejects.toBeInstanceOf(
+    PairingUnauthorizedError,
+  );
+});
+
+it("zlyhá zrozumiteľne pri chybe servera", async () => {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 500 })));
+  await expect(searchPairings({ q: "", state: "all", page: 1 })).rejects.toThrow(
+    "Zoznam párovania sa nepodarilo načítať",
+  );
+});
+
+it("potvrdenie BEZ ručnej adresy odošle telo bez poľa supplierUrl (potvrdí uloženú adresu)", async () => {
+  const spy = vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+  vi.stubGlobal("fetch", spy);
+
+  await confirmPairing("40237/3XL");
+
+  const volanie = spy.mock.calls[0] as [string, RequestInit];
+  expect(volanie[0]).toBe("/api/pairing/confirm");
+  expect(JSON.parse(volanie[1].body as string)).toEqual({ variantCode: "40237/3XL" });
+});
+
+it("potvrdenie S ručnou adresou pošle supplierUrl v tele", async () => {
+  const spy = vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+  vi.stubGlobal("fetch", spy);
+
+  await confirmPairing("40237/3XL", "https://www.grube.sk/p/1");
+
+  const volanie = spy.mock.calls[0] as [string, RequestInit];
+  expect(JSON.parse(volanie[1].body as string)).toEqual({
+    variantCode: "40237/3XL",
+    supplierUrl: "https://www.grube.sk/p/1",
+  });
+});
+
+it("odovzdá hlásenie servera namiesto všeobecnej hlášky, keď ho server pošle", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue(new Response(JSON.stringify({ error: "Chýba adresa produktu u dodávateľa" }), { status: 400 })),
+  );
+  await expect(confirmPairing("40237/3XL")).rejects.toThrow("Chýba adresa produktu u dodávateľa");
+});

--- a/apps/web/src/pairingApi.ts
+++ b/apps/web/src/pairingApi.ts
@@ -1,0 +1,80 @@
+import { z } from "zod";
+
+// Zrkadlí `PairingListItem`/`PairingSearchInput` z
+// `apps/api/src/modules/pairing/queries.ts` — vlastná zod schéma namiesto
+// zdieľaného typu, rovnaký vzor ako `catalogApi.ts`/`ordersApi.ts` (frontend a
+// backend sú samostatné balíčky, žiadny zdieľaný typový balík medzi nimi zatiaľ
+// neexistuje).
+export type PairingState = "all" | "navrhnute" | "potvrdene";
+
+const pairingItemSchema = z.object({
+  variantCode: z.string(),
+  variantName: z.string(),
+  sizeLabel: z.string().nullable(),
+  productSupplier: z.string().nullable(),
+  supplierUrl: z.string().nullable(),
+  state: z.enum(["navrhnute", "potvrdene"]),
+  confirmedByName: z.string().nullable(),
+  confirmedAt: z.string().nullable(),
+});
+
+const searchSchema = z.object({ total: z.number(), items: z.array(pairingItemSchema) });
+
+export type PairingItem = z.infer<typeof pairingItemSchema>;
+
+export const PAGE_SIZE = 50;
+
+/** Relácia medzitým vypršala (401) — rovnaký vzor ako `CatalogUnauthorizedError`. */
+export class PairingUnauthorizedError extends Error {
+  constructor() {
+    super("Neprihlásený");
+  }
+}
+
+const errorBodySchema = z.object({ error: z.string() });
+
+async function serverErrorMessage(response: Response, fallback: string): Promise<string> {
+  try {
+    const parsed = errorBodySchema.safeParse(await response.json());
+    if (parsed.success) return parsed.data.error;
+  } catch {
+    // Telo nie je platný JSON (alebo chýba) — použi všeobecnú hlášku.
+  }
+  return fallback;
+}
+
+async function readJson(response: Response, fallback: string): Promise<unknown> {
+  if (response.status === 401) throw new PairingUnauthorizedError();
+  if (!response.ok) throw new Error(await serverErrorMessage(response, fallback));
+  return await response.json();
+}
+
+export async function searchPairings(input: {
+  readonly q: string;
+  readonly state: PairingState;
+  readonly page: number;
+}): Promise<z.infer<typeof searchSchema>> {
+  const query = new URLSearchParams({
+    q: input.q,
+    state: input.state,
+    page: String(input.page),
+    pageSize: String(PAGE_SIZE),
+  });
+  const response = await fetch(`/api/pairing?${query.toString()}`);
+  return searchSchema.parse(await readJson(response, "Zoznam párovania sa nepodarilo načítať"));
+}
+
+/**
+ * Potvrdí párovanie variantu. `supplierUrl` VYNECHANÉ (nie `null`, nie `""`)
+ * → potvrdí sa aktuálne uložená/navrhnutá adresa ("✓ jedným klikom");
+ * `supplierUrl` PRÍTOMNÉ → prepíše uloženú adresu novou a rovno ju potvrdí
+ * (zamietnutie pôvodného kandidáta + ručný výber inej URL).
+ */
+export async function confirmPairing(variantCode: string, supplierUrl?: string): Promise<void> {
+  const response = await fetch("/api/pairing/confirm", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(supplierUrl === undefined ? { variantCode } : { variantCode, supplierUrl }),
+  });
+  await readJson(response, "Potvrdenie párovania sa nepodarilo");
+}

--- a/apps/web/tests/e2e/pairing.spec.ts
+++ b/apps/web/tests/e2e/pairing.spec.ts
@@ -1,0 +1,106 @@
+import { expect, test, type ConsoleMessage } from "@playwright/test";
+
+const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
+
+// Rovnaká a JEDINÁ povolená výnimka ako v login.spec.ts/catalog.spec.ts/orders.spec.ts.
+const jeOcakavane = (m: ConsoleMessage): boolean =>
+  m.location().url.includes("/api/me") && m.text().includes("401");
+
+// #45: obrazovka "Kontrola párovania". `pairing` tabuľka nemá pri E2E setupe
+// ŽIADEN riadok (#46 automatické hľadanie kandidátov ešte neexistuje) — variant
+// "4859/46" (`scripts/e2e-setup.ts`, dodávateľ "DODAVATEL-TEST-1") sa preto pri
+// PRVOM zobrazení musí ukázať ako "Navrhnuté" s prázdnou adresou (LEFT JOIN,
+// nie INNER — viď návrhový komentár na issue 45), a manažér ho tu VÔBEC PRVÝKRÁT
+// napáruje ručne zadanou adresou.
+test("manažér ručne napáruje variant bez existujúceho kandidáta, zmena pretrvá po obnovení stránky, konzola je čistá", async ({
+  page,
+}) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/");
+  await page.getByLabel("E-mail").fill("e2e@forestshop.sk");
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await expect(page.getByRole("heading", { name: "Kontrola párovania" })).toBeVisible();
+
+  const riadok = page.getByTestId("pairing-4859/46");
+  await expect(riadok).toBeVisible();
+  await expect(riadok).toContainText("Nohavice Hart Wild-T");
+  await expect(riadok).toContainText("DODAVATEL-TEST-1");
+  await expect(riadok).toContainText("Navrhnuté");
+  // Bez uloženej adresy je "✓ Potvrdiť" disabled — nie je čo potvrdiť jedným klikom.
+  await expect(riadok.getByTestId("confirm-4859/46")).toBeDisabled();
+
+  await riadok.getByTestId("reject-4859/46").click();
+  await riadok.getByLabel("Adresa u dodávateľa pre 4859/46").fill("https://www.grube.sk/p/nohavice-hart-wild-t/1");
+  await riadok.getByRole("button", { name: "Potvrdiť" }).click();
+
+  await expect(riadok).toContainText("Potvrdené");
+  await expect(riadok).toContainText("E2E Manažér");
+  await expect(riadok.getByRole("link", { name: "https://www.grube.sk/p/nohavice-hart-wild-t/1" })).toBeVisible();
+  await expect(page.getByRole("alert")).toHaveCount(0);
+
+  await page.reload();
+  await expect(page.getByRole("heading", { name: "Kontrola párovania" })).toBeVisible();
+  const riadokPoReloade = page.getByTestId("pairing-4859/46");
+  await expect(riadokPoReloade).toContainText("Potvrdené");
+  await expect(
+    riadokPoReloade.getByRole("link", { name: "https://www.grube.sk/p/nohavice-hart-wild-t/1" }),
+  ).toBeVisible();
+
+  expect(chyby).toEqual([]);
+});
+
+// Variant "40287" (bez dodávateľa) má `scripts/e2e-setup.ts`'s ZÁMERNE
+// PREDNASTAVENÝ, ešte nepotvrdený pairing kandidát (simuluje to, čo by inak
+// vložilo budúce #46) — jediný spôsob, ako cez SKUTOČNÝ prehliadač overiť
+// "✓ Potvrdiť jedným klikom" (appka sama dnes žiadny takýto riadok
+// nevytvorí, viď komentár v `e2e-setup.ts`). Tá istá stránka aj overuje
+// filter podľa stavu.
+test("manažér potvrdí navrhnutú adresu jedným klikom, filter podľa stavu funguje, konzola je čistá", async ({ page }) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/");
+  await page.getByLabel("E-mail").fill("e2e@forestshop.sk");
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await expect(page.getByRole("heading", { name: "Kontrola párovania" })).toBeVisible();
+
+  const riadok = page.getByTestId("pairing-40287");
+  await expect(riadok).toBeVisible();
+  await expect(riadok).toContainText("Čiapka Polar FOREST");
+  await expect(riadok).toContainText("Navrhnuté");
+  await expect(riadok.getByRole("link", { name: "https://www.grube.sk/p/ciapka-polar-forest/1" })).toBeVisible();
+
+  await riadok.getByTestId("confirm-40287").click();
+  await expect(riadok).toContainText("Potvrdené");
+  await expect(riadok).toContainText("E2E Manažér");
+  // Adresa ostáva NEZMENENÁ — jedným klikom sa potvrdila tá istá, uložená.
+  await expect(riadok.getByRole("link", { name: "https://www.grube.sk/p/ciapka-polar-forest/1" })).toBeVisible();
+  await expect(page.getByRole("alert")).toHaveCount(0);
+
+  await page.getByLabel("Stav párovania").selectOption("navrhnute");
+  await page.getByRole("button", { name: "Filtrovať" }).click();
+  await expect(page.getByTestId("pairing-40287")).toHaveCount(0);
+
+  await page.getByLabel("Stav párovania").selectOption("potvrdene");
+  await page.getByRole("button", { name: "Filtrovať" }).click();
+  await expect(page.getByTestId("pairing-40287")).toBeVisible();
+
+  await page.getByLabel("Stav párovania").selectOption("all");
+  await page.getByRole("button", { name: "Filtrovať" }).click();
+
+  expect(chyby).toEqual([]);
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.23",
+  "version": "0.3.0-dev.24",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -9,7 +9,7 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { createDb } from "../apps/api/src/db/client.js";
-import { orderLines, orders, users } from "../apps/api/src/db/schema.js";
+import { orderLines, orders, pairings, users } from "../apps/api/src/db/schema.js";
 import { hashPassword } from "../apps/api/src/modules/auth/passwords.js";
 import { ingestCatalog } from "../apps/api/src/modules/catalog/ingest.js";
 import { DEFAULT_SNAPSHOT_LIMITS } from "../apps/api/src/modules/catalog/validation.js";
@@ -132,6 +132,19 @@ await db.insert(orderLines).values({
   orderId: objednavkaBezDodavatela.id,
   variantCode: "40287",
   quantity: 1,
+});
+
+// F4 (#45): jeden UŽ NAVRHNUTÝ (nepotvrdený) pairing kandidát — simuluje to,
+// čo by inak vložilo #46 (automatické hľadanie kandidátov, ešte
+// neimplementované). Bez tohto by "pairing.spec.ts" nemalo ako otestovať
+// "✓ Potvrdiť jedným klikom" cez skutočný prehliadač (žiadna appkina vlastná
+// akcia dnes nevytvorí riadok v stave 'navrhnute' S vyplnenou adresou —
+// ručné zadanie adresy cez UI rovno aj potvrdzuje, viď návrhový komentár na
+// issue 45) — variant "4859/46" zostáva zámerne BEZ pairing riadku vôbec
+// (LEFT JOIN prípad, otestovaný v prvom teste súboru).
+await db.insert(pairings).values({
+  variantCode: "40287",
+  supplierUrl: "https://www.grube.sk/p/ciapka-polar-forest/1",
 });
 
 await pool.end();


### PR DESCRIPTION
## Čo pridáva

F4: obrazovka **Kontrola párovania** — manažér vidí náš produkt vedľa
navrhnutej/zadanej adresy u dodávateľa a jedným klikom potvrdí zhodu, alebo
zamietne a ručne zadá inú adresu (rovno aj potvrdí). Nahrádza rovnomennú
záložku v starej appke.

- `apps/api/src/modules/pairing/queries.ts` — `listPairings()`, LEFT JOIN
  `variant → product → pairing → users` (nie INNER — `pairing` dnes nemá ani
  jeden riadok, kým budúca úloha na automatické hľadanie kandidátov
  nepristane; LEFT JOIN umožňuje ručné párovanie od prvého dňa).
- `apps/api/src/modules/pairing/state.ts` — `confirmPairing()`, jedna
  funkcia pre obe akcie ("✓ potvrdiť" aj "zamietni a zadaj inú adresu ručne"),
  upsert + audit v jednej transakcii, `.for("update")` proti súbežným
  potvrdeniam toho istého variantu.
- `apps/api/src/http/pairing-routes.ts` — `GET /api/pairing`,
  `POST /api/pairing/confirm` (variantCode v TELE, nie v ceste — kódy
  variantov nesú lomku).
- `apps/web/src/pairingApi.ts` + `apps/web/src/components/PairingSection.tsx`
  — zapojené do `App.tsx` vedľa `OrdersSection`.
- `apps/api/src/modules/catalog/queries.ts`'s `escapeLikePattern` exportovaná
  na zdieľanie namiesto duplicity.

## Testy

- 15 nových integračných testov (`pairing-http.integration.test.ts`):
  LEFT JOIN prípad, filter podľa stavu, fulltext, potvrdenie s/bez ručnej
  adresy, 404/400, role/CSRF.
- Unit testy `pairingApi.test.ts` + `PairingSection.test.tsx`.
- 2 nové Playwright e2e testy (`pairing.spec.ts`) — jeden overuje LEFT JOIN
  (variant bez existujúceho pairing riadku), druhý `scripts/e2e-setup.ts`'s
  zámerne prednastavený nepotvrdený kandidát pre "✓ jedným klikom" +
  filter podľa stavu. Zero console errors okrem povolenej `/api/me` 401.

## Design rationale

Zapísaný na issue 45 PRED prvým kódovým commitom: https://github.com/zbynekdrlik/forestshop-app/issues/45#issuecomment-5129954514

## Nezávislý code review

Dispatchnutý pred pushom — 0 🔴 0 🟡, dva 🔵 (re-confirm bez varovania je
zámerné a slúži presne účelu "priebežne kontrolovať a opravovať" z popisu
úlohy; `finalUrl === ""` obranná kontrola je zámerne ponechaná pre budúce
volania funkcie mimo HTTP trasy). Verdikt: ready to merge.

Closes #45
