### PR TITLE
docs(playbook): F4 pairing gotchas + version bump

### DIFF
--- a/.claude/rules/pairing.md
+++ b/.claude/rules/pairing.md
@@ -1,0 +1,67 @@
+---
+paths:
+  - "apps/api/src/modules/pairing/**"
+  - "apps/api/src/http/pairing-routes.ts"
+  - "apps/api/src/db/schema-pairing.ts"
+  - "apps/web/src/pairingApi.ts"
+  - "apps/web/src/components/PairingSection.tsx"
+---
+
+# Kontrola párovania (F4, #45)
+
+- **`GET /api/pairing` je LEFT JOIN `variant → product → pairing → users`,
+  NIE INNER.** `pairing` tabuľka (#44) dnes nemá ani jeden riadok —
+  automatické hľadanie kandidátov (budúca úloha #46) ešte neexistuje.
+  INNER JOIN by preto vracal VŽDY prázdny zoznam, kým #46 nepristane.
+  Chýbajúci riadok sa zobrazí ako `state: "navrhnute"` s `supplierUrl:
+  null` (presne zodpovedá východiskovému stavu DB automatu, `queries.ts`'s
+  `toItem()` robí `row.pairingState ?? "navrhnute"`) — filter podľa stavu
+  preto v SQL používa `coalesce(pairing.state, 'navrhnute')`, nikdy holé
+  `pairing.state = ...` (to by ticho vynechalo práve nespárované varianty).
+- **`confirmPairing()` je JEDNA funkcia pre OBE akcie starej appky** ("✓
+  potvrdiť" aj "zamietni a zadaj inú adresu ručne") — rozlišuje sa len
+  podľa toho, či telo požiadavky nesie voliteľné `supplierUrl`: prítomné →
+  prepíše uloženú/navrhnutú adresu a rovno potvrdí; chýbajúce → potvrdí
+  AKTUÁLNE uloženú. Zámerne NIE JE samostatná "zamietni bez náhrady" trasa
+  — pri dnešnom dvojstavovom automate (`navrhnute`/`potvrdene`) by nemala
+  kam viesť (žiadny druhý kandidát na skúsenie, kým nepríde #46).
+- **`variantCode` ide v TELE POST požiadavky, NIE ako cestový parameter.**
+  Kódy variantov nesú lomku (napr. `"40237/3XL"`) — existujúca `/api/catalog/
+  variants/:code` trasa (F1) má presne tento neoverený risk (z web klienta
+  ju dnes nikto nevolá, takže sa nikdy neukázalo, či lomka v ceste vôbec
+  prejde cez Hono/URL-encoding). Nová zapisovacia trasa (`POST /api/pairing/
+  confirm`) sa tomuto riziku vyhla úplne — `variantCode` nesie zod-validované
+  telo, žiadny cestový segment.
+- **Web labely v `PairingSection.tsx` sú ZÁMERNE odlišné od `CatalogPage.tsx`'s
+  rovnomenných prvkov na TEJ ISTEJ stránke** — "Kód variantu alebo produktu"
+  (nie "Kód alebo názov"), "Stav párovania" (nie holé "Stav"), tlačidlo
+  "Filtrovať" (nie "Hľadať"). Dôvod: `App.tsx` renderuje `CatalogPage` +
+  `OrdersSection` + `PairingSection` + `SchedulerSection` NARAZ na jednej
+  stránke; Playwright's `getByLabel`/`getByRole({name})` robia substring
+  zhodu (case-insensitive) BEZ `exact: true` — rovnaký typ kolízie, aký #25
+  našiel AŽ PO mergi (`.claude/rules/testing.md`). Tu bola nájdená a
+  vyriešená PRED mergom kontrolou existujúcich `apps/web/tests/e2e/*.spec.ts`
+  locator-ov (`grep -n 'getByLabel\|getByRole("button"'`) hneď pri písaní
+  nového formulára. **Kontrolný zoznam pre KAŽDÝ nový `<label>`/tlačidlo na
+  tejto zdieľanej stránke:** pred písaním e2e testu spusti ten istý grep cez
+  VŠETKY existujúce `*.spec.ts` súbory a over, či text nového prvku (alebo
+  jeho SUBSTRING) už niekde nefiguruje ako bare (nie `exact: true`)
+  `getByLabel`/`getByRole` cieľ — ak áno, daj novému prvku odlišnejší text,
+  nikdy neobetuj existujúci test.
+- **Po úspešnom potvrdení sa `PairingSection.tsx` znova NAČÍTA (refetch),
+  nie lokálna aktualizácia stavu** (na rozdiel od `OrdersSection`'s
+  `changeState`, ktorá si vystačí s lokálnou úpravou). Dôvod: tabuľka
+  zobrazuje AJ `confirmedByName`/`confirmedAt` — hodnoty, ktoré klient
+  nepozná vopred (server ich odvodí z prihlásenej relácie a aktuálneho
+  času). Skúšaný prvý pokus (lokálne nastaviť `state: "potvrdene"` bez
+  týchto polí) prešiel unit testom, ale zlyhal v E2E (stĺpec "Potvrdil"
+  ostal "—" aj po potvrdení) — chyba bola nájdená a opravená PRED mergom
+  spustením skutočného Playwright behu, nie len unit testov s mockmi.
+- **`scripts/e2e-setup.ts` má JEDEN zámerne PREDNASTAVENÝ, ešte
+  nepotvrdený `pairing` riadok** (variant `"40287"`, žiadny dodávateľ) —
+  simuluje to, čo by inak vložilo budúce #46. Bez neho by "✓ Potvrdiť
+  jedným klikom" nemalo ako sa otestovať cez skutočný prehliadač (appka
+  sama dnes žiadnu takú kombináciu — `state='navrhnute'` S vyplnenou
+  adresou — nevytvorí; ručné zadanie adresy cez UI rovno aj potvrdzuje).
+  Variant `"4859/46"` zostáva zámerne BEZ pairing riadku vôbec (testuje
+  LEFT JOIN prípad namiesto toho).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,4 +29,5 @@ Per-area rules live in `.claude/rules/<area>.md` with `paths:` frontmatter.
 - katalóg zo Shoptetu (import, snapshoty, dostupnosť) → `.claude/rules/catalog.md`
 - plánovač úloh (F2 — nočné joby, job_run, advisory zámok) → `.claude/rules/scheduler.md`
 - objednávky zo Shoptetu (F3 — import, sčítanie riadkov, pseudo-položky) → `.claude/rules/orders.md`
+- kontrola párovania (F4 — LEFT JOIN dizajn, confirmPairing, e2e label kolízie) → `.claude/rules/pairing.md`
 - citlivé hodnoty (heslá/tokeny/hash= sa nikdy nepíšu do repa) → `.claude/rules/sensitive-values.md`

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -517,3 +517,66 @@ nové heslo sa nikde v pushnutom obsahu nenachádza.
 - Drobné postrehy z review (chýbajúci index na `pairing.confirmed_by`,
   case/whitespace normalizácia `supplier.name` joinu) zaznamenané na
   #46 a #48 pre budúce úlohy — žiadna zmena v tomto PR.
+
+## 2026-07-30 — #45 (F4: obrazovka "Kontrola párovania")
+
+- Verzia: `0.3.0-dev.23` → `0.3.0-dev.24`, commit `276fcd1` (prvý na `dev`,
+  pred design komentárom).
+- Design komentár (root cause + zvolený prístup + zamietnutá alternatíva
+  samostatnej "reject bez náhrady" trasy) zapísaný PRED prvým kódovým
+  commitom: https://github.com/zbynekdrlik/forestshop-app/issues/45#issuecomment-5129954514.
+- Nové `apps/api/src/modules/pairing/{queries,state}.ts` +
+  `http/pairing-routes.ts` (`GET /api/pairing`, `POST /api/pairing/confirm`)
+  + web `pairingApi.ts`/`PairingSection.tsx`, zapojené do `App.tsx` vedľa
+  `OrdersSection`. **LEFT JOIN, nie INNER** na `pairing` (dnes nemá ani jeden
+  riadok — automatické hľadanie kandidátov #46 ešte neexistuje) — chýbajúci
+  riadok sa zobrazí ako "navrhnuté" s prázdnou adresou, presne zodpovedá
+  DB automatu, a manažér tak môže párovať RUČNE od prvého dňa. Jedna funkcia
+  `confirmPairing()` pokrýva obe akcie starej appky ("✓"/"zamietni a zadaj
+  inú adresu ručne") podľa toho, či telo nesie `supplierUrl` override.
+  `variantCode` ide v TELE POST, nie v ceste (kódy nesú lomku, napr.
+  "40237/3XL" — existujúca `/api/catalog/variants/:code` trasa má tento istý
+  neoverený risk, ale z web klienta ju dnes nikto nevolá).
+- `escapeLikePattern` (`modules/catalog/queries.ts`) exportovaná na
+  zdieľanie s `pairing/queries.ts` namiesto duplicitnej kópie.
+- Nové labely v `PairingSection.tsx` ("Kód variantu alebo produktu", "Stav
+  párovania", tlačidlo "Filtrovať") zámerne ODLIŠNÉ od `CatalogPage.tsx`'s
+  "Kód alebo názov"/"Stav"/"Hľadať" — rovnaká trieda gotcha ako #25
+  (`getByLabel`/`getByRole` substring zhoda na tej istej stránke), tentokrát
+  vyriešená PRED mergom, nie až dodatočným review nálezom.
+- Testy: 15 integračných (`pairing-http.integration.test.ts` — LEFT JOIN,
+  filter podľa stavu, fulltext, potvrdenie s/bez ručnej adresy, 404/400,
+  role/CSRF), unit testy `pairingApi.test.ts`/`PairingSection.test.tsx`
+  (komponent po úspešnom potvrdení znova NAČÍTA stránku výsledkov —
+  `confirmedByName`/`confirmedAt` sú AUTORITATÍVNE zo servera, nie
+  odhadnuté klientom, rovnaký vzor ako `CatalogPage`'s `runIngest`), 2 nové
+  Playwright e2e (`pairing.spec.ts` — jeden LEFT JOIN prípad nad variantom
+  "4859/46" bez existujúceho pairing riadku, druhý s `scripts/e2e-setup.ts`'s
+  novým zámerne prednastaveným NEPOTVRDENÝM kandidátom pre "40287", jediný
+  spôsob, ako "✓ jedným klikom" overiť cez skutočný prehliadač skôr, než
+  #46 pristane).
+- Nezávislý code-review subagent dispatchnutý PRED pushom (celý diff): 0 🔴
+  0 🟡, dva 🔵 akceptované s odôvodnením (re-confirm bez varovania je
+  ZÁMERNÉ — presne slúži "priebežne kontrolovať a opravovať" z popisu
+  úlohy; `finalUrl === ""` obranná kontrola v `state.ts` je zámerne
+  ponechaná pre budúce volania funkcie mimo dnešnej HTTP trasy). Verdikt:
+  ready to merge.
+- PR: **#54** (`dev` → `main`), `Closes #45`, merged `64c21ce`. CI all
+  green (check, integration, e2e, docker-build, version-check) na push aj
+  pull_request behu.
+- Deployed + verified na https://forestshop-novy.newlevel.media
+  (v0.3.0-dev.24, `/api/version` commit sedí s `64c21cef`): prihlásený ako
+  skutočný vlastník (`vychod@varos.sk`, rola `admin`), obrazovka "Kontrola
+  párovania" ukázala všetkých 14 110 reálnych produkčných variantov ako
+  "Navrhnuté" (potvrdzuje LEFT JOIN dizajn na živých dátach — `pairing`
+  tabuľka je dnes prázdna), "✓ Potvrdiť" správne disabled bez adresy.
+  Funkčne overené: "✗ Zadať inú adresu" na reálnom variante
+  ("0.8331.MC9") → zadaná testovacia adresa → "Potvrdiť" → riadok sa
+  zmenil na "Potvrdené", stĺpec "Potvrdil" ukázal "Zbyněk (30. 7. 2026)"
+  (skutočný prihlásený účet), adresa sa vykreslila ako klikateľný odkaz;
+  konzola čistá (žiadna chyba nad rámec povolenej `/api/me` 401 pri
+  prvom neprihlásenom načítaní). Testovací pairing riadok následne
+  ODSTRÁNENÝ priamo v produkčnej DB (`DELETE FROM pairing WHERE
+  variant_code = '0.8331.MC9'`), aby v produkcii nezostala fingovaná
+  adresa vyzerajúca ako reálne potvrdené párovanie.
+- Per-ticket Discord card fired (`notify --run-card`, confirmed delivered).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.24",
+  "version": "0.3.0-dev.25",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Post-ticket playbook capture for issue 45 (Kontrola párovania) — see `.claude/rules/pairing.md`. Docs-only, no code change. Version bump 0.3.0-dev.24 -> 0.3.0-dev.25 (main caught up to dev after PR 54).