### PR TITLE
F4: Rozdelenie párovania podľa veľkostí (issue 47)

### DIFF
--- a/.claude/rules/pairing.md
+++ b/.claude/rules/pairing.md
@@ -65,3 +65,30 @@ paths:
   adresou — nevytvorí; ručné zadanie adresy cez UI rovno aj potvrdzuje).
   Variant `"4859/46"` zostáva zámerne BEZ pairing riadku vôbec (testuje
   LEFT JOIN prípad namiesto toho).
+- **Re-potvrdenie UŽ potvrdeného riadku s NEZMENENOU adresou je no-op —
+  NIKDY neprepisuje `confirmedBy`/`confirmedAt`** (review nález na PR 54,
+  issue 45, oprava v `state.ts`'s `confirmPairing()`): pred upsertom sa
+  overí `existing?.state === "potvrdene" && existing.supplierUrl ===
+  finalUrl`; ak platí, funkcia vráti `"ok"` bez zápisu (žiadny upsert,
+  žiadny audit event). Bez tejto kontroly ktorýkoľvek ďalší klik na "✓
+  Potvrdiť" (druhým manažérom, alebo aj tým istým znova) ticho ukradol
+  attribution, hoci nebolo urobené žiadne nové rozhodnutie. Skutočná ZMENA
+  adresy (ručná oprava cez "✗ Zadať inú adresu" na INÚ adresu) JE nové
+  rozhodnutie — normálna cesta (upsert + audit) sa nemení. Web strana
+  pridáva `item.state === "potvrdene"` do `disabled` na "✓ Potvrdiť"
+  tlačidle — je to len UX vrstva (predchádza zbytočnému kliku), server
+  ostáva skutočnou bránou (priamy API call/stale UI by inak obišiel
+  disabled tlačidlo). Test na KAŽDÝ ďalší podobný "potvrď/ulož" endpoint,
+  ktorý má koncept "kto a kedy": over, či opätovné volanie s NEZMENENÝMI
+  dátami skutočne zachová pôvodnú attribution, nielen že vráti rovnaký
+  HTTP status.
+- **Integračný test-súbor pre párovanie je rozdelený DVOMA súbormi kvôli
+  ESLint `max-lines` (400), NIE kvôli inej téme:** `pairing-http.
+  integration.test.ts` (CRUD/HTTP správanie) a `pairing-reconfirm.
+  integration.test.ts` (no-op re-potvrdenie, potrebuje DVOCH súčasne
+  prihlásených manažérov — vlastný `withCleanDb()` helper, nie zdieľaný
+  `boot()`). Ďalší test pre párovanie, ktorý by `pairing-http.
+  integration.test.ts` posunul cez 400 riadkov, patrí do `pairing-
+  reconfirm.integration.test.ts` (ak súvisí s re-potvrdením) alebo ďalšieho
+  nového `pairing-*.integration.test.ts` súboru (inak) — nie do
+  jedného rastúceho monolitu.

--- a/apps/api/src/modules/pairing/queries.ts
+++ b/apps/api/src/modules/pairing/queries.ts
@@ -12,6 +12,16 @@ export interface PairingListItem {
   readonly variantCode: string;
   readonly variantName: string;
   readonly sizeLabel: string | null;
+  // `productKey`/`productName` (issue 47, F4 rozdelenie podľa veľkostí) —
+  // umožňuje frontendu zoskupiť plochý zoznam variantov podľa produktu, aby
+  // manažér videl/zadal JEDNU adresu pre VŠETKY veľkosti naraz namiesto
+  // opakovania toho istého N-krát. Zámerne BEZ akéhokoľvek nového stĺpca v
+  // `pairing`/novej migrácie — `pairing` je už dnes kľúčovaná per variant
+  // (veľkosť), takže "rozdelené/nerozdelené" sa ODVODZUJE na frontende z
+  // toho, či sa `supplierUrl` naprieč variantmi produktu zhoduje (viď
+  // `apps/web/src/pairingGroups.ts`), nikdy sa nepersistuje.
+  readonly productKey: string;
+  readonly productName: string;
   // `product.supplier` — INFORMATÍVNY reťazec zo Shoptet exportu (kto nám
   // produkt oficiálne dodáva), NIE cieľ párovania. Cieľ párovania je
   // `supplierUrl` nižšie (konkrétna adresa produktu u veľkoobchodného
@@ -44,6 +54,8 @@ const listColumns = {
   variantCode: variants.code,
   variantName: variants.name,
   sizeLabel: variants.sizeLabel,
+  productKey: products.key,
+  productName: products.name,
   productSupplier: products.supplier,
   supplierUrl: pairings.supplierUrl,
   pairingState: pairings.state,
@@ -55,6 +67,8 @@ type ListRow = {
   readonly variantCode: string;
   readonly variantName: string;
   readonly sizeLabel: string | null;
+  readonly productKey: string;
+  readonly productName: string;
   readonly productSupplier: string | null;
   readonly supplierUrl: string | null;
   readonly pairingState: PairingDisplayState | null;
@@ -67,6 +81,8 @@ function toItem(row: ListRow): PairingListItem {
     variantCode: row.variantCode,
     variantName: row.variantName,
     sizeLabel: row.sizeLabel,
+    productKey: row.productKey,
+    productName: row.productName,
     productSupplier: row.productSupplier,
     supplierUrl: row.supplierUrl,
     // Chýbajúci riadok (LEFT JOIN nenašiel zhodu) → `pairingState` je `null`

--- a/apps/api/tests/helpers/orders.ts
+++ b/apps/api/tests/helpers/orders.ts
@@ -56,3 +56,61 @@ export async function insertTestVariant(
     missingSince: null,
   });
 }
+
+/**
+ * Vloží JEDEN variant (veľkosť) patriaci k VIACVARIANTNÉMU produktu — na
+ * rozdiel od `insertTestVariant` (ktorá vždy vytvorí NOVÝ produkt, kľúčovaný
+ * samotným `code`) tu volajúci sám zadá zdieľaný `productKey`, takže
+ * viacero volaní so ROVNAKÝM `productKey` a RÔZNYMI `code` vytvorí presne
+ * to, čo issue 47 (F4 rozdelenie podľa veľkostí) potrebuje testovať:
+ * zoskupenie `apps/api/src/modules/pairing/queries.ts`'s `listPairings()`
+ * podľa produktu. `.onConflictDoNothing()` na produkte — DRUHÉ a ďalšie
+ * volanie pre ten istý `productKey` zámerne NEPREPÍŠE už vložený riadok
+ * produktu (rovnaký produkt, len iný variant).
+ */
+export async function insertTestVariantForProduct(
+  db: Database,
+  productKey: string,
+  code: string,
+  options: { readonly sizeLabel?: string | null; readonly supplier?: string | null; readonly productName?: string } = {},
+): Promise<void> {
+  const snapshotId = await insertTestSnapshot(db);
+  await db
+    .insert(products)
+    .values({
+      key: productKey,
+      name: options.productName ?? `Test produkt ${productKey}`,
+      supplier: options.supplier ?? "Test dodávateľ",
+      firstSeenAt: new Date("2026-01-01T00:00:00Z"),
+      lastSeenAt: new Date("2026-01-01T00:00:00Z"),
+      lastSeenSnapshotId: snapshotId,
+    })
+    .onConflictDoNothing();
+  await db.insert(variants).values({
+    code,
+    productKey,
+    guid: productKey,
+    sizeLabel: options.sizeLabel ?? null,
+    pairCode: null,
+    name: options.productName ?? `Test produkt ${productKey}`,
+    currency: "EUR",
+    price: "10.00",
+    standardPrice: null,
+    purchasePrice: null,
+    actionPrice: null,
+    actionFrom: null,
+    actionUntil: null,
+    percentVat: null,
+    includingVat: null,
+    stock: 5,
+    availabilityInStockText: "Skladom",
+    availabilityOutOfStockText: "Není skladem",
+    availabilityText: "Skladom",
+    productVisibility: "visible",
+    state: "sellable",
+    firstSeenAt: new Date("2026-01-01T00:00:00Z"),
+    lastSeenAt: new Date("2026-01-01T00:00:00Z"),
+    lastSeenSnapshotId: snapshotId,
+    missingSince: null,
+  });
+}

--- a/apps/api/tests/pairing-groups.integration.test.ts
+++ b/apps/api/tests/pairing-groups.integration.test.ts
@@ -1,0 +1,68 @@
+import { expect, it } from "vitest";
+import { createApp } from "../src/http/app.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import { withCleanDb } from "./helpers/db.js";
+import { insertTestVariantForProduct } from "./helpers/orders.js";
+import { users } from "../src/db/schema.js";
+
+const HESLO = "test-heslo-abc"; // testovacie údaje, nie tajomstvo
+
+// Issue 47 (F4 rozdelenie podľa veľkostí) — `GET /api/pairing` teraz posiela
+// AJ `productKey`/`productName` na KAŽDOM riadku, aby si frontend vedel
+// zoskupiť plochý zoznam variantov podľa produktu (`apps/web/src/
+// pairingGroups.ts`). Toto sú JEDINÉ dve nové polia, ktoré táto úloha do
+// odpovede pridáva — samotné zoskupenie a "rozdelené"/"nerozdelené" je
+// odvodené len na frontende, žiadna nová DB migrácia.
+it("GET /api/pairing posiela productKey/productName rovnaké pre všetky varianty toho istého produktu", async () => {
+  const ctx = await withCleanDb();
+  try {
+    await ctx.db.insert(users).values({
+      email: "manazer@forestshop.sk",
+      passwordHash: await hashPassword(HESLO),
+      displayName: "Manažér",
+      role: "manazer",
+    });
+    const app = createApp(ctx.db, { cookieSecure: false });
+    const login = await app.request("/api/login", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ email: "manazer@forestshop.sk", password: HESLO }),
+    });
+    const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+
+    await insertTestVariantForProduct(ctx.db, "40260", "40260/M", {
+      sizeLabel: "M",
+      productName: "Bunda FOREST",
+    });
+    await insertTestVariantForProduct(ctx.db, "40260", "40260/L", {
+      sizeLabel: "L",
+      productName: "Bunda FOREST",
+    });
+    // Kontrolná skupina — INÝ produkt, aby test overil, že sa produkty
+    // nezmiešajú (rôzny `productKey` musí zostať rôzny).
+    await insertTestVariantForProduct(ctx.db, "40261", "40261/M", {
+      sizeLabel: "M",
+      productName: "Vesta FOREST",
+    });
+
+    const res = await app.request("/api/pairing?pageSize=200", { headers: { cookie } });
+    expect(res.status).toBe(200);
+    const telo = (await res.json()) as {
+      total: number;
+      items: readonly { variantCode: string; productKey: string; productName: string }[];
+    };
+    expect(telo.total).toBe(3);
+
+    const bunda = telo.items.filter((i) => i.variantCode.startsWith("40260/"));
+    expect(bunda).toHaveLength(2);
+    for (const item of bunda) {
+      expect(item.productKey).toBe("40260");
+      expect(item.productName).toBe("Bunda FOREST");
+    }
+
+    const vesta = telo.items.find((i) => i.variantCode === "40261/M");
+    expect(vesta).toMatchObject({ productKey: "40261", productName: "Vesta FOREST" });
+  } finally {
+    await ctx.close();
+  }
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -80,7 +80,7 @@ export function App(): JSX.Element {
       <OrdersSection role={me.role} onSessionExpired={reload} />
       <PairingSection role={me.role} onSessionExpired={reload} />
       <SchedulerSection role={me.role} onSessionExpired={reload} />
-      <ChangePasswordForm onSessionExpired={reload} />
+      <ChangePasswordForm email={me.email} onSessionExpired={reload} />
       <Footer />
     </main>
   );

--- a/apps/web/src/components/ChangePasswordForm.test.tsx
+++ b/apps/web/src/components/ChangePasswordForm.test.tsx
@@ -29,8 +29,22 @@ function odosli(): void {
   fireEvent.click(screen.getByRole("button", { name: "Zmeniť heslo" }));
 }
 
+// Issue 47 (komentár k zbaleniu): Chrome logoval accessibility hint kvôli
+// chýbajúcemu username poľu na tomto formulári — over, že skryté pole
+// existuje a nesie prihláseného používateľa (nikdy neide na server, viď
+// komentár pri props v `ChangePasswordForm.tsx`).
+it("nesie skryté autoComplete=\"username\" pole s e-mailom prihláseného používateľa", () => {
+  render(<ChangePasswordForm email="e2e@forestshop.sk" onSessionExpired={() => {}} />);
+
+  const usernameField = document.querySelector('input[name="username"]');
+  expect(usernameField).not.toBeNull();
+  expect(usernameField?.getAttribute("autocomplete")).toBe("username");
+  expect((usernameField as HTMLInputElement).value).toBe("e2e@forestshop.sk");
+  expect(usernameField?.hasAttribute("hidden")).toBe(true);
+});
+
 it("nezhodujúce sa potvrdenie nového hesla ukáže chybu a nezavolá server", () => {
-  render(<ChangePasswordForm onSessionExpired={() => {}} />);
+  render(<ChangePasswordForm email="manazer@forestshop.sk" onSessionExpired={() => {}} />);
   vyplnIba({ stareHeslo: "stare-heslo", noveHeslo: "nove-heslo-123", potvrdenie: "ine-heslo-456" });
   odosli();
 
@@ -39,7 +53,7 @@ it("nezhodujúce sa potvrdenie nového hesla ukáže chybu a nezavolá server", 
 });
 
 it("príliš krátke nové heslo ukáže chybu a nezavolá server", () => {
-  render(<ChangePasswordForm onSessionExpired={() => {}} />);
+  render(<ChangePasswordForm email="manazer@forestshop.sk" onSessionExpired={() => {}} />);
   vyplnIba({ stareHeslo: "stare-heslo", noveHeslo: "krat", potvrdenie: "krat" });
   odosli();
 
@@ -49,7 +63,7 @@ it("príliš krátke nové heslo ukáže chybu a nezavolá server", () => {
 
 it("úspešná zmena ukáže potvrdenie a vyprázdni polia", async () => {
   postChangePassword.mockResolvedValue({ ok: true });
-  render(<ChangePasswordForm onSessionExpired={() => {}} />);
+  render(<ChangePasswordForm email="manazer@forestshop.sk" onSessionExpired={() => {}} />);
   vyplnIba({ stareHeslo: "stare-heslo", noveHeslo: "nove-heslo-123", potvrdenie: "nove-heslo-123" });
   odosli();
 
@@ -61,7 +75,7 @@ it("úspešná zmena ukáže potvrdenie a vyprázdni polia", async () => {
 
 it("zlé staré heslo zo servera ukáže chybovú hlášku servera", async () => {
   postChangePassword.mockResolvedValue({ ok: false, error: "Nesprávne staré heslo" });
-  render(<ChangePasswordForm onSessionExpired={() => {}} />);
+  render(<ChangePasswordForm email="manazer@forestshop.sk" onSessionExpired={() => {}} />);
   vyplnIba({ stareHeslo: "zle-heslo", noveHeslo: "nove-heslo-123", potvrdenie: "nove-heslo-123" });
   odosli();
 
@@ -72,7 +86,7 @@ it("zlé staré heslo zo servera ukáže chybovú hlášku servera", async () =>
 it("keď relácia medzitým vypršala, zavolá onSessionExpired", async () => {
   postChangePassword.mockRejectedValue(new PasswordChangeUnauthorizedError());
   const onSessionExpired = vi.fn();
-  render(<ChangePasswordForm onSessionExpired={onSessionExpired} />);
+  render(<ChangePasswordForm email="manazer@forestshop.sk" onSessionExpired={onSessionExpired} />);
   vyplnIba({ stareHeslo: "stare-heslo", noveHeslo: "nove-heslo-123", potvrdenie: "nove-heslo-123" });
   odosli();
 
@@ -90,7 +104,7 @@ it("tlačidlo sa počas prebiehajúcej požiadavky vypne a druhý klik nevyšle 
       }),
   );
 
-  render(<ChangePasswordForm onSessionExpired={() => {}} />);
+  render(<ChangePasswordForm email="manazer@forestshop.sk" onSessionExpired={() => {}} />);
   vyplnIba({ stareHeslo: "stare-heslo", noveHeslo: "nove-heslo-123", potvrdenie: "nove-heslo-123" });
   odosli();
 

--- a/apps/web/src/components/ChangePasswordForm.tsx
+++ b/apps/web/src/components/ChangePasswordForm.tsx
@@ -7,8 +7,19 @@ import { PasswordChangeUnauthorizedError, postChangePassword } from "../password
 const MIN_NEW_PASSWORD_LENGTH = 8;
 
 export function ChangePasswordForm({
+  email,
   onSessionExpired,
 }: {
+  // E-mail PRIHLÁSENÉHO používateľa (issue 47, komentár k zbaleniu) — nesie
+  // ho len skryté `autoComplete="username"` pole nižšie, aby Chrome prestal
+  // pri KAŽDOM načítaní logovať accessibility hint "Password forms should
+  // have (optionally hidden) username fields" (formulár mal predtým 3
+  // heslové polia a ŽIADNE meno používateľa — PR 56 doplnila len
+  // `autoComplete="current-password"`/`"new-password"` na samotné polia,
+  // toto rieši ZVYŠNÝ hint). Appka žiadny <form> na zmenu e-mailu nemá, takže
+  // toto pole nikdy nič neodošle na server ani ho nemení — čisto pre
+  // prehliadačov password manager.
+  readonly email: string;
   readonly onSessionExpired: () => void;
 }): JSX.Element {
   const [oldPassword, setOldPassword] = useState("");
@@ -59,6 +70,9 @@ export function ChangePasswordForm({
     <section>
       <h2>Zmena hesla</h2>
       <form onSubmit={(e) => { void submit(e); }}>
+        {/* Skryté, nikdy needituje/needosiela nič — len autoComplete="username"
+            pre prehliadačov password manager (viď komentár pri props vyššie). */}
+        <input type="text" name="username" autoComplete="username" value={email} readOnly hidden />
         <label htmlFor="old-password">Staré heslo</label>
         <input
           id="old-password"

--- a/apps/web/src/components/PairingGroupRow.tsx
+++ b/apps/web/src/components/PairingGroupRow.tsx
@@ -1,0 +1,132 @@
+import type { JSX } from "react";
+import { groupConfirmation, isGroupFullyConfirmed, type ProductGroup } from "../pairingGroups.js";
+
+const STATE_LABELS = { navrhnute: "Navrhnuté", potvrdene: "Potvrdené" } as const;
+
+/**
+ * ZBALENÝ riadok pre viacvariantný produkt, ktorého varianty majú (zatiaľ)
+ * VŠETKY zhodnú adresu u dodávateľa (issue 47) — jedno pole na adresu,
+ * akcie sa aplikujú na VŠETKY jeho veľkosti naraz. Vykresľuje sa LEN keď
+ * `isGroupHomogeneous(group)` platí a manažér skupinu ručne neotvoril cez
+ * "✂ Rozdeliť na veľkosti" (rozhoduje volajúci `PairingSection.tsx`).
+ */
+export function PairingGroupRow({
+  group,
+  canConfirm,
+  editingGroupKey,
+  groupUrlDraft,
+  busyGroupKey,
+  onGroupUrlDraftChange,
+  onStartEditGroup,
+  onCancelEditGroup,
+  onSaveManualUrlForGroup,
+  onConfirmGroupAsIs,
+  onOpenSplit,
+}: {
+  readonly group: ProductGroup;
+  readonly canConfirm: boolean;
+  readonly editingGroupKey: string | null;
+  readonly groupUrlDraft: string;
+  readonly busyGroupKey: string | null;
+  readonly onGroupUrlDraftChange: (value: string) => void;
+  readonly onStartEditGroup: (group: ProductGroup) => void;
+  readonly onCancelEditGroup: () => void;
+  readonly onSaveManualUrlForGroup: (group: ProductGroup) => void;
+  readonly onConfirmGroupAsIs: (group: ProductGroup) => void;
+  readonly onOpenSplit: (productKey: string) => void;
+}): JSX.Element {
+  const isEditing = editingGroupKey === group.productKey;
+  const isBusy = busyGroupKey === group.productKey;
+  const representativeUrl = group.variants[0]?.supplierUrl ?? null;
+  const productSupplier = group.variants[0]?.productSupplier ?? null;
+  const sizes = group.variants.map((v) => v.sizeLabel ?? v.variantCode).join(", ");
+  const confirmed = groupConfirmation(group);
+  const fullyConfirmed = isGroupFullyConfirmed(group);
+
+  return (
+    <tr data-testid={`pairing-group-${group.productKey}`}>
+      <td>—</td>
+      <td>{group.productName}</td>
+      <td>{sizes}</td>
+      <td>{productSupplier ?? "—"}</td>
+      <td>
+        {isEditing ? (
+          <>
+            <input
+              aria-label={`Adresa u dodávateľa pre ${group.productName} (všetky veľkosti)`}
+              type="url"
+              value={groupUrlDraft}
+              disabled={isBusy}
+              onChange={(e) => {
+                onGroupUrlDraftChange(e.target.value);
+              }}
+            />
+            <button
+              type="button"
+              disabled={isBusy || groupUrlDraft.trim() === ""}
+              onClick={() => {
+                onSaveManualUrlForGroup(group);
+              }}
+            >
+              Potvrdiť
+            </button>
+            <button type="button" disabled={isBusy} onClick={onCancelEditGroup}>
+              Zrušiť
+            </button>
+          </>
+        ) : representativeUrl === null ? (
+          "—"
+        ) : (
+          <a href={representativeUrl} target="_blank" rel="noreferrer">
+            {representativeUrl}
+          </a>
+        )}
+      </td>
+      <td>{STATE_LABELS[fullyConfirmed ? "potvrdene" : "navrhnute"]}</td>
+      <td>
+        {confirmed.confirmedByName === null
+          ? "—"
+          : `${confirmed.confirmedByName} (${new Date(confirmed.confirmedAt ?? "").toLocaleDateString("sk-SK")})`}
+      </td>
+      {canConfirm && (
+        <td>
+          {!isEditing && (
+            <>
+              <button
+                type="button"
+                data-testid={`confirm-group-${group.productKey}`}
+                disabled={representativeUrl === null || fullyConfirmed || isBusy}
+                onClick={() => {
+                  onConfirmGroupAsIs(group);
+                }}
+              >
+                ✓ Potvrdiť
+              </button>
+              <button
+                type="button"
+                data-testid={`reject-group-${group.productKey}`}
+                disabled={isBusy}
+                onClick={() => {
+                  onStartEditGroup(group);
+                }}
+              >
+                ✗ Zadať inú adresu
+              </button>
+              <button
+                type="button"
+                data-testid={`split-${group.productKey}`}
+                disabled={isBusy}
+                title="Nastaviť inú adresu dodávateľa pre každú veľkosť zvlášť"
+                onClick={() => {
+                  onOpenSplit(group.productKey);
+                }}
+              >
+                ✂ Rozdeliť na veľkosti
+              </button>
+            </>
+          )}
+        </td>
+      )}
+    </tr>
+  );
+}

--- a/apps/web/src/components/PairingSection.test.tsx
+++ b/apps/web/src/components/PairingSection.test.tsx
@@ -17,10 +17,17 @@ vi.mock("../pairingApi.js", async (importOriginal) => {
 
 const { PairingUnauthorizedError } = await import("../pairingApi.js");
 
+// `40238/M`/`40237/3XL` majú ROZDIELNY `productKey` (rôzne produkty, náhoda
+// v podobných kódoch) — issue 47's zoskupovacie testy nižšie majú VLASTNÉ
+// fixtúry (`VELKOST_M`/`VELKOST_L`) s rovnakým `productKey`, tieto tri
+// zostávajú jednovariantné (`productKey` === vlastný `variantCode`), presne
+// ako pred touto zmenou (byte-identická renderovacia cesta).
 const NAVRHNUTY = {
   variantCode: "40237/3XL",
   variantName: "Nohavice FOREST 1003",
   sizeLabel: "3XL",
+  productKey: "40237/3XL",
+  productName: "Nohavice FOREST 1003",
   productSupplier: "GRUBE",
   supplierUrl: "https://www.grube.sk/p/1",
   state: "navrhnute" as const,
@@ -32,6 +39,8 @@ const POTVRDENY = {
   variantCode: "40238/M",
   variantName: "Nohavice FOREST 1003",
   sizeLabel: "M",
+  productKey: "40238/M",
+  productName: "Nohavice FOREST 1003",
   productSupplier: "GRUBE",
   supplierUrl: "https://www.grube.sk/p/2",
   state: "potvrdene" as const,
@@ -43,11 +52,34 @@ const BEZ_ADRESY = {
   variantCode: "40239/S",
   variantName: "Čiapka Polar FOREST",
   sizeLabel: null,
+  productKey: "40239/S",
+  productName: "Čiapka Polar FOREST",
   productSupplier: null,
   supplierUrl: null,
   state: "navrhnute" as const,
   confirmedByName: null,
   confirmedAt: null,
+};
+
+// Issue 47 (F4 rozdelenie podľa veľkostí) — jeden produkt ("40260"), DVE
+// veľkosti, ROVNAKÁ adresa u dodávateľa (homogénne, zbalené zobrazenie).
+const VELKOST_M = {
+  variantCode: "40260/M",
+  variantName: "Bunda FOREST",
+  sizeLabel: "M",
+  productKey: "40260",
+  productName: "Bunda FOREST",
+  productSupplier: "GRUBE",
+  supplierUrl: "https://www.grube.sk/p/bunda",
+  state: "navrhnute" as const,
+  confirmedByName: null,
+  confirmedAt: null,
+};
+
+const VELKOST_L = {
+  ...VELKOST_M,
+  variantCode: "40260/L",
+  sizeLabel: "L",
 };
 
 afterEach(() => {
@@ -207,4 +239,110 @@ it("potvrdenie pri 401 zavolá onSessionExpired namiesto zobrazenia chyby", asyn
   await waitFor(() => {
     expect(onSessionExpired).toHaveBeenCalledTimes(1);
   });
+});
+
+// Issue 47 — F4 rozdelenie podľa veľkostí. Skupinové (zbalené) zobrazenie sa
+// aktivuje LEN pre produkt s viac ako 1 variantom; zoskupenie je odvodené
+// (`pairingGroups.ts`), nikdy sa nepersistuje.
+it("viacvariantný produkt s ROVNAKOU adresou na oboch veľkostiach sa zobrazí ako JEDEN zbalený riadok", async () => {
+  searchPairings.mockResolvedValue({ total: 2, items: [VELKOST_M, VELKOST_L] });
+
+  render(<PairingSection role="manazer" onSessionExpired={() => {}} />);
+
+  const skupina = await screen.findByTestId("pairing-group-40260");
+  expect(skupina.textContent).toContain("Bunda FOREST");
+  expect(skupina.textContent).toContain("M, L");
+  expect(screen.queryByTestId("pairing-40260/M")).toBeNull();
+  expect(screen.queryByTestId("pairing-40260/L")).toBeNull();
+});
+
+it("viacvariantný produkt s ROZDIELNOU adresou na veľkostiach sa zobrazí AUTOMATICKY rozdelený (bez klikania)", async () => {
+  const inaAdresa = { ...VELKOST_L, supplierUrl: "https://www.grube.sk/p/bunda-inak" };
+  searchPairings.mockResolvedValue({ total: 2, items: [VELKOST_M, inaAdresa] });
+
+  render(<PairingSection role="manazer" onSessionExpired={() => {}} />);
+
+  await screen.findByTestId("pairing-40260/M");
+  expect(screen.getByTestId("pairing-40260/L")).toBeTruthy();
+  expect(screen.queryByTestId("pairing-group-40260")).toBeNull();
+});
+
+it("✂ Rozdeliť na veľkosti rozbalí homogénnu skupinu na jednotlivé veľkosti; ↩ Zlúčiť veľkosti ju zabalí späť", async () => {
+  searchPairings.mockResolvedValue({ total: 2, items: [VELKOST_M, VELKOST_L] });
+
+  render(<PairingSection role="manazer" onSessionExpired={() => {}} />);
+
+  fireEvent.click(await screen.findByTestId("split-40260"));
+
+  await screen.findByTestId("pairing-40260/M");
+  expect(screen.getByTestId("pairing-40260/L")).toBeTruthy();
+  expect(screen.queryByTestId("pairing-group-40260")).toBeNull();
+
+  fireEvent.click(screen.getByTestId("merge-40260"));
+
+  await screen.findByTestId("pairing-group-40260");
+  expect(screen.queryByTestId("pairing-40260/M")).toBeNull();
+});
+
+it("✓ Potvrdiť na zbalenej skupine potvrdí VŠETKY jej veľkosti (bulk, jeden POST na variant)", async () => {
+  searchPairings.mockResolvedValueOnce({ total: 2, items: [VELKOST_M, VELKOST_L] });
+  searchPairings.mockResolvedValueOnce({
+    total: 2,
+    items: [
+      { ...VELKOST_M, state: "potvrdene", confirmedByName: "Manažér", confirmedAt: "2026-07-30T12:00:00.000Z" },
+      { ...VELKOST_L, state: "potvrdene", confirmedByName: "Manažér", confirmedAt: "2026-07-30T12:00:00.000Z" },
+    ],
+  });
+  confirmPairing.mockResolvedValue(undefined);
+
+  render(<PairingSection role="manazer" onSessionExpired={() => {}} />);
+
+  fireEvent.click(await screen.findByTestId("confirm-group-40260"));
+
+  await waitFor(() => {
+    expect(confirmPairing).toHaveBeenCalledWith("40260/M");
+    expect(confirmPairing).toHaveBeenCalledWith("40260/L");
+  });
+  await waitFor(() => {
+    expect(screen.getByTestId("pairing-group-40260").textContent).toContain("Potvrdené");
+  });
+});
+
+it("✗ Zadať inú adresu na zbalenej skupine pošle ROVNAKÚ novú adresu na VŠETKY jej veľkosti", async () => {
+  searchPairings.mockResolvedValueOnce({ total: 2, items: [VELKOST_M, VELKOST_L] });
+  const novaAdresa = "https://www.grube.sk/p/bunda-nova";
+  searchPairings.mockResolvedValueOnce({
+    total: 2,
+    items: [
+      { ...VELKOST_M, supplierUrl: novaAdresa, state: "potvrdene", confirmedByName: "Manažér", confirmedAt: "2026-07-30T12:00:00.000Z" },
+      { ...VELKOST_L, supplierUrl: novaAdresa, state: "potvrdene", confirmedByName: "Manažér", confirmedAt: "2026-07-30T12:00:00.000Z" },
+    ],
+  });
+  confirmPairing.mockResolvedValue(undefined);
+
+  render(<PairingSection role="manazer" onSessionExpired={() => {}} />);
+
+  fireEvent.click(await screen.findByTestId("reject-group-40260"));
+  fireEvent.change(screen.getByLabelText("Adresa u dodávateľa pre Bunda FOREST (všetky veľkosti)"), {
+    target: { value: novaAdresa },
+  });
+  fireEvent.click(screen.getByRole("button", { name: "Potvrdiť" }));
+
+  await waitFor(() => {
+    expect(confirmPairing).toHaveBeenCalledWith("40260/M", novaAdresa);
+    expect(confirmPairing).toHaveBeenCalledWith("40260/L", novaAdresa);
+  });
+  await waitFor(() => {
+    expect(screen.getByTestId("pairing-group-40260").textContent).toContain("Potvrdené");
+  });
+});
+
+it("rola citanie nevidí Akcie ani na zbalenej skupine (žiadne tlačidlo Rozdeliť)", async () => {
+  searchPairings.mockResolvedValue({ total: 2, items: [VELKOST_M, VELKOST_L] });
+
+  render(<PairingSection role="citanie" onSessionExpired={() => {}} />);
+
+  await screen.findByTestId("pairing-group-40260");
+  expect(screen.queryByTestId("split-40260")).toBeNull();
+  expect(screen.queryByTestId("confirm-group-40260")).toBeNull();
 });

--- a/apps/web/src/components/PairingSection.tsx
+++ b/apps/web/src/components/PairingSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState, type SyntheticEvent, type JSX } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type SyntheticEvent, type JSX } from "react";
 import type { Me } from "../api.js";
 import {
   confirmPairing,
@@ -7,11 +7,14 @@ import {
   type PairingItem,
   type PairingState,
 } from "../pairingApi.js";
-
-const STATE_LABELS: Record<PairingItem["state"], string> = {
-  navrhnute: "Navrhnuté",
-  potvrdene: "Potvrdené",
-};
+import {
+  assertBulkConfirmSucceeded,
+  groupPairingItems,
+  isGroupHomogeneous,
+  type ProductGroup,
+} from "../pairingGroups.js";
+import { PairingGroupRow } from "./PairingGroupRow.js";
+import { PairingVariantRow } from "./PairingVariantRow.js";
 
 // Rovnaké dve role, ktoré server vyžaduje pre `POST /api/pairing/confirm`
 // (`requireRole("admin", "manazer")`, `pairing-routes.ts`) — server ostáva
@@ -34,11 +37,23 @@ export function PairingSection({
   const [searchError, setSearchError] = useState("");
   const canConfirm = CAN_CONFIRM_ROLES.has(role);
 
-  // Ručné zadanie/oprava adresy pre PRÁVE JEDEN riadok naraz (rovnaký vzor
+  // Ručné zadanie/oprava adresy pre PRÁVE JEDEN variant naraz (rovnaký vzor
   // ako `OrdersSection`'s e-mailová úprava dodávateľa).
   const [editingCode, setEditingCode] = useState<string | null>(null);
   const [urlDraft, setUrlDraft] = useState("");
   const [busyCode, setBusyCode] = useState<string | null>(null);
+  // Bulk (per-produkt) obdoba vyššie — issue 47, F4 rozdelenie podľa
+  // veľkostí. Zámerne SAMOSTATNÝ stav (nie zdieľaný s `editingCode`/
+  // `busyCode`) — jednovariantný riadok aj naďalej beží presne pôvodnou
+  // cestou, bulk cesta pribúda popri nej, nikdy ju nenahrádza.
+  const [editingGroupKey, setEditingGroupKey] = useState<string | null>(null);
+  const [groupUrlDraft, setGroupUrlDraft] = useState("");
+  const [busyGroupKey, setBusyGroupKey] = useState<string | null>(null);
+  // Produkty, ktoré manažér RUČNE otvoril cez "✂ Rozdeliť na veľkosti" —
+  // prechodné (transient), nikdy sa nepersistuje (viď návrhový komentár na
+  // issue 47). Efektívne rozdelené produkty (rôzne adresy naprieč
+  // veľkosťami) sa zobrazujú rozdelené AJ BEZ prítomnosti tu.
+  const [manuallyOpenedGroups, setManuallyOpenedGroups] = useState<ReadonlySet<string>>(new Set());
   const [actionError, setActionError] = useState("");
 
   // Len najnovšia požiadavka smie zapísať výsledok — rovnaký dôvod ako
@@ -92,6 +107,8 @@ export function PairingSection({
   const refetch = useCallback(() => {
     search(query, state);
   }, [search, query, state]);
+
+  const groups = useMemo(() => groupPairingItems(items), [items]);
 
   // "✓ jedným klikom" — potvrdí aktuálne uloženú/navrhnutú adresu bez zmeny.
   const confirmAsIs = useCallback(
@@ -153,14 +170,177 @@ export function PairingSection({
     [refetch, onSessionExpired, urlDraft],
   );
 
+  // Bulk obdoby vyššie — issue 47: rovnaká akcia, len aplikovaná na VŠETKY
+  // varianty produktu naraz (paralelné volania existujúceho `POST /api/
+  // pairing/confirm`, žiadny nový backend endpoint). `refetch()` beží VŽDY,
+  // aj pri čiastočnom zlyhaní — časť veľkostí mohla prejsť.
+  const confirmGroupAsIs = useCallback(
+    (group: ProductGroup) => {
+      const url = group.variants[0]?.supplierUrl ?? null;
+      if (url === null) return;
+      setActionError("");
+      setBusyGroupKey(group.productKey);
+      const codes = group.variants.map((v) => v.variantCode);
+      Promise.allSettled(codes.map((code) => confirmPairing(code)))
+        .then((results) => {
+          refetch();
+          assertBulkConfirmSucceeded(codes, results);
+        })
+        .catch((err: unknown) => {
+          if (err instanceof PairingUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setActionError(err instanceof Error ? err.message : "Potvrdenie sa nepodarilo.");
+        })
+        .finally(() => {
+          setBusyGroupKey(null);
+        });
+    },
+    [refetch, onSessionExpired],
+  );
+
+  const startEditGroup = useCallback((group: ProductGroup) => {
+    setEditingGroupKey(group.productKey);
+    setGroupUrlDraft(group.variants[0]?.supplierUrl ?? "");
+    setActionError("");
+  }, []);
+
+  const cancelEditGroup = useCallback(() => {
+    setEditingGroupKey(null);
+    setActionError("");
+  }, []);
+
+  const saveManualUrlForGroup = useCallback(
+    (group: ProductGroup) => {
+      setActionError("");
+      setBusyGroupKey(group.productKey);
+      const url = groupUrlDraft.trim();
+      const codes = group.variants.map((v) => v.variantCode);
+      Promise.allSettled(codes.map((code) => confirmPairing(code, url)))
+        .then((results) => {
+          setEditingGroupKey(null);
+          refetch();
+          assertBulkConfirmSucceeded(codes, results);
+        })
+        .catch((err: unknown) => {
+          if (err instanceof PairingUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setActionError(err instanceof Error ? err.message : "Uloženie adresy sa nepodarilo.");
+        })
+        .finally(() => {
+          setBusyGroupKey(null);
+        });
+    },
+    [refetch, onSessionExpired, groupUrlDraft],
+  );
+
+  const openSplit = useCallback((productKey: string) => {
+    setManuallyOpenedGroups((prev) => new Set(prev).add(productKey));
+  }, []);
+
+  const closeSplit = useCallback((productKey: string) => {
+    setManuallyOpenedGroups((prev) => {
+      if (!prev.has(productKey)) return prev;
+      const next = new Set(prev);
+      next.delete(productKey);
+      return next;
+    });
+  }, []);
+
   const showingAll = total === 0 || items.length >= total;
+
+  // Jednovariantný produkt → presne dnešný riadok, nezmenené. Viacvariantný
+  // produkt s ROZDIELNYMI adresami ("efektívne rozdelený") alebo ručne
+  // otvorený cez "✂ Rozdeliť na veľkosti" → hlavičkový riadok produktu +
+  // rovnaký per-variantný riadok pre KAŽDÚ jeho veľkosť. Inak (homogénny,
+  // neotvorený) → jeden zbalený riadok s bulk akciami (issue 47).
+  function renderGroup(group: ProductGroup): readonly JSX.Element[] {
+    if (group.variants.length === 1) {
+      const only = group.variants[0];
+      if (only === undefined) return [];
+      return [
+        <PairingVariantRow
+          key={only.variantCode}
+          item={only}
+          canConfirm={canConfirm}
+          editingCode={editingCode}
+          urlDraft={urlDraft}
+          busyCode={busyCode}
+          onUrlDraftChange={setUrlDraft}
+          onStartEdit={startEdit}
+          onCancelEdit={cancelEdit}
+          onSaveManualUrl={saveManualUrl}
+          onConfirmAsIs={confirmAsIs}
+        />,
+      ];
+    }
+
+    const homogeneous = isGroupHomogeneous(group);
+    const split = !homogeneous || manuallyOpenedGroups.has(group.productKey);
+    if (!split) {
+      return [
+        <PairingGroupRow
+          key={group.productKey}
+          group={group}
+          canConfirm={canConfirm}
+          editingGroupKey={editingGroupKey}
+          groupUrlDraft={groupUrlDraft}
+          busyGroupKey={busyGroupKey}
+          onGroupUrlDraftChange={setGroupUrlDraft}
+          onStartEditGroup={startEditGroup}
+          onCancelEditGroup={cancelEditGroup}
+          onSaveManualUrlForGroup={saveManualUrlForGroup}
+          onConfirmGroupAsIs={confirmGroupAsIs}
+          onOpenSplit={openSplit}
+        />,
+      ];
+    }
+
+    return [
+      <tr key={`${group.productKey}-header`} data-testid={`pairing-group-header-${group.productKey}`}>
+        <td colSpan={canConfirm ? 8 : 7}>
+          <strong>{group.productName}</strong> — {String(group.variants.length)} veľkostí
+          {homogeneous && canConfirm && (
+            <button
+              type="button"
+              data-testid={`merge-${group.productKey}`}
+              onClick={() => {
+                closeSplit(group.productKey);
+              }}
+            >
+              ↩ Zlúčiť veľkosti
+            </button>
+          )}
+        </td>
+      </tr>,
+      ...group.variants.map((item) => (
+        <PairingVariantRow
+          key={item.variantCode}
+          item={item}
+          canConfirm={canConfirm}
+          editingCode={editingCode}
+          urlDraft={urlDraft}
+          busyCode={busyCode}
+          onUrlDraftChange={setUrlDraft}
+          onStartEdit={startEdit}
+          onCancelEdit={cancelEdit}
+          onSaveManualUrl={saveManualUrl}
+          onConfirmAsIs={confirmAsIs}
+        />
+      )),
+    ];
+  }
 
   return (
     <section>
       <h2>Kontrola párovania</h2>
       <p>
         Náš produkt oproti navrhnutej/zadanej adrese u dodávateľa — jedným klikom potvrďte zhodu,
-        alebo zadajte inú adresu ručne.
+        alebo zadajte inú adresu ručne. Produkt s viacerými veľkosťami môžete rozdeliť a nastaviť
+        každej veľkosti vlastnú adresu.
       </p>
 
       <form onSubmit={submit}>
@@ -230,91 +410,7 @@ export function PairingSection({
             </tr>
           </thead>
           <tbody>
-            {items.map((item) => (
-              <tr key={item.variantCode} data-testid={`pairing-${item.variantCode}`}>
-                <td>{item.variantCode}</td>
-                <td>{item.variantName}</td>
-                <td>{item.sizeLabel ?? "—"}</td>
-                <td>{item.productSupplier ?? "—"}</td>
-                <td>
-                  {editingCode === item.variantCode ? (
-                    <>
-                      <input
-                        aria-label={`Adresa u dodávateľa pre ${item.variantCode}`}
-                        type="url"
-                        value={urlDraft}
-                        disabled={busyCode === item.variantCode}
-                        onChange={(e) => {
-                          setUrlDraft(e.target.value);
-                        }}
-                      />
-                      <button
-                        type="button"
-                        disabled={busyCode === item.variantCode || urlDraft.trim() === ""}
-                        onClick={() => {
-                          saveManualUrl(item.variantCode);
-                        }}
-                      >
-                        Potvrdiť
-                      </button>
-                      <button type="button" disabled={busyCode === item.variantCode} onClick={cancelEdit}>
-                        Zrušiť
-                      </button>
-                    </>
-                  ) : item.supplierUrl === null ? (
-                    "—"
-                  ) : (
-                    <a href={item.supplierUrl} target="_blank" rel="noreferrer">
-                      {item.supplierUrl}
-                    </a>
-                  )}
-                </td>
-                <td>{STATE_LABELS[item.state]}</td>
-                <td>
-                  {item.confirmedByName === null
-                    ? "—"
-                    : `${item.confirmedByName} (${new Date(item.confirmedAt ?? "").toLocaleDateString("sk-SK")})`}
-                </td>
-                {canConfirm && (
-                  <td>
-                    {editingCode !== item.variantCode && (
-                      <>
-                        <button
-                          type="button"
-                          data-testid={`confirm-${item.variantCode}`}
-                          // Už potvrdený riadok (state "potvrdene") sa opravuje
-                          // len cez "✗ Zadať inú adresu" (rovno zapíše novú
-                          // adresu a potvrdí), nikdy opätovným kliknutím na
-                          // "✓ Potvrdiť" — server (`state.ts`) takéto opätovné
-                          // potvrdenie berie ako no-op a zachová PÔVODNÉHO
-                          // potvrdzujúceho, takže tlačidlo tu len predchádza
-                          // zbytočnému kliknutiu (review nález na PR 54,
-                          // issue 45), server ostáva skutočnou bránou.
-                          disabled={
-                            item.supplierUrl === null || item.state === "potvrdene" || busyCode === item.variantCode
-                          }
-                          onClick={() => {
-                            confirmAsIs(item);
-                          }}
-                        >
-                          ✓ Potvrdiť
-                        </button>
-                        <button
-                          type="button"
-                          data-testid={`reject-${item.variantCode}`}
-                          disabled={busyCode === item.variantCode}
-                          onClick={() => {
-                            startEdit(item);
-                          }}
-                        >
-                          ✗ Zadať inú adresu
-                        </button>
-                      </>
-                    )}
-                  </td>
-                )}
-              </tr>
-            ))}
+            {groups.flatMap((group) => renderGroup(group))}
           </tbody>
         </table>
       )}

--- a/apps/web/src/components/PairingVariantRow.tsx
+++ b/apps/web/src/components/PairingVariantRow.tsx
@@ -1,0 +1,121 @@
+import type { JSX } from "react";
+import type { PairingItem } from "../pairingApi.js";
+
+const STATE_LABELS: Record<PairingItem["state"], string> = {
+  navrhnute: "Navrhnuté",
+  potvrdene: "Potvrdené",
+};
+
+/**
+ * Presne JEDEN riadok tabuľky pre JEDEN variant (veľkosť) — vyňaté z
+ * `PairingSection.tsx` bezo zmeny správania/testid-ov (issue 47, F4
+ * rozdelenie podľa veľkostí), aby sa dal použiť na DVOCH miestach: pre
+ * jednovariantné produkty (nezmenené, ako pred touto zmenou) AJ pre
+ * "rozdelený" pohľad viacvariantného produktu (`PairingGroupRow.tsx` mu
+ * predchádza len hlavičkovým riadkom produktu).
+ */
+export function PairingVariantRow({
+  item,
+  canConfirm,
+  editingCode,
+  urlDraft,
+  busyCode,
+  onUrlDraftChange,
+  onStartEdit,
+  onCancelEdit,
+  onSaveManualUrl,
+  onConfirmAsIs,
+}: {
+  readonly item: PairingItem;
+  readonly canConfirm: boolean;
+  readonly editingCode: string | null;
+  readonly urlDraft: string;
+  readonly busyCode: string | null;
+  readonly onUrlDraftChange: (value: string) => void;
+  readonly onStartEdit: (item: PairingItem) => void;
+  readonly onCancelEdit: () => void;
+  readonly onSaveManualUrl: (variantCode: string) => void;
+  readonly onConfirmAsIs: (item: PairingItem) => void;
+}): JSX.Element {
+  const isEditing = editingCode === item.variantCode;
+  const isBusy = busyCode === item.variantCode;
+
+  return (
+    <tr data-testid={`pairing-${item.variantCode}`}>
+      <td>{item.variantCode}</td>
+      <td>{item.variantName}</td>
+      <td>{item.sizeLabel ?? "—"}</td>
+      <td>{item.productSupplier ?? "—"}</td>
+      <td>
+        {isEditing ? (
+          <>
+            <input
+              aria-label={`Adresa u dodávateľa pre ${item.variantCode}`}
+              type="url"
+              value={urlDraft}
+              disabled={isBusy}
+              onChange={(e) => {
+                onUrlDraftChange(e.target.value);
+              }}
+            />
+            <button
+              type="button"
+              disabled={isBusy || urlDraft.trim() === ""}
+              onClick={() => {
+                onSaveManualUrl(item.variantCode);
+              }}
+            >
+              Potvrdiť
+            </button>
+            <button type="button" disabled={isBusy} onClick={onCancelEdit}>
+              Zrušiť
+            </button>
+          </>
+        ) : item.supplierUrl === null ? (
+          "—"
+        ) : (
+          <a href={item.supplierUrl} target="_blank" rel="noreferrer">
+            {item.supplierUrl}
+          </a>
+        )}
+      </td>
+      <td>{STATE_LABELS[item.state]}</td>
+      <td>
+        {item.confirmedByName === null
+          ? "—"
+          : `${item.confirmedByName} (${new Date(item.confirmedAt ?? "").toLocaleDateString("sk-SK")})`}
+      </td>
+      {canConfirm && (
+        <td>
+          {!isEditing && (
+            <>
+              <button
+                type="button"
+                data-testid={`confirm-${item.variantCode}`}
+                // Už potvrdený riadok (state "potvrdene") sa opravuje len cez
+                // "✗ Zadať inú adresu" — server berie opätovné potvrdenie ako
+                // no-op a zachová PÔVODNÉHO potvrdzujúceho (issue 45).
+                disabled={item.supplierUrl === null || item.state === "potvrdene" || isBusy}
+                onClick={() => {
+                  onConfirmAsIs(item);
+                }}
+              >
+                ✓ Potvrdiť
+              </button>
+              <button
+                type="button"
+                data-testid={`reject-${item.variantCode}`}
+                disabled={isBusy}
+                onClick={() => {
+                  onStartEdit(item);
+                }}
+              >
+                ✗ Zadať inú adresu
+              </button>
+            </>
+          )}
+        </td>
+      )}
+    </tr>
+  );
+}

--- a/apps/web/src/pairingApi.test.ts
+++ b/apps/web/src/pairingApi.test.ts
@@ -20,6 +20,8 @@ it("prečíta zoznam párovania", async () => {
         variantCode: "40237/3XL",
         variantName: "Nohavice FOREST 1003",
         sizeLabel: "3XL",
+        productKey: "40237",
+        productName: "Nohavice FOREST 1003",
         productSupplier: "GRUBE",
         supplierUrl: null,
         state: "navrhnute" as const,

--- a/apps/web/src/pairingApi.ts
+++ b/apps/web/src/pairingApi.ts
@@ -11,6 +11,8 @@ const pairingItemSchema = z.object({
   variantCode: z.string(),
   variantName: z.string(),
   sizeLabel: z.string().nullable(),
+  productKey: z.string(),
+  productName: z.string(),
   productSupplier: z.string().nullable(),
   supplierUrl: z.string().nullable(),
   state: z.enum(["navrhnute", "potvrdene"]),

--- a/apps/web/src/pairingGroups.test.ts
+++ b/apps/web/src/pairingGroups.test.ts
@@ -1,0 +1,172 @@
+import { expect, it } from "vitest";
+import { PairingUnauthorizedError, type PairingItem } from "./pairingApi.js";
+import {
+  assertBulkConfirmSucceeded,
+  groupConfirmation,
+  groupPairingItems,
+  isGroupFullyConfirmed,
+  isGroupHomogeneous,
+} from "./pairingGroups.js";
+
+function item(overrides: Partial<PairingItem> & { variantCode: string; productKey: string }): PairingItem {
+  return {
+    variantName: "Test produkt",
+    sizeLabel: null,
+    productName: "Test produkt",
+    productSupplier: null,
+    supplierUrl: null,
+    state: "navrhnute",
+    confirmedByName: null,
+    confirmedAt: null,
+    ...overrides,
+  };
+}
+
+it("zoskupí varianty podľa productKey, v poradí prvého výskytu produktu", () => {
+  const items = [
+    item({ variantCode: "40237/M", productKey: "40237" }),
+    item({ variantCode: "40238/S", productKey: "40238" }),
+    item({ variantCode: "40237/L", productKey: "40237" }),
+  ];
+
+  const groups = groupPairingItems(items);
+
+  expect(groups.map((g) => g.productKey)).toEqual(["40237", "40238"]);
+  expect(groups[0]?.variants.map((v) => v.variantCode)).toEqual(["40237/M", "40237/L"]);
+  expect(groups[1]?.variants.map((v) => v.variantCode)).toEqual(["40238/S"]);
+});
+
+it("produkt s jedným variantom je vždy homogénny a nesie jeho productName", () => {
+  const groups = groupPairingItems([
+    item({ variantCode: "40287", productKey: "40287", productName: "Čiapka Polar FOREST" }),
+  ]);
+
+  expect(groups).toHaveLength(1);
+  expect(groups[0]?.productName).toBe("Čiapka Polar FOREST");
+  const group = groups[0];
+  if (group === undefined) throw new Error("group missing");
+  expect(isGroupHomogeneous(group)).toBe(true);
+});
+
+it("skupina so ZHODNOU adresou na všetkých variantoch je homogénna (nerozdelená)", () => {
+  const groups = groupPairingItems([
+    item({ variantCode: "40237/M", productKey: "40237", supplierUrl: "https://x.sk/1" }),
+    item({ variantCode: "40237/L", productKey: "40237", supplierUrl: "https://x.sk/1" }),
+  ]);
+  const group = groups[0];
+  if (group === undefined) throw new Error("group missing");
+  expect(isGroupHomogeneous(group)).toBe(true);
+});
+
+it("skupina bez ŽIADNEJ uloženej adresy (všetky null) je tiež homogénna", () => {
+  const groups = groupPairingItems([
+    item({ variantCode: "40237/M", productKey: "40237" }),
+    item({ variantCode: "40237/L", productKey: "40237" }),
+  ]);
+  const group = groups[0];
+  if (group === undefined) throw new Error("group missing");
+  expect(isGroupHomogeneous(group)).toBe(true);
+});
+
+it("skupina s RÔZNYMI adresami je efektívne rozdelená (nie homogénna)", () => {
+  const groups = groupPairingItems([
+    item({ variantCode: "40237/M", productKey: "40237", supplierUrl: "https://x.sk/1" }),
+    item({ variantCode: "40237/L", productKey: "40237", supplierUrl: "https://x.sk/2" }),
+  ]);
+  const group = groups[0];
+  if (group === undefined) throw new Error("group missing");
+  expect(isGroupHomogeneous(group)).toBe(false);
+});
+
+it("isGroupFullyConfirmed vyžaduje POTVRDENÉ na KAŽDOM variante", () => {
+  const groups = groupPairingItems([
+    item({ variantCode: "40237/M", productKey: "40237", state: "potvrdene" }),
+    item({ variantCode: "40237/L", productKey: "40237", state: "navrhnute" }),
+  ]);
+  const group = groups[0];
+  if (group === undefined) throw new Error("group missing");
+  expect(isGroupFullyConfirmed(group)).toBe(false);
+});
+
+it("groupConfirmation vráti spoločnú atribúciu, keď je zhodná na všetkých variantoch", () => {
+  const groups = groupPairingItems([
+    item({
+      variantCode: "40237/M",
+      productKey: "40237",
+      state: "potvrdene",
+      confirmedByName: "Manažér",
+      confirmedAt: "2026-07-30T10:00:00.000Z",
+    }),
+    item({
+      variantCode: "40237/L",
+      productKey: "40237",
+      state: "potvrdene",
+      confirmedByName: "Manažér",
+      confirmedAt: "2026-07-30T10:00:00.000Z",
+    }),
+  ]);
+  const group = groups[0];
+  if (group === undefined) throw new Error("group missing");
+  expect(groupConfirmation(group)).toEqual({ confirmedByName: "Manažér", confirmedAt: "2026-07-30T10:00:00.000Z" });
+});
+
+it("groupConfirmation vráti null, keď sa atribúcia medzi variantmi LÍŠI (zmiešaná skupina)", () => {
+  const groups = groupPairingItems([
+    item({
+      variantCode: "40237/M",
+      productKey: "40237",
+      state: "potvrdene",
+      confirmedByName: "Manažér A",
+      confirmedAt: "2026-07-30T10:00:00.000Z",
+    }),
+    item({
+      variantCode: "40237/L",
+      productKey: "40237",
+      state: "potvrdene",
+      confirmedByName: "Manažér B",
+      confirmedAt: "2026-07-30T11:00:00.000Z",
+    }),
+  ]);
+  const group = groups[0];
+  if (group === undefined) throw new Error("group missing");
+  expect(groupConfirmation(group)).toEqual({ confirmedByName: null, confirmedAt: null });
+});
+
+it("assertBulkConfirmSucceeded neurobí nič, keď VŠETKY sľuby uspeli", () => {
+  const results: PromiseSettledResult<void>[] = [
+    { status: "fulfilled", value: undefined },
+    { status: "fulfilled", value: undefined },
+  ];
+  expect(() => { assertBulkConfirmSucceeded(["a", "b"], results); }).not.toThrow();
+});
+
+it("assertBulkConfirmSucceeded pri ÚPLNOM zlyhaní hlási pôvodnú hlášku bez počtu", () => {
+  const results: PromiseSettledResult<void>[] = [
+    { status: "rejected", reason: new Error("Chýba adresa produktu u dodávateľa") },
+    { status: "rejected", reason: new Error("Chýba adresa produktu u dodávateľa") },
+  ];
+  expect(() => { assertBulkConfirmSucceeded(["a", "b"], results); }).toThrow(
+    "Chýba adresa produktu u dodávateľa",
+  );
+});
+
+it("assertBulkConfirmSucceeded pri ČIASTOČNOM zlyhaní pridá počet zlyhaných", () => {
+  const results: PromiseSettledResult<void>[] = [
+    { status: "fulfilled", value: undefined },
+    { status: "rejected", reason: new Error("Variant sa nenašiel") },
+  ];
+  expect(() => { assertBulkConfirmSucceeded(["a", "b"], results); }).toThrow(
+    "Variant sa nenašiel (zlyhalo 1 z 2 veľkostí)",
+  );
+});
+
+it("assertBulkConfirmSucceeded prehodí TÚ ISTÚ PairingUnauthorizedError inštanciu (nikdy nezabalenú)", () => {
+  const unauthorized = new PairingUnauthorizedError();
+  const results: PromiseSettledResult<void>[] = [{ status: "rejected", reason: unauthorized }];
+  try {
+    assertBulkConfirmSucceeded(["a"], results);
+    throw new Error("malo vyhodiť");
+  } catch (err) {
+    expect(err).toBe(unauthorized);
+  }
+});

--- a/apps/web/src/pairingGroups.ts
+++ b/apps/web/src/pairingGroups.ts
@@ -1,0 +1,104 @@
+import { PairingUnauthorizedError, type PairingItem } from "./pairingApi.js";
+
+/**
+ * Zoskupenie plochého zoznamu variantov (`GET /api/pairing`) podľa produktu
+ * (issue 47, F4 rozdelenie podľa veľkostí) — čisto ODVODENÉ z aktuálnych
+ * dát, nikdy nepersistuje "split" rozhodnutie (viď návrhový komentár na
+ * issue 47): produkt so ZHODNOU `supplierUrl` naprieč všetkými svojimi
+ * variantmi sa zobrazí ako JEDEN zbalený riadok (bulk akcie na všetky
+ * veľkosti naraz); akonáhle sa adresy variantov reálne LÍŠIA, je produkt
+ * "efektívne rozdelený" a zobrazí sa (alebo zostáva zobrazený) po
+ * veľkostiach — presne ako dnešný plochý zoznam pred touto zmenou.
+ */
+export interface ProductGroup {
+  readonly productKey: string;
+  readonly productName: string;
+  readonly variants: readonly PairingItem[];
+}
+
+/**
+ * Zoskupí PODĽA PRODUKTU, v poradí PRVÉHO výskytu produktu v pôvodnom
+ * (server-triedenom podľa `variant.code`) zozname — takže varianty toho
+ * istého produktu, aj keby v abecednom triedení neboli súvislé, skončia v
+ * JEDNEJ skupine na svojom prvom mieste výskytu.
+ */
+export function groupPairingItems(items: readonly PairingItem[]): readonly ProductGroup[] {
+  const order: string[] = [];
+  const byKey = new Map<string, PairingItem[]>();
+  for (const item of items) {
+    const existing = byKey.get(item.productKey);
+    if (existing === undefined) {
+      order.push(item.productKey);
+      byKey.set(item.productKey, [item]);
+    } else {
+      existing.push(item);
+    }
+  }
+  return order.map((productKey) => {
+    const variants = byKey.get(productKey) ?? [];
+    return { productKey, productName: variants[0]?.productName ?? "", variants };
+  });
+}
+
+/**
+ * `true`, keď VŠETKY varianty produktu majú PRESNE rovnakú `supplierUrl`
+ * (vrátane "všetky null") — jediný prípad, kedy dáva zmysel zobraziť ich
+ * ako JEDEN zbalený riadok s JEDNÝM poľom na adresu.
+ */
+export function isGroupHomogeneous(group: ProductGroup): boolean {
+  const [first, ...rest] = group.variants;
+  if (first === undefined) return true;
+  return rest.every((v) => v.supplierUrl === first.supplierUrl);
+}
+
+/** `true`, keď je KAŽDÝ variant produktu potvrdený. */
+export function isGroupFullyConfirmed(group: ProductGroup): boolean {
+  return group.variants.length > 0 && group.variants.every((v) => v.state === "potvrdene");
+}
+
+/**
+ * Kto/kedy potvrdil skupinu — len keď je KAŽDÝ variant potvrdený TOU ISTOU
+ * osobou v ten istý čas (bežný prípad po bulk potvrdení). Inak `null`, aby
+ * zbalený riadok nikdy nepredstieral jednotnú atribúciu, ktorá v skutočnosti
+ * je zmiešaná — podrobnosti sú vždy dostupné po rozdelení na veľkosti.
+ */
+export function groupConfirmation(group: ProductGroup): {
+  readonly confirmedByName: string | null;
+  readonly confirmedAt: string | null;
+} {
+  const [first, ...rest] = group.variants;
+  if (first === undefined || first.confirmedByName === null) return { confirmedByName: null, confirmedAt: null };
+  const same = rest.every(
+    (v) => v.confirmedByName === first.confirmedByName && v.confirmedAt === first.confirmedAt,
+  );
+  return same ? { confirmedByName: first.confirmedByName, confirmedAt: first.confirmedAt } : { confirmedByName: null, confirmedAt: null };
+}
+
+/**
+ * Overí výsledky bulk potvrdenia (jeden `POST /api/pairing/confirm` na
+ * KAŽDÝ variant kód skupiny, volané paralelne cez `Promise.allSettled` —
+ * žiadny nový backend endpoint, `confirmPairing` je už bezpečný idempotentný
+ * upsert per variant). Pri ČIASTOČNOM zlyhaní (niektoré varianty prešli,
+ * iné nie) hlási počet zlyhaných; pri `PairingUnauthorizedError`
+ * PREHODÍ TÚ ISTÚ inštanciu (nikdy nezabalenú), aby komponent stále vedel
+ * rozoznať vypršanú reláciu od bežnej chyby.
+ */
+export function assertBulkConfirmSucceeded(
+  variantCodes: readonly string[],
+  results: readonly PromiseSettledResult<void>[],
+): void {
+  const failed = results.filter((r): r is PromiseRejectedResult => r.status === "rejected");
+  if (failed.length === 0) return;
+  // `PromiseRejectedResult.reason` je v TS libe typované ako `any` — explicitné
+  // `unknown` tu zabraňuje `@typescript-eslint/no-unsafe-assignment` a núti
+  // ďalej pracovať len cez `instanceof` zúženie (rovnaký vzor ako
+  // `pairingApi.ts`'s `catch (err: unknown)`).
+  const first: unknown = failed[0]?.reason;
+  if (first instanceof PairingUnauthorizedError) throw first;
+  const message = first instanceof Error ? first.message : "Uloženie adresy sa nepodarilo.";
+  throw new Error(
+    failed.length === variantCodes.length
+      ? message
+      : `${message} (zlyhalo ${String(failed.length)} z ${String(variantCodes.length)} veľkostí)`,
+  );
+}

--- a/apps/web/tests/e2e/pairing.spec.ts
+++ b/apps/web/tests/e2e/pairing.spec.ts
@@ -12,6 +12,15 @@ const jeOcakavane = (m: ConsoleMessage): boolean =>
 // PRVOM zobrazení musí ukázať ako "Navrhnuté" s prázdnou adresou (LEFT JOIN,
 // nie INNER — viď návrhový komentár na issue 45), a manažér ho tu VÔBEC PRVÝKRÁT
 // napáruje ručne zadanou adresou.
+//
+// "Nohavice Hart Wild-T" (guid nižšie) má vo fixtúre 7 veľkostí (46-58),
+// VŠETKY bez adresy → homogénna skupina → issue 47 (F4 rozdelenie podľa
+// veľkostí) ju pri PRVOM zobrazení zbalí do JEDNÉHO riadku. Test najprv
+// klikne "✂ Rozdeliť na veľkosti", aby sa dostal na PÔVODNÝ per-veľkostný
+// riadok "4859/46" — samotný scenár (ručné napárovanie JEDNEJ veľkosti bez
+// kandidáta) sa tým nemení.
+const NOHAVICE_HART_PRODUCT_KEY = "611a6160-e5b1-11e8-a065-0cc47a6c92bc";
+
 test("manažér ručne napáruje variant bez existujúceho kandidáta, zmena pretrvá po obnovení stránky, konzola je čistá", async ({
   page,
 }) => {
@@ -29,6 +38,7 @@ test("manažér ručne napáruje variant bez existujúceho kandidáta, zmena pre
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
   await expect(page.getByRole("heading", { name: "Kontrola párovania" })).toBeVisible();
 
+  await page.getByTestId(`split-${NOHAVICE_HART_PRODUCT_KEY}`).click();
   const riadok = page.getByTestId("pairing-4859/46");
   await expect(riadok).toBeVisible();
   await expect(riadok).toContainText("Nohavice Hart Wild-T");
@@ -101,6 +111,99 @@ test("manažér potvrdí navrhnutú adresu jedným klikom, filter podľa stavu f
 
   await page.getByLabel("Stav párovania").selectOption("all");
   await page.getByRole("button", { name: "Filtrovať" }).click();
+
+  expect(chyby).toEqual([]);
+});
+
+// Issue 47 (F4 rozdelenie podľa veľkostí). "Nohavice FOREST 1003" (guid
+// "0a486205-d9e7-11e0-92ec-e1ef0b66e031") má vo fixtúre 9 veľkostí (3XL, 4XL,
+// 5XL, 6XL, L, M, S, XL, XXL) a ŽIADEN z nich nemá v `scripts/e2e-setup.ts`
+// prednastavený pairing riadok — takže sa pri PRVOM zobrazení ukáže ako JEDEN
+// zbalený riadok (homogénne: všetkých 9 veľkostí má `supplierUrl: null`).
+const PRODUCT_KEY = "0a486205-d9e7-11e0-92ec-e1ef0b66e031";
+
+// VLASTNÝ účet (nie zdieľaný `e2e@forestshop.sk`) — `checkLoginRateLimit`
+// (`apps/api/src/http/login-rate-limit.ts`) počíta KAŽDÝ `POST /api/login`
+// proti dvojici (IP, e-mail), max. 10 v 5-minútovom okne, a celý e2e beh
+// zdieľa JEDEN API server proces. So zvyškom balíka (catalog+login+orders+
+// zvyšné pairing testy pod `e2e@forestshop.sk`) by TENTO test ako 11.
+// prihlásenie pod tou istou dvojicou limit prekročil — reálne pozorované pri
+// `--workers=2` ("Nesprávny e-mail alebo heslo"), nie flaka. Rovnaký
+// mechanizmus ako `E2E_HESLO_ZMENA_EMAIL` v `scripts/e2e-setup.ts`, len iný
+// dôvod izolácie (rate limit, nie súbežná mutácia hesla).
+const E2E_SKUPINY_EMAIL = "e2e-skupiny@forestshop.sk";
+
+test("manažér nastaví JEDNU adresu pre všetkých 9 veľkostí naraz, potom rozdelí a JEDNU veľkosť opraví na inú adresu bez dotknutia ostatných, konzola je čistá", async ({
+  page,
+}) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/");
+  await page.getByLabel("E-mail").fill(E2E_SKUPINY_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await expect(page.getByRole("heading", { name: "Kontrola párovania" })).toBeVisible();
+
+  const skupina = page.getByTestId(`pairing-group-${PRODUCT_KEY}`);
+  await expect(skupina).toBeVisible();
+  await expect(skupina).toContainText("Nohavice FOREST 1003");
+  await expect(skupina).toContainText("3XL, 4XL, 5XL, 6XL, L, M, S, XL, XXL");
+  // Bez uloženej adresy je "✓ Potvrdiť" disabled — rovnaký dôvod ako v teste
+  // vyššie (nič spoločné čo potvrdiť jedným klikom).
+  await expect(skupina.getByTestId(`confirm-group-${PRODUCT_KEY}`)).toBeDisabled();
+  await expect(page.getByTestId("pairing-40237/M")).toHaveCount(0); // zbalené, žiadne per-veľkostné riadky
+
+  const bulkAdresa = "https://www.grube.sk/p/nohavice-forest-1003/1";
+  await skupina.getByTestId(`reject-group-${PRODUCT_KEY}`).click();
+  await skupina.getByLabel("Adresa u dodávateľa pre Nohavice FOREST 1003 (všetky veľkosti)").fill(bulkAdresa);
+  await skupina.getByRole("button", { name: "Potvrdiť" }).click();
+
+  await expect(skupina).toContainText("Potvrdené");
+  await expect(skupina.getByRole("link", { name: bulkAdresa })).toBeVisible();
+  await expect(page.getByRole("alert")).toHaveCount(0);
+
+  await page.reload();
+  await expect(page.getByRole("heading", { name: "Kontrola párovania" })).toBeVisible();
+  const skupinaPoReloade = page.getByTestId(`pairing-group-${PRODUCT_KEY}`);
+  await expect(skupinaPoReloade).toContainText("Potvrdené");
+  await expect(skupinaPoReloade.getByRole("link", { name: bulkAdresa })).toBeVisible();
+
+  // Rozdelenie na veľkosti + oprava JEDNEJ veľkosti na INÚ adresu — jadro
+  // issue 47 (per-size párovanie namiesto jedného spoločného, viď návrhový
+  // komentár na issue 47/ticket 44).
+  await skupinaPoReloade.getByTestId(`split-${PRODUCT_KEY}`).click();
+  const riadokM = page.getByTestId("pairing-40237/M");
+  const riadokL = page.getByTestId("pairing-40237/L");
+  await expect(riadokM).toBeVisible();
+  await expect(riadokM).toContainText("Potvrdené");
+  await expect(riadokM.getByRole("link", { name: bulkAdresa })).toBeVisible();
+  await expect(riadokL.getByRole("link", { name: bulkAdresa })).toBeVisible();
+
+  const inaAdresa = "https://www.grube.sk/p/nohavice-forest-1003-m/1";
+  await riadokM.getByTestId("reject-40237/M").click();
+  await riadokM.getByLabel("Adresa u dodávateľa pre 40237/M").fill(inaAdresa);
+  await riadokM.getByRole("button", { name: "Potvrdiť" }).click();
+
+  await expect(riadokM.getByRole("link", { name: inaAdresa })).toBeVisible();
+  // Susedná veľkosť ostáva NEDOTKNUTÁ — presne to, čo stará appka (JSON per
+  // produkt) nevedela zaručiť (#273/#304 v starom repe).
+  await expect(riadokL.getByRole("link", { name: bulkAdresa })).toBeVisible();
+  await expect(page.getByRole("alert")).toHaveCount(0);
+
+  await page.reload();
+  await expect(page.getByRole("heading", { name: "Kontrola párovania" })).toBeVisible();
+  // Adresy sa teraz LÍŠIA naprieč veľkosťami → skupina je EFEKTÍVNE
+  // rozdelená a zostáva zobrazená rozdelene AJ BEZ opätovného klikania.
+  await expect(page.getByTestId(`pairing-group-${PRODUCT_KEY}`)).toHaveCount(0);
+  const riadokMPoReloade = page.getByTestId("pairing-40237/M");
+  await expect(riadokMPoReloade.getByRole("link", { name: inaAdresa })).toBeVisible();
+  await expect(page.getByTestId("pairing-40237/L").getByRole("link", { name: bulkAdresa })).toBeVisible();
 
   expect(chyby).toEqual([]);
 });

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -579,4 +579,47 @@ nové heslo sa nikde v pushnutom obsahu nenachádza.
   ODSTRÁNENÝ priamo v produkčnej DB (`DELETE FROM pairing WHERE
   variant_code = '0.8331.MC9'`), aby v produkcii nezostala fingovaná
   adresa vyzerajúca ako reálne potvrdené párovanie.
+
+## Fixup review nálezov z PR #54 (bez GitHub issue — 2026-07-30)
+
+- Bez trackovacieho issue (dispatch inštrukcia): tri review nálezy z PR #54
+  (issue 45) — mŕtvy kód, skutočný defekt "krádež attribution" pri
+  opätovnom potvrdení, chýbajúce `autocomplete`.
+- **Skutočný defekt** (`state.ts`'s `confirmPairing()`): `onConflictDoUpdate`
+  bezohľadne prepisoval `confirmedBy`/`confirmedAt` pri KAŽDOM volaní —
+  druhý manažér kliknúci "✓ Potvrdiť" na už potvrdenom riadku ticho ukradol
+  attribution bez toho, aby urobil nové rozhodnutie. Oprava: no-op
+  re-potvrdenie (žiadny upsert, žiadny audit) presne keď je riadok už
+  `potvrdene` A výsledná adresa je NEZMENENÁ; skutočná zmena adresy zostáva
+  novým rozhodnutím (upsert + audit ako doteraz). Web strana: "✓ Potvrdiť"
+  teraz aj disabled pri `state === "potvrdene"` (UX vrstva, server ostáva
+  bránou).
+- Mŕtvy kód (`finalUrl === ""` vetva) odstránený — jediný zapisovač
+  `pairings.supplier_url` je táto istá funkcia, kŕmená len `null` alebo
+  zod-overenou neprázdnou URL.
+- RED→GREEN: `6e3f229` (red, nový integračný test v novom
+  `pairing-reconfirm.integration.test.ts` zlyhá proti pôvodnému kódu) →
+  `0562063` (green, oprava + mŕtvy kód). Nový súbor vznikol PRI red commite
+  kvôli `max-lines` (400) ESLint pravidlu — `pairing-http.integration.test.ts`
+  by inak prekročil limit; nie je to iná téma, len rozdelenie kvôli dĺžke.
+- `autoComplete="current-password"`/`"new-password"` pridané do
+  `ChangePasswordForm.tsx` (`43c4638`).
+- PR: **#56** (`dev` → `main`), merged `ce4a3ab`. CI all green (check,
+  integration, e2e, docker-build, version-check) na push aj pull_request
+  behu; main push CI `version-check` bežal `skipped` (očakávané — main-push
+  event, nie dev-vs-main porovnanie).
+- Deployed + verified na https://forestshop-novy.newlevel.media
+  (v0.3.0-dev.26, `/api/version` commit sedí s `ce4a3ab`). Produkcia mala v
+  čase overovania 0 potvrdených pairing riadkov (`#46` auto-kandidáti ešte
+  nepristali), takže disabled-stav "✓ Potvrdiť" na už potvrdenom riadku sa
+  overil rovnakým testovacím vzorom ako pri PR #54: reálny variant
+  `0.8331.MC9` → "✗ Zadať inú adresu" → testovacia adresa → "Potvrdiť" →
+  overené `confirmDisabled: true`, `rejectDisabled: false`, stĺpec
+  "Potvrdil" ukázal "Zbyněk (30. 7. 2026)"; konzola 0 chýb/0 varovaní
+  (jediná VERBOSE hláška je nesúvisiaci Chrome hint o chýbajúcom
+  username poli, nie o autocomplete). Testovací pairing riadok následne
+  ODSTRÁNENÝ priamo v produkčnej DB (rovnaký `DELETE FROM pairing WHERE
+  variant_code = '0.8331.MC9'` postup), variant overený späť v stave
+  "Navrhnuté" bez adresy.
+- Per-ticket Discord card fired (`notify --run-card`, confirmed delivered).
 - Per-ticket Discord card fired (`notify --run-card`, confirmed delivered).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.26",
+  "version": "0.3.0-dev.27",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -29,6 +29,21 @@ const E2E_HESLO = "e2e-test-heslo"; // musí sa zhodovať s hodnotou v login.spe
 // ktorého heslo sa kedy mení — nikto iný sa pod ním neprihlasuje.
 const E2E_HESLO_ZMENA_EMAIL = "e2e-heslo@forestshop.sk"; // musí sa zhodovať s hodnotou v login.spec.ts
 
+// Issue 47 (F4 rozdelenie podľa veľkostí) — VLASTNÝ, IZOLOVANÝ účet pre
+// `pairing.spec.ts`'s test skupinového (bulk) párovania. Dôvod je INÝ ako pri
+// `E2E_HESLO_ZMENA_EMAIL` vyššie (tam ide o súbežnú MUTÁCIU hesla), ale
+// rovnaký mechanizmus rieši aj tento: `checkLoginRateLimit`
+// (`apps/api/src/http/login-rate-limit.ts`) počíta KAŽDÝ `POST /api/login`
+// (úspešný aj neúspešný) proti dvojici (IP, e-mail), max. 10 v 5-minútovom
+// okne — a CELÝ e2e beh zdieľa JEDEN dlho bežiaci API server proces. Nový
+// test (9 veľkostí naraz) pridal 3. prihlásenie pod `e2e@forestshop.sk` v
+// `pairing.spec.ts` a spolu so zvyškom balíka (catalog+login+orders+pairing)
+// to prekročilo 10 prihlásení pod TOU ISTOU dvojicou (IP, e-mail) — reálne
+// pozorované zlyhanie "Nesprávny e-mail alebo heslo" pri `--workers=2`, nie
+// flaka. Vlastný e-mail = vlastný rate-limit priestor, žiadny zásah do
+// bezpečnostného limitu.
+const E2E_SKUPINY_EMAIL = "e2e-skupiny@forestshop.sk"; // musí sa zhodovať s hodnotou v pairing.spec.ts
+
 const { db, pool } = createDb();
 // Konštantný literál bez interpolácie — obyčajný reťazec je tu rovnako bezpečný
 // ako `sql` tagovaná šablóna (tú používa ekvivalentný apps/api/tests/helpers/db.ts),
@@ -61,6 +76,12 @@ await db.insert(users).values({
 // SAMOSTATNÝM riadkom v `users`, izolovaným od zdieľaného účtu vyššie.
 await db.insert(users).values({
   email: E2E_HESLO_ZMENA_EMAIL,
+  passwordHash: await hashPassword(E2E_HESLO),
+  displayName: "E2E Manažér",
+  role: "manazer",
+});
+await db.insert(users).values({
+  email: E2E_SKUPINY_EMAIL,
   passwordHash: await hashPassword(E2E_HESLO),
   displayName: "E2E Manažér",
   role: "manazer",


### PR DESCRIPTION
## Súhrn

- **F4: Rozdelenie párovania podľa veľkostí** — `GET /api/pairing` teraz posiela `productKey`/`productName` (žiadna migrácia). Web zoskupí plochý zoznam variantov podľa produktu: homogénny viacvariantný produkt (rovnaká adresa na všetkých veľkostiach) sa zobrazí ako JEDEN zbalený riadok s bulk akciami; akonáhle sa adresy reálne líšia (alebo manažér klikne "✂ Rozdeliť na veľkosti"), zobrazí sa presne dnešný per-veľkostný riadok pre KAŽDÚ veľkosť zvlášť. "Split" je odvodený, prechodný UI koncept — nikdy sa nepersistuje.
- **Bonus (komentár na tickete):** skryté `autoComplete="username"` pole na `ChangePasswordForm` — odstraňuje Chrome accessibility hint.

Closes #47

## Návrhový komentár

https://github.com/zbynekdrlik/forestshop-app/issues/47#issuecomment-5130911077 (root cause, zvolený prístup, zamietnutá alternatíva — pred prvým kódovým commitom)

## Testy

- `apps/web/src/pairingGroups.test.ts` — čisté zoskupovacie/odvodzovacie funkcie (homogenita, plné potvrdenie, spoločná atribúcia, bulk-zlyhanie).
- `apps/web/src/components/PairingSection.test.tsx` — 6 nových testov (zbalené zobrazenie, automatické rozdelenie pri odlišných adresách, ✂/↩ toggle, bulk potvrdenie, bulk ručná adresa, rola citanie nevidí akcie).
- `apps/api/tests/pairing-groups.integration.test.ts` — `productKey`/`productName` sú rovnaké naprieč variantmi toho istého produktu.
- `apps/web/tests/e2e/pairing.spec.ts` — nový e2e test cez skutočný prehliadač: bulk adresa pre 9 veľkostí naraz → rozdelenie → oprava JEDNEJ veľkosti bez dotknutia ostatných, s DB-perzistenciou cez reload. Existujúci test upravený (produkt "Nohavice Hart Wild-T" má 7 veľkostí vo fixtúre, takže sa teraz pri prvom zobrazení zbalí — test si ho najprv rozdelí).
- `apps/web/src/components/ChangePasswordForm.test.tsx` — nový test na skryté username pole.

## CI

Run 30545383962 — všetky joby zelené (check, integration, e2e, docker-build, version-check).
