### PR TITLE
feat(orders): read supplier link + supplier code from Shoptet export

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -1,0 +1,56 @@
+---
+paths:
+  - "apps/web/src/**"
+  - "apps/web/src/styles/**"
+---
+
+# Frontend design (visual foundation, issue 57)
+
+- **The legacy app (`parovanie_produktov`) is a reference for BEHAVIOUR/functionality
+  only — NEVER for looks.** The owner explicitly rejected copying its visual
+  design ("stará appka je hrozná, navrhni to lepšie"). A prior in-flight
+  attempt (never committed) had literally copied its CSS values into
+  `app.css` — corrected before merge. When unsure what a screen must DO, read
+  the legacy app; when deciding how it should LOOK, use this app's own tokens
+  below and make an original, good design.
+- **Design tokens live in `apps/web/src/styles/app.css`'s `:root`** —
+  `--fs-*` custom properties for color, typography scale, spacing (4px
+  base), radius, shadow. New screens/components MUST reuse these tokens
+  (`var(--fs-brand)`, `var(--fs-space-4)`, …), never introduce a new raw hex
+  color or px value that duplicates an existing token's intent. Generic
+  element resets (`table`, `button`, `input`, `label`, `h1-h3`,
+  `[role=alert]`/`[role=status]`) in the same file give even HIDDEN screens
+  (below) a consistent baseline without touching their TSX.
+- **Nav registry (`apps/web/src/nav.ts`) — `NAV` (visible sidebar
+  folders/tabs) vs. `HIDDEN_TABS` (still coded + tested, reachable only via
+  `?tab=<id>`, no sidebar entry).** Adding a new VISIBLE tab = one entry in
+  `NAV`, no `App.tsx`/`Sidebar.tsx` change needed. Moving a tab from hidden
+  to visible = move its entry from `HIDDEN_TABS` to a `NAV` folder — the
+  component itself needs no change (`findTab`/`isVisibleTabId` already
+  handle both).
+- **User account controls (greeting/logout/change-password) live in
+  `Topbar.tsx` as a dropdown "user menu" in the HEADER — not the sidebar
+  footer.** This was an explicit ticket decision (#57): "change-password
+  must stay reachable, e.g. via a user menu in the header." Click the
+  signed-in user's name (`data-testid="greeting"`) to open/close the panel;
+  `passwordPanelOpen` is lifted to `App.tsx` (decides whether
+  `ChangePasswordForm` renders), the menu's own open/closed state is local
+  to `Topbar`. E2E tests interacting with "Zmeniť heslo"/"Odhlásiť" must
+  click the greeting first to open the menu.
+- **`scripts/e2e-setup.ts` always seeds two real open orders** (variant
+  `4859/46` under supplier `DODAVATEL-TEST-1`, variant `40287` with no
+  supplier) — a NEW e2e test must never assert the "Na objednanie" screen is
+  empty; assert the real seeded supplier group instead
+  (`getByTestId("supplier-DODAVATEL-TEST-1")`).
+- **Adding a new e2e spec file with its own logins under the SHARED
+  `e2e@forestshop.sk` account risks overflowing `MAX_ATTEMPTS=10` in
+  `login-rate-limit.ts`** (5-minute window, shared across the whole e2e run
+  since all spec files hit one long-lived API server process) — count the
+  running total across ALL spec files before adding more logins to the
+  shared account; if it would exceed 10, add your OWN isolated seeded
+  account in `scripts/e2e-setup.ts` (same pattern as
+  `E2E_HESLO_ZMENA_EMAIL`/`E2E_SKUPINY_EMAIL`/`E2E_NAV_EMAIL`) rather than
+  reusing the shared one. Exceeding it shows up as an unrelated-looking
+  "Nesprávny e-mail alebo heslo" on a RANDOM later test in the same run, not
+  a rate-limit-specific error (the client's `postLogin()` collapses every
+  non-2xx response, including 429, to the same generic failure).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,3 +31,4 @@ Per-area rules live in `.claude/rules/<area>.md` with `paths:` frontmatter.
 - objednávky zo Shoptetu (F3 — import, sčítanie riadkov, pseudo-položky) → `.claude/rules/orders.md`
 - kontrola párovania (F4 — LEFT JOIN dizajn, confirmPairing, e2e label kolízie) → `.claude/rules/pairing.md`
 - citlivé hodnoty (heslá/tokeny/hash= sa nikdy nepíšu do repa) → `.claude/rules/sensitive-values.md`
+- frontend dizajn (vizuálne tokeny, nav registry, user-menu, e2e login rate-limit) → `.claude/rules/frontend-design.md`

--- a/apps/api/drizzle/0011_medical_ronan.sql
+++ b/apps/api/drizzle/0011_medical_ronan.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "product" ADD COLUMN "internal_note" text;--> statement-breakpoint
+ALTER TABLE "variant" ADD COLUMN "external_code" text;

--- a/apps/api/drizzle/meta/0011_snapshot.json
+++ b/apps/api/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,1381 @@
+{
+  "id": "f4b0e305-cdad-4409-ae8f-69163a934beb",
+  "prevId": "3ca5df73-8bad-4439-b713-7c8e7d693d9b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_code": {
+          "name": "external_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing": {
+      "name": "pairing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_url": {
+          "name": "supplier_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "pairing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'navrhnute'"
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pairing_state_idx": {
+          "name": "pairing_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_confirmed_by_idx": {
+          "name": "pairing_confirmed_by_idx",
+          "columns": [
+            {
+              "expression": "confirmed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_variant_code_variant_code_fk": {
+          "name": "pairing_variant_code_variant_code_fk",
+          "tableFrom": "pairing",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pairing_confirmed_by_users_id_fk": {
+          "name": "pairing_confirmed_by_users_id_fk",
+          "tableFrom": "pairing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pairing_variant_code_unique": {
+          "name": "pairing_variant_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pairing_confirmation_ck": {
+          "name": "pairing_confirmation_ck",
+          "value": "(\"pairing\".\"state\" = 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)\n        OR (\"pairing\".\"state\" != 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NULL AND \"pairing\".\"confirmed_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier": {
+      "name": "supplier",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wholesale_base_url": {
+          "name": "wholesale_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_key": {
+          "name": "adapter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne"
+      ]
+    },
+    "public.pairing_state": {
+      "name": "pairing_state",
+      "schema": "public",
+      "values": [
+        "navrhnute",
+        "potvrdene"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1785407621230,
       "tag": "0010_dusty_skullbuster",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1785422767454,
+      "tag": "0011_medical_ronan",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema-catalog.ts
+++ b/apps/api/src/db/schema-catalog.ts
@@ -86,6 +86,17 @@ export const products = pgTable(
     key: text("key").primaryKey(),
     name: text("name").notNull(),
     supplier: text("supplier"),
+    // Odkaz na tovar u dodávateľa, PRESNE ako export's `internalNote` (surový
+    // text, žiadna extrakcia URL pri zápise — issue 67). Je to vlastnosť
+    // PRODUKTU, nie variantu: na reálnom exporte (14 014 riadkov, 4 519
+    // produktov) mal KAŽDÝ produkt naprieč všetkými svojimi veľkosťami vždy
+    // presne jednu hodnotu tohto poľa — na rozdiel od `externalCode` nižšie
+    // (`schema-catalog.ts`'s `variants`), ktorý sa medzi veľkosťami toho
+    // istého produktu bežne LÍŠI. Extrakcia URL z prípadného labelovaného
+    // textu (`Dodávateľ: X - https://...`) beží AŽ pri čítaní
+    // (`modules/catalog/supplier-link.ts`), nikdy pri importe — žiadny ďalší
+    // odvodený stĺpec, žiadne riziko rozídenia sa algoritmu a uložených dát.
+    internalNote: text("internal_note"),
     firstSeenAt: timestamp("first_seen_at", { withTimezone: true }).notNull(),
     lastSeenAt: timestamp("last_seen_at", { withTimezone: true }).notNull(),
     lastSeenSnapshotId: uuid("last_seen_snapshot_id")
@@ -115,6 +126,11 @@ export const variants = pgTable(
     guid: text("guid").notNull(),
     sizeLabel: text("size_label"),
     pairCode: text("pair_code"),
+    // Kód tovaru u dodávateľa, export's `externalCode` (issue 67) — na rozdiel
+    // od `internalNote` na `products` vyššie je toto vlastnosť VARIANTU: na
+    // reálnom exporte sa medzi veľkosťami toho istého produktu bežne líši
+    // (napr. jeden produkt mal `AJ26-L`, `AJ26-M`, `AJ26-S`, `AJ26-XL`).
+    externalCode: text("external_code"),
     name: text("name").notNull(),
     currency: text("currency"),
     price: numeric("price", { precision: 12, scale: 2 }),

--- a/apps/api/src/modules/catalog/ingest.ts
+++ b/apps/api/src/modules/catalog/ingest.ts
@@ -229,11 +229,11 @@ export async function ingestCatalog(
 
   // Beží bez ohľadu na úspech parsovania — pri zlyhaní je `records` prázdne pole,
   // takže je to no-op (nič sa neprepočítava druhýkrát).
-  const productValues = new Map<string, { name: string; supplier: string | null }>();
+  const productValues = new Map<string, { name: string; supplier: string | null; internalNote: string | null }>();
   for (const record of records) {
     const known = productValues.get(record.productKey);
     if (known === undefined) {
-      productValues.set(record.productKey, { name: record.name, supplier: record.supplier });
+      productValues.set(record.productKey, { name: record.name, supplier: record.supplier, internalNote: record.internalNote });
       continue;
     }
     if (known.name !== record.name) {
@@ -368,6 +368,7 @@ export async function ingestCatalog(
               key,
               name: value.name,
               supplier: value.supplier,
+              internalNote: value.internalNote,
               firstSeenAt: options.now,
               lastSeenAt: options.now,
               lastSeenSnapshotId: snapshotId,
@@ -378,6 +379,7 @@ export async function ingestCatalog(
             set: {
               name: sql`excluded.name`,
               supplier: sql`excluded.supplier`,
+              internalNote: sql`excluded.internal_note`,
               lastSeenAt: options.now,
               lastSeenSnapshotId: snapshotId,
             },
@@ -390,14 +392,15 @@ export async function ingestCatalog(
           .values(
             batch.map((record) => ({
               // Polia sa vypisujú EXPLICITNE, nie `...record` (minor, review
-              // task-5-fix-1) — `record.supplier` patrí stĺpcu `product`, nie
-              // `variant`; predtým to fungovalo len preto, že ORM neznáme
-              // kľúče ticho zahodí.
+              // task-5-fix-1) — `record.supplier`/`record.internalNote`
+              // patria stĺpcu `product`, nie `variant`; predtým to fungovalo
+              // len preto, že ORM neznáme kľúče ticho zahodí.
               code: record.code,
               productKey: record.productKey,
               guid: record.guid,
               sizeLabel: record.sizeLabel,
               pairCode: record.pairCode,
+              externalCode: record.externalCode,
               name: record.name,
               currency: record.currency,
               price: record.price,
@@ -427,6 +430,7 @@ export async function ingestCatalog(
               guid: sql`excluded.guid`,
               sizeLabel: sql`excluded.size_label`,
               pairCode: sql`excluded.pair_code`,
+              externalCode: sql`excluded.external_code`,
               name: sql`excluded.name`,
               currency: sql`excluded.currency`,
               price: sql`excluded.price`,

--- a/apps/api/src/modules/catalog/map-row.test.ts
+++ b/apps/api/src/modules/catalog/map-row.test.ts
@@ -20,8 +20,10 @@ function bareRow(overrides: Record<string, string> = {}): Record<string, string>
     code: "TEST/1",
     guid: "guid-test-0001",
     pairCode: "",
+    externalCode: "",
     name: "Testovací produkt",
     supplier: "",
+    internalNote: "",
     price: "",
     standardPrice: "",
     purchasePrice: "",
@@ -144,6 +146,22 @@ describe("mapRow nad reálnymi riadkami fixtúry", () => {
 
   it("zapíše dodávateľa, keď ho export uvádza", () => {
     expect(mapRow(fixtureRow("4859/46")).record?.supplier).toBe("DODAVATEL-TEST-1");
+  });
+
+  // issue 67: `internalNote` (odkaz na tovar u dodávateľa) a `externalCode`
+  // (kód tovaru u dodávateľa) — obe polia fixtúra reálne obsahuje pre tento
+  // variant (holý odkaz, bez popisu).
+  it("zapíše odkaz na dodávateľa (internalNote) aj kód dodávateľa (externalCode), keď ich export uvádza", () => {
+    const { record } = mapRow(fixtureRow("4859/46"));
+    expect(record?.internalNote).toBe("https://www.huntingshop.eu/wild-t-green-nohavice");
+    expect(record?.externalCode).toBe("OB832");
+  });
+
+  it("prázdny internalNote/externalCode v exporte sa mapuje na null, nie na chybu", () => {
+    const { record, issues } = mapRow(fixtureRow("40287"));
+    expect(record?.internalNote).toBeNull();
+    expect(record?.externalCode).toBeNull();
+    expect(issues).toEqual([]);
   });
 });
 

--- a/apps/api/src/modules/catalog/map-row.ts
+++ b/apps/api/src/modules/catalog/map-row.ts
@@ -16,9 +16,10 @@ export interface RowIssue {
   readonly detail: Record<string, string>;
 }
 
-/** Polia zodpovedajú 1:1 stĺpcom tabuľky `variant`, okrem: `supplier` (ten je
- *  stĺpec tabuľky `product`, Task 5 ho tam zapíše) a `firstSeenAt`/`lastSeenAt`/
- *  `lastSeenSnapshotId`/`missingSince` (tie dopĺňa ingest, Task 5). */
+/** Polia zodpovedajú 1:1 stĺpcom tabuľky `variant`, okrem: `supplier` a
+ *  `internalNote` (tie sú stĺpce tabuľky `product`, Task 5/issue 67 ich tam
+ *  zapíšu) a `firstSeenAt`/`lastSeenAt`/`lastSeenSnapshotId`/`missingSince`
+ *  (tie dopĺňa ingest, Task 5). */
 export interface VariantRecord {
   readonly code: string;
   // Identita produktu — export's `guid`, nikdy prefix `code` pred lomkou
@@ -29,8 +30,17 @@ export interface VariantRecord {
   readonly guid: string;
   readonly sizeLabel: string | null;
   readonly pairCode: string | null;
+  // Kód tovaru u dodávateľa (issue 67), export's `externalCode` — na rozdiel
+  // od `internalNote` nižšie ide PRIAMO do stĺpca `variant.external_code`
+  // (medzi veľkosťami toho istého produktu sa bežne líši, `schema-catalog.ts`).
+  readonly externalCode: string | null;
   readonly name: string;
   readonly supplier: string | null;
+  // Odkaz na tovar u dodávateľa (issue 67), export's `internalNote` — patrí
+  // stĺpcu `product.internal_note` (ingest.ts ho tam zapíše, rovnaká cesta
+  // ako `supplier` nižšie), NIE `variant` — na reálnom exporte je v rámci
+  // jedného produktu vždy rovnaké naprieč všetkými veľkosťami.
+  readonly internalNote: string | null;
   readonly currency: string | null;
   readonly price: string | null;
   readonly standardPrice: string | null;
@@ -181,8 +191,10 @@ export function mapRow(row: Readonly<Record<string, string>>): {
       guid,
       sizeLabel,
       pairCode: textOrNull((row["pairCode"] ?? "").trim()),
+      externalCode: textOrNull((row["externalCode"] ?? "").trim()),
       name,
       supplier: textOrNull((row["supplier"] ?? "").trim()),
+      internalNote: textOrNull((row["internalNote"] ?? "").trim()),
       currency,
       price,
       standardPrice,

--- a/apps/api/src/modules/catalog/supplier-link.test.ts
+++ b/apps/api/src/modules/catalog/supplier-link.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { extractSupplierLink } from "./supplier-link.js";
+
+// Tri tvary `internalNote` z reálneho exportu (issue 67) + hranice (prázdne,
+// biele znaky).
+describe("extractSupplierLink", () => {
+  it("holý odkaz → url aj note", () => {
+    expect(extractSupplierLink("https://www.huntingshop.eu/fairfax-fz-mikina")).toEqual({
+      url: "https://www.huntingshop.eu/fairfax-fz-mikina",
+      note: "https://www.huntingshop.eu/fairfax-fz-mikina",
+    });
+  });
+
+  it("text s popisom obsahujúci odkaz → vytiahne URL, note nesie celý pôvodný text", () => {
+    expect(extractSupplierLink("Dodávateľ: Trigona - https://trigona.sk/smith-s/polovnicke/c199")).toEqual({
+      url: "https://trigona.sk/smith-s/polovnicke/c199",
+      note: "Dodávateľ: Trigona - https://trigona.sk/smith-s/polovnicke/c199",
+    });
+  });
+
+  it("text bez odkazu → url je null, note je pôvodný text (zobrazí sa ako plain text)", () => {
+    expect(extractSupplierLink("Soxland")).toEqual({ url: null, note: "Soxland" });
+  });
+
+  it("prázdny reťazec → url aj note null (odkaz nemáme, nie chyba)", () => {
+    expect(extractSupplierLink("")).toEqual({ url: null, note: null });
+  });
+
+  it("null → url aj note null", () => {
+    expect(extractSupplierLink(null)).toEqual({ url: null, note: null });
+  });
+
+  it("len biele znaky → traktuje sa ako prázdne", () => {
+    expect(extractSupplierLink("   ")).toEqual({ url: null, note: null });
+  });
+
+  it("odkaz s vedúcimi/koncovými bielymi znakmi sa orezáva", () => {
+    expect(extractSupplierLink("  https://example.com/produkt  ")).toEqual({
+      url: "https://example.com/produkt",
+      note: "https://example.com/produkt",
+    });
+  });
+
+  it("http (nie https) sa tiež rozpozná ako odkaz", () => {
+    expect(extractSupplierLink("http://example.com/x")).toEqual({
+      url: "http://example.com/x",
+      note: "http://example.com/x",
+    });
+  });
+});

--- a/apps/api/src/modules/catalog/supplier-link.ts
+++ b/apps/api/src/modules/catalog/supplier-link.ts
@@ -1,0 +1,32 @@
+// Extrakcia odkazu na tovar u dodávateľa z export's `internalNote`
+// (`product.internalNote`, `schema-catalog.ts` — issue 67). ČISTÁ funkcia,
+// volaná AŽ pri ČÍTANÍ (`modules/orders/queries.ts`, `modules/orders/
+// mail.ts`), nikdy pri importe — žiadny ďalší odvodený stĺpec v DB, takže
+// budúca zmena tejto extrakcie sa prejaví okamžite na všetkých zobrazeniach,
+// bez potreby re-importu.
+//
+// Na reálnom exporte (14 014 riadkov) má `internalNote` tri tvary:
+//  - prázdne — dodávateľ odkaz vôbec neuviedol ("odkaz nemáme", nie chyba).
+//  - holý odkaz (`https://www.huntingshop.eu/fairfax-fz-mikina`).
+//  - text s popisom OBSAHUJÚCI odkaz (`Dodávateľ: Trigona - https://trigona.sk/...`).
+//  - text BEZ odkazu, len poznámka (`Soxland`) — zobrazí sa ako obyčajný text.
+
+export interface SupplierLink {
+  /** Extrahovaný odkaz, alebo `null`, keď v pôvodnom texte žiadny nie je. */
+  readonly url: string | null;
+  /**
+   * Pôvodný text `internalNote` (orezaný), pre zobrazenie ako plain-text
+   * fallback, keď `url` je `null` — inak `null` (prázdny/neprítomný vstup).
+   */
+  readonly note: string | null;
+}
+
+const URL_RE = /https?:\/\/\S+/i;
+
+export function extractSupplierLink(internalNote: string | null): SupplierLink {
+  const raw = (internalNote ?? "").trim();
+  if (raw === "") return { url: null, note: null };
+  const match = URL_RE.exec(raw);
+  if (match === null) return { url: null, note: raw };
+  return { url: match[0], note: raw };
+}

--- a/apps/api/src/modules/orders/mail.test.ts
+++ b/apps/api/src/modules/orders/mail.test.ts
@@ -6,7 +6,9 @@ import { formatSupplierOrderMailText, type SupplierOrderMailLine } from "./mail.
 // zdieľa medzi náhľadom aj odoslaním (`supplier-routes.ts`).
 describe("formatSupplierOrderMailText", () => {
   it("predmet aj prvý riadok tela sú zhodné, jednotné číslo pre presne 1 položku", () => {
-    const lines: SupplierOrderMailLine[] = [{ variantCode: "40287", sizeLabel: null, quantity: 1 }];
+    const lines: SupplierOrderMailLine[] = [
+      { variantCode: "40287", sizeLabel: null, quantity: 1, externalCode: null, supplierUrl: null },
+    ];
     const { subject, body } = formatSupplierOrderMailText("DODAVATEL-TEST-1", lines);
     expect(subject).toBe("Objednávka — DODAVATEL-TEST-1 (1 položka)");
     expect(body.split("\n")[0]).toBe(subject);
@@ -24,19 +26,25 @@ describe("formatSupplierOrderMailText", () => {
       variantCode: `KOD-${String(i)}`,
       sizeLabel: null,
       quantity: 1,
+      externalCode: null,
+      supplierUrl: null,
     }));
     const { subject } = formatSupplierOrderMailText("Dodávateľ", lines);
     expect(subject).toBe(`Objednávka — Dodávateľ (${String(count)} ${expectedWord})`);
   });
 
   it("riadok s veľkosťou skladá kód | veľkosť | N ks", () => {
-    const lines: SupplierOrderMailLine[] = [{ variantCode: "4859/46", sizeLabel: "46", quantity: 3 }];
+    const lines: SupplierOrderMailLine[] = [
+      { variantCode: "4859/46", sizeLabel: "46", quantity: 3, externalCode: null, supplierUrl: null },
+    ];
     const { body } = formatSupplierOrderMailText("DODAVATEL-TEST-1", lines);
     expect(body.split("\n")[1]).toBe("4859/46 | 46 | 3 ks");
   });
 
   it("riadok bez veľkosti (jednovariantný produkt) vynechá prázdnu časť, nepridá prázdny stĺpec", () => {
-    const lines: SupplierOrderMailLine[] = [{ variantCode: "40287", sizeLabel: null, quantity: 2 }];
+    const lines: SupplierOrderMailLine[] = [
+      { variantCode: "40287", sizeLabel: null, quantity: 2, externalCode: null, supplierUrl: null },
+    ];
     const { body } = formatSupplierOrderMailText("Dodávateľ", lines);
     expect(body.split("\n")[1]).toBe("40287 | 2 ks");
   });
@@ -45,5 +53,31 @@ describe("formatSupplierOrderMailText", () => {
     const { subject, body } = formatSupplierOrderMailText("Prázdny dodávateľ", []);
     expect(subject).toBe("Objednávka — Prázdny dodávateľ (0 položiek)");
     expect(body).toBe(subject);
+  });
+
+  // issue 67: kód dodávateľa aj odkaz na tovar u dodávateľa — rovnaké poradie
+  // ako stará appka's `orderCopyLines` (`kód | grube-id | veľkosť | N ks | url`).
+  it("riadok s kódom dodávateľa aj odkazom zaradí oba na správne miesto", () => {
+    const lines: SupplierOrderMailLine[] = [
+      {
+        variantCode: "4859/46",
+        sizeLabel: "46",
+        quantity: 3,
+        externalCode: "OB832",
+        supplierUrl: "https://www.huntingshop.eu/wild-t-green-nohavice",
+      },
+    ];
+    const { body } = formatSupplierOrderMailText("DODAVATEL-TEST-1", lines);
+    expect(body.split("\n")[1]).toBe(
+      "4859/46 | kód OB832 | 46 | 3 ks | https://www.huntingshop.eu/wild-t-green-nohavice",
+    );
+  });
+
+  it("riadok len s kódom dodávateľa (bez odkazu) vynechá prázdnu časť pre odkaz", () => {
+    const lines: SupplierOrderMailLine[] = [
+      { variantCode: "40287", sizeLabel: null, quantity: 1, externalCode: "X1", supplierUrl: null },
+    ];
+    const { body } = formatSupplierOrderMailText("Dodávateľ", lines);
+    expect(body.split("\n")[1]).toBe("40287 | kód X1 | 1 ks");
   });
 });

--- a/apps/api/src/modules/orders/mail.ts
+++ b/apps/api/src/modules/orders/mail.ts
@@ -2,6 +2,7 @@ import { and, asc, eq, isNull } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
 import { orderLines, orders, products, supplierContacts, variants } from "../../db/schema.js";
 import { log } from "../../logger.js";
+import { extractSupplierLink } from "../catalog/supplier-link.js";
 import type { MailTransport } from "../mail/transport.js";
 import { NEZNAMY_DODAVATEL } from "./queries.js";
 import { itemsWord } from "./pluralize.js";
@@ -10,10 +11,15 @@ import { itemsWord } from "./pluralize.js";
 // množstva podľa `variant.code` naprieč VŠETKÝMI otvorenými objednávkami
 // toho dodávateľa (veľkosť je súčasťou kódu variantu, netreba samostatný
 // agregačný kľúč ako stará appka's `code + size`, viď komentár na tickete).
+// `externalCode`/`supplierUrl` (issue 67) sú vlastnosti VARIANTU (kód) resp.
+// ODVODENÉ z produktu (odkaz) — stabilné pre daný `variantCode` naprieč
+// všetkými agregovanými objednávkami, preto sa neagregujú, len prenesú.
 export interface SupplierOrderMailLine {
   readonly variantCode: string;
   readonly sizeLabel: string | null;
   readonly quantity: number;
+  readonly externalCode: string | null;
+  readonly supplierUrl: string | null;
 }
 
 export interface SupplierOrderMailContent {
@@ -24,16 +30,22 @@ export interface SupplierOrderMailContent {
   readonly itemCount: number;
 }
 
-// Jeden riadok textu = `[kód, veľkosť, "N ks"].filter(Boolean).join(' | ')` —
-// rovnaká `.filter(Boolean).join(' | ')` kostra ako stará appka's
-// `orderCopyLines` (`app.js:2076-2142`), len BEZ jej dvoch ďalších polí
-// (per-dodávateľské "grube id", URL produktu) — nová dátová schéma tohoto
-// projektu tieto dva zdroje štruktúrovo nemá (žiadny per-dodávateľský kód
-// položky, žiadna URL v `variant`/`product`), takže v tom istom
-// `filter(Boolean)` mechanizme vždy vypadnú, presne ako by vypadlo prázdne
-// pole u ktoréhokoľvek iného dodávateľa v starej appke.
+// Jeden riadok textu = `.filter(Boolean).join(' | ')` — rovnaká kostra ako
+// stará appka's `orderCopyLines` (`app.js:2076-2142`, `[kód, grube-id,
+// veľkosť, N ks, url]`). issue 67 doplnil presne tie dve chýbajúce polia —
+// `externalCode` (kód dodávateľa, staré app's "grube id" bolo len
+// dodávateľ-špecifické pomenovanie toho istého konceptu) a `supplierUrl`
+// (odkaz, extrahovaný z `product.internalNote`) — do rovnakého poradia ako
+// stará appka. Keď je `null` (dodávateľ v exporte kód/odkaz neuviedol),
+// segment sa v `filter(Boolean)` jednoducho vynechá, presne ako doteraz.
 function formatSupplierOrderMailLine(line: SupplierOrderMailLine): string {
-  return [line.variantCode, line.sizeLabel ?? "", `${String(line.quantity)} ks`]
+  return [
+    line.variantCode,
+    line.externalCode !== null ? `kód ${line.externalCode}` : "",
+    line.sizeLabel ?? "",
+    `${String(line.quantity)} ks`,
+    line.supplierUrl ?? "",
+  ]
     .filter((part) => part !== "")
     .join(" | ");
 }
@@ -63,6 +75,8 @@ async function loadOutstandingLines(db: Database, supplier: string): Promise<Sup
       variantCode: orderLines.variantCode,
       sizeLabel: variants.sizeLabel,
       quantity: orderLines.quantity,
+      externalCode: variants.externalCode,
+      internalNote: products.internalNote,
     })
     .from(orderLines)
     .innerJoin(orders, eq(orders.id, orderLines.orderId))
@@ -75,7 +89,13 @@ async function loadOutstandingLines(db: Database, supplier: string): Promise<Sup
   for (const row of rows) {
     const existing = byCode.get(row.variantCode);
     if (existing === undefined) {
-      byCode.set(row.variantCode, { variantCode: row.variantCode, sizeLabel: row.sizeLabel, quantity: row.quantity });
+      byCode.set(row.variantCode, {
+        variantCode: row.variantCode,
+        sizeLabel: row.sizeLabel,
+        quantity: row.quantity,
+        externalCode: row.externalCode,
+        supplierUrl: extractSupplierLink(row.internalNote).url,
+      });
     } else {
       byCode.set(row.variantCode, { ...existing, quantity: existing.quantity + row.quantity });
     }

--- a/apps/api/src/modules/orders/queries.ts
+++ b/apps/api/src/modules/orders/queries.ts
@@ -1,6 +1,7 @@
 import { asc, desc, eq } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
 import { orderLines, orders, products, supplierContacts, variants, type OrderLineState } from "../../db/schema.js";
+import { extractSupplierLink } from "../catalog/supplier-link.js";
 
 export interface OpenOrderLine {
   readonly lineId: string;
@@ -14,6 +15,14 @@ export interface OpenOrderLine {
   readonly sizeLabel: string | null;
   readonly quantity: number;
   readonly state: OrderLineState;
+  // issue 67: odkaz na tovar u dodávateľa (extrahovaný z `product.internalNote`
+  // cez `extractSupplierLink`) a kód tovaru u dodávateľa (`variant.externalCode`,
+  // priamo). `supplierUrl` je `null`, keď v `internalNote` nie je odkaz —
+  // vtedy `supplierNote` (surový pôvodný text, ak nejaký je) slúži ako
+  // plain-text fallback na obrazovke.
+  readonly supplierUrl: string | null;
+  readonly supplierNote: string | null;
+  readonly externalCode: string | null;
 }
 
 export interface SupplierOpenOrders {
@@ -61,6 +70,8 @@ export async function listOpenOrderLinesBySupplier(db: Database): Promise<readon
       quantity: orderLines.quantity,
       state: orderLines.state,
       supplier: products.supplier,
+      internalNote: products.internalNote,
+      externalCode: variants.externalCode,
     })
     .from(orderLines)
     .innerJoin(orders, eq(orders.id, orderLines.orderId))
@@ -74,6 +85,7 @@ export async function listOpenOrderLinesBySupplier(db: Database): Promise<readon
 
   const bySupplier = new Map<string, OpenOrderLine[]>();
   for (const row of rows) {
+    const supplierLink = extractSupplierLink(row.internalNote);
     const line: OpenOrderLine = {
       lineId: row.lineId,
       orderId: row.orderId,
@@ -86,6 +98,9 @@ export async function listOpenOrderLinesBySupplier(db: Database): Promise<readon
       sizeLabel: row.sizeLabel,
       quantity: row.quantity,
       state: row.state,
+      supplierUrl: supplierLink.url,
+      supplierNote: supplierLink.note,
+      externalCode: row.externalCode,
     };
     const supplierKey = row.supplier ?? NEZNAMY_DODAVATEL;
     let lines = bySupplier.get(supplierKey);

--- a/apps/api/tests/helpers/orders.ts
+++ b/apps/api/tests/helpers/orders.ts
@@ -12,18 +12,22 @@ import { insertTestSnapshot } from "./catalog.js";
  * rovnaká ako doteraz, takže existujúce volania sa nemenia. `null` je
  * explicitne povolené (nie len string) — `product.supplier` je v schéme
  * nepovinný stĺpec (`.claude/rules/orders.md`) a `queries.ts`'s zoskupenie
- * musí zvládnuť aj tento prípad.
+ * musí zvládnuť aj tento prípad. Nepovinný `options` (issue 67) — odkaz na
+ * dodávateľa (`internalNote`) a kód u dodávateľa (`externalCode`), oba
+ * predvolene `null` (existujúce volania sa nemenia).
  */
 export async function insertTestVariant(
   db: Database,
   code: string,
   supplier: string | null = "Test dodávateľ",
+  options: { readonly internalNote?: string | null; readonly externalCode?: string | null } = {},
 ): Promise<void> {
   const snapshotId = await insertTestSnapshot(db);
   await db.insert(products).values({
     key: code,
     name: `Test produkt ${code}`,
     supplier,
+    internalNote: options.internalNote ?? null,
     firstSeenAt: new Date("2026-01-01T00:00:00Z"),
     lastSeenAt: new Date("2026-01-01T00:00:00Z"),
     lastSeenSnapshotId: snapshotId,
@@ -34,6 +38,7 @@ export async function insertTestVariant(
     guid: code,
     sizeLabel: null,
     pairCode: null,
+    externalCode: options.externalCode ?? null,
     name: `Test produkt ${code}`,
     currency: "EUR",
     price: "10.00",

--- a/apps/api/tests/orders-http.integration.test.ts
+++ b/apps/api/tests/orders-http.integration.test.ts
@@ -101,6 +101,59 @@ it("vráti otvorené objednávky zoskupené podľa dodávateľa, riadky zostupne
   expect(beta?.lines[0]).toMatchObject({ externalOrderId: "1002", variantCode: "B-1", quantity: 5 });
 });
 
+// issue 67: odkaz na tovar u dodávateľa (extrahovaný z `internalNote`) a kód
+// dodávateľa (`externalCode`) sa objavia v `/api/orders/open`, v troch
+// tvaroch, aké export skutočne obsahuje (holý odkaz, odkaz s popisom, žiadny
+// odkaz — len poznámka).
+it("vráti odkaz na dodávateľa a kód dodávateľa pri riadku, vo všetkých troch tvaroch internalNote", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  await insertTestVariant(db, "HOLY-URL", "Dodávateľ Holý", {
+    internalNote: "https://www.huntingshop.eu/fairfax-fz-mikina",
+    externalCode: "OB832",
+  });
+  await insertTestVariant(db, "S-POPISOM", "Dodávateľ Popis", {
+    internalNote: "Dodávateľ: Trigona - https://trigona.sk/smith-s/polovnicke/c199",
+    externalCode: "TRG-1",
+  });
+  await insertTestVariant(db, "BEZ-URL", "Dodávateľ Bez odkazu", { internalNote: "Soxland" });
+
+  const [objednavka] = await db
+    .insert(orders)
+    .values({ externalOrderId: "4001", customerName: "Zákazník", placedAt: new Date("2026-07-20T00:00:00Z") })
+    .returning();
+  if (objednavka === undefined) throw new Error("insert zlyhal");
+  await db.insert(orderLines).values([
+    { orderId: objednavka.id, variantCode: "HOLY-URL", quantity: 1 },
+    { orderId: objednavka.id, variantCode: "S-POPISOM", quantity: 1 },
+    { orderId: objednavka.id, variantCode: "BEZ-URL", quantity: 1 },
+  ]);
+
+  const res = await app.request("/api/orders/open", { headers: { cookie } });
+  const telo = (await res.json()) as {
+    suppliers: {
+      supplier: string;
+      lines: { variantCode: string; supplierUrl: string | null; supplierNote: string | null; externalCode: string | null }[];
+    }[];
+  };
+
+  const linePre = (supplier: string) => telo.suppliers.find((s) => s.supplier === supplier)?.lines[0];
+
+  expect(linePre("Dodávateľ Holý")).toMatchObject({
+    supplierUrl: "https://www.huntingshop.eu/fairfax-fz-mikina",
+    externalCode: "OB832",
+  });
+  expect(linePre("Dodávateľ Popis")).toMatchObject({
+    supplierUrl: "https://trigona.sk/smith-s/polovnicke/c199",
+    supplierNote: "Dodávateľ: Trigona - https://trigona.sk/smith-s/polovnicke/c199",
+    externalCode: "TRG-1",
+  });
+  expect(linePre("Dodávateľ Bez odkazu")).toMatchObject({
+    supplierUrl: null,
+    supplierNote: "Soxland",
+    externalCode: null,
+  });
+});
+
 // Review finding: `product.supplier` je nepovinný stĺpec (Shoptet export
 // niekedy nesie prázdnu hodnotu, `map-row.ts`'s `textOrNull`) — bez tohto
 // testu by regresia zlomeného `?? NEZNAMY_DODAVATEL` fallbacku (napr.

--- a/apps/api/tests/supplier-mail.integration.test.ts
+++ b/apps/api/tests/supplier-mail.integration.test.ts
@@ -191,6 +191,33 @@ it("náhľad agreguje množstvo podľa kódu variantu naprieč objednávkami, vy
   expect(telo.body).toBe("Objednávka — Dodávateľ Alfa (1 položka)\n4859/46 | 5 ks");
 });
 
+// issue 67: kód dodávateľa (`externalCode`) a odkaz na tovar u dodávateľa
+// (extrahovaný z `internalNote`) sa objavia v textovom náhľade, presne v
+// tvare, aký `formatSupplierOrderMailLine` skladá.
+it("náhľad zahrnie kód dodávateľa aj odkaz, keď ich export uviedol", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await insertTestVariant(db, "4859/46", "Dodávateľ Alfa", {
+    internalNote: "https://www.huntingshop.eu/wild-t-green-nohavice",
+    externalCode: "OB832",
+  });
+  const [obj] = await db
+    .insert(orders)
+    .values({ externalOrderId: "6010", customerName: "Zákazník", placedAt: new Date("2026-07-01T00:00:00Z") })
+    .returning();
+  if (obj === undefined) throw new Error("insert zlyhal");
+  await db.insert(orderLines).values({ orderId: obj.id, variantCode: "4859/46", quantity: 2 });
+  await db.insert(supplierContacts).values({ supplier: "Dodávateľ Alfa", email: "alfa@dodavatel.example" });
+
+  const res = await app.request(`/api/suppliers/${encodeURIComponent("Dodávateľ Alfa")}/order-mail`, {
+    headers: { cookie },
+  });
+  expect(res.status).toBe(200);
+  const telo = (await res.json()) as { body: string };
+  expect(telo.body).toBe(
+    "Objednávka — Dodávateľ Alfa (1 položka)\n4859/46 | kód OB832 | 2 ks | https://www.huntingshop.eu/wild-t-green-nohavice",
+  );
+});
+
 it("náhľad pre dodávateľa bez e-mailu vráti to: null", async () => {
   const { app, cookie, db } = await boot("manazer");
   await insertTestVariant(db, "Z-1", "Dodávateľ Zeta");

--- a/apps/web/src/components/OrdersSection.test.tsx
+++ b/apps/web/src/components/OrdersSection.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, expect, it, vi } from "vitest";
 import { OrdersSection } from "./OrdersSection.js";
 
@@ -40,6 +40,9 @@ const LINE_STARA = {
   sizeLabel: "3XL",
   quantity: 2,
   state: "objednane" as const,
+  supplierUrl: null,
+  supplierNote: null,
+  externalCode: null,
 };
 
 const LINE_NOVA = {
@@ -54,6 +57,9 @@ const LINE_NOVA = {
   sizeLabel: null,
   quantity: 1,
   state: "skladom" as const,
+  supplierUrl: null,
+  supplierNote: null,
+  externalCode: null,
 };
 
 afterEach(() => {
@@ -101,6 +107,45 @@ it("chýbajúcu veľkosť a komentár zobrazí ako pomlčku", async () => {
   const riadok = await screen.findByTestId(`order-line-${LINE_NOVA.lineId}`);
   // LINE_NOVA má sizeLabel: null — zobrazí sa pomlčka namiesto prázdneho políčka.
   expect(riadok.textContent).toContain("—");
+});
+
+// issue 67: odkaz na tovar u dodávateľa a kód dodávateľa — tri tvary, aké
+// export skutočne obsahuje.
+it("riadok s odkazom na dodávateľa zobrazí klikateľný odkaz aj kód dodávateľa", async () => {
+  const riadokSOdkazom = {
+    ...LINE_STARA,
+    supplierUrl: "https://www.huntingshop.eu/wild-t-green-nohavice",
+    supplierNote: "https://www.huntingshop.eu/wild-t-green-nohavice",
+    externalCode: "OB832",
+  };
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [riadokSOdkazom], email: null }]);
+
+  render(<OrdersSection role="citanie" onSessionExpired={() => {}} />);
+
+  const bunka = await screen.findByTestId(`supplier-link-${LINE_STARA.lineId}`);
+  const odkaz = within(bunka).getByRole<HTMLAnchorElement>("link", { name: "Odkaz na dodávateľa" });
+  expect(odkaz.getAttribute("href")).toBe("https://www.huntingshop.eu/wild-t-green-nohavice");
+  expect(bunka.textContent).toContain("OB832");
+});
+
+it("riadok bez odkazu, len s poznámkou (internalNote bez URL), zobrazí obyčajný text namiesto odkazu", async () => {
+  const riadokBezOdkazu = { ...LINE_STARA, supplierUrl: null, supplierNote: "Soxland", externalCode: null };
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [riadokBezOdkazu], email: null }]);
+
+  render(<OrdersSection role="citanie" onSessionExpired={() => {}} />);
+
+  const bunka = await screen.findByTestId(`supplier-link-${LINE_STARA.lineId}`);
+  expect(within(bunka).queryByRole("link", { name: "Odkaz na dodávateľa" })).toBeNull();
+  expect(bunka.textContent).toContain("Soxland");
+});
+
+it("riadok bez akéhokoľvek údaja o dodávateľovi zobrazí pomlčku", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_STARA], email: null }]);
+
+  render(<OrdersSection role="citanie" onSessionExpired={() => {}} />);
+
+  const bunka = await screen.findByTestId(`supplier-link-${LINE_STARA.lineId}`);
+  expect(bunka.textContent).toBe("—");
 });
 
 it("pri 401 zavolá onSessionExpired namiesto zobrazenia všeobecnej chyby", async () => {

--- a/apps/web/src/components/OrdersSection.tsx
+++ b/apps/web/src/components/OrdersSection.tsx
@@ -331,6 +331,7 @@ export function OrdersSection({
                 <th>Produkt</th>
                 <th>Veľkosť</th>
                 <th>Množstvo</th>
+                <th>Dodávateľ</th>
                 <th>Stav</th>
                 <th>Objednané</th>
                 <th>Komentár</th>
@@ -349,6 +350,18 @@ export function OrdersSection({
                   <td>{line.variantName}</td>
                   <td>{line.sizeLabel ?? "—"}</td>
                   <td className="ord-qty">{line.quantity} ks</td>
+                  <td className="ord-supplier-cell" data-testid={`supplier-link-${line.lineId}`}>
+                    {line.supplierUrl !== null ? (
+                      <a href={line.supplierUrl} target="_blank" rel="noreferrer" className="ord-supplier-link">
+                        Odkaz na dodávateľa
+                      </a>
+                    ) : line.supplierNote !== null ? (
+                      <span className="ord-supplier-note">{line.supplierNote}</span>
+                    ) : (
+                      "—"
+                    )}
+                    {line.externalCode !== null && <div className="ord-supplier-code">kód {line.externalCode}</div>}
+                  </td>
                   <td>
                     {canChangeState ? (
                       <select

--- a/apps/web/src/ordersApi.test.ts
+++ b/apps/web/src/ordersApi.test.ts
@@ -21,6 +21,9 @@ const LINE = {
   sizeLabel: null,
   quantity: 1,
   state: "objednane" as const,
+  supplierUrl: null,
+  supplierNote: null,
+  externalCode: null,
 };
 
 it("prečíta otvorené objednávky zoskupené podľa dodávateľa, vrátane e-mailu dodávateľa", async () => {

--- a/apps/web/src/ordersApi.ts
+++ b/apps/web/src/ordersApi.ts
@@ -17,6 +17,12 @@ const orderLineSchema = z.object({
   sizeLabel: z.string().nullable(),
   quantity: z.number(),
   state: z.enum(["objednane", "caka_sa", "skladom", "nedostupne"]),
+  // issue 67: odkaz na tovar u dodávateľa (`supplierUrl`, `null` keď v
+  // exporte nie je odkaz) + surový text pre plain-text fallback
+  // (`supplierNote`) + kód tovaru u dodávateľa (`externalCode`).
+  supplierUrl: z.string().nullable(),
+  supplierNote: z.string().nullable(),
+  externalCode: z.string().nullable(),
 });
 
 // Zrkadlí `OrdersIngestResult` z `apps/api/src/modules/orders/ingest.ts` —

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -646,3 +646,17 @@ tr:last-child td {
   font: inherit;
   font-size: var(--fs-text-sm);
 }
+/* issue 67: odkaz/kód dodávateľa pri riadku objednávky. */
+.ord-supplier-cell {
+  white-space: nowrap;
+}
+.ord-supplier-link {
+  font-weight: var(--fs-weight-medium);
+}
+.ord-supplier-note {
+  color: var(--fs-ink-muted);
+}
+.ord-supplier-code {
+  font-size: var(--fs-text-xs);
+  color: var(--fs-ink-faint);
+}

--- a/apps/web/tests/e2e/orders.spec.ts
+++ b/apps/web/tests/e2e/orders.spec.ts
@@ -40,6 +40,13 @@ test("manažér vidí otvorené objednávky zoskupené podľa dodávateľa, konz
   await expect(riadokAlfa).toContainText("Čaká sa");
   await expect(riadokAlfa).toContainText("Zavolať pred doručením");
 
+  // issue 67: fixtúra ("4859/46") má reálny holý odkaz na dodávateľa
+  // (`internalNote`) aj kód dodávateľa (`externalCode`, "OB832") —
+  // over cez map-row.test.ts, ak sa fixtúra niekedy zmení.
+  const odkazAlfa = riadokAlfa.getByRole("link", { name: "Odkaz na dodávateľa" });
+  await expect(odkazAlfa).toHaveAttribute("href", "https://www.huntingshop.eu/wild-t-green-nohavice");
+  await expect(riadokAlfa).toContainText("OB832");
+
   // Objednávka 9002 je nad variantom "40287", ktorý nemá dodávateľa
   // (`product.supplier` je `null`) — zoskupí sa pod zástupný kľúč, nie pod
   // "null" a nezmizne.

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -623,3 +623,33 @@ nové heslo sa nikde v pushnutom obsahu nenachádza.
   "Navrhnuté" bez adresy.
 - Per-ticket Discord card fired (`notify --run-card`, confirmed delivered).
 - Per-ticket Discord card fired (`notify --run-card`, confirmed delivered).
+
+## Issue 57 — Ľavé menu (Systém/Sync zo Shoptetu, Eshop/Na objednanie) + vlastný vzhľad
+
+- Resumed from a stopped worker's uncommitted tree (nav.ts registry,
+  Sidebar/Topbar/SyncSection, className refactors) — kept the structure,
+  replaced `app.css` entirely (it had literally copied the legacy app's CSS
+  values, which the owner explicitly rejected), moved change-password from
+  the sidebar footer to a user-menu dropdown in the Topbar header (owner's
+  explicit instruction), fixed a missing `within` import in
+  `SyncSection.test.tsx`.
+- Design comment posted BEFORE first commit:
+  https://github.com/zbynekdrlik/forestshop-app/issues/57#issuecomment-5131902935
+- Fixed while finishing: `nav.spec.ts` wrongly asserted the orders screen is
+  empty (e2e-setup.ts always seeds 2 real orders) + a login-rate-limit
+  overflow on the shared e2e account (new isolated `e2e-nav@forestshop.sk`,
+  same pattern as issue 47's `E2E_SKUPINY_EMAIL`).
+- Commit `54b497b` (feature) on `dev`; PR **#68** (`dev` → `main`), merged
+  `2683840`. CI all green (check, integration 184/184, e2e 14/14 ×2 stable
+  runs, docker-build, version-check).
+- Deployed + verified on https://forestshop-novy.newlevel.media
+  (v0.3.0-dev.28, matches DOM). Sidebar shows exactly the two folders/tabs,
+  Sync screen shows real catalog+orders sync status, "Na objednanie" shows
+  real order data with the new design, user-menu reveals "Zmeniť
+  heslo"/"Odhlásiť". Console: 0 errors/0 warnings.
+- Playbook: new `.claude/rules/frontend-design.md` (design tokens, nav
+  registry pattern, user-menu-in-header decision, e2e login-rate-limit
+  gotcha) + CLAUDE.md router entry — commits `e0804cb`/`c0caca2` on `dev`
+  (docs-only, rides the next feature PR; required its own version bump to
+  `0.3.0-dev.29` after CI's version-check correctly caught the omission).
+- Per-ticket Discord card fired (`notify --run-card`, confirmed delivered).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.29",
+  "version": "0.3.0-dev.30",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.28",
+  "version": "0.3.0-dev.29",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Súhrn

- `internalNote` (odkaz na tovar u dodávateľa) a `externalCode` (kód tovaru u dodávateľa) zo Shoptet exportu sa teraz pri importe ukladajú (`product.internal_note`, `variant.external_code` — migrácia 0011).
- Odkaz sa extrahuje z troch reálne pozorovaných tvarov `internalNote` (holý odkaz / odkaz s popisom / žiadny odkaz) čistou funkciou `modules/catalog/supplier-link.ts`, volanou pri čítaní — žiadny ďalší odvodený stĺpec.
- Obrazovka „Na objednanie" (`OrdersSection.tsx`) zobrazuje pri riadku odkaz na dodávateľa (alebo obyčajný text, keď odkaz nie je) + kód dodávateľa, vlastným vizuálom appky.
- Kopírovaný/mailovaný text objednávky (`modules/orders/mail.ts`) dostal dva ďalšie voliteľné segmenty v poradí zodpovedajúcom starej appke (`kód | kód dodávateľa | veľkosť | N ks | odkaz`).

Design komentár s koreňovou príčinou + zvoleným prístupom + zavrhnutou alternatívou: https://github.com/zbynekdrlik/forestshop-app/issues/67#issuecomment-5132315183

Closes #67

## Test plan

- [x] `pnpm typecheck` zelené
- [x] `pnpm lint` zelené
- [x] `pnpm test` (248 + 152 unit testov) zelené
- [x] `pnpm test:integration` (186 testov) zelené
- [x] `pnpm --filter @forestshop/web e2e` (14 testov, vrátane novej asercie na reálny odkaz z fixtúry) zelené
- [x] CI (verzia/check/integration/docker-build/e2e) zelené
