### PR TITLE
fix: URL bracket-balancing and aria-label size collision (issue 72)

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -132,6 +132,28 @@ paths:
   `change-password.integration.test.ts`/`login.spec.ts`'s dvoj-kontextový
   e2e test — presne takto sa to odhalilo (e2e test napísaný najprv na 4xx
   zlyhal na tomto pravidle).
+- **`@testing-library/react`'s `getByRole(..., { name })` robí PRESNÚ zhodu
+  (celý accessible name musí sedieť), na rozdiel od Playwright's
+  substring/case-insensitive zhody popísanej nižšie.** Pridanie `aria-label`
+  na prvok (issue 70: `aria-label` s názvom produktu na odkaze "Odkaz na
+  dodávateľa", aby riadky nemali identické prístupné meno) PREPÍŠE celý
+  accessible name — existujúci vitest test s `getByRole("link", { name:
+  "Odkaz na dodávateľa" })` prestane nachádzať prvok a treba ho upraviť na
+  presný nový name (`` `Odkaz na dodávateľa — ${variantName}` ``). Playwright
+  e2e testy s tým istým textom OSTANÚ fungovať bez zmeny — ich substring
+  zhoda `"Odkaz na dodávateľa"` je stále obsiahnutá v novom dlhšom name.
+- **`.claude/rules/testing.md`'s eslint `max-lines: 400` (skipBlankLines,
+  skipComments) platí AJ na integračné testy, nielen unit testy** — pridanie
+  jedného ďalšieho testu do `orders-http.integration.test.ts` (issue 70) ho
+  poslalo cez limit. Zavedený vzor: vyčleniť tematicky súvislý blok (vlastný
+  `boot()`, vlastné pomocné funkcie, vlastné testy) do NOVÉHO súboru s
+  komentárom "Vydelené z X, aby ani jeden nenarástol cez limit" — presne
+  ako existujúci `catalog-http.integration.test.ts` /
+  `catalog-http-ingest.integration.test.ts` split. Nový vzor: `orders-http
+  .integration.test.ts` (čítanie + import) / `orders-http-state.integration
+  .test.ts` (#25 zmena stavu riadku). Pri pridávaní testu do už veľkého
+  integračného súboru `pnpm lint` VŽDY over PRED pushom, nie až keď to
+  spadne v CI.
 - **Playwright's `getByLabel`/`getByText` robia SUBSTRING zhodu (case-
   insensitive), nie presnú, pokiaľ nedáš `{ exact: true }`** — nové
   `aria-label` pridané do jednej sekcie môže tichým spôsobom kolidovať s

--- a/apps/api/src/modules/catalog/supplier-link.test.ts
+++ b/apps/api/src/modules/catalog/supplier-link.test.ts
@@ -106,4 +106,18 @@ describe("extractSupplierLink", () => {
       note: "[pozri https://shop.example.com/y]",
     });
   });
+
+  it("zložená zátvorka vyvážená vnútri url sa neorezáva (tretí typ zátvorky)", () => {
+    expect(extractSupplierLink("https://shop.example.com/a_{b}")).toEqual({
+      url: "https://shop.example.com/a_{b}",
+      note: "https://shop.example.com/a_{b}",
+    });
+  });
+
+  it("otváracia zátvorka BEZ zatváracej sa neorezáva (url nekončí zátvorkou)", () => {
+    expect(extractSupplierLink("https://shop.example.com/a(b")).toEqual({
+      url: "https://shop.example.com/a(b",
+      note: "https://shop.example.com/a(b",
+    });
+  });
 });

--- a/apps/api/src/modules/catalog/supplier-link.test.ts
+++ b/apps/api/src/modules/catalog/supplier-link.test.ts
@@ -75,4 +75,35 @@ describe("extractSupplierLink", () => {
       note: "Primárny https://a.example.com/prvy, záložný https://b.example.com/druhy",
     });
   });
+
+  // issue 72: naivné orezanie triedy znakov `)]}...` bralo AJ zátvorku, ktorá
+  // je súčasťou samotnej URL (nie obalujúceho textu) — treba počítať
+  // vyváženosť zátvoriek v kandidátnej URL, nie orezávať naslepo.
+  it("zátvorka VYVÁŽENÁ vnútri samotnej url sa neorezáva (je súčasťou adresy)", () => {
+    expect(extractSupplierLink("https://shop.example.com/a_(b)")).toEqual({
+      url: "https://shop.example.com/a_(b)",
+      note: "https://shop.example.com/a_(b)",
+    });
+  });
+
+  it("zmiešaný koniec — vyvážená zátvorka v url + koncová bodka mimo nej", () => {
+    expect(extractSupplierLink("Pozri https://shop.example.com/a_(b).")).toEqual({
+      url: "https://shop.example.com/a_(b)",
+      note: "Pozri https://shop.example.com/a_(b).",
+    });
+  });
+
+  it("hranatá zátvorka vyvážená vnútri url sa neorezáva", () => {
+    expect(extractSupplierLink("https://shop.example.com/a_[b]")).toEqual({
+      url: "https://shop.example.com/a_[b]",
+      note: "https://shop.example.com/a_[b]",
+    });
+  });
+
+  it("hranatá zátvorka NEVYVÁŽENÁ (obaľuje celý odkaz) sa aj naďalej orezáva", () => {
+    expect(extractSupplierLink("[pozri https://shop.example.com/y]")).toEqual({
+      url: "https://shop.example.com/y",
+      note: "[pozri https://shop.example.com/y]",
+    });
+  });
 });

--- a/apps/api/src/modules/catalog/supplier-link.ts
+++ b/apps/api/src/modules/catalog/supplier-link.ts
@@ -41,6 +41,13 @@ const NON_BRACKET_TRAILING_RE = /[.,;:!?'">]+$/;
 // ("(pozri https://...)"). Preto sa zatváracia zátvorka orezáva LEN keď je
 // vo vnútri kandidátnej URL NEVYVÁŽENÁ (viac zatváracích než otváracích —
 // bola prevzatá z obalujúceho textu, nepatrí URL), nikdy keď je vyvážená.
+//
+// Zámerné zjednodušenie (code review, PR 73): počet výskytov, nie
+// poradie/zásobník — `"https://x.com/)a(b)"` (osamotená `)` PRED skutočným
+// párom) by sa vyhodnotil ako vyvážený (1×`(`, 1×`)`) a osamotenú `)` na
+// začiatku by nechal bez zmeny. V reálnych `internalNote` tvaroch (bodka/
+// zátvorka AŽ za odkazom, issue 70/72) sa to nevyskytuje — poradovo presný
+// zásobníkový parser by bol zbytočná komplexita pre tento vstup.
 const BRACKET_PAIRS: readonly (readonly [open: string, close: string])[] = [
   ["(", ")"],
   ["[", "]"],

--- a/apps/api/src/modules/catalog/supplier-link.ts
+++ b/apps/api/src/modules/catalog/supplier-link.ts
@@ -30,13 +30,65 @@ const URL_RE = /https?:\/\/\S+/i;
 // znakov po matchi orežú. Poznámka s VIACERÝMI odkazmi (issue 70's test)
 // zámerne berie len PRVÝ výskyt — žiadny zoznam odkazov sa v UI zatiaľ
 // nezobrazuje.
-const TRAILING_PUNCTUATION_RE = /[)\]}>.,;:!?'"]+$/;
+//
+// Neborovkovaná (non-bracket) interpunkcia sa orezáva VŽDY bez podmienky —
+// nikdy nie je legitímnou súčasťou URL cesty v tomto exporte.
+const NON_BRACKET_TRAILING_RE = /[.,;:!?'">]+$/;
+
+// issue 72: naivné orezanie CELEJ triedy `)]}...` bralo aj zátvorku, ktorá je
+// SÚČASŤOU samotnej URL (napr. `https://shop.example.com/a_(b)` — reálne
+// existujúce URL tvary s zátvorkou v ceste), nie len obalujúceho textu
+// ("(pozri https://...)"). Preto sa zatváracia zátvorka orezáva LEN keď je
+// vo vnútri kandidátnej URL NEVYVÁŽENÁ (viac zatváracích než otváracích —
+// bola prevzatá z obalujúceho textu, nepatrí URL), nikdy keď je vyvážená.
+const BRACKET_PAIRS: readonly (readonly [open: string, close: string])[] = [
+  ["(", ")"],
+  ["[", "]"],
+  ["{", "}"],
+];
+
+function countOccurrences(haystack: string, needle: string): number {
+  let count = 0;
+  for (const char of haystack) {
+    if (char === needle) count += 1;
+  }
+  return count;
+}
+
+// Iteruje, kým sa niečo mení — pokrýva zmiešané/opakované konce ako `(b).`
+// alebo `x).`: najprv orež nezátvorkovú interpunkciu, potom over/orež
+// nevyváženú zátvorku, opakuj.
+function trimTrailingPunctuation(candidate: string): string {
+  let url = candidate;
+  let changed = true;
+  while (changed) {
+    changed = false;
+
+    const withoutTrailingPunctuation = url.replace(NON_BRACKET_TRAILING_RE, "");
+    if (withoutTrailingPunctuation !== url) {
+      url = withoutTrailingPunctuation;
+      changed = true;
+      continue;
+    }
+
+    for (const [open, close] of BRACKET_PAIRS) {
+      if (!url.endsWith(close)) continue;
+      const isUnbalanced = countOccurrences(url, close) > countOccurrences(url, open);
+      if (isUnbalanced) {
+        url = url.slice(0, -1);
+        changed = true;
+        break;
+      }
+    }
+  }
+  return url;
+}
 
 export function extractSupplierLink(internalNote: string | null): SupplierLink {
   const raw = (internalNote ?? "").trim();
   if (raw === "") return { url: null, note: null };
   const match = URL_RE.exec(raw);
   if (match === null) return { url: null, note: raw };
-  const url = match[0].replace(TRAILING_PUNCTUATION_RE, "");
+  const url = trimTrailingPunctuation(match[0]);
   return { url, note: raw };
 }

--- a/apps/web/src/components/OrdersSection.test.tsx
+++ b/apps/web/src/components/OrdersSection.test.tsx
@@ -124,13 +124,51 @@ it("riadok s odkazom na dodávateľa zobrazí klikateľný odkaz aj kód dodáva
 
   const bunka = await screen.findByTestId(`supplier-link-${LINE_STARA.lineId}`);
   // issue 70: aria-label nesie názov produktu, aby riadky nemali rovnaké
-  // prístupné meno — viditeľný text ostáva "Odkaz na dodávateľa".
+  // prístupné meno — viditeľný text ostáva "Odkaz na dodávateľa". issue 72:
+  // samotný variantName ešte nestačí — dva riadky toho istého produktu v
+  // rôznych veľkostiach majú rovnaký variantName, líšia sa len variantCode —
+  // preto ho aria-label musí niesť tiež.
   const odkaz = within(bunka).getByRole<HTMLAnchorElement>("link", {
-    name: `Odkaz na dodávateľa — ${LINE_STARA.variantName}`,
+    name: `Odkaz na dodávateľa — ${LINE_STARA.variantName} (${LINE_STARA.variantCode})`,
   });
   expect(odkaz.getAttribute("href")).toBe("https://www.huntingshop.eu/wild-t-green-nohavice");
   expect(odkaz.getAttribute("rel")).toBe("noreferrer noopener");
   expect(bunka.textContent).toContain("OB832");
+});
+
+// issue 72: dva riadky TOHO ISTÉHO produktu v DVOCH rôznych veľkostiach majú
+// zhodný variantName — bez variantCode v aria-labeli by mali identické
+// prístupné meno a čítačka obrazovky by ich nevedela rozlíšiť.
+it("dva riadky rovnakého produktu v rôznych veľkostiach majú odlišné prístupné mená odkazu", async () => {
+  const velkostS = {
+    ...LINE_STARA,
+    lineId: "33333333-3333-3333-3333-333333333333",
+    variantCode: "A-1/S",
+    sizeLabel: "S",
+    supplierUrl: "https://www.huntingshop.eu/nohavice-s",
+    supplierNote: "https://www.huntingshop.eu/nohavice-s",
+  };
+  const velkostM = {
+    ...LINE_STARA,
+    lineId: "44444444-4444-4444-4444-444444444444",
+    variantCode: "A-1/M",
+    sizeLabel: "M",
+    supplierUrl: "https://www.huntingshop.eu/nohavice-m",
+    supplierNote: "https://www.huntingshop.eu/nohavice-m",
+  };
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [velkostS, velkostM], email: null }]);
+
+  render(<OrdersSection role="citanie" onSessionExpired={() => {}} />);
+
+  const bunkaS = await screen.findByTestId(`supplier-link-${velkostS.lineId}`);
+  const bunkaM = await screen.findByTestId(`supplier-link-${velkostM.lineId}`);
+  const odkazS = within(bunkaS).getByRole<HTMLAnchorElement>("link", {
+    name: `Odkaz na dodávateľa — ${velkostS.variantName} (${velkostS.variantCode})`,
+  });
+  const odkazM = within(bunkaM).getByRole<HTMLAnchorElement>("link", {
+    name: `Odkaz na dodávateľa — ${velkostM.variantName} (${velkostM.variantCode})`,
+  });
+  expect(odkazS.getAttribute("aria-label")).not.toBe(odkazM.getAttribute("aria-label"));
 });
 
 it("riadok bez odkazu, len s poznámkou (internalNote bez URL), zobrazí obyčajný text namiesto odkazu", async () => {

--- a/apps/web/src/components/OrdersSection.tsx
+++ b/apps/web/src/components/OrdersSection.tsx
@@ -357,7 +357,10 @@ export function OrdersSection({
                         target="_blank"
                         rel="noreferrer noopener"
                         className="ord-supplier-link"
-                        aria-label={`Odkaz na dodávateľa — ${line.variantName}`}
+                        // issue 72: variantName sám nestačí — dva riadky
+                        // toho istého produktu v rôznych veľkostiach majú
+                        // zhodný variantName, líšia sa len variantCode.
+                        aria-label={`Odkaz na dodávateľa — ${line.variantName} (${line.variantCode})`}
                       >
                         Odkaz na dodávateľa
                       </a>

--- a/apps/web/tests/e2e/orders.spec.ts
+++ b/apps/web/tests/e2e/orders.spec.ts
@@ -92,7 +92,16 @@ test("manažér prepne stav riadku cez select, zmena pretrvá po obnovení strá
   await expect(select).toHaveValue("caka_sa");
 
   await select.selectOption("skladom");
-  await expect(riadok).toContainText("Skladom");
+  // Nie `toContainText("Skladom")` — VŠETKY štyri `STATE_LABELS` sú vždy
+  // vykreslené ako `<option>` deti selectu bez ohľadu na to, ktorý je
+  // vybraný, takže taká kontrola textu je tautológia (vždy prejde, aj keď sa
+  // zápis nikdy nedokončí). `toHaveValue` na SAMOTNOM selecte skutočne čaká,
+  // kým lokálny optimistický update prebehne (deje sa AŽ po úspešnom
+  // vyriešení PATCH promisu, `OrdersSection.tsx`'s `changeState`), čím
+  // zaručuje, že zápis je na serveri potvrdený PRED nasledujúcim reloadom —
+  // bez tejto zmeny mohol pod pomalším CI behom `page.reload()` predbehnúť
+  // ešte neuzavretý zápis a nasledujúca kontrola po reloade náhodne zlyhala.
+  await expect(select).toHaveValue("skladom");
   await expect(page.getByRole("alert")).toHaveCount(0);
 
   await page.reload();

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -687,3 +687,56 @@ nové heslo sa nikde v pushnutom obsahu nenachádza.
   supplier codes (e.g. "OB041 / XHGOSH") render on real "Na objednanie"
   rows, clickable, correct `href`. Console: 0 errors/0 warnings.
 - Per-ticket Discord card fired (`notify --run-card`, confirmed delivered).
+
+## Issue 70 — code-review follow-up on PR 69 (2026-07-30)
+
+- Two independent post-merge reviews of PR 69 (issue 67, merge `a602cd7`)
+  found 9 real defects in that diff. Filed as issue **#70** (`Scope-gate:
+  planned-work`), design comment posted before first code commit.
+- 1) `extractSupplierLink`'s `URL_RE`'s greedy `\S+` swallowed trailing
+  punctuation (`.`, `)`) right after the URL — trimmed with a
+  `TRAILING_PUNCTUATION_RE` post-match replace. RED/GREEN:
+  `supplier-link.test.ts` (3 new cases) → `supplier-link.ts`.
+- 2) `OrdersSection.tsx`'s `—` placeholder ignored `externalCode` — now
+  shown only when `supplierUrl`, `supplierNote` AND `externalCode` are all
+  null. RED/GREEN: `OrdersSection.test.tsx` → `OrdersSection.tsx` (also
+  bundled 4/8 below, same lines).
+- 3) `.ord-supplier-cell`'s unbounded `nowrap` bounded with
+  `overflow/text-overflow/ellipsis`, matching `.folder-head .ftitle`'s
+  existing pattern; `title` attr added for the full text (CSS-only, no
+  unit-testable behavior — manually verified live).
+- 4) `rel="noopener"` added alongside `noreferrer`.
+- 5) `ordersApi.ts`'s `supplierUrl` zod schema now regex-checks
+  `^https?:\/\//` as an independent second layer. RED/GREEN:
+  `ordersApi.test.ts` → `ordersApi.ts`.
+- 6) `getOrderDetail`/`OrderDetailLine` (`queries.ts`) extended with the
+  three fields — third read path unified with `listOpenOrderLinesBySupplier`
+  / `mail.ts`. RED/GREEN: `orders-http.integration.test.ts` →
+  `queries.ts`.
+- 7) Multi-URL-in-one-note case added to `supplier-link.test.ts` (first-match
+  is intentional, now documented + tested).
+- 8) `aria-label` on the supplier link now carries the product name
+  (distinct accessible name per row) — bundled with fix 2/4.
+- 9) 128-char line in `ingest.ts` wrapped.
+- Side-effect: the new order-detail test pushed
+  `orders-http.integration.test.ts` over eslint's 400-line cap — split
+  state-change (#25) tests into a new `orders-http-state.integration
+  .test.ts`, same pattern as the existing `catalog-http`/
+  `catalog-http-ingest` split. See `.claude/rules/testing.md`.
+- Deliberately NOT fixed (documented in PR body): the " | " ambiguity in
+  copied order text — human-read only, never re-parsed.
+- Commits (12, `dev`): version bump 0.3.0-dev.32, 4 RED/GREEN pairs (1, 2,
+  5, 6), 2 pure fixes (3+4+8 bundled into fix 2's commit, 9 standalone),
+  the eslint-line-cap split. PR **#71** (`dev` → `main`), merged `6f97afd`.
+  CI all green both on the PR and on `main` (version-check, check,
+  integration 187/187, docker-build, e2e 14/14; Deploy workflow green).
+  Local: typecheck + lint + unit (405) + integration (187) + e2e (14) all
+  green before push.
+- Deployed + verified on https://forestshop-novy.newlevel.media
+  (v0.3.0-dev.32, commit matches `git log origin/main -1`). Live-checked
+  against real production order data (864 supplier cells): 0 cells show
+  the `—` placeholder alongside a supplier code, `rel="noreferrer
+  noopener"` + product-name `aria-label` present on every link, supplier
+  notes truncate with `title` + ellipsis CSS applied. Console: 0
+  errors/0 warnings.
+- Per-ticket Discord card fired (`notify --run-card`, confirmed delivered).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.32",
+  "version": "0.3.0-dev.33",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.33",
+  "version": "0.3.0-dev.34",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Fixes issue 72: dve zvyškové chyby po issue 70 / PR 71, obe overené priamym
spustením nasadeného kódu pred opravou.

**Defekt A** — `supplier-link.ts`'s orezanie koncovej interpunkcie brávalo AJ
zatváraciu zátvorku, ktorá je súčasťou samotnej URL (napr.
`https://shop.example.com/a_(b)` → orezané na `.../a_(b`, mŕtvy odkaz). Oprava:
zatváracia zátvorka sa orezáva LEN keď je vo vnútri kandidátnej URL
nevyvážená (viac zatváracích než otváracích).

**Defekt B** — prístupné meno (`aria-label`) odkazu na dodávateľa v
`OrdersSection.tsx` niesol len názov produktu, takže dva riadky rovnakého
produktu v rôznych veľkostiach mali identické prístupné meno. Doplnený
`variantCode`.

Design rozhodnutie (root cause + zvolený/zamietnutý prístup) zaznamenané na
issue 72 pred prvým commitom kódu.

Closes #72

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
