### PR TITLE
Na objednanie: filter podľa stavu objednávky zo Shoptetu (issue 59)

### DIFF
--- a/.claude/rules/catalog.md
+++ b/.claude/rules/catalog.md
@@ -173,3 +173,16 @@ paths:
   produktu alebo variantu: over na reálnych dátach (`python3` + `csv.DictReader`
   nad `parovanie_produktov/data/backups/export_*.csv`, READ-ONLY), nikdy
   nehádaj z názvu stĺpca.
+- **Orezávanie koncovej interpunkcie z extrahovanej URL (`supplier-link.ts`)
+  NESMIE orezať zatváraciu zátvorku naslepo — tá môže byť SÚČASŤOU samotnej
+  URL** (issue 72: `https://shop.example.com/a_(b)` je reálny tvar URL, nie
+  len "(pozri https://...)" obalený odkaz). Riešenie: `trimTrailingPunctuation()`
+  ráta výskyty otváracej/zatváracej zátvorky KAŽDÉHO typu (`()`, `[]`, `{}`)
+  priamo v kandidátnej URL a zatváraciu orezáva LEN keď sú nevyvážené (viac
+  zatváracích než otváracích — vtedy vieme, že bola prevzatá z obalujúceho
+  textu). Zámerné zjednodušenie: počet výskytov, nie poradie/zásobník —
+  nerozlíši osamotenú `)` PRED skutočným párom (`"https://x.com/)a(b)"`), čo
+  sa v reálnych `internalNote` tvaroch (bodka/zátvorka vždy AŽ za odkazom)
+  nevyskytuje. Pri pridávaní ĎALŠIEHO typu koncovej interpunkcie/zátvorky do
+  tejto funkcie vždy over na reálnom skladovom pare (napr. z `huntingshop.eu`)
+  cez `python3` + `csv.DictReader`, nie len na vymyslenom príklade.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -206,3 +206,18 @@ paths:
   request) prepísali do vlastného výstupu; korelácia timestampov medzi
   zlyhaním a týmito logmi je rýchlejšia cesta k skutočnej príčine než
   hádanie z popisu symptómu.
+- **`toContainText`/`toHaveText` na riadku/kontajneri, ktorý obsahuje NATÍVNY
+  `<select>`, je tautológia, ak kontrolovaný text zodpovedá jednému z VŽDY
+  vykreslených `<option>` popisiek** — všetky možnosti `<select>`u sú v DOM
+  strome PRÍTOMNÉ ako deti bez ohľadu na to, ktorá je aktuálne vybraná
+  (issue 72, `orders.spec.ts`'s test zmeny stavu). Taká kontrola PREJDE aj
+  keď sa zmena nikdy neuloží — nikdy nečaká na skutočné dokončenie async
+  zápisu, takže pod pomalším CI behom môže `page.reload()` predbehnúť ešte
+  neuzavretý PATCH a NASLEDUJÚCA (skutočná) kontrola po reloade náhodne
+  zlyhá. Namiesto kontroly textu okolo selectu vždy over PRIAMO
+  `expect(select).toHaveValue("...")` — to skutočne čaká na lokálny
+  optimistický update (ktorý nastáva AŽ po vyriešení promisu zápisu), takže
+  zaručuje, že zápis je potvrdený PRED ďalším krokom testu (napr. reloadom).
+  Pri pridávaní/úprave e2e testu okolo AKÉHOKOĽVEK `<select>`u v tejto appke
+  vždy skontroluj, či asercia naozaj testuje VYBRANÚ hodnotu, nie len
+  prítomnosť textu niekde v okolí.

--- a/apps/api/drizzle/0012_tiresome_gamma_corps.sql
+++ b/apps/api/drizzle/0012_tiresome_gamma_corps.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "order_open_status" (
+	"status_name" text PRIMARY KEY NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "order" ADD COLUMN "status_name" text DEFAULT 'Vybavuje sa' NOT NULL;
+--> statement-breakpoint
+-- issue 59: sensible default seed — bez tohto riadku by appka hneď po
+-- nasadení (predtým, než správca čokoľvek nastaví) zobrazovala "Na
+-- objednanie" prázdne pre KAŽDÚ objednávku (žiadny nakonfigurovaný otvorený
+-- stav = nič sa nezhoduje), presne opak toho, čo má byť predvolené správanie
+-- (rovnaké ako stará appka: "Vybavuje sa"). "ON CONFLICT DO NOTHING" robí
+-- migráciu bezpečne opakovateľnou, keby niekedy bežala nad DB, ktorá už tento
+-- riadok má.
+INSERT INTO "order_open_status" ("status_name") VALUES ('Vybavuje sa') ON CONFLICT ("status_name") DO NOTHING;

--- a/apps/api/drizzle/meta/0012_snapshot.json
+++ b/apps/api/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,1414 @@
+{
+  "id": "e9b5d52d-7915-4c13-bb7a-ae5e9fb8b069",
+  "prevId": "f4b0e305-cdad-4409-ae8f-69163a934beb",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_code": {
+          "name": "external_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_open_status": {
+      "name": "order_open_status",
+      "schema": "",
+      "columns": {
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Vybavuje sa'"
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing": {
+      "name": "pairing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_url": {
+          "name": "supplier_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "pairing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'navrhnute'"
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pairing_state_idx": {
+          "name": "pairing_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_confirmed_by_idx": {
+          "name": "pairing_confirmed_by_idx",
+          "columns": [
+            {
+              "expression": "confirmed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_variant_code_variant_code_fk": {
+          "name": "pairing_variant_code_variant_code_fk",
+          "tableFrom": "pairing",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pairing_confirmed_by_users_id_fk": {
+          "name": "pairing_confirmed_by_users_id_fk",
+          "tableFrom": "pairing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pairing_variant_code_unique": {
+          "name": "pairing_variant_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pairing_confirmation_ck": {
+          "name": "pairing_confirmation_ck",
+          "value": "(\"pairing\".\"state\" = 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)\n        OR (\"pairing\".\"state\" != 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NULL AND \"pairing\".\"confirmed_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier": {
+      "name": "supplier",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wholesale_base_url": {
+          "name": "wholesale_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_key": {
+          "name": "adapter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne"
+      ]
+    },
+    "public.pairing_state": {
+      "name": "pairing_state",
+      "schema": "public",
+      "values": [
+        "navrhnute",
+        "potvrdene"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1785422767454,
       "tag": "0011_medical_ronan",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1785429993068,
+      "tag": "0012_tiresome_gamma_corps",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema-orders.ts
+++ b/apps/api/src/db/schema-orders.ts
@@ -44,11 +44,37 @@ export const orders = pgTable(
     // Manažérov voľný komentár k objednávke (stará appka, obrazovka "Na
     // objednanie" — potvrdené v docs/stara-appka-inventar.md, bod 1).
     comment: text("comment"),
+    // issue 59: Shoptet-ov stav objednávky (napr. "Vybavuje sa"/"Vybavená"),
+    // opakovaný na KAŽDOM riadku exportu tej istej objednávky — importer
+    // (`modules/orders/ingest.ts`) berie prvý výskyt, rovnaký vzor ako
+    // `customerName`/`placedAt`, a OSVIEŽUJE ho pri re-importe (na rozdiel od
+    // `comment`/`order_line.state` nižšie, toto pole je VŽDY Shoptetovo,
+    // nikdy appkou/manažérom vlastnené). Rozhoduje, či sa objednávka ukáže v
+    // "Na objednanie" (`modules/orders/queries.ts` + `modules/orders/
+    // open-statuses.ts`). DB `default` je LEN záchranná sieť pre ručne
+    // vložené riadky (testy/fixtúry) — produkčný import vždy zapíše
+    // skutočnú hodnotu z exportu, nikdy sa nespolieha na tento default.
+    statusName: text("status_name").notNull().default("Vybavuje sa"),
     placedAt: timestamp("placed_at", { withTimezone: true }).notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => [index("order_placed_at_idx").on(t.placedAt)],
 );
+
+// issue 59: ktoré Shoptet stavy sa počítajú ako "objednávka sa ešte
+// vybavuje" — jediný nastaviteľný zoznam, ktorý táto appka potrebuje.
+// Stará appka (`parovanie_produktov`) má na tom istom mieste ŠTYRI zoznamy
+// (`to_order`/`terminal`/`known_open`/`cancelled` + "impact preview" pred
+// uložením) — tie ostatné tri existujú LEN kvôli funkciám, ktoré táto appka
+// (zatiaľ) nemá vôbec: mazanie starých značiek podľa stavu, pripomienkové
+// e-maily zákazníkom, Pošta automatizácia. Kopírovať ich sem by bola
+// neaktívna zložitosť bez jediného volajúceho (MVP filozofia, zavrhnutá
+// alternatíva v návrhovom komentári na #59) — pribudnú samostatne, ak
+// niektorá z tých funkcií niekedy vznikne.
+export const orderOpenStatuses = pgTable("order_open_status", {
+  statusName: text("status_name").primaryKey(),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+});
 
 // E-mailový kontakt na dodávateľa (#31) — nová dátová položka, ktorá v
 // starej appke nikdy neexistovala (dodávateľ tam bol len názov, viď komentár

--- a/apps/api/src/http/orders-routes.ts
+++ b/apps/api/src/http/orders-routes.ts
@@ -41,15 +41,14 @@ export function registerOrdersRoutes(
     c.json({ suppliers: await listOpenOrderLinesBySupplier(db) }),
   );
 
-  app.get("/api/orders/:id", requireUser(db), zValidator("param", orderParam), async (c) => {
-    const detail = await getOrderDetail(db, c.req.valid("param").id);
-    if (detail === null) return c.json({ error: "Objednávka sa nenašla" }, 404);
-    return c.json(detail);
-  });
-
   // issue 59: nastavenie, ktoré Shoptet stavy sa počítajú ako "objednávka sa
-  // ešte vybavuje" (rozhoduje o obsahu `/api/orders/open` vyššie). Čítanie
-  // má rovnaké oprávnenie ako zvyšok obrazovky (`requireUser`, žiadne
+  // ešte vybavuje" (rozhoduje o obsahu `/api/orders/open` vyššie). MUSÍ byť
+  // zaregistrované PRED `/api/orders/:id` nižšie — Hono zhoduje trasy v
+  // poradí registrácie, takže parametrizovaná `:id` by inak "open-statuses"
+  // zožrala ako svoj parameter (zlyhala by na neplatnom UUID) skôr, než by
+  // sa vôbec dostalo k tejto konkrétnej ceste (zistené naživo, e2e beh).
+  //
+  // Čítanie má rovnaké oprávnenie ako zvyšok obrazovky (`requireUser`, žiadne
   // obmedzenie roly) — vidieť nastavenie nie je citlivejšie než vidieť
   // samotné otvorené objednávky.
   app.get("/api/orders/open-statuses", requireUser(db), async (c) => {
@@ -77,6 +76,12 @@ export function registerOrdersRoutes(
       return c.json({ ok: true as const, statuses: result.statuses });
     },
   );
+
+  app.get("/api/orders/:id", requireUser(db), zValidator("param", orderParam), async (c) => {
+    const detail = await getOrderDetail(db, c.req.valid("param").id);
+    if (detail === null) return c.json({ error: "Objednávka sa nenašla" }, 404);
+    return c.json(detail);
+  });
 
   // Zmena stavu riadku objednávky (#25) — rovnaké oprávnenie ako spustenie
   // importu (`requireRole("admin", "manazer")`): manažér stavy mení, `citanie`/

--- a/apps/api/src/http/orders-routes.ts
+++ b/apps/api/src/http/orders-routes.ts
@@ -6,6 +6,7 @@ import { orderLineState } from "../db/schema.js";
 import { log } from "../logger.js";
 import { record } from "../modules/audit/service.js";
 import { ORDERS_EXPORT_URL_NOT_CONFIGURED, type OrdersIngestResult, type RunOrdersIngest } from "../modules/orders/ingest.js";
+import { listKnownStatusNames, listOpenStatusNames, replaceOpenStatusNames } from "../modules/orders/open-statuses.js";
 import { getOrderDetail, listOpenOrderLinesBySupplier } from "../modules/orders/queries.js";
 import { setOrderLineState } from "../modules/orders/state.js";
 import { requireRole, requireUser, type AppBindings } from "./middleware.js";
@@ -17,6 +18,11 @@ const orderLineParam = z.object({ lineId: z.string().uuid() });
 // schémou, `schema-orders.ts`) — nikdy ručne prepísaná únia, ktorá by sa mohla
 // rozísť pri pridaní ďalšieho stavu.
 const orderLineStateBody = z.object({ state: z.enum(orderLineState.enumValues) });
+// issue 59: `min(1)` len zachytí zjavne prázdny request skôr, než sa vôbec
+// dostane k `replaceOpenStatusNames` — SKUTOČNÉ čistenie (normalizácia,
+// orezanie prázdnych/duplicít po trime) beží až v module, lebo "['   ']"
+// prejde touto schémou, ale po očistení je to prázdny zoznam.
+const openStatusesBody = z.object({ statuses: z.array(z.string()).min(1).max(50) });
 
 // Re-exportované, aby `http/app.ts` nemusel meniť svoj import — kanonická
 // definícia žije v `modules/orders/ingest.ts` (rovnaký vzor ako katalógov
@@ -40,6 +46,37 @@ export function registerOrdersRoutes(
     if (detail === null) return c.json({ error: "Objednávka sa nenašla" }, 404);
     return c.json(detail);
   });
+
+  // issue 59: nastavenie, ktoré Shoptet stavy sa počítajú ako "objednávka sa
+  // ešte vybavuje" (rozhoduje o obsahu `/api/orders/open` vyššie). Čítanie
+  // má rovnaké oprávnenie ako zvyšok obrazovky (`requireUser`, žiadne
+  // obmedzenie roly) — vidieť nastavenie nie je citlivejšie než vidieť
+  // samotné otvorené objednávky.
+  app.get("/api/orders/open-statuses", requireUser(db), async (c) => {
+    const [statuses, knownStatuses] = await Promise.all([listOpenStatusNames(db), listKnownStatusNames(db)]);
+    return c.json({ statuses, knownStatuses });
+  });
+
+  // Zápis — rovnaké oprávnenie + CSRF disciplína ako zmena stavu riadku
+  // objednávky (`requireRole("admin", "manazer")`).
+  app.put(
+    "/api/orders/open-statuses",
+    requireSameOrigin(),
+    requireUser(db),
+    requireRole("admin", "manazer"),
+    zValidator("json", openStatusesBody),
+    async (c) => {
+      const { statuses } = c.req.valid("json");
+      const user = c.get("user");
+      const now = new Date();
+      const result = await replaceOpenStatusNames(db, { statuses, actorUserId: user.userId, now });
+      if (result.status === "empty") {
+        return c.json({ error: "Zoznam stavov nesmie ostať prázdny — musí obsahovať aspoň jeden stav." }, 400);
+      }
+      log.info({ actorUserId: user.userId, statuses: result.statuses }, "zmena nastavenia otvorených stavov objednávok");
+      return c.json({ ok: true as const, statuses: result.statuses });
+    },
+  );
 
   // Zmena stavu riadku objednávky (#25) — rovnaké oprávnenie ako spustenie
   // importu (`requireRole("admin", "manazer")`): manažér stavy mení, `citanie`/

--- a/apps/api/src/modules/orders/ingest.ts
+++ b/apps/api/src/modules/orders/ingest.ts
@@ -190,13 +190,14 @@ export async function ingestOrders(db: Database, options: OrdersIngestOptions): 
   // `${externalOrderId}:${variantCode}`) — zámerne, aby žiadna voľba
   // oddeľovača (dvojbodka, medzera, akýkoľvek znak) nemohla teoreticky
   // kolidovať s obsahom niektorého z oboch reťazcov.
-  const orderInfo = new Map<string, { customerName: string; placedAt: Date }>();
+  const orderInfo = new Map<string, { customerName: string; placedAt: Date; statusName: string }>();
   const lineTotals = new Map<string, Map<string, { externalOrderId: string; variantCode: string; quantity: number }>>();
   for (const candidate of candidates) {
     if (!orderInfo.has(candidate.externalOrderId)) {
       orderInfo.set(candidate.externalOrderId, {
         customerName: candidate.customerName,
         placedAt: candidate.placedAt,
+        statusName: candidate.statusName,
       });
     }
     let byVariant = lineTotals.get(candidate.externalOrderId);
@@ -274,6 +275,7 @@ export async function ingestOrders(db: Database, options: OrdersIngestOptions): 
             batch.map(([externalOrderId, info]) => ({
               externalOrderId,
               customerName: info.customerName,
+              statusName: info.statusName,
               placedAt: info.placedAt,
             })),
           )
@@ -281,9 +283,13 @@ export async function ingestOrders(db: Database, options: OrdersIngestOptions): 
             target: orders.externalOrderId,
             // `comment` sa ZÁMERNE nedáva do SET — je to manažérovo vlastné
             // pole (nikdy nepochádza zo Shoptetu, `schema-orders.ts`), re-import
-            // ho nesmie prepísať/vynulovať.
+            // ho nesmie prepísať/vynulovať. `status_name` (issue 59) je presný
+            // OPAK — je to VŽDY Shoptetovo pole, re-import ho preto MUSÍ
+            // osviežiť (objednávka prejde "Vybavuje sa" → "Vybavená" len tak,
+            // že ju appka pri ďalšom importe znova uvidí).
             set: {
               customerName: sql`excluded.customer_name`,
+              statusName: sql`excluded.status_name`,
               placedAt: sql`excluded.placed_at`,
             },
           })

--- a/apps/api/src/modules/orders/open-statuses.ts
+++ b/apps/api/src/modules/orders/open-statuses.ts
@@ -1,0 +1,108 @@
+import { asc } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { orderOpenStatuses, orders } from "../../db/schema.js";
+import { record } from "../audit/service.js";
+import { normalizeStatusName } from "./parser.js";
+
+// issue 59: rovnaké obranné hranice ako stará appka's `ORDER_STATUS_MAX`/
+// `ORDERS_UNKNOWN_STATUS_MAXLEN` (`export_helpers.py`/`app.py`) — stav je
+// voľný text, ktorý zadáva správca, a nekonečne dlhý/nekonečne veľký zoznam
+// by bol len obranné ihrisko na omyl (vložený celý súbor namiesto zoznamu
+// stavov), nie legitímne použitie. Bežná appka má rádovo jednotky stavov.
+const STATUS_NAME_MAX_LENGTH = 120;
+const OPEN_STATUSES_MAX_COUNT = 50;
+const KNOWN_STATUSES_MAX_COUNT = 200;
+
+// Rovnaká hodnota, akú migrácia `0012_tiresome_gamma_corps.sql` seeduje do
+// `order_open_status` (a `order.status_name`'s DB `default` v `schema-
+// orders.ts`) — vytiahnuté sem ako pomenovaná konštanta, aby ju testové
+// pomôcky (`tests/helpers/db.ts`, `scripts/e2e-setup.ts`), ktoré po TRUNCATE
+// musia tento "čerstvo zmigrovaný" stav znova zostaviť RUČNE (nová koreňová
+// tabuľka, `.claude/rules/testing.md`), nemuseli opakovať ako magický reťazcový
+// literál. SQL v migrácii ju nemôže importovať priamo — ak sa táto hodnota
+// niekedy zmení, migrácia aj tu uvedené volania treba zmeniť SPOLU.
+export const DEFAULT_ORDER_OPEN_STATUS = "Vybavuje sa";
+
+export interface ReplaceOpenStatusesInput {
+  readonly statuses: readonly string[];
+  readonly actorUserId: string;
+  readonly now: Date;
+}
+
+export type ReplaceOpenStatusesResult =
+  | { readonly status: "ok"; readonly statuses: readonly string[] }
+  // Prázdny zoznam by natrvalo vyprázdnil "Na objednanie" pre KAŽDÚ
+  // objednávku (žiadny nakonfigurovaný stav = nič sa nezhoduje) — rovnaká
+  // obrana ako stará appka's `ORDER_STATUS_REQUIRED` pre `to_order`, len bez
+  // jej "impact preview" mechanizmu (ten patrí k funkciám, ktoré táto appka
+  // nemá, viď návrhový komentár na #59).
+  | { readonly status: "empty" };
+
+/**
+ * Vyčistí vstup správcu: normalizácia (rovnaká ako pri importe, aby sa
+ * porovnávacia forma nikdy nerozišla), orezanie prázdnych, odstránenie
+ * duplicít (poradie prvého výskytu), orezanie na rozumný počet/dĺžku.
+ * Rovnaký zámer ako stará appka's `_clean_status_list`, len pre JEDEN
+ * zoznam namiesto štyroch.
+ */
+function cleanStatusList(statuses: readonly string[]): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const raw of statuses) {
+    const value = normalizeStatusName(raw).slice(0, STATUS_NAME_MAX_LENGTH);
+    if (value === "" || seen.has(value)) continue;
+    seen.add(value);
+    out.push(value);
+    if (out.length >= OPEN_STATUSES_MAX_COUNT) break;
+  }
+  return out;
+}
+
+/** Nastavené stavy, ktoré sa počítajú ako "objednávka sa ešte vybavuje" —
+ * abecedne, pre stabilné, ľahko overiteľné poradie na obrazovke. */
+export async function listOpenStatusNames(db: Database): Promise<readonly string[]> {
+  const rows = await db
+    .select({ statusName: orderOpenStatuses.statusName })
+    .from(orderOpenStatuses)
+    .orderBy(asc(orderOpenStatuses.statusName));
+  return rows.map((r) => r.statusName);
+}
+
+// Distinct hodnoty `order.status_name`, aké appka SKUTOČNE videla v
+// exportoch — pomôcka pre správcu (rovnaký zámer ako stará appka's
+// `export_statuses`), aby si pri úprave zoznamu vedel overiť, či nezapísal
+// preklep. Prázdny reťazec (nenaimportovaná/ručne vložená objednávka bez
+// stavu) sa vynecháva — nie je to skutočný Shoptet stav, len DB default.
+export async function listKnownStatusNames(db: Database): Promise<readonly string[]> {
+  const rows = await db
+    .selectDistinct({ statusName: orders.statusName })
+    .from(orders)
+    .orderBy(asc(orders.statusName))
+    .limit(KNOWN_STATUSES_MAX_COUNT);
+  return rows.map((r) => r.statusName).filter((s) => s !== "");
+}
+
+/** Nahradí CELÝ nastavený zoznam naraz (rovnaký zámer ako stará appka's
+ * uloženie textarea obsahu) — jedna transakcia, spolu s auditovým záznamom,
+ * rovnaký vzor ako `orders/state.ts`'s `setOrderLineState`. */
+export async function replaceOpenStatusNames(
+  db: Database,
+  input: ReplaceOpenStatusesInput,
+): Promise<ReplaceOpenStatusesResult> {
+  const cleaned = cleanStatusList(input.statuses);
+  if (cleaned.length === 0) return { status: "empty" };
+
+  await db.transaction(async (tx) => {
+    await tx.delete(orderOpenStatuses);
+    await tx.insert(orderOpenStatuses).values(cleaned.map((statusName) => ({ statusName })));
+    await record(tx, {
+      at: input.now,
+      actorUserId: input.actorUserId,
+      action: "order_open_status.changed",
+      entity: "order_open_status",
+      data: { statuses: cleaned },
+    });
+  });
+
+  return { status: "ok", statuses: cleaned };
+}

--- a/apps/api/src/modules/orders/parser.test.ts
+++ b/apps/api/src/modules/orders/parser.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import {
   decodeCp1250,
   mapOrderRow,
+  normalizeStatusName,
   parseDelimited,
   parseShopLocalDateTime,
   parseShoptetOrdersCsv,
@@ -66,6 +67,37 @@ describe("mapOrderRow — reálna položka", () => {
     expect(mapped.record?.variantCode).toBe("40237/XL");
     expect(mapped.record?.quantity).toBe(2);
     expect(mapped.record?.customerName).toBe("Ján Novák");
+    // issue 59: fixtúra nesie order 20300001 v stave "Vybavuje sa".
+    expect(mapped.record?.statusName).toBe("Vybavuje sa");
+  });
+
+  // issue 59: normalizácia (NFC + orez) musí bežať aj v `mapOrderRow`, nie
+  // len v `normalizeStatusName` samostatne — inak by porovnanie s
+  // `order_open_status` (nastavené presne cez rovnakú funkciu,
+  // `open-statuses.ts`) mohlo zlyhať na medzere/inej Unicode forme.
+  it("statusName sa normalizuje (orez medzier)", () => {
+    const mapped = mapOrderRow({
+      code: "20300004",
+      date: "2026-06-16 08:00:00",
+      statusName: "  Vybavuje sa  ",
+      billFullName: "X",
+      itemName: "Y",
+      itemAmount: "1",
+      itemCode: "40238/M",
+    });
+    expect(mapped.record?.statusName).toBe("Vybavuje sa");
+  });
+
+  it("chýbajúci stĺpec statusName na riadku → prázdny reťazec (nikdy nevyhodí)", () => {
+    const mapped = mapOrderRow({
+      code: "20300005",
+      date: "2026-06-16 08:00:00",
+      billFullName: "X",
+      itemName: "Y",
+      itemAmount: "1",
+      itemCode: "40238/M",
+    });
+    expect(mapped.record?.statusName).toBe("");
   });
 
   it("customerName spadne na deliveryFullName, keď je billFullName prázdne", () => {
@@ -158,5 +190,32 @@ describe("parseShopLocalDateTime", () => {
   it("vráti null pre nerozpoznateľný tvar", () => {
     expect(parseShopLocalDateTime("nie je dátum")).toBeNull();
     expect(parseShopLocalDateTime("2026-07-15")).toBeNull();
+  });
+});
+
+// issue 59: rovnaká normalizácia ako stará appka's `norm_status`
+// (`export_helpers.py`) — musí byť rovnaká na oboch stranách porovnania
+// (export vs. `order_open_status`), inak sa zhoda nikdy nenájde.
+describe("normalizeStatusName", () => {
+  it("orezáva okolité medzery", () => {
+    expect(normalizeStatusName("  Vybavuje sa  ")).toBe("Vybavuje sa");
+  });
+
+  it("NFC-normalizuje rozlozenu diakritiku na zlozenu formu", () => {
+    // holé "a" + SAMOSTATNY kombinujuci accent (U+0301, NFD) vyzera
+    // identicky ako zlozene "a s dlzňom" (NFC), je to vsak BAJTOVO INY retazec.
+    const nfd = "Vybaven" + "á";
+    expect(nfd).not.toBe("Vybavená");
+    expect(normalizeStatusName(nfd)).toBe("Vybavená");
+  });
+
+  it("prázdny reťazec ostáva prázdny", () => {
+    expect(normalizeStatusName("")).toBe("");
+  });
+});
+
+describe("REQUIRED_ORDER_COLUMNS", () => {
+  it("obsahuje statusName (issue 59) — bez neho appka nemá podľa čoho filtrovať 'Na objednanie'", () => {
+    expect(REQUIRED_ORDER_COLUMNS).toContain("statusName");
   });
 });

--- a/apps/api/src/modules/orders/parser.ts
+++ b/apps/api/src/modules/orders/parser.ts
@@ -90,6 +90,11 @@ export const REQUIRED_ORDER_COLUMNS: readonly string[] = Object.freeze([
   "itemName",
   "itemAmount",
   "itemCode",
+  // issue 59: bez tohto stĺpca appka nemá podľa čoho rozhodnúť, ktoré
+  // objednávky patria do "Na objednanie" — chýbajúci stĺpec preto odmieta
+  // CELÝ import nahlas (rovnaká disciplína ako zvyšok zoznamu), nikdy ticho
+  // nezapíše polovičné dáta bez stavu.
+  "statusName",
 ]);
 
 function toRecord(columns: readonly string[], values: readonly string[]): Record<string, string> {
@@ -195,9 +200,24 @@ export interface OrderRowIssue {
 export interface OrderLineCandidate {
   readonly externalOrderId: string;
   readonly customerName: string;
+  // issue 59: Shoptet-ov stav objednávky, normalizovaný (`normalizeStatusName`).
+  readonly statusName: string;
   readonly placedAt: Date;
   readonly variantCode: string;
   readonly quantity: number;
+}
+
+/**
+ * issue 59: `statusName` je voľný text, ktorý si obchod nastavuje priamo v
+ * Shoptete, a appka ho porovnáva na DVOCH miestach — raz z exportu (tu),
+ * raz z toho, čo správca zapíše do `order_open_status` (`open-statuses.ts`).
+ * NFC normalizácia + orez sú nutné, aby oba zdroje porovnávali v ROVNAKEJ
+ * forme (rovnaký dôvod ako stará appka's `norm_status`, `export_helpers.py`):
+ * "Vybavuje sa" vložené zo zdroja, ktorý rozkladá diakritiku, vyzerá na
+ * obrazovke identicky, ale je bajtovo iné a nezhodovalo by sa s ničím.
+ */
+export function normalizeStatusName(value: string): string {
+  return value.normalize("NFC").trim();
 }
 
 function customerNameOf(row: Readonly<Record<string, string>>): string {
@@ -262,6 +282,7 @@ export function mapOrderRow(row: Readonly<Record<string, string>>): {
     record: {
       externalOrderId,
       customerName: customerNameOf(row),
+      statusName: normalizeStatusName(row["statusName"] ?? ""),
       placedAt,
       variantCode,
       quantity,

--- a/apps/api/src/modules/orders/queries.ts
+++ b/apps/api/src/modules/orders/queries.ts
@@ -1,7 +1,8 @@
-import { asc, desc, eq } from "drizzle-orm";
+import { asc, desc, eq, inArray } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
 import { orderLines, orders, products, supplierContacts, variants, type OrderLineState } from "../../db/schema.js";
 import { extractSupplierLink } from "../catalog/supplier-link.js";
+import { listOpenStatusNames } from "./open-statuses.js";
 
 export interface OpenOrderLine {
   readonly lineId: string;
@@ -51,11 +52,18 @@ export const NEZNAMY_DODAVATEL = "(bez dodávateľa)";
 // Zoskupenie je na ÚROVNI RIADKA objednávky, nie na úrovni objednávky —
 // jedna objednávka môže obsahovať položky od VIACERÝCH dodávateľov
 // (`docs/stara-appka-inventar.md` bod 1: "Otvorené objednávky zoskupené
-// podľa dodávateľa"). "Otvorená" v v1 znamená VŠETKY riadky objednávok —
-// `order_line.state` (objednane/caka_sa/skladom/nedostupne) zatiaľ nemá
-// žiadny "hotový/zatvorený" stav (ten príde až s #25), takže nič dnes riadok
-// z tohto zoznamu neodstráni.
+// podľa dodávateľa"). `order_line.state` (objednane/caka_sa/skladom/
+// nedostupne) je appkou/manažérom riadený automat NEZÁVISLÝ od tohto
+// filtra — "otvorená" tu (issue 59) znamená, že SAMOTNÁ OBJEDNÁVKA má v
+// Shoptete jeden z nastavených stavov (`order.status_name`,
+// `open-statuses.ts`), rovnaký zámer ako stará appka's `to_order`. Bez
+// nastaveného stavu (čo `replaceOpenStatusNames` nedovolí) by dopyt nemal
+// podľa čoho filtrovať — vtedy sa vráti prázdny zoznam namiesto behu
+// `inArray` s prázdnym poľom.
 export async function listOpenOrderLinesBySupplier(db: Database): Promise<readonly SupplierOpenOrders[]> {
+  const openStatuses = await listOpenStatusNames(db);
+  if (openStatuses.length === 0) return [];
+
   const rows = await db
     .select({
       lineId: orderLines.id,
@@ -77,6 +85,7 @@ export async function listOpenOrderLinesBySupplier(db: Database): Promise<readon
     .innerJoin(orders, eq(orders.id, orderLines.orderId))
     .innerJoin(variants, eq(variants.code, orderLines.variantCode))
     .innerJoin(products, eq(products.key, variants.productKey))
+    .where(inArray(orders.statusName, [...openStatuses]))
     // Sekundárne triedenie podľa najnovšej objednávky ako prvej v rámci
     // dodávateľa — rovnaký zámer ako katalógov `desc(fetchedAt), desc(id)`
     // tie-break, len tu na `placedAt`/`lineId`, aby poradie bolo stabilné aj

--- a/apps/api/tests/helpers/db.ts
+++ b/apps/api/tests/helpers/db.ts
@@ -1,6 +1,8 @@
 import { sql } from "drizzle-orm";
 import pg from "pg";
 import { createDb, type Database } from "../../src/db/client.js";
+import { orderOpenStatuses } from "../../src/db/schema.js";
+import { DEFAULT_ORDER_OPEN_STATUS } from "../../src/modules/orders/open-statuses.js";
 
 /**
  * Distinct advisory-lock key for serializing `withCleanDb()` across
@@ -41,9 +43,19 @@ export async function withCleanDb(): Promise<{ db: Database; close: () => Promis
     // the supplier NAME string, no FK at all. "pairing" (#44) DOES have an FK
     // into "variant" so `TRUNCATE variant CASCADE` already reaches it — listed
     // explicitly anyway for the same self-documenting reason "order_line" is.
+    // "order_open_status" (issue 59) is the SAME situation again — no FK in
+    // either direction (keyed on a free-text status name) — CASCADE never
+    // reaches it.
     await db.execute(
-      sql`TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier RESTART IDENTITY CASCADE`,
+      sql`TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status RESTART IDENTITY CASCADE`,
     );
+    // issue 59: `order_open_status` is a NEW table with real production
+    // content (the migration seeds it) — TRUNCATE alone would leave every
+    // test starting from an EMPTY set, silently blanking `listOpenOrderLinesBySupplier`
+    // for every test that relies on the default open behavior (nearly all of
+    // them). Re-seed the same default the migration writes on a fresh
+    // install, so each test starts from the identical "just migrated" state.
+    await db.insert(orderOpenStatuses).values({ statusName: DEFAULT_ORDER_OPEN_STATUS });
   } catch (err) {
     try {
       await pool.end();

--- a/apps/api/tests/orders-ingest-lock.integration.test.ts
+++ b/apps/api/tests/orders-ingest-lock.integration.test.ts
@@ -15,7 +15,7 @@ const WINDOW_START = new Date("2020-01-01T00:00:00Z");
 const WINDOW_END = new Date("2030-01-01T00:00:00Z");
 const NOW = new Date("2026-07-30T10:00:00Z");
 
-const HEADER = ["code", "date", "billFullName", "itemName", "itemAmount", "itemCode"] as const;
+const HEADER = ["code", "date", "statusName", "billFullName", "itemName", "itemAmount", "itemCode"] as const;
 
 function buildCsv(rows: readonly Record<string, string>[]): Buffer {
   const esc = (v: string): string => `"${v.replaceAll('"', '""')}"`;

--- a/apps/api/tests/orders-ingest.integration.test.ts
+++ b/apps/api/tests/orders-ingest.integration.test.ts
@@ -40,6 +40,15 @@ function fetcherOf(body: Buffer): OrdersExportFetcher {
   return () => Promise.resolve({ body, sourceLabel: "fixtúra" });
 }
 
+// POZOR (issue 59): vrátený Buffer je UTF-8, ale `ingestOrders` VŽDY dekóduje
+// vstup ako windows-1250 (`decodeCp1250`, rovnaký zámer ako skutočný
+// Shoptet export) — akýkoľvek non-ASCII znak (diakritika) v `rows` tu preto
+// vyjde na druhej strane pokazený (mojibake), lebo dva rôzne bajty UTF-8
+// znaku sa dekódujú AKO DVA samostatné cp1250 znaky. Testy nad touto
+// funkciou preto musia byť ASCII-only (rovnaký dôvod, prečo existujúce
+// testy nikdy nepoužili diakritiku priamo tu) — skutočná diakritika sa
+// testuje cez commitnutú fixtúru (`fixtures/orders-sample.csv`), ktorá JE
+// natívne cp1250 na disku.
 function buildCsv(header: readonly string[], rows: readonly Record<string, string>[]): Buffer {
   const esc = (v: string): string => `"${v.replaceAll('"', '""')}"`;
   const lines = [header.map(esc).join(";") + ";"];
@@ -49,7 +58,7 @@ function buildCsv(header: readonly string[], rows: readonly Record<string, strin
   return Buffer.from(lines.join("\r\n") + "\r\n", "utf-8");
 }
 
-const HEADER = ["code", "date", "billFullName", "deliveryFullName", "itemName", "itemAmount", "itemCode"] as const;
+const HEADER = ["code", "date", "statusName", "billFullName", "deliveryFullName", "itemName", "itemAmount", "itemCode"] as const;
 
 it("prijme fixtúru: reálne položky zapíše, duplicitný riadok sčíta, pseudo-položky aj neznámy variant preskočí", async () => {
   const { db, dir } = await boot();
@@ -84,8 +93,35 @@ it("prijme fixtúru: reálne položky zapíše, duplicitný riadok sčíta, pseu
 
   const order1 = await db.select().from(orders).where(eq(orders.externalOrderId, "20300001"));
   expect(order1[0]?.customerName).toBe("Ján Novák");
+  // issue 59: fixtúra nesie order 20300001 v stave "Vybavuje sa" (otvorená),
+  // 20300002 v stave "Vybavená" (uzavretá) — presne to appka teraz ukladá.
+  expect(order1[0]?.statusName).toBe("Vybavuje sa");
   const order2 = await db.select().from(orders).where(eq(orders.externalOrderId, "20300002"));
   expect(order2[0]?.customerName).toBe("Eva Malá"); // fallback na deliveryFullName
+  expect(order2[0]?.statusName).toBe("Vybavená");
+});
+
+// issue 59: `status_name` je VŽDY Shoptetovo pole (na rozdiel od `comment`/
+// `order_line.state` v teste vyššie) — re-import ho MUSÍ osviežiť, inak by
+// objednávka prejdená v Shoptete z "Vybavuje sa" na "Vybavená" navždy
+// zostala v appke ako otvorená.
+it("objednávka nesie stav zo Shoptetu a re-import ho osvieži, keď sa v Shoptete zmení", async () => {
+  const { db, dir } = await boot();
+  await insertTestVariant(db, "40237/XL");
+
+  const otvorena = buildCsv(HEADER, [
+    { code: "9101", date: "2026-07-01 10:00:00", statusName: "Vybavuje sa", billFullName: "X", itemName: "Y", itemAmount: "1", itemCode: "40237/XL" },
+  ]);
+  await ingestOrders(db, { fetchExport: fetcherOf(otvorena), now: NOW, rawDir: dir, windowStart: WINDOW_START, windowEnd: WINDOW_END });
+  const [prvyRead] = await db.select().from(orders).where(eq(orders.externalOrderId, "9101"));
+  expect(prvyRead?.statusName).toBe("Vybavuje sa");
+
+  const uzavreta = buildCsv(HEADER, [
+    { code: "9101", date: "2026-07-01 10:00:00", statusName: "Vybavena", billFullName: "X", itemName: "Y", itemAmount: "1", itemCode: "40237/XL" },
+  ]);
+  await ingestOrders(db, { fetchExport: fetcherOf(uzavreta), now: NOW, rawDir: dir, windowStart: WINDOW_START, windowEnd: WINDOW_END });
+  const [druhyRead] = await db.select().from(orders).where(eq(orders.externalOrderId, "9101"));
+  expect(druhyRead?.statusName).toBe("Vybavena");
 });
 
 it("re-import tej istej fixtúry je idempotentný — žiadne duplicitné riadky, množstvo ostáva rovnaké", async () => {

--- a/apps/api/tests/orders-open-statuses.integration.test.ts
+++ b/apps/api/tests/orders-open-statuses.integration.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, expect, it } from "vitest";
+import { auditEvents, orderLines, orderOpenStatuses, orders, users } from "../src/db/schema.js";
+import { listOpenOrderLinesBySupplier } from "../src/modules/orders/queries.js";
+import { insertTestVariant } from "./helpers/orders.js";
+import { withCleanDb } from "./helpers/db.js";
+import {
+  listKnownStatusNames,
+  listOpenStatusNames,
+  replaceOpenStatusNames,
+} from "../src/modules/orders/open-statuses.js";
+
+// `auditEvents.actorUserId` má FK na `users.id` (`record`, `modules/audit/
+// service.ts`) — testy, ktoré skutočne PÍŠU audit záznam, potrebujú REÁLNy
+// riadok v `users`, rovnaký vzor ako `orders-state-lock.integration.test.ts`
+// ("x" ako heslo, nikdy sa v tomto teste neoveruje).
+async function insertTestUser(db: Awaited<ReturnType<typeof withCleanDb>>["db"]): Promise<string> {
+  const [pouzivatel] = await db
+    .insert(users)
+    .values({ email: "aktor@forestshop.sk", passwordHash: "x", displayName: "Aktor", role: "manazer" })
+    .returning({ id: users.id });
+  if (pouzivatel === undefined) throw new Error("insert používateľa zlyhal");
+  return pouzivatel.id;
+}
+
+let close: (() => Promise<void>) | undefined;
+
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+});
+
+// issue 59: `listOpenOrderLinesBySupplier` musí ukázať LEN objednávky, ktorých
+// `order.status_name` je v nastavenom otvorenom zozname — objednávka so
+// stavom mimo neho ("Vybavená") sa v "Na objednanie" nesmie objaviť vôbec,
+// bez ohľadu na to, v akom stave je jej `order_line.state` (ten je appkou/
+// manažérom riadený nezávisle, viď `queries.ts`'s komentár).
+it("zoznam 'Na objednanie' ukáže len objednávky s nastaveným otvoreným stavom, uzavretá objednávka zmizne", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const db = ctx.db;
+
+  await insertTestVariant(db, "A-1", "Dodávateľ Alfa");
+
+  const [otvorena] = await db
+    .insert(orders)
+    .values({
+      externalOrderId: "8001",
+      customerName: "Zákazník otvorenej",
+      statusName: "Vybavuje sa",
+      placedAt: new Date("2026-07-01T00:00:00Z"),
+    })
+    .returning();
+  if (otvorena === undefined) throw new Error("insert zlyhal");
+  await db.insert(orderLines).values({ orderId: otvorena.id, variantCode: "A-1", quantity: 1 });
+
+  const [uzavreta] = await db
+    .insert(orders)
+    .values({
+      externalOrderId: "8002",
+      customerName: "Zákazník uzavretej",
+      statusName: "Vybavená",
+      placedAt: new Date("2026-07-02T00:00:00Z"),
+    })
+    .returning();
+  if (uzavreta === undefined) throw new Error("insert zlyhal");
+  await db.insert(orderLines).values({ orderId: uzavreta.id, variantCode: "A-1", quantity: 1 });
+
+  const suppliers = await listOpenOrderLinesBySupplier(db);
+  const alfa = suppliers.find((s) => s.supplier === "Dodávateľ Alfa");
+  expect(alfa?.lines.map((l) => l.externalOrderId)).toEqual(["8001"]);
+});
+
+it("bez nastaveného otvoreného stavu (prázdny order_open_status) sa vráti prázdny zoznam, nikdy nepadne", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const db = ctx.db;
+
+  await insertTestVariant(db, "A-1", "Dodávateľ Alfa");
+  const [objednavka] = await db
+    .insert(orders)
+    .values({ externalOrderId: "8003", customerName: "Zákazník", placedAt: new Date("2026-07-03T00:00:00Z") })
+    .returning();
+  if (objednavka === undefined) throw new Error("insert zlyhal");
+  await db.insert(orderLines).values({ orderId: objednavka.id, variantCode: "A-1", quantity: 1 });
+
+  await db.delete(orderOpenStatuses);
+
+  const suppliers = await listOpenOrderLinesBySupplier(db);
+  expect(suppliers).toEqual([]);
+});
+
+it("replaceOpenStatusNames vyčistí vstup (orez, NFC, duplicity, prázdne) a zapíše audit", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const db = ctx.db;
+  const aktorId = await insertTestUser(db);
+
+  const vysledok = await replaceOpenStatusNames(db, {
+    statuses: ["  Vybavuje sa  ", "Vybavuje sa", "", "   ", "Osob. odber"],
+    actorUserId: aktorId,
+    now: new Date("2026-07-30T12:00:00Z"),
+  });
+  expect(vysledok).toEqual({ status: "ok", statuses: ["Vybavuje sa", "Osob. odber"] });
+
+  expect(await listOpenStatusNames(db)).toEqual(["Osob. odber", "Vybavuje sa"]); // abecedne
+
+  const udalosti = await db.select().from(auditEvents);
+  const udalost = udalosti.find((e) => e.action === "order_open_status.changed");
+  expect(udalost).toBeDefined();
+  expect(udalost?.actorUserId).toBe(aktorId);
+  expect(udalost?.data).toMatchObject({ statuses: ["Vybavuje sa", "Osob. odber"] });
+});
+
+it("replaceOpenStatusNames odmietne zoznam, ktorý je po vyčistení prázdny — nesmie natrvalo vyprázdniť 'Na objednanie'", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const db = ctx.db;
+  const aktorId = await insertTestUser(db);
+
+  const povodne = await listOpenStatusNames(db);
+  const vysledok = await replaceOpenStatusNames(db, {
+    statuses: ["   ", ""],
+    actorUserId: aktorId,
+    now: new Date("2026-07-30T12:00:00Z"),
+  });
+  expect(vysledok).toEqual({ status: "empty" });
+  expect(await listOpenStatusNames(db)).toEqual(povodne); // nezmenené
+});
+
+it("listKnownStatusNames vráti distinct statusName reálne videné v objednávkach, bez prázdnych", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const db = ctx.db;
+
+  await insertTestVariant(db, "A-1", "Dodávateľ Alfa");
+  await db.insert(orders).values([
+    { externalOrderId: "8101", customerName: "X", statusName: "Vybavuje sa", placedAt: new Date("2026-07-01T00:00:00Z") },
+    { externalOrderId: "8102", customerName: "Y", statusName: "Vybavená", placedAt: new Date("2026-07-02T00:00:00Z") },
+    { externalOrderId: "8103", customerName: "Z", statusName: "Vybavuje sa", placedAt: new Date("2026-07-03T00:00:00Z") },
+  ]);
+
+  expect(await listKnownStatusNames(db)).toEqual(["Vybavená", "Vybavuje sa"]);
+});

--- a/apps/web/src/components/OrderOpenStatusesPanel.test.tsx
+++ b/apps/web/src/components/OrderOpenStatusesPanel.test.tsx
@@ -1,0 +1,127 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { OrderOpenStatusesPanel } from "./OrderOpenStatusesPanel.js";
+
+const { fetchOpenStatusesConfig, saveOpenStatuses } = vi.hoisted(() => ({
+  fetchOpenStatusesConfig: vi.fn(),
+  saveOpenStatuses: vi.fn(),
+}));
+
+// `OrdersUnauthorizedError` ostáva SKUTOČNÁ trieda z reálneho modulu — rovnaký
+// dôvod ako `OrdersSection.test.tsx`: `instanceof` v komponente musí fungovať
+// aj v teste.
+vi.mock("../ordersApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../ordersApi.js")>();
+  return { ...actual, fetchOpenStatusesConfig, saveOpenStatuses };
+});
+
+const { OrdersUnauthorizedError } = await import("../ordersApi.js");
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+it("panel je predvolene zatvorený a nenačíta nastavenie, kým ho manažér neotvorí", () => {
+  render(<OrderOpenStatusesPanel onSessionExpired={() => {}} onSaved={() => {}} />);
+  expect(screen.queryByTestId("order-open-statuses-textarea")).toBeNull();
+  expect(fetchOpenStatusesConfig).not.toHaveBeenCalled();
+});
+
+it("po otvorení načíta nastavené aj videné stavy a zobrazí ich", async () => {
+  fetchOpenStatusesConfig.mockResolvedValue({
+    statuses: ["Vybavuje sa", "Osob. odber"],
+    knownStatuses: ["Vybavená", "Vybavuje sa", "Osob. odber"],
+  });
+
+  render(<OrderOpenStatusesPanel onSessionExpired={() => {}} onSaved={() => {}} />);
+  fireEvent.click(screen.getByRole("button", { name: "⚙️ Nastavenie stavov objednávok" }));
+
+  const textarea = await screen.findByTestId<HTMLTextAreaElement>("order-open-statuses-textarea");
+  expect(textarea.value).toBe("Vybavuje sa\nOsob. odber");
+  expect(screen.getByTestId("order-open-statuses-known").textContent).toContain("Vybavená · Vybavuje sa · Osob. odber");
+});
+
+it("uloženie pošle vyčistený (orezaný, bez prázdnych) zoznam a zobrazí očistenú odpoveď servera", async () => {
+  fetchOpenStatusesConfig.mockResolvedValue({ statuses: ["Vybavuje sa"], knownStatuses: [] });
+  saveOpenStatuses.mockResolvedValue(["Vybavuje sa", "Osob. odber"]);
+  const onSaved = vi.fn();
+
+  render(<OrderOpenStatusesPanel onSessionExpired={() => {}} onSaved={onSaved} />);
+  fireEvent.click(screen.getByRole("button", { name: "⚙️ Nastavenie stavov objednávok" }));
+  const textarea = await screen.findByTestId<HTMLTextAreaElement>("order-open-statuses-textarea");
+
+  fireEvent.change(textarea, { target: { value: "Vybavuje sa\n  \nOsob. odber\n" } });
+  fireEvent.click(screen.getByRole("button", { name: "💾 Uložiť" }));
+
+  await waitFor(() => {
+    expect(saveOpenStatuses).toHaveBeenCalledWith(["Vybavuje sa", "Osob. odber"]);
+  });
+  await waitFor(() => {
+    expect(textarea.value).toBe("Vybavuje sa\nOsob. odber");
+  });
+  expect(onSaved).toHaveBeenCalledTimes(1);
+  expect(screen.getByRole("status").textContent).toContain("Uložené");
+});
+
+it("zlyhané uloženie (napr. prázdny zoznam) zobrazí slovenskú hlášku zo servera", async () => {
+  fetchOpenStatusesConfig.mockResolvedValue({ statuses: ["Vybavuje sa"], knownStatuses: [] });
+  saveOpenStatuses.mockRejectedValue(new Error("Zoznam stavov nesmie ostať prázdny — musí obsahovať aspoň jeden stav."));
+  const onSaved = vi.fn();
+
+  render(<OrderOpenStatusesPanel onSessionExpired={() => {}} onSaved={onSaved} />);
+  fireEvent.click(screen.getByRole("button", { name: "⚙️ Nastavenie stavov objednávok" }));
+  const textarea = await screen.findByTestId("order-open-statuses-textarea");
+  fireEvent.change(textarea, { target: { value: "" } });
+  fireEvent.click(screen.getByRole("button", { name: "💾 Uložiť" }));
+
+  await waitFor(() => {
+    expect(screen.getByRole("alert").textContent).toBe("Zoznam stavov nesmie ostať prázdny — musí obsahovať aspoň jeden stav.");
+  });
+  expect(onSaved).not.toHaveBeenCalled();
+  // Regresia: textarea/uložiť tlačidlo MUSIA ostať viditeľné aj po zlyhanom
+  // uložení, aby sa dalo skúsiť znova — pôvodná (chybná) podmienka ich
+  // skrývala pri akomkoľvek `error`, nielen pri zlyhanom NAČÍTANÍ.
+  expect(screen.getByTestId("order-open-statuses-textarea")).toBeTruthy();
+  expect(screen.getByRole("button", { name: "💾 Uložiť" })).toBeTruthy();
+});
+
+it("keď načítanie zlyhá inou chybou, zobrazí hlášku a NEukáže prázdnu textarea (nemá čo editovať)", async () => {
+  fetchOpenStatusesConfig.mockRejectedValue(new Error("network"));
+
+  render(<OrderOpenStatusesPanel onSessionExpired={() => {}} onSaved={() => {}} />);
+  fireEvent.click(screen.getByRole("button", { name: "⚙️ Nastavenie stavov objednávok" }));
+
+  await waitFor(() => {
+    expect(screen.getByRole("alert").textContent).toBe("Nastavenie otvorených stavov sa nepodarilo načítať.");
+  });
+  expect(screen.queryByTestId("order-open-statuses-textarea")).toBeNull();
+});
+
+it("pri 401 pri načítaní zavolá onSessionExpired namiesto zobrazenia chyby", async () => {
+  fetchOpenStatusesConfig.mockRejectedValue(new OrdersUnauthorizedError());
+  const onSessionExpired = vi.fn();
+
+  render(<OrderOpenStatusesPanel onSessionExpired={onSessionExpired} onSaved={() => {}} />);
+  fireEvent.click(screen.getByRole("button", { name: "⚙️ Nastavenie stavov objednávok" }));
+
+  await waitFor(() => {
+    expect(onSessionExpired).toHaveBeenCalledTimes(1);
+  });
+  expect(screen.queryByRole("alert")).toBeNull();
+});
+
+it("opätovné kliknutie na tlačidlo panel zatvorí bez ďalšieho načítania", async () => {
+  fetchOpenStatusesConfig.mockResolvedValue({ statuses: ["Vybavuje sa"], knownStatuses: [] });
+
+  render(<OrderOpenStatusesPanel onSessionExpired={() => {}} onSaved={() => {}} />);
+  fireEvent.click(screen.getByRole("button", { name: "⚙️ Nastavenie stavov objednávok" }));
+  await screen.findByTestId("order-open-statuses-textarea");
+
+  fireEvent.click(screen.getByRole("button", { name: "⌄ Skryť nastavenie stavov objednávok" }));
+  expect(screen.queryByTestId("order-open-statuses-textarea")).toBeNull();
+
+  fireEvent.click(screen.getByRole("button", { name: "⚙️ Nastavenie stavov objednávok" }));
+  await screen.findByTestId("order-open-statuses-textarea");
+  expect(fetchOpenStatusesConfig).toHaveBeenCalledTimes(1); // druhé otvorenie znova nenačíta
+});

--- a/apps/web/src/components/OrderOpenStatusesPanel.tsx
+++ b/apps/web/src/components/OrderOpenStatusesPanel.tsx
@@ -1,0 +1,145 @@
+import { useCallback, useState, type JSX } from "react";
+import {
+  fetchOpenStatusesConfig,
+  OrdersUnauthorizedError,
+  saveOpenStatuses,
+} from "../ordersApi.js";
+
+// issue 59: nastavenie, ktoré Shoptet stavy sa počítajú ako "objednávka sa
+// ešte vybavuje" (rozhoduje o obsahu zoznamu "Na objednanie"). Vydelené z
+// `OrdersSection.tsx` do vlastného súboru — pridanie panela priamo tam by
+// posunulo súbor cez eslint's `max-lines: 400`, rovnaký dôvod ako existujúci
+// `orders-http`/`orders-http-state` split (`.claude/rules/testing.md`).
+//
+// Jednoduchý panel (textarea, jeden stav na riadok) — zámerne BEZ stará
+// appka's `terminal`/`known_open`/`cancelled` zoznamov ani jej "impact
+// preview" dialógu s počítaním pripomienkových e-mailov: táto appka (zatiaľ)
+// nemá ani "Nedostupné" tab, ani pripomienkové e-maily, takže tie tri ďalšie
+// zoznamy by boli špekulatívna zložitosť navyše (MVP, zavrhnutá alternatíva
+// v návrhovom komentári na #59).
+export function OrderOpenStatusesPanel({
+  onSessionExpired,
+  onSaved,
+}: {
+  readonly onSessionExpired: () => void;
+  // Zavolané PO úspešnom uložení — `OrdersSection.tsx` ním znova načíta
+  // zoznam objednávok, aby sa nová filtrácia prejavila hneď, bez reloadu.
+  readonly onSaved: () => void;
+}): JSX.Element {
+  const [open, setOpen] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  // Rozlišuje "načítanie zlyhalo" (nemá zmysel ukázať textarea/uložiť —
+  // niet čo editovať) od "uloženie zlyhalo" (textarea MUSÍ ostať viditeľná,
+  // aby sa dalo skúsiť znova) — obe cesty zdieľajú `error` nižšie na
+  // zobrazenie hlášky, ale len TÁTO rozhoduje, čo sa vykreslí okolo nej.
+  const [configLoaded, setConfigLoaded] = useState(false);
+  const [error, setError] = useState("");
+  const [draft, setDraft] = useState("");
+  const [knownStatuses, setKnownStatuses] = useState<readonly string[]>([]);
+  const [busy, setBusy] = useState(false);
+  const [saveMessage, setSaveMessage] = useState("");
+
+  const load = useCallback(() => {
+    setError("");
+    fetchOpenStatusesConfig()
+      .then((config) => {
+        setDraft(config.statuses.join("\n"));
+        setKnownStatuses(config.knownStatuses);
+        setConfigLoaded(true);
+        setLoaded(true);
+      })
+      .catch((err: unknown) => {
+        setLoaded(true);
+        if (err instanceof OrdersUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setError("Nastavenie otvorených stavov sa nepodarilo načítať.");
+      });
+  }, [onSessionExpired]);
+
+  const toggleOpen = useCallback(() => {
+    setOpen((current) => {
+      const next = !current;
+      if (next && !loaded) load();
+      return next;
+    });
+  }, [load, loaded]);
+
+  const save = useCallback(() => {
+    setBusy(true);
+    setError("");
+    setSaveMessage("");
+    // Prázdne riadky sa odfiltrujú už tu — server aj tak čistí (orez, NFC,
+    // duplicity), toto len ušetrí zjavne prázdne položky pri odosielaní.
+    const statuses = draft
+      .split("\n")
+      .map((s) => s.trim())
+      .filter((s) => s !== "");
+    saveOpenStatuses(statuses)
+      .then((ulozene) => {
+        setDraft(ulozene.join("\n"));
+        setSaveMessage("Uložené. Zoznam 'Na objednanie' sa práve obnovuje.");
+        onSaved();
+      })
+      .catch((err: unknown) => {
+        if (err instanceof OrdersUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setError(err instanceof Error ? err.message : "Uloženie sa nepodarilo.");
+      })
+      .finally(() => {
+        setBusy(false);
+      });
+  }, [draft, onSaved, onSessionExpired]);
+
+  return (
+    <div className="order-open-statuses" data-testid="order-open-statuses-panel">
+      <button type="button" className="btn sm ghost" onClick={toggleOpen}>
+        {open ? "⌄ Skryť nastavenie stavov objednávok" : "⚙️ Nastavenie stavov objednávok"}
+      </button>
+      {open && (
+        <div className="oos-body">
+          {!loaded && <p>Načítavam nastavenie…</p>}
+          {error !== "" && <p role="alert">{error}</p>}
+          {/* `configLoaded`, NIE `loaded` — `loaded` je pravdivé AJ po
+              ZLYHANOM prvom načítaní (inak by "Načítavam…" zostalo navždy),
+              takže textarea/uložiť tlačidlo sa smú vykresliť LEN vtedy, keď
+              GET skutočne priniesol dáta na editáciu. Zlyhané ULOŽENIE
+              (`error` sa nastaví AŽ PO úspešnom `configLoaded`) naopak
+              textarea nesmie skryť — používateľ musí vedieť skúsiť znova. */}
+          {configLoaded && (
+            <>
+              <p className="oos-help">
+                Do zoznamu "Na objednanie" sa dostanú len objednávky, ktorých stav v Shoptete je niektorý z tohto
+                zoznamu (jeden stav na riadok). Ostatné objednávky zo zoznamu samy zmiznú.
+              </p>
+              <textarea
+                className="oos-textarea"
+                aria-label="Stavy objednávok, ktoré sa počítajú ako otvorené"
+                data-testid="order-open-statuses-textarea"
+                rows={Math.max(3, draft.split("\n").length + 1)}
+                value={draft}
+                disabled={busy}
+                onChange={(e) => {
+                  setDraft(e.target.value);
+                  setSaveMessage("");
+                }}
+              />
+              {knownStatuses.length > 0 && (
+                <p className="oos-known" data-testid="order-open-statuses-known">
+                  Stavy videné v objednávkach: {knownStatuses.join(" · ")}
+                </p>
+              )}
+              <button type="button" className="btn sm good" disabled={busy} onClick={save}>
+                💾 Uložiť
+              </button>
+              {saveMessage !== "" && <p role="status">{saveMessage}</p>}
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/OrdersSection.tsx
+++ b/apps/web/src/components/OrdersSection.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState, type JSX } from "react";
 import type { Me } from "../api.js";
+import { OrderOpenStatusesPanel } from "./OrderOpenStatusesPanel.js";
 import {
   fetchOpenOrders,
   fetchSupplierOrderMailPreview,
@@ -238,6 +239,7 @@ export function OrdersSection({
       {!loaded && <p>Načítavam otvorené objednávky…</p>}
       {error !== "" && <p role="alert">{error}</p>}
       {stateError !== "" && <p role="alert">{stateError}</p>}
+      {canChangeState && <OrderOpenStatusesPanel onSessionExpired={onSessionExpired} onSaved={load} />}
       {loaded && totalLines === 0 && (
         <p className="empty" data-testid="orders-empty">Zatiaľ nie sú žiadne otvorené objednávky.</p>
       )}

--- a/apps/web/src/ordersApi.test.ts
+++ b/apps/web/src/ordersApi.test.ts
@@ -2,7 +2,9 @@ import { expect, it, vi } from "vitest";
 import {
   OrdersUnauthorizedError,
   fetchOpenOrders,
+  fetchOpenStatusesConfig,
   fetchSupplierOrderMailPreview,
+  saveOpenStatuses,
   sendSupplierOrderMail,
   setSupplierEmail,
   triggerOrdersIngest,
@@ -258,4 +260,61 @@ it("triggerOrdersIngest zlyhá zrozumiteľne, keď export nie je nakonfigurovan�
     ),
   );
   await expect(triggerOrdersIngest()).rejects.toThrow("Import objednávok nie je nakonfigurovaný");
+});
+
+// issue 59: nastavenie otvorených stavov objednávok.
+
+it("fetchOpenStatusesConfig prečíta nastavené aj distinct videné stavy", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ statuses: ["Vybavuje sa"], knownStatuses: ["Vybavená", "Vybavuje sa"] }), {
+        status: 200,
+      }),
+    ),
+  );
+  await expect(fetchOpenStatusesConfig()).resolves.toEqual({
+    statuses: ["Vybavuje sa"],
+    knownStatuses: ["Vybavená", "Vybavuje sa"],
+  });
+});
+
+it("fetchOpenStatusesConfig pri 401 vyhodí OrdersUnauthorizedError", async () => {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 401 })));
+  await expect(fetchOpenStatusesConfig()).rejects.toBeInstanceOf(OrdersUnauthorizedError);
+});
+
+it("saveOpenStatuses pošle PUT s telom { statuses } a vráti očistený zoznam zo servera", async () => {
+  const fetchMock = vi.fn().mockResolvedValue(
+    new Response(JSON.stringify({ ok: true, statuses: ["Vybavuje sa", "Osob. odber"] }), { status: 200 }),
+  );
+  vi.stubGlobal("fetch", fetchMock);
+
+  await expect(saveOpenStatuses(["  Vybavuje sa  ", "Osob. odber"])).resolves.toEqual(["Vybavuje sa", "Osob. odber"]);
+
+  expect(fetchMock).toHaveBeenCalledWith(
+    "/api/orders/open-statuses",
+    expect.objectContaining({
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ statuses: ["  Vybavuje sa  ", "Osob. odber"] }),
+    }),
+  );
+});
+
+it("saveOpenStatuses pri prázdnom zozname (400) vráti slovenskú hlášku z tela odpovede", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: "Zoznam stavov nesmie ostať prázdny — musí obsahovať aspoň jeden stav." }), {
+        status: 400,
+      }),
+    ),
+  );
+  await expect(saveOpenStatuses([])).rejects.toThrow("Zoznam stavov nesmie ostať prázdny");
+});
+
+it("saveOpenStatuses pri 401 vyhodí OrdersUnauthorizedError", async () => {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 401 })));
+  await expect(saveOpenStatuses(["Vybavuje sa"])).rejects.toBeInstanceOf(OrdersUnauthorizedError);
 });

--- a/apps/web/src/ordersApi.ts
+++ b/apps/web/src/ordersApi.ts
@@ -102,6 +102,36 @@ export async function triggerOrdersIngest(): Promise<OrdersIngestOutcome> {
   return ordersIngestOutcomeSchema.parse(await readJson(response, "Import objednávok sa nepodarilo spustiť"));
 }
 
+// issue 59: nastavenie, ktoré Shoptet stavy sa počítajú ako "objednávka sa
+// ešte vybavuje" (rozhoduje o obsahu `fetchOpenOrders` vyššie).
+const openStatusesConfigSchema = z.object({
+  statuses: z.array(z.string()),
+  // Distinct hodnoty `status_name`, aké appka skutočne videla v exportoch —
+  // pomôcka pri editácii (over preklep), nikdy sa neposiela naspäť pri uložení.
+  knownStatuses: z.array(z.string()),
+});
+
+export type OpenStatusesConfig = z.infer<typeof openStatusesConfigSchema>;
+
+export async function fetchOpenStatusesConfig(): Promise<OpenStatusesConfig> {
+  const response = await fetch("/api/orders/open-statuses");
+  return openStatusesConfigSchema.parse(await readJson(response, "Nastavenie otvorených stavov sa nepodarilo načítať"));
+}
+
+const saveOpenStatusesResultSchema = z.object({ ok: z.literal(true), statuses: z.array(z.string()) });
+
+export async function saveOpenStatuses(statuses: readonly string[]): Promise<readonly string[]> {
+  const response = await fetch("/api/orders/open-statuses", {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ statuses }),
+  });
+  const telo = saveOpenStatusesResultSchema.parse(
+    await readJson(response, "Nastavenie otvorených stavov sa nepodarilo uložiť"),
+  );
+  return telo.statuses;
+}
+
 export async function fetchOpenOrders(): Promise<readonly SupplierOpenOrders[]> {
   const response = await fetch("/api/orders/open");
   const parsed = openOrdersSchema.parse(

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -670,3 +670,38 @@ tr:last-child td {
   font-size: var(--fs-text-xs);
   color: var(--fs-ink-faint);
 }
+
+/* issue 59: nastavenie otvorených stavov objednávok — rovnaký vizuálny
+   jazyk ako `.autostatus`/`.mail-preview` vyššie (karta na svetlom podklade),
+   vlastný namespace, aby sa nekolidovalo s tabuľkovými triedami. */
+.order-open-statuses {
+  margin-bottom: var(--fs-space-4);
+}
+.oos-body {
+  background: var(--fs-surface);
+  border: 1px solid var(--fs-border);
+  border-radius: var(--fs-radius-md);
+  box-shadow: var(--fs-shadow-sm);
+  padding: var(--fs-space-4);
+  margin-top: var(--fs-space-2);
+  max-width: 32rem;
+}
+.oos-help {
+  font-size: var(--fs-text-sm);
+  color: var(--fs-ink-muted);
+  margin: 0 0 var(--fs-space-2);
+}
+.oos-textarea {
+  width: 100%;
+  font: inherit;
+  font-size: var(--fs-text-sm);
+  padding: var(--fs-space-2);
+  border: 1px solid var(--fs-border);
+  border-radius: var(--fs-radius-sm);
+  resize: vertical;
+}
+.oos-known {
+  font-size: var(--fs-text-xs);
+  color: var(--fs-ink-faint);
+  margin: var(--fs-space-2) 0;
+}

--- a/apps/web/tests/e2e/orders.spec.ts
+++ b/apps/web/tests/e2e/orders.spec.ts
@@ -181,3 +181,55 @@ test("manažér nastaví e-mail dodávateľa a uvidí náhľad mailu so správne
 
   expect(chyby).toEqual([]);
 });
+
+// issue 59: VLASTNÝ izolovaný účet (nie zdieľaný `e2e@forestshop.sk`) —
+// balík je už na hranici `MAX_ATTEMPTS=10` (viď `scripts/e2e-setup.ts`'s
+// komentár k `E2E_NAV_EMAIL`), ďalšie prihlásenie pod zdieľaným účtom by ho
+// prekročilo.
+const E2E_OTVORENE_STAVY_EMAIL = "e2e-otvorene-stavy@forestshop.sk";
+
+// `scripts/e2e-setup.ts` zakladá TRETIU objednávku (9003, zákazník "E2E
+// Zákazník Uzavretá") so stavom "E2E-Uzavreta" — zámerne MIMO predvoleného
+// otvoreného zoznamu ("Vybavuje sa"). Test dokazuje OBE polovice ticketu
+// naraz: (a) uzavretá objednávka sa v "Na objednanie" vôbec neukáže, (b) po
+// pridaní jej stavu cez nastavenie priamo v UI sa objaví bez reloadu —
+// presne "zoznam reaguje na zmenu nastavenia".
+test("uzavretá objednávka sa v 'Na objednanie' neukáže, kým sa jej stav nepridá do nastavenia, konzola je čistá", async ({ page }) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/?tab=orders");
+  await page.getByLabel("E-mail").fill(E2E_OTVORENE_STAVY_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await expect(page.getByRole("heading", { name: "Na objednanie" })).toBeVisible();
+
+  const skupinaBezDodavatela = page.getByTestId("supplier-(bez dodávateľa)");
+  await expect(skupinaBezDodavatela).toBeVisible();
+  await expect(skupinaBezDodavatela).not.toContainText("E2E Zákazník Uzavretá");
+
+  const panel = page.getByTestId("order-open-statuses-panel");
+  await panel.getByRole("button", { name: "⚙️ Nastavenie stavov objednávok" }).click();
+  const textarea = panel.getByTestId("order-open-statuses-textarea");
+  await expect(textarea).toHaveValue("Vybavuje sa");
+
+  // Pridáva sa (nikdy nenahrádza) k existujúcemu zoznamu — 9001/9002 (stav
+  // "Vybavuje sa") musia zostať viditeľné aj po uložení.
+  await textarea.fill("Vybavuje sa\nE2E-Uzavreta");
+  await panel.getByRole("button", { name: "💾 Uložiť" }).click();
+  await expect(panel.getByRole("status")).toContainText("Uložené");
+
+  await expect(skupinaBezDodavatela).toContainText("E2E Zákazník Uzavretá");
+  // Pôvodné objednávky (default stav) ostávajú viditeľné — pridanie stavu do
+  // zoznamu nikdy neodstráni iný, už nastavený stav.
+  await expect(skupinaBezDodavatela).toContainText("E2E Zákazník Bez dodávateľa");
+  const skupinaTest1 = page.getByTestId("supplier-DODAVATEL-TEST-1");
+  await expect(skupinaTest1).toContainText("9001");
+
+  expect(chyby).toEqual([]);
+});

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -740,3 +740,55 @@ nové heslo sa nikde v pushnutom obsahu nenachádza.
   notes truncate with `title` + ellipsis CSS applied. Console: 0
   errors/0 warnings.
 - Per-ticket Discord card fired (`notify --run-card`, confirmed delivered).
+
+## Issue 72 — residual defects after issue 70/PR 71 (2026-07-30)
+
+- Two residual defects, both proven live by executing the shipped code before
+  fixing: 1) `extractSupplierLink`'s trailing-punctuation trimmer stripped
+  ANY trailing closing bracket, even one that is part of the URL itself
+  (`https://shop.example.com/a_(b)` → truncated to `.../a_(b`, dead link).
+  2) `OrdersSection.tsx`'s supplier-link `aria-label` only carried
+  `variantName`, so two order lines of the same product in different sizes
+  had an identical accessible name. Filed as **#72** (`Scope-gate:
+  planned-work`), design comment posted before first code commit.
+- Fix 1: `trimTrailingPunctuation()` replaces the blind regex — non-bracket
+  trailing punctuation still stripped unconditionally, a trailing closing
+  bracket stripped ONLY when unbalanced within the candidate URL (more
+  closers than openers of that type), iterated for mixed suffixes (`(b).`).
+  RED/GREEN: `supplier-link.test.ts` (commit `b6cc565` RED → `290e0d3`
+  GREEN), later extended (code-review 🔵 findings) with a third bracket
+  type (`{}`) and an unclosed-opening-bracket case (commit `fdf7fe2`).
+- Fix 2: `aria-label` now interpolates `variantCode` alongside `variantName`.
+  RED/GREEN: `OrdersSection.test.tsx` (same commits) — existing test's
+  exact-match name updated + a new dedicated two-different-sizes test.
+- Side-effect discovered while driving PR 73's CI green (not part of the
+  original scope, fixed in the same PR since it blocked merge): `orders
+  .spec.ts`'s state-change e2e test asserted `toContainText("Skladom")`,
+  which is tautological — ALL FOUR `STATE_LABELS` are always rendered as
+  `<option>` children of the `<select>` regardless of selection, so the
+  assertion never waited for the state-change PATCH to actually resolve.
+  Under CI's slower runner `page.reload()` occasionally raced ahead of the
+  still-in-flight write (observed once, PR 73's first CI run). Fixed by
+  asserting `toHaveValue("skladom")` directly on the select — this
+  genuinely waits for the local optimistic update, which only fires after
+  the PATCH promise resolves. Commit `8fe21cd`.
+- Commits (5, `dev`): version bump 0.3.0-dev.34, RED test commit, GREEN fix
+  commit, e2e-flake fix commit, code-review-followup test commit. PR **#73**
+  (`dev` → `main`), merged `edb2b8e`. CI all green on the PR (check,
+  integration, e2e 14/14, docker-build, version-check) and on `main`
+  (check, integration, e2e, docker-build). Local: typecheck + lint +
+  unit (257 API + 155 web) + full e2e suite (14/14, 0 console errors)
+  all green before push.
+- Deep code review (`requesting-code-review`) found 0 🔴 0 🟡, 4 🔵 — 3
+  addressed (missing `{}` bracket test, missing unclosed-opening test, a
+  documentation comment on the count-based-not-stack-based balance check
+  limitation), 1 explicitly pre-existing/out-of-scope (an all-punctuation
+  candidate trims to bare `https://` — same failure mode existed before
+  this PR, unrelated to issue 72).
+- Deployed + verified on https://forestshop-novy.newlevel.media
+  (v0.3.0-dev.34, `/api/version` commit + DOM version label both match
+  `edb2b8e` = `origin/main` HEAD). Live-checked "Na objednanie": supplier
+  links render with `aria-label` now carrying `variantCode` (e.g. "Odkaz na
+  dodávateľa — Poľovnícke kraťasy HART GOROSTA-SH (62621/52)"). Console:
+  0 errors/0 warnings.
+- Per-ticket Discord card fired (`notify --run-card`, confirmed delivered).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.34",
+  "version": "0.3.0-dev.35",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -9,10 +9,11 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { createDb } from "../apps/api/src/db/client.js";
-import { orderLines, orders, pairings, users } from "../apps/api/src/db/schema.js";
+import { orderLines, orderOpenStatuses, orders, pairings, users } from "../apps/api/src/db/schema.js";
 import { hashPassword } from "../apps/api/src/modules/auth/passwords.js";
 import { ingestCatalog } from "../apps/api/src/modules/catalog/ingest.js";
 import { DEFAULT_SNAPSHOT_LIMITS } from "../apps/api/src/modules/catalog/validation.js";
+import { DEFAULT_ORDER_OPEN_STATUS } from "../apps/api/src/modules/orders/open-statuses.js";
 
 const E2E_HESLO = "e2e-test-heslo"; // musí sa zhodovať s hodnotou v login.spec.ts/catalog.spec.ts/orders.spec.ts
 
@@ -71,9 +72,16 @@ const { db, pool } = createDb();
 // reťazcom mena dodávateľa, žiadny FK. "pairing" (#44) FK do "variant" má, takže
 // by ho CASCADE strhol aj bez uvedenia — pridané ručne kvôli tej istej
 // sebadokumentujúcej dôslednosti ako "order_line".
+// "order_open_status" (issue 59) je rovnaký prípad ako "supplier_contact"/
+// "supplier" vyššie v komentári tesne pod TRUNCATE — kľúčovaný voľným
+// textom stavu, žiadny FK, CASCADE ho nikdy nestrhne.
 await db.execute(
-  'TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier RESTART IDENTITY CASCADE',
+  'TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status RESTART IDENTITY CASCADE',
 );
+// Rovnaký dôvod ako `tests/helpers/db.ts`: bez tohto by "Na objednanie" bolo
+// v CELOM e2e behu prázdne pre KAŽDÚ objednávku (žiadny nastavený otvorený
+// stav). Reseeduje presne to, čo produkčná migrácia zapíše na čerstvej DB.
+await db.insert(orderOpenStatuses).values({ statusName: DEFAULT_ORDER_OPEN_STATUS });
 await db.insert(users).values({
   email: "e2e@forestshop.sk",
   passwordHash: await hashPassword(E2E_HESLO),
@@ -136,12 +144,17 @@ await db.execute("UPDATE variant SET missing_since = now() WHERE code = '40287'"
 // map-row.test.ts), "40287" ho nemá (`product.supplier` je `null`) —
 // zámerne pokrýva OBE vetvy zoskupenia podľa dodávateľa, vrátane zástupného
 // kľúča "(bez dodávateľa)" (`modules/orders/queries.ts`).
+// issue 59: `statusName` explicitne na predvolený otvorený stav — nie
+// preto, že by inak neplatilo (DB `default` na stĺpci je tá istá hodnota),
+// ale aby to bolo tu VIDIEŤ, prečo tieto objednávky vôbec zostávajú v
+// zozname "Na objednanie" po pridaní filtra podľa stavu.
 const [objednavkaAlfa] = await db
   .insert(orders)
   .values({
     externalOrderId: "9001",
     customerName: "E2E Zákazník Alfa",
     comment: "Zavolať pred doručením",
+    statusName: DEFAULT_ORDER_OPEN_STATUS,
     placedAt: new Date("2026-07-20T10:00:00Z"),
   })
   .returning();
@@ -158,6 +171,7 @@ const [objednavkaBezDodavatela] = await db
   .values({
     externalOrderId: "9002",
     customerName: "E2E Zákazník Bez dodávateľa",
+    statusName: DEFAULT_ORDER_OPEN_STATUS,
     placedAt: new Date("2026-07-21T09:00:00Z"),
   })
   .returning();
@@ -168,6 +182,30 @@ await db.insert(orderLines).values({
   orderId: objednavkaBezDodavatela.id,
   variantCode: "40287",
   quantity: 1,
+});
+
+// issue 59: TRETIA objednávka, zámerne v stave MIMO predvoleného otvoreného
+// zoznamu ("E2E-Uzavreta" — vymyslený, testovo-vyhradený literál, nikdy
+// nekolidujúci so skutočným Shoptet stavom) — `orders.spec.ts` ňou dokazuje,
+// že (a) sa NEUKÁŽE, kým nie je jej stav v nastavenom zozname, a (b) po
+// pridaní stavu cez nastavenie priamo v UI sa objaví, bez reloadu. Pridáva
+// sa (nikdy nenahrádza) do zdieľaného zoznamu — bezpečné voči súbežne
+// bežiacim iným e2e spec súborom presne z rovnakého dôvodu ako
+// `frontend-design.md`'s zdieľaný `e2e@forestshop.sk` účet.
+const [objednavkaUzavreta] = await db
+  .insert(orders)
+  .values({
+    externalOrderId: "9003",
+    customerName: "E2E Zákazník Uzavretá",
+    statusName: "E2E-Uzavreta",
+    placedAt: new Date("2026-07-22T09:00:00Z"),
+  })
+  .returning();
+if (objednavkaUzavreta === undefined) throw new Error("E2E objednávka (uzavretá) sa nepodarila vložiť");
+await db.insert(orderLines).values({
+  orderId: objednavkaUzavreta.id,
+  variantCode: "40287",
+  quantity: 3,
 });
 
 // F4 (#45): jeden UŽ NAVRHNUTÝ (nepotvrdený) pairing kandidát — simuluje to,

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -54,6 +54,12 @@ const E2E_SKUPINY_EMAIL = "e2e-skupiny@forestshop.sk"; // musí sa zhodovať s h
 // e-mail), nie flaka. Vlastný e-mail = vlastný rate-limit priestor.
 const E2E_NAV_EMAIL = "e2e-nav@forestshop.sk"; // musí sa zhodovať s hodnotou v nav.spec.ts
 
+// issue 59: rovnaký mechanizmus a dôvod ako `E2E_NAV_EMAIL`/`E2E_SKUPINY_EMAIL`
+// vyššie — balík je UŽ na hranici `MAX_ATTEMPTS` (komentár vyššie), takže
+// nový test (nastavenie otvorených stavov) dostáva VLASTNÝ izolovaný účet
+// namiesto ďalšieho prihlásenia pod zdieľaným `e2e@forestshop.sk`.
+const E2E_OTVORENE_STAVY_EMAIL = "e2e-otvorene-stavy@forestshop.sk"; // musí sa zhodovať s hodnotou v orders.spec.ts
+
 const { db, pool } = createDb();
 // Konštantný literál bez interpolácie — obyčajný reťazec je tu rovnako bezpečný
 // ako `sql` tagovaná šablóna (tú používa ekvivalentný apps/api/tests/helpers/db.ts),
@@ -105,6 +111,12 @@ await db.insert(users).values({
 });
 await db.insert(users).values({
   email: E2E_NAV_EMAIL,
+  passwordHash: await hashPassword(E2E_HESLO),
+  displayName: "E2E Manažér",
+  role: "manazer",
+});
+await db.insert(users).values({
+  email: E2E_OTVORENE_STAVY_EMAIL,
   passwordHash: await hashPassword(E2E_HESLO),
   displayName: "E2E Manažér",
   role: "manazer",
@@ -206,6 +218,16 @@ await db.insert(orderLines).values({
   orderId: objednavkaUzavreta.id,
   variantCode: "40287",
   quantity: 3,
+  // `state: "skladom"` (NIE predvolené "objednane") — `mail.ts`'s
+  // `loadOutstandingLines` agreguje LEN riadky v stave "objednane" naprieč
+  // VŠETKÝMI objednávkami toho istého dodávateľa, bez ohľadu na
+  // `order.status_name` (mail agregácia a Shoptet-ov stav objednávky sú
+  // zámerne nezávislé, viď `.claude/rules/orders.md`). Default "objednane"
+  // by preto TÚTO objednávku prisčítal do "(bez dodávateľa)" mailového
+  // náhľadu (1 ks → 4 ks) a rozbil `orders.spec.ts`'s existujúci mailový
+  // test, hoci s "Na objednanie" zoznamom (predmet TOHTO ticketu) to
+  // nemá nič spoločné.
+  state: "skladom",
 });
 
 // F4 (#45): jeden UŽ NAVRHNUTÝ (nepotvrdený) pairing kandidát — simuluje to,


### PR DESCRIPTION
## Súhrn

Issue 59: záložka "Na objednanie" doteraz zobrazovala ÚPLNE VŠETKY
naimportované objednávky bez ohľadu na to, či sú v Shoptete už dávno
vybavené/odoslané — appka si stav objednávky zo Shoptetu vôbec neukladala.

- Pri sťahovaní objednávok sa teraz ukladá aj Shoptet-ov stav objednávky
  (`order.status_name`), refreshovaný pri každom re-importe.
- Nová tabuľka `order_open_status` (jednoduchý zoznam stavov, ktoré sa
  počítajú ako "objednávka sa ešte vybavuje"), seedovaná defaultom
  "Vybavuje sa" — presne to, čo stará appka predvolene používala, takže sa
  po nasadení nič ticho nezmení, kým to správca sám neupraví.
- `GET/PUT /api/orders/open-statuses` (čítanie = ktokoľvek prihlásený,
  zápis = admin/manazer, rovnaká brána ako zmena stavu riadku) + jednoduchý
  panel priamo na obrazovke "Na objednanie" (textarea, jeden stav na
  riadok, plus zoznam stavov reálne videných v objednávkach ako pomôcka
  proti preklepu). **Nová obrazovka NEPRIDÁVA položku menu** — issue 57
  zamyká ľavý sidebar na presne dve položky, panel žije priamo v "Na
  objednanie".
- Zavrhnutá alternatíva (celý návrhový komentár na #59): kopírovať starú
  appku's 4-zoznamový model (`to_order`/`terminal`/`known_open`/
  `cancelled` + "impact preview" počítajúci pripomienkové e-maily) —
  zamietnuté, tie tri ďalšie zoznamy existujú len kvôli funkciám, ktoré
  táto appka (zatiaľ) nemá vôbec.

## Testy

- RED→GREEN regresný pár (`54252fd`/`24fa075`): nový integračný test
  dokázal defekt (uzavretá objednávka zostáva viditeľná) proti pôvodnému
  nefiltrovanému dopytu, potom filter test zazelenal.
- Jednotkové testy: `parser.ts` (normalizácia stavu, REQUIRED_ORDER_COLUMNS),
  `open-statuses.ts` cez integračné testy (čistenie vstupu, audit, prázdny
  zoznam sa odmietne), `ordersApi.ts`, `OrderOpenStatusesPanel.tsx`.
- Nový e2e test (`orders.spec.ts`) cez skutočný prehliadač: tretia seedovaná
  objednávka (stav mimo predvoleného zoznamu) sa neukáže, po pridaní jej
  stavu cez UI sa objaví bez reloadu — 0 console chýb/varovaní.
- Popri tom opravený routovací bug (GET/PUT `/api/orders/open-statuses`
  registrované AŽ PO parametrizovanej `/api/orders/:id` — Hono si "open-
  statuses" zobralo ako `:id` a padalo na neplatnom UUID skôr, než sa
  dostalo k správnej trase) a komponentový bug (textarea sa vykresľovala
  prázdna aj pri zlyhanom načítaní) — oba zistené priamo pri lokálnom e2e
  behu, opravené a pokryté regresnými testami/asserciami.

Design komentár s príčinou/zvoleným prístupom/zavrhnutou alternatívou:
https://github.com/zbynekdrlik/forestshop-app/issues/59#issuecomment-5133725274
