### PR TITLE
Na objednanie: odškrtnutie objednaného a hromadné označenie skupiny dodávateľa (issue 60)

### DIFF
--- a/.claude/rules/http-routes.md
+++ b/.claude/rules/http-routes.md
@@ -1,0 +1,25 @@
+---
+paths:
+  - "apps/api/src/http/**"
+---
+
+# HTTP routes (Hono)
+
+- **A literal-path route under a prefix that already has a parameterized
+  sibling (`/:id`) MUST be registered BEFORE that parameterized route.**
+  Hono matches routes in REGISTRATION ORDER, not by specificity — `app.get("/api/orders/:id", ...)`
+  registered before `app.get("/api/orders/open-statuses", ...)` means a
+  request for `/api/orders/open-statuses` matches `:id = "open-statuses"`
+  FIRST, fails the param's `z.string().uuid()` validation, and never
+  reaches the intended handler at all (found live, issue 59 — the response
+  was a confusing `ZodError` on `path: ["id"]`, nothing about the actual
+  route). Fix: put every literal-path sibling ABOVE the `:param` route in
+  the same file (`orders-routes.ts` now has both `GET`/`PUT
+  /api/orders/open-statuses` registered before `GET /api/orders/:id`).
+  **No unit or integration test caught this** — those call the module
+  function directly or hit the route with a valid UUID, never through the
+  full route table with a non-UUID literal segment. The ONLY thing that
+  surfaced it was the local e2e run against the real dev server. When
+  adding a new literal-path route under an existing `:id`/`:param` prefix
+  in ANY `http/*-routes.ts` file, check the registration order before
+  assuming "the route exists" means "the route is reachable".

--- a/.claude/rules/orders.md
+++ b/.claude/rules/orders.md
@@ -146,3 +146,26 @@ paths:
   `transport.ts`) — vedomé rozhodnutie mimo rozsahu #38, nie prehliadnutá
   medzera; ak niekedy pribudne, ide do `env.ts` vedľa `MAIL_FROM` a
   `createSmtpMailTransport`'s recipient zoznamu.
+- **Objednávka nesie Shoptet-ov `status_name` (issue 59)** — order-level
+  pole ako `customerName`/`placedAt` (opakuje sa na KAŽDOM riadku tej istej
+  objednávky, importer berie prvý výskyt), normalizované `normalizeStatusName`
+  (NFC + orez, `parser.ts`) rovnakým vzorom ako stará appka's `norm_status` —
+  MUSÍ byť rovnaká normalizácia na oboch stranách porovnania (export vs.
+  `order_open_status`), inak sa zhoda nikdy nenájde. Na rozdiel od
+  `comment`/`order_line.state` (appkou/manažérom vlastnené, re-import ich
+  NEPREPÍŠE) je `status_name` VŽDY Shoptetovo pole — re-import ho vždy
+  OSVIEŽI. `order_open_status` (nastaviteľný zoznam "ešte sa vybavuje",
+  `modules/orders/open-statuses.ts`) rozhoduje, čo ukáže "Na objednanie"
+  (`queries.ts`'s `listOpenOrderLinesBySupplier`) — zámerne LEN tento jeden
+  zoznam, nie stará appka's `to_order`/`terminal`/`known_open`/`cancelled`
+  štvorica (tie tri navyše existujú len kvôli "Nedostupné" tabu a
+  pripomienkovým e-mailom, ktoré táto appka nemá).
+- **`orders-ingest.integration.test.ts`'s `buildCsv` vracia UTF-8 Buffer, ale
+  `ingestOrders` VŽDY dekóduje ako windows-1250** (`decodeCp1250`, rovnaký
+  zámer ako skutočný Shoptet export) — akýkoľvek non-ASCII znak (diakritika)
+  priamo v `buildCsv`-vytváraných riadkoch preto vyjde na druhej strane
+  pokazený (mojibake, napr. "Vybavená" → "VybavenĂˇ"), lebo dva bajty UTF-8
+  znaku sa dekódujú ako DVA samostatné cp1250 znaky. Testy nad `buildCsv`
+  preto zostávajú ASCII-only — skutočná diakritika sa testuje cez
+  commitnutú fixtúru (`fixtures/orders-sample.csv`), ktorá JE natívne cp1250
+  na disku.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -109,6 +109,20 @@ paths:
   SQL kľúčové slovo, v raw SQL literáli (`sql\`TRUNCATE TABLE ...\``) MUSÍ byť
   ručne uvodzovkované (`"order"`) — drizzle-ove query buildre to robia
   automaticky, priamy SQL string nie.
+- **Nová "koreňová" tabuľka, ktorá NESIE reálny produkčný obsah (napr.
+  seedovaný migráciou, nie len prázdna štruktúra) potrebuje po TRUNCATE aj
+  RESEED, nielen pridanie do zoznamu.** `order_open_status` (issue 59) je
+  ten istý prípad ako `supplier_contact`/`supplier` vyššie (žiadny FK v
+  žiadnom smere), ALE navyše migrácia doň seeduje default riadok
+  ("Vybavuje sa") — bez re-insertu HNEĎ po TRUNCATE by KAŽDÝ test začínal s
+  PRÁZDNYM zoznamom, čo ticho vyprázdni "Na objednanie" pre úplne každý
+  test, čo naň spolieha (skoro všetky). Vzor: exportovaná konštanta
+  (`DEFAULT_ORDER_OPEN_STATUS` v `modules/orders/open-statuses.ts`) namiesto
+  reťazcového literálu na dvoch miestach (`tests/helpers/db.ts` +
+  `scripts/e2e-setup.ts`), aby default nikdy nerozišiel medzi migráciou a
+  testovými pomôckami. Test na KAŽDÚ ďalšiu takúto tabuľku: nesie
+  seedovaný/predvolený obsah, na ktorý sa iné testy SPOLIEHAJÚ? Ak áno,
+  po TRUNCATE treba reseed, nielen pridanie do zoznamu.
 - **Standalone skript v `scripts/*.ts` (mimo TS projektu `apps/api`) hlási
   falošné `@typescript-eslint/no-unsafe-*` na AKÝKOĽVEK priamy import z
   `"drizzle-orm"`** — nielen na tagovanú šablónu `sql` (ako pôvodne

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,3 +37,4 @@ Per-area rules live in `.claude/rules/<area>.md` with `paths:` frontmatter.
 - kontrola párovania (F4 — LEFT JOIN dizajn, confirmPairing, e2e label kolízie) → `.claude/rules/pairing.md`
 - citlivé hodnoty (heslá/tokeny/hash= sa nikdy nepíšu do repa) → `.claude/rules/sensitive-values.md`
 - frontend dizajn (vizuálne tokeny, nav registry, user-menu, e2e login rate-limit) → `.claude/rules/frontend-design.md`
+- HTTP trasy (Hono, poradie registrácie literal-vs-`:param`) → `.claude/rules/http-routes.md`

--- a/apps/api/drizzle/0013_worthless_thunderbird.sql
+++ b/apps/api/drizzle/0013_worthless_thunderbird.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "order_line" ADD COLUMN "ordered" boolean DEFAULT false NOT NULL;

--- a/apps/api/drizzle/meta/0013_snapshot.json
+++ b/apps/api/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,1421 @@
+{
+  "id": "d57158d9-bace-4426-abad-6cc34f4eb701",
+  "prevId": "e9b5d52d-7915-4c13-bb7a-ae5e9fb8b069",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_code": {
+          "name": "external_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_open_status": {
+      "name": "order_open_status",
+      "schema": "",
+      "columns": {
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Vybavuje sa'"
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing": {
+      "name": "pairing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_url": {
+          "name": "supplier_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "pairing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'navrhnute'"
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pairing_state_idx": {
+          "name": "pairing_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_confirmed_by_idx": {
+          "name": "pairing_confirmed_by_idx",
+          "columns": [
+            {
+              "expression": "confirmed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_variant_code_variant_code_fk": {
+          "name": "pairing_variant_code_variant_code_fk",
+          "tableFrom": "pairing",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pairing_confirmed_by_users_id_fk": {
+          "name": "pairing_confirmed_by_users_id_fk",
+          "tableFrom": "pairing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pairing_variant_code_unique": {
+          "name": "pairing_variant_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pairing_confirmation_ck": {
+          "name": "pairing_confirmation_ck",
+          "value": "(\"pairing\".\"state\" = 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)\n        OR (\"pairing\".\"state\" != 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NULL AND \"pairing\".\"confirmed_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier": {
+      "name": "supplier",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wholesale_base_url": {
+          "name": "wholesale_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_key": {
+          "name": "adapter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne"
+      ]
+    },
+    "public.pairing_state": {
+      "name": "pairing_state",
+      "schema": "public",
+      "values": [
+        "navrhnute",
+        "potvrdene"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1785429993068,
       "tag": "0012_tiresome_gamma_corps",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1785433474838,
+      "tag": "0013_worthless_thunderbird",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema-orders.ts
+++ b/apps/api/src/db/schema-orders.ts
@@ -1,5 +1,6 @@
 import { sql } from "drizzle-orm";
 import {
+  boolean,
   check,
   index,
   integer,
@@ -107,6 +108,17 @@ export const orderLines = pgTable(
       .references(() => variants.code),
     quantity: integer("quantity").notNull(),
     state: orderLineState("state").notNull().default("objednane"),
+    // issue 60: NEZÁVISLÝ príznak od `state` vyššie — "manažér reálne objednal
+    // tento riadok u dodávateľa" (stará appka's samostatný `ORDERED` boolean,
+    // oddelený od WAITING/INSTOCK/UNAVAIL, `webreview/static/app.js`'s
+    // `saveOrdered`/`markGroupOrdered`). `state`'s `objednane` hodnota je
+    // VÝCHODISKOVÝ stav riadku (pozri komentár vyššie + `OrdersSection.tsx`'s
+    // `OUTSTANDING_STATE`), NIE potvrdenie objednania — preto appka doteraz
+    // nemala žiadne pole na "toto som už objednal", len postupový automat
+    // (čaká sa/skladom/nedostupné), ktorý s tým nesúvisí. Manažér môže riadok
+    // odškrtnúť ako objednané v ĽUBOVOĽNOM `state`, rovnako ako v starej appke
+    // mohli byť ORDERED aj WAITING/INSTOCK/UNAVAIL nezávisle nastavené.
+    ordered: boolean("ordered").notNull().default(false),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => [

--- a/apps/api/src/http/orders-routes.ts
+++ b/apps/api/src/http/orders-routes.ts
@@ -8,7 +8,7 @@ import { record } from "../modules/audit/service.js";
 import { ORDERS_EXPORT_URL_NOT_CONFIGURED, type OrdersIngestResult, type RunOrdersIngest } from "../modules/orders/ingest.js";
 import { listKnownStatusNames, listOpenStatusNames, replaceOpenStatusNames } from "../modules/orders/open-statuses.js";
 import { getOrderDetail, listOpenOrderLinesBySupplier } from "../modules/orders/queries.js";
-import { setOrderLineState } from "../modules/orders/state.js";
+import { setOrderLineOrdered, setOrderLineState } from "../modules/orders/state.js";
 import { requireRole, requireUser, type AppBindings } from "./middleware.js";
 import { requireSameOrigin } from "./origin-check.js";
 
@@ -18,6 +18,8 @@ const orderLineParam = z.object({ lineId: z.string().uuid() });
 // schémou, `schema-orders.ts`) — nikdy ručne prepísaná únia, ktorá by sa mohla
 // rozísť pri pridaní ďalšieho stavu.
 const orderLineStateBody = z.object({ state: z.enum(orderLineState.enumValues) });
+// issue 60: odškrtávacie políčko "objednané u dodávateľa".
+const orderLineOrderedBody = z.object({ ordered: z.boolean() });
 // issue 59: `min(1)` len zachytí zjavne prázdny request skôr, než sa vôbec
 // dostane k `replaceOpenStatusNames` — SKUTOČNÉ čistenie (normalizácia,
 // orezanie prázdnych/duplicít po trime) beží až v module, lebo "['   ']"
@@ -110,6 +112,36 @@ export function registerOrdersRoutes(
       }
       log.info({ actorUserId: user.userId, lineId, state }, "zmena stavu riadku objednávky");
       return c.json({ ok: true as const, state });
+    },
+  );
+
+  // issue 60: odškrtávacie políčko "objednané u dodávateľa" — NEZÁVISLÉ od
+  // stavu vyššie (viď `modules/orders/state.ts`'s `setOrderLineOrdered`
+  // komentár). Rovnaké oprávnenie ako zmena stavu.
+  app.post(
+    "/api/orders/lines/:lineId/ordered",
+    requireSameOrigin(),
+    requireUser(db),
+    requireRole("admin", "manazer"),
+    zValidator("param", orderLineParam),
+    zValidator("json", orderLineOrderedBody),
+    async (c) => {
+      const { lineId } = c.req.valid("param");
+      const { ordered } = c.req.valid("json");
+      const user = c.get("user");
+      const now = new Date();
+
+      const result = await setOrderLineOrdered(db, {
+        lineId,
+        ordered,
+        actorUserId: user.userId,
+        now,
+      });
+      if (result === "not_found") {
+        return c.json({ error: "Riadok objednávky sa nenašiel" }, 404);
+      }
+      log.info({ actorUserId: user.userId, lineId, ordered }, "zmena príznaku objednané riadku objednávky");
+      return c.json({ ok: true as const, ordered });
     },
   );
 

--- a/apps/api/src/http/supplier-routes.ts
+++ b/apps/api/src/http/supplier-routes.ts
@@ -6,6 +6,7 @@ import { log } from "../logger.js";
 import { record } from "../modules/audit/service.js";
 import type { MailTransport } from "../modules/mail/transport.js";
 import { buildSupplierOrderMailContent, sendSupplierOrderMail } from "../modules/orders/mail.js";
+import { setSupplierLinesOrdered } from "../modules/orders/state.js";
 import { setSupplierContactEmail } from "../modules/orders/supplier-contact.js";
 import { requireRole, requireUser, type AppBindings } from "./middleware.js";
 import { requireSameOrigin } from "./origin-check.js";
@@ -17,6 +18,9 @@ const supplierParam = z.object({ supplier: z.string().min(1) });
 const setSupplierEmailBody = z.object({
   email: z.preprocess((value) => (value === "" ? null : value), z.string().email().nullable()),
 });
+
+// issue 60: hromadné označenie/zrušenie celej skupiny dodávateľa ako objednané.
+const setSupplierOrderedBody = z.object({ ordered: z.boolean() });
 
 export function registerSupplierRoutes(app: Hono<AppBindings>, db: Database, sendMail: MailTransport | undefined): void {
   // E-mailový kontakt dodávateľa (#31) — rovnaké oprávnenie ako zmena stavu
@@ -38,6 +42,32 @@ export function registerSupplierRoutes(app: Hono<AppBindings>, db: Database, sen
       await setSupplierContactEmail(db, { supplier, email, actorUserId: user.userId, now });
       log.info({ actorUserId: user.userId, supplier, hasEmail: email !== null }, "zmena e-mailu dodávateľa");
       return c.json({ ok: true as const, email });
+    },
+  );
+
+  // issue 60: hromadné "označiť celú skupinu dodávateľa ako objednané"
+  // (opačným smerom = zrušenie). Rovnaké oprávnenie + CSRF disciplína ako
+  // zmena stavu jedného riadku — `setSupplierLinesOrdered` sama nájde presne
+  // tie riadky, ktoré `/api/orders/open` pre tohto dodávateľa PRÁVE TERAZ
+  // zobrazuje (viď komentár v `modules/orders/state.ts`).
+  app.put(
+    "/api/suppliers/:supplier/order-lines/ordered",
+    requireSameOrigin(),
+    requireUser(db),
+    requireRole("admin", "manazer"),
+    zValidator("param", supplierParam),
+    zValidator("json", setSupplierOrderedBody),
+    async (c) => {
+      const { supplier } = c.req.valid("param");
+      const { ordered } = c.req.valid("json");
+      const user = c.get("user");
+      const now = new Date();
+      const result = await setSupplierLinesOrdered(db, { supplier, ordered, actorUserId: user.userId, now });
+      log.info(
+        { actorUserId: user.userId, supplier, ordered, lineCount: result.lineCount },
+        "hromadná zmena príznaku objednané pre dodávateľa",
+      );
+      return c.json({ ok: true as const, ordered, lineCount: result.lineCount });
     },
   );
 

--- a/apps/api/src/modules/orders/queries.ts
+++ b/apps/api/src/modules/orders/queries.ts
@@ -1,4 +1,4 @@
-import { asc, desc, eq, inArray } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNull } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
 import { orderLines, orders, products, supplierContacts, variants, type OrderLineState } from "../../db/schema.js";
 import { extractSupplierLink } from "../catalog/supplier-link.js";
@@ -16,6 +16,9 @@ export interface OpenOrderLine {
   readonly sizeLabel: string | null;
   readonly quantity: number;
   readonly state: OrderLineState;
+  // issue 60: nezávislý príznak "objednané u dodávateľa" (viď komentár k
+  // `orderLines.ordered` v `schema-orders.ts`) — oddelené od `state` vyššie.
+  readonly ordered: boolean;
   // issue 67: odkaz na tovar u dodávateľa (extrahovaný z `product.internalNote`
   // cez `extractSupplierLink`) a kód tovaru u dodávateľa (`variant.externalCode`,
   // priamo). `supplierUrl` je `null`, keď v `internalNote` nie je odkaz —
@@ -77,6 +80,7 @@ export async function listOpenOrderLinesBySupplier(db: Database): Promise<readon
       sizeLabel: variants.sizeLabel,
       quantity: orderLines.quantity,
       state: orderLines.state,
+      ordered: orderLines.ordered,
       supplier: products.supplier,
       internalNote: products.internalNote,
       externalCode: variants.externalCode,
@@ -107,6 +111,7 @@ export async function listOpenOrderLinesBySupplier(db: Database): Promise<readon
       sizeLabel: row.sizeLabel,
       quantity: row.quantity,
       state: row.state,
+      ordered: row.ordered,
       supplierUrl: supplierLink.url,
       supplierNote: supplierLink.note,
       externalCode: row.externalCode,
@@ -135,6 +140,32 @@ export async function listOpenOrderLinesBySupplier(db: Database): Promise<readon
   }));
 }
 
+// issue 60: ID riadkov, ktoré `listOpenOrderLinesBySupplier` PRÁVE TERAZ
+// zobrazuje pre JEDNÉHO dodávateľa — používa `modules/orders/state.ts`'s
+// `setSupplierLinesOrdered` (hromadné označenie skupiny), aby hromadná akcia
+// vždy dopadla presne na to, čo manažér na obrazovke "Na objednanie" vidí.
+// Rovnaký filter (otvorené Shoptet stavy) a rovnaký zástupný kľúč
+// (`NEZNAMY_DODAVATEL`) ako hlavný zoskupovací dopyt vyššie — zámerne
+// SAMOSTATNÝ, užší dopyt (len ID, žiadne meno/veľkosť/odkaz na dodávateľa),
+// nie filtrovanie výstupu `listOpenOrderLinesBySupplier` v pamäti, aby
+// hromadná akcia nemusela ťahať VŠETKÝCH dodávateľov len kvôli jednému.
+export async function listOpenOrderLineIdsForSupplier(db: Database, supplier: string): Promise<readonly string[]> {
+  const openStatuses = await listOpenStatusNames(db);
+  if (openStatuses.length === 0) return [];
+
+  const supplierFilter = supplier === NEZNAMY_DODAVATEL ? isNull(products.supplier) : eq(products.supplier, supplier);
+
+  const rows = await db
+    .select({ lineId: orderLines.id })
+    .from(orderLines)
+    .innerJoin(orders, eq(orders.id, orderLines.orderId))
+    .innerJoin(variants, eq(variants.code, orderLines.variantCode))
+    .innerJoin(products, eq(products.key, variants.productKey))
+    .where(and(inArray(orders.statusName, [...openStatuses]), supplierFilter));
+
+  return rows.map((row) => row.lineId);
+}
+
 export interface OrderDetailLine {
   readonly lineId: string;
   readonly variantCode: string;
@@ -143,6 +174,8 @@ export interface OrderDetailLine {
   readonly supplier: string;
   readonly quantity: number;
   readonly state: OrderLineState;
+  // issue 60: rovnaký nezávislý príznak ako `OpenOrderLine.ordered`.
+  readonly ordered: boolean;
   // issue 70: tretia čítacia cesta zjednotená s `listOpenOrderLinesBySupplier`
   // a `mail.ts`'s `loadOutstandingLines` — rovnaký zámer, rovnaké polia.
   readonly supplierUrl: string | null;
@@ -172,6 +205,7 @@ export async function getOrderDetail(db: Database, id: string): Promise<OrderDet
       supplier: products.supplier,
       quantity: orderLines.quantity,
       state: orderLines.state,
+      ordered: orderLines.ordered,
       internalNote: products.internalNote,
       externalCode: variants.externalCode,
     })
@@ -197,6 +231,7 @@ export async function getOrderDetail(db: Database, id: string): Promise<OrderDet
         supplier: row.supplier ?? NEZNAMY_DODAVATEL,
         quantity: row.quantity,
         state: row.state,
+        ordered: row.ordered,
         supplierUrl: supplierLink.url,
         supplierNote: supplierLink.note,
         externalCode: row.externalCode,

--- a/apps/api/src/modules/orders/state.ts
+++ b/apps/api/src/modules/orders/state.ts
@@ -1,7 +1,8 @@
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
 import { orderLines, type OrderLineState } from "../../db/schema.js";
 import { record } from "../audit/service.js";
+import { listOpenOrderLineIdsForSupplier } from "./queries.js";
 
 export type SetOrderLineStateResult = "ok" | "not_found";
 
@@ -55,4 +56,97 @@ export async function setOrderLineState(
 
     return "ok";
   });
+}
+
+export type SetOrderLineOrderedResult = "ok" | "not_found";
+
+export interface SetOrderLineOrderedInput {
+  readonly lineId: string;
+  readonly ordered: boolean;
+  readonly actorUserId: string;
+  readonly now: Date;
+}
+
+// issue 60: odškrtávacie políčko "objednané u dodávateľa" — NEZÁVISLÝ
+// príznak od `state` vyššie (viď komentár k `orderLines.ordered` v
+// `schema-orders.ts`). Rovnaký vzor ako `setOrderLineState`: jedna
+// transakcia, `.for("update")` proti tej istej race medzi dvoma súbežnými
+// zmenami TOHO ISTÉHO riadku, audit v tej istej transakcii.
+export async function setOrderLineOrdered(
+  db: Database,
+  input: SetOrderLineOrderedInput,
+): Promise<SetOrderLineOrderedResult> {
+  return db.transaction(async (tx) => {
+    const [line] = await tx
+      .select({ orderId: orderLines.orderId, variantCode: orderLines.variantCode, ordered: orderLines.ordered })
+      .from(orderLines)
+      .where(eq(orderLines.id, input.lineId))
+      .for("update")
+      .limit(1);
+    if (line === undefined) return "not_found";
+
+    await tx.update(orderLines).set({ ordered: input.ordered }).where(eq(orderLines.id, input.lineId));
+
+    await record(tx, {
+      at: input.now,
+      actorUserId: input.actorUserId,
+      action: "order_line.ordered.changed",
+      entity: "order_line",
+      entityId: input.lineId,
+      data: {
+        orderId: line.orderId,
+        variantCode: line.variantCode,
+        from: line.ordered,
+        to: input.ordered,
+      },
+    });
+
+    return "ok";
+  });
+}
+
+export interface SetSupplierLinesOrderedInput {
+  readonly supplier: string;
+  readonly ordered: boolean;
+  readonly actorUserId: string;
+  readonly now: Date;
+}
+
+export interface SetSupplierLinesOrderedResult {
+  readonly lineCount: number;
+}
+
+// issue 60: hromadné "označiť celú skupinu dodávateľa ako objednané"/zrušenie
+// (stará appka's `markGroupOrdered`, bez jej `commitSeq`/optimistic-retry
+// zložitosti — appka má jedného-pár súčasne prihlásených manažérov, nie
+// desiatky súbežných editorov, rovnaký zámer ako zjednodušenie spomenuté v
+// review na #59/#44). Zoznam dotknutých riadkov sa počíta z RIADKOV, ktoré
+// `GET /api/orders/open` PRÁVE TERAZ zobrazuje pre daného dodávateľa
+// (`listOpenOrderLineIdsForSupplier`) — teda presne to, čo manažér na
+// obrazovke vidí, nie všetky historické riadky toho dodávateľa. Samotný
+// zápis + JEDEN agregovaný audit záznam (namiesto jedného na riadok — inak
+// by kliknutie na 20-riadkovú skupinu vyrobilo 20 auditových riadkov za
+// jednu manažérovu akciu) bežia v JEDNEJ transakcii. Prázdna skupina (0
+// riadkov) je NEŠKODNÝ no-op, nie chyba — nič sa nezapíše, ani do auditu.
+export async function setSupplierLinesOrdered(
+  db: Database,
+  input: SetSupplierLinesOrderedInput,
+): Promise<SetSupplierLinesOrderedResult> {
+  const lineIds = await listOpenOrderLineIdsForSupplier(db, input.supplier);
+  if (lineIds.length === 0) return { lineCount: 0 };
+
+  await db.transaction(async (tx) => {
+    await tx.update(orderLines).set({ ordered: input.ordered }).where(inArray(orderLines.id, [...lineIds]));
+
+    await record(tx, {
+      at: input.now,
+      actorUserId: input.actorUserId,
+      action: "order_line.ordered.bulk_changed",
+      entity: "supplier_contact",
+      entityId: input.supplier,
+      data: { supplier: input.supplier, ordered: input.ordered, lineIds, lineCount: lineIds.length },
+    });
+  });
+
+  return { lineCount: lineIds.length };
 }

--- a/apps/api/tests/orders-http-ordered.integration.test.ts
+++ b/apps/api/tests/orders-http-ordered.integration.test.ts
@@ -1,0 +1,249 @@
+import { eq } from "drizzle-orm";
+import { afterEach, expect, it } from "vitest";
+import { auditEvents, orderLines, orderOpenStatuses, orders, users } from "../src/db/schema.js";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import type { UserRole } from "../src/modules/auth/service.js";
+import { NEZNAMY_DODAVATEL } from "../src/modules/orders/queries.js";
+import { insertTestVariant } from "./helpers/orders.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// Testy pre `POST /api/orders/lines/:lineId/ordered` a
+// `PUT /api/suppliers/:supplier/order-lines/ordered` (issue 60 — nezávislý
+// príznak "objednané u dodávateľa" + hromadné označenie celej skupiny).
+// Vlastný súbor, rovnaký dôvod ako `orders-http-state.integration.test.ts`
+// (eslint `max-lines: 400`, `.claude/rules/testing.md`).
+
+const HESLO = "test-heslo-abc"; // testovacie údaje, nie tajomstvo
+
+let close: (() => Promise<void>) | undefined;
+
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  resetLoginRateLimit();
+});
+
+async function boot(role: UserRole) {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const [pouzivatel] = await ctx.db
+    .insert(users)
+    .values({
+      email: "manazer@forestshop.sk",
+      passwordHash: await hashPassword(HESLO),
+      displayName: "Manažér",
+      role,
+    })
+    .returning({ id: users.id });
+  if (pouzivatel === undefined) throw new Error("testovací používateľ sa nepodarilo vložiť");
+
+  const app = createApp(ctx.db, { cookieSecure: false });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "manazer@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie, db: ctx.db, userId: pouzivatel.id };
+}
+
+let poradieVlozenia = 0;
+async function vlozRiadok(
+  db: Awaited<ReturnType<typeof boot>>["db"],
+  supplier: string | null = "Dodávateľ Alfa",
+): Promise<{ orderId: string; lineId: string }> {
+  poradieVlozenia += 1;
+  const kod = `B-${String(poradieVlozenia)}`;
+  await insertTestVariant(db, kod, supplier);
+  const [objednavka] = await db
+    .insert(orders)
+    .values({
+      externalOrderId: `500${String(poradieVlozenia)}`,
+      customerName: "Zákazník",
+      placedAt: new Date("2026-07-20T00:00:00Z"),
+    })
+    .returning();
+  if (objednavka === undefined) throw new Error("insert objednávky zlyhal");
+  const [riadok] = await db
+    .insert(orderLines)
+    .values({ orderId: objednavka.id, variantCode: kod, quantity: 1 })
+    .returning();
+  if (riadok === undefined) throw new Error("insert riadku zlyhal");
+  return { orderId: objednavka.id, lineId: riadok.id };
+}
+
+it("manažér odškrtne riadok ako objednaný, zápis sa uloží aj do auditu", async () => {
+  const { app, cookie, db, userId } = await boot("manazer");
+  const { orderId, lineId } = await vlozRiadok(db);
+
+  const res = await app.request(`/api/orders/lines/${lineId}/ordered`, {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ ordered: true }),
+  });
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ ok: true, ordered: true });
+
+  const [riadok] = await db.select().from(orderLines).where(eq(orderLines.id, lineId));
+  expect(riadok?.ordered).toBe(true);
+
+  const udalosti = await db.select().from(auditEvents);
+  const udalost = udalosti.find((e) => e.action === "order_line.ordered.changed");
+  expect(udalost).toBeDefined();
+  expect(udalost?.actorUserId).toBe(userId);
+  expect(udalost?.entity).toBe("order_line");
+  expect(udalost?.entityId).toBe(lineId);
+  expect(udalost?.data).toMatchObject({ orderId, from: false, to: true });
+
+  // Odškrtnutie späť funguje rovnako (opačná hodnota).
+  const zrusenie = await app.request(`/api/orders/lines/${lineId}/ordered`, {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ ordered: false }),
+  });
+  expect(zrusenie.status).toBe(200);
+  const [riadokPoZruseni] = await db.select().from(orderLines).where(eq(orderLines.id, lineId));
+  expect(riadokPoZruseni?.ordered).toBe(false);
+});
+
+// Rola citanie a rola sef, KAŽDÁ vo VLASTNOM teste (vlastné `boot()` volanie,
+// vlastné `afterEach` uzavretie) — dva `boot()`-štýl helpery volané v jednom
+// teste (bez uzavretia prvého) by si prepísali `withCleanDb()`'s advisory
+// zámok a druhé volanie by sa navždy zaseklo (`.claude/rules/testing.md`).
+it("rola citanie nesmie zmeniť príznak objednané", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const { lineId } = await vlozRiadok(db);
+  const res = await app.request(`/api/orders/lines/${lineId}/ordered`, {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ ordered: true }),
+  });
+  expect(res.status).toBe(403);
+});
+
+it("rola sef nesmie zmeniť príznak objednané", async () => {
+  const { app, cookie, db } = await boot("sef");
+  const { lineId } = await vlozRiadok(db);
+  const res = await app.request(`/api/orders/lines/${lineId}/ordered`, {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ ordered: true }),
+  });
+  expect(res.status).toBe(403);
+});
+
+it("neznámy riadok vráti 404, neplatná hodnota vráti 400", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await vlozRiadok(db);
+
+  const neznamy = await app.request("/api/orders/lines/11111111-1111-1111-1111-111111111111/ordered", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ ordered: true }),
+  });
+  expect(neznamy.status).toBe(404);
+
+  const { lineId } = await vlozRiadok(db);
+  const neplatny = await app.request(`/api/orders/lines/${lineId}/ordered`, {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ ordered: "ano" }),
+  });
+  expect(neplatny.status).toBe(400);
+});
+
+it("manažér označí celú skupinu dodávateľa ako objednané naraz, JEDEN agregovaný audit záznam", async () => {
+  const { app, cookie, db, userId } = await boot("manazer");
+  await db.insert(orderOpenStatuses).values({ statusName: "Vybavuje sa" }).onConflictDoNothing();
+  const prvy = await vlozRiadok(db, "Dodávateľ Bulk");
+  const druhy = await vlozRiadok(db, "Dodávateľ Bulk");
+  // Iný dodávateľ v tom istom behu — bulk naň nesmie siahnuť.
+  const cudzi = await vlozRiadok(db, "Iný dodávateľ");
+
+  const res = await app.request(`/api/suppliers/${encodeURIComponent("Dodávateľ Bulk")}/order-lines/ordered`, {
+    method: "PUT",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ ordered: true }),
+  });
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ ok: true, ordered: true, lineCount: 2 });
+
+  const riadky = await db.select().from(orderLines);
+  const stavPrveho = riadky.find((r) => r.id === prvy.lineId);
+  const stavDruheho = riadky.find((r) => r.id === druhy.lineId);
+  const stavCudzieho = riadky.find((r) => r.id === cudzi.lineId);
+  expect(stavPrveho?.ordered).toBe(true);
+  expect(stavDruheho?.ordered).toBe(true);
+  expect(stavCudzieho?.ordered).toBe(false);
+
+  const udalosti = await db.select().from(auditEvents);
+  const bulkUdalosti = udalosti.filter((e) => e.action === "order_line.ordered.bulk_changed");
+  expect(bulkUdalosti).toHaveLength(1);
+  expect(bulkUdalosti[0]?.actorUserId).toBe(userId);
+  expect(bulkUdalosti[0]?.entityId).toBe("Dodávateľ Bulk");
+  expect(bulkUdalosti[0]?.data).toMatchObject({
+    supplier: "Dodávateľ Bulk",
+    ordered: true,
+    lineCount: 2,
+    lineIds: expect.arrayContaining([prvy.lineId, druhy.lineId]) as unknown,
+  });
+
+  // Opačným smerom — zrušenie celej skupiny naraz.
+  const zrusenie = await app.request(`/api/suppliers/${encodeURIComponent("Dodávateľ Bulk")}/order-lines/ordered`, {
+    method: "PUT",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ ordered: false }),
+  });
+  expect(zrusenie.status).toBe(200);
+  expect(await zrusenie.json()).toEqual({ ok: true, ordered: false, lineCount: 2 });
+});
+
+it("hromadné označenie zástupnej skupiny '(bez dodávateľa)' zasiahne len riadky bez dodávateľa", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await db.insert(orderOpenStatuses).values({ statusName: "Vybavuje sa" }).onConflictDoNothing();
+  const bezDodavatela = await vlozRiadok(db, null);
+  const sDodavatelom = await vlozRiadok(db, "Dodávateľ Iný");
+
+  const res = await app.request(`/api/suppliers/${encodeURIComponent(NEZNAMY_DODAVATEL)}/order-lines/ordered`, {
+    method: "PUT",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ ordered: true }),
+  });
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ ok: true, ordered: true, lineCount: 1 });
+
+  const riadky = await db.select().from(orderLines);
+  expect(riadky.find((r) => r.id === bezDodavatela.lineId)?.ordered).toBe(true);
+  expect(riadky.find((r) => r.id === sDodavatelom.lineId)?.ordered).toBe(false);
+});
+
+it("hromadné označenie na dodávateľa bez otvorených riadkov je neškodný no-op (0, žiadny audit)", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await db.insert(orderOpenStatuses).values({ statusName: "Vybavuje sa" }).onConflictDoNothing();
+
+  const res = await app.request(`/api/suppliers/${encodeURIComponent("Neexistujuci dodavatel")}/order-lines/ordered`, {
+    method: "PUT",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ ordered: true }),
+  });
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ ok: true, ordered: true, lineCount: 0 });
+
+  const udalosti = await db.select().from(auditEvents);
+  expect(udalosti.some((e) => e.action === "order_line.ordered.bulk_changed")).toBe(false);
+});
+
+it("rola citanie nesmie hromadne meniť príznak objednané", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  await db.insert(orderOpenStatuses).values({ statusName: "Vybavuje sa" }).onConflictDoNothing();
+  await vlozRiadok(db, "Dodávateľ X");
+
+  const res = await app.request(`/api/suppliers/${encodeURIComponent("Dodávateľ X")}/order-lines/ordered`, {
+    method: "PUT",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ ordered: true }),
+  });
+  expect(res.status).toBe(403);
+});

--- a/apps/web/src/components/OrderLineRow.tsx
+++ b/apps/web/src/components/OrderLineRow.tsx
@@ -1,0 +1,113 @@
+import type { JSX } from "react";
+import type { OrderLine } from "../ordersApi.js";
+
+// issue 60: `objednane` je VÝCHODISKOVÝ stav riadku (pred tým, než sa
+// čokoľvek stane), NIE potvrdenie, že manažér objednal — preto sa nazýva
+// "Nevybavené", nie "Objednané" (to slovo teraz patrí VÝLUČNE odškrtávaciemu
+// políčku v tomto riadku, `OrderLine["ordered"]`, aby appka nemala na jednej
+// obrazovke tri rôzne veci s tým istým názvom).
+export const STATE_LABELS: Record<OrderLine["state"], string> = {
+  objednane: "Nevybavené",
+  caka_sa: "Čaká sa",
+  skladom: "Skladom",
+  nedostupne: "Nedostupné",
+};
+
+// Jeden riadok tabuľky "Na objednanie" — vyčlenené z `OrdersSection.tsx`
+// (issue 60 pridalo odškrtávacie políčko + premenovaný stĺpec dátumu, čo
+// poslalo pôvodný súbor cez eslint `max-lines: 400`, `.claude/rules/testing.md`).
+export function OrderLineRow({
+  line,
+  canChangeState,
+  busyLineId,
+  busyOrderedLineId,
+  onChangeState,
+  onChangeOrdered,
+}: {
+  readonly line: OrderLine;
+  readonly canChangeState: boolean;
+  readonly busyLineId: string | null;
+  readonly busyOrderedLineId: string | null;
+  readonly onChangeState: (lineId: string, newState: OrderLine["state"]) => void;
+  readonly onChangeOrdered: (lineId: string, ordered: boolean) => void;
+}): JSX.Element {
+  return (
+    <tr
+      className={"order-row state-" + line.state + (line.ordered ? " ordered" : "")}
+      data-testid={`order-line-${line.lineId}`}
+    >
+      <td>
+        <input
+          type="checkbox"
+          data-testid={`ordered-checkbox-${line.lineId}`}
+          aria-label={`Označiť riadok objednávky ${line.externalOrderId} / ${line.variantCode} ako objednané u dodávateľa`}
+          checked={line.ordered}
+          disabled={!canChangeState || busyOrderedLineId === line.lineId}
+          onChange={(e) => {
+            onChangeOrdered(line.lineId, e.target.checked);
+          }}
+        />
+      </td>
+      <td>{line.externalOrderId}</td>
+      <td>{line.customerName}</td>
+      <td>{line.variantCode}</td>
+      <td>{line.variantName}</td>
+      <td>{line.sizeLabel ?? "—"}</td>
+      <td className="ord-qty">{line.quantity} ks</td>
+      <td className="ord-supplier-cell" data-testid={`supplier-link-${line.lineId}`}>
+        {line.supplierUrl !== null ? (
+          <a
+            href={line.supplierUrl}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="ord-supplier-link"
+            // issue 72: variantName sám nestačí — dva riadky toho istého
+            // produktu v rôznych veľkostiach majú zhodný variantName, líšia
+            // sa len variantCode.
+            aria-label={`Odkaz na dodávateľa — ${line.variantName} (${line.variantCode})`}
+          >
+            Odkaz na dodávateľa
+          </a>
+        ) : line.supplierNote !== null ? (
+          <span className="ord-supplier-note" title={line.supplierNote}>
+            {line.supplierNote}
+          </span>
+        ) : line.externalCode === null ? (
+          "—"
+        ) : null}
+        {line.externalCode !== null && <div className="ord-supplier-code">kód {line.externalCode}</div>}
+      </td>
+      <td>
+        {canChangeState ? (
+          <select
+            // Code review finding (#25): pôvodne bez slova "stav" v
+            // aria-labeli (obchádzka Playwright's substring
+            // `getByLabel("Stav")` kolízie s katalógovým filtrom), čo by
+            // čítačke obrazovky neoznámilo, čo tento prvok robí. Skutočná
+            // oprava patrí na stranu KOLÍDUJÚCEHO testu (`catalog.spec.ts`
+            // teraz používa `{ exact: true }`), nie na obetovanie
+            // prístupnosti tu — tento select smie mať plnohodnotný popis.
+            aria-label={`Zmeniť stav riadku objednávky ${line.externalOrderId} / ${line.variantCode}`}
+            data-testid={`state-select-${line.lineId}`}
+            className="ord-state-select"
+            value={line.state}
+            disabled={busyLineId === line.lineId}
+            onChange={(e) => {
+              onChangeState(line.lineId, e.target.value as OrderLine["state"]);
+            }}
+          >
+            {(Object.keys(STATE_LABELS) as OrderLine["state"][]).map((s) => (
+              <option key={s} value={s}>
+                {STATE_LABELS[s]}
+              </option>
+            ))}
+          </select>
+        ) : (
+          STATE_LABELS[line.state]
+        )}
+      </td>
+      <td>{new Date(line.placedAt).toLocaleDateString("sk-SK")}</td>
+      <td>{line.comment ?? "—"}</td>
+    </tr>
+  );
+}

--- a/apps/web/src/components/OrdersSection.test.tsx
+++ b/apps/web/src/components/OrdersSection.test.tsx
@@ -2,14 +2,23 @@ import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-li
 import { afterEach, expect, it, vi } from "vitest";
 import { OrdersSection } from "./OrdersSection.js";
 
-const { fetchOpenOrders, updateOrderLineState, setSupplierEmail, fetchSupplierOrderMailPreview, sendSupplierOrderMail } =
-  vi.hoisted(() => ({
-    fetchOpenOrders: vi.fn(),
-    updateOrderLineState: vi.fn(),
-    setSupplierEmail: vi.fn(),
-    fetchSupplierOrderMailPreview: vi.fn(),
-    sendSupplierOrderMail: vi.fn(),
-  }));
+const {
+  fetchOpenOrders,
+  updateOrderLineState,
+  updateOrderLineOrdered,
+  setSupplierLinesOrdered,
+  setSupplierEmail,
+  fetchSupplierOrderMailPreview,
+  sendSupplierOrderMail,
+} = vi.hoisted(() => ({
+  fetchOpenOrders: vi.fn(),
+  updateOrderLineState: vi.fn(),
+  updateOrderLineOrdered: vi.fn(),
+  setSupplierLinesOrdered: vi.fn(),
+  setSupplierEmail: vi.fn(),
+  fetchSupplierOrderMailPreview: vi.fn(),
+  sendSupplierOrderMail: vi.fn(),
+}));
 
 // `OrdersUnauthorizedError` ostáva SKUTOČNÁ trieda z reálneho modulu — rovnaký
 // dôvod ako `SchedulerSection.test.tsx`'s `SchedulerUnauthorizedError`:
@@ -20,6 +29,8 @@ vi.mock("../ordersApi.js", async (importOriginal) => {
     ...actual,
     fetchOpenOrders,
     updateOrderLineState,
+    updateOrderLineOrdered,
+    setSupplierLinesOrdered,
     setSupplierEmail,
     fetchSupplierOrderMailPreview,
     sendSupplierOrderMail,
@@ -40,6 +51,7 @@ const LINE_STARA = {
   sizeLabel: "3XL",
   quantity: 2,
   state: "objednane" as const,
+  ordered: false,
   supplierUrl: null,
   supplierNote: null,
   externalCode: null,
@@ -57,6 +69,7 @@ const LINE_NOVA = {
   sizeLabel: null,
   quantity: 1,
   state: "skladom" as const,
+  ordered: false,
   supplierUrl: null,
   supplierNote: null,
   externalCode: null,
@@ -96,7 +109,9 @@ it("zoskupí riadky podľa dodávateľa a zobrazí produkt, veľkosť, množstvo
 
   const stary = screen.getByTestId(`order-line-${LINE_STARA.lineId}`);
   expect(stary.textContent).toContain("3XL");
-  expect(stary.textContent).toContain("Objednané");
+  // issue 60: východiskový stav "objednane" sa teraz volá "Nevybavené" — slovo
+  // "Objednané" je odteraz VÝLUČNE nové odškrtávacie políčko, nie tento stav.
+  expect(stary.textContent).toContain("Nevybavené");
 });
 
 it("chýbajúcu veľkosť a komentár zobrazí ako pomlčku", async () => {
@@ -294,6 +309,88 @@ it("zmena stavu pri 401 zavolá onSessionExpired namiesto zobrazenia chyby", asy
     expect(onSessionExpired).toHaveBeenCalledTimes(1);
   });
   expect(screen.queryByRole("alert")).toBeNull();
+});
+
+// issue 60: odškrtávacie políčko "objednané u dodávateľa" — per riadok aj
+// hromadne pre celú skupinu.
+
+it("rola citanie vidí políčko objednané ako needitovateľné", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_STARA], email: null }]);
+
+  render(<OrdersSection role="citanie" onSessionExpired={() => {}} />);
+
+  const checkbox = await screen.findByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_STARA.lineId}`);
+  expect(checkbox.checked).toBe(false);
+  expect(checkbox.disabled).toBe(true);
+});
+
+it("manažér odškrtne riadok ako objednaný, riadok sa vizuálne stlmí bez nového načítania", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_STARA], email: null }]);
+  updateOrderLineOrdered.mockResolvedValue(undefined);
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const checkbox = await screen.findByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_STARA.lineId}`);
+  expect(checkbox.checked).toBe(false);
+  expect(checkbox.disabled).toBe(false);
+
+  fireEvent.click(checkbox);
+
+  await waitFor(() => {
+    expect(updateOrderLineOrdered).toHaveBeenCalledWith(LINE_STARA.lineId, true);
+  });
+  await waitFor(() => {
+    expect(screen.getByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_STARA.lineId}`).checked).toBe(true);
+  });
+  expect(screen.getByTestId(`order-line-${LINE_STARA.lineId}`).className).toContain("ordered");
+  // Presne JEDNO volanie fetchOpenOrders (počiatočné načítanie) — lokálna
+  // aktualizácia, žiadny refetch.
+  expect(fetchOpenOrders).toHaveBeenCalledTimes(1);
+  expect(screen.queryByRole("alert")).toBeNull();
+});
+
+it("zlyhaná zmena príznaku objednané zobrazí slovenskú hlášku a checkbox sa nezmení", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_STARA], email: null }]);
+  updateOrderLineOrdered.mockRejectedValue(new Error("Zmena príznaku objednané sa nepodarila"));
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const checkbox = await screen.findByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_STARA.lineId}`);
+  fireEvent.click(checkbox);
+
+  await waitFor(() => {
+    expect(screen.getByRole("alert").textContent).toBe("Zmena príznaku objednané sa nepodarila");
+  });
+  expect(screen.getByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_STARA.lineId}`).checked).toBe(false);
+});
+
+it("manažér označí celú skupinu dodávateľa naraz, tlačidlo sa prepne na zrušenie", async () => {
+  fetchOpenOrders.mockResolvedValue([
+    { supplier: "Dodávateľ Alfa", lines: [LINE_STARA, LINE_NOVA], email: null },
+  ]);
+  setSupplierLinesOrdered.mockResolvedValue({ lineCount: 2 });
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const oznacit = await screen.findByRole("button", { name: "✔ Označiť skupinu ako objednané" });
+  fireEvent.click(oznacit);
+
+  await waitFor(() => {
+    expect(setSupplierLinesOrdered).toHaveBeenCalledWith("Dodávateľ Alfa", true);
+  });
+  await waitFor(() => {
+    expect(screen.getByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_STARA.lineId}`).checked).toBe(true);
+  });
+  expect(screen.getByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_NOVA.lineId}`).checked).toBe(true);
+
+  // Skupina je teraz celá objednaná — tlačidlo prepína OPAČNÝM smerom.
+  const zrusit = await screen.findByRole("button", { name: "↺ Zrušiť označenie skupiny" });
+  setSupplierLinesOrdered.mockResolvedValue({ lineCount: 2 });
+  fireEvent.click(zrusit);
+
+  await waitFor(() => {
+    expect(setSupplierLinesOrdered).toHaveBeenCalledWith("Dodávateľ Alfa", false);
+  });
 });
 
 // #31: e-mailový kontakt dodávateľa + odoslanie objednávky mailom.

--- a/apps/web/src/components/OrdersSection.tsx
+++ b/apps/web/src/components/OrdersSection.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState, type JSX } from "react";
 import type { Me } from "../api.js";
+import { OrderLineRow } from "./OrderLineRow.js";
 import { OrderOpenStatusesPanel } from "./OrderOpenStatusesPanel.js";
 import {
   fetchOpenOrders,
@@ -7,18 +8,13 @@ import {
   OrdersUnauthorizedError,
   sendSupplierOrderMail,
   setSupplierEmail,
+  setSupplierLinesOrdered,
+  updateOrderLineOrdered,
   updateOrderLineState,
   type OrderLine,
   type OrderMailPreview,
   type SupplierOpenOrders,
 } from "../ordersApi.js";
-
-const STATE_LABELS: Record<OrderLine["state"], string> = {
-  objednane: "Objednané",
-  caka_sa: "Čaká sa",
-  skladom: "Skladom",
-  nedostupne: "Nedostupné",
-};
 
 // Rovnaké dve role, ktoré server vyžaduje pre
 // `POST /api/orders/lines/:lineId/state` (`requireRole("admin", "manazer")`,
@@ -29,7 +25,10 @@ const CAN_CHANGE_STATE_ROLES: ReadonlySet<Me["role"]> = new Set(["admin", "manaz
 
 // Riadky, ktoré ešte treba objednať u dodávateľa (rovnaký zámer ako stará
 // appka's `outstandingOf`/`!isHandled`, #31) — východiskový stav pred tým,
-// než manažér čokoľvek ručne posunie ďalej.
+// než manažér čokoľvek ručne posunie ďalej. Toto gejtuje LEN tlačidlo
+// "odoslať objednávku mailom" (server-strana `mail.ts` filtruje rovnako) —
+// je to NEZÁVISLÉ od nového `ordered` príznaku (issue 60) nižšie, mail sa dá
+// odoslať/skopírovať bez ohľadu na to, či je riadok už odškrtnutý.
 const OUTSTANDING_STATE: OrderLine["state"] = "objednane";
 
 export function OrdersSection({
@@ -101,6 +100,69 @@ export function OrdersSection({
         })
         .finally(() => {
           setBusyLineId(null);
+        });
+    },
+    [onSessionExpired],
+  );
+
+  // issue 60: odškrtávacie políčko "objednané u dodávateľa" — per riadok aj
+  // hromadne pre celú skupinu dodávateľa. NEZÁVISLÉ od `changeState` vyššie.
+  const [busyOrderedLineId, setBusyOrderedLineId] = useState<string | null>(null);
+  const [busyOrderedSupplier, setBusyOrderedSupplier] = useState<string | null>(null);
+
+  const changeOrdered = useCallback(
+    (lineId: string, ordered: boolean) => {
+      setStateError("");
+      setBusyOrderedLineId(lineId);
+      updateOrderLineOrdered(lineId, ordered)
+        .then(() => {
+          setSuppliers((current) =>
+            current.map((group) => ({
+              ...group,
+              lines: group.lines.map((line) => (line.lineId === lineId ? { ...line, ordered } : line)),
+            })),
+          );
+        })
+        .catch((err: unknown) => {
+          if (err instanceof OrdersUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setStateError(err instanceof Error ? err.message : "Zmena príznaku objednané sa nepodarila.");
+        })
+        .finally(() => {
+          setBusyOrderedLineId(null);
+        });
+    },
+    [onSessionExpired],
+  );
+
+  // Hromadné označenie/zrušenie CELEJ skupiny dodávateľa naraz (stará appka's
+  // `markGroupOrdered` — jedno tlačidlo, ktoré prepína smer podľa toho, či je
+  // skupina UŽ celá objednaná, `webreview/static/app.js`'s `allOrdered`).
+  const toggleGroupOrdered = useCallback(
+    (supplier: string, ordered: boolean) => {
+      setStateError("");
+      setBusyOrderedSupplier(supplier);
+      setSupplierLinesOrdered(supplier, ordered)
+        .then(() => {
+          setSuppliers((current) =>
+            current.map((group) =>
+              group.supplier === supplier
+                ? { ...group, lines: group.lines.map((line) => ({ ...line, ordered })) }
+                : group,
+            ),
+          );
+        })
+        .catch((err: unknown) => {
+          if (err instanceof OrdersUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setStateError(err instanceof Error ? err.message : "Hromadné označenie skupiny sa nepodarilo.");
+        })
+        .finally(() => {
+          setBusyOrderedSupplier(null);
         });
     },
     [onSessionExpired],
@@ -283,6 +345,20 @@ export function OrdersSection({
             </div>
             {canChangeState && (
               <div className="tosup-actions">
+                {/* issue 60: hromadné označenie/zrušenie CELEJ skupiny naraz —
+                    jedno tlačidlo, ktoré prepína smer podľa toho, či je skupina
+                    UŽ celá odškrtnutá (rovnaký zámer ako stará appka's
+                    `markGroupOrdered`/`allOrdered`). */}
+                <button
+                  type="button"
+                  className="btn sm ghost"
+                  disabled={busyOrderedSupplier === group.supplier}
+                  onClick={() => {
+                    toggleGroupOrdered(group.supplier, !group.lines.every((l) => l.ordered));
+                  }}
+                >
+                  {group.lines.every((l) => l.ordered) ? "↺ Zrušiť označenie skupiny" : "✔ Označiť skupinu ako objednané"}
+                </button>
                 <button type="button" className="btn sm ghost" onClick={() => { copyOrderToClipboard(group.supplier); }}>
                   📋 Kopírovať objednávku
                 </button>
@@ -327,6 +403,10 @@ export function OrdersSection({
           <table className="orders-table">
             <thead>
               <tr>
+                {/* issue 60: odškrtávacie políčko — JEDINÉ miesto na obrazovke,
+                    ktoré sa smie volať "Objednané" (viď `STATE_LABELS`
+                    a stĺpec dátumu nižšie, obe premenované, aby nekolidovali). */}
+                <th>Objednané</th>
                 <th>Objednávka</th>
                 <th>Zákazník</th>
                 <th>Kód</th>
@@ -335,79 +415,21 @@ export function OrdersSection({
                 <th>Množstvo</th>
                 <th>Dodávateľ</th>
                 <th>Stav</th>
-                <th>Objednané</th>
+                <th>Dátum objednávky</th>
                 <th>Komentár</th>
               </tr>
             </thead>
             <tbody>
               {group.lines.map((line) => (
-                <tr
+                <OrderLineRow
                   key={line.lineId}
-                  className={"order-row state-" + line.state}
-                  data-testid={`order-line-${line.lineId}`}
-                >
-                  <td>{line.externalOrderId}</td>
-                  <td>{line.customerName}</td>
-                  <td>{line.variantCode}</td>
-                  <td>{line.variantName}</td>
-                  <td>{line.sizeLabel ?? "—"}</td>
-                  <td className="ord-qty">{line.quantity} ks</td>
-                  <td className="ord-supplier-cell" data-testid={`supplier-link-${line.lineId}`}>
-                    {line.supplierUrl !== null ? (
-                      <a
-                        href={line.supplierUrl}
-                        target="_blank"
-                        rel="noreferrer noopener"
-                        className="ord-supplier-link"
-                        // issue 72: variantName sám nestačí — dva riadky
-                        // toho istého produktu v rôznych veľkostiach majú
-                        // zhodný variantName, líšia sa len variantCode.
-                        aria-label={`Odkaz na dodávateľa — ${line.variantName} (${line.variantCode})`}
-                      >
-                        Odkaz na dodávateľa
-                      </a>
-                    ) : line.supplierNote !== null ? (
-                      <span className="ord-supplier-note" title={line.supplierNote}>
-                        {line.supplierNote}
-                      </span>
-                    ) : line.externalCode === null ? (
-                      "—"
-                    ) : null}
-                    {line.externalCode !== null && <div className="ord-supplier-code">kód {line.externalCode}</div>}
-                  </td>
-                  <td>
-                    {canChangeState ? (
-                      <select
-                        // Code review finding (#25): pôvodne bez slova "stav"
-                        // v aria-labeli (obchádzka Playwright's substring
-                        // `getByLabel("Stav")` kolízie s katalógovým filtrom),
-                        // čo by čítačke obrazovky neoznámilo, čo tento prvok
-                        // robí. Skutočná oprava patrí na stranu KOLÍDUJÚCEHO
-                        // testu (`catalog.spec.ts` teraz používa
-                        // `{ exact: true }`), nie na obetovanie prístupnosti
-                        // tu — tento select smie mať plnohodnotný popis.
-                        aria-label={`Zmeniť stav riadku objednávky ${line.externalOrderId} / ${line.variantCode}`}
-                        data-testid={`state-select-${line.lineId}`}
-                        className="ord-state-select"
-                        value={line.state}
-                        disabled={busyLineId === line.lineId}
-                        onChange={(e) => {
-                          changeState(line.lineId, e.target.value as OrderLine["state"]);
-                        }}
-                      >
-                        {(Object.keys(STATE_LABELS) as OrderLine["state"][]).map((s) => (
-                          <option key={s} value={s}>
-                            {STATE_LABELS[s]}
-                          </option>
-                        ))}
-                      </select>
-                    ) : (
-                      STATE_LABELS[line.state]
-                    )}
-                  </td>
-                  <td>{new Date(line.placedAt).toLocaleDateString("sk-SK")}</td>
-                  <td>{line.comment ?? "—"}</td>
-                </tr>
+                  line={line}
+                  canChangeState={canChangeState}
+                  busyLineId={busyLineId}
+                  busyOrderedLineId={busyOrderedLineId}
+                  onChangeState={changeState}
+                  onChangeOrdered={changeOrdered}
+                />
               ))}
             </tbody>
           </table>

--- a/apps/web/src/ordersApi.test.ts
+++ b/apps/web/src/ordersApi.test.ts
@@ -7,7 +7,9 @@ import {
   saveOpenStatuses,
   sendSupplierOrderMail,
   setSupplierEmail,
+  setSupplierLinesOrdered,
   triggerOrdersIngest,
+  updateOrderLineOrdered,
   updateOrderLineState,
 } from "./ordersApi.js";
 
@@ -23,6 +25,7 @@ const LINE = {
   sizeLabel: null,
   quantity: 1,
   state: "objednane" as const,
+  ordered: false,
   supplierUrl: null,
   supplierNote: null,
   externalCode: null,
@@ -126,6 +129,51 @@ it("updateOrderLineState bez tela odpovede použije všeobecnú hlášku", async
   vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 500 })));
   await expect(updateOrderLineState("11111111-1111-1111-1111-111111111111", "skladom")).rejects.toThrow(
     "Zmena stavu sa nepodarila",
+  );
+});
+
+// issue 60: odškrtávacie políčko "objednané u dodávateľa".
+it("updateOrderLineOrdered pošle POST na správnu trasu s telom { ordered }", async () => {
+  const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true, ordered: true }), { status: 200 }));
+  vi.stubGlobal("fetch", fetchMock);
+
+  await updateOrderLineOrdered("11111111-1111-1111-1111-111111111111", true);
+
+  expect(fetchMock).toHaveBeenCalledWith(
+    "/api/orders/lines/11111111-1111-1111-1111-111111111111/ordered",
+    expect.objectContaining({
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ordered: true }),
+    }),
+  );
+});
+
+it("updateOrderLineOrdered pri 401 vyhodí OrdersUnauthorizedError", async () => {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 401 })));
+  await expect(updateOrderLineOrdered("11111111-1111-1111-1111-111111111111", true)).rejects.toBeInstanceOf(
+    OrdersUnauthorizedError,
+  );
+});
+
+it("setSupplierLinesOrdered pošle PUT s URL-enkódovaným menom dodávateľa a vráti počet zmenených riadkov", async () => {
+  const fetchMock = vi
+    .fn()
+    .mockResolvedValue(new Response(JSON.stringify({ ok: true, ordered: true, lineCount: 3 }), { status: 200 }));
+  vi.stubGlobal("fetch", fetchMock);
+
+  await expect(setSupplierLinesOrdered("Dodávateľ Alfa", true)).resolves.toEqual({ lineCount: 3 });
+
+  expect(fetchMock).toHaveBeenCalledWith(
+    "/api/suppliers/Dod%C3%A1vate%C4%BE%20Alfa/order-lines/ordered",
+    expect.objectContaining({ method: "PUT", body: JSON.stringify({ ordered: true }) }),
+  );
+});
+
+it("setSupplierLinesOrdered zlyhá zrozumiteľne pri chybe servera", async () => {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 500 })));
+  await expect(setSupplierLinesOrdered("Dodávateľ Alfa", true)).rejects.toThrow(
+    "Hromadné označenie skupiny sa nepodarilo",
   );
 });
 

--- a/apps/web/src/ordersApi.ts
+++ b/apps/web/src/ordersApi.ts
@@ -17,6 +17,9 @@ const orderLineSchema = z.object({
   sizeLabel: z.string().nullable(),
   quantity: z.number(),
   state: z.enum(["objednane", "caka_sa", "skladom", "nedostupne"]),
+  // issue 60: nezávislý príznak "objednané u dodávateľa" (viď `state.ts`'s
+  // komentár) — oddelené od `state` vyššie.
+  ordered: z.boolean(),
   // issue 67: odkaz na tovar u dodávateľa (`supplierUrl`, `null` keď v
   // exporte nie je odkaz) + surový text pre plain-text fallback
   // (`supplierNote`) + kód tovaru u dodávateľa (`externalCode`).
@@ -152,6 +155,37 @@ export async function updateOrderLineState(
     body: JSON.stringify({ state }),
   });
   await readJson(response, "Zmena stavu sa nepodarila");
+}
+
+// issue 60: odškrtávacie políčko "objednané u dodávateľa" — NEZÁVISLÉ od
+// `updateOrderLineState` vyššie.
+export async function updateOrderLineOrdered(lineId: string, ordered: boolean): Promise<void> {
+  const response = await fetch(`/api/orders/lines/${lineId}/ordered`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ ordered }),
+  });
+  await readJson(response, "Zmena príznaku objednané sa nepodarila");
+}
+
+const setSupplierLinesOrderedResultSchema = z.object({ ok: z.literal(true), ordered: z.boolean(), lineCount: z.number() });
+
+// issue 60: hromadné označenie/zrušenie CELEJ skupiny dodávateľa naraz — server
+// sám nájde presne tie riadky, ktoré `fetchOpenOrders` pre daného dodávateľa
+// PRÁVE TERAZ zobrazuje (`modules/orders/state.ts`'s `setSupplierLinesOrdered`).
+export async function setSupplierLinesOrdered(
+  supplier: string,
+  ordered: boolean,
+): Promise<{ readonly lineCount: number }> {
+  const response = await fetch(`/api/suppliers/${encodeURIComponent(supplier)}/order-lines/ordered`, {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ ordered }),
+  });
+  const telo = setSupplierLinesOrderedResultSchema.parse(
+    await readJson(response, "Hromadné označenie skupiny sa nepodarilo"),
+  );
+  return { lineCount: telo.lineCount };
 }
 
 // #31: e-mailový kontakt dodávateľa + odoslanie objednávky mailom.

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -635,6 +635,12 @@ tr:last-child td {
 .orders-table tr.state-nedostupne td:first-child {
   box-shadow: inset 3px 0 0 var(--fs-danger);
 }
+/* issue 60: odškrtnuté "objednané u dodávateľa" — stlmí CELÝ riadok bez
+   ohľadu na `state-*` farbu vyššie (rovnaká hodnota, akú appka už používa
+   pre `.btn:disabled`, nie prevzaté zo starej appky). */
+.orders-table tr.ordered {
+  opacity: 0.55;
+}
 .ord-qty {
   font-weight: var(--fs-weight-semibold);
   color: var(--fs-ink);

--- a/apps/web/tests/e2e/orders.spec.ts
+++ b/apps/web/tests/e2e/orders.spec.ts
@@ -57,8 +57,10 @@ test("manažér vidí otvorené objednávky zoskupené podľa dodávateľa, konz
   await expect(riadokBez).toContainText("E2E Zákazník Bez dodávateľa");
   await expect(riadokBez).toContainText("40287");
   await expect(riadokBez).toContainText("Čiapka Polar FOREST");
-  // Predvolený stav riadku (schema default "objednane") a chýbajúca veľkosť.
-  await expect(riadokBez).toContainText("Objednané");
+  // Predvolený stav riadku (schema default "objednane") a chýbajúca veľkosť —
+  // issue 60: premenované na "Nevybavené" (slovo "Objednané" teraz patrí
+  // výlučne novému odškrtávaciemu políčku).
+  await expect(riadokBez).toContainText("Nevybavené");
 
   expect(chyby).toEqual([]);
 });
@@ -230,6 +232,65 @@ test("uzavretá objednávka sa v 'Na objednanie' neukáže, kým sa jej stav nep
   await expect(skupinaBezDodavatela).toContainText("E2E Zákazník Bez dodávateľa");
   const skupinaTest1 = page.getByTestId("supplier-DODAVATEL-TEST-1");
   await expect(skupinaTest1).toContainText("9001");
+
+  expect(chyby).toEqual([]);
+});
+
+// issue 60: VLASTNÝ izolovaný účet — balík je už na hranici MAX_ATTEMPTS=10
+// (viď `scripts/e2e-setup.ts`'s komentár k `E2E_OBJEDNANE_EMAIL`).
+const E2E_OBJEDNANE_EMAIL = "e2e-objednane@forestshop.sk";
+
+// issue 60: odškrtávacie políčko "objednané u dodávateľa" (per riadok) a
+// hromadné označenie/zrušenie CELEJ skupiny naraz. Používa skupinu
+// "DODAVATEL-TEST-1" (objednávka 9001, JEDINÝ riadok) — nie
+// "(bez dodávateľa)", ktorú iný test v tomto súbore (uzavretá objednávka
+// vyššie) môže medzičasom rozšíriť o druhý riadok; DODAVATEL-TEST-1 má vždy
+// presne jeden riadok bez ohľadu na poradie behu ostatných testov v súbore.
+test("manažér odškrtne riadok ako objednaný a hromadne označí/zruší celú skupinu, konzola je čistá", async ({ page }) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/?tab=orders");
+  await page.getByLabel("E-mail").fill(E2E_OBJEDNANE_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await expect(page.getByRole("heading", { name: "Na objednanie" })).toBeVisible();
+
+  const skupina = page.getByTestId("supplier-DODAVATEL-TEST-1");
+  const riadok = skupina.locator("[data-testid^='order-line-']");
+  const checkbox = riadok.locator("input[type='checkbox']");
+  await expect(checkbox).not.toBeChecked();
+  await expect(riadok).not.toHaveClass(/ordered/);
+
+  // Per riadok — odškrtnutie stlmí CELÝ riadok a pretrvá po obnovení stránky.
+  await checkbox.check();
+  await expect(checkbox).toBeChecked();
+  await expect(riadok).toHaveClass(/ordered/);
+  await expect(page.getByRole("alert")).toHaveCount(0);
+
+  await page.reload();
+  await expect(page.getByRole("heading", { name: "Na objednanie" })).toBeVisible();
+  const riadokPoReloade = page.getByTestId("supplier-DODAVATEL-TEST-1").locator("[data-testid^='order-line-']");
+  await expect(riadokPoReloade.locator("input[type='checkbox']")).toBeChecked();
+
+  // Hromadné tlačidlo — skupina je UŽ celá objednaná, tlačidlo preto ponúka
+  // ZRUŠENIE (opačný smer), nie opätovné označenie.
+  const zrusitTlacidlo = skupina.getByRole("button", { name: "↺ Zrušiť označenie skupiny" });
+  await expect(zrusitTlacidlo).toBeVisible();
+  await zrusitTlacidlo.click();
+  await expect(riadokPoReloade.locator("input[type='checkbox']")).not.toBeChecked();
+  await expect(riadokPoReloade).not.toHaveClass(/ordered/);
+
+  // Tlačidlo sa prepne späť na "označiť" a hromadné označenie funguje aj
+  // opačným smerom.
+  const oznacitTlacidlo = skupina.getByRole("button", { name: "✔ Označiť skupinu ako objednané" });
+  await oznacitTlacidlo.click();
+  await expect(riadokPoReloade.locator("input[type='checkbox']")).toBeChecked();
 
   expect(chyby).toEqual([]);
 });

--- a/apps/web/tests/e2e/orders.spec.ts
+++ b/apps/web/tests/e2e/orders.spec.ts
@@ -268,7 +268,13 @@ test("manažér odškrtne riadok ako objednaný a hromadne označí/zruší cel�
   await expect(riadok).not.toHaveClass(/ordered/);
 
   // Per riadok — odškrtnutie stlmí CELÝ riadok a pretrvá po obnovení stránky.
-  await checkbox.check();
+  // `.click()`, NIE `.check()` — `.check()` si sám ihneď po kliku overí stav,
+  // no zápis je async (POST na server), takže by na pomalšom CI behu zlyhal
+  // presne rovnakým dôvodom ako `<select>` v teste vyššie
+  // (`.claude/rules/testing.md`): `expect(...).toBeChecked()` nižšie SKUTOČNE
+  // čaká (opakovane skúša), kým sa lokálny optimistický update po vyriešení
+  // promisu prejaví.
+  await checkbox.click();
   await expect(checkbox).toBeChecked();
   await expect(riadok).toHaveClass(/ordered/);
   await expect(page.getByRole("alert")).toHaveCount(0);

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -792,3 +792,63 @@ nové heslo sa nikde v pushnutom obsahu nenachádza.
   dodávateľa — Poľovnícke kraťasy HART GOROSTA-SH (62621/52)"). Console:
   0 errors/0 warnings.
 - Per-ticket Discord card fired (`notify --run-card`, confirmed delivered).
+
+## 2026-07-30 — #59 (Na objednanie: filter podľa stavu objednávky zo Shoptetu)
+
+- Validated live first: DB schema on dev2 had NO status column at all
+  (`\d "order"`), and the live "Na objednanie" showed all 864 lines
+  unfiltered — issue confirmed still real.
+- Design comment posted BEFORE any code:
+  https://github.com/zbynekdrlik/forestshop-app/issues/59#issuecomment-5133725274
+  (2026-07-30T16:46:09Z, before first code commit `40c823f`).
+- Commits (5, `dev`): version bump 0.3.0-dev.35; `feat` — capture
+  `order.status_name` at ingest (migration `0012`, `parser.ts`/`ingest.ts`,
+  own tests) `40c823f`; RED — failing integration test proving the
+  unfiltered list `54252fd`; GREEN — `queries.ts` filter by
+  `order_open_status` `24fa075`; `feat` — admin settings panel +
+  `GET/PUT /api/orders/open-statuses` + e2e `0a8e467`. PR **#74** (`dev` →
+  `main`), merged `5adb8c3a`.
+- Deliberately did NOT copy the legacy app's 4-set model
+  (`to_order`/`terminal`/`known_open`/`cancelled` + impact-preview dialog)
+  — this app has neither "Nedostupné" nor reminder e-mails, so those three
+  sets would be dead complexity (MVP). Single `order_open_status` list,
+  seeded with the legacy default ("Vybavuje sa") so nothing silently
+  changes on deploy.
+- Two real bugs found + fixed during this ticket, both worth remembering:
+  1. **Route registration order matters in Hono** — `GET/PUT
+     /api/orders/open-statuses` registered AFTER the parameterized `GET
+     /api/orders/:id` meant Hono matched "open-statuses" as `:id` first and
+     404/400'd on invalid UUID before the intended handler ever ran. Fix:
+     register literal-path routes BEFORE parameterized siblings on the same
+     prefix. Caught by the local e2e run, not by any unit/integration test
+     (those call the module functions directly, never through the full
+     route table) — worth remembering for the next literal-vs-`:param`
+     route added under an existing `:id` prefix.
+  2. **`order_open_status` is a new ROOT table `TRUNCATE ... CASCADE` never
+     reaches** (same class as `supplier_contact`/`supplier`, no FK either
+     direction) — `tests/helpers/db.ts` and `scripts/e2e-setup.ts` both
+     needed it added to their TRUNCATE list AND a re-seed of the default
+     row after, or the table would either leak mutations across tests or
+     start every test from a silently-empty (nothing-ever-shows) state.
+     `DEFAULT_ORDER_OPEN_STATUS` exported from `open-statuses.ts` so both
+     helpers and the migration's seed value stay tied together.
+  3. `buildCsv` test helper in `orders-ingest.integration.test.ts` encodes
+     UTF-8 while `ingestOrders` always decodes as windows-1250 (matching
+     the real Shoptet export) — a non-ASCII literal in a hand-built test
+     CSV row mojibakes. Hand-built CSV tests in that file must stay
+     ASCII-only; real diacritics are covered by the committed cp1250
+     fixture instead.
+- CI green on the PR (check, integration, e2e, docker-build,
+  version-check) and on `main`. Local: typecheck + lint + unit (263 API +
+  167 web) + integration (193) + full e2e (15/15) all green before push.
+- Deployed + verified on https://forestshop-novy.newlevel.media
+  (v0.3.0-dev.35, commit `5adb8c3a` matches `/api/version` and the DOM
+  label). Triggered a real "Stiahnuť teraz" re-import on production to
+  populate real statuses on existing orders (they carried the migration's
+  DB-default status until the next re-import) — "Na objednanie" dropped
+  from 864 unfiltered lines to 39 correctly-filtered lines. Settings panel
+  read back the real distinct statuses Shoptet uses (Kompletná, Nevybavená,
+  Osob. odber, Stornovaná, Vratený tovar, Vybavená, Vybavená výmena,
+  Vybavený Dobropis, Vybavuje sa) — no typo-guessing needed. Console: 0
+  errors/0 warnings throughout.
+- Per-ticket Discord card fired (`notify --run-card`, confirmed delivered).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.35",
+  "version": "0.3.0-dev.36",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -60,6 +60,13 @@ const E2E_NAV_EMAIL = "e2e-nav@forestshop.sk"; // musí sa zhodovať s hodnotou 
 // namiesto ďalšieho prihlásenia pod zdieľaným `e2e@forestshop.sk`.
 const E2E_OTVORENE_STAVY_EMAIL = "e2e-otvorene-stavy@forestshop.sk"; // musí sa zhodovať s hodnotou v orders.spec.ts
 
+// issue 60: rovnaký mechanizmus a dôvod ako `E2E_OTVORENE_STAVY_EMAIL`
+// vyššie — balík je UŽ na hranici `MAX_ATTEMPTS` (komentár vyššie), takže
+// nový test (odškrtávacie políčko + hromadné označenie skupiny) dostáva
+// VLASTNÝ izolovaný účet namiesto ďalšieho prihlásenia pod zdieľaným
+// `e2e@forestshop.sk`.
+const E2E_OBJEDNANE_EMAIL = "e2e-objednane@forestshop.sk"; // musí sa zhodovať s hodnotou v orders.spec.ts
+
 const { db, pool } = createDb();
 // Konštantný literál bez interpolácie — obyčajný reťazec je tu rovnako bezpečný
 // ako `sql` tagovaná šablóna (tú používa ekvivalentný apps/api/tests/helpers/db.ts),
@@ -117,6 +124,12 @@ await db.insert(users).values({
 });
 await db.insert(users).values({
   email: E2E_OTVORENE_STAVY_EMAIL,
+  passwordHash: await hashPassword(E2E_HESLO),
+  displayName: "E2E Manažér",
+  role: "manazer",
+});
+await db.insert(users).values({
+  email: E2E_OBJEDNANE_EMAIL,
   passwordHash: await hashPassword(E2E_HESLO),
   displayName: "E2E Manažér",
   role: "manazer",


### PR DESCRIPTION
## Summary

Adds a new, independent `order_line.ordered` flag (migration 0013) plus:

- `POST /api/orders/lines/:lineId/ordered` — per-row checkbox toggle (audited).
- `PUT /api/suppliers/:supplier/order-lines/ordered` — mark/unmark a supplier's
  whole currently-open group at once (single aggregate audit event).
- Frontend checkbox column + per-group bulk toggle button; the checked row
  visually dims.
- Renamed the two pre-existing, colliding "Objednané" labels: the default
  `state` option is now "Nevybavené" and the order-date column is now
  "Dátum objednávky" — "Objednané" now names exactly one thing on the screen
  (the new checkbox).

Design rationale (root cause, chosen approach, rejected alternative) posted
to the issue before the first commit: https://github.com/zbynekdrlik/forestshop-app/issues/60#issuecomment-5134292105

Closes #60
