### PR TITLE
Fix code-review findings on PR 75 (na-objednanie checkbox + bulk toggle)

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -54,3 +54,15 @@ paths:
   "Nesprávny e-mail alebo heslo" on a RANDOM later test in the same run, not
   a rate-limit-specific error (the client's `postLogin()` collapses every
   non-2xx response, including 429, to the same generic failure).
+- **A component file that grows past eslint's `max-lines: 400` after adding a
+  feature gets its TABLE ROW / list-item rendering extracted into its own
+  component file, not trimmed by removing comments/whitespace.** Issue 60
+  added a checkbox column + a renamed header to `OrdersSection.tsx`, pushing
+  it to 454 lines — extracted the `<tr>` body (plus the `STATE_LABELS` map it
+  alone uses) into `OrderLineRow.tsx`, taking `line`/`canChangeState`/busy-flag
+  props and two callbacks (`onChangeState`/`onChangeOrdered`) from the parent,
+  which stayed the state/data-fetching owner. Same principle as the
+  established test-file split pattern (`orders-http.integration.test.ts` /
+  `orders-http-state.integration.test.ts`) — when a component crosses the
+  cap, pull out the REPEATED per-item rendering unit first; it is almost
+  always the largest, most self-contained slice.

--- a/.claude/rules/orders.md
+++ b/.claude/rules/orders.md
@@ -169,3 +169,15 @@ paths:
   preto zostávajú ASCII-only — skutočná diakritika sa testuje cez
   commitnutú fixtúru (`fixtures/orders-sample.csv`), ktorá JE natívne cp1250
   na disku.
+- **`order_line.ordered` (issue 60) je NEZÁVISLÝ boolean od `order_line.state`
+  enumu — nezamieňať.** `state` (objednane/caka_sa/skladom/nedostupne) sleduje
+  POSTUP u dodávateľa (a jeho `objednane` hodnota je VÝCHODISKOVÝ/predvolený
+  stav riadku — vo frontende zobrazený ako "Nevybavené", NIE "Objednané", od
+  issue 60). `ordered` je samostatný príznak "manažér toto reálne objednal u
+  dodávateľa" (checkbox + hromadné tlačidlo na "Na objednanie", `state.ts`'s
+  `setOrderLineOrdered`/`setSupplierLinesOrdered`) — rovnaký zámer ako stará
+  appka's samostatný `ORDERED` flag, oddelený od WAITING/INSTOCK/UNAVAIL.
+  Manažér ho môže odškrtnúť v ĽUBOVOĽNOM `state`; mailová agregácia (`mail.ts`)
+  aj ďalej filtruje LEN podľa `state === "objednane"`, `ordered` na ňu vôbec
+  nevplýva. Ďalšia funkcia, ktorá by potrebovala "bolo toto už vybavené",
+  siahni po `ordered`, nie po pridávaní ďalšej hodnoty do `state` enumu.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -235,3 +235,17 @@ paths:
   Pri pridávaní/úprave e2e testu okolo AKÉHOKOĽVEK `<select>`u v tejto appke
   vždy skontroluj, či asercia naozaj testuje VYBRANÚ hodnotu, nie len
   prítomnosť textu niekde v okolí.
+- **Rovnaký problém, iný tvar: Playwright's `locator.check()` na kontrolovanom
+  (`checked={...}`) checkboxe, ktorého `onChange` spúšťa ASYNC zápis (fetch na
+  server), zlyhá s "Clicking the checkbox did not change its state"** —
+  `.check()` si SÁM ihneď po kliku overí, že checkbox je zaškrtnutý, ale
+  optimistický lokálny update sa prejaví AŽ po vyriešení promisu, takže na
+  pomalšom CI behu (nie lokálne) prehrá závod. Zistené issue 60
+  (`orders.spec.ts`'s test odškrtávacieho políčka "objednané u dodávateľa" —
+  lokálne 100% prešiel, na GitHub Actions runneri spadol na prvom pokuse).
+  Fix je rovnaký princíp ako `<select>` vyššie: `.click()` namiesto
+  `.check()`/`.uncheck()`, a POTOM `await expect(checkbox).toBeChecked()`
+  (alebo `.not.toBeChecked()`) — to SKUTOČNE čaká/opakuje, kým sa zápis
+  potvrdí. Pri pridávaní e2e testu okolo AKÉHOKOĽVEK kontrolovaného
+  checkboxu v tejto appke použi `.click()` + `expect().toBeChecked()`, nikdy
+  `.check()`/`.uncheck()` priamo.

--- a/apps/api/src/modules/orders/open-statuses.ts
+++ b/apps/api/src/modules/orders/open-statuses.ts
@@ -59,8 +59,12 @@ function cleanStatusList(statuses: readonly string[]): string[] {
 }
 
 /** Nastavené stavy, ktoré sa počítajú ako "objednávka sa ešte vybavuje" —
- * abecedne, pre stabilné, ľahko overiteľné poradie na obrazovke. */
-export async function listOpenStatusNames(db: Database): Promise<readonly string[]> {
+ * abecedne, pre stabilné, ľahko overiteľné poradie na obrazovke.
+ * `Pick<Database, "select">` (nie celý `Database`) — review of PR 75, finding
+ * 3: `queries.ts`'s `listOpenOrderLineIdsForSupplier` teraz volá toto aj
+ * s `tx` (`PgTransaction`), ktorý nemá `Database`'s `$client`
+ * (`.claude/rules/database.md`). */
+export async function listOpenStatusNames(db: Pick<Database, "select">): Promise<readonly string[]> {
   const rows = await db
     .select({ statusName: orderOpenStatuses.statusName })
     .from(orderOpenStatuses)

--- a/apps/api/src/modules/orders/queries.ts
+++ b/apps/api/src/modules/orders/queries.ts
@@ -149,7 +149,27 @@ export async function listOpenOrderLinesBySupplier(db: Database): Promise<readon
 // SAMOSTATNÝ, užší dopyt (len ID, žiadne meno/veľkosť/odkaz na dodávateľa),
 // nie filtrovanie výstupu `listOpenOrderLinesBySupplier` v pamäti, aby
 // hromadná akcia nemusela ťahať VŠETKÝCH dodávateľov len kvôli jednému.
-export async function listOpenOrderLineIdsForSupplier(db: Database, supplier: string): Promise<readonly string[]> {
+//
+// Code review (review of PR 75, issue 60, finding 3): pôvodne bežal tento
+// dopyt MIMO transakcie, ktorá potom vykonáva hromadný UPDATE — medzi
+// prečítaním a zápisom mohol súbežný re-import objednávok alebo per-riadkové
+// prepnutie stavu zmeniť, ktoré riadky sú pre daného dodávateľa "otvorené"
+// (úzke TOCTOU okno, bez straty dát — zápis ide vždy na explicitné ID — ale
+// hromadná akcia mohla občas zasiahnuť riadok, ktorý medzitým opustil/vstúpil
+// do otvorenej skupiny). Volajúci (`state.ts`'s `setSupplierLinesOrdered`)
+// teraz volá TENTO dopyt AŽ VNÚTRI vlastnej transakcie a `.for("update")`
+// zamyká VŠETKY tabuľky JOINu bez ohľadu obmedzenia (žiadny `of` zoznam) —
+// vrátane `order`, takže súbežná zmena stavu objednávky (aj `setOrderLineState`'s
+// vlastný `.for("update")` na `order_line`) musí počkať na COMMIT tejto
+// transakcie, nie naopak. Parameter je preto zúžený na `Pick<Database,
+// "select">` (rovnaký vzor ako `audit/service.ts`'s `AuditExecutor`) — `tx`
+// (`PgTransaction`) nemá `Database`'s `$client`, takže by ho `tsc` odmietol
+// ako celý `Database` (`.claude/rules/database.md`). Regresný dôkaz:
+// `tests/orders-supplier-bulk-lock.integration.test.ts`.
+export async function listOpenOrderLineIdsForSupplier(
+  db: Pick<Database, "select">,
+  supplier: string,
+): Promise<readonly string[]> {
   const openStatuses = await listOpenStatusNames(db);
   if (openStatuses.length === 0) return [];
 
@@ -161,7 +181,8 @@ export async function listOpenOrderLineIdsForSupplier(db: Database, supplier: st
     .innerJoin(orders, eq(orders.id, orderLines.orderId))
     .innerJoin(variants, eq(variants.code, orderLines.variantCode))
     .innerJoin(products, eq(products.key, variants.productKey))
-    .where(and(inArray(orders.statusName, [...openStatuses]), supplierFilter));
+    .where(and(inArray(orders.statusName, [...openStatuses]), supplierFilter))
+    .for("update");
 
   return rows.map((row) => row.lineId);
 }

--- a/apps/api/src/modules/orders/state.ts
+++ b/apps/api/src/modules/orders/state.ts
@@ -123,30 +123,42 @@ export interface SetSupplierLinesOrderedResult {
 // review na #59/#44). Zoznam dotknutých riadkov sa počíta z RIADKOV, ktoré
 // `GET /api/orders/open` PRÁVE TERAZ zobrazuje pre daného dodávateľa
 // (`listOpenOrderLineIdsForSupplier`) — teda presne to, čo manažér na
-// obrazovke vidí, nie všetky historické riadky toho dodávateľa. Samotný
+// obrazovke vidí, nie všetky historické riadky toho dodávateľa. Lookup +
 // zápis + JEDEN agregovaný audit záznam (namiesto jedného na riadok — inak
 // by kliknutie na 20-riadkovú skupinu vyrobilo 20 auditových riadkov za
-// jednu manažérovu akciu) bežia v JEDNEJ transakcii. Prázdna skupina (0
-// riadkov) je NEŠKODNÝ no-op, nie chyba — nič sa nezapíše, ani do auditu.
+// jednu manažérovu akciu) bežia VŠETKY v JEDNEJ transakcii (review of PR 75,
+// finding 3 — lookup pôvodne bežal MIMO nej, `.claude/rules/orders.md`
+// odkazuje na `queries.ts`'s komentár pre detail race/opravy). Prázdna
+// skupina (0 riadkov) je NEŠKODNÝ no-op, nie chyba — transakcia sa aj tak
+// otvorí a hneď commitne bez zápisu, nič sa nezapíše ani do auditu.
 export async function setSupplierLinesOrdered(
   db: Database,
   input: SetSupplierLinesOrderedInput,
 ): Promise<SetSupplierLinesOrderedResult> {
-  const lineIds = await listOpenOrderLineIdsForSupplier(db, input.supplier);
-  if (lineIds.length === 0) return { lineCount: 0 };
+  return db.transaction(async (tx) => {
+    const lineIds = await listOpenOrderLineIdsForSupplier(tx, input.supplier);
+    if (lineIds.length === 0) return { lineCount: 0 };
 
-  await db.transaction(async (tx) => {
     await tx.update(orderLines).set({ ordered: input.ordered }).where(inArray(orderLines.id, [...lineIds]));
 
+    // Review of PR 75, finding 1: pôvodne `entity: "supplier_contact"` —
+    // tento zápis mutuje `order_line` riadky, nie e-mailový kontakt
+    // dodávateľa, takže audit query filtrovaný podľa `entity = "order_line"`
+    // by ho ticho vynechal a filter podľa `"supplier_contact"` by ho miešal s
+    // nesúvisiacimi udalosťami e-mailového kontaktu. Rovnaký entity typ ako
+    // KAŽDÁ iná `order_line`-mutujúca akcia v tomto súbore (`state.ts:47,94`);
+    // `entityId` ostáva `null` (žiadny JEDEN riadok, na ktorý by mal
+    // ukazovať — rovnaký vzor ako `orders-routes.ts`'s bulk
+    // `orders.ingest.trigger` udalosť), dodávateľ + zasiahnuté ID zostávajú v
+    // `data`.
     await record(tx, {
       at: input.now,
       actorUserId: input.actorUserId,
       action: "order_line.ordered.bulk_changed",
-      entity: "supplier_contact",
-      entityId: input.supplier,
+      entity: "order_line",
       data: { supplier: input.supplier, ordered: input.ordered, lineIds, lineCount: lineIds.length },
     });
-  });
 
-  return { lineCount: lineIds.length };
+    return { lineCount: lineIds.length };
+  });
 }

--- a/apps/api/tests/orders-http-ordered.integration.test.ts
+++ b/apps/api/tests/orders-http-ordered.integration.test.ts
@@ -182,7 +182,14 @@ it("manažér označí celú skupinu dodávateľa ako objednané naraz, JEDEN ag
   const bulkUdalosti = udalosti.filter((e) => e.action === "order_line.ordered.bulk_changed");
   expect(bulkUdalosti).toHaveLength(1);
   expect(bulkUdalosti[0]?.actorUserId).toBe(userId);
-  expect(bulkUdalosti[0]?.entityId).toBe("Dodávateľ Bulk");
+  // Review of PR 75, finding 1: hromadná akcia mutuje `order_line` riadky,
+  // nie e-mailový kontakt dodávateľa — entity musí byť rovnaké ako pri
+  // KAŽDEJ inej `order_line`-mutujúcej akcii (`state.ts:47,94`), inak by
+  // audit dopyt filtrovaný podľa `entity = "order_line"` túto hromadnú zmenu
+  // ticho vynechal. `entityId` ostáva `null` (žiadny JEDEN riadok) —
+  // dodávateľ je v `data` nižšie.
+  expect(bulkUdalosti[0]?.entity).toBe("order_line");
+  expect(bulkUdalosti[0]?.entityId).toBeNull();
   expect(bulkUdalosti[0]?.data).toMatchObject({
     supplier: "Dodávateľ Bulk",
     ordered: true,

--- a/apps/api/tests/orders-http-ordered.integration.test.ts
+++ b/apps/api/tests/orders-http-ordered.integration.test.ts
@@ -254,3 +254,97 @@ it("rola citanie nesmie hromadne meniť príznak objednané", async () => {
   });
   expect(res.status).toBe(403);
 });
+
+// Review of PR 75, finding 4: `orders-http-state.integration.test.ts` testuje
+// rolu "sef" popri "citanie" pri zmene stavu (:101,:112) — rovnaká rola
+// chýbala tu pre hromadnú akciu.
+it("rola sef nesmie hromadne meniť príznak objednané", async () => {
+  const { app, cookie, db } = await boot("sef");
+  await db.insert(orderOpenStatuses).values({ statusName: "Vybavuje sa" }).onConflictDoNothing();
+  await vlozRiadok(db, "Dodávateľ X");
+
+  const res = await app.request(`/api/suppliers/${encodeURIComponent("Dodávateľ X")}/order-lines/ordered`, {
+    method: "PUT",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ ordered: true }),
+  });
+  expect(res.status).toBe(403);
+});
+
+// Review of PR 75, finding 5: per-riadkový endpoint má "neplatné telo → 400"
+// test (vyššie, `neplatná hodnota vráti 400`) — hromadný endpoint ho nemal.
+it("hromadná akcia s neplatným telom vráti 400", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await db.insert(orderOpenStatuses).values({ statusName: "Vybavuje sa" }).onConflictDoNothing();
+  await vlozRiadok(db, "Dodávateľ X");
+
+  const res = await app.request(`/api/suppliers/${encodeURIComponent("Dodávateľ X")}/order-lines/ordered`, {
+    method: "PUT",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ ordered: "ano" }),
+  });
+  expect(res.status).toBe(400);
+});
+
+// Review of PR 75, finding 2: `orders-http-state.integration.test.ts` má
+// cudzí-Origin (403) / rovnaký-pôvod (200) test pre zmenu stavu — ani jeden
+// z dvoch NOVÝCH endpointov (issue 60) ho nemal, hoci `requireSameOrigin()`
+// je na oboch zaregistrovaný.
+it("zmena príznaku objednané s cudzím Origin je odmietnutá (403), rovnaký pôvod prejde", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  const { lineId } = await vlozRiadok(db);
+
+  const cudzi = await app.request(`/api/orders/lines/${lineId}/ordered`, {
+    method: "POST",
+    headers: {
+      cookie,
+      "content-type": "application/json",
+      origin: "https://utocnik.example",
+      host: "forestshop.example",
+    },
+    body: JSON.stringify({ ordered: true }),
+  });
+  expect(cudzi.status).toBe(403);
+
+  const rovnaky = await app.request(`/api/orders/lines/${lineId}/ordered`, {
+    method: "POST",
+    headers: {
+      cookie,
+      "content-type": "application/json",
+      origin: "https://forestshop.example",
+      host: "forestshop.example",
+    },
+    body: JSON.stringify({ ordered: true }),
+  });
+  expect(rovnaky.status).toBe(200);
+});
+
+it("hromadná zmena príznaku objednané s cudzím Origin je odmietnutá (403), rovnaký pôvod prejde", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await db.insert(orderOpenStatuses).values({ statusName: "Vybavuje sa" }).onConflictDoNothing();
+  await vlozRiadok(db, "Dodávateľ Origin");
+
+  const cudzi = await app.request(`/api/suppliers/${encodeURIComponent("Dodávateľ Origin")}/order-lines/ordered`, {
+    method: "PUT",
+    headers: {
+      cookie,
+      "content-type": "application/json",
+      origin: "https://utocnik.example",
+      host: "forestshop.example",
+    },
+    body: JSON.stringify({ ordered: true }),
+  });
+  expect(cudzi.status).toBe(403);
+
+  const rovnaky = await app.request(`/api/suppliers/${encodeURIComponent("Dodávateľ Origin")}/order-lines/ordered`, {
+    method: "PUT",
+    headers: {
+      cookie,
+      "content-type": "application/json",
+      origin: "https://forestshop.example",
+      host: "forestshop.example",
+    },
+    body: JSON.stringify({ ordered: true }),
+  });
+  expect(rovnaky.status).toBe(200);
+});

--- a/apps/api/tests/orders-supplier-bulk-lock.integration.test.ts
+++ b/apps/api/tests/orders-supplier-bulk-lock.integration.test.ts
@@ -1,0 +1,108 @@
+import pg from "pg";
+import { afterEach, expect, it } from "vitest";
+import { orderLines, orderOpenStatuses, orders, users } from "../src/db/schema.js";
+import { setSupplierLinesOrdered } from "../src/modules/orders/state.js";
+import { insertTestVariant } from "./helpers/orders.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// Code review finding on review of PR 75 (issue 60, finding 3):
+// `listOpenOrderLineIdsForSupplier` was originally read OUTSIDE the
+// transaction that later performs the bulk UPDATE — between the read and
+// the write, a concurrent order re-import or per-row toggle could change
+// which lines count as "open" for that supplier (no data corruption, each
+// write is by explicit id, but a real narrow TOCTOU window). Fix: the id
+// lookup now runs INSIDE the same transaction as the write, `.for("update")`
+// on the joined `order_line`/`order`/`variant`/`product` query.
+//
+// Same deterministic proof technique as `orders-state-lock.integration.test.ts`:
+// hold `SELECT ... FOR UPDATE` on the `order` row (part of the lookup's
+// JOIN) open in an uncommitted transaction from a second raw connection.
+// `FOR UPDATE` with no `OF` list locks rows in EVERY table referenced by the
+// query (Postgres docs) — so once the lookup runs `.for("update")` across
+// the join, it must lock the matched `order` row too, and therefore block on
+// this held lock. BEFORE the fix, the lookup was a plain unlocked SELECT
+// outside any transaction — a plain read never waits on another
+// transaction's row lock in Postgres MVCC, so the bulk call would race
+// ahead completely unaffected by the held lock. This is what makes the test
+// fail on the unfixed code (the call resolves well before the raw
+// connection commits) and pass on the fixed code (the call blocks until the
+// commit).
+
+let close: (() => Promise<void>) | undefined;
+
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+});
+
+it("hromadné označenie čaká na riadkový zámok objednávky — lookup beží VNÚTRI transakcie s FOR UPDATE", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const db = ctx.db;
+
+  await db.insert(orderOpenStatuses).values({ statusName: "Vybavuje sa" }).onConflictDoNothing();
+  await insertTestVariant(db, "L-1", "Dodávateľ Lock");
+  const [pouzivatel] = await db
+    .insert(users)
+    .values({
+      email: "manazer-bulk-lock-test@forestshop.sk",
+      passwordHash: "x", // FK potrebuje existujúci riadok, heslo sa v tomto teste nikdy neoveruje
+      displayName: "Manažér",
+      role: "manazer",
+    })
+    .returning({ id: users.id });
+  if (pouzivatel === undefined) throw new Error("insert používateľa zlyhal");
+
+  const [objednavka] = await db
+    .insert(orders)
+    .values({ externalOrderId: "6001", customerName: "Zákazník", placedAt: new Date("2026-07-20T00:00:00Z") })
+    .returning();
+  if (objednavka === undefined) throw new Error("insert objednávky zlyhal");
+  const [riadok] = await db
+    .insert(orderLines)
+    .values({ orderId: objednavka.id, variantCode: "L-1", quantity: 1 })
+    .returning();
+  if (riadok === undefined) throw new Error("insert riadku zlyhal");
+
+  const databaseUrl = process.env["DATABASE_URL"];
+  if (databaseUrl === undefined || databaseUrl === "") {
+    throw new Error("Integračné testy potrebujú DATABASE_URL");
+  }
+  const rawClient = new pg.Client({ connectionString: databaseUrl });
+  await rawClient.connect();
+  await rawClient.query("BEGIN");
+  // Podrží riadkový zámok na `order` riadku — súčasti JOINu, ktorý
+  // `listOpenOrderLineIdsForSupplier` používa.
+  await rawClient.query('SELECT id FROM "order" WHERE id = $1 FOR UPDATE', [objednavka.id]);
+
+  try {
+    const bulk = setSupplierLinesOrdered(db, {
+      supplier: "Dodávateľ Lock",
+      ordered: true,
+      actorUserId: pouzivatel.id,
+      now: new Date("2026-07-30T10:00:00Z"),
+    });
+
+    let doriesene = false;
+    void bulk.then(() => {
+      doriesene = true;
+    });
+
+    // Dá bulk lookupu dosť času dôjsť k zámku a zaseknúť sa naň — zámok drží
+    // `rawClient`, takže "príliš neskoro" tu nehrozí, len čakáme, kým sa naň
+    // naozaj zasekne.
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(doriesene).toBe(false);
+
+    // Simuluje súbežnú zmenu, ktorá stihla commitnúť MEDZITÝM — priamo, mimo
+    // `setSupplierLinesOrdered`, presne v momente, keď je bulk akcia
+    // zaseknutá na zámku.
+    await rawClient.query("COMMIT");
+
+    const result = await bulk;
+    expect(result).toEqual({ lineCount: 1 });
+    expect(doriesene).toBe(true);
+  } finally {
+    await rawClient.end();
+  }
+});

--- a/apps/web/src/components/OrderLineRow.tsx
+++ b/apps/web/src/components/OrderLineRow.tsx
@@ -21,6 +21,7 @@ export function OrderLineRow({
   canChangeState,
   busyLineId,
   busyOrderedLineId,
+  supplierBusy,
   onChangeState,
   onChangeOrdered,
 }: {
@@ -28,6 +29,14 @@ export function OrderLineRow({
   readonly canChangeState: boolean;
   readonly busyLineId: string | null;
   readonly busyOrderedLineId: string | null;
+  // Review of PR 75, finding 6: TRUE, keď práve prebieha hromadné "označiť/
+  // zrušiť skupinu ako objednané" PRE DODÁVATEĽA tohto riadku
+  // (`OrdersSection.tsx`'s `busyOrderedSupplier === group.supplier`) —
+  // nezávislé od `busyOrderedLineId` (vlastný per-riadkový zápis). Bez toho
+  // mohol manažér kliknúť na tento riadok ešte kým hromadný zápis pre celú
+  // skupinu bežal, čo krátkodobo rozhádzalo optimistický UI (posledný zápis
+  // vyhrá, žiadna strata dát, len zmätočné UX).
+  readonly supplierBusy: boolean;
   readonly onChangeState: (lineId: string, newState: OrderLine["state"]) => void;
   readonly onChangeOrdered: (lineId: string, ordered: boolean) => void;
 }): JSX.Element {
@@ -42,7 +51,7 @@ export function OrderLineRow({
           data-testid={`ordered-checkbox-${line.lineId}`}
           aria-label={`Označiť riadok objednávky ${line.externalOrderId} / ${line.variantCode} ako objednané u dodávateľa`}
           checked={line.ordered}
-          disabled={!canChangeState || busyOrderedLineId === line.lineId}
+          disabled={!canChangeState || busyOrderedLineId === line.lineId || supplierBusy}
           onChange={(e) => {
             onChangeOrdered(line.lineId, e.target.checked);
           }}

--- a/apps/web/src/components/OrdersSection.ordered.test.tsx
+++ b/apps/web/src/components/OrdersSection.ordered.test.tsx
@@ -1,0 +1,188 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { OrdersSection } from "./OrdersSection.js";
+
+// issue 60: odškrtávacie políčko "objednané u dodávateľa" — per riadok aj
+// hromadne pre celú skupinu. Vydelené z `OrdersSection.test.tsx`, aby ani
+// jeden zo súborov nenarástol cez eslint `max-lines: 400`
+// (`.claude/rules/frontend-design.md`) — rovnaký vzor ako existujúci
+// `orders-http.integration.test.ts` / `orders-http-state.integration.test.ts`
+// split na strane API testov.
+
+const { fetchOpenOrders, updateOrderLineOrdered, setSupplierLinesOrdered } = vi.hoisted(() => ({
+  fetchOpenOrders: vi.fn(),
+  updateOrderLineOrdered: vi.fn(),
+  setSupplierLinesOrdered: vi.fn(),
+}));
+
+vi.mock("../ordersApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../ordersApi.js")>();
+  return {
+    ...actual,
+    fetchOpenOrders,
+    updateOrderLineOrdered,
+    setSupplierLinesOrdered,
+  };
+});
+
+const LINE_STARA = {
+  lineId: "11111111-1111-1111-1111-111111111111",
+  orderId: "aaaaaaaa-1111-1111-1111-111111111111",
+  externalOrderId: "1001",
+  customerName: "Zákazník Starý",
+  comment: null,
+  placedAt: "2026-07-01T00:00:00.000Z",
+  variantCode: "A-1",
+  variantName: "Nohavice FOREST 1003",
+  sizeLabel: "3XL",
+  quantity: 2,
+  state: "objednane" as const,
+  ordered: false,
+  supplierUrl: null,
+  supplierNote: null,
+  externalCode: null,
+};
+
+const LINE_NOVA = {
+  lineId: "22222222-2222-2222-2222-222222222222",
+  orderId: "bbbbbbbb-2222-2222-2222-222222222222",
+  externalOrderId: "1002",
+  customerName: "Zákazník Nový",
+  comment: "Zavolať pred doručením",
+  placedAt: "2026-07-15T00:00:00.000Z",
+  variantCode: "B-1",
+  variantName: "Bunda FOREST 2001",
+  sizeLabel: null,
+  quantity: 1,
+  state: "skladom" as const,
+  ordered: false,
+  supplierUrl: null,
+  supplierNote: null,
+  externalCode: null,
+};
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+it("rola citanie vidí políčko objednané ako needitovateľné", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_STARA], email: null }]);
+
+  render(<OrdersSection role="citanie" onSessionExpired={() => {}} />);
+
+  const checkbox = await screen.findByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_STARA.lineId}`);
+  expect(checkbox.checked).toBe(false);
+  expect(checkbox.disabled).toBe(true);
+});
+
+it("manažér odškrtne riadok ako objednaný, riadok sa vizuálne stlmí bez nového načítania", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_STARA], email: null }]);
+  updateOrderLineOrdered.mockResolvedValue(undefined);
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const checkbox = await screen.findByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_STARA.lineId}`);
+  expect(checkbox.checked).toBe(false);
+  expect(checkbox.disabled).toBe(false);
+
+  fireEvent.click(checkbox);
+
+  await waitFor(() => {
+    expect(updateOrderLineOrdered).toHaveBeenCalledWith(LINE_STARA.lineId, true);
+  });
+  await waitFor(() => {
+    expect(screen.getByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_STARA.lineId}`).checked).toBe(true);
+  });
+  expect(screen.getByTestId(`order-line-${LINE_STARA.lineId}`).className).toContain("ordered");
+  // Presne JEDNO volanie fetchOpenOrders (počiatočné načítanie) — lokálna
+  // aktualizácia, žiadny refetch.
+  expect(fetchOpenOrders).toHaveBeenCalledTimes(1);
+  expect(screen.queryByRole("alert")).toBeNull();
+});
+
+it("zlyhaná zmena príznaku objednané zobrazí slovenskú hlášku a checkbox sa nezmení", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_STARA], email: null }]);
+  updateOrderLineOrdered.mockRejectedValue(new Error("Zmena príznaku objednané sa nepodarila"));
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const checkbox = await screen.findByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_STARA.lineId}`);
+  fireEvent.click(checkbox);
+
+  await waitFor(() => {
+    expect(screen.getByRole("alert").textContent).toBe("Zmena príznaku objednané sa nepodarila");
+  });
+  expect(screen.getByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_STARA.lineId}`).checked).toBe(false);
+});
+
+it("manažér označí celú skupinu dodávateľa naraz, tlačidlo sa prepne na zrušenie", async () => {
+  fetchOpenOrders.mockResolvedValue([
+    { supplier: "Dodávateľ Alfa", lines: [LINE_STARA, LINE_NOVA], email: null },
+  ]);
+  setSupplierLinesOrdered.mockResolvedValue({ lineCount: 2 });
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const oznacit = await screen.findByRole("button", { name: "✔ Označiť skupinu ako objednané" });
+  fireEvent.click(oznacit);
+
+  await waitFor(() => {
+    expect(setSupplierLinesOrdered).toHaveBeenCalledWith("Dodávateľ Alfa", true);
+  });
+  await waitFor(() => {
+    expect(screen.getByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_STARA.lineId}`).checked).toBe(true);
+  });
+  expect(screen.getByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_NOVA.lineId}`).checked).toBe(true);
+
+  // Skupina je teraz celá objednaná — tlačidlo prepína OPAČNÝM smerom.
+  const zrusit = await screen.findByRole("button", { name: "↺ Zrušiť označenie skupiny" });
+  setSupplierLinesOrdered.mockResolvedValue({ lineCount: 2 });
+  fireEvent.click(zrusit);
+
+  await waitFor(() => {
+    expect(setSupplierLinesOrdered).toHaveBeenCalledWith("Dodávateľ Alfa", false);
+  });
+});
+
+// Review of PR 75, finding 6: per-riadkový checkbox bol doteraz disabled LEN
+// cez `busyOrderedLineId` (vlastný per-riadkový zápis) — nie aj počas
+// hromadnej "označiť skupinu" akcie PRE TEN ISTÝ dodávateľ
+// (`busyOrderedSupplier` v `OrdersSection.tsx`). Súbežný per-riadkový klik
+// počas ešte prebiehajúceho hromadného zápisu nechal optimistický UI na
+// krátko nekonzistentný (posledný zápis vyhrá, žiadna strata dát, ale
+// zmätočné UX).
+it("riadok checkbox je disabled počas hromadnej akcie pre jeho dodávateľa, po jej dokončení sa znova sprístupní", async () => {
+  fetchOpenOrders.mockResolvedValue([
+    { supplier: "Dodávateľ Alfa", lines: [LINE_STARA, LINE_NOVA], email: null },
+  ]);
+  let resolveBulk: ((value: { lineCount: number }) => void) | undefined;
+  setSupplierLinesOrdered.mockImplementation(
+    () =>
+      new Promise((resolve) => {
+        resolveBulk = resolve;
+      }),
+  );
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const oznacit = await screen.findByRole("button", { name: "✔ Označiť skupinu ako objednané" });
+  const checkboxStara = await screen.findByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_STARA.lineId}`);
+  expect(checkboxStara.disabled).toBe(false);
+
+  fireEvent.click(oznacit);
+
+  // Kým hromadný zápis ešte beží, OBIDVA riadky tohto dodávateľa musia byť
+  // needitovateľné — nielen ten, na ktorý by manažér prípadne klikol zvlášť.
+  await waitFor(() => {
+    expect(screen.getByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_STARA.lineId}`).disabled).toBe(true);
+  });
+  expect(screen.getByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_NOVA.lineId}`).disabled).toBe(true);
+
+  resolveBulk?.({ lineCount: 2 });
+
+  await waitFor(() => {
+    expect(screen.getByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_STARA.lineId}`).disabled).toBe(false);
+  });
+  expect(screen.getByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_NOVA.lineId}`).disabled).toBe(false);
+});

--- a/apps/web/src/components/OrdersSection.test.tsx
+++ b/apps/web/src/components/OrdersSection.test.tsx
@@ -2,19 +2,18 @@ import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-li
 import { afterEach, expect, it, vi } from "vitest";
 import { OrdersSection } from "./OrdersSection.js";
 
+// `updateOrderLineOrdered`/`setSupplierLinesOrdered` mocks moved to
+// `OrdersSection.ordered.test.tsx` alongside the tests that actually
+// exercise them (review of PR 75, finding 6 — same file split).
 const {
   fetchOpenOrders,
   updateOrderLineState,
-  updateOrderLineOrdered,
-  setSupplierLinesOrdered,
   setSupplierEmail,
   fetchSupplierOrderMailPreview,
   sendSupplierOrderMail,
 } = vi.hoisted(() => ({
   fetchOpenOrders: vi.fn(),
   updateOrderLineState: vi.fn(),
-  updateOrderLineOrdered: vi.fn(),
-  setSupplierLinesOrdered: vi.fn(),
   setSupplierEmail: vi.fn(),
   fetchSupplierOrderMailPreview: vi.fn(),
   sendSupplierOrderMail: vi.fn(),
@@ -29,8 +28,6 @@ vi.mock("../ordersApi.js", async (importOriginal) => {
     ...actual,
     fetchOpenOrders,
     updateOrderLineState,
-    updateOrderLineOrdered,
-    setSupplierLinesOrdered,
     setSupplierEmail,
     fetchSupplierOrderMailPreview,
     sendSupplierOrderMail,
@@ -312,128 +309,10 @@ it("zmena stavu pri 401 zavolá onSessionExpired namiesto zobrazenia chyby", asy
 });
 
 // issue 60: odškrtávacie políčko "objednané u dodávateľa" — per riadok aj
-// hromadne pre celú skupinu.
-
-it("rola citanie vidí políčko objednané ako needitovateľné", async () => {
-  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_STARA], email: null }]);
-
-  render(<OrdersSection role="citanie" onSessionExpired={() => {}} />);
-
-  const checkbox = await screen.findByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_STARA.lineId}`);
-  expect(checkbox.checked).toBe(false);
-  expect(checkbox.disabled).toBe(true);
-});
-
-it("manažér odškrtne riadok ako objednaný, riadok sa vizuálne stlmí bez nového načítania", async () => {
-  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_STARA], email: null }]);
-  updateOrderLineOrdered.mockResolvedValue(undefined);
-
-  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
-
-  const checkbox = await screen.findByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_STARA.lineId}`);
-  expect(checkbox.checked).toBe(false);
-  expect(checkbox.disabled).toBe(false);
-
-  fireEvent.click(checkbox);
-
-  await waitFor(() => {
-    expect(updateOrderLineOrdered).toHaveBeenCalledWith(LINE_STARA.lineId, true);
-  });
-  await waitFor(() => {
-    expect(screen.getByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_STARA.lineId}`).checked).toBe(true);
-  });
-  expect(screen.getByTestId(`order-line-${LINE_STARA.lineId}`).className).toContain("ordered");
-  // Presne JEDNO volanie fetchOpenOrders (počiatočné načítanie) — lokálna
-  // aktualizácia, žiadny refetch.
-  expect(fetchOpenOrders).toHaveBeenCalledTimes(1);
-  expect(screen.queryByRole("alert")).toBeNull();
-});
-
-it("zlyhaná zmena príznaku objednané zobrazí slovenskú hlášku a checkbox sa nezmení", async () => {
-  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_STARA], email: null }]);
-  updateOrderLineOrdered.mockRejectedValue(new Error("Zmena príznaku objednané sa nepodarila"));
-
-  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
-
-  const checkbox = await screen.findByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_STARA.lineId}`);
-  fireEvent.click(checkbox);
-
-  await waitFor(() => {
-    expect(screen.getByRole("alert").textContent).toBe("Zmena príznaku objednané sa nepodarila");
-  });
-  expect(screen.getByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_STARA.lineId}`).checked).toBe(false);
-});
-
-it("manažér označí celú skupinu dodávateľa naraz, tlačidlo sa prepne na zrušenie", async () => {
-  fetchOpenOrders.mockResolvedValue([
-    { supplier: "Dodávateľ Alfa", lines: [LINE_STARA, LINE_NOVA], email: null },
-  ]);
-  setSupplierLinesOrdered.mockResolvedValue({ lineCount: 2 });
-
-  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
-
-  const oznacit = await screen.findByRole("button", { name: "✔ Označiť skupinu ako objednané" });
-  fireEvent.click(oznacit);
-
-  await waitFor(() => {
-    expect(setSupplierLinesOrdered).toHaveBeenCalledWith("Dodávateľ Alfa", true);
-  });
-  await waitFor(() => {
-    expect(screen.getByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_STARA.lineId}`).checked).toBe(true);
-  });
-  expect(screen.getByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_NOVA.lineId}`).checked).toBe(true);
-
-  // Skupina je teraz celá objednaná — tlačidlo prepína OPAČNÝM smerom.
-  const zrusit = await screen.findByRole("button", { name: "↺ Zrušiť označenie skupiny" });
-  setSupplierLinesOrdered.mockResolvedValue({ lineCount: 2 });
-  fireEvent.click(zrusit);
-
-  await waitFor(() => {
-    expect(setSupplierLinesOrdered).toHaveBeenCalledWith("Dodávateľ Alfa", false);
-  });
-});
-
-// Review of PR 75, finding 6: per-riadkový checkbox bol doteraz disabled LEN
-// cez `busyOrderedLineId` (vlastný per-riadkový zápis) — nie aj počas
-// hromadnej "označiť skupinu" akcie PRE TEN ISTÝ dodávateľ
-// (`busyOrderedSupplier` v `OrdersSection.tsx`). Súbežný per-riadkový klik
-// počas ešte prebiehajúceho hromadného zápisu nechal optimistický UI na
-// krátko nekonzistentný (posledný zápis vyhrá, žiadna strata dát, ale
-// zmätočné UX).
-it("riadok checkbox je disabled počas hromadnej akcie pre jeho dodávateľa, po jej dokončení sa znova sprístupní", async () => {
-  fetchOpenOrders.mockResolvedValue([
-    { supplier: "Dodávateľ Alfa", lines: [LINE_STARA, LINE_NOVA], email: null },
-  ]);
-  let resolveBulk: ((value: { lineCount: number }) => void) | undefined;
-  setSupplierLinesOrdered.mockImplementation(
-    () =>
-      new Promise((resolve) => {
-        resolveBulk = resolve;
-      }),
-  );
-
-  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
-
-  const oznacit = await screen.findByRole("button", { name: "✔ Označiť skupinu ako objednané" });
-  const checkboxStara = await screen.findByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_STARA.lineId}`);
-  expect(checkboxStara.disabled).toBe(false);
-
-  fireEvent.click(oznacit);
-
-  // Kým hromadný zápis ešte beží, OBIDVA riadky tohto dodávateľa musia byť
-  // needitovateľné — nielen ten, na ktorý by manažér prípadne klikol zvlášť.
-  await waitFor(() => {
-    expect(screen.getByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_STARA.lineId}`).disabled).toBe(true);
-  });
-  expect(screen.getByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_NOVA.lineId}`).disabled).toBe(true);
-
-  resolveBulk?.({ lineCount: 2 });
-
-  await waitFor(() => {
-    expect(screen.getByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_STARA.lineId}`).disabled).toBe(false);
-  });
-  expect(screen.getByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_NOVA.lineId}`).disabled).toBe(false);
-});
+// hromadne pre celú skupinu — vydelené do vlastného súboru
+// `OrdersSection.ordered.test.tsx` (review of PR 75, finding 6 pridalo ďalší
+// test a poslalo tento súbor cez eslint `max-lines: 400`,
+// `.claude/rules/frontend-design.md`).
 
 // #31: e-mailový kontakt dodávateľa + odoslanie objednávky mailom.
 

--- a/apps/web/src/components/OrdersSection.test.tsx
+++ b/apps/web/src/components/OrdersSection.test.tsx
@@ -393,6 +393,48 @@ it("manažér označí celú skupinu dodávateľa naraz, tlačidlo sa prepne na 
   });
 });
 
+// Review of PR 75, finding 6: per-riadkový checkbox bol doteraz disabled LEN
+// cez `busyOrderedLineId` (vlastný per-riadkový zápis) — nie aj počas
+// hromadnej "označiť skupinu" akcie PRE TEN ISTÝ dodávateľ
+// (`busyOrderedSupplier` v `OrdersSection.tsx`). Súbežný per-riadkový klik
+// počas ešte prebiehajúceho hromadného zápisu nechal optimistický UI na
+// krátko nekonzistentný (posledný zápis vyhrá, žiadna strata dát, ale
+// zmätočné UX).
+it("riadok checkbox je disabled počas hromadnej akcie pre jeho dodávateľa, po jej dokončení sa znova sprístupní", async () => {
+  fetchOpenOrders.mockResolvedValue([
+    { supplier: "Dodávateľ Alfa", lines: [LINE_STARA, LINE_NOVA], email: null },
+  ]);
+  let resolveBulk: ((value: { lineCount: number }) => void) | undefined;
+  setSupplierLinesOrdered.mockImplementation(
+    () =>
+      new Promise((resolve) => {
+        resolveBulk = resolve;
+      }),
+  );
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const oznacit = await screen.findByRole("button", { name: "✔ Označiť skupinu ako objednané" });
+  const checkboxStara = await screen.findByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_STARA.lineId}`);
+  expect(checkboxStara.disabled).toBe(false);
+
+  fireEvent.click(oznacit);
+
+  // Kým hromadný zápis ešte beží, OBIDVA riadky tohto dodávateľa musia byť
+  // needitovateľné — nielen ten, na ktorý by manažér prípadne klikol zvlášť.
+  await waitFor(() => {
+    expect(screen.getByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_STARA.lineId}`).disabled).toBe(true);
+  });
+  expect(screen.getByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_NOVA.lineId}`).disabled).toBe(true);
+
+  resolveBulk?.({ lineCount: 2 });
+
+  await waitFor(() => {
+    expect(screen.getByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_STARA.lineId}`).disabled).toBe(false);
+  });
+  expect(screen.getByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_NOVA.lineId}`).disabled).toBe(false);
+});
+
 // #31: e-mailový kontakt dodávateľa + odoslanie objednávky mailom.
 
 it("rola citanie nevidí tlačidlá na úpravu e-mailu ani odoslanie mailom, len text", async () => {

--- a/apps/web/src/components/OrdersSection.tsx
+++ b/apps/web/src/components/OrdersSection.tsx
@@ -427,6 +427,10 @@ export function OrdersSection({
                   canChangeState={canChangeState}
                   busyLineId={busyLineId}
                   busyOrderedLineId={busyOrderedLineId}
+                  // Review of PR 75, finding 6: kým hromadná akcia pre TOHTO
+                  // dodávateľa beží, žiadny riadok jeho skupiny sa nesmie dať
+                  // meniť per-riadkovo naraz.
+                  supplierBusy={busyOrderedSupplier === group.supplier}
                   onChangeState={changeState}
                   onChangeOrdered={changeOrdered}
                 />

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -852,3 +852,51 @@ nové heslo sa nikde v pushnutom obsahu nenachádza.
   Vybavený Dobropis, Vybavuje sa) — no typo-guessing needed. Console: 0
   errors/0 warnings throughout.
 - Per-ticket Discord card fired (`notify --run-card`, confirmed delivered).
+
+## 2026-07-30 — issue 60 (na objednanie: odškrtnutie objednaného + hromadné označenie skupiny)
+
+- Design comment posted before first commit: https://github.com/zbynekdrlik/forestshop-app/issues/60#issuecomment-5134292105
+  (root cause: `state` enum's `objednane` value is the row's DEFAULT/pending
+  state, not a confirmation of ordering — three different UI spots used the
+  word "Objednané" with three different meanings; chosen approach: a new
+  independent `order_line.ordered` boolean, orthogonal to `state`, mirroring
+  the legacy app's separate `ORDERED` flag; rejected: folding it into the
+  existing `state` enum).
+- Version bump `fdcc30e` (0.3.0-dev.35 → .36). Backend `d394504`: migration
+  0013 (`order_line.ordered boolean default false`), `setOrderLineOrdered`/
+  `setSupplierLinesOrdered` in `modules/orders/state.ts`,
+  `listOpenOrderLineIdsForSupplier` in `queries.ts`,
+  `POST /api/orders/lines/:lineId/ordered` + `PUT /api/suppliers/:supplier/
+  order-lines/ordered`, new integration test file
+  `orders-http-ordered.integration.test.ts` (8 tests). Frontend `add3164`:
+  checkbox column + per-supplier bulk toggle button (label flips between
+  "✔ Označiť skupinu ako objednané" / "↺ Zrušiť označenie skupiny", legacy
+  `markGroupOrdered` UX minus its `commitSeq` concurrency machinery — MVP,
+  single/few concurrent managers); renamed the two colliding "Objednané"
+  labels (`STATE_LABELS.objednane` → "Nevybavené", date column → "Dátum
+  objednávky"); extracted `OrderLineRow.tsx` to stay under eslint's
+  `max-lines: 400` (`OrdersSection.tsx` hit 454). No RED/GREEN — greenfield
+  feature (implement-then-test, per `tdd-workflow.md`), not a bug fix.
+- Fix commit `c801810`: the new `orders.spec.ts` e2e test used
+  `checkbox.check()`, which raced the async POST on GitHub Actions (passed
+  locally, failed on the PR-triggered CI run) — switched to `.click()` +
+  `expect(...).toBeChecked()`, same principle already documented for
+  `<select>` in `.claude/rules/testing.md`.
+- CI green (check/integration/e2e/docker-build/version-check) on `dev` push,
+  on the PR (`#75`), and on `main` after merge (`42153ac9`). Local before
+  push: typecheck + lint + unit (263 API + 175 web) + integration (201) +
+  full e2e (16/16, including 3 repeated fresh runs) all green.
+- Deployed + verified on https://forestshop-novy.newlevel.media
+  (v0.3.0-dev.36, commit `42153ac9` matches `/api/version`). Manually
+  exercised on a REAL production order line + a real 7-line supplier group
+  (BETALOV): checkbox check/uncheck persisted across reload and dimmed the
+  row; bulk button marked all 7 lines and flipped its own label, then
+  unmarked them again — both directions verified, prod data restored to its
+  original (unchecked) state afterward. 0 console errors/warnings.
+- Playbook updated: `.claude/rules/testing.md` (Playwright `.check()` vs
+  `.click()` race on a controlled checkbox with async `onChange`),
+  `.claude/rules/orders.md` (`ordered` boolean is independent of `state`,
+  never fold future "already handled" needs into the `state` enum),
+  `.claude/rules/frontend-design.md` (component-file max-lines split
+  pattern — extract the repeated row/item renderer first).
+- Per-ticket Discord card fired (`notify --run-card`, confirmed delivered).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.36",
+  "version": "0.3.0-dev.37",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Fixes the 6 code-review findings raised against the just-merged PR #75
(issue 60 — na-objednanie checkbox + bulk supplier toggle).

1. Bulk "označiť skupinu ako objednané" audit event now uses
   `entity: "order_line"` (was `"supplier_contact"`, mixing it with
   unrelated e-mail-contact events and hiding it from `order_line`-scoped
   audit queries). `entityId` is now `null` (no single row), supplier +
   affected line ids/count stay in `data`.
2. Added the missing CSRF (cross-origin 403 / same-origin 200) regression
   tests for both new endpoints (`POST /api/orders/lines/:lineId/ordered`,
   `PUT /api/suppliers/:supplier/order-lines/ordered`) — the middleware was
   already correct, just untested, unlike the sibling state-change endpoint.
3. Closed a narrow TOCTOU window: the bulk action's "which lines are open
   for this supplier" lookup now runs INSIDE the same transaction as the
   write, with `FOR UPDATE` on the joined query — a concurrent order
   re-import or per-row toggle can no longer race the snapshot the bulk
   action acts on.
4. Added the missing "sef" role-rejection test for the bulk endpoint
   (the per-line endpoint already tested it).
5. Added the missing "invalid body → 400" test for the bulk endpoint.
6. The per-row "objednané" checkbox is now also disabled while a bulk
   "mark supplier group as ordered" request for the SAME supplier is in
   flight, on top of its existing per-row busy check.

Each testable finding got its own RED (failing) test committed before the
GREEN fix — see `git log` for the paired commits.
