### PR TITLE
fix: five review-of-PR-76 findings — FOR UPDATE lock scope, test determinism, group-toggle busy guard

### DIFF
--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -103,3 +103,29 @@ paths:
   Test na KAŽDÚ ďalšiu takúto FK+CHECK kombináciu: over, či `onDelete` reálne
   vie nastať v STAVE, kde CHECK vyžaduje ten stĺpec vyplnený — ak nie,
   `restrict` je pravdivejší popis než `set null`/`cascade`.
+- **`SELECT ... FOR UPDATE` (drizzle's `.for("update")`) BEZ `of` zoznamu
+  zamyká riadky VO VŠETKÝCH tabuľkách JOINu, nielen v primárne vybranej** —
+  Postgres dokumentácia: locking klauzuly bez `OF` zoznamu ovplyvňujú
+  všetky tabuľky použité v príkaze. Review of PR 75, finding 3
+  (`orders/queries.ts`'s `listOpenOrderLineIdsForSupplier`, ktorý JOINuje
+  `order_line`/`order`/`variant`/`product`): presun tohto dopytu VNÚTRI
+  transakcie `setSupplierLinesOrdered` (`state.ts`) spolu s `.for("update")`
+  zatvoril TOCTOU okno (súbežný re-import/per-riadkový toggle už nemôže
+  zmeniť "otvorenú" množinu medzi čítaním a zápisom) presne PRETO, že zámok
+  pokrýva aj `order` riadok, nielen `order_line`. Deterministický regresný
+  test (`tests/orders-supplier-bulk-lock.integration.test.ts`, rovnaká
+  technika ako `orders-state-lock.integration.test.ts`) to dokazuje tak, že
+  drží `SELECT ... FOR UPDATE` z druhého pripojenia na `order` riadku (NIE
+  `order_line`) — obyčajný nezamknutý SELECT (stav pred opravou) by naň
+  vôbec nečakal, takže test spoľahlivo zlyhá na starom kóde a prejde na
+  novom. Rovnaký trik na ĎALŠIU takúto opravu: zamkni z druhého pripojenia
+  tabuľku, ktorá je LEN súčasťou JOINu (nie tá, na ktorú priamo mieri
+  finálny UPDATE) — ak sa volajúci kód naň zasekne, dôkaz, že `.for("update")`
+  skutočne beží cez celý JOIN vo vnútri tej istej transakcie.
+- **Funkcia, ktorá má bežať aj s `tx`, potrebuje zúžený parameter aj pre
+  `.select()`, nielen pre `.insert()`** (rozšírenie vzoru vyššie z `audit/
+  service.ts`'s `AuditExecutor`) — `orders/open-statuses.ts`'s
+  `listOpenStatusNames` a `orders/queries.ts`'s
+  `listOpenOrderLineIdsForSupplier` majú teraz `Pick<Database, "select">`
+  namiesto celého `Database`, aby ich šlo volať aj s `tx` (`PgTransaction`
+  nemá `Database`'s `$client`).

--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -104,24 +104,62 @@ paths:
   vie nastať v STAVE, kde CHECK vyžaduje ten stĺpec vyplnený — ak nie,
   `restrict` je pravdivejší popis než `set null`/`cascade`.
 - **`SELECT ... FOR UPDATE` (drizzle's `.for("update")`) BEZ `of` zoznamu
-  zamyká riadky VO VŠETKÝCH tabuľkách JOINu, nielen v primárne vybranej** —
-  Postgres dokumentácia: locking klauzuly bez `OF` zoznamu ovplyvňujú
-  všetky tabuľky použité v príkaze. Review of PR 75, finding 3
-  (`orders/queries.ts`'s `listOpenOrderLineIdsForSupplier`, ktorý JOINuje
-  `order_line`/`order`/`variant`/`product`): presun tohto dopytu VNÚTRI
-  transakcie `setSupplierLinesOrdered` (`state.ts`) spolu s `.for("update")`
-  zatvoril TOCTOU okno (súbežný re-import/per-riadkový toggle už nemôže
-  zmeniť "otvorenú" množinu medzi čítaním a zápisom) presne PRETO, že zámok
-  pokrýva aj `order` riadok, nielen `order_line`. Deterministický regresný
-  test (`tests/orders-supplier-bulk-lock.integration.test.ts`, rovnaká
-  technika ako `orders-state-lock.integration.test.ts`) to dokazuje tak, že
-  drží `SELECT ... FOR UPDATE` z druhého pripojenia na `order` riadku (NIE
-  `order_line`) — obyčajný nezamknutý SELECT (stav pred opravou) by naň
-  vôbec nečakal, takže test spoľahlivo zlyhá na starom kóde a prejde na
-  novom. Rovnaký trik na ĎALŠIU takúto opravu: zamkni z druhého pripojenia
-  tabuľku, ktorá je LEN súčasťou JOINu (nie tá, na ktorú priamo mieri
-  finálny UPDATE) — ak sa volajúci kód naň zasekne, dôkaz, že `.for("update")`
-  skutočne beží cez celý JOIN vo vnútri tej istej transakcie.
+  zamyká riadky VO VŠETKÝCH tabuľkách JOINu, nielen v primárne vybranej —
+  a KEĎ to spraví zbytočne pre tabuľky, ktoré zápis vôbec nemení, riskuje
+  DEADLOCK s inou transakciou, čo tie isté tabuľky zamyká v OPAČNOM poradí,
+  nielen zbytočné čakanie.** Postgres dokumentácia: locking klauzuly bez
+  `OF` zoznamu ovplyvňujú všetky tabuľky použité v príkaze. Review of PR 75,
+  finding 3 (`orders/queries.ts`'s `listOpenOrderLineIdsForSupplier`, ktorý
+  JOINuje `order_line`/`order`/`variant`/`product`): presun tohto dopytu
+  VNÚTRI transakcie `setSupplierLinesOrdered` (`state.ts`) spolu s
+  `.for("update")` (VTEDY ešte bez `of` zoznamu) zatvoril TOCTOU okno
+  (súbežný re-import/per-riadkový toggle už nemôže zmeniť "otvorenú"
+  množinu medzi čítaním a zápisom) — ale review of PR 76, finding 1 hneď
+  potom odhalil, že ten istý bezzoznamový zámok POKRÝVAL AJ `variant`/
+  `product`, hoci tento zápis mutuje LEN `order_line`. `catalog/ingest.ts`
+  berie svoj dlhý import v poradí produkt → variant (upsert produktov, potom
+  variantov, plus záverečný hromadný `UPDATE variant`), zatiaľ čo LockRows
+  uzol tohto dopytu by zamykal v opačnom poradí rozsahovej tabuľky
+  (order_line → order → variant → product) — opačné poradie zámkov medzi
+  dvomi transakciami je klasický predpoklad na deadlock, nielen na čakanie.
+  Konečná oprava: `.for("update", { of: [orderLines, orders] })` — TOCTOU
+  uzáver zostáva (zámok stále pokrýva `order`), katalógové tabuľky sa už
+  nezamykajú vôbec. **Pravidlo pre KAŽDÉ ďalšie `.for("update")` cez JOIN:
+  `of` zoznam sa vyberá podľa toho, ČO zápis SKUTOČNE mutuje, nikdy podľa
+  toho, čo JOIN len na filtrovanie/čítanie potrebuje** — aj keď na
+  uzavretie TOCTOU okna stačí zamknúť viac než primárnu tabuľku (tu aj
+  `order`, nielen `order_line`), nikdy nezamykaj tabuľku, ktorú tento zápis
+  vôbec nemení.
+  Dva doplňujúce regresné testy (`tests/orders-supplier-bulk-lock
+  .integration.test.ts`, rovnaká technika ako `orders-state-lock
+  .integration.test.ts`) dokazujú OBE vlastnosti nezávisle:
+  1. **TOCTOU uzáver stále platí** — drží `SELECT ... FOR UPDATE` z druhého
+     pripojenia na `order` riadku (NIE `order_line`); obyčajný nezamknutý
+     SELECT (stav pred pôvodnou PR 75 opravou) by naň vôbec nečakal.
+  2. **Katalógové tabuľky už nie sú zamknuté** — drží zámok na `product`
+     riadku (súčasť JOINu, ale mimo `of` zoznamu) a NEUVOĽNÍ ho, kým sám
+     testovaný `await` nedokončí; na bezzoznamovom `.for("update")` (stav
+     pred touto opravou) by preto `await` nikdy nedokončil a test by
+     spoľahlivo padol na `testTimeout` (30s) namiesto rýchleho prejdenia.
+  Rovnaký dvojitý test na ĎALŠIU takúto opravu: over ZVLÁŠŤ, že žiadaný
+  zámok (tabuľka, na ktorej TOCTOU skutočne závisí) stále blokuje, AJ že
+  nežiaduci zámok (tabuľka mimo `of` zoznamu, ale v tom istom JOINe) už
+  neblokuje — jeden test dokazujúci len jednu z dvoch vlastností by druhú
+  regresiu (návrat k celoplošnému zámku, alebo príliš úzky zámok, čo znovu
+  otvorí TOCTOU) nechal nepovšimnutú.
+  **Deterministický "NEBLOKUJE" dôkaz bez čakania na promise-timing:**
+  namiesto sledovania JS-strany flagu (`.then()` nastaveného flagu) sa
+  "je/nie je ešte zaseknuté na zámku" dá zistiť PRIAMO z Postgresu —
+  `SELECT count(*) FROM pg_stat_activity WHERE wait_event_type = 'Lock' AND
+  pid <> pg_backend_pid()` z druhého pripojenia, opakovane pollované do
+  krátkeho deadline. Review of PR 76, finding 2 + 4 nahradil pôvodný pevný
+  200ms `setTimeout` + neošetrený `.then()` (na preťaženom CI runneri mohla
+  aj pred-opravová odomknutá cesta trvať dlhšie než 200ms → falošne zelený
+  test; nerejectovaný `.then()` mohol unhandled rejection pripísať
+  neskoršiemu testu v tom istom jednoprocesovom behu) presne týmto —
+  `withCleanDb()`'s advisory izolačný zámok + `fileParallelism: false`
+  (`.claude/rules/testing.md`) garantujú, že žiadny INÝ backend v tú chvíľu
+  nebeží, takže "niekto je zaseknutý na zámku" môže byť len testovaný kód.
 - **Funkcia, ktorá má bežať aj s `tx`, potrebuje zúžený parameter aj pre
   `.select()`, nielen pre `.insert()`** (rozšírenie vzoru vyššie z `audit/
   service.ts`'s `AuditExecutor`) — `orders/open-statuses.ts`'s

--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -66,3 +66,18 @@ paths:
   `orders-http-state.integration.test.ts`) — when a component crosses the
   cap, pull out the REPEATED per-item rendering unit first; it is almost
   always the largest, most self-contained slice.
+- **A per-item busy-guard vs. a group busy-guard needs to be disabled in
+  BOTH directions, or it will be found missing one at a time.** Issue 60's
+  "objednané" checkbox (per-row) + group toggle button pair got this fix
+  TWICE: review of PR 75 finding 6 disabled the per-row checkbox while the
+  group's own bulk write (`busyOrderedSupplier`) was in flight, and review
+  of PR 76 finding 5 then had to add the MIRROR — disabling the group
+  button while a per-row write (`busyOrderedLineId`) for a line IN that
+  group was in flight (`group.lines.some((l) => l.lineId ===
+  busyOrderedLineId)`, `OrdersSection.tsx`). Both directions matter because
+  either write can complete after the other and repaint the same rows with
+  a stale computed value — no data loss (last write to the DB still wins),
+  but confusing UI. When adding ANY new busy-flag pair like this (an
+  individual-item action + a group/bulk action touching the same items),
+  add BOTH disables in the SAME change, don't wait for a second review pass
+  to catch the missing direction.

--- a/.claude/rules/orders.md
+++ b/.claude/rules/orders.md
@@ -181,3 +181,20 @@ paths:
   aj ďalej filtruje LEN podľa `state === "objednane"`, `ordered` na ňu vôbec
   nevplýva. Ďalšia funkcia, ktorá by potrebovala "bolo toto už vybavené",
   siahni po `ordered`, nie po pridávaní ďalšej hodnoty do `state` enumu.
+- **Audit `entity` musí byť to, čo sa REÁLNE MUTUJE, nikdy zoskupovací kľúč
+  vstupu.** Code review na PR 75 (finding 1): `setSupplierLinesOrdered`
+  (hromadné "objednané" na CELÚ skupinu dodávateľa, `state.ts`) pôvodne
+  zapisovala `entity: "supplier_contact"` len preto, že VSTUP je dodávateľ —
+  ale mutuje `order_line` riadky, takže audit dopyt filtrovaný podľa
+  `entity = "order_line"` ju ticho vynechával a filter podľa
+  `"supplier_contact"` ju miešal s nesúvisiacimi udalosťami e-mailového
+  kontaktu (`supplier-routes.ts`'s `email`/`order-mail/send`). Oprava:
+  `entity` rovnaké ako pri KAŽDEJ inej `order_line`-mutujúcej akcii v tomto
+  súbore (`"order_line"`), `entityId: null` (žiadny JEDEN riadok pri
+  hromadnej akcii), dodávateľ + zasiahnuté ID zostávajú v `data`. Test pre
+  ĎALŠIU hromadnú/agregovanú akciu: `entity` sa vždy odvodzuje od TOHO, ČO sa
+  v DB mení, nie od parametra, podľa ktorého sa vyberajú riadky.
+  Podrobný TOCTOU fix (finding 3, presun `listOpenOrderLineIdsForSupplier`
+  do tej istej transakcie s `.for("update")`) je zdokumentovaný v
+  `.claude/rules/database.md` (Postgres `FOR UPDATE` bez `OF` zoznamu
+  zamyká celý JOIN, nielen primárnu tabuľku).

--- a/apps/api/src/modules/orders/queries.ts
+++ b/apps/api/src/modules/orders/queries.ts
@@ -158,14 +158,16 @@ export async function listOpenOrderLinesBySupplier(db: Database): Promise<readon
 // hromadná akcia mohla občas zasiahnuť riadok, ktorý medzitým opustil/vstúpil
 // do otvorenej skupiny). Volajúci (`state.ts`'s `setSupplierLinesOrdered`)
 // teraz volá TENTO dopyt AŽ VNÚTRI vlastnej transakcie a `.for("update")`
-// zamyká VŠETKY tabuľky JOINu bez ohľadu obmedzenia (žiadny `of` zoznam) —
-// vrátane `order`, takže súbežná zmena stavu objednávky (aj `setOrderLineState`'s
-// vlastný `.for("update")` na `order_line`) musí počkať na COMMIT tejto
-// transakcie, nie naopak. Parameter je preto zúžený na `Pick<Database,
-// "select">` (rovnaký vzor ako `audit/service.ts`'s `AuditExecutor`) — `tx`
-// (`PgTransaction`) nemá `Database`'s `$client`, takže by ho `tsc` odmietol
-// ako celý `Database` (`.claude/rules/database.md`). Regresný dôkaz:
-// `tests/orders-supplier-bulk-lock.integration.test.ts`.
+// pokrýva aj `order` (viď `of` zoznam pri samotnom dopyte nižšie — od review
+// of PR 76, finding 1 už NIE je bezzoznamový, pozri ten komentár pre presné
+// dôvody a rozsah), takže súbežná zmena stavu objednávky (aj
+// `setOrderLineState`'s vlastný `.for("update")` na `order_line`) musí
+// počkať na COMMIT tejto transakcie, nie naopak. Parameter je preto zúžený
+// na `Pick<Database, "select">` (rovnaký vzor ako `audit/service.ts`'s
+// `AuditExecutor`) — `tx` (`PgTransaction`) nemá `Database`'s `$client`,
+// takže by ho `tsc` odmietol ako celý `Database` (`.claude/rules/
+// database.md`). Regresný dôkaz: `tests/orders-supplier-bulk-lock
+// .integration.test.ts`.
 export async function listOpenOrderLineIdsForSupplier(
   db: Pick<Database, "select">,
   supplier: string,

--- a/apps/api/src/modules/orders/queries.ts
+++ b/apps/api/src/modules/orders/queries.ts
@@ -182,7 +182,18 @@ export async function listOpenOrderLineIdsForSupplier(
     .innerJoin(variants, eq(variants.code, orderLines.variantCode))
     .innerJoin(products, eq(products.key, variants.productKey))
     .where(and(inArray(orders.statusName, [...openStatuses]), supplierFilter))
-    .for("update");
+    // Code review (review of PR 76, finding 1): `.for("update")` bez `of`
+    // zoznamu zamyká VŠETKY štyri JOINnuté tabuľky (aj `variant`/`product`,
+    // ktoré tento zápis vôbec nemutuje) — `catalog/ingest.ts` berie svoj
+    // dlhý import v poradí product → variant (upsert produktov, potom
+    // variantov, plus záverečný hromadný `UPDATE variant`), zatiaľ čo
+    // LockRows uzol tohto dopytu by zamykal v poradí rozsahovej tabuľky
+    // (order_line → order → variant → product) — opačné poradie zámkov medzi
+    // dvomi transakciami je klasický predpoklad na deadlock. Zúženie na `of:
+    // [orderLines, orders]` zachováva presne ten istý TOCTOU uzáver (viď
+    // komentár vyššie + `.claude/rules/database.md`), bez zamykania
+    // katalógových tabuliek, ktoré tento zápis nikdy nemení.
+    .for("update", { of: [orderLines, orders] });
 
   return rows.map((row) => row.lineId);
 }

--- a/apps/api/tests/orders-supplier-bulk-lock.integration.test.ts
+++ b/apps/api/tests/orders-supplier-bulk-lock.integration.test.ts
@@ -35,6 +35,36 @@ afterEach(async () => {
   close = undefined;
 });
 
+// Code review (review of PR 76, finding 2 + finding 4): the first version of
+// this "is it still blocked?" check slept a fixed 200ms and then read a flag
+// set by an unhandled-rejection-prone `.then()`. On a loaded CI runner the
+// PRE-FIX (unlocked) path could easily take longer than 200ms too, so the
+// sleep could pass against unfixed code (false green) — and a rejected
+// `bulk` promise (e.g. a lock-timeout or deadlock abort) would surface as an
+// unhandled rejection Vitest could blame on an unrelated later test in this
+// single-process run. This poll instead asks Postgres DIRECTLY whether some
+// OTHER backend is genuinely blocked on a row lock — deterministic, and
+// completely decoupled from how fast the JS event loop schedules
+// microtasks. `withCleanDb()`'s advisory isolation lock + this project's
+// `fileParallelism: false` (`.claude/rules/testing.md`) guarantee no other
+// backend is active during this test, so any blocked backend found here can
+// only be the bulk call under test.
+async function waitUntilSomeBackendIsLockBlocked(rawClient: pg.Client, deadlineMs = 10_000): Promise<void> {
+  const start = Date.now();
+  for (;;) {
+    const { rows } = await rawClient.query<{ n: number }>(
+      "SELECT count(*)::int AS n FROM pg_stat_activity WHERE wait_event_type = 'Lock' AND pid <> pg_backend_pid()",
+    );
+    if ((rows[0]?.n ?? 0) > 0) return;
+    if (Date.now() - start > deadlineMs) {
+      throw new Error(
+        "Bulk volanie sa v " + String(deadlineMs) + "ms nikdy nezaseklo na zámku (pg_stat_activity nič neukázal)",
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+}
+
 it("hromadné označenie čaká na riadkový zámok objednávky — lookup beží VNÚTRI transakcie s FOR UPDATE", async () => {
   const ctx = await withCleanDb();
   close = ctx.close;
@@ -83,26 +113,114 @@ it("hromadné označenie čaká na riadkový zámok objednávky — lookup bež�
       now: new Date("2026-07-30T10:00:00Z"),
     });
 
-    let doriesene = false;
-    void bulk.then(() => {
-      doriesene = true;
-    });
+    // Code review (review of PR 76, finding 4): `.then(onFulfilled)` bez
+    // druhého argumentu necháva `bulk`-ov prípadný reject (napr. lock
+    // timeout/deadlock) bez ošetrenia — Node by taký unhandled rejection
+    // mohol pripísať úplne inému, neskoršiemu testu v tomto
+    // jednoprocesovom behu (`fileParallelism: false`). Druhý argument
+    // (no-op) ošetrenie pridáva bez toho, aby menil `settled`'s zámer.
+    let settled = false;
+    bulk.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
 
-    // Dá bulk lookupu dosť času dôjsť k zámku a zaseknúť sa naň — zámok drží
-    // `rawClient`, takže "príliš neskoro" tu nehrozí, len čakáme, kým sa naň
-    // naozaj zasekne.
-    await new Promise((resolve) => setTimeout(resolve, 200));
-    expect(doriesene).toBe(false);
+    // Code review (review of PR 76, finding 2): namiesto pevného 200ms
+    // spánku (na preťaženom CI runneri mohla aj PRE-FIX odomknutá cesta
+    // trvať dlhšie, čo by test nechalo prejsť aj proti nefixnutému kódu)
+    // sa čaká DETERMINISTICKY, kým Postgres sám nepotvrdí, že bulk volanie
+    // je zaseknuté na zámku (`pg_stat_activity.wait_event_type = 'Lock'`).
+    await waitUntilSomeBackendIsLockBlocked(rawClient);
+    expect(settled).toBe(false);
 
     // Simuluje súbežnú zmenu, ktorá stihla commitnúť MEDZITÝM — priamo, mimo
     // `setSupplierLinesOrdered`, presne v momente, keď je bulk akcia
     // zaseknutá na zámku.
     await rawClient.query("COMMIT");
 
+    // Code review (review of PR 76, finding 3): `expect(settled).toBe(true)`
+    // TU by bolo tautologické — `.then()` zaregistrovaný vyššie sa
+    // vyhodnotí ako mikroúloha PRED pokračovaním tohto `await`u, takže by
+    // bol vždy `true` bez ohľadu na to, či testovaný kód skutočne funguje.
+    // Skutočný dôkaz dokončenia je samotný úspešný `await bulk` +
+    // očakávaný výsledok nižšie — žiadna ďalšia kontrola `settled` netreba.
     const result = await bulk;
     expect(result).toEqual({ lineCount: 1 });
-    expect(doriesene).toBe(true);
   } finally {
+    await rawClient.end();
+  }
+});
+
+// Code review (review of PR 76, finding 1): `.for("update")` bez `of`
+// zoznamu zamyká VŠETKY štyri JOINnuté tabuľky (`order_line`, `order`,
+// `variant`, `product`) — aj tie dve KATALÓGOVÉ, ktoré tento zápis vôbec
+// nemutuje. `catalog/ingest.ts` berie svoj dlhý import v poradí produkt →
+// variant (upsert produktov, potom variantov, plus záverečný hromadný
+// `UPDATE variant`), zatiaľ čo LockRows uzol tohto dopytu by zamykal v
+// poradí rozsahovej tabuľky (order_line → order → variant → product) —
+// OPAČNÉ poradie zámkov medzi dvomi transakciami je klasický predpoklad na
+// deadlock (a v najlepšom prípade aspoň zbytočné čakanie hromadnej akcie na
+// celý beh importu). Fix zužuje zámok na `of: [orderLines, orders]` —
+// zachováva ten istý TOCTOU uzáver (test vyššie), ale prestáva zamykať
+// `variant`/`product` riadky.
+it("hromadné označenie NEČAKÁ na zámok katalógovej tabuľky (product) — .for(\"update\") je zúžený na order_line + order", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const db = ctx.db;
+
+  await db.insert(orderOpenStatuses).values({ statusName: "Vybavuje sa" }).onConflictDoNothing();
+  await insertTestVariant(db, "L-2", "Dodávateľ Lock2");
+  const [pouzivatel] = await db
+    .insert(users)
+    .values({
+      email: "manazer-bulk-lock-scope-test@forestshop.sk",
+      passwordHash: "x",
+      displayName: "Manažér",
+      role: "manazer",
+    })
+    .returning({ id: users.id });
+  if (pouzivatel === undefined) throw new Error("insert používateľa zlyhal");
+
+  const [objednavka] = await db
+    .insert(orders)
+    .values({ externalOrderId: "6002", customerName: "Zákazník", placedAt: new Date("2026-07-20T00:00:00Z") })
+    .returning();
+  if (objednavka === undefined) throw new Error("insert objednávky zlyhal");
+  const [riadok] = await db
+    .insert(orderLines)
+    .values({ orderId: objednavka.id, variantCode: "L-2", quantity: 1 })
+    .returning();
+  if (riadok === undefined) throw new Error("insert riadku zlyhal");
+
+  const databaseUrl = process.env["DATABASE_URL"];
+  if (databaseUrl === undefined || databaseUrl === "") {
+    throw new Error("Integračné testy potrebujú DATABASE_URL");
+  }
+  const rawClient = new pg.Client({ connectionString: databaseUrl });
+  await rawClient.connect();
+  await rawClient.query("BEGIN");
+  // Zamkne PRODUKTOVÝ riadok — súčasť toho istého JOINu, ale nie tabuľku,
+  // ktorú tento zápis mutuje. Zámok sa NEUVOĽNÍ (COMMIT ide až v `finally`,
+  // PO `await` na bulk volanie nižšie) — na nezúženom `.for("update")` (bez
+  // `of`) by preto `await setSupplierLinesOrdered(...)` NIKDY nedokončil a
+  // test by spoľahlivo padol na `testTimeout` (30s, `vitest.config.ts`).
+  await rawClient.query('SELECT key FROM "product" WHERE key = $1 FOR UPDATE', ["L-2"]);
+
+  try {
+    const result = await setSupplierLinesOrdered(db, {
+      supplier: "Dodávateľ Lock2",
+      ordered: true,
+      actorUserId: pouzivatel.id,
+      now: new Date("2026-07-30T10:00:00Z"),
+    });
+
+    expect(result).toEqual({ lineCount: 1 });
+  } finally {
+    await rawClient.query("COMMIT");
     await rawClient.end();
   }
 });

--- a/apps/api/tests/orders-supplier-bulk-lock.integration.test.ts
+++ b/apps/api/tests/orders-supplier-bulk-lock.integration.test.ts
@@ -47,13 +47,17 @@ afterEach(async () => {
 // completely decoupled from how fast the JS event loop schedules
 // microtasks. `withCleanDb()`'s advisory isolation lock + this project's
 // `fileParallelism: false` (`.claude/rules/testing.md`) guarantee no other
-// backend is active during this test, so any blocked backend found here can
-// only be the bulk call under test.
+// CLIENT backend is active during this test, so any lock-blocked client
+// backend found here can only be the bulk call under test — `backend_type =
+// 'client backend'` (deep-review suggestion, review of PR 76) narrows this
+// further, excluding autovacuum/background-writer/checkpointer backends
+// that could theoretically also show `wait_event_type = 'Lock'` briefly.
 async function waitUntilSomeBackendIsLockBlocked(rawClient: pg.Client, deadlineMs = 10_000): Promise<void> {
   const start = Date.now();
   for (;;) {
     const { rows } = await rawClient.query<{ n: number }>(
-      "SELECT count(*)::int AS n FROM pg_stat_activity WHERE wait_event_type = 'Lock' AND pid <> pg_backend_pid()",
+      "SELECT count(*)::int AS n FROM pg_stat_activity" +
+        " WHERE wait_event_type = 'Lock' AND backend_type = 'client backend' AND pid <> pg_backend_pid()",
     );
     if ((rows[0]?.n ?? 0) > 0) return;
     if (Date.now() - start > deadlineMs) {

--- a/apps/web/src/components/OrdersSection.ordered.test.tsx
+++ b/apps/web/src/components/OrdersSection.ordered.test.tsx
@@ -186,3 +186,52 @@ it("riadok checkbox je disabled počas hromadnej akcie pre jeho dodávateľa, po
   });
   expect(screen.getByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_NOVA.lineId}`).disabled).toBe(false);
 });
+
+// Review of PR 76, finding 5: fix 6 above (PR 75, finding 6) was applied in
+// only one direction — the per-row checkbox is blocked during a bulk write,
+// but the group toggle button was NOT blocked while a per-row change is in
+// flight for its own supplier. Scenario: A=checked, B=unchecked; manager
+// unchecks A (POST A=false in flight, optimistic update lands only on
+// resolve) and immediately clicks the group button — `every(l => l.ordered)`
+// still reads `false` for a moment, so the bulk sends `ordered: true`; the
+// bulk's `.then` paints both rows checked, then A's own per-row `.then`
+// repaints A unchecked while the DB actually holds `true`. No data loss, but
+// exactly the confusing-UI class the original finding targeted, mirrored.
+it("skupinové tlačidlo je disabled počas per-riadkovej zmeny v tej istej skupine, po jej dokončení sa znova sprístupní", async () => {
+  fetchOpenOrders.mockResolvedValue([
+    { supplier: "Dodávateľ Alfa", lines: [LINE_STARA, LINE_NOVA], email: null },
+  ]);
+  let resolveRiadok: (() => void) | undefined;
+  updateOrderLineOrdered.mockImplementation(
+    () =>
+      new Promise<void>((resolve) => {
+        resolveRiadok = resolve;
+      }),
+  );
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const oznacit = await screen.findByRole("button", { name: "✔ Označiť skupinu ako objednané" });
+  expect(oznacit.hasAttribute("disabled")).toBe(false);
+
+  const checkboxStara = await screen.findByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_STARA.lineId}`);
+  fireEvent.click(checkboxStara);
+
+  // Kým per-riadkový zápis pre TENTO dodávateľ ešte beží, skupinové
+  // tlačidlo musí byť needitovateľné — inak by mohlo poslať hromadný zápis
+  // na základe ešte-neaktualizovaného `ordered` a jeho výsledok by neskôr
+  // prepísala odpoveď per-riadkového zápisu (opačné poradie ako fix 6).
+  await waitFor(() => {
+    expect(
+      screen.getByRole("button", { name: "✔ Označiť skupinu ako objednané" }).hasAttribute("disabled"),
+    ).toBe(true);
+  });
+
+  resolveRiadok?.();
+
+  await waitFor(() => {
+    expect(
+      screen.getByRole("button", { name: "✔ Označiť skupinu ako objednané" }).hasAttribute("disabled"),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/components/OrdersSection.tsx
+++ b/apps/web/src/components/OrdersSection.tsx
@@ -348,11 +348,22 @@ export function OrdersSection({
                 {/* issue 60: hromadné označenie/zrušenie CELEJ skupiny naraz —
                     jedno tlačidlo, ktoré prepína smer podľa toho, či je skupina
                     UŽ celá odškrtnutá (rovnaký zámer ako stará appka's
-                    `markGroupOrdered`/`allOrdered`). */}
+                    `markGroupOrdered`/`allOrdered`). Review of PR 76, finding 5:
+                    mirror smeru fixu 6 (review of PR 75, finding 6) — tlačidlo
+                    musí byť needitovateľné AJ kým beží per-riadkový zápis pre
+                    NIEKTORÝ riadok TEJTO skupiny (`busyOrderedLineId`), nielen
+                    počas vlastného hromadného zápisu (`busyOrderedSupplier`).
+                    Bez toho by klik na tlačidlo tesne po odškrtnutí jedného
+                    riadku poslal hromadný zápis počítaný z ešte-neaktuálneho
+                    `ordered` (optimistický update toho riadku sa prejaví až po
+                    vyriešení jeho vlastného promisu). */}
                 <button
                   type="button"
                   className="btn sm ghost"
-                  disabled={busyOrderedSupplier === group.supplier}
+                  disabled={
+                    busyOrderedSupplier === group.supplier ||
+                    (busyOrderedLineId !== null && group.lines.some((l) => l.lineId === busyOrderedLineId))
+                  }
                   onClick={() => {
                     toggleGroupOrdered(group.supplier, !group.lines.every((l) => l.ordered));
                   }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.37",
+  "version": "0.3.0-dev.38",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Summary

Fixes five code-review findings from an independent review of PR 76's own diff (PR 76 itself already fixed six findings from a review of PR 75 — this is a second-order review, one layer deeper).

1. **Lock-order deadlock risk** — `listOpenOrderLineIdsForSupplier`'s `FOR UPDATE` had no `of` list, so it locked all four joined tables (order_line, order, variant, product), including the two catalog tables this write never touches. The catalog importer locks product then variant in its own long transaction; this query's join order is the reverse, which is a textbook deadlock setup. Narrowed to `of: [orderLines, orders]` — same TOCTOU closure, no more catalog-table locking.
2. **Non-deterministic lock-proof test** — the existing regression test proved "still blocked" with a fixed 200ms sleep, which could pass against unfixed code on a loaded CI runner. Replaced with polling `pg_stat_activity` for a genuinely lock-blocked backend.
3. **Tautological assertion** — a `.then()`-set flag checked right after `await bulk` could never be false regardless of the code under test (the `.then()` callback always settles before the `await` continuation runs). Removed; the meaningful check (the earlier "not yet resolved" assertion, now proven deterministically) already covers it.
4. **Unhandled rejection risk** — that same `.then()` had no rejection handler, so a rejected bulk call could surface as an unhandled rejection blamed on an unrelated later test in this single-process test run. Added a no-op rejection handler.
5. **Missing mirror of a UI busy-guard** — the per-row "objednané" checkbox is disabled while a group bulk write for its supplier is in flight (PR 75 fix), but the group toggle button was not disabled while a per-row write for a line in that group was in flight. Added the mirror.

Also adds a new regression test proving finding 1's lock-scope fix (locks a `product` row from a second connection and confirms the bulk call no longer waits on it), and corrects/extends the project playbook (`.claude/rules/database.md`, `.claude/rules/frontend-design.md`) with what was learned.

## Test plan

- [x] `pnpm -w lint` — clean
- [x] `pnpm -w typecheck` — clean
- [x] `pnpm --filter @forestshop/api test` — 263/263 passed
- [x] `pnpm --filter @forestshop/api test:integration` — 207/207 passed (Postgres on 5433)
- [x] `pnpm --filter @forestshop/web test` — 177/177 passed
- [x] Each finding's regression test verified RED against the unfixed code locally, then GREEN after the fix (see report)
- [ ] CI green on this PR
- [ ] Live Playwright verification on forestshop-novy.newlevel.media after deploy
