### PR TITLE
fix(api): install graceful SIGTERM/SIGINT shutdown handler

### DIFF
--- a/.claude/rules/deploy.md
+++ b/.claude/rules/deploy.md
@@ -173,15 +173,42 @@ paths:
   --failed` — čerstvý pull znova stiahne vrstvu od nuly. Ak sa to isté zopakuje
   DRUHÝKRÁT za sebou, už to nie je transientný jav — over `docker system df`
   (miesto na disku) a zváž reštart `containerd`/`docker` služby na dev2.
-- **DRUHÝ pozorovaný transientný symptom TEJ ISTEJ triedy (#25, 2026-07-30):
-  `docker compose up -d` zlyhá na `Error response from daemon: No such
-  container: <hash>_forestshop-app-1` počas kroku "Recreate"** — opäť žiadna
-  zmena závislostí v danom PR, teda opäť lokálny containerd/docker stav na
-  dev2, nie obsah image. Rovnaká liečba ako vyššie: `gh run rerun <run-id>
-  --failed` (jeden rerun stačil, prešiel hneď). Ak sa PRI DEPLOJI objaví
-  INÁ hláška než "failed to extract layer", nepredpokladaj automaticky inú
-  príčinu — over najprv jednoduchým rerunom, až pri DRUHOM zlyhaní za sebou
-  rieš ako skutočný problém.
+- **OPRAVA k nižšie zdokumentovanému nálezu z #25 — NEBOL to transientný
+  containerd jav, bol to skutočný, DETERMINISTICKÝ bug appky (issue 78,
+  vyriešené).** Pôvodný záznam (nižšie, ponechaný pre históriu) priradil
+  `Error response from daemon: No such container: <hash>_forestshop-app-1`
+  počas "Recreate" k rovnakej triede ako `failed to extract layer`
+  (containerd/overlayfs korupcia) — mylne, len preto, že jeden rerun vtedy
+  "pomohol". Skutočná príčina: appka (`apps/api/src/index.ts`) nemala ŽIADEN
+  `SIGTERM`/`SIGINT` handler a `Dockerfile`'s `CMD` beží bez init procesu
+  (PID 1) — jadro preto default dispozíciu signálu vôbec neaplikovalo, appka
+  SIGTERM úplne ignorovala a bežala ďalej celý `stop_grace_period` (10s), kým
+  ju Docker nezabil SIGKILLom; `docker compose up`'s "Recreate" krok si
+  medzitým interne pripravil "nahradiť starý kontajner" podľa jeho dočasného
+  ID, ale kontajner bol už `destroy`nutý skôr, než sa k tomu kroku dostal —
+  odtiaľ "No such container". Rerun vtedy "pomohol" len preto, že táto
+  časovacia hra nie je pri KAŽDOM behu istá (compose's interné časovanie
+  recreate kroku niekedy stihne, niekedy nie) — bug bol prítomný pri KAŽDOM
+  deployi, len sa nie vždy prejavil viditeľným zlyhaním. Fix: `apps/api/src/
+  shutdown.ts`'s `createShutdownHandler` (explicitný, idempotentný handler,
+  zavrie HTTP server aj DB pool, `process.exit(0)`, ohraničený force-exit
+  fallback) + `docker-compose.prod.yml`'s `app` service dostala explicitný
+  `stop_grace_period: 15s` ako doplnkovú rezervu. **Ponaučenie pre budúci
+  podobný nález:** "jeden rerun pomohol" dokazuje len že chyba je
+  NEDETERMINISTICKÁ v ČASOVANÍ prejavu, nie že príčina je transientná
+  infraštruktúra — over `docker events` (kill signal, timing medzi SIGTERM
+  a SIGKILL) PRED zápisom "transientný jav" do playbooku.
+
+- **PÔVODNÝ (čiastočne mylný) záznam, ponechaný pre históriu — pozri opravu
+  vyššie:** DRUHÝ pozorovaný transientný symptom TEJ ISTEJ triedy (#25,
+  2026-07-30): `docker compose up -d` zlyhá na `Error response from daemon:
+  No such container: <hash>_forestshop-app-1` počas kroku "Recreate" — opäť
+  žiadna zmena závislostí v danom PR, teda opäť lokálny containerd/docker
+  stav na dev2, nie obsah image. Rovnaká liečba ako vyššie: `gh run rerun
+  <run-id> --failed` (jeden rerun stačil, prešiel hneď). Ak sa PRI DEPLOJI
+  objaví INÁ hláška než "failed to extract layer", nepredpokladaj
+  automaticky inú príčinu — over najprv jednoduchým rerunom, až pri DRUHOM
+  zlyhaní za sebou rieš ako skutočný problém.
 
 - **`build` job (GitHub-hosted, nahráva do ghcr.io) potrebuje explicitný
   `docker/setup-buildx-action@v3` PRED `docker/build-push-action@v6`** —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,15 @@ nasadenie na dev2 cez GHCR a Cloudflare tunel.
 body,title,state,labels,comments` namiesto toho (žiadne Projects polia sa
 nepýtajú, takže to prejde).
 
+**Airuleset's `block-sensitive-staging.sh` (globálny `git add`/`git commit`
+hook) hlási FALOŠNÝ pozitív na plný 40-znakový git SHA v ktoromkoľvek
+súbore/commit správe** — jeho "40+ char hex blob (possible key/token)"
+vzor nevie odlíšiť SHA1 hash commitu od skutočného leaknutého tokenu
+(issue 78, `apps/api/tests/shutdown.integration.test.ts`: komentár
+citujúci merge SHA blokoval `git add`). Fix nie je bypass (`# airuleset:
+secret-ok`), je jednoduchý: v komentároch/commit správach citovať SHA
+SKRÁTENÉ (7-8 znakov, `d19f8eae`), nikdy plných 40.
+
 ## Playbook router
 
 Per-area rules live in `.claude/rules/<area>.md` with `paths:` frontmatter.

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -20,10 +20,11 @@ import {
   sessionCleanupJob,
 } from "./modules/scheduler/jobs.js";
 import { startScheduler } from "./modules/scheduler/scheduler.js";
+import { createShutdownHandler } from "./shutdown.js";
 import { appVersion } from "./version.js";
 
 const env = loadEnv();
-const { db } = createDb(env.DATABASE_URL);
+const { db, pool } = createDb(env.DATABASE_URL);
 
 // Migrácie beží aplikácia sama pri štarte — nasadenie tak nemá druhý, samostatne
 // zlyhateľný krok. Drizzle spúšťa každú migráciu vo VLASTNEJ transakcii, takže
@@ -131,5 +132,19 @@ if (existsSync(publicDir)) {
   );
 }
 
-serve({ fetch: app.fetch, port: env.PORT });
+const server = serve({ fetch: app.fetch, port: env.PORT });
 console.log(JSON.stringify({ msg: "api beží", port: env.PORT, version: appVersion() }));
+
+// issue 78: appka nemala žiadny SIGTERM/SIGINT handler — v produkčnom
+// kontajneri (bez init procesu, appka je PID 1) jadro preto default
+// dispozíciu signálu vôbec neaplikovalo a appka SIGTERM úplne ignorovala,
+// kým ju Docker po stop_grace_period nezabil SIGKILLom (viď shutdown.ts pre
+// plné vysvetlenie aj docker-events dôkaz). Explicitný handler toto
+// obchádza — signál sa vždy doručí, bez ohľadu na PID.
+const shutdown = createShutdownHandler({ server, pool });
+process.on("SIGTERM", () => {
+  shutdown("SIGTERM");
+});
+process.on("SIGINT", () => {
+  shutdown("SIGINT");
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -99,7 +99,7 @@ const app = createApp(db, {
 // dostávajú svoj `run*Ingest` (môže byť `undefined`, keď zodpovedajúca URL
 // nie je nastavená — job to zaznamená ako "failure" s vysvetlením, nikdy sa
 // nepreskočí ticho).
-startScheduler(db, [
+const scheduler = startScheduler(db, [
   catalogImportJob(runIngest),
   pruneRawExportsJob(),
   sessionCleanupJob(),
@@ -135,13 +135,8 @@ if (existsSync(publicDir)) {
 const server = serve({ fetch: app.fetch, port: env.PORT });
 console.log(JSON.stringify({ msg: "api beží", port: env.PORT, version: appVersion() }));
 
-// issue 78: appka nemala žiadny SIGTERM/SIGINT handler — v produkčnom
-// kontajneri (bez init procesu, appka je PID 1) jadro preto default
-// dispozíciu signálu vôbec neaplikovalo a appka SIGTERM úplne ignorovala,
-// kým ju Docker po stop_grace_period nezabil SIGKILLom (viď shutdown.ts pre
-// plné vysvetlenie aj docker-events dôkaz). Explicitný handler toto
-// obchádza — signál sa vždy doručí, bez ohľadu na PID.
-const shutdown = createShutdownHandler({ server, pool });
+// issue 78 — plné vysvetlenie prečo toto existuje je v shutdown.ts.
+const shutdown = createShutdownHandler({ server, pool, scheduler });
 process.on("SIGTERM", () => {
   shutdown("SIGTERM");
 });

--- a/apps/api/src/shutdown.ts
+++ b/apps/api/src/shutdown.ts
@@ -1,0 +1,85 @@
+import { log } from "./logger.js";
+
+/**
+ * Vytvorí idempotentný SIGTERM/SIGINT handler pre graceful shutdown appky
+ * (issue 78).
+ *
+ * Prečo toto existuje: appka doteraz nemala ŽIADEN signal handler.
+ * `Dockerfile`'s `CMD ["node", "apps/api/dist/index.js"]` beží bez init
+ * procesu (žiadny `tini`/`docker compose`'s `init: true`), takže appka je v
+ * kontajneri PID 1 — a Linux jadro pre PID 1 NEAPLIKUJE default dispozíciu
+ * signálu (SIG_DFL), pokiaľ proces sám nezaregistruje explicitný handler.
+ * Appka preto SIGTERM úplne ignorovala, bežala ďalej celý
+ * `stop_grace_period` (Docker default 10s), kým ju Docker nezabil SIGKILLom.
+ * Medzitým `docker compose up`'s "Recreate" krok stihol interne pripraviť
+ * "nahradiť starý kontajner" podľa jeho dočasného ID, ale kontajner bol už
+ * `destroy`nutý (SIGKILL → die → destroy) skôr, než sa k tomu kroku dostal —
+ * odtiaľ "No such container" pri deployi. Explicitný handler (táto funkcia)
+ * obchádza PID-1 problém úplne: signál sa VŽDY doručí zaregistrovanému JS
+ * handleru bez ohľadu na to, či proces beží ako PID 1.
+ */
+
+export interface ShutdownServer {
+  close: (callback: (err?: Error) => void) => void;
+}
+
+export interface ShutdownPool {
+  end: () => Promise<void>;
+}
+
+export interface ShutdownDeps {
+  server: ShutdownServer;
+  pool: ShutdownPool;
+  /** Bounded fallback — force-exit ak sa graceful cesta nestihne včas (default 8s). */
+  forceExitAfterMs?: number;
+  /** Injektovateľné pre testy — reálny default volá process.exit(). */
+  exit?: (code: number) => void;
+}
+
+export function createShutdownHandler({
+  server,
+  pool,
+  forceExitAfterMs = 8000,
+  exit = (code: number) => process.exit(code),
+}: ShutdownDeps): (signal: NodeJS.Signals) => void {
+  let shuttingDown = false;
+
+  return (signal: NodeJS.Signals) => {
+    if (shuttingDown) {
+      log.debug({ signal }, "shutdown už prebieha — ďalší signál ignorovaný");
+      return;
+    }
+    shuttingDown = true;
+    log.info({ signal }, "prijatý ukončovací signál — spúšťam graceful shutdown");
+
+    const forceTimer = setTimeout(() => {
+      log.error(
+        { signal, forceExitAfterMs },
+        "graceful shutdown neskončil včas — vynútený exit(1)",
+      );
+      exit(1);
+    }, forceExitAfterMs);
+    forceTimer.unref();
+
+    server.close((err) => {
+      if (err) {
+        log.error({ err }, "chyba pri zatváraní HTTP servera počas shutdownu");
+      } else {
+        log.info("HTTP server prestal prijímať nové spojenia");
+      }
+
+      pool
+        .end()
+        .then(() => {
+          log.info("DB pool zatvorený — shutdown dokončený");
+          clearTimeout(forceTimer);
+          exit(0);
+        })
+        .catch((poolErr: unknown) => {
+          log.error({ err: poolErr }, "chyba pri zatváraní DB poolu počas shutdownu");
+          clearTimeout(forceTimer);
+          exit(1);
+        });
+    });
+  };
+}

--- a/apps/api/src/shutdown.ts
+++ b/apps/api/src/shutdown.ts
@@ -21,15 +21,30 @@ import { log } from "./logger.js";
 
 export interface ShutdownServer {
   close: (callback: (err?: Error) => void) => void;
+  /** Voliteľné — reálny http.Server ju má (Node 18.2+), testovacie fake objekty nemusia. */
+  closeIdleConnections?: () => void;
 }
 
 export interface ShutdownPool {
   end: () => Promise<void>;
 }
 
+export interface ShutdownScheduler {
+  stop: () => void;
+}
+
 export interface ShutdownDeps {
   server: ShutdownServer;
   pool: ShutdownPool;
+  /**
+   * Voliteľné — keď appka beží aj s naplánovanými úlohami (`startScheduler()`),
+   * `.stop()` sa zavolá HNEĎ na začiatku shutdownu, aby počas neho nezačal
+   * nový tick (issue 78 review, finding 1: appka bez tohto rizikovala, že
+   * `pool.end()` bude čakať na DB klienta vzatého rozbehnutou úlohou).
+   * `.stop()` len zruší budúci `setInterval` tick — UŽ bežiacu úlohu
+   * neprerušuje, tá sa dobehne (alebo ju odreže force-exit fallback).
+   */
+  scheduler?: ShutdownScheduler;
   /** Bounded fallback — force-exit ak sa graceful cesta nestihne včas (default 8s). */
   forceExitAfterMs?: number;
   /** Injektovateľné pre testy — reálny default volá process.exit(). */
@@ -39,6 +54,7 @@ export interface ShutdownDeps {
 export function createShutdownHandler({
   server,
   pool,
+  scheduler,
   forceExitAfterMs = 8000,
   exit = (code: number) => process.exit(code),
 }: ShutdownDeps): (signal: NodeJS.Signals) => void {
@@ -66,6 +82,15 @@ export function createShutdownHandler({
     }
     shuttingDown = true;
     log.info({ signal }, "prijatý ukončovací signál — spúšťam graceful shutdown");
+
+    if (scheduler) {
+      scheduler.stop();
+      log.info("plánovač zastavený — žiadny nový tick sa už nespustí");
+    }
+    // Nečaká na callback (na rozdiel od server.close() nižšie) — len urýchli
+    // bežný prípad (žiadne aktívne spojenia), aby server.close() nemusel
+    // čakať na idle keep-alive sokety a nespoliehal sa len na force-exit.
+    server.closeIdleConnections?.();
 
     const forceTimer = setTimeout(() => {
       log.error(

--- a/apps/api/src/shutdown.ts
+++ b/apps/api/src/shutdown.ts
@@ -43,6 +43,21 @@ export function createShutdownHandler({
   exit = (code: number) => process.exit(code),
 }: ShutdownDeps): (signal: NodeJS.Signals) => void {
   let shuttingDown = false;
+  // Chráni pred DVOJITÝM zavolaním `exit()` — force-exit timer aj graceful
+  // cesta (server.close → pool.end) mohli by teoreticky obe dobehnúť (napr.
+  // force timer vystrelí exit(1), a tesne nato sa aj pomalé pool.end()
+  // vyrieši a zavolá exit(0)). V produkcii je to neškodné (reálny
+  // process.exit() proces okamžite ukončí, žiadny ďalší JS kód sa nespustí),
+  // ale injektovaný `exit` v testoch NEukončuje nič — bez tejto stráže by ho
+  // teda šlo zavolať dvakrát s rôznym kódom.
+  let exited = false;
+  const exitOnce = (code: number) => {
+    if (exited) {
+      return;
+    }
+    exited = true;
+    exit(code);
+  };
 
   return (signal: NodeJS.Signals) => {
     if (shuttingDown) {
@@ -57,7 +72,7 @@ export function createShutdownHandler({
         { signal, forceExitAfterMs },
         "graceful shutdown neskončil včas — vynútený exit(1)",
       );
-      exit(1);
+      exitOnce(1);
     }, forceExitAfterMs);
     forceTimer.unref();
 
@@ -73,12 +88,12 @@ export function createShutdownHandler({
         .then(() => {
           log.info("DB pool zatvorený — shutdown dokončený");
           clearTimeout(forceTimer);
-          exit(0);
+          exitOnce(0);
         })
         .catch((poolErr: unknown) => {
           log.error({ err: poolErr }, "chyba pri zatváraní DB poolu počas shutdownu");
           clearTimeout(forceTimer);
-          exit(1);
+          exitOnce(1);
         });
     });
   };

--- a/apps/api/tests/shutdown.integration.test.ts
+++ b/apps/api/tests/shutdown.integration.test.ts
@@ -22,7 +22,7 @@ describe("createShutdownHandler", () => {
   let poolEnd: (() => Promise<void>) | undefined;
 
   afterEach(async () => {
-    server?.closeAllConnections?.();
+    server?.closeAllConnections();
     await poolEnd?.().catch(() => undefined);
     server = undefined;
     poolEnd = undefined;
@@ -79,7 +79,7 @@ describe("createShutdownHandler", () => {
 
   it("vynúti exit(1), keď sa server.close() nestihne skončiť včas", async () => {
     const neverClosingServer = {
-      close: (_cb?: (err?: Error) => void) => {
+      close: () => {
         // zámerne nikdy nezavolá callback — simuluje zaseknuté keep-alive spojenie
       },
     };

--- a/apps/api/tests/shutdown.integration.test.ts
+++ b/apps/api/tests/shutdown.integration.test.ts
@@ -77,6 +77,57 @@ describe("createShutdownHandler", () => {
     poolEnd = undefined;
   });
 
+  it("prebiehajúci request pri signáli sa dokončí normálne, server sa zavrie až potom", async () => {
+    const url = process.env["DATABASE_URL"];
+    if (url === undefined || url === "") {
+      throw new Error("Integračné testy potrebujú DATABASE_URL na testovaciu databázu");
+    }
+    const { pool } = createDb(url);
+    poolEnd = () => pool.end();
+
+    // Handler zámerne odpovie AŽ po malom oneskorení — simuluje request, ktorý
+    // ešte beží v momente, keď príde ukončovací signál. `server.close()` musí
+    // nechať TENTO request dobehnúť (nezruší ho), len prestane prijímať NOVÉ
+    // spojenia — presne toto správanie tento test dokazuje priamo, nielen
+    // odvodzuje z Node dokumentácie. `Connection: close` je nutné explicitne
+    // nastaviť — bez neho by keep-alive socket ostal otvorený a
+    // `server.close()`'s callback by čakal na Node-ov `keepAliveTimeout`
+    // (default 5s), namiesto toho, aby sa zavrel hneď po dokončení odpovede.
+    server = createServer((_req, res) => {
+      setTimeout(() => {
+        res.setHeader("Connection", "close");
+        res.end("ok");
+      }, 150);
+    });
+    const { port } = await new Promise<{ port: number }>((resolve) => {
+      server?.listen(0, () => {
+        const address = server?.address();
+        resolve({ port: typeof address === "object" && address !== null ? address.port : 0 });
+      });
+    });
+
+    const exit = vi.fn<(code: number) => void>();
+    const handler = createShutdownHandler({ server, pool, exit });
+
+    const responsePromise = fetch(`http://127.0.0.1:${port.toString()}/`);
+    // Signál príde krátko po odoslaní requestu, kým appka ešte odpovedá.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    handler("SIGTERM");
+
+    const response = await responsePromise;
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("ok");
+
+    await vi.waitFor(
+      () => {
+        expect(exit).toHaveBeenCalledWith(0);
+      },
+      { timeout: 3000 },
+    );
+    expect(server.listening).toBe(false);
+    poolEnd = undefined;
+  });
+
   it("vynúti exit(1), keď sa server.close() nestihne skončiť včas", async () => {
     const neverClosingServer = {
       close: () => {

--- a/apps/api/tests/shutdown.integration.test.ts
+++ b/apps/api/tests/shutdown.integration.test.ts
@@ -1,0 +1,105 @@
+import { createServer, type Server } from "node:http";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDb } from "../src/db/client.js";
+import { createShutdownHandler } from "../src/shutdown.js";
+
+// issue 78: appka nemala žiadny SIGTERM/SIGINT handler — v produkčnom
+// kontajneri (Dockerfile's CMD beží ako PID 1, bez init procesu ako tini)
+// preto proces signál ÚPLNE ignoroval (jadro pre PID 1 neaplikuje default
+// dispozíciu signálu, pokiaľ nie je explicitne zaregistrovaný handler) a bežal
+// ďalej celý stop_grace_period, kým ho Docker nezabil SIGKILLom. Medzitým
+// `docker compose up`'s "Recreate" krok stihol interne pripraviť "nahradiť
+// starý kontajner" podľa jeho dočasného ID, ale kontajner bol už `destroy`nutý
+// — odtiaľ "No such container" (deploy run 30576765525, merge sha
+// d19f8eae — skrátené, plný sha je v issue 78). Tieto testy overujú, že
+// `createShutdownHandler` naozaj zavrie HTTP server aj DB pool a ukončí
+// proces (cez injektovaný `exit`, aby test runner sám neumrel) — v produkcii
+// by teda signál viedol na rýchle a čisté ukončenie namiesto 10s čakania na
+// SIGKILL.
+
+describe("createShutdownHandler", () => {
+  let server: Server | undefined;
+  let poolEnd: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    server?.closeAllConnections?.();
+    await poolEnd?.().catch(() => undefined);
+    server = undefined;
+    poolEnd = undefined;
+  });
+
+  it("zavrie HTTP server aj DB pool a ukončí proces s kódom 0", async () => {
+    const url = process.env["DATABASE_URL"];
+    if (url === undefined || url === "") {
+      throw new Error("Integračné testy potrebujú DATABASE_URL na testovaciu databázu");
+    }
+    const { pool } = createDb(url);
+    poolEnd = () => pool.end();
+
+    server = createServer((_req, res) => res.end("ok"));
+    await new Promise<void>((resolve) => server?.listen(0, resolve));
+
+    const exit = vi.fn<(code: number) => void>();
+    const handler = createShutdownHandler({ server, pool, exit });
+
+    handler("SIGTERM");
+
+    await vi.waitFor(() => {
+      expect(exit).toHaveBeenCalledWith(0);
+    });
+
+    expect(server.listening).toBe(false);
+    // pool.end() bol skutočne zavolaný — ďalší dopyt na zatvorenom pool-e musí zlyhať
+    await expect(pool.query("select 1")).rejects.toThrow();
+    poolEnd = undefined; // pool je už zatvorený, druhé .end() by zlyhalo
+  });
+
+  it("ignoruje druhý signál, kým prebieha shutdown (idempotencia)", async () => {
+    const url = process.env["DATABASE_URL"];
+    if (url === undefined || url === "") {
+      throw new Error("Integračné testy potrebujú DATABASE_URL na testovaciu databázu");
+    }
+    const { pool } = createDb(url);
+    poolEnd = () => pool.end();
+
+    server = createServer((_req, res) => res.end("ok"));
+    await new Promise<void>((resolve) => server?.listen(0, resolve));
+
+    const exit = vi.fn<(code: number) => void>();
+    const handler = createShutdownHandler({ server, pool, exit });
+
+    handler("SIGTERM");
+    handler("SIGTERM"); // druhé volanie počas prebiehajúceho shutdownu — musí byť no-op
+
+    await vi.waitFor(() => {
+      expect(exit).toHaveBeenCalledTimes(1);
+    });
+    poolEnd = undefined;
+  });
+
+  it("vynúti exit(1), keď sa server.close() nestihne skončiť včas", async () => {
+    const neverClosingServer = {
+      close: (_cb?: (err?: Error) => void) => {
+        // zámerne nikdy nezavolá callback — simuluje zaseknuté keep-alive spojenie
+      },
+    };
+    const neverEndingPool = { end: () => new Promise<void>(() => undefined) };
+    const exit = vi.fn<(code: number) => void>();
+
+    const handler = createShutdownHandler({
+      server: neverClosingServer,
+      pool: neverEndingPool,
+      exit,
+      forceExitAfterMs: 50,
+    });
+
+    handler("SIGTERM");
+
+    await vi.waitFor(
+      () => {
+        expect(exit).toHaveBeenCalledWith(1);
+      },
+      { timeout: 2000 },
+    );
+  });
+});

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -28,6 +28,12 @@ services:
   app:
     image: ghcr.io/zbynekdrlik/forestshop-app:${IMAGE_TAG:-latest}
     restart: unless-stopped
+    # Doplnok k appka's vlastnému SIGTERM handleru (apps/api/src/shutdown.ts,
+    # issue 78) — appka sa dnes ukončí za pár ms, ale 15s dáva rezervu pre
+    # prípad pomalšieho zatvárania DB spojení pod záťažou. Toto NIE JE
+    # náhrada za handler: appka bez neho SIGTERM ignorovala úplne (PID 1 bez
+    # init procesu) a čakala by celých 15s pri KAŽDOM deployi namiesto pár ms.
+    stop_grace_period: 15s
     depends_on:
       postgres: { condition: service_healthy }
     environment:

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -967,3 +967,40 @@ nové heslo sa nikde v pushnutom obsahu nenachádza.
 - No PR number appears in any commit message (`#N` bans the design-comment
   hook on this repo) — "PR 76"/"PR 77" written in prose throughout.
 - Shared PR: `#77`.
+
+## 2026-07-30 — issue 78 (deploy SIGTERM/recreate race)
+
+- Root cause: `apps/api/src/index.ts` had NO signal handler at all. The
+  container runs as PID 1 (`Dockerfile`'s `CMD`, no `tini`/`init: true`), and
+  the kernel does not apply a signal's default disposition to PID 1 unless
+  the process installs an explicit handler — so SIGTERM was silently
+  ignored for the full `stop_grace_period` (10s) until Docker SIGKILLed the
+  process, racing `docker compose up`'s Recreate step ("No such container").
+  Same symptom had already hit deploy for PR 25 and was misdiagnosed there
+  as transient containerd flakiness (fixed by a rerun) — corrected that
+  playbook entry in place (`.claude/rules/deploy.md`) rather than leaving
+  the wrong lesson for the next occurrence.
+- New `apps/api/src/shutdown.ts`: `createShutdownHandler()` — idempotent,
+  stops the scheduler (`.stop()`, so no new tick starts mid-shutdown),
+  proactively closes idle HTTP connections, closes the HTTP server then the
+  DB pool, `process.exit(0)`; bounded 8s force-exit(1) fallback, guarded
+  against a double `exit()` call. `docker-compose.prod.yml`'s `app` service
+  got an explicit `stop_grace_period: 15s` as a complementary margin.
+- RED/GREEN: `bf7f593` (test, `[red]`, confirmed failing — module didn't
+  exist yet) → `a022b27` (fix, `[green]`). Three follow-up commits from
+  self-review + an independent code-review subagent: `8059324` (double-exit
+  guard), `ceaf2b4` (stop_grace_period + playbook correction — landed
+  between red/green and the follow-ups), `c18f23b` (scheduler stop +
+  closeIdleConnections + a fourth test proving an in-flight request
+  completes normally when the signal arrives mid-request — this test
+  surfaced a real subtlety: `server.close()` waits on Node's
+  `keepAliveTimeout` unless the response sets `Connection: close`).
+- Verified end-to-end THREE times against the actual built production
+  Docker image running as real PID 1 (not just the integration test): a
+  bare `docker stop -t 15` on the unfixed image would have hung the full
+  grace period; on the fixed image it exited in 431ms, then 211ms after the
+  scheduler-stop wiring, both with exit code 0.
+- CI green (check/integration ×211/e2e/docker-build/version-check) on `dev`
+  push and on the PR (`#79`) across all three pushes; local before each
+  push: lint + typecheck clean.
+- Shared PR: `#79`.

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -900,3 +900,70 @@ nové heslo sa nikde v pushnutom obsahu nenachádza.
   `.claude/rules/frontend-design.md` (component-file max-lines split
   pattern — extract the repeated row/item renderer first).
 - Per-ticket Discord card fired (`notify --run-card`, confirmed delivered).
+
+## 2026-07-30 — review of PR 76 (five findings, no GitHub issue — direct review-fix cycle)
+
+- Not a GitHub-issue-tracked ticket: user handed five code-review findings
+  from an independent review of PR 76's own diff directly, to fix in one PR
+  (`explicitly: do NOT file a GitHub issue for them`). Version bump `225b113`
+  (`0.3.0-dev.38`).
+- **Finding 1** (deadlock risk): `queries.ts`'s
+  `listOpenOrderLineIdsForSupplier`'s `.for("update")` had no `of` list,
+  locking `variant`/`product` too — opposite lock order vs.
+  `catalog/ingest.ts`'s product→variant. RED `b18dbfa` (new test
+  `"hromadné označenie NEČAKÁ na zámok katalógovej tabuľky (product)…"`,
+  confirmed hangs to the 30s `testTimeout` against the unfixed query — see
+  report) → GREEN `bbc92bf` (`.for("update", { of: [orderLines, orders] })`).
+- **Findings 2/3/4** (test-quality only, same file, RED-only commit
+  `b18dbfa` since no production code changed): replaced the existing lock
+  test's fixed 200ms sleep with `pg_stat_activity` polling (deterministic
+  "still blocked" proof), removed a tautological `expect(settled).toBe(true)`
+  right after `await bulk` (a `.then()` registered earlier always resolves
+  first), added a rejection handler to that same `.then()`.
+- **Finding 5** (UI busy-guard mirror): `OrdersSection.tsx`'s group toggle
+  button was disabled only for its own bulk write (`busyOrderedSupplier`),
+  not for a per-row write in flight for a line in that group
+  (`busyOrderedLineId`) — the reverse of PR 75's finding 6. RED `a8718f6`
+  (new test `"skupinové tlačidlo je disabled počas per-riadkovej zmeny…"`,
+  confirmed fails against unfixed component) → GREEN `ca550d6` (added the
+  mirror condition to `disabled`).
+- Deep-review subagent (`superpowers:requesting-code-review`) came back
+  0 🔴 0 🟡, 2 🔵 (both same-file touch-ups, not new scope) → fixed in
+  `93acfb5`: corrected a stale docblock comment in `queries.ts` that still
+  described the pre-finding-1 unscoped lock, and added `backend_type =
+  'client backend'` to the `pg_stat_activity` poll to rule out a
+  theoretical autovacuum false positive.
+- Docs commits `6f2f7f8` (`.claude/rules/database.md` — rewrote the
+  `FOR UPDATE` note to cover findings 1-4 together, replacing the
+  now-incomplete PR-75-only version) and `c08a1db`
+  (`.claude/rules/frontend-design.md` — bidirectional busy-guard gotcha,
+  same pattern needed a fix in both directions across PR 75 + PR 76).
+- CI green (check/integration/e2e/docker-build/version-check) on `dev`
+  push, on the PR (`#77`), and on `main` after merge (`d19f8eae`). Local
+  before push: lint + typecheck clean, unit 263 API + 177 web, integration
+  207 (Postgres 5433).
+- **Deploy hit an unrelated infra race**: `docker compose up -d` on dev2
+  failed (`No such container: 4403a25ef63f_forestshop-app-1`) because the
+  OLD `0.3.0-dev.37` container did not exit on `SIGTERM` within the 10s
+  stop grace period and got `SIGKILL`ed mid-recreate, leaving prod down
+  (502) with `forestshop-app-1` fully removed. Recovered manually
+  (`docker compose -f docker-compose.prod.yml up -d` on dev2) — confirmed
+  `/api/version` back to `0.3.0-dev.38`/`d19f8eae`, clean logs. Filed as a
+  separate issue (`#78`, scope-gate `cross-cutting`) rather than fixed here
+  — `apps/api/src/index.ts` has no `SIGTERM`/`SIGINT` handler at all, root
+  cause needs its own investigation + design (touches both the app's
+  shutdown path and `docker-compose.prod.yml`), out of scope for these five
+  findings.
+- Deployed + verified on https://forestshop-novy.newlevel.media
+  (v0.3.0-dev.38, commit `d19f8eae` matches `/api/version`). Playwright on
+  the live "Na objednanie" screen: single checkbox (order 20261263,
+  variant 62605/6) ticked, reload confirmed it stayed ticked + row dimmed;
+  supplier group "Citrade" (2 lines) group-toggled to ordered (label
+  flipped to "↺ Zrušiť označenie skupiny"), then toggled back to unordered
+  (label back to "✔ Označiť skupinu ako objednané") — both directions
+  confirmed via DOM read. Reload afterward: all 39 checkboxes on the page
+  unchecked (data restored). 0 console errors/warnings across the whole
+  session.
+- No PR number appears in any commit message (`#N` bans the design-comment
+  hook on this repo) — "PR 76"/"PR 77" written in prose throughout.
+- Shared PR: `#77`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.38",
+  "version": "0.3.0-dev.39",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Čo a prečo

Deploy na main po zlúčení PR 77 zlyhal: `docker compose up -d` skončil na `Error response from daemon: No such container: <hash>_forestshop-app-1` počas kroku "Recreate", appka bola dole, vyžadovalo si to ručný zásah na dev2.

Koreňová príčina (potvrdená cez `docker events` v issue 78 aj priamym overením proti postavenému produkčnému obrazu, viď komentáre na issue): appka nemala žiadny `SIGTERM`/`SIGINT` handler. `Dockerfile`'s `CMD` beží bez init procesu, takže appka je v kontajneri PID 1 — jadro pre PID 1 neaplikuje default dispozíciu signálu, pokiaľ appka sama nezaregistruje explicitný handler. SIGTERM sa preto úplne ignoroval, appka bežala ďalej celý `stop_grace_period` (10s), kým ju Docker nezabil SIGKILLom — a `docker compose up`'s recreate krok si medzitým interne pripravil "nahradiť starý kontajner" podľa jeho dočasného ID, no kontajner bol už `destroy`nutý.

Ten istý symptóm sa už raz predtým objavil (deploy PR 25) a bol vtedy mylne priradený k transientnej containerd chybe — opravené aj v playbooku (`.claude/rules/deploy.md`).

## Zmeny

- **`apps/api/src/shutdown.ts`** (nové) — `createShutdownHandler()`: idempotentný handler, zavrie HTTP server (`server.close()`), potom DB pool (`pool.end()`), `process.exit(0)`; ohraničený 8s force-exit(1) fallback.
- **`apps/api/src/index.ts`** — zachytáva `server`/`pool` handle, registruje handler pre `SIGTERM` aj `SIGINT`.
- **`docker-compose.prod.yml`** — `app` service dostala explicitný `stop_grace_period: 15s` ako rezervu (doplnok k handleru, nie náhrada).
- **`.claude/rules/deploy.md`** — opravený mylný playbook záznam o "transientnom" jave z PR 25.
- **`apps/api/tests/shutdown.integration.test.ts`** (nové) — RED→GREEN regresný test proti reálnemu HTTP serveru + reálnemu DB poolu.

## Overenie

- `pnpm test` (263+177 unit testov), `pnpm test:integration` (32 súborov, 210 testov) — všetko zelené.
- `pnpm typecheck` + `pnpm lint` — čisté.
- Priame overenie proti postavenému produkčnému Docker obrazu ako PID 1 (rovnaké podmienky ako dev2): pred fixom `docker stop` appku vôbec nezastavil rýchlo, po fixe kontajner skončil za 431ms s exit code 0 — pozri komentár na issue 78.

Closes #78
