### PR TITLE
Na objednanie: supplier filters, remaining summary, hide-resolved toggle

### DIFF
--- a/apps/web/src/components/OrdersSection.tsx
+++ b/apps/web/src/components/OrdersSection.tsx
@@ -1,7 +1,10 @@
 import { useCallback, useEffect, useState, type JSX } from "react";
 import type { Me } from "../api.js";
+import { isLineResolved } from "../ordersSummary.js";
 import { OrderLineRow } from "./OrderLineRow.js";
 import { OrderOpenStatusesPanel } from "./OrderOpenStatusesPanel.js";
+import { OrdersToolbar } from "./OrdersToolbar.js";
+import { SupplierActionsPanel } from "./SupplierActionsPanel.js";
 import {
   fetchOpenOrders,
   fetchSupplierOrderMailPreview,
@@ -23,13 +26,20 @@ import {
 // `CatalogPage`'s `IMPORT_ROLES`/`SchedulerSection`'s `SCHEDULER_ROLES`).
 const CAN_CHANGE_STATE_ROLES: ReadonlySet<Me["role"]> = new Set(["admin", "manazer"]);
 
-// Riadky, ktoré ešte treba objednať u dodávateľa (rovnaký zámer ako stará
-// appka's `outstandingOf`/`!isHandled`, #31) — východiskový stav pred tým,
-// než manažér čokoľvek ručne posunie ďalej. Toto gejtuje LEN tlačidlo
-// "odoslať objednávku mailom" (server-strana `mail.ts` filtruje rovnako) —
-// je to NEZÁVISLÉ od nového `ordered` príznaku (issue 60) nižšie, mail sa dá
-// odoslať/skopírovať bez ohľadu na to, či je riadok už odškrtnutý.
-const OUTSTANDING_STATE: OrderLine["state"] = "objednane";
+// issue 61: kľúč pre prepínač "skryť vybavené riadky" — jediný stav, ktorý
+// má prežiť obnovenie stránky (issue to pýta výslovne LEN preň, výber
+// dodávateľa/chipu ostáva zámerne len klientský stav bez perzistencie).
+const HIDE_RESOLVED_STORAGE_KEY = "forestshop.orders.hideResolved";
+
+function readHideResolvedPreference(): boolean {
+  try {
+    return window.localStorage.getItem(HIDE_RESOLVED_STORAGE_KEY) === "1";
+  } catch {
+    // localStorage nedostupné (napr. prehliadač so zakázaným úložiskom) —
+    // prepínač jednoducho nezačne predvyplnený, nič nespadne.
+    return false;
+  }
+}
 
 export function OrdersSection({
   role,
@@ -44,6 +54,24 @@ export function OrdersSection({
   const [stateError, setStateError] = useState("");
   const [busyLineId, setBusyLineId] = useState<string | null>(null);
   const canChangeState = CAN_CHANGE_STATE_ROLES.has(role);
+
+  // issue 61: vybraný dodávateľ (chip) — `null` = "Všetci". Prepínač "skryť
+  // vybavené" sa naopak číta raz pri mount-e priamo z localStorage (lazy
+  // init), aby appka po reloade neblikla najprv nefiltrovaný zoznam.
+  const [selectedSupplier, setSelectedSupplier] = useState<string | null>(null);
+  const [hideResolved, setHideResolved] = useState<boolean>(readHideResolvedPreference);
+
+  const toggleHideResolved = useCallback(() => {
+    setHideResolved((current) => {
+      const next = !current;
+      try {
+        window.localStorage.setItem(HIDE_RESOLVED_STORAGE_KEY, next ? "1" : "0");
+      } catch {
+        // localStorage nedostupné — voľba ostáva platná len pre túto reláciu.
+      }
+      return next;
+    });
+  }, []);
 
   // #31: e-mailový kontakt dodávateľa (editovateľný priamo v zozname).
   const [editingEmailSupplier, setEditingEmailSupplier] = useState<string | null>(null);
@@ -296,6 +324,18 @@ export function OrdersSection({
   // preskupovanie na klientovi.
   const totalLines = suppliers.reduce((sum, group) => sum + group.lines.length, 0);
 
+  // issue 61: dodávatelia zúžení podľa vybraného chipu — hromadné akcie
+  // (`SupplierActionsPanel`) dostávajú vždy PLNÉ `group.lines` (nefiltrované
+  // podľa `hideResolved`), lebo server aj tak mutuje celú skupinu naraz;
+  // filtrovaný pohľad je len na to, ktoré RIADKY tabuľky sa vykreslia.
+  const filteredGroups = suppliers.filter(
+    (group) => selectedSupplier === null || group.supplier === selectedSupplier,
+  );
+  const visibleLinesCount = filteredGroups.reduce(
+    (sum, group) => sum + (hideResolved ? group.lines.filter((line) => !isLineResolved(line)).length : group.lines.length),
+    0,
+  );
+
   return (
     <section className="orders-section">
       {!loaded && <p>Načítavam otvorené objednávky…</p>}
@@ -305,151 +345,91 @@ export function OrdersSection({
       {loaded && totalLines === 0 && (
         <p className="empty" data-testid="orders-empty">Zatiaľ nie sú žiadne otvorené objednávky.</p>
       )}
-      {suppliers.map((group) => (
-        <div key={group.supplier} className="order-group" data-testid={`supplier-${group.supplier}`}>
-          <div className="toorder-supplier">
-            <span className="tosup-label">
-              {group.supplier} — {group.lines.length} {group.lines.length === 1 ? "riadok" : "riadky"}
-            </span>
-            <div className="tosup-contact" data-testid={`supplier-contact-${group.supplier}`}>
-              {editingEmailSupplier === group.supplier ? (
-                <>
-                  <input
-                    className="tosup-emailinput"
-                    aria-label={`E-mail dodávateľa ${group.supplier}`}
-                    type="email"
-                    value={emailDraft}
-                    disabled={emailBusy}
-                    onChange={(e) => {
-                      setEmailDraft(e.target.value);
-                    }}
+      {loaded && totalLines > 0 && (
+        <OrdersToolbar
+          suppliers={suppliers}
+          selectedSupplier={selectedSupplier}
+          onSelectSupplier={setSelectedSupplier}
+          hideResolved={hideResolved}
+          onToggleHideResolved={toggleHideResolved}
+        />
+      )}
+      {loaded && totalLines > 0 && hideResolved && visibleLinesCount === 0 && (
+        <p className="empty" data-testid="orders-hidden-empty">
+          {selectedSupplier === null
+            ? "Všetko vybavené — vybavené riadky sú skryté."
+            : "Tento dodávateľ je vybavený — vybavené riadky sú skryté."}
+        </p>
+      )}
+      {filteredGroups.map((group) => {
+        const visibleLines = hideResolved ? group.lines.filter((line) => !isLineResolved(line)) : group.lines;
+        if (visibleLines.length === 0) return null;
+        return (
+          <div key={group.supplier} className="order-group" data-testid={`supplier-${group.supplier}`}>
+            <SupplierActionsPanel
+              group={group}
+              canChangeState={canChangeState}
+              editingEmailSupplier={editingEmailSupplier}
+              emailDraft={emailDraft}
+              emailBusy={emailBusy}
+              emailError={emailError}
+              onEmailDraftChange={setEmailDraft}
+              onStartEditEmail={startEditEmail}
+              onSaveEmail={saveEmail}
+              onCancelEditEmail={cancelEditEmail}
+              busyOrderedSupplier={busyOrderedSupplier}
+              busyOrderedLineId={busyOrderedLineId}
+              onToggleGroupOrdered={toggleGroupOrdered}
+              onCopyOrderToClipboard={copyOrderToClipboard}
+              previewSupplier={previewSupplier}
+              preview={preview}
+              previewError={previewError}
+              sendBusy={sendBusy}
+              sendResult={sendResult}
+              onOpenPreview={openPreview}
+              onClosePreview={closePreview}
+              onConfirmSend={confirmSend}
+            />
+            <table className="orders-table">
+              <thead>
+                <tr>
+                  {/* issue 60: odškrtávacie políčko — JEDINÉ miesto na obrazovke,
+                      ktoré sa smie volať "Objednané" (viď `STATE_LABELS`
+                      a stĺpec dátumu nižšie, obe premenované, aby nekolidovali). */}
+                  <th>Objednané</th>
+                  <th>Objednávka</th>
+                  <th>Zákazník</th>
+                  <th>Kód</th>
+                  <th>Produkt</th>
+                  <th>Veľkosť</th>
+                  <th>Množstvo</th>
+                  <th>Dodávateľ</th>
+                  <th>Stav</th>
+                  <th>Dátum objednávky</th>
+                  <th>Komentár</th>
+                </tr>
+              </thead>
+              <tbody>
+                {visibleLines.map((line) => (
+                  <OrderLineRow
+                    key={line.lineId}
+                    line={line}
+                    canChangeState={canChangeState}
+                    busyLineId={busyLineId}
+                    busyOrderedLineId={busyOrderedLineId}
+                    // Review of PR 75, finding 6: kým hromadná akcia pre TOHTO
+                    // dodávateľa beží, žiadny riadok jeho skupiny sa nesmie dať
+                    // meniť per-riadkovo naraz.
+                    supplierBusy={busyOrderedSupplier === group.supplier}
+                    onChangeState={changeState}
+                    onChangeOrdered={changeOrdered}
                   />
-                  <button type="button" className="btn sm good" disabled={emailBusy} onClick={() => { saveEmail(group.supplier); }}>
-                    Uložiť
-                  </button>
-                  <button type="button" className="btn sm ghost" disabled={emailBusy} onClick={cancelEditEmail}>
-                    Zrušiť
-                  </button>
-                  {emailError !== "" && <p role="alert">{emailError}</p>}
-                </>
-              ) : (
-                <>
-                  <span className="tosup-email">E-mail dodávateľa: {group.email ?? "nenastavený"}</span>
-                  {canChangeState && (
-                    <button type="button" className="btn sm ghost" onClick={() => { startEditEmail(group); }}>
-                      Upraviť e-mail
-                    </button>
-                  )}
-                </>
-              )}
-            </div>
-            {canChangeState && (
-              <div className="tosup-actions">
-                {/* issue 60: hromadné označenie/zrušenie CELEJ skupiny naraz —
-                    jedno tlačidlo, ktoré prepína smer podľa toho, či je skupina
-                    UŽ celá odškrtnutá (rovnaký zámer ako stará appka's
-                    `markGroupOrdered`/`allOrdered`). Review of PR 76, finding 5:
-                    mirror smeru fixu 6 (review of PR 75, finding 6) — tlačidlo
-                    musí byť needitovateľné AJ kým beží per-riadkový zápis pre
-                    NIEKTORÝ riadok TEJTO skupiny (`busyOrderedLineId`), nielen
-                    počas vlastného hromadného zápisu (`busyOrderedSupplier`).
-                    Bez toho by klik na tlačidlo tesne po odškrtnutí jedného
-                    riadku poslal hromadný zápis počítaný z ešte-neaktuálneho
-                    `ordered` (optimistický update toho riadku sa prejaví až po
-                    vyriešení jeho vlastného promisu). */}
-                <button
-                  type="button"
-                  className="btn sm ghost"
-                  disabled={
-                    busyOrderedSupplier === group.supplier ||
-                    (busyOrderedLineId !== null && group.lines.some((l) => l.lineId === busyOrderedLineId))
-                  }
-                  onClick={() => {
-                    toggleGroupOrdered(group.supplier, !group.lines.every((l) => l.ordered));
-                  }}
-                >
-                  {group.lines.every((l) => l.ordered) ? "↺ Zrušiť označenie skupiny" : "✔ Označiť skupinu ako objednané"}
-                </button>
-                <button type="button" className="btn sm ghost" onClick={() => { copyOrderToClipboard(group.supplier); }}>
-                  📋 Kopírovať objednávku
-                </button>
-                <button
-                  type="button"
-                  className="btn sm good"
-                  disabled={group.email === null || !group.lines.some((l) => l.state === OUTSTANDING_STATE)}
-                  title={
-                    group.email === null
-                      ? "Pre odoslanie mailom treba najprv nastaviť e-mail dodávateľa."
-                      : undefined
-                  }
-                  onClick={() => { openPreview(group.supplier); }}
-                >
-                  ✉️ Poslať objednávku e-mailom
-                </button>
-              </div>
-            )}
+                ))}
+              </tbody>
+            </table>
           </div>
-          {canChangeState && group.email === null && (
-            <p className="reenote">Pre odoslanie mailom treba najprv nastaviť e-mail dodávateľa.</p>
-          )}
-          {sendResult?.supplier === group.supplier && <p role="status">{sendResult.message}</p>}
-          {previewSupplier === group.supplier && (
-            <div className="mail-preview" data-testid={`mail-preview-${group.supplier}`}>
-              {previewError !== "" && <p role="alert">{previewError}</p>}
-              {preview !== null && (
-                <>
-                  <p>Komu: {preview.to ?? "—"}</p>
-                  <p>Predmet: {preview.subject}</p>
-                  <pre>{preview.body}</pre>
-                  <button type="button" className="btn sm good" disabled={sendBusy} onClick={() => { confirmSend(group.supplier); }}>
-                    Odoslať
-                  </button>
-                  <button type="button" className="btn sm ghost" disabled={sendBusy} onClick={closePreview}>
-                    Zrušiť
-                  </button>
-                </>
-              )}
-            </div>
-          )}
-          <table className="orders-table">
-            <thead>
-              <tr>
-                {/* issue 60: odškrtávacie políčko — JEDINÉ miesto na obrazovke,
-                    ktoré sa smie volať "Objednané" (viď `STATE_LABELS`
-                    a stĺpec dátumu nižšie, obe premenované, aby nekolidovali). */}
-                <th>Objednané</th>
-                <th>Objednávka</th>
-                <th>Zákazník</th>
-                <th>Kód</th>
-                <th>Produkt</th>
-                <th>Veľkosť</th>
-                <th>Množstvo</th>
-                <th>Dodávateľ</th>
-                <th>Stav</th>
-                <th>Dátum objednávky</th>
-                <th>Komentár</th>
-              </tr>
-            </thead>
-            <tbody>
-              {group.lines.map((line) => (
-                <OrderLineRow
-                  key={line.lineId}
-                  line={line}
-                  canChangeState={canChangeState}
-                  busyLineId={busyLineId}
-                  busyOrderedLineId={busyOrderedLineId}
-                  // Review of PR 75, finding 6: kým hromadná akcia pre TOHTO
-                  // dodávateľa beží, žiadny riadok jeho skupiny sa nesmie dať
-                  // meniť per-riadkovo naraz.
-                  supplierBusy={busyOrderedSupplier === group.supplier}
-                  onChangeState={changeState}
-                  onChangeOrdered={changeOrdered}
-                />
-              ))}
-            </tbody>
-          </table>
-        </div>
-      ))}
+        );
+      })}
     </section>
   );
 }

--- a/apps/web/src/components/OrdersToolbar.test.tsx
+++ b/apps/web/src/components/OrdersToolbar.test.tsx
@@ -1,0 +1,160 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { OrdersToolbar } from "./OrdersToolbar.js";
+import type { OrderLine, SupplierOpenOrders } from "../ordersApi.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+const makeLine = (overrides: Partial<OrderLine> = {}): OrderLine => ({
+  lineId: overrides.lineId ?? "l1",
+  orderId: "o1",
+  externalOrderId: "1001",
+  customerName: "Zákazník",
+  comment: null,
+  placedAt: "2026-07-01T00:00:00.000Z",
+  variantCode: "A-1",
+  variantName: "Produkt",
+  sizeLabel: null,
+  quantity: 1,
+  state: "objednane",
+  ordered: false,
+  supplierUrl: null,
+  supplierNote: null,
+  externalCode: null,
+  ...overrides,
+});
+
+const SUPPLIERS: readonly SupplierOpenOrders[] = [
+  {
+    supplier: "Dodávateľ Alfa",
+    email: null,
+    lines: [makeLine({ lineId: "a1", state: "objednane", ordered: false })],
+  },
+  {
+    supplier: "Dodávateľ Beta",
+    email: null,
+    lines: [makeLine({ lineId: "b1", state: "caka_sa", ordered: false })],
+  },
+];
+
+it("zobrazí chip 'Všetci' aj chip pre každého dodávateľa s počtom riadkov", () => {
+  render(
+    <OrdersToolbar
+      suppliers={SUPPLIERS}
+      selectedSupplier={null}
+      onSelectSupplier={() => {}}
+      hideResolved={false}
+      onToggleHideResolved={() => {}}
+    />,
+  );
+
+  expect(screen.getByTestId("supplier-chip-all").textContent).toBe("Všetci (2)");
+  expect(screen.getByTestId("supplier-chip-Dodávateľ Alfa").textContent).toBe("Dodávateľ Alfa (1)");
+  expect(screen.getByTestId("supplier-chip-Dodávateľ Beta").textContent).toBe("Dodávateľ Beta (1)");
+});
+
+it("klik na chip dodávateľa zavolá onSelectSupplier s jeho menom", () => {
+  const onSelectSupplier = vi.fn();
+  render(
+    <OrdersToolbar
+      suppliers={SUPPLIERS}
+      selectedSupplier={null}
+      onSelectSupplier={onSelectSupplier}
+      hideResolved={false}
+      onToggleHideResolved={() => {}}
+    />,
+  );
+
+  fireEvent.click(screen.getByTestId("supplier-chip-Dodávateľ Beta"));
+  expect(onSelectSupplier).toHaveBeenCalledWith("Dodávateľ Beta");
+});
+
+it("klik na 'Všetci' zavolá onSelectSupplier s null", () => {
+  const onSelectSupplier = vi.fn();
+  render(
+    <OrdersToolbar
+      suppliers={SUPPLIERS}
+      selectedSupplier="Dodávateľ Alfa"
+      onSelectSupplier={onSelectSupplier}
+      hideResolved={false}
+      onToggleHideResolved={() => {}}
+    />,
+  );
+
+  fireEvent.click(screen.getByTestId("supplier-chip-all"));
+  expect(onSelectSupplier).toHaveBeenCalledWith(null);
+});
+
+it("vybraný chip nesie triedu 'active', dodávateľ bez nevybavených riadkov triedu 'done'", () => {
+  const doneSupplier: readonly SupplierOpenOrders[] = [
+    { supplier: "Hotový", email: null, lines: [makeLine({ lineId: "h1", state: "skladom" })] },
+  ];
+  render(
+    <OrdersToolbar
+      suppliers={doneSupplier}
+      selectedSupplier="Hotový"
+      onSelectSupplier={() => {}}
+      hideResolved={false}
+      onToggleHideResolved={() => {}}
+    />,
+  );
+
+  const chip = screen.getByTestId("supplier-chip-Hotový");
+  expect(chip.className).toContain("active");
+  expect(chip.className).toContain("done");
+});
+
+it("súhrn počíta 'Všetci' cez všetky riadky a mení sa podľa vybraného dodávateľa", () => {
+  const { rerender } = render(
+    <OrdersToolbar
+      suppliers={SUPPLIERS}
+      selectedSupplier={null}
+      onSelectSupplier={() => {}}
+      hideResolved={false}
+      onToggleHideResolved={() => {}}
+    />,
+  );
+  expect(screen.getByTestId("orders-summary").textContent).toBe("Ostáva vybaviť 1 z 2 · Čaká sa 1");
+
+  rerender(
+    <OrdersToolbar
+      suppliers={SUPPLIERS}
+      selectedSupplier="Dodávateľ Beta"
+      onSelectSupplier={() => {}}
+      hideResolved={false}
+      onToggleHideResolved={() => {}}
+    />,
+  );
+  expect(screen.getByTestId("orders-summary").textContent).toBe("Dodávateľ Beta: ostáva vybaviť 0 z 1 · Čaká sa 1");
+});
+
+it("prepínač 'skryť vybavené' zobrazí správny text podľa stavu a klik zavolá callback", () => {
+  const onToggleHideResolved = vi.fn();
+  const { rerender } = render(
+    <OrdersToolbar
+      suppliers={SUPPLIERS}
+      selectedSupplier={null}
+      onSelectSupplier={() => {}}
+      hideResolved={false}
+      onToggleHideResolved={onToggleHideResolved}
+    />,
+  );
+
+  const toggle = screen.getByTestId("orders-hide-resolved-toggle");
+  expect(toggle.textContent).toBe("👁 Skryť vybavené");
+  fireEvent.click(toggle);
+  expect(onToggleHideResolved).toHaveBeenCalledTimes(1);
+
+  rerender(
+    <OrdersToolbar
+      suppliers={SUPPLIERS}
+      selectedSupplier={null}
+      onSelectSupplier={() => {}}
+      hideResolved={true}
+      onToggleHideResolved={onToggleHideResolved}
+    />,
+  );
+  expect(screen.getByTestId("orders-hide-resolved-toggle").textContent).toBe("🙈 Vybavené skryté");
+});

--- a/apps/web/src/components/OrdersToolbar.tsx
+++ b/apps/web/src/components/OrdersToolbar.tsx
@@ -1,0 +1,80 @@
+import type { JSX } from "react";
+import type { OrderLine, SupplierOpenOrders } from "../ordersApi.js";
+import { formatOrderSummaryText, summarizeOrderLines } from "../ordersSummary.js";
+
+// issue 61 — filtrovacie štítky dodávateľov + súhrn "ostáva vybaviť" +
+// prepínač "skryť vybavené". Čisto prezentačný komponent: `OrdersSection.tsx`
+// zostáva vlastníkom dát aj stavu (vybraný dodávateľ, prepínač), presne ako
+// pri `OrderLineRow`/`SupplierActionsPanel` — sem sa posielajú len hodnoty +
+// callbacky.
+export function OrdersToolbar({
+  suppliers,
+  selectedSupplier,
+  onSelectSupplier,
+  hideResolved,
+  onToggleHideResolved,
+}: {
+  readonly suppliers: readonly SupplierOpenOrders[];
+  readonly selectedSupplier: string | null;
+  readonly onSelectSupplier: (supplier: string | null) => void;
+  readonly hideResolved: boolean;
+  readonly onToggleHideResolved: () => void;
+}): JSX.Element {
+  const allLines: readonly OrderLine[] = suppliers.flatMap((group) => group.lines);
+  const scopedLines =
+    selectedSupplier === null ? allLines : (suppliers.find((g) => g.supplier === selectedSupplier)?.lines ?? []);
+  const allSummary = summarizeOrderLines(allLines);
+  const allDone = allLines.length > 0 && allSummary.remaining === 0;
+
+  return (
+    <div className="orders-toolbar" data-testid="orders-toolbar">
+      <div className="chip-row">
+        <button
+          type="button"
+          className={"chip" + (selectedSupplier === null ? " active" : "") + (allDone ? " done" : "")}
+          data-testid="supplier-chip-all"
+          onClick={() => {
+            onSelectSupplier(null);
+          }}
+        >
+          {`Všetci (${String(allLines.length)})`}
+        </button>
+        {suppliers.map((group) => {
+          const groupSummary = summarizeOrderLines(group.lines);
+          const done = group.lines.length > 0 && groupSummary.remaining === 0;
+          return (
+            <button
+              key={group.supplier}
+              type="button"
+              className={"chip" + (selectedSupplier === group.supplier ? " active" : "") + (done ? " done" : "")}
+              data-testid={`supplier-chip-${group.supplier}`}
+              onClick={() => {
+                onSelectSupplier(group.supplier);
+              }}
+            >
+              {`${group.supplier} (${String(group.lines.length)})`}
+            </button>
+          );
+        })}
+      </div>
+      <div className="orders-toolbar-summary-row">
+        <p className="orders-summary" data-testid="orders-summary">
+          {formatOrderSummaryText(summarizeOrderLines(scopedLines), selectedSupplier)}
+        </p>
+        <button
+          type="button"
+          className={"btn sm ghost" + (hideResolved ? " on" : "")}
+          data-testid="orders-hide-resolved-toggle"
+          title={
+            hideResolved
+              ? "Zobraziť aj riadky, ktoré sú už vybavené"
+              : "Skryť riadky, ktoré sú už vybavené (objednané / čaká sa / skladom / nedostupné)"
+          }
+          onClick={onToggleHideResolved}
+        >
+          {hideResolved ? "🙈 Vybavené skryté" : "👁 Skryť vybavené"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/SupplierActionsPanel.tsx
+++ b/apps/web/src/components/SupplierActionsPanel.tsx
@@ -1,0 +1,197 @@
+import type { JSX } from "react";
+import type { OrderMailPreview, SupplierOpenOrders } from "../ordersApi.js";
+
+// issue 61 — mechanicky vyňaté z `OrdersSection.tsx` (hlavička skupiny +
+// e-mailový kontakt (#31) + hromadné akcie + náhľad/odoslanie mailom), BEZ
+// zmeny správania alebo markupu — `OrdersSection.tsx` bol už na hranici
+// eslint `max-lines: 400` (`.claude/rules/testing.md`) a pridanie filtrovacích
+// chipov/súhrnu (issue 61) by ho poslalo cez limit. Rovnaký vzor ako
+// `OrderLineRow` extrakcia (`.claude/rules/frontend-design.md`): vyňať
+// najväčší samostatný blok, nechať `OrdersSection.tsx` vlastníkom dát/stavu.
+export function SupplierActionsPanel({
+  group,
+  canChangeState,
+  editingEmailSupplier,
+  emailDraft,
+  emailBusy,
+  emailError,
+  onEmailDraftChange,
+  onStartEditEmail,
+  onSaveEmail,
+  onCancelEditEmail,
+  busyOrderedSupplier,
+  busyOrderedLineId,
+  onToggleGroupOrdered,
+  onCopyOrderToClipboard,
+  previewSupplier,
+  preview,
+  previewError,
+  sendBusy,
+  sendResult,
+  onOpenPreview,
+  onClosePreview,
+  onConfirmSend,
+}: {
+  readonly group: SupplierOpenOrders;
+  readonly canChangeState: boolean;
+  readonly editingEmailSupplier: string | null;
+  readonly emailDraft: string;
+  readonly emailBusy: boolean;
+  readonly emailError: string;
+  readonly onEmailDraftChange: (value: string) => void;
+  readonly onStartEditEmail: (group: SupplierOpenOrders) => void;
+  readonly onSaveEmail: (supplier: string) => void;
+  readonly onCancelEditEmail: () => void;
+  readonly busyOrderedSupplier: string | null;
+  readonly busyOrderedLineId: string | null;
+  readonly onToggleGroupOrdered: (supplier: string, ordered: boolean) => void;
+  readonly onCopyOrderToClipboard: (supplier: string) => void;
+  readonly previewSupplier: string | null;
+  readonly preview: OrderMailPreview | null;
+  readonly previewError: string;
+  readonly sendBusy: boolean;
+  readonly sendResult: { readonly supplier: string; readonly message: string } | null;
+  readonly onOpenPreview: (supplier: string) => void;
+  readonly onClosePreview: () => void;
+  readonly onConfirmSend: (supplier: string) => void;
+}): JSX.Element {
+  // Riadky, ktoré ešte treba objednať u dodávateľa (rovnaký zámer ako stará
+  // appka's `outstandingOf`/`!isHandled`, #31) — východiskový stav pred tým,
+  // než manažér čokoľvek ručne posunie ďalej. Toto gejtuje LEN tlačidlo
+  // "odoslať objednávku mailom" (server-strana `mail.ts` filtruje rovnako) —
+  // je to NEZÁVISLÉ od `ordered` príznaku (issue 60), mail sa dá
+  // odoslať/skopírovať bez ohľadu na to, či je riadok už odškrtnutý. Jediné
+  // miesto, ktoré túto konštantu po extrakcii (issue 61) potrebuje.
+  const outstandingState = "objednane";
+
+  return (
+    <>
+      <div className="toorder-supplier">
+        <span className="tosup-label">
+          {group.supplier} — {group.lines.length} {group.lines.length === 1 ? "riadok" : "riadky"}
+        </span>
+        <div className="tosup-contact" data-testid={`supplier-contact-${group.supplier}`}>
+          {editingEmailSupplier === group.supplier ? (
+            <>
+              <input
+                className="tosup-emailinput"
+                aria-label={`E-mail dodávateľa ${group.supplier}`}
+                type="email"
+                value={emailDraft}
+                disabled={emailBusy}
+                onChange={(e) => {
+                  onEmailDraftChange(e.target.value);
+                }}
+              />
+              <button
+                type="button"
+                className="btn sm good"
+                disabled={emailBusy}
+                onClick={() => {
+                  onSaveEmail(group.supplier);
+                }}
+              >
+                Uložiť
+              </button>
+              <button type="button" className="btn sm ghost" disabled={emailBusy} onClick={onCancelEditEmail}>
+                Zrušiť
+              </button>
+              {emailError !== "" && <p role="alert">{emailError}</p>}
+            </>
+          ) : (
+            <>
+              <span className="tosup-email">E-mail dodávateľa: {group.email ?? "nenastavený"}</span>
+              {canChangeState && (
+                <button
+                  type="button"
+                  className="btn sm ghost"
+                  onClick={() => {
+                    onStartEditEmail(group);
+                  }}
+                >
+                  Upraviť e-mail
+                </button>
+              )}
+            </>
+          )}
+        </div>
+        {canChangeState && (
+          <div className="tosup-actions">
+            {/* issue 60: hromadné označenie/zrušenie CELEJ skupiny naraz —
+                jedno tlačidlo, ktoré prepína smer podľa toho, či je skupina
+                UŽ celá odškrtnutá (rovnaký zámer ako stará appka's
+                `markGroupOrdered`/`allOrdered`). Review of PR 76, finding 5:
+                mirror smeru fixu 6 (review of PR 75, finding 6) — tlačidlo
+                musí byť needitovateľné AJ kým beží per-riadkový zápis pre
+                NIEKTORÝ riadok TEJTO skupiny (`busyOrderedLineId`), nielen
+                počas vlastného hromadného zápisu (`busyOrderedSupplier`). */}
+            <button
+              type="button"
+              className="btn sm ghost"
+              disabled={
+                busyOrderedSupplier === group.supplier ||
+                (busyOrderedLineId !== null && group.lines.some((l) => l.lineId === busyOrderedLineId))
+              }
+              onClick={() => {
+                onToggleGroupOrdered(group.supplier, !group.lines.every((l) => l.ordered));
+              }}
+            >
+              {group.lines.every((l) => l.ordered) ? "↺ Zrušiť označenie skupiny" : "✔ Označiť skupinu ako objednané"}
+            </button>
+            <button
+              type="button"
+              className="btn sm ghost"
+              onClick={() => {
+                onCopyOrderToClipboard(group.supplier);
+              }}
+            >
+              📋 Kopírovať objednávku
+            </button>
+            <button
+              type="button"
+              className="btn sm good"
+              disabled={group.email === null || !group.lines.some((l) => l.state === outstandingState)}
+              title={
+                group.email === null ? "Pre odoslanie mailom treba najprv nastaviť e-mail dodávateľa." : undefined
+              }
+              onClick={() => {
+                onOpenPreview(group.supplier);
+              }}
+            >
+              ✉️ Poslať objednávku e-mailom
+            </button>
+          </div>
+        )}
+      </div>
+      {canChangeState && group.email === null && (
+        <p className="reenote">Pre odoslanie mailom treba najprv nastaviť e-mail dodávateľa.</p>
+      )}
+      {sendResult?.supplier === group.supplier && <p role="status">{sendResult.message}</p>}
+      {previewSupplier === group.supplier && (
+        <div className="mail-preview" data-testid={`mail-preview-${group.supplier}`}>
+          {previewError !== "" && <p role="alert">{previewError}</p>}
+          {preview !== null && (
+            <>
+              <p>Komu: {preview.to ?? "—"}</p>
+              <p>Predmet: {preview.subject}</p>
+              <pre>{preview.body}</pre>
+              <button
+                type="button"
+                className="btn sm good"
+                disabled={sendBusy}
+                onClick={() => {
+                  onConfirmSend(group.supplier);
+                }}
+              >
+                Odoslať
+              </button>
+              <button type="button" className="btn sm ghost" disabled={sendBusy} onClick={onClosePreview}>
+                Zrušiť
+              </button>
+            </>
+          )}
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/ordersSummary.test.ts
+++ b/apps/web/src/ordersSummary.test.ts
@@ -1,0 +1,61 @@
+import { expect, it } from "vitest";
+import { formatOrderSummaryText, isLineResolved, summarizeOrderLines } from "./ordersSummary.js";
+
+const line = (state: "objednane" | "caka_sa" | "skladom" | "nedostupne", ordered: boolean) => ({
+  state,
+  ordered,
+});
+
+it("riadok v predvolenom stave a bez odškrtnutia je NEvybavený", () => {
+  expect(isLineResolved(line("objednane", false))).toBe(false);
+});
+
+it("riadok odškrtnutý ako objednané je vybavený, aj keď je stav stále predvolený", () => {
+  expect(isLineResolved(line("objednane", true))).toBe(true);
+});
+
+it("riadok posunutý za predvolený stav je vybavený, aj bez odškrtnutia", () => {
+  expect(isLineResolved(line("caka_sa", false))).toBe(true);
+  expect(isLineResolved(line("skladom", false))).toBe(true);
+  expect(isLineResolved(line("nedostupne", false))).toBe(true);
+});
+
+it("summarizeOrderLines spočíta total/remaining a rozpis podľa stavov/odškrtnutia", () => {
+  const summary = summarizeOrderLines([
+    line("objednane", false), // nevybavený → remaining
+    line("caka_sa", false),
+    line("skladom", false),
+    line("nedostupne", false),
+    line("objednane", true), // odškrtnutý, stav stále predvolený → ordered bucket, nie remaining
+  ]);
+
+  expect(summary).toEqual({ total: 5, remaining: 1, ordered: 1, waiting: 1, stock: 1, unavailable: 1 });
+});
+
+it("rozpis NIE JE rozklad total na disjunktné časti — riadok môže byť v OBOCH bucketoch naraz", () => {
+  // odškrtnutý AJ v stave "čaká sa" súčasne — počíta sa do OBOCH, total ostáva 1.
+  const summary = summarizeOrderLines([line("caka_sa", true)]);
+
+  expect(summary).toEqual({ total: 1, remaining: 0, ordered: 1, waiting: 1, stock: 0, unavailable: 0 });
+});
+
+it("formatOrderSummaryText bez vybraného dodávateľa a bez rozpisu (žiadny bucket nenulový)", () => {
+  const summary = summarizeOrderLines([line("objednane", false)]);
+  expect(formatOrderSummaryText(summary, null)).toBe("Ostáva vybaviť 1 z 1");
+});
+
+it("formatOrderSummaryText s vybraným dodávateľom pridá jeho meno pred súhrn", () => {
+  const summary = summarizeOrderLines([line("caka_sa", false)]);
+  expect(formatOrderSummaryText(summary, "DODAVATEL-TEST-1")).toBe(
+    "DODAVATEL-TEST-1: ostáva vybaviť 0 z 1 · Čaká sa 1",
+  );
+});
+
+it("formatOrderSummaryText vynechá nulové bucketa, zachová poradie neprázdnych", () => {
+  const summary = summarizeOrderLines([
+    line("objednane", false),
+    line("skladom", false),
+    line("nedostupne", true), // ordered aj nedostupné naraz
+  ]);
+  expect(formatOrderSummaryText(summary, null)).toBe("Ostáva vybaviť 1 z 3 · Objednané 1 · Skladom 1 · Nedostupné 1");
+});

--- a/apps/web/src/ordersSummary.ts
+++ b/apps/web/src/ordersSummary.ts
@@ -1,0 +1,66 @@
+import type { OrderLine } from "./ordersApi.js";
+
+// issue 61 — priamy náprotivok starej appky's `isHandled` (`ORDERED[o.key] ||
+// WAITING[o.key] || INSTOCK[o.key] || UNAVAIL[o.key]`, `app.js:2332-2498`).
+// Nová appka nemá štyri nezávislé boolean mapy — má `order_line.ordered`
+// (issue 60, náprotivok ORDERED) a `order_line.state` (náprotivok WAITING/
+// INSTOCK/UNAVAIL, kde predvolené "objednane" = nič z toho troch). Riadok je
+// teda "vybavený" presne vtedy, keď je odškrtnutý ako objednané ALEBO jeho
+// stav postúpil za predvolený "objednane" (`.claude/rules/orders.md`).
+export function isLineResolved(line: Pick<OrderLine, "ordered" | "state">): boolean {
+  return line.ordered || line.state !== "objednane";
+}
+
+export interface OrderLinesSummary {
+  readonly total: number;
+  readonly remaining: number;
+  readonly ordered: number;
+  readonly waiting: number;
+  readonly stock: number;
+  readonly unavailable: number;
+}
+
+/**
+ * Rozpis NIE JE rozklad `total` na disjunktné časti — jeden riadok môže byť
+ * súčasne `ordered` AJ v inom stave než "objednane" (rovnaký zámer ako stará
+ * appka's `toOrderSummary`, ktorej komentár to hovorí výslovne: "the
+ * breakdown is not a partition of total"). `remaining` sa preto počíta
+ * priamo cez `isLineResolved`, nikdy odčítaním súčtu rozpisu od `total`.
+ */
+export function summarizeOrderLines(
+  lines: readonly Pick<OrderLine, "ordered" | "state">[],
+): OrderLinesSummary {
+  let ordered = 0;
+  let waiting = 0;
+  let stock = 0;
+  let unavailable = 0;
+  let remaining = 0;
+  for (const line of lines) {
+    if (line.ordered) ordered += 1;
+    if (line.state === "caka_sa") waiting += 1;
+    if (line.state === "skladom") stock += 1;
+    if (line.state === "nedostupne") unavailable += 1;
+    if (!isLineResolved(line)) remaining += 1;
+  }
+  return { total: lines.length, remaining, ordered, waiting, stock, unavailable };
+}
+
+const BREAKDOWN_PARTS: readonly (readonly ["ordered" | "waiting" | "stock" | "unavailable", string])[] = [
+  ["ordered", "Objednané"],
+  ["waiting", "Čaká sa"],
+  ["stock", "Skladom"],
+  ["unavailable", "Nedostupné"],
+];
+
+// `supplierLabel` = `null` pre "Všetci" (žiadny chip vybraný), inak meno
+// vybraného dodávateľa (vrátane zástupného "(bez dodávateľa)").
+export function formatOrderSummaryText(summary: OrderLinesSummary, supplierLabel: string | null): string {
+  const head = supplierLabel !== null ? `${supplierLabel}: ostáva vybaviť` : "Ostáva vybaviť";
+  const bits = BREAKDOWN_PARTS.filter(([key]) => summary[key] > 0).map(
+    ([key, label]) => `${label} ${String(summary[key])}`,
+  );
+  return (
+    `${head} ${String(summary.remaining)} z ${String(summary.total)}` +
+    (bits.length > 0 ? ` · ${bits.join(" · ")}` : "")
+  );
+}

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -560,6 +560,62 @@ tr:last-child td {
 .order-group {
   margin-bottom: var(--fs-space-6);
 }
+
+/* issue 61: filtrovacie štítky dodávateľov + súhrn "ostáva vybaviť" +
+   prepínač "skryť vybavené" — vlastný jazyk tejto appky (issue výslovne
+   žiada dizajn podľa NOVEJ appky, nie prevzaté farby starej). */
+.orders-toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: var(--fs-space-2);
+  margin-bottom: var(--fs-space-5);
+  padding-bottom: var(--fs-space-3);
+  border-bottom: 1px solid var(--fs-border-soft);
+}
+.chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--fs-space-2);
+}
+.chip {
+  display: inline-flex;
+  align-items: center;
+  font-size: var(--fs-text-xs);
+  font-weight: var(--fs-weight-medium);
+  padding: var(--fs-space-1) var(--fs-space-3);
+  border-radius: 999px;
+  background: var(--fs-surface-alt);
+  color: var(--fs-ink);
+  border: 1px solid var(--fs-border);
+  cursor: pointer;
+}
+.chip.done {
+  background: var(--fs-success-bg);
+  color: var(--fs-success);
+  border-color: transparent;
+}
+.chip.active {
+  background: var(--fs-brand);
+  color: #fff;
+  border-color: var(--fs-brand);
+  font-weight: var(--fs-weight-bold);
+}
+.orders-toolbar-summary-row {
+  display: flex;
+  align-items: center;
+  gap: var(--fs-space-3);
+  flex-wrap: wrap;
+}
+.orders-summary {
+  font-size: var(--fs-text-sm);
+  color: var(--fs-ink-muted);
+  margin: 0;
+}
+.btn.ghost.on {
+  background: var(--fs-brand-soft);
+  color: var(--fs-brand-strong);
+  border-color: var(--fs-brand);
+}
 .toorder-supplier {
   display: flex;
   align-items: center;

--- a/apps/web/tests/e2e/orders.spec.ts
+++ b/apps/web/tests/e2e/orders.spec.ts
@@ -10,6 +10,77 @@ const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáz
 const jeOcakavane = (m: ConsoleMessage): boolean =>
   m.location().url.includes("/api/me") && m.text().includes("401");
 
+// issue 61: VLASTNÝ izolovaný účet (`scripts/e2e-setup.ts`'s komentár k
+// `E2E_FILTRE_EMAIL` vysvetľuje dôvod aj poradie). Tento test je ZÁMERNE
+// PRVÝ v súbore — overuje PÔVODNÉ seedované dáta skôr, než ich testy nižšie
+// (zmena stavu, pridanie stavu do nastavenia, odškrtnutie "objednané")
+// zmutujú. `scripts/e2e-setup.ts`: DODAVATEL-TEST-1 má 1 riadok v stave
+// "caka_sa" (vybavený — posunutý za predvolený "objednane"), "(bez
+// dodávateľa)" má 1 riadok v predvolenom "objednane" (nevybavený).
+const E2E_FILTRE_EMAIL = "e2e-filtre@forestshop.sk";
+
+test("manažér filtruje podľa dodávateľa, vidí súhrn ostáva vybaviť a skryje vybavené riadky, ktoré ostanú skryté aj po obnovení stránky, konzola je čistá", async ({
+  page,
+}) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/?tab=orders");
+  await page.getByLabel("E-mail").fill(E2E_FILTRE_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await expect(page.getByRole("heading", { name: "Na objednanie" })).toBeVisible();
+
+  await expect(page.getByTestId("supplier-chip-all")).toHaveText("Všetci (2)");
+  await expect(page.getByTestId("supplier-chip-DODAVATEL-TEST-1")).toHaveText("DODAVATEL-TEST-1 (1)");
+  await expect(page.getByTestId("supplier-chip-(bez dodávateľa)")).toHaveText("(bez dodávateľa) (1)");
+
+  const summary = page.getByTestId("orders-summary");
+  await expect(summary).toHaveText("Ostáva vybaviť 1 z 2 · Čaká sa 1");
+
+  // Klik na chip DODAVATEL-TEST-1 zúži zoznam len na jeho skupinu.
+  await page.getByTestId("supplier-chip-DODAVATEL-TEST-1").click();
+  await expect(page.getByTestId("supplier-DODAVATEL-TEST-1")).toBeVisible();
+  await expect(page.getByTestId("supplier-(bez dodávateľa)")).not.toBeVisible();
+  await expect(summary).toHaveText("DODAVATEL-TEST-1: ostáva vybaviť 0 z 1 · Čaká sa 1");
+
+  // Klik na "(bez dodávateľa)" prepne filter na druhého dodávateľa.
+  await page.getByTestId("supplier-chip-(bez dodávateľa)").click();
+  await expect(page.getByTestId("supplier-(bez dodávateľa)")).toBeVisible();
+  await expect(page.getByTestId("supplier-DODAVATEL-TEST-1")).not.toBeVisible();
+  await expect(summary).toHaveText("(bez dodávateľa): ostáva vybaviť 1 z 1");
+
+  // Späť na "Všetci" — obe skupiny opäť viditeľné.
+  await page.getByTestId("supplier-chip-all").click();
+  await expect(page.getByTestId("supplier-DODAVATEL-TEST-1")).toBeVisible();
+  await expect(page.getByTestId("supplier-(bez dodávateľa)")).toBeVisible();
+
+  // Skryť vybavené riadky — DODAVATEL-TEST-1 (celý vybavený, "caka_sa") zmizne,
+  // "(bez dodávateľa)" (má nevybavený riadok) ostáva viditeľný.
+  const toggle = page.getByTestId("orders-hide-resolved-toggle");
+  await expect(toggle).toHaveText("👁 Skryť vybavené");
+  await toggle.click();
+  await expect(page.getByTestId("supplier-DODAVATEL-TEST-1")).not.toBeVisible();
+  await expect(page.getByTestId("supplier-(bez dodávateľa)")).toBeVisible();
+
+  // Prepínač prežije obnovenie stránky (localStorage, issue 61's hlavná požiadavka).
+  await page.reload();
+  await expect(page.getByRole("heading", { name: "Na objednanie" })).toBeVisible();
+  await expect(page.getByTestId("orders-hide-resolved-toggle")).toHaveText("🙈 Vybavené skryté");
+  await expect(page.getByTestId("supplier-DODAVATEL-TEST-1")).not.toBeVisible();
+
+  // Vypnutie prepínača vráti skrytú skupinu späť.
+  await page.getByTestId("orders-hide-resolved-toggle").click();
+  await expect(page.getByTestId("supplier-DODAVATEL-TEST-1")).toBeVisible();
+
+  expect(chyby).toEqual([]);
+});
+
 test("manažér vidí otvorené objednávky zoskupené podľa dodávateľa, konzola je čistá", async ({ page }) => {
   const chyby: string[] = [];
   page.on("console", (m) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.39",
+  "version": "0.3.0-dev.40",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -67,6 +67,16 @@ const E2E_OTVORENE_STAVY_EMAIL = "e2e-otvorene-stavy@forestshop.sk"; // musí sa
 // `e2e@forestshop.sk`.
 const E2E_OBJEDNANE_EMAIL = "e2e-objednane@forestshop.sk"; // musí sa zhodovať s hodnotou v orders.spec.ts
 
+// issue 61: VLASTNÝ izolovaný účet — rovnaký mechanizmus a dôvod ako vyššie
+// (balík je už na hranici `MAX_ATTEMPTS`). Test pod týmto účtom je zámerne
+// PRVÝ v `orders.spec.ts` (nie posledný ako ostatné nové testy vyššie) —
+// overuje PÔVODNÉ, ešte-nezmenené seedované dáta (DODAVATEL-TEST-1 v
+// "caka_sa", "(bez dodávateľa)" v predvolenom "objednane"), kým ich testy
+// NIŽŠIE v súbore (zmena stavu/objednané, pridanie stavu do nastavenia)
+// ešte nestihli zmutovať — poradie testov v súbore je tu preto zámerne
+// dôležité, nie náhodné.
+const E2E_FILTRE_EMAIL = "e2e-filtre@forestshop.sk"; // musí sa zhodovať s hodnotou v orders.spec.ts
+
 const { db, pool } = createDb();
 // Konštantný literál bez interpolácie — obyčajný reťazec je tu rovnako bezpečný
 // ako `sql` tagovaná šablóna (tú používa ekvivalentný apps/api/tests/helpers/db.ts),
@@ -130,6 +140,12 @@ await db.insert(users).values({
 });
 await db.insert(users).values({
   email: E2E_OBJEDNANE_EMAIL,
+  passwordHash: await hashPassword(E2E_HESLO),
+  displayName: "E2E Manažér",
+  role: "manazer",
+});
+await db.insert(users).values({
+  email: E2E_FILTRE_EMAIL,
   passwordHash: await hashPassword(E2E_HESLO),
   displayName: "E2E Manažér",
   role: "manazer",


### PR DESCRIPTION
Closes #61

Implements supplier filter chips (with counts, click narrows the list), a
"ostáva vybaviť N z M" remaining-summary with a per-state/ordered breakdown
scoped to the active filter, and a "skryť vybavené riadky" toggle persisted
in localStorage, on the "Na objednanie" (orders) screen.

Design comment (root cause, chosen approach, rejected alternative): see
issue 61.

- `apps/web/src/ordersSummary.ts` — pure logic (isLineResolved,
  summarizeOrderLines, formatOrderSummaryText), unit tested.
- `apps/web/src/components/OrdersToolbar.tsx` — chips + summary + toggle,
  unit tested.
- `apps/web/src/components/SupplierActionsPanel.tsx` — mechanical
  extraction from `OrdersSection.tsx` (eslint max-lines:400 headroom),
  no behavior change.
- `apps/web/src/components/OrdersSection.tsx` — wires the above + per-row
  hideResolved filtering (group bulk actions keep operating on the full
  unfiltered group).
- New Playwright e2e test (own isolated e2e account, placed first in
  `orders.spec.ts` to see pristine seeded data).
