### PR TITLE
docs: playbook + autopilot log for issue 61

### DIFF
--- a/.claude/rules/orders.md
+++ b/.claude/rules/orders.md
@@ -198,3 +198,13 @@ paths:
   do tej istej transakcie s `.for("update")`) je zdokumentovaný v
   `.claude/rules/database.md` (Postgres `FOR UPDATE` bez `OF` zoznamu
   zamyká celý JOIN, nielen primárnu tabuľku).
+- **Kanonická definícia "vybavený riadok" (issue 61) je
+  `apps/web/src/ordersSummary.ts`'s `isLineResolved` — `ordered || state !==
+  "objednane"`.** Priamy náprotivok starej appky's `isHandled` (`ORDERED ||
+  WAITING || INSTOCK || UNAVAIL`) — nový `ordered` nahrádza jej `ORDERED`,
+  tri ne-predvolené `state` hodnoty nahrádzajú `WAITING`/`INSTOCK`/
+  `UNAVAIL`. Ktorákoľvek ĎALŠIA funkcia, čo potrebuje "je tento riadok
+  vybavený/hotový" (napr. budúci dashboard, ďalší filter), nech importuje
+  `isLineResolved`/`summarizeOrderLines` odtiaľ — nie novú vlastnú
+  definíciu, riziko rozídenia (napr. počítať len podľa `state`, čo by
+  ignorovalo `ordered=true` pri `state="objednane"`).

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -249,3 +249,27 @@ paths:
   potvrdí. Pri pridávaní e2e testu okolo AKÉHOKOĽVEK kontrolovaného
   checkboxu v tejto appke použi `.click()` + `expect().toBeChecked()`, nikdy
   `.check()`/`.uncheck()` priamo.
+- **`@typescript-eslint/restrict-template-expressions` zakazuje `number` v
+  šablónovom literáli** (`` `${count}` `` v `.ts`/`.tsx`, vrátane JSX textu
+  zapísaného ako šablóna) — zistené issue 61 (`OrdersToolbar.tsx`'s chip
+  popisky "Dodávateľ (N)", `ordersSummary.ts`'s formátovanie súhrnu). Fix je
+  `` `${String(pocet)}` ``, nie `eslint-disable` ani presun na obyčajnú JSX
+  interpoláciu (`{pocet} ks` mimo šablóny eslint nerieši, ale v komponente s
+  viacslovným textom okolo čísla by to vytvorilo viac samostatných text-node
+  uzlov s nepredvídateľným whitespace správaním — šablóna + `String()` je
+  jednoduchšie aj čitateľnejšie).
+- **Nový e2e test do súboru so ZDIEĽANÝMI seedovanými dátami (`scripts/
+  e2e-setup.ts`) môže potrebovať konkrétnu POZÍCIU v súbore, nie len
+  VLASTNÝ izolovaný účet.** Vlastný účet (vzor vyššie, `E2E_HESLO_ZMENA_
+  EMAIL` a ďalšie) rieši LEN rate-limit priestor — dáta (`order`/`order_
+  line`/`order_open_status`) sú GLOBÁLNE, zdieľané naprieč VŠETKÝMI účtami
+  v tom istom súbore, a testy v jednom súbore bežia sekvenčne (jeden
+  worker na súbor). Issue 61 (`orders.spec.ts`) potreboval overiť PÔVODNÉ,
+  ešte-nezmutované seedované dáta (DODAVATEL-TEST-1 v "caka_sa",
+  "(bez dodávateľa)" v predvolenom "objednane") — namiesto pridávania
+  DALŠÍCH riadkov/dodávateľov (čo by rozbilo existujúce testy, ktoré
+  spoliehajú na PRESNÝ počet riadkov danej skupiny, napr. "DODAVATEL-
+  TEST-1 má vždy presne 1 riadok") bol nový test vložený ako PRVÝ v súbore,
+  PRED testami, ktoré stav/`ordered`/`order_open_status` mutujú. Pri
+  ďalšom teste, ktorý potrebuje pôvodné dáta, zváž POZÍCIU v súbore skôr
+  než pridávanie nových fixtúrových riadkov k existujúcemu dodávateľovi.

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -1004,3 +1004,42 @@ nové heslo sa nikde v pushnutom obsahu nenachádza.
   push and on the PR (`#79`) across all three pushes; local before each
   push: lint + typecheck clean.
 - Shared PR: `#79`.
+
+## Issue 61 — Na objednanie: supplier filters, remaining summary, hide-resolved toggle
+
+- Design comment posted on issue 61 before any code (root cause: no
+  filter/summary/toggle existed on "Na objednanie"; chosen approach: pure
+  client-side filter over the already-fully-loaded `/api/orders/open`
+  data, `isLineResolved = ordered || state !== "objednane"` as the direct
+  translation of the legacy app's `isHandled`; rejected alternative:
+  breakdown by `state` alone, which would silently drop `ordered=true`
+  lines still in the default state).
+- New pure logic module `apps/web/src/ordersSummary.ts`
+  (`isLineResolved`/`summarizeOrderLines`/`formatOrderSummaryText`, unit
+  tested in `ordersSummary.test.ts`) + `OrdersToolbar.tsx` (chips/summary/
+  toggle, unit tested) + `SupplierActionsPanel.tsx` (mechanical extraction
+  from `OrdersSection.tsx`, no behavior change — the file was already at
+  eslint's `max-lines: 400` cap before this feature).
+- Hide-resolved toggle persists via `localStorage`
+  (`forestshop.orders.hideResolved`); supplier-chip selection is
+  deliberately NOT persisted (issue only asked persistence for the
+  toggle). Group-level bulk actions (email, bulk "objednané", mail
+  preview/send) keep operating on the FULL unfiltered `group.lines` —
+  only the rendered table rows respect `hideResolved`.
+- New isolated e2e account (`e2e-filtre@forestshop.sk`) + a new
+  `orders.spec.ts` test placed FIRST in the file (not last, unlike the
+  other isolated-account tests) so it observes the pristine seeded data
+  before later tests in the same file mutate state/`ordered`/
+  `order_open_status` — see `.claude/rules/testing.md`.
+- Commits: `f27510e` (version bump 0.3.0-dev.40) → `98d767e`
+  (SupplierActionsPanel extraction) → `a4f1724` (feature + tests).
+- Verified live on `https://forestshop-novy.newlevel.media/?tab=orders`
+  against real production data (39 lines / 17 supplier groups): chips
+  narrow correctly, summary recomputes per active filter, hide-resolved
+  toggle hides a fully-resolved supplier and survives a reload — then the
+  test mutation (one line's "objednané" checkbox) was reverted, restoring
+  the data to its original state. Zero console errors/warnings throughout.
+- CI green (check/integration/e2e/docker-build/version-check) on `dev`
+  push and PR `#80`; main CI + Deploy green on merge `ed2b153`; live
+  `/api/version` matched (`0.3.0-dev.40` @ `ed2b153`).
+- Shared PR: `#80`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.40",
+  "version": "0.3.0-dev.41",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Docs-only follow-up to PR #80 (issue #61) — playbook-review lessons and
the autopilot-log entry that should have ridden that PR but were written
after it had already merged. No application code changed.

- `.claude/rules/testing.md`: eslint `restrict-template-expressions`
  needs `String(n)` for numbers in template literals; new e2e
  test-placement-for-determinism pattern (own account solves rate-limit,
  file POSITION solves shared-data mutation ordering).
- `.claude/rules/orders.md`: `isLineResolved`/`ordersSummary.ts` as the
  canonical "vybavený riadok" definition for future features.
- `docs/autopilot-log.md`: entry for issue #61.
