### PR TITLE
Version bump 0.3.0-dev.43 + playbook updates from issue 62

### DIFF
--- a/.claude/rules/catalog.md
+++ b/.claude/rules/catalog.md
@@ -86,6 +86,24 @@ paths:
   60035, BR1611, 4859), v cp1250 a s pôvodnou hlavičkou. Fixtúra má 35 riadkov, takže
   testy aj `scripts/e2e-setup.ts` posúvajú limity brány (`minByteSize: 1_000`,
   `absoluteMinRows: 10`) — pomer 0,8 zostáva rovnaký ako v produkcii.
+- **Bezpečná úprava JEDNÉHO poľa vo fixtúre (issue 62 — potreboval nový
+  `supplier` pre jeden rezervný variant, "60055/10") je BYTE-FOR-BYTE, nikdy
+  read-decode-write celého súboru.** Fixtúra má NEROVNOMERNÉ kvótovanie:
+  hlavičkový riadok je BEZ úvodzoviek (`code;pairCode;name;...`), ale KAŽDÝ
+  dátový riadok má KAŽDÉ pole zacitované (`"60055/10";"77";...`, aj polia bez
+  špeciálnych znakov) — `csv.writer(..., quoting=csv.QUOTE_ALL)` nad celým
+  súborom by preto ticho pridalo úvodzovky aj do hlavičky a rozišlo by sa od
+  bajtovej zhody. Bezpečný postup (python3, mimo appky): `csv.reader` cez
+  `cp1250`-dekódovaný text nájde cieľový riadok podľa `row[0] == kód`,
+  `csv.writer(..., quoting=csv.QUOTE_ALL, lineterminator='\r\n')` serializuje
+  LEN TEN JEDEN riadok naspäť (cp1250-encoded), over `raw.count(old_bytes) ==
+  1` PRED nahradením (dôkaz, že sa serializovaná podoba riadku zhoduje s tým,
+  čo je skutočne v súbore, a že je v súbore JEDINÝ raz) a `raw.replace(old,
+  new)` len na surových bajtoch — nikdy neprepisuj celý dekódovaný text a
+  neukladaj ho späť ako celok. Pri výbere KTORÝ nepoužitý variant zmeniť:
+  over `grep`-om, že jeho kód sa nikde v `apps/api/src/**/*.test.ts` ani
+  `apps/api/tests/**/*.test.ts` nespomína menovite (`60055/10` bol dovtedy
+  úplne netestovaný, na rozdiel od `60055/8`, ktorý map-row.test.ts používa).
 - **Import beží v jednej transakcii po dávkach 500 riadkov.** Väčšia dávka narazí na
   limit 65 535 parametrov na príkaz v protokole Postgresu (tabuľka `variant` má
   25 stĺpcov po pridaní `guid`, review task-5-fix-1). Ako PRVÝ príkaz v transakcii

--- a/.claude/rules/orders.md
+++ b/.claude/rules/orders.md
@@ -208,3 +208,17 @@ paths:
   `isLineResolved`/`summarizeOrderLines` odtiaľ — nie novú vlastnú
   definíciu, riziko rozídenia (napr. počítať len podľa `state`, čo by
   ignorovalo `ordered=true` pri `state="objednane"`).
+- **Kanonické per-produktové zoskupenie naprieč riadkami DODÁVATEĽA (issue
+  62) je `apps/web/src/ordersSummary.ts`'s `computeVariantTotals`/
+  `formatVariantTotalChip`** — priamy náprotivok starej appky's
+  `groupQtyTotals`/`totalChipSpec` (`app.js:1918-1962`). Kľúčuje podľa
+  `variantCode` (kód UŽ nesie aj veľkosť), počíta nad CELOU (nefiltrovanou)
+  `group.lines` danej skupiny, nikdy nad pohľadom zúženým `hideResolved` —
+  volajúci (`OrdersSection.tsx`) posiela vždy `group.lines`. Chip sa smie
+  zobraziť LEN keď produkt má v skupine ≥2 riadky (`lineCount >= 2`). Ako
+  odvodená hodnota počítaná PRI KAŽDOM RENDRI (rovnaký vzor ako
+  `isLineResolved`/`summarizeOrderLines` vyššie) sa automaticky prepočíta na
+  akúkoľvek zmenu `suppliers` stavu — žiadny extra React stav, žiadny
+  imperatívny prepočítavací krok. ĎALŠIA funkcia potrebujúca "súčet toho
+  istého produktu v rámci dodávateľa" nech importuje odtiaľto, nie novú
+  vlastnú definíciu.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -273,3 +273,18 @@ paths:
   PRED testami, ktoré stav/`ordered`/`order_open_status` mutujú. Pri
   ďalšom teste, ktorý potrebuje pôvodné dáta, zváž POZÍCIU v súbore skôr
   než pridávanie nových fixtúrových riadkov k existujúcemu dodávateľovi.
+- **Test, ktorý potrebuje DVA riadky s TÝM ISTÝM `variantCode` v jednej
+  skupine dodávateľa (issue 62 — súčtový chip), nesmie ich pridať do
+  `DODAVATEL-TEST-1` ani `(bez dodávateľa)`** — `orders.spec.ts`'s úplne
+  prvý test (`E2E_FILTRE_EMAIL`) overuje PRESNÝ globálny počet riadkov
+  ("Všetci (N)", "Ostáva vybaviť X z N") naprieč VŠETKÝMI dodávateľmi, takže
+  pridanie čohokoľvek k existujúcej skupine ho ticho rozbije. Riešenie: NOVÁ,
+  dovtedy nepoužitá skupina dodávateľa — vezmi jeden nepoužívaný fixtúrový
+  variant (grep, že jeho kód sa nikde netestuje, `.claude/rules/catalog.md`'s
+  CSV-editačný vzor vyššie) a daj mu vo fixtúre nový `supplier` reťazec.
+  Global count assertions v prvom teste treba ZVÝŠIŤ presne o toľko nových
+  riadkov, koľko pridáš (a o zodpovedajúci "ostáva vybaviť"/bucket rozdiel,
+  podľa toho, v akom stave nové riadky sú) — spočítaj to explicitne, nehádaj.
+  Ako pri predchádzajúcom bode: nová skupina potrebuje aj VLASTNÝ izolovaný
+  e2e účet (balík je na hranici `MAX_ATTEMPTS=10`), nikdy ďalšie prihlásenie
+  pod zdieľaným `e2e@forestshop.sk`.

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -1043,3 +1043,42 @@ nové heslo sa nikde v pushnutom obsahu nenachádza.
   push and PR `#80`; main CI + Deploy green on merge `ed2b153`; live
   `/api/version` matched (`0.3.0-dev.40` @ `ed2b153`).
 - Shared PR: `#80`.
+
+## Issue 62 — súčet kusov toho istého produktu naprieč objednávkami dodávateľa
+
+- Root cause / design comment posted to issue 62 BEFORE the first feature
+  commit: legacy `app.js:1918-1962`'s `groupQtyTotals`/`totalChipSpec`
+  (per-supplier chip, ≥2 lines of the same `itemCode`, "remaining" text +
+  "total" tooltip) ported as a DERIVED value computed on every render
+  (`ordersSummary.ts`'s `computeVariantTotals`/`formatVariantTotalChip`) —
+  rejected the legacy's imperative DOM-patch approach (`refreshOrderTotals`)
+  since this app has no non-React editor state that a repaint would disturb.
+- New chip class `.qty-total-chip` in `OrderLineRow.tsx`'s qty cell,
+  intentionally non-clickable/visually distinct from the filter `.chip`
+  (issue 61). Computed over the group's FULL (unfiltered) `group.lines`, so
+  it never depends on the "skryť vybavené" toggle.
+- E2E fixture needed a genuinely-repeating product WITHOUT touching
+  `DODAVATEL-TEST-1`/`(bez dodávateľa)` (other tests assert their EXACT
+  line counts, e.g. "Všetci (2)") — added a brand-new supplier
+  `DODAVATEL-TEST-2` by changing ONE previously-unused-in-tests CSV fixture
+  row's `supplier` field (`60055/10`, was empty) and two new orders in
+  `scripts/e2e-setup.ts` referencing it twice (3 ks + 2 ks). CSV edit done
+  byte-for-byte via a Python round-trip script (file is cp1250, quoted data
+  rows but an UNQUOTED header row — `csv.QUOTE_ALL` on the whole file would
+  have silently re-quoted the header too). New isolated e2e account
+  `e2e-sucet@forestshop.sk` (shared account already at `MAX_ATTEMPTS=10`).
+  Updated the ONE existing global-count assertion in `orders.spec.ts`
+  ("Všetci (2)"/"Ostáva vybaviť 1 z 2 · Čaká sa 1" → "(4)"/"3 z 4 · Čaká sa 1").
+- Commits: `c8805d0` (version bump 0.3.0-dev.42) → `a3cf6d6` (feature + tests).
+- Verified live on production (39 real order lines, 0 naturally-repeating
+  `variantCode` right now) — confirmed the ABSENCE of any chip is correct
+  (no false positive), then toggled one real row's "ordered" checkbox and
+  back via Playwright: write persisted instantly (no reload), console
+  stayed at 0 errors/0 warnings, all 39 rows confirmed back to unchecked
+  afterwards. The actual sum/live-recompute-on-repeat behavior is proven by
+  the new CI-green `orders.spec.ts` test (controlled `DODAVATEL-TEST-2`
+  fixture), since live data has no natural repeat at verification time.
+- CI green (version-check/check/integration/e2e/docker-build) on `dev` push
+  and PR `#82`; main CI + Deploy green on merge `04435a5`; live
+  `/api/version` matched (`0.3.0-dev.42` @ `04435a5`).
+- Shared PR: `#82`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.42",
+  "version": "0.3.0-dev.43",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Čo je v PR

Nasleduje po zmergnutej PR 82 (issue 62 — súčet kusov toho istého tovaru
naprieč objednávkami) — dva menšie followup-kroky, ktoré patria do
samostatného CI cyklu, keďže PR 82 sa už zmergovala predtým, než sa stihli
dokončiť:

1. Version bump 0.3.0-dev.43 (verzia na `dev` po predchádzajúcom merge
   zodpovedala `main`, treba ju posunúť pred ďalšou zmenou).
2. `playbook-review` výstup — tri playbook nálezy z issue 62 uložené do
   `.claude/rules/`: byte-safe úprava cp1250 fixtúry (`catalog.md`), vzor
   "nová dodávateľská skupina namiesto pridávania riadku do existujúcej,
   ktorej presný počet iné testy overujú" (`testing.md`), a kanonický
   `computeVariantTotals`/`formatVariantTotalChip` pointer (`orders.md`).

Bez zmeny správania — len docs + version bump.

## Overené lokálne

- `pnpm lint` — čisté
- CI (run 30586176356): version-check, check, integration, e2e,
  docker-build — všetky zelené
