### PR TITLE
Playbook + version bump for issue 63

### DIFF
--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -167,3 +167,19 @@ paths:
   `listOpenOrderLineIdsForSupplier` majú teraz `Pick<Database, "select">`
   namiesto celého `Database`, aby ich šlo volať aj s `tx` (`PgTransaction`
   nemá `Database`'s `$client`).
+- **`\s` (a KAŽDÝ iný jednopísmenový backslash-escape, ktorý JS
+  nepozná — `\d`, `\w`, ...) VNÚTRI drizzle's `sql` tagovaného šablónového
+  literálu TICHO STRATÍ backslash** — JS šablónové/reťazcové literály
+  neuznávajú `\s` ako escape sekvenciu, takže `` sql`... '\s+' ...` ``
+  reálne odošle na Postgres text `'s+'`, nie `'\s+'` (regex na
+  whitespace). Zistené issue 63 (`modules/orders/supplier-key.ts`'s
+  `normalizedSupplierKeySql`, `regexp_replace(..., '\s+', ' ', 'g')`) —
+  `.toSQL()` na dopyte ukázal presne túto tichú zmenu, funkcia preto
+  prestala zbierať viacnásobné medzery (namiesto zlúčenia dvoch pravopisov
+  dodávateľa do jednej skupiny nechala kľúč nezmenený). Fix: `\\s+`
+  (dvojitý backslash) — jediný spôsob, ako dostať doslovné `\s+` do SQL
+  textu z JS šablóny. Pri KAŽDOM ďalšom raw regexe/escape sekvencii vnútri
+  `sql` šablóny over `drizzle`'s `.toSQL().sql` (alebo `q.toSQL()`) priamo
+  proti reálnej DB predtým, než tomu dôveruješ — "vyzerá to ako správny SQL
+  text v zdrojáku" nestačí, JS parsing šablóny beží PRED tým, než sa
+  reťazec vôbec dostane k drizzle.

--- a/.claude/rules/orders.md
+++ b/.claude/rules/orders.md
@@ -215,10 +215,35 @@ paths:
   `variantCode` (kód UŽ nesie aj veľkosť), počíta nad CELOU (nefiltrovanou)
   `group.lines` danej skupiny, nikdy nad pohľadom zúženým `hideResolved` —
   volajúci (`OrdersSection.tsx`) posiela vždy `group.lines`. Chip sa smie
-  zobraziť LEN keď produkt má v skupine ≥2 riadky (`lineCount >= 2`). Ako
-  odvodená hodnota počítaná PRI KAŽDOM RENDRI (rovnaký vzor ako
-  `isLineResolved`/`summarizeOrderLines` vyššie) sa automaticky prepočíta na
-  akúkoľvek zmenu `suppliers` stavu — žiadny extra React stav, žiadny
-  imperatívny prepočítavací krok. ĎALŠIA funkcia potrebujúca "súčet toho
-  istého produktu v rámci dodávateľa" nech importuje odtiaľto, nie novú
-  vlastnú definíciu.
+  zobraziť LEN keď produkt má v skupine ≥2 riadky (`lineCount >= 2`) A ešte
+  zostáva niečo objednať (`remaining > 0`, issue 63 — pôvodne sa rozhodovalo
+  LEN podľa `lineCount`, takže celý vybavený opakovaný produkt navždy
+  ukazoval "Σ spolu 0 ks"). Ako odvodená hodnota počítaná PRI KAŽDOM RENDRI
+  (rovnaký vzor ako `isLineResolved`/`summarizeOrderLines` vyššie) sa
+  automaticky prepočíta na akúkoľvek zmenu `suppliers` stavu — žiadny extra
+  React stav, žiadny imperatívny prepočítavací krok. ĎALŠIA funkcia
+  potrebujúca "súčet toho istého produktu v rámci dodávateľa" nech
+  importuje odtiaľto, nie novú vlastnú definíciu.
+- **Efektívny dodávateľ riadku (issue 63) je `apps/api/src/modules/orders/
+  supplier-key.ts`'s `effectiveSupplierSql`** — `coalesce(product.supplier,
+  product_supplier_override.supplier)`, LEFT JOIN na novú tabuľku
+  `product_supplier_override` (kľúčovanú `product.key`, migrácia 0014).
+  Toto (nie holé `products.supplier`) je odvtedy jediný správny zdroj
+  "aký dodávateľ patrí tomuto riadku" na VŠETKÝCH troch čítacích cestách —
+  `queries.ts`'s `listOpenOrderLinesBySupplier` +
+  `listOpenOrderLineIdsForSupplier` (hromadná akcia) a `mail.ts`'s
+  `loadOutstandingLines`. Zoskupenie/porovnanie je NAVYŠE
+  case/whitespace-insensitive (`normalizedSupplierKeySql`/
+  `normalizeSupplierKeyJs`, priamy náprotivok legacy `supKey`) — dva
+  pravopisy toho istého mena (case/medzery) sú VŽDY jedna skupina, aj keď
+  jeden pochádza z katalógu a druhý z ručného priradenia. Zobrazovaný
+  pravopis pri zlúčení: `pickCanonicalSupplierSpelling` (najčastejší podľa
+  počtu riadkov, remíza → abecedne). ĎALŠIA funkcia, ktorá potrebuje "aký
+  dodávateľ", nech použije `effectiveSupplierSql` (SQL strana) alebo číta z
+  už vrátenej `SupplierOpenOrders.supplier`/`OpenOrderLine.
+  manualSupplierOverride`, nikdy priamo `products.supplier` — to by ticho
+  ignorovalo ručné priradenie a nezlúčilo by rozdielne pravopisy.
+  Override je zámerne len FALLBACK (ľavá strana `coalesce` vyhráva) — keď
+  Shoptet raz dodá reálnu hodnotu, tá prebije ručné priradenie, nikdy
+  naopak (ticket to žiada explicitne: priradenie je pre riadok BEZ
+  dodávateľa, nie trvalý pin).

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -288,3 +288,29 @@ paths:
   Ako pri predchádzajúcom bode: nová skupina potrebuje aj VLASTNÝ izolovaný
   e2e účet (balík je na hranici `MAX_ATTEMPTS=10`), nikdy ďalšie prihlásenie
   pod zdieľaným `e2e@forestshop.sk`.
+- **`options.field ?? "predvolená hodnota"` v testovom helperi TICHO
+  ignoruje výslovne zadané `field: null`** — `??` fallbackuje na `null` AJ
+  `undefined` rovnako, takže volajúci, ktorý chce SKUTOČNÉ `null` (nie len
+  "nezadal som to"), dostane predvolenú hodnotu namiesto neho. Zistené
+  issue 63 (`tests/helpers/orders.ts`'s `insertTestVariantForProduct`,
+  `supplier: options.supplier ?? "Test dodávateľ"` — žiadny existujúci test
+  dovtedy nepotreboval zdieľaný produkt BEZ dodávateľa, takže sa to
+  neprejavilo skôr). Fix: `"pole" in options ? options.pole :
+  predvolená` — rozlíši "kľúč vôbec nezadaný" od "zadané ako null".
+  Rovnaký test pri KAŽDOM ďalšom helperi s `nullable` voliteľným poľom a
+  `??` defaultom: potrebuje niekedy volajúci vynútiť `null` PROTI
+  defaultu? Ak áno, `??` to nedovolí.
+- **Wide inline obsah (vstup + tlačidlo) v úzkom `<td>` bez zalomenia
+  (`white-space: nowrap`) môže VIZUÁLNE pretiecť do SUSEDNÉHO stĺpca a
+  ukradnúť Playwright kliky mierené na prvok v ňom** — `locator.click()`
+  padá opakovane na "`<iný prvok>` ... intercepts pointer events" (nie
+  flaka, deterministicky, kým sa CSS neopraví). Zistené issue 63
+  (`.ord-supplier-assign` stĺpec — vstup 140px + tlačidlo pri `nowrap`
+  pretiekli do susedného stĺpca "Stav", ktorého `<select>` (neskôr v DOM-e,
+  teda navrchu) potom kradol kliky na tlačidlo pod ním). Fix: `display:
+  flex; flex-wrap: wrap` na bunke namiesto `white-space: nowrap` — obsah sa
+  zalomí VNÚTRI bunky (rastie výška riadku), nikdy nepretečie do
+  suseda. Rovnaký test pri KAŽDOM ďalšom stĺpci s viacerými inline
+  ovládacími prvkami v jednej `<td>`: over reálnym Playwright behom (nie
+  len vizuálne v prehliadači na širokej obrazovke), že klik na KAŽDÝ prvok
+  skutočne trafí TEN prvok, nie souseda pod ním po pretečení.

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -1082,3 +1082,86 @@ nové heslo sa nikde v pushnutom obsahu nenachádza.
   and PR `#82`; main CI + Deploy green on merge `04435a5`; live
   `/api/version` matched (`0.3.0-dev.42` @ `04435a5`).
 - Shared PR: `#82`.
+
+## Issue 63 — Na objednanie: ručné priradenie dodávateľa k riadku bez dodávateľa
+
+- Design comment posted BEFORE any code (root cause: `product.supplier`
+  is the only source of truth for grouping and is `null` exactly when
+  Shoptet doesn't carry it — nothing survives a nightly catalog
+  re-import, and grouping was exact-string, not case/whitespace
+  tolerant). Verified live against production DB first: exactly 3 open
+  order lines with no supplier (matching the ticket), plus real
+  case-duplicate supplier names already in the catalog
+  (`HUNTING24`/`Hunting24`, `Werra`/`WERRA`, `L.A. Team`/`L.A. TEAM`).
+- New `product_supplier_override` table (migration 0014), keyed by
+  `product_key` (not variant) so one assignment applies to every sibling
+  size. Effective supplier everywhere is `coalesce(product.supplier,
+  override.supplier)` (`modules/orders/supplier-key.ts`'s
+  `effectiveSupplierSql`) — a fallback, never a permanent pin: a later
+  real Shoptet value wins. Case/whitespace-insensitive grouping
+  (`normalizedSupplierKeySql`/`normalizeSupplierKeyJs`) applied on ALL
+  THREE read paths that group/filter by supplier
+  (`listOpenOrderLinesBySupplier`, `listOpenOrderLineIdsForSupplier` —
+  bulk "ordered" toggle, and `mail.ts`'s `loadOutstandingLines`) — missing
+  any one of the three would silently under-reach a merged group.
+  Canonical display spelling on a merge: most-frequent raw spelling
+  (`pickCanonicalSupplierSpelling`), tie-broken alphabetically.
+- New `POST /api/orders/lines/:lineId/supplier` (assignOrderLineSupplier)
+  upserts the override for the line's product. Frontend: inline text
+  input + shared `<datalist id="known-suppliers">` (built from the
+  already-loaded `/api/orders/open` groups, no new GET route) on any line
+  where `supplierAssignable` (i.e. `product.supplier === null`). Save
+  triggers a full refetch (line changes GROUP, same reasoning as
+  `PairingSection`'s refetch-after-confirm). Extracted
+  `SupplierOrderGroup.tsx` from `OrdersSection.tsx` (same mechanical
+  reason as the earlier `OrderLineRow`/`SupplierActionsPanel`
+  extractions — no line-count headroom left for the new state/callback).
+- Two real bugs found and fixed during implementation (both documented in
+  `.claude/rules/database.md`/`testing.md`): (1) `\s` inside a drizzle
+  `sql` JS template literal silently loses its backslash (JS doesn't
+  recognize `\s` as an escape, so the SQL text sent to Postgres was
+  `'s+'`, not `'\s+'`) — fixed with `\\s+`, caught via `.toSQL()` +
+  direct DB probing, not by inspection. (2) `insertTestVariantForProduct`
+  test helper's `options.supplier ?? "Test dodávateľ"` silently ignored
+  an explicitly-passed `null` (no prior test needed a shared-product
+  fixture with no supplier) — fixed to `"supplier" in options ? ... :
+  ...`. (3) The new `.ord-supplier-assign` table cell's input+button
+  visually overflowed into the neighbouring "Stav" column under
+  `white-space: nowrap`, whose `<select>` (later in the DOM) then stole
+  Playwright clicks meant for the save button — fixed with `display:
+  flex; flex-wrap: wrap` instead of `nowrap`.
+- Small fold-in fix from a comment on the same ticket:
+  `formatVariantTotalChip` (issue 62) now also hides the chip when
+  `remaining === 0`, not just `lineCount < 2` — own unit test.
+- Tests: unit (`supplier-key.test.ts` — normalization + canonical-spelling
+  picking, `ordersSummary.test.ts` — chip hide), integration
+  (`orders-supplier-assignment.integration.test.ts` — persistence,
+  propagation to a sibling size, case/whitespace merge reaching a bulk
+  action AND the mail aggregation, 403/404/400), e2e (new fixture: order
+  9006, variants `60035/L`/`60035/M` — two sizes of the same product,
+  both with no supplier in the CSV fixture — new isolated
+  `e2e-priradenie@forestshop.sk` account, positioned LAST in
+  `orders.spec.ts` since it permanently moves those lines out of
+  "(bez dodávateľa)"). Updated the file's pre-existing exact-count/text
+  assertions the new global fixture lines shifted (first test's chip
+  counts + summary, the mail-preview test's aggregated item count/body,
+  a row locator that became ambiguous once "(bez dodávateľa)" grew past
+  1 line), plus `exact: true` on an existing "Uložiť" button locator that
+  started colliding (substring match) with the new per-line save
+  button's aria-label.
+- Verified live on production (`https://forestshop-novy.newlevel.media`):
+  assigned a real no-supplier line (`20261228 / 40258/XL`) to a
+  throwaway test supplier via Playwright — row moved groups immediately
+  ("(bez dodávateľa)" 3→2, new group appeared, "Všetci" stayed 39),
+  survived a reload, console stayed at 0 errors/0 warnings throughout.
+  Deleted the test override row directly in `product_supplier_override`
+  afterward and reloaded — line returned to "(bez dodávateľa) (3)"
+  exactly; production data confirmed restored (39 open lines, 0 marked
+  ordered).
+- Commits: `6fcc039` (version bump 0.3.0-dev.44) → `8a9e18c` (migration)
+  → `ead8ae3` (backend) → `b2a006d` (frontend) → `2b5b0e2` (chip fix) →
+  `ec9bd8d` (e2e).
+- CI green (version-check/check/integration/e2e/docker-build) on `dev`
+  push and PR `#84`; main CI + Deploy green on merge `3e66505`; live
+  `/api/version` matched (`0.3.0-dev.44` @ `3e66505`).
+- Shared PR: `#84`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.44",
+  "version": "0.3.0-dev.45",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Docs-only follow-up: playbook additions (drizzle sql-template backslash gotcha, test-helper null-vs-undefined bug, Playwright table-overflow gotcha, effectiveSupplierSql canonical concept) + docs/autopilot-log.md entry for issue 63. Version bump 0.3.0-dev.45 (required since dev/main matched after PR #84 merged).