### PR TITLE
Ručné priradenie dodávateľa: kontrola na zapisovacej strane (issue 86)

### DIFF
--- a/apps/api/src/http/orders-routes.ts
+++ b/apps/api/src/http/orders-routes.ts
@@ -23,8 +23,11 @@ const orderLineStateBody = z.object({ state: z.enum(orderLineState.enumValues) }
 const orderLineOrderedBody = z.object({ ordered: z.boolean() });
 // issue 63: ručné priradenie dodávateľa — orezané + neprázdne; case sa
 // NEFOLDUJE (presne to, čo manažér napísal, sa uloží, `supplier-key.ts`'s
-// komentár k `normalizeSupplierKeyJs` vysvetľuje prečo).
-const orderLineSupplierBody = z.object({ supplier: z.string().trim().min(1) });
+// komentár k `normalizeSupplierKeyJs` vysvetľuje prečo). `.max(200)` (issue 86,
+// nezávislý audit): rovnaká horná hranica ako ostatné voľné textové vstupy
+// v projekte (`catalog-routes.ts`, `pairing-routes.ts`) — hodnota sa neskôr
+// vkladá aj do mailu dodávateľovi, chýbajúci limit bol prehliadnutá medzera.
+const orderLineSupplierBody = z.object({ supplier: z.string().trim().min(1).max(200) });
 // issue 59: `min(1)` len zachytí zjavne prázdny request skôr, než sa vôbec
 // dostane k `replaceOpenStatusNames` — SKUTOČNÉ čistenie (normalizácia,
 // orezanie prázdnych/duplicít po trime) beží až v module, lebo "['   ']"
@@ -170,6 +173,12 @@ export function registerOrdersRoutes(
       const result = await assignOrderLineSupplier(db, { lineId, supplier, actorUserId: user.userId, now });
       if (result === "not_found") {
         return c.json({ error: "Riadok objednávky sa nenašiel" }, 404);
+      }
+      // issue 86: produkt medzitým dostal dodávateľa v katalógu (súbeh s
+      // importom, alebo zabudnutá otvorená stránka) — ručné priradenie sa už
+      // netýka tohto riadku, `assignOrderLineSupplier` nič nezapísala.
+      if (result === "already_has_supplier") {
+        return c.json({ error: "Produkt už má dodávateľa v katalógu — ručné priradenie nie je možné" }, 409);
       }
       log.info({ actorUserId: user.userId, lineId, supplier }, "ručné priradenie dodávateľa riadku objednávky");
       return c.json({ ok: true as const, supplier });

--- a/apps/api/src/modules/orders/supplier-assignment.ts
+++ b/apps/api/src/modules/orders/supplier-assignment.ts
@@ -1,9 +1,9 @@
 import { eq } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
-import { orderLines, productSupplierOverrides, variants } from "../../db/schema.js";
+import { orderLines, productSupplierOverrides, products, variants } from "../../db/schema.js";
 import { record } from "../audit/service.js";
 
-export type AssignOrderLineSupplierResult = "ok" | "not_found";
+export type AssignOrderLineSupplierResult = "ok" | "not_found" | "already_has_supplier";
 
 export interface AssignOrderLineSupplierInput {
   readonly lineId: string;
@@ -29,18 +29,35 @@ export interface AssignOrderLineSupplierInput {
 // prísnejšie zamykanie proti súbežnému prepisu tej istej hodnoty by pridalo
 // zložitosť bez reálneho prínosu — Postgres `onConflictDoUpdate` je aj tak
 // atomický, posledný zápis vyhráva presne tak, ako pri kontakte.
+// issue 86 (nezávislý audit): server si dovtedy NIKDY neoverila, že produkt
+// naozaj nemá dodávateľa v katalógu — pravidlo "priradiť sa smie len riadok
+// bez `product.supplier`" (`queries.ts`'s `supplierAssignable`) bolo
+// vynucované LEN vo frontende (`OrderLineRow.tsx`). Zabudnutá otvorená
+// stránka, priame API volanie, alebo súbeh s nočným importom katalógu medzi
+// načítaním a odoslaním mohli zapísať override aj pre produkt, ktorý UŽ
+// dodávateľa má — override by potom ležal nečinne (`effectiveSupplierSql`
+// uprednostní katalóg), kým neskorší import katalógu legitímne nevráti
+// `product.supplier` späť na `null`, čím by sa starý pravopis potichu znova
+// aktivoval bez zásahu manažéra. Fix: SELECT teraz číta aj `products.supplier`
+// (JOIN na `products`, dovtedy chýbajúci — pôvodný SELECT sa cez `variants`
+// k nemu vôbec nedostal) a podmienka sa vyhodnotí VNÚTRI TEJ ISTEJ transakcie
+// ako upsert nižšie. Žiadne `.for("update")` naviac — rovnaké zdôvodnenie ako
+// komentár nižšie (fallback pole pre nízkofrekventovanú ručnú akciu, nie dáta
+// citlivé na mikrosekundové okno súbehu).
 export async function assignOrderLineSupplier(
   db: Database,
   input: AssignOrderLineSupplierInput,
 ): Promise<AssignOrderLineSupplierResult> {
   return db.transaction(async (tx) => {
     const [line] = await tx
-      .select({ productKey: variants.productKey })
+      .select({ productKey: variants.productKey, catalogSupplier: products.supplier })
       .from(orderLines)
       .innerJoin(variants, eq(variants.code, orderLines.variantCode))
+      .innerJoin(products, eq(products.key, variants.productKey))
       .where(eq(orderLines.id, input.lineId))
       .limit(1);
     if (line === undefined) return "not_found";
+    if (line.catalogSupplier !== null) return "already_has_supplier";
 
     await tx
       .insert(productSupplierOverrides)

--- a/apps/api/tests/orders-supplier-assignment.integration.test.ts
+++ b/apps/api/tests/orders-supplier-assignment.integration.test.ts
@@ -1,5 +1,6 @@
+import { eq } from "drizzle-orm";
 import { afterEach, expect, it } from "vitest";
-import { orderLines, orders, users } from "../src/db/schema.js";
+import { orderLines, orders, productSupplierOverrides, users } from "../src/db/schema.js";
 import { createApp } from "../src/http/app.js";
 import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
 import { hashPassword } from "../src/modules/auth/passwords.js";
@@ -212,4 +213,52 @@ it("rola citanie nesmie priradiť dodávateľa (403)", async () => {
     body: JSON.stringify({ supplier: "Niekto" }),
   });
   expect(res.status).toBe(403);
+});
+
+// issue 86 (nezávislý audit): server dovtedy vôbec neoveroval, že produkt
+// nemá dodávateľa v katalógu — pravidlo bolo vynucované LEN vo frontende.
+// Riadok, ktorého produkt UŽ má `product.supplier` vyplnené, nesmie ísť
+// priradiť ručne, a NESMIE sa pri tom zapísať žiadny `product_supplier_
+// override` riadok (dormantný override, čo by sa neskôr potichu aktivoval).
+it("priradenie riadku, ktorého produkt UŽ má dodávateľa v katalógu, vráti 409 a nezapíše override", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await insertTestVariant(db, "N-D", "Existujúci Katalógový Dodávateľ");
+  const [objednavka] = await db
+    .insert(orders)
+    .values({ externalOrderId: "6006", customerName: "Zákazník", placedAt: new Date("2026-07-07T00:00:00Z") })
+    .returning();
+  if (objednavka === undefined) throw new Error("insert zlyhal");
+  const [line] = await db.insert(orderLines).values({ orderId: objednavka.id, variantCode: "N-D", quantity: 1 }).returning();
+  if (line === undefined) throw new Error("insert zlyhal");
+
+  const res = await app.request(`/api/orders/lines/${line.id}/supplier`, {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ supplier: "Ručne Napísaný Dodávateľ" }),
+  });
+  expect(res.status).toBe(409);
+
+  const override = await db.select().from(productSupplierOverrides).where(eq(productSupplierOverrides.productKey, "N-D"));
+  expect(override).toHaveLength(0);
+});
+
+// issue 86 (nezávislý audit): `.max(200)` na `orderLineSupplierBody`,
+// rovnaká horná hranica ako ostatné voľné textové vstupy v projekte.
+it("priradenie dodávateľa s reťazcom nad 200 znakov vráti 400 (validácia)", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await insertTestVariant(db, "N-E", null);
+  const [objednavka] = await db
+    .insert(orders)
+    .values({ externalOrderId: "6007", customerName: "Zákazník", placedAt: new Date("2026-07-08T00:00:00Z") })
+    .returning();
+  if (objednavka === undefined) throw new Error("insert zlyhal");
+  const [line] = await db.insert(orderLines).values({ orderId: objednavka.id, variantCode: "N-E", quantity: 1 }).returning();
+  if (line === undefined) throw new Error("insert zlyhal");
+
+  const res = await app.request(`/api/orders/lines/${line.id}/supplier`, {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ supplier: "x".repeat(201) }),
+  });
+  expect(res.status).toBe(400);
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.45",
+  "version": "0.3.0-dev.46",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Nezávislý audit kódu po zlúčení issue 63 (ručné priradenie dodávateľa) našiel dve drobné medzery na zápisovej strane, obe opravené tu:

1. `assignOrderLineSupplier` server-side teraz znova overí, že produkt naozaj nemá dodávateľa v katalógu (`products.supplier IS NULL`) VNÚTRI tej istej transakcie ako upsert — pravidlo bolo dovtedy vynucované len vo frontende. Neplatný pokus vráti HTTP 409, nič sa nezapíše.
2. `orderLineSupplierBody` má nový `.max(200)`, rovnaké ako ostatné voľné textové vstupy v projekte.

Design rozhodnutie + zamietnutá alternatíva: issue 86, komentár https://github.com/zbynekdrlik/forestshop-app/issues/86#issuecomment-5137353081

Closes #86

## Testy
- 2 nové integračné testy (RED→GREEN, `d0eaae8` → `0d94d75`): priradenie na riadok s už-existujúcim katalógovým dodávateľom vráti 409 a nezapíše override; priradenie s reťazcom nad 200 znakov vráti 400.
- `pnpm test` (271+196), `pnpm test:integration` (219 testov), `pnpm lint`, `pnpm typecheck` — všetko lokálne zelené pred pushom.
