### PR TITLE
Hardening findings from PR 87 review (issue 89)

### DIFF
--- a/.claude/rules/orders.md
+++ b/.claude/rules/orders.md
@@ -269,3 +269,21 @@ paths:
   banner automaticky. Pri pridávaní ďalšieho chybového stavu na už
   používanú zápisovú trasu najprv over, či `readJson` volajúcej funkcie už
   nerieši všeobecný prípad — často áno.
+- **Nezávislý audit k issue 86 upozornil na napätie medzi novým 409
+  (`already_has_supplier`, vyššie) a `.claude/rules/testing.md`'s pravidlom
+  "bežné, OČAKÁVANÉ doménové zlyhanie, ktoré sa niekedy overuje aj cez
+  Playwright, nesmie vracať 4xx/5xx" (Chromium loguje "Failed to load
+  resource" pre KAŽDÝ `fetch()` s ne-2xx odpoveďou, a nulová-konzola asercia
+  v `orders.spec.ts` by na to spadla). Tento 409 je ARGUMENTOVATEĽNE presne
+  taký prípad — súbeh (produkt medzitým dostal dodávateľa inou cestou) je
+  bežná, očakávaná situácia, nie chyba servera. **Nemení sa na 200
+  `{ok:false,error}`** (predpísaný vzor by bol rovnaký ako
+  `/api/catalog/ingest`'s `{status:"busy"}`) — issue 89 to necháva zámerne
+  otvorené, lebo dnešný `orders.spec.ts` tento konkrétny 409 vôbec
+  neoveruje cez Playwright. Kto napíše PRVÝ e2e test tejto hlášky
+  (banner po zamietnutom priradení), MUSÍ sa s týmto napätím vysporiadať
+  ZÁMERNE — buď zmenou trasy na 200 `{ok:false,error}` (rovnaký vzor ako
+  `sendSupplierOrderMail`), alebo explicitným filtrom v `jeOcakavane`
+  (rovnaký vzor ako existujúca `/api/me` 401 výnimka). **Zakázané: "opraviť"
+  to rozšírením konzolovej výnimky na hocijakú ĎALŠIU cestu/kód bez tejto
+  úvahy** — presne to `testing.md` výslovne zakazuje.

--- a/apps/api/src/http/orders-routes.ts
+++ b/apps/api/src/http/orders-routes.ts
@@ -177,7 +177,15 @@ export function registerOrdersRoutes(
       // issue 86: produkt medzitým dostal dodávateľa v katalógu (súbeh s
       // importom, alebo zabudnutá otvorená stránka) — ručné priradenie sa už
       // netýka tohto riadku, `assignOrderLineSupplier` nič nezapísala.
+      // issue 89 (review PR 87): predtým sa vracalo PRED `log.info` nižšie,
+      // takže odmietnutý zápis nezanechal žiadnu stopu — `warn`, lebo ide o
+      // odmietnutý/zablokovaný zápis (anomália nad bežnú prevádzku), nie
+      // bežný informačný záznam.
       if (result === "already_has_supplier") {
+        log.warn(
+          { actorUserId: user.userId, lineId, supplier },
+          "odmietnuté ručné priradenie dodávateľa — produkt už má dodávateľa v katalógu",
+        );
         return c.json({ error: "Produkt už má dodávateľa v katalógu — ručné priradenie nie je možné" }, 409);
       }
       log.info({ actorUserId: user.userId, lineId, supplier }, "ručné priradenie dodávateľa riadku objednávky");

--- a/apps/api/tests/orders-supplier-assignment.integration.test.ts
+++ b/apps/api/tests/orders-supplier-assignment.integration.test.ts
@@ -1,8 +1,9 @@
 import { eq } from "drizzle-orm";
-import { afterEach, expect, it } from "vitest";
+import { afterEach, expect, it, vi } from "vitest";
 import { orderLines, orders, productSupplierOverrides, users } from "../src/db/schema.js";
 import { createApp } from "../src/http/app.js";
 import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import { log } from "../src/logger.js";
 import { hashPassword } from "../src/modules/auth/passwords.js";
 import type { UserRole } from "../src/modules/auth/service.js";
 import { insertTestVariant, insertTestVariantForProduct } from "./helpers/orders.js";
@@ -240,6 +241,42 @@ it("priradenie riadku, ktorého produkt UŽ má dodávateľa v katalógu, vráti
 
   const override = await db.select().from(productSupplierOverrides).where(eq(productSupplierOverrides.productKey, "N-D"));
   expect(override).toHaveLength(0);
+});
+
+// issue 89 (review PR 87): predtým sa vracalo pred `log.info` skorej v tomto
+// súbore (ten sa netýka tejto vetvy), takže odmietnutý zápis nezanechal
+// ŽIADNU stopu — teraz musí zanechať `log.warn` s kým, ktorým riadkom a
+// akou hodnotou sa pokúsil priradiť.
+it("priradenie riadku, ktorého produkt UŽ má dodávateľa, zaznamená log.warn s aktérom, riadkom a pokúšanou hodnotou", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await insertTestVariant(db, "N-LOG", "Existujúci Katalógový Dodávateľ");
+  const [objednavka] = await db
+    .insert(orders)
+    .values({ externalOrderId: "6007", customerName: "Zákazník", placedAt: new Date("2026-07-08T00:00:00Z") })
+    .returning();
+  if (objednavka === undefined) throw new Error("insert zlyhal");
+  const [line] = await db.insert(orderLines).values({ orderId: objednavka.id, variantCode: "N-LOG", quantity: 1 }).returning();
+  if (line === undefined) throw new Error("insert zlyhal");
+
+  const warnSpy = vi.spyOn(log, "warn").mockImplementation(() => undefined);
+  try {
+    const res = await app.request(`/api/orders/lines/${line.id}/supplier`, {
+      method: "POST",
+      headers: { cookie, "content-type": "application/json" },
+      body: JSON.stringify({ supplier: "Nový Pokus O Priradenie" }),
+    });
+    expect(res.status).toBe(409);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const [zaznam, hlaska] = warnSpy.mock.calls[0] ?? [];
+    expect(typeof hlaska).toBe("string");
+    const payload = zaznam as Record<string, unknown>;
+    expect(typeof payload["actorUserId"]).toBe("string");
+    expect(payload["lineId"]).toBe(line.id);
+    expect(payload["supplier"]).toBe("Nový Pokus O Priradenie");
+  } finally {
+    warnSpy.mockRestore();
+  }
 });
 
 // issue 86 (nezávislý audit): `.max(200)` na `orderLineSupplierBody`,

--- a/apps/web/src/components/OrdersSection.assignSupplier.test.tsx
+++ b/apps/web/src/components/OrdersSection.assignSupplier.test.tsx
@@ -1,0 +1,114 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { OrdersSection } from "./OrdersSection.js";
+
+// issue 63: ručné priradenie dodávateľa riadku bez dodávateľa. Vydelené z
+// `OrdersSection.test.tsx` (rovnaký vzor ako existujúci
+// `OrdersSection.ordered.test.tsx` split, `.claude/rules/testing.md`).
+//
+// issue 89 (review PR 87): predtým žiadny test tejto obrazovky vôbec
+// nevolal `assignOrderLineSupplierApi` — tvrdenie, že po zlyhaní netreba nič
+// meniť vo frontende, nebolo ničím kryté. Tento súbor dokazuje aj refetch po
+// zamietnutí (predtým sa `load()` volalo LEN v úspešnej vetve).
+
+const { fetchOpenOrders, assignOrderLineSupplier } = vi.hoisted(() => ({
+  fetchOpenOrders: vi.fn(),
+  assignOrderLineSupplier: vi.fn(),
+}));
+
+vi.mock("../ordersApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../ordersApi.js")>();
+  return {
+    ...actual,
+    fetchOpenOrders,
+    assignOrderLineSupplier,
+  };
+});
+
+const LINE_BEZ_DODAVATELA = {
+  lineId: "33333333-3333-3333-3333-333333333333",
+  orderId: "cccccccc-3333-3333-3333-333333333333",
+  externalOrderId: "1003",
+  customerName: "Zákazník 3",
+  comment: null,
+  placedAt: "2026-07-20T00:00:00.000Z",
+  variantCode: "C-1",
+  variantName: "Čiapka FOREST 3001",
+  sizeLabel: null,
+  quantity: 1,
+  state: "objednane" as const,
+  ordered: false,
+  supplierUrl: null,
+  supplierNote: null,
+  externalCode: null,
+  supplierAssignable: true,
+  manualSupplierOverride: null,
+};
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+function vstupNaPriradenie() {
+  return screen.findByLabelText(
+    `Priradiť dodávateľa riadku objednávky ${LINE_BEZ_DODAVATELA.externalOrderId} / ${LINE_BEZ_DODAVATELA.variantCode}`,
+  );
+}
+
+it("úspešné priradenie dodávateľa spraví refetch zoznamu", async () => {
+  fetchOpenOrders.mockResolvedValue([
+    { supplier: "(bez dodávateľa)", lines: [LINE_BEZ_DODAVATELA], email: null },
+  ]);
+  assignOrderLineSupplier.mockResolvedValue(undefined);
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const vstup = await vstupNaPriradenie();
+  fireEvent.change(vstup, { target: { value: "Nový Dodávateľ" } });
+  fireEvent.keyDown(vstup, { key: "Enter" });
+
+  await waitFor(() => {
+    expect(assignOrderLineSupplier).toHaveBeenCalledWith(LINE_BEZ_DODAVATELA.lineId, "Nový Dodávateľ");
+  });
+  // Počiatočné načítanie + refetch po úspechu.
+  await waitFor(() => {
+    expect(fetchOpenOrders).toHaveBeenCalledTimes(2);
+  });
+});
+
+// issue 89 (review PR 87), nález 1: zamietnutie (napr. 409 "Produkt už má
+// dodávateľa v katalógu — ručné priradenie nie je možné", keď produkt
+// medzitým dostal dodávateľa inou cestou) predtým NErobilo refetch — stará
+// verzia zoznamu zostala, vstupné pole na priradenie ostalo viditeľné
+// navždy. Teraz sa zoznam obnoví AJ pri zlyhaní, a hláška (nezávislý stav
+// `stateError`) prežije refetch.
+it("zamietnuté priradenie (409) zobrazí slovenskú hlášku A ZÁROVEŇ spraví refetch zoznamu", async () => {
+  fetchOpenOrders.mockResolvedValue([
+    { supplier: "(bez dodávateľa)", lines: [LINE_BEZ_DODAVATELA], email: null },
+  ]);
+  assignOrderLineSupplier.mockRejectedValue(
+    new Error("Produkt už má dodávateľa v katalógu — ručné priradenie nie je možné"),
+  );
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const vstup = await vstupNaPriradenie();
+  fireEvent.change(vstup, { target: { value: "Konkurenčný Zápis" } });
+  fireEvent.keyDown(vstup, { key: "Enter" });
+
+  await waitFor(() => {
+    expect(screen.getByRole("alert").textContent).toBe(
+      "Produkt už má dodávateľa v katalógu — ručné priradenie nie je možné",
+    );
+  });
+  // Počiatočné načítanie + refetch po zlyhaní — samo-vyliečenie stránky,
+  // ktorá by inak zostala navždy s neplatným vstupným poľom.
+  await waitFor(() => {
+    expect(fetchOpenOrders).toHaveBeenCalledTimes(2);
+  });
+  // Banner prežil refetch (`load()` nemení `stateError`, nezávislý stav).
+  expect(screen.getByRole("alert").textContent).toBe(
+    "Produkt už má dodávateľa v katalógu — ručné priradenie nie je možné",
+  );
+});

--- a/apps/web/src/components/OrdersSection.tsx
+++ b/apps/web/src/components/OrdersSection.tsx
@@ -185,6 +185,15 @@ export function OrdersSection({
             return;
           }
           setStateError(err instanceof Error ? err.message : "Priradenie dodávateľa sa nepodarilo.");
+          // issue 89 (review PR 87): predtým sa `load()` volalo LEN v úspešnej
+          // vetve vyššie — pri zamietnutí (napr. server vráti 409, lebo
+          // produkt medzitým dostal dodávateľa v katalógu inou cestou, súbeh s
+          // importom alebo dlho otvorená stránka iného manažéra) zoznam
+          // zostal STARÝ a vstupné pole na priradenie by tak ostalo viditeľné
+          // navždy — manažér by mohol skúšať donekonečna. `load()` mení len
+          // `suppliers`/`loaded`/`error`, nikdy `stateError` (nezávislý stav
+          // vyššie), takže táto hláška ostáva viditeľná aj po refetchi.
+          load();
         })
         .finally(() => {
           setBusySupplierLineId(null);

--- a/apps/web/src/ordersApi.test.ts
+++ b/apps/web/src/ordersApi.test.ts
@@ -1,6 +1,7 @@
 import { expect, it, vi } from "vitest";
 import {
   OrdersUnauthorizedError,
+  assignOrderLineSupplier,
   fetchOpenOrders,
   fetchOpenStatusesConfig,
   fetchSupplierOrderMailPreview,
@@ -156,6 +157,46 @@ it("updateOrderLineOrdered pri 401 vyhodí OrdersUnauthorizedError", async () =>
   await expect(updateOrderLineOrdered("11111111-1111-1111-1111-111111111111", true)).rejects.toBeInstanceOf(
     OrdersUnauthorizedError,
   );
+});
+
+// issue 89 (review PR 87), nález 4: doteraz žiadny test tohto súboru
+// nevolal `assignOrderLineSupplier` — tvrdenie "netreba meniť frontend,
+// slovenská hláška prejde sama" nebolo ničím kryté.
+it("assignOrderLineSupplier pošle POST na správnu trasu s telom { supplier }", async () => {
+  const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true, supplier: "Alfa" }), { status: 200 }));
+  vi.stubGlobal("fetch", fetchMock);
+
+  await assignOrderLineSupplier("11111111-1111-1111-1111-111111111111", "Alfa");
+
+  expect(fetchMock).toHaveBeenCalledWith(
+    "/api/orders/lines/11111111-1111-1111-1111-111111111111/supplier",
+    expect.objectContaining({
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ supplier: "Alfa" }),
+    }),
+  );
+});
+
+it("assignOrderLineSupplier pri 409 (produkt už má dodávateľa) vyhodí Error so slovenskou hláškou z tela odpovede", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: "Produkt už má dodávateľa v katalógu — ručné priradenie nie je možné" }), {
+        status: 409,
+      }),
+    ),
+  );
+  await expect(assignOrderLineSupplier("11111111-1111-1111-1111-111111111111", "Konkurenčný Zápis")).rejects.toThrow(
+    "Produkt už má dodávateľa v katalógu — ručné priradenie nie je možné",
+  );
+});
+
+it("assignOrderLineSupplier pri 401 vyhodí OrdersUnauthorizedError", async () => {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 401 })));
+  await expect(
+    assignOrderLineSupplier("11111111-1111-1111-1111-111111111111", "Alfa"),
+  ).rejects.toBeInstanceOf(OrdersUnauthorizedError);
 });
 
 it("setSupplierLinesOrdered pošle PUT s URL-enkódovaným menom dodávateľa a vráti počet zmenených riadkov", async () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.47",
+  "version": "0.3.0-dev.48",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Closes #89

Four small hardening findings from an independent code review of PR 87
(server-side guard for manual supplier assignment, issue 86), bundled into
one PR per issue 89:

1. `OrdersSection.tsx`'s `assignSupplier` refetches the order list only on
   success. On a rejected assignment (e.g. the issue 86 409 when the
   product got a supplier elsewhere) the list stayed stale and the
   now-invalid assign input kept showing forever. `load()` now runs in the
   `.catch()` too — it never touches `stateError`, so the Slovak banner
   survives the refetch.
2. `orders-routes.ts` returned before the existing `log.info` on the
   `already_has_supplier` 409 branch, so a rejected write left no trace.
   Added `log.warn` with `actorUserId`, `lineId` and the attempted
   supplier value.
3. `.claude/rules/orders.md` records the tension between the new 409 and
   `testing.md`'s "no 4xx for a normal domain failure ever exercised
   through Playwright" rule — not changed to 200 here (no e2e exercises
   this banner yet), left as a deliberate note for whoever writes it.
4. `ordersApi.test.ts` had zero test cases for `assignOrderLineSupplier` —
   added coverage proving the Slovak 409 message really does surface as
   the thrown `Error.message`.

A fifth review finding (a migration to clean up dormant
`product_supplier_override` rows) is deliberately out of scope — the
production table was verified empty (0 rows).

Design/root-cause writeup posted to issue 89 before the first commit.
