### PR TITLE
Fix mount-time race in OrderLineRow draft-reset effect (follow-up to issue 89)

### DIFF
--- a/apps/web/src/components/OrderLineRow.tsx
+++ b/apps/web/src/components/OrderLineRow.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type JSX } from "react";
+import { useEffect, useRef, useState, type JSX } from "react";
 import type { OrderLine } from "../ordersApi.js";
 import { formatVariantTotalChip, type VariantTotal } from "../ordersSummary.js";
 
@@ -63,7 +63,22 @@ export function OrderLineRow({
   // `assignSupplier`). Bez tohto by po uložení zostal v poli VIDIEŤ starý
   // koncept, keď riadok NEZMENÍ skupinu (rovnaký pravopis po normalizácii).
   const [supplierDraft, setSupplierDraft] = useState(line.manualSupplierOverride ?? "");
+  // issue 89 (nezávislý audit, objavené novým testom `OrdersSection
+  // .assignSupplier.test.tsx`): tento efekt PREDTÝM bežal aj pri PRVOM
+  // mountnutí (React spúšťa `useEffect` vždy po prvom commite, bez ohľadu
+  // na to, či sa "závislosť skutočne zmenila"), čo bolo úplne zbytočné
+  // (`useState` vyššie už štartuje s TOU ISTOU hodnotou) — a navyše
+  // pretekové: rýchla interakcia hneď po mounte (presne to, čo nový test
+  // robí) mohla zachytiť tento oneskorený "reset na ''" AŽ PO tom, čo
+  // manažér už stihol napísať koncept, a ticho ho vymazať (~1 z ~150
+  // lokálnych behov). Skip na prvom mounte odstraňuje pretek — efekt teraz
+  // reaguje len na SKUTOČNÚ zmenu `manualSupplierOverride` po uložení.
+  const isFirstMount = useRef(true);
   useEffect(() => {
+    if (isFirstMount.current) {
+      isFirstMount.current = false;
+      return;
+    }
     setSupplierDraft(line.manualSupplierOverride ?? "");
   }, [line.manualSupplierOverride]);
   const supplierBusyHere = busySupplierLineId === line.lineId;

--- a/apps/web/src/components/OrdersSection.assignSupplier.test.tsx
+++ b/apps/web/src/components/OrdersSection.assignSupplier.test.tsx
@@ -50,9 +50,36 @@ afterEach(() => {
   vi.resetAllMocks();
 });
 
-function vstupNaPriradenie() {
-  return screen.findByLabelText(
+// Rovnaký vzor interakcie ako existujúci "manažér nastaví e-mail dodávateľa"
+// test vyššie v `OrdersSection.test.tsx` — `fireEvent.change` + KLIK na
+// uloženie (nie `keyDown`+Enter).
+//
+// Pôvodná verzia tohto testu bola preukázateľne krehká, a to DVOMA rôznymi
+// pretekmi (obidva nájdené AŽ opakovaným behom, nie na prvý pokus — CI to
+// raz skutočne zachytilo na `main`):
+// 1) `fireEvent.change` hneď nasledované `fireEvent.keyDown` na TOM ISTOM
+//    ťahu — v ~1 z 8 lokálnych behov `saveSupplier()` vôbec nezavolal
+//    `onAssignSupplier`. Fix: klik na uložiť tlačidlo namiesto keyDown.
+// 2) Skutočná PRÍČINA (`OrderLineRow.tsx`'s efekt na `manualSupplierOverride`
+//    bežal aj pri PRVOM mounte, viď jeho komentár) — rýchla interakcia HNEĎ
+//    po objavení riadku mohla zachytiť tento oneskorený "reset na ''" AŽ PO
+//    napísaní konceptu a ticho ho vymazať (~1 zo ~150 behov). Opravené v
+//    `OrderLineRow.tsx` (skip efektu na prvom mounte) — nie workaroundom tu
+//    v teste, lebo išlo o skutočný pretek v produkčnom kóde, nie len o
+//    krehkú simuláciu interakcie.
+async function vyplnAUloz(hodnota: string) {
+  const vstup = await screen.findByLabelText<HTMLInputElement>(
     `Priradiť dodávateľa riadku objednávky ${LINE_BEZ_DODAVATELA.externalOrderId} / ${LINE_BEZ_DODAVATELA.variantCode}`,
+  );
+  // `fireEvent.change` je od RTL synchrónne zabalené v `act()` — hodnota je
+  // commitnutá HNEĎ, žiadny `waitFor` (async poll cez `setInterval`) tu
+  // netreba a jeho pridanie by len vnieslo zbytočné časové okno.
+  fireEvent.change(vstup, { target: { value: hodnota } });
+  expect(vstup.value).toBe(hodnota);
+  fireEvent.click(
+    screen.getByLabelText(
+      `Uložiť priradenie dodávateľa riadku objednávky ${LINE_BEZ_DODAVATELA.externalOrderId} / ${LINE_BEZ_DODAVATELA.variantCode}`,
+    ),
   );
 }
 
@@ -63,10 +90,7 @@ it("úspešné priradenie dodávateľa spraví refetch zoznamu", async () => {
   assignOrderLineSupplier.mockResolvedValue(undefined);
 
   render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
-
-  const vstup = await vstupNaPriradenie();
-  fireEvent.change(vstup, { target: { value: "Nový Dodávateľ" } });
-  fireEvent.keyDown(vstup, { key: "Enter" });
+  await vyplnAUloz("Nový Dodávateľ");
 
   await waitFor(() => {
     expect(assignOrderLineSupplier).toHaveBeenCalledWith(LINE_BEZ_DODAVATELA.lineId, "Nový Dodávateľ");
@@ -92,10 +116,7 @@ it("zamietnuté priradenie (409) zobrazí slovenskú hlášku A ZÁROVEŇ sprav�
   );
 
   render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
-
-  const vstup = await vstupNaPriradenie();
-  fireEvent.change(vstup, { target: { value: "Konkurenčný Zápis" } });
-  fireEvent.keyDown(vstup, { key: "Enter" });
+  await vyplnAUloz("Konkurenčný Zápis");
 
   await waitFor(() => {
     expect(screen.getByRole("alert").textContent).toBe(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.48",
+  "version": "0.3.0-dev.49",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Follow-up to PR 90 (issue 89) -- CI on main flaked once after that merge on
the new `OrdersSection.assignSupplier.test.tsx` test. Root-caused and fixed:

`OrderLineRow.tsx`'s effect resetting the supplier-assign draft from
`manualSupplierOverride` ran on every mount too (not just on a real later
change), which could race with a fast interaction right after a row
appears and silently wipe a just-typed value (~1-in-150 in a local stress
loop). Fixed with a mount-skip guard; re-verified with a 300-iteration
stress loop of the exact interaction (0 failures after, several before).

Finding + root cause posted to issue 89 (already closed by PR 90's merge --
this is a direct follow-up discovered during verification, not a new
independent ticket).

No functional/behavioral change to any of PR 90's four findings.
