### PR TITLE
Add order-comment write path (issue 64)

### DIFF
--- a/apps/api/src/http/orders-routes.ts
+++ b/apps/api/src/http/orders-routes.ts
@@ -9,7 +9,7 @@ import { ORDERS_EXPORT_URL_NOT_CONFIGURED, type OrdersIngestResult, type RunOrde
 import { listKnownStatusNames, listOpenStatusNames, replaceOpenStatusNames } from "../modules/orders/open-statuses.js";
 import { getOrderDetail, listOpenOrderLinesBySupplier } from "../modules/orders/queries.js";
 import { assignOrderLineSupplier } from "../modules/orders/supplier-assignment.js";
-import { setOrderLineOrdered, setOrderLineState } from "../modules/orders/state.js";
+import { setOrderComment, setOrderLineOrdered, setOrderLineState } from "../modules/orders/state.js";
 import { requireRole, requireUser, type AppBindings } from "./middleware.js";
 import { requireSameOrigin } from "./origin-check.js";
 
@@ -28,6 +28,12 @@ const orderLineOrderedBody = z.object({ ordered: z.boolean() });
 // v projekte (`catalog-routes.ts`, `pairing-routes.ts`) — hodnota sa neskôr
 // vkladá aj do mailu dodávateľovi, chýbajúci limit bol prehliadnutá medzera.
 const orderLineSupplierBody = z.object({ supplier: z.string().trim().min(1).max(200) });
+// issue 64: manažérova voľná poznámka k CELEJ objednávke — na rozdiel od
+// `orderLineSupplierBody` vyššie ZÁMERNE bez `.min(1)` (prázdny orezaný vstup
+// je platný spôsob, ako poznámku vymazať, route ho mapuje na `null`). Cap
+// 2000 znakov — rovnaká horná hranica ako legacy appka's `ORDER_COMMENT_MAX`
+// (`parovanie_produktov/webreview/app.py`, čítané len pre správanie).
+const orderCommentBody = z.object({ comment: z.string().trim().max(2000) });
 // issue 59: `min(1)` len zachytí zjavne prázdny request skôr, než sa vôbec
 // dostane k `replaceOpenStatusNames` — SKUTOČNÉ čistenie (normalizácia,
 // orezanie prázdnych/duplicít po trime) beží až v module, lebo "['   ']"
@@ -92,6 +98,41 @@ export function registerOrdersRoutes(
     if (detail === null) return c.json({ error: "Objednávka sa nenašla" }, 404);
     return c.json(detail);
   });
+
+  // issue 64: manažérova voľná poznámka k CELEJ objednávke (`order.comment`,
+  // stĺpec existuje od F3 (#21), import ho nikdy neprepíše — `.claude/rules/
+  // orders.md`). Trojsegmentová cesta (`:id`/`comment`) sa NEKOLÍDUJE s
+  // dvojsegmentovým `GET /api/orders/:id` vyššie ani so 4/5-segmentovými
+  // `/api/orders/lines/...` trasami nižšie (`.claude/rules/http-routes.md`'s
+  // upozornenie platí len pre trasy s ROVNAKÝM počtom segmentov). Rovnaké
+  // oprávnenie ako ostatné zápisy v tomto súbore.
+  app.put(
+    "/api/orders/:id/comment",
+    requireSameOrigin(),
+    requireUser(db),
+    requireRole("admin", "manazer"),
+    zValidator("param", orderParam),
+    zValidator("json", orderCommentBody),
+    async (c) => {
+      const { id } = c.req.valid("param");
+      const { comment } = c.req.valid("json");
+      const user = c.get("user");
+      const now = new Date();
+      const normalizedComment = comment === "" ? null : comment;
+
+      const result = await setOrderComment(db, {
+        orderId: id,
+        comment: normalizedComment,
+        actorUserId: user.userId,
+        now,
+      });
+      if (result === "not_found") {
+        return c.json({ error: "Objednávka sa nenašla" }, 404);
+      }
+      log.info({ actorUserId: user.userId, orderId: id }, "zmena poznámky k objednávke");
+      return c.json({ ok: true as const, comment: normalizedComment });
+    },
+  );
 
   // Zmena stavu riadku objednávky (#25) — rovnaké oprávnenie ako spustenie
   // importu (`requireRole("admin", "manazer")`): manažér stavy mení, `citanie`/

--- a/apps/api/src/modules/orders/state.ts
+++ b/apps/api/src/modules/orders/state.ts
@@ -1,6 +1,6 @@
 import { eq, inArray } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
-import { orderLines, type OrderLineState } from "../../db/schema.js";
+import { orderLines, orders, type OrderLineState } from "../../db/schema.js";
 import { record } from "../audit/service.js";
 import { listOpenOrderLineIdsForSupplier } from "./queries.js";
 
@@ -99,6 +99,50 @@ export async function setOrderLineOrdered(
         from: line.ordered,
         to: input.ordered,
       },
+    });
+
+    return "ok";
+  });
+}
+
+export type SetOrderCommentResult = "ok" | "not_found";
+
+export interface SetOrderCommentInput {
+  readonly orderId: string;
+  readonly comment: string | null;
+  readonly actorUserId: string;
+  readonly now: Date;
+}
+
+// issue 64: manažérova voľná poznámka k CELEJ objednávke (nie k riadku,
+// `order.comment` stĺpec — `.claude/rules/orders.md` vysvetľuje, prečo ho
+// import nikdy neprepíše). Rovnaký vzor ako `setOrderLineState`/
+// `setOrderLineOrdered` vyššie: jedna transakcia, `.for("update")` proti
+// súbežnej zmene TOHO ISTÉHO záznamu (dvaja manažéri upravujú tú istú
+// poznámku súčasne), audit v tej istej transakcii. `comment: null` maže
+// poznámku (prázdny orezaný vstup, mapované v `orders-routes.ts`).
+export async function setOrderComment(
+  db: Database,
+  input: SetOrderCommentInput,
+): Promise<SetOrderCommentResult> {
+  return db.transaction(async (tx) => {
+    const [order] = await tx
+      .select({ comment: orders.comment })
+      .from(orders)
+      .where(eq(orders.id, input.orderId))
+      .for("update")
+      .limit(1);
+    if (order === undefined) return "not_found";
+
+    await tx.update(orders).set({ comment: input.comment }).where(eq(orders.id, input.orderId));
+
+    await record(tx, {
+      at: input.now,
+      actorUserId: input.actorUserId,
+      action: "order.comment.changed",
+      entity: "order",
+      entityId: input.orderId,
+      data: { from: order.comment, to: input.comment },
     });
 
     return "ok";

--- a/apps/api/tests/orders-http-comment.integration.test.ts
+++ b/apps/api/tests/orders-http-comment.integration.test.ts
@@ -1,0 +1,183 @@
+import { eq } from "drizzle-orm";
+import { afterEach, expect, it } from "vitest";
+import { auditEvents, orderLines, orders, users } from "../src/db/schema.js";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import type { UserRole } from "../src/modules/auth/service.js";
+import { insertTestVariant } from "./helpers/orders.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// Testy pre `PUT /api/orders/:id/comment` (issue 64 — manažérova voľná
+// poznámka k CELEJ objednávke). Vlastný súbor, rovnaký dôvod ako
+// `orders-http-state.integration.test.ts`/`orders-http-ordered.integration
+// .test.ts` (eslint `max-lines: 400`, `.claude/rules/testing.md`).
+
+const HESLO = "test-heslo-abc"; // testovacie údaje, nie tajomstvo
+
+let close: (() => Promise<void>) | undefined;
+
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  resetLoginRateLimit();
+});
+
+async function boot(role: UserRole) {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const [pouzivatel] = await ctx.db
+    .insert(users)
+    .values({
+      email: "manazer@forestshop.sk",
+      passwordHash: await hashPassword(HESLO),
+      displayName: "Manažér",
+      role,
+    })
+    .returning({ id: users.id });
+  if (pouzivatel === undefined) throw new Error("testovací používateľ sa nepodarilo vložiť");
+
+  const app = createApp(ctx.db, { cookieSecure: false });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "manazer@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie, db: ctx.db, userId: pouzivatel.id };
+}
+
+// `poradie` robí variant/objednávku UNIKÁTNU pri viacerých volaniach v tom
+// istom teste — rovnaký vzor ako `orders-http-state.integration.test.ts`.
+let poradieVlozenia = 0;
+async function vlozObjednavku(
+  db: Awaited<ReturnType<typeof boot>>["db"],
+  comment: string | null = null,
+): Promise<{ orderId: string }> {
+  poradieVlozenia += 1;
+  const kod = `K-${String(poradieVlozenia)}`;
+  await insertTestVariant(db, kod, "Dodávateľ Alfa");
+  const [objednavka] = await db
+    .insert(orders)
+    .values({
+      externalOrderId: `500${String(poradieVlozenia)}`,
+      customerName: "Zákazník",
+      comment,
+      placedAt: new Date("2026-07-20T00:00:00Z"),
+    })
+    .returning();
+  if (objednavka === undefined) throw new Error("insert objednávky zlyhal");
+  await db.insert(orderLines).values({ orderId: objednavka.id, variantCode: kod, quantity: 1 });
+  return { orderId: objednavka.id };
+}
+
+it("manažér nastaví poznámku k objednávke, zápis sa uloží aj do auditu s tým, kto ho spravil", async () => {
+  const { app, cookie, db, userId } = await boot("manazer");
+  const { orderId } = await vlozObjednavku(db);
+
+  const res = await app.request(`/api/orders/${orderId}/comment`, {
+    method: "PUT",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ comment: "Zavolať pred doručením" }),
+  });
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ ok: true, comment: "Zavolať pred doručením" });
+
+  const [objednavka] = await db.select().from(orders).where(eq(orders.id, orderId));
+  expect(objednavka?.comment).toBe("Zavolať pred doručením");
+
+  const udalosti = await db.select().from(auditEvents);
+  const udalost = udalosti.find((e) => e.action === "order.comment.changed");
+  expect(udalost).toBeDefined();
+  expect(udalost?.actorUserId).toBe(userId);
+  expect(udalost?.entity).toBe("order");
+  expect(udalost?.entityId).toBe(orderId);
+  expect(udalost?.data).toMatchObject({ from: null, to: "Zavolať pred doručením" });
+});
+
+it("prázdna (orezaná) poznámka vymaže existujúcu hodnotu na null", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  const { orderId } = await vlozObjednavku(db, "stará poznámka");
+
+  const res = await app.request(`/api/orders/${orderId}/comment`, {
+    method: "PUT",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ comment: "   " }),
+  });
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ ok: true, comment: null });
+
+  const [objednavka] = await db.select().from(orders).where(eq(orders.id, orderId));
+  expect(objednavka?.comment).toBeNull();
+});
+
+it("rola citanie nesmie zmeniť poznámku k objednávke", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const { orderId } = await vlozObjednavku(db);
+  const res = await app.request(`/api/orders/${orderId}/comment`, {
+    method: "PUT",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ comment: "pokus" }),
+  });
+  expect(res.status).toBe(403);
+});
+
+it("rola sef tiež nesmie zmeniť poznámku k objednávke", async () => {
+  const { app, cookie, db } = await boot("sef");
+  const { orderId } = await vlozObjednavku(db);
+  const res = await app.request(`/api/orders/${orderId}/comment`, {
+    method: "PUT",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ comment: "pokus" }),
+  });
+  expect(res.status).toBe(403);
+});
+
+it("neznáma objednávka vráti 404, príliš dlhá poznámka vráti 400", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await vlozObjednavku(db);
+
+  const neznama = await app.request("/api/orders/11111111-1111-1111-1111-111111111111/comment", {
+    method: "PUT",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ comment: "pokus" }),
+  });
+  expect(neznama.status).toBe(404);
+
+  const { orderId } = await vlozObjednavku(db);
+  const prilisDlha = await app.request(`/api/orders/${orderId}/comment`, {
+    method: "PUT",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ comment: "x".repeat(2001) }),
+  });
+  expect(prilisDlha.status).toBe(400);
+});
+
+it("zmena poznámky s cudzím Origin je odmietnutá (403), rovnaký pôvod prejde", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  const { orderId } = await vlozObjednavku(db);
+
+  const cudzi = await app.request(`/api/orders/${orderId}/comment`, {
+    method: "PUT",
+    headers: {
+      cookie,
+      "content-type": "application/json",
+      origin: "https://utocnik.example",
+      host: "forestshop.example",
+    },
+    body: JSON.stringify({ comment: "pokus" }),
+  });
+  expect(cudzi.status).toBe(403);
+
+  const rovnaky = await app.request(`/api/orders/${orderId}/comment`, {
+    method: "PUT",
+    headers: {
+      cookie,
+      "content-type": "application/json",
+      origin: "https://forestshop.example",
+      host: "forestshop.example",
+    },
+    body: JSON.stringify({ comment: "pokus" }),
+  });
+  expect(rovnaky.status).toBe(200);
+});

--- a/apps/web/src/components/OrderLineRow.tsx
+++ b/apps/web/src/components/OrderLineRow.tsx
@@ -25,9 +25,11 @@ export function OrderLineRow({
   supplierBusy,
   variantTotal,
   busySupplierLineId,
+  busyCommentOrderId,
   onChangeState,
   onChangeOrdered,
   onAssignSupplier,
+  onChangeComment,
 }: {
   readonly line: OrderLine;
   readonly canChangeState: boolean;
@@ -51,9 +53,13 @@ export function OrderLineRow({
   // issue 63: riadok, ktorého ručné priradenie dodávateľa PRÁVE TERAZ ukladá
   // (needitovateľné, kým sa neskončí).
   readonly busySupplierLineId: string | null;
+  // issue 64: objednávka (nie riadok — poznámka patrí CELEJ objednávke),
+  // ktorej poznámka PRÁVE TERAZ ukladá.
+  readonly busyCommentOrderId: string | null;
   readonly onChangeState: (lineId: string, newState: OrderLine["state"]) => void;
   readonly onChangeOrdered: (lineId: string, ordered: boolean) => void;
   readonly onAssignSupplier: (lineId: string, supplier: string) => void;
+  readonly onChangeComment: (orderId: string, comment: string | null) => void;
 }): JSX.Element {
   const qtyChip = variantTotal !== undefined ? formatVariantTotalChip(variantTotal) : null;
 
@@ -86,6 +92,30 @@ export function OrderLineRow({
     const trimmed = supplierDraft.trim();
     if (trimmed === "") return;
     onAssignSupplier(line.lineId, trimmed);
+  };
+
+  // issue 64: rovnaký "controlled draft, resetovaný z props po uložení"
+  // vzor ako `supplierDraft` vyššie — vrátane rovnakého "skip prvý mount"
+  // guardu (`.claude/rules/frontend-design.md`'s zdokumentovaný pretek: bez
+  // neho by rýchla interakcia hneď po mounte mohla zachytiť oneskorený
+  // reset a ticho prepísať rozostavaný koncept). NEZÁVISLÝ od `line.comment`
+  // zmeny cez INÝ riadok tej istej objednávky — každý riadok má vlastnú
+  // kópiu draftu, ale všetky sa po uložení prepíšu na TÚ ISTÚ hodnotu
+  // (`OrdersSection.tsx`'s `changeComment` aktualizuje všetky riadky s
+  // rovnakým `orderId`), takže syncujú aj bez zdieľaného stavu.
+  const [commentDraft, setCommentDraft] = useState(line.comment ?? "");
+  const isCommentFirstMount = useRef(true);
+  useEffect(() => {
+    if (isCommentFirstMount.current) {
+      isCommentFirstMount.current = false;
+      return;
+    }
+    setCommentDraft(line.comment ?? "");
+  }, [line.comment]);
+  const commentBusyHere = busyCommentOrderId === line.orderId;
+  const saveComment = (): void => {
+    const trimmed = commentDraft.trim();
+    onChangeComment(line.orderId, trimmed === "" ? null : trimmed);
   };
 
   return (
@@ -211,7 +241,43 @@ export function OrderLineRow({
         )}
       </td>
       <td>{new Date(line.placedAt).toLocaleDateString("sk-SK")}</td>
-      <td>{line.comment ?? "—"}</td>
+      <td className="ord-comment-cell" data-testid={`comment-cell-${line.lineId}`}>
+        {canChangeState ? (
+          <>
+            <input
+              type="text"
+              className="ord-comment-input"
+              data-testid={`comment-input-${line.lineId}`}
+              aria-label={`Poznámka k objednávke ${line.externalOrderId} / ${line.variantCode}`}
+              placeholder="poznámka…"
+              maxLength={2000}
+              value={commentDraft}
+              disabled={commentBusyHere}
+              onChange={(e) => {
+                setCommentDraft(e.target.value);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  saveComment();
+                }
+              }}
+            />
+            <button
+              type="button"
+              className="btn sm good"
+              data-testid={`comment-save-${line.lineId}`}
+              aria-label={`Uložiť poznámku k objednávke ${line.externalOrderId} / ${line.variantCode}`}
+              disabled={commentBusyHere}
+              onClick={saveComment}
+            >
+              💾
+            </button>
+          </>
+        ) : (
+          (line.comment ?? "—")
+        )}
+      </td>
     </tr>
   );
 }

--- a/apps/web/src/components/OrderLineRow.tsx
+++ b/apps/web/src/components/OrderLineRow.tsx
@@ -103,18 +103,33 @@ export function OrderLineRow({
   // kópiu draftu, ale všetky sa po uložení prepíšu na TÚ ISTÚ hodnotu
   // (`OrdersSection.tsx`'s `changeComment` aktualizuje všetky riadky s
   // rovnakým `orderId`), takže syncujú aj bez zdieľaného stavu.
+  //
+  // Code review (issue 64, pred mergom): keďže poznámka je zdieľaná naprieč
+  // VŠETKÝMI riadkami tej istej objednávky, uloženie poznámky cez INÝ riadok
+  // (napr. riadok B) tej istej objednávky zmení `line.comment` aj na TOMTO
+  // riadku (A) — bez ďalšieho stráženia by vyššie uvedený reset efekt vtedy
+  // zbehol AJ na riadku A a ticho by prepísal jeho ešte NEULOŽENÝ rozpísaný
+  // koncept. `isCommentDirty` sleduje presne toto: nastaví sa pri KAŽDOM
+  // stlačení klávesy vo vstupe, vyčistí sa až pri KLIKU na uložiť TOHTO
+  // riadku (optimisticky — zápis môže ešte bežať, ale vstup je vtedy aj tak
+  // `disabled`, viď `commentBusyHere` nižšie, takže sa medzitým nedá znova
+  // rozpísať). Reset efekt teda prepíše draft LEN keď manažér na TOMTO
+  // riadku práve NIČ nerozpisuje.
   const [commentDraft, setCommentDraft] = useState(line.comment ?? "");
   const isCommentFirstMount = useRef(true);
+  const isCommentDirty = useRef(false);
   useEffect(() => {
     if (isCommentFirstMount.current) {
       isCommentFirstMount.current = false;
       return;
     }
+    if (isCommentDirty.current) return;
     setCommentDraft(line.comment ?? "");
   }, [line.comment]);
   const commentBusyHere = busyCommentOrderId === line.orderId;
   const saveComment = (): void => {
     const trimmed = commentDraft.trim();
+    isCommentDirty.current = false;
     onChangeComment(line.orderId, trimmed === "" ? null : trimmed);
   };
 
@@ -254,6 +269,7 @@ export function OrderLineRow({
               value={commentDraft}
               disabled={commentBusyHere}
               onChange={(e) => {
+                isCommentDirty.current = true;
                 setCommentDraft(e.target.value);
               }}
               onKeyDown={(e) => {

--- a/apps/web/src/components/OrdersSection.comment.test.tsx
+++ b/apps/web/src/components/OrdersSection.comment.test.tsx
@@ -1,0 +1,141 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { OrdersSection } from "./OrdersSection.js";
+
+// issue 64: manažérova voľná poznámka k CELEJ objednávke. Vydelené z
+// `OrdersSection.test.tsx` (rovnaký vzor ako existujúce
+// `OrdersSection.ordered.test.tsx`/`OrdersSection.assignSupplier.test.tsx`
+// splity, `.claude/rules/testing.md`).
+
+const { fetchOpenOrders, updateOrderComment } = vi.hoisted(() => ({
+  fetchOpenOrders: vi.fn(),
+  updateOrderComment: vi.fn(),
+}));
+
+vi.mock("../ordersApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../ordersApi.js")>();
+  return {
+    ...actual,
+    fetchOpenOrders,
+    updateOrderComment,
+  };
+});
+
+const ORDER_ID = "dddddddd-4444-4444-4444-444444444444";
+
+// Dva riadky TEJ ISTEJ objednávky (rovnaké `orderId`), rôzne varianty — dôkaz,
+// že uloženie poznámky cez JEDEN riadok sa prejaví aj na DRUHOM (poznámka
+// patrí objednávke, nie riadku).
+const RIADOK_1 = {
+  lineId: "11111111-4444-4444-4444-444444444444",
+  orderId: ORDER_ID,
+  externalOrderId: "1004",
+  customerName: "Zákazník 4",
+  comment: null,
+  placedAt: "2026-07-20T00:00:00.000Z",
+  variantCode: "D-1",
+  variantName: "Čiapka FOREST 4001",
+  sizeLabel: null,
+  quantity: 1,
+  state: "objednane" as const,
+  ordered: false,
+  supplierUrl: null,
+  supplierNote: null,
+  externalCode: null,
+  supplierAssignable: false,
+  manualSupplierOverride: null,
+};
+
+const RIADOK_2 = { ...RIADOK_1, lineId: "22222222-4444-4444-4444-444444444444", variantCode: "D-2" };
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+it("napísanie a uloženie poznámky sa lokálne prejaví na VŠETKÝCH riadkoch tej istej objednávky", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "(bez dodávateľa)", lines: [RIADOK_1, RIADOK_2], email: null }]);
+  updateOrderComment.mockResolvedValue(undefined);
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const vstup1 = await screen.findByLabelText<HTMLInputElement>(
+    `Poznámka k objednávke ${RIADOK_1.externalOrderId} / ${RIADOK_1.variantCode}`,
+  );
+  fireEvent.change(vstup1, { target: { value: "Zavolať pred doručením" } });
+  expect(vstup1.value).toBe("Zavolať pred doručením");
+  fireEvent.click(
+    screen.getByLabelText(`Uložiť poznámku k objednávke ${RIADOK_1.externalOrderId} / ${RIADOK_1.variantCode}`),
+  );
+
+  await waitFor(() => {
+    expect(updateOrderComment).toHaveBeenCalledWith(ORDER_ID, "Zavolať pred doručením");
+  });
+
+  // Druhý riadok TEJ ISTEJ objednávky ukazuje TÚ ISTÚ poznámku, hoci
+  // interakcia prebehla len na prvom riadku — dôkaz, že `changeComment`
+  // v `OrdersSection.tsx` aktualizuje všetky riadky s rovnakým `orderId`.
+  const vstup2 = await screen.findByLabelText<HTMLInputElement>(
+    `Poznámka k objednávke ${RIADOK_2.externalOrderId} / ${RIADOK_2.variantCode}`,
+  );
+  await waitFor(() => {
+    expect(vstup2.value).toBe("Zavolať pred doručením");
+  });
+  // Žiadny refetch — lokálna aktualizácia stačí (rovnaký vzor ako
+  // `changeState`/`changeOrdered`, na rozdiel od `assignSupplier`).
+  expect(fetchOpenOrders).toHaveBeenCalledTimes(1);
+});
+
+it("prázdny vstup uloží null (vymazanie poznámky)", async () => {
+  const RIADOK_S_POZNAMKOU = { ...RIADOK_1, comment: "stará poznámka" };
+  fetchOpenOrders.mockResolvedValue([{ supplier: "(bez dodávateľa)", lines: [RIADOK_S_POZNAMKOU], email: null }]);
+  updateOrderComment.mockResolvedValue(undefined);
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const vstup = await screen.findByLabelText<HTMLInputElement>(
+    `Poznámka k objednávke ${RIADOK_1.externalOrderId} / ${RIADOK_1.variantCode}`,
+  );
+  expect(vstup.value).toBe("stará poznámka");
+  fireEvent.change(vstup, { target: { value: "   " } });
+  fireEvent.click(
+    screen.getByLabelText(`Uložiť poznámku k objednávke ${RIADOK_1.externalOrderId} / ${RIADOK_1.variantCode}`),
+  );
+
+  await waitFor(() => {
+    expect(updateOrderComment).toHaveBeenCalledWith(ORDER_ID, null);
+  });
+});
+
+it("zlyhané uloženie poznámky zobrazí slovenskú hlášku, bez refetchu", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "(bez dodávateľa)", lines: [RIADOK_1], email: null }]);
+  updateOrderComment.mockRejectedValue(new Error("Uloženie poznámky sa nepodarilo"));
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const vstup = await screen.findByLabelText<HTMLInputElement>(
+    `Poznámka k objednávke ${RIADOK_1.externalOrderId} / ${RIADOK_1.variantCode}`,
+  );
+  fireEvent.change(vstup, { target: { value: "pokus" } });
+  fireEvent.click(
+    screen.getByLabelText(`Uložiť poznámku k objednávke ${RIADOK_1.externalOrderId} / ${RIADOK_1.variantCode}`),
+  );
+
+  await waitFor(() => {
+    expect(screen.getByRole("alert").textContent).toBe("Uloženie poznámky sa nepodarilo");
+  });
+  expect(fetchOpenOrders).toHaveBeenCalledTimes(1);
+});
+
+it("rola citanie vidí poznámku len na čítanie, bez vstupného poľa", async () => {
+  const RIADOK_S_POZNAMKOU = { ...RIADOK_1, comment: "Zavolať pred doručením" };
+  fetchOpenOrders.mockResolvedValue([{ supplier: "(bez dodávateľa)", lines: [RIADOK_S_POZNAMKOU], email: null }]);
+
+  render(<OrdersSection role="citanie" onSessionExpired={() => {}} />);
+
+  await screen.findByTestId(`comment-cell-${RIADOK_1.lineId}`);
+  expect(screen.getByTestId(`comment-cell-${RIADOK_1.lineId}`).textContent).toBe("Zavolať pred doručením");
+  expect(
+    screen.queryByLabelText(`Poznámka k objednávke ${RIADOK_1.externalOrderId} / ${RIADOK_1.variantCode}`),
+  ).toBeNull();
+});

--- a/apps/web/src/components/OrdersSection.comment.test.tsx
+++ b/apps/web/src/components/OrdersSection.comment.test.tsx
@@ -86,6 +86,48 @@ it("napísanie a uloženie poznámky sa lokálne prejaví na VŠETKÝCH riadkoch
   expect(fetchOpenOrders).toHaveBeenCalledTimes(1);
 });
 
+// Code review (issue 64, pred mergom): keďže poznámka je zdieľaná naprieč
+// VŠETKÝMI riadkami tej istej objednávky, uloženie cez INÝ riadok (B) tej
+// istej objednávky predtým ticho PREPÍSALO nerozostavaný, ešte NEULOŽENÝ
+// koncept na riadku A — `OrderLineRow.tsx`'s reset efekt na `line.comment`
+// nerozlišoval "toto sa zmenilo, lebo SOM to práve JA uložil" od "toto sa
+// zmenilo, lebo niekto INÝ uložil poznámku tej istej objednávky odinakiaľ".
+// `isCommentDirty` guard to rieši — reset sa vynechá, kým riadok drží
+// neuložený koncept.
+it("nerozostavaný koncept na riadku A PREŽIJE uloženie poznámky cez riadok B tej istej objednávky", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "(bez dodávateľa)", lines: [RIADOK_1, RIADOK_2], email: null }]);
+  updateOrderComment.mockResolvedValue(undefined);
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  // Manažér rozpíše koncept na riadku A, ale NEULOŽÍ ho.
+  const vstupA = await screen.findByLabelText<HTMLInputElement>(
+    `Poznámka k objednávke ${RIADOK_1.externalOrderId} / ${RIADOK_1.variantCode}`,
+  );
+  fireEvent.change(vstupA, { target: { value: "Rozpísaný, ešte neuložený koncept" } });
+  expect(vstupA.value).toBe("Rozpísaný, ešte neuložený koncept");
+
+  // Medzitým uloží INÚ poznámku cez riadok B TEJ ISTEJ objednávky.
+  const vstupB = screen.getByLabelText<HTMLInputElement>(
+    `Poznámka k objednávke ${RIADOK_2.externalOrderId} / ${RIADOK_2.variantCode}`,
+  );
+  fireEvent.change(vstupB, { target: { value: "Poznámka uložená cez riadok B" } });
+  fireEvent.click(
+    screen.getByLabelText(`Uložiť poznámku k objednávke ${RIADOK_2.externalOrderId} / ${RIADOK_2.variantCode}`),
+  );
+  await waitFor(() => {
+    expect(updateOrderComment).toHaveBeenCalledWith(ORDER_ID, "Poznámka uložená cez riadok B");
+  });
+  // Riadok B (ten, čo reálne uložil) sa synchronizuje na uloženú hodnotu.
+  await waitFor(() => {
+    expect(vstupB.value).toBe("Poznámka uložená cez riadok B");
+  });
+
+  // Riadok A NEBOL uložený — jeho rozostavaný koncept musí PREŽIŤ, nesmie sa
+  // ticho prepísať na hodnotu, ktorú práve uložil riadok B.
+  expect(vstupA.value).toBe("Rozpísaný, ešte neuložený koncept");
+});
+
 it("prázdny vstup uloží null (vymazanie poznámky)", async () => {
   const RIADOK_S_POZNAMKOU = { ...RIADOK_1, comment: "stará poznámka" };
   fetchOpenOrders.mockResolvedValue([{ supplier: "(bez dodávateľa)", lines: [RIADOK_S_POZNAMKOU], email: null }]);

--- a/apps/web/src/components/OrdersSection.tsx
+++ b/apps/web/src/components/OrdersSection.tsx
@@ -1,22 +1,21 @@
 import { useCallback, useEffect, useState, type JSX } from "react";
 import type { Me } from "../api.js";
 import { isLineResolved } from "../ordersSummary.js";
+import { useSupplierMailActions } from "../useSupplierMailActions.js";
 import { OrderOpenStatusesPanel } from "./OrderOpenStatusesPanel.js";
 import { OrdersToolbar } from "./OrdersToolbar.js";
 import { SupplierOrderGroup } from "./SupplierOrderGroup.js";
 import {
   assignOrderLineSupplier as assignOrderLineSupplierApi,
   fetchOpenOrders,
-  fetchSupplierOrderMailPreview,
   NEZNAMY_DODAVATEL,
   OrdersUnauthorizedError,
-  sendSupplierOrderMail,
   setSupplierEmail,
   setSupplierLinesOrdered,
+  updateOrderComment,
   updateOrderLineOrdered,
   updateOrderLineState,
   type OrderLine,
-  type OrderMailPreview,
   type SupplierOpenOrders,
 } from "../ordersApi.js";
 
@@ -80,12 +79,21 @@ export function OrdersSection({
   const [emailBusy, setEmailBusy] = useState(false);
   const [emailError, setEmailError] = useState("");
 
-  // #31: náhľad + potvrdenie pred odoslaním objednávky mailom.
-  const [previewSupplier, setPreviewSupplier] = useState<string | null>(null);
-  const [preview, setPreview] = useState<OrderMailPreview | null>(null);
-  const [previewError, setPreviewError] = useState("");
-  const [sendBusy, setSendBusy] = useState(false);
-  const [sendResult, setSendResult] = useState<{ readonly supplier: string; readonly message: string } | null>(null);
+  // #31: náhľad + potvrdenie pred odoslaním objednávky mailom — vyňaté do
+  // vlastného hooku (issue 64), aby sa v tomto súbore uvoľnilo miesto pod
+  // eslint `max-lines: 400` pre novú funkciu nižšie (poznámka k objednávke),
+  // BEZ zmeny správania (`useSupplierMailActions.ts`).
+  const {
+    previewSupplier,
+    preview,
+    previewError,
+    sendBusy,
+    sendResult,
+    openPreview,
+    closePreview,
+    confirmSend,
+    copyOrderToClipboard,
+  } = useSupplierMailActions(onSessionExpired);
 
   const load = useCallback(() => {
     fetchOpenOrders()
@@ -271,86 +279,36 @@ export function OrdersSection({
     [emailDraft, onSessionExpired],
   );
 
-  // #31: náhľad pred odoslaním — server prepočíta predmet/telo/adresáta zo
-  // skutočného aktuálneho stavu (nikdy sa nedôveruje tomu, čo je práve
-  // zobrazené na klientovi).
-  const openPreview = useCallback(
-    (supplier: string) => {
-      setPreviewSupplier(supplier);
-      setPreview(null);
-      setPreviewError("");
-      setSendResult(null);
-      fetchSupplierOrderMailPreview(supplier)
-        .then((p) => {
-          setPreview(p);
+  // issue 64: manažérova voľná poznámka k CELEJ objednávke — NEZÁVISLÉ od
+  // riadku (na rozdiel od `changeState`/`changeOrdered` vyššie, kľúčované
+  // `orderId`, nie `lineId`). Po úspechu sa lokálne aktualizujú VŠETKY
+  // riadky s rovnakým `orderId` naprieč VŠETKÝMI skupinami dodávateľov (na
+  // rozdiel od `toggleGroupOrdered`, ktoré mutuje len JEDNU skupinu — jedna
+  // objednávka môže mať riadky u viacerých dodávateľov naraz).
+  const [busyCommentOrderId, setBusyCommentOrderId] = useState<string | null>(null);
+
+  const changeComment = useCallback(
+    (orderId: string, comment: string | null) => {
+      setStateError("");
+      setBusyCommentOrderId(orderId);
+      updateOrderComment(orderId, comment)
+        .then(() => {
+          setSuppliers((current) =>
+            current.map((group) => ({
+              ...group,
+              lines: group.lines.map((line) => (line.orderId === orderId ? { ...line, comment } : line)),
+            })),
+          );
         })
         .catch((err: unknown) => {
           if (err instanceof OrdersUnauthorizedError) {
             onSessionExpired();
             return;
           }
-          setPreviewError(err instanceof Error ? err.message : "Náhľad mailu sa nepodarilo načítať.");
-        });
-    },
-    [onSessionExpired],
-  );
-
-  const closePreview = useCallback(() => {
-    setPreviewSupplier(null);
-    setPreview(null);
-    setPreviewError("");
-  }, []);
-
-  const confirmSend = useCallback(
-    (supplier: string) => {
-      setSendBusy(true);
-      sendSupplierOrderMail(supplier)
-        .then((result) => {
-          setSendResult({
-            supplier,
-            message: result.ok
-              ? `Objednávka bola odoslaná na ${preview?.to ?? "e-mail dodávateľa"}.`
-              : (result.error ?? "Odoslanie sa nepodarilo."),
-          });
-          if (result.ok) {
-            setPreviewSupplier(null);
-            setPreview(null);
-          }
-        })
-        .catch((err: unknown) => {
-          if (err instanceof OrdersUnauthorizedError) {
-            onSessionExpired();
-            return;
-          }
-          setSendResult({ supplier, message: err instanceof Error ? err.message : "Odoslanie sa nepodarilo." });
+          setStateError(err instanceof Error ? err.message : "Uloženie poznámky sa nepodarilo.");
         })
         .finally(() => {
-          setSendBusy(false);
-        });
-    },
-    [onSessionExpired, preview],
-  );
-
-  const copyOrderToClipboard = useCallback(
-    (supplier: string) => {
-      fetchSupplierOrderMailPreview(supplier)
-        .then(async (p) => {
-          try {
-            await navigator.clipboard.writeText(p.body);
-            setSendResult({ supplier, message: "Text objednávky skopírovaný do schránky." });
-          } catch {
-            setSendResult({ supplier, message: "Kopírovanie do schránky sa nepodarilo." });
-          }
-        })
-        .catch((err: unknown) => {
-          if (err instanceof OrdersUnauthorizedError) {
-            onSessionExpired();
-            return;
-          }
-          setSendResult({
-            supplier,
-            message: err instanceof Error ? err.message : "Text objednávky sa nepodarilo pripraviť.",
-          });
+          setBusyCommentOrderId(null);
         });
     },
     [onSessionExpired],
@@ -423,9 +381,11 @@ export function OrdersSection({
           busyOrderedLineId={busyOrderedLineId}
           busyOrderedSupplier={busyOrderedSupplier}
           busySupplierLineId={busySupplierLineId}
+          busyCommentOrderId={busyCommentOrderId}
           onChangeState={changeState}
           onChangeOrdered={changeOrdered}
           onAssignSupplier={assignSupplier}
+          onChangeComment={changeComment}
           editingEmailSupplier={editingEmailSupplier}
           emailDraft={emailDraft}
           emailBusy={emailBusy}

--- a/apps/web/src/components/SupplierOrderGroup.tsx
+++ b/apps/web/src/components/SupplierOrderGroup.tsx
@@ -20,9 +20,11 @@ export function SupplierOrderGroup({
   busyOrderedLineId,
   busyOrderedSupplier,
   busySupplierLineId,
+  busyCommentOrderId,
   onChangeState,
   onChangeOrdered,
   onAssignSupplier,
+  onChangeComment,
   editingEmailSupplier,
   emailDraft,
   emailBusy,
@@ -50,9 +52,12 @@ export function SupplierOrderGroup({
   readonly busyOrderedSupplier: string | null;
   // issue 63: riadok, ktorého ručné priradenie dodávateľa PRÁVE TERAZ ukladá.
   readonly busySupplierLineId: string | null;
+  // issue 64: objednávka, ktorej poznámka PRÁVE TERAZ ukladá.
+  readonly busyCommentOrderId: string | null;
   readonly onChangeState: (lineId: string, newState: OrderLine["state"]) => void;
   readonly onChangeOrdered: (lineId: string, ordered: boolean) => void;
   readonly onAssignSupplier: (lineId: string, supplier: string) => void;
+  readonly onChangeComment: (orderId: string, comment: string | null) => void;
   readonly editingEmailSupplier: string | null;
   readonly emailDraft: string;
   readonly emailBusy: boolean;
@@ -142,9 +147,11 @@ export function SupplierOrderGroup({
               supplierBusy={busyOrderedSupplier === group.supplier}
               variantTotal={variantTotals.get(line.variantCode)}
               busySupplierLineId={busySupplierLineId}
+              busyCommentOrderId={busyCommentOrderId}
               onChangeState={onChangeState}
               onChangeOrdered={onChangeOrdered}
               onAssignSupplier={onAssignSupplier}
+              onChangeComment={onChangeComment}
             />
           ))}
         </tbody>

--- a/apps/web/src/ordersApi.test.ts
+++ b/apps/web/src/ordersApi.test.ts
@@ -10,6 +10,7 @@ import {
   setSupplierEmail,
   setSupplierLinesOrdered,
   triggerOrdersIngest,
+  updateOrderComment,
   updateOrderLineOrdered,
   updateOrderLineState,
 } from "./ordersApi.js";
@@ -196,6 +197,42 @@ it("assignOrderLineSupplier pri 401 vyhodí OrdersUnauthorizedError", async () =
   vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 401 })));
   await expect(
     assignOrderLineSupplier("11111111-1111-1111-1111-111111111111", "Alfa"),
+  ).rejects.toBeInstanceOf(OrdersUnauthorizedError);
+});
+
+// issue 64: manažérova voľná poznámka k CELEJ objednávke.
+it("updateOrderComment pošle PUT na správnu trasu s telom { comment }", async () => {
+  const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true, comment: "Zavolať" }), { status: 200 }));
+  vi.stubGlobal("fetch", fetchMock);
+
+  await updateOrderComment("22222222-2222-2222-2222-222222222222", "Zavolať");
+
+  expect(fetchMock).toHaveBeenCalledWith(
+    "/api/orders/22222222-2222-2222-2222-222222222222/comment",
+    expect.objectContaining({
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ comment: "Zavolať" }),
+    }),
+  );
+});
+
+it("updateOrderComment posiela null ako prázdny reťazec (server ho mapuje na vymazanie)", async () => {
+  const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true, comment: null }), { status: 200 }));
+  vi.stubGlobal("fetch", fetchMock);
+
+  await updateOrderComment("22222222-2222-2222-2222-222222222222", null);
+
+  expect(fetchMock).toHaveBeenCalledWith(
+    "/api/orders/22222222-2222-2222-2222-222222222222/comment",
+    expect.objectContaining({ body: JSON.stringify({ comment: "" }) }),
+  );
+});
+
+it("updateOrderComment pri 401 vyhodí OrdersUnauthorizedError", async () => {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 401 })));
+  await expect(
+    updateOrderComment("22222222-2222-2222-2222-222222222222", "pokus"),
   ).rejects.toBeInstanceOf(OrdersUnauthorizedError);
 });
 

--- a/apps/web/src/ordersApi.ts
+++ b/apps/web/src/ordersApi.ts
@@ -193,6 +193,21 @@ export async function assignOrderLineSupplier(lineId: string, supplier: string):
   await readJson(response, "Priradenie dodávateľa sa nepodarilo");
 }
 
+// issue 64: manažérova voľná poznámka k CELEJ objednávke — `orderId` je
+// spoločný pre VŠETKY riadky tej istej objednávky (`OrderLine.orderId`),
+// server-strana `setOrderComment` (`modules/orders/state.ts`) mutuje
+// `order.comment` priamo, nezávisle od `lineId`. Prázdny reťazec (po orezaní
+// na serveri) maže poznámku — volajúci (`OrdersSection.tsx`'s `changeComment`)
+// posiela `comment ?? ""` rovnakým vzorom ako `setSupplierEmail`.
+export async function updateOrderComment(orderId: string, comment: string | null): Promise<void> {
+  const response = await fetch(`/api/orders/${orderId}/comment`, {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ comment: comment ?? "" }),
+  });
+  await readJson(response, "Uloženie poznámky sa nepodarilo");
+}
+
 const setSupplierLinesOrderedResultSchema = z.object({ ok: z.literal(true), ordered: z.boolean(), lineCount: z.number() });
 
 // issue 60: hromadné označenie/zrušenie CELEJ skupiny dodávateľa naraz — server

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -772,6 +772,27 @@ tr:last-child td {
   font-size: var(--fs-text-sm);
 }
 
+/* issue 64: poznámka k CELEJ objednávke — rovnaký vizuálny jazyk ako
+   `.ord-supplier-assign`/`-input` vyššie (`flex-wrap: wrap`, rovnaký dôvod:
+   bez zalomenia by vstup + tlačidlo pri užšom stĺpci pretiekli do
+   susedného stĺpca). Širšie ako priradenie dodávateľa — voľný text (max
+   2000 znakov) je typicky dlhší než meno dodávateľa. */
+.ord-comment-cell {
+  display: flex;
+  align-items: center;
+  gap: var(--fs-space-1);
+  flex-wrap: wrap;
+  max-width: 220px;
+}
+.ord-comment-input {
+  width: 160px;
+  padding: var(--fs-space-1) var(--fs-space-2);
+  border: 1px solid var(--fs-border);
+  border-radius: var(--fs-radius-sm);
+  font: inherit;
+  font-size: var(--fs-text-sm);
+}
+
 /* issue 59: nastavenie otvorených stavov objednávok — rovnaký vizuálny
    jazyk ako `.autostatus`/`.mail-preview` vyššie (karta na svetlom podklade),
    vlastný namespace, aby sa nekolidovalo s tabuľkovými triedami. */

--- a/apps/web/src/useSupplierMailActions.ts
+++ b/apps/web/src/useSupplierMailActions.ts
@@ -1,0 +1,134 @@
+import { useCallback, useState } from "react";
+import {
+  fetchSupplierOrderMailPreview,
+  OrdersUnauthorizedError,
+  sendSupplierOrderMail,
+  type OrderMailPreview,
+} from "./ordersApi.js";
+
+// issue 64: mechanicky vyňaté z `OrdersSection.tsx` (#31 — náhľad + odoslanie
+// objednávky mailom dodávateľovi + kopírovanie do schránky), BEZ ZMENY
+// SPRÁVANIA — rovnaký zámer ako predchádzajúce extrakcie
+// (`OrderLineRow.tsx`/`SupplierOrderGroup.tsx`, `.claude/rules/
+// frontend-design.md`), len tentokrát vlastný HOOK namiesto komponenty: tento
+// blok nemá vlastný markup, je to čisto stav + tri handlery, ktoré
+// `SupplierActionsPanel` dostáva ako props. Extrakcia uvoľnila v
+// `OrdersSection.tsx` miesto (eslint `max-lines: 400`) pre novú funkciu
+// tohto ticketu (poznámka k objednávke) bez toho, aby sa čokoľvek z tejto
+// mailovej logiky menilo.
+export interface SupplierMailActions {
+  readonly previewSupplier: string | null;
+  readonly preview: OrderMailPreview | null;
+  readonly previewError: string;
+  readonly sendBusy: boolean;
+  readonly sendResult: { readonly supplier: string; readonly message: string } | null;
+  readonly openPreview: (supplier: string) => void;
+  readonly closePreview: () => void;
+  readonly confirmSend: (supplier: string) => void;
+  readonly copyOrderToClipboard: (supplier: string) => void;
+}
+
+export function useSupplierMailActions(onSessionExpired: () => void): SupplierMailActions {
+  const [previewSupplier, setPreviewSupplier] = useState<string | null>(null);
+  const [preview, setPreview] = useState<OrderMailPreview | null>(null);
+  const [previewError, setPreviewError] = useState("");
+  const [sendBusy, setSendBusy] = useState(false);
+  const [sendResult, setSendResult] = useState<{ readonly supplier: string; readonly message: string } | null>(null);
+
+  // #31: náhľad pred odoslaním — server prepočíta predmet/telo/adresáta zo
+  // skutočného aktuálneho stavu (nikdy sa nedôveruje tomu, čo je práve
+  // zobrazené na klientovi).
+  const openPreview = useCallback(
+    (supplier: string) => {
+      setPreviewSupplier(supplier);
+      setPreview(null);
+      setPreviewError("");
+      setSendResult(null);
+      fetchSupplierOrderMailPreview(supplier)
+        .then((p) => {
+          setPreview(p);
+        })
+        .catch((err: unknown) => {
+          if (err instanceof OrdersUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setPreviewError(err instanceof Error ? err.message : "Náhľad mailu sa nepodarilo načítať.");
+        });
+    },
+    [onSessionExpired],
+  );
+
+  const closePreview = useCallback(() => {
+    setPreviewSupplier(null);
+    setPreview(null);
+    setPreviewError("");
+  }, []);
+
+  const confirmSend = useCallback(
+    (supplier: string) => {
+      setSendBusy(true);
+      sendSupplierOrderMail(supplier)
+        .then((result) => {
+          setSendResult({
+            supplier,
+            message: result.ok
+              ? `Objednávka bola odoslaná na ${preview?.to ?? "e-mail dodávateľa"}.`
+              : (result.error ?? "Odoslanie sa nepodarilo."),
+          });
+          if (result.ok) {
+            setPreviewSupplier(null);
+            setPreview(null);
+          }
+        })
+        .catch((err: unknown) => {
+          if (err instanceof OrdersUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setSendResult({ supplier, message: err instanceof Error ? err.message : "Odoslanie sa nepodarilo." });
+        })
+        .finally(() => {
+          setSendBusy(false);
+        });
+    },
+    [onSessionExpired, preview],
+  );
+
+  const copyOrderToClipboard = useCallback(
+    (supplier: string) => {
+      fetchSupplierOrderMailPreview(supplier)
+        .then(async (p) => {
+          try {
+            await navigator.clipboard.writeText(p.body);
+            setSendResult({ supplier, message: "Text objednávky skopírovaný do schránky." });
+          } catch {
+            setSendResult({ supplier, message: "Kopírovanie do schránky sa nepodarilo." });
+          }
+        })
+        .catch((err: unknown) => {
+          if (err instanceof OrdersUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setSendResult({
+            supplier,
+            message: err instanceof Error ? err.message : "Text objednávky sa nepodarilo pripraviť.",
+          });
+        });
+    },
+    [onSessionExpired],
+  );
+
+  return {
+    previewSupplier,
+    preview,
+    previewError,
+    sendBusy,
+    sendResult,
+    openPreview,
+    closePreview,
+    confirmSend,
+    copyOrderToClipboard,
+  };
+}

--- a/apps/web/tests/e2e/orders.spec.ts
+++ b/apps/web/tests/e2e/orders.spec.ts
@@ -175,7 +175,13 @@ test("manažér vidí otvorené objednávky zoskupené podľa dodávateľa, konz
   await expect(riadokAlfa).toContainText("46");
   await expect(riadokAlfa).toContainText("2");
   await expect(riadokAlfa).toContainText("Čaká sa");
-  await expect(riadokAlfa).toContainText("Zavolať pred doručením");
+  // issue 64: poznámka k objednávke je pre `canChangeState` role (tento účet
+  // je "manazer") editovateľný `<input>`, nie prostý text — `toContainText`
+  // číta `textContent`, ktorý hodnotu `<input>` NEOBSAHUJE. Skutočnú hodnotu
+  // preto overuje `toHaveValue` na samotnom vstupe (rovnaký dôvod ako
+  // `.claude/rules/testing.md`'s poznámka o jest-dom matcheroch — tu ide o
+  // Playwright, nie vitest, ale princíp "vstup nie je text" je ten istý).
+  await expect(riadokAlfa.getByLabel("Poznámka k objednávke 9001 / 4859/46")).toHaveValue("Zavolať pred doručením");
 
   // issue 67: fixtúra ("4859/46") má reálny holý odkaz na dodávateľa
   // (`internalNote`) aj kód dodávateľa (`externalCode`, "OB832") —
@@ -288,7 +294,13 @@ test("manažér nastaví e-mail dodávateľa a uvidí náhľad mailu so správne
   const skupinaTest1 = page.getByTestId("supplier-DODAVATEL-TEST-1");
   await skupinaTest1.getByRole("button", { name: "Upraviť e-mail" }).click();
   await skupinaTest1.getByLabel("E-mail dodávateľa DODAVATEL-TEST-1").fill("test1@dodavatel.example");
-  await skupinaTest1.getByRole("button", { name: "Uložiť" }).click();
+  // issue 64: `{ exact: true }` — skupina teraz obsahuje AJ tlačidlo na
+  // uloženie poznámky k objednávke ("💾", aria-label "Uložiť poznámku k
+  // objednávke…"), ktorého accessible name OBSAHUJE "Uložiť" ako substring
+  // (rovnaký zistený vzor ako issue 63 nižšie, `.claude/rules/http-routes.md`
+  // susedný komentár vysvetľuje princíp: oprava patrí na stranu TOHTO
+  // (existujúceho, užšieho) locatora).
+  await skupinaTest1.getByRole("button", { name: "Uložiť", exact: true }).click();
   await expect(skupinaTest1.getByText("E-mail dodávateľa: test1@dodavatel.example")).toBeVisible();
   await expect(skupinaTest1.getByRole("button", { name: "✉️ Poslať objednávku e-mailom" })).toBeDisabled();
 
@@ -450,6 +462,60 @@ test("manažér odškrtne riadok ako objednaný a hromadne označí/zruší cel�
   const oznacitTlacidlo = skupina.getByRole("button", { name: "✔ Označiť skupinu ako objednané" });
   await oznacitTlacidlo.click();
   await expect(riadokPoReloade.locator("input[type='checkbox']")).toBeChecked();
+
+  expect(chyby).toEqual([]);
+});
+
+// issue 64: rovnaký mechanizmus a dôvod ako `E2E_PRIRADENIE_EMAIL`/
+// `E2E_OBJEDNANE_EMAIL` vyššie — balík je UŽ na hranici `MAX_ATTEMPTS`
+// (komentár pri `E2E_NAV_EMAIL` v `scripts/e2e-setup.ts`).
+const E2E_KOMENTAR_EMAIL = "e2e-komentar@forestshop.sk";
+
+// issue 64: manažérova voľná poznámka k CELEJ objednávke. Používa objednávku 9001
+// (skupina "DODAVATEL-TEST-1", JEDINÝ riadok, seedovaná s poznámkou "Zavolať
+// pred doručením") — test EDITUJE túto zdieľanú poznámku, ale nepridáva ani
+// nepresúva žiadny riadok (na rozdiel od testu priradenia nižšie), takže
+// nemení počty, na ktoré sa spolieha test odškrtávania vyššie ("skupina má
+// vždy presne 1 riadok"). Poznámka sa na konci VRÁTI na pôvodnú hodnotu —
+// hygiena zdieľaných dát pre prípadné ďalšie testy pridané neskôr v tomto
+// súbore (rovnaká disciplína ako restore-at-end kdekoľvek inde v projekte).
+test("manažér napíše a upraví poznámku k objednávke, zmena pretrvá po obnovení stránky, konzola je čistá", async ({
+  page,
+}) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/?tab=orders");
+  await page.getByLabel("E-mail").fill(E2E_KOMENTAR_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await expect(page.getByRole("heading", { name: "Na objednanie" })).toBeVisible();
+
+  const vstup = page.getByLabel("Poznámka k objednávke 9001 / 4859/46");
+  await expect(vstup).toHaveValue("Zavolať pred doručením");
+
+  await vstup.fill("Vyzdvihnúť v sklade do piatku");
+  await page.getByLabel("Uložiť poznámku k objednávke 9001 / 4859/46").click();
+  // `toHaveValue` skutočne čaká (opakovane skúša), kým lokálny optimistický
+  // update po vyriešení PUT promisu prejaví — rovnaký dôvod ako `<select>`
+  // v teste stavu vyššie (`.claude/rules/testing.md`).
+  await expect(vstup).toHaveValue("Vyzdvihnúť v sklade do piatku");
+  await expect(page.getByRole("alert")).toHaveCount(0);
+
+  await page.reload();
+  await expect(page.getByRole("heading", { name: "Na objednanie" })).toBeVisible();
+  const vstupPoReloade = page.getByLabel("Poznámka k objednávke 9001 / 4859/46");
+  await expect(vstupPoReloade).toHaveValue("Vyzdvihnúť v sklade do piatku");
+
+  // Vrátenie na pôvodnú hodnotu (hygiena zdieľaných fixtúrových dát).
+  await vstupPoReloade.fill("Zavolať pred doručením");
+  await page.getByLabel("Uložiť poznámku k objednávke 9001 / 4859/46").click();
+  await expect(vstupPoReloade).toHaveValue("Zavolať pred doručením");
 
   expect(chyby).toEqual([]);
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.50",
+  "version": "0.3.0-dev.51",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -91,6 +91,14 @@ const E2E_SUCET_EMAIL = "e2e-sucet@forestshop.sk"; // musí sa zhodovať s hodno
 // `max-lines`, `.claude/rules/testing.md`).
 const E2E_PRIRADENIE_EMAIL = "e2e-priradenie@forestshop.sk"; // musí sa zhodovať s hodnotou v orders-supplier-assign.spec.ts
 
+// issue 64: rovnaký mechanizmus a dôvod ako `E2E_PRIRADENIE_EMAIL` vyššie —
+// zdieľaný `e2e@forestshop.sk` je PRESNE na hranici `MAX_ATTEMPTS` (10
+// prihlásení naprieč `catalog.spec.ts`(3)+`login.spec.ts`(2)+
+// `orders.spec.ts`(3)+`pairing.spec.ts`(2), overené naživo počítaním pred
+// touto zmenou) — nový test (poznámka k objednávke) dostáva VLASTNÝ
+// izolovaný účet namiesto ďalšieho prihlásenia pod zdieľaným.
+const E2E_KOMENTAR_EMAIL = "e2e-komentar@forestshop.sk"; // musí sa zhodovať s hodnotou v orders.spec.ts
+
 const { db, pool } = createDb();
 // Konštantný literál bez interpolácie — obyčajný reťazec je tu rovnako bezpečný
 // ako `sql` tagovaná šablóna (tú používa ekvivalentný apps/api/tests/helpers/db.ts),
@@ -172,6 +180,12 @@ await db.insert(users).values({
 });
 await db.insert(users).values({
   email: E2E_PRIRADENIE_EMAIL,
+  passwordHash: await hashPassword(E2E_HESLO),
+  displayName: "E2E Manažér",
+  role: "manazer",
+});
+await db.insert(users).values({
+  email: E2E_KOMENTAR_EMAIL,
   passwordHash: await hashPassword(E2E_HESLO),
   displayName: "E2E Manažér",
   role: "manazer",


### PR DESCRIPTION
Closes #64

## Čo pridáva

Manažér (rola `admin`/`manazer`) teraz môže napísať a upraviť voľnú poznámku
k CELEJ objednávke priamo v stĺpci "Komentár" na obrazovke "Na objednanie" —
inline vstup + uložiť tlačidlo, rovnaký vizuálny jazyk ako existujúce ručné
priradenie dodávateľa. `order.comment` stĺpec už existoval (import ho nikdy
neprepíše), chýbala len zápisová trasa + UI.

- `PUT /api/orders/:id/comment` (`orders-routes.ts` + `state.ts`'s
  `setOrderComment`) — rovnaké oprávnenie ako ostatné zápisy v tomto súbore,
  audit v tej istej transakcii, cap 2000 znakov (rovnaký ako legacy appka).
- Editovateľný vstup v `OrderLineRow.tsx`, viditeľný len pre `canChangeState`
  role. Uloženie aktualizuje VŠETKY riadky tej istej objednávky (poznámka
  patrí objednávke, nie riadku).
- Enabling refaktor: mailový náhľad/odoslanie (#31) mechanicky vyňaté z
  `OrdersSection.tsx` do `useSupplierMailActions.ts` (bez zmeny správania),
  aby sa uvoľnilo miesto pod eslint `max-lines: 400`.

Návrh + zamietnuté alternatívy: issue 64 komentár.

## Test plan

- [x] `apps/api/tests/orders-http-comment.integration.test.ts` — 6 nových testov
- [x] `apps/web/src/ordersApi.test.ts` — 3 nové testy
- [x] `apps/web/src/components/OrdersSection.comment.test.tsx` — 4 nové testy
- [x] `apps/web/tests/e2e/orders.spec.ts` — nový e2e test (napísať, uložiť,
      reload, pretrváva) + 2 existujúce testy opravené (kolízia s novým UI)
- [x] CI zelené (check, docker-build, integration, version-check, e2e)
