### PR TITLE
Playbook + autopilot log for issue 64 (docs only)

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -113,3 +113,22 @@ paths:
   dodávateľa" test) is `fireEvent.change` followed by `fireEvent.click`
   on the actual save/submit BUTTON — use that, not a keyDown-Enter
   shortcut, for any new form-field-plus-save-button interaction test.
+- **The "controlled draft reset via `useEffect` + skip-first-mount" pattern
+  (established for `supplierDraft`, issue 63) needs an EXTRA "dirty" guard
+  when the same prop can change for a reason OTHER than "this row's own
+  save resolved".** Issue 64's `commentDraft` in `OrderLineRow.tsx`:
+  `line.comment` is shared across every row of the same order
+  (`OrdersSection.tsx`'s `changeComment` updates all of them on any one
+  row's save), so the reset effect fires on EVERY sibling row too — not
+  just the row that actually saved. Without an extra guard, an unsaved
+  draft on row A is silently overwritten the moment row B (same order)
+  saves. Fix: an `isCommentDirty` ref, set on every keystroke, cleared only
+  when THIS row's own save fires; the reset effect skips the reset while
+  dirty. Found by code review (`superpowers:requesting-code-review`)
+  BEFORE merge, not by a test — the existing propagation test only proved
+  the happy path (edit-then-verify-sibling-updates), never two
+  simultaneously-dirty drafts. Test on any FUTURE prop-syncing effect of
+  this shape: does the same prop change for a reason OTHER than "this
+  instance's own action completed"? If yes, "skip first mount" alone is
+  not enough — add the dirty guard too (see `.claude/rules/orders.md`'s
+  matching entry for the full mechanism).

--- a/.claude/rules/orders.md
+++ b/.claude/rules/orders.md
@@ -287,3 +287,20 @@ paths:
   (rovnaký vzor ako existujúca `/api/me` 401 výnimka). **Zakázané: "opraviť"
   to rozšírením konzolovej výnimky na hocijakú ĎALŠIU cestu/kód bez tejto
   úvahy** — presne to `testing.md` výslovne zakazuje.
+- **Zápis, ktorý je vlastníctvom OBJEDNÁVKY (nie riadku) a zobrazuje sa na
+  VIACERÝCH riadkoch naraz, potrebuje NAVYŠE "dirty" strážcu na reset efekte,
+  nielen "skip prvý mount" guard.** Issue 64 (`PUT /api/orders/:id/comment` +
+  `OrderLineRow.tsx`'s editovateľná bunka "Komentár"): `OrdersSection.tsx`'s
+  `changeComment` aktualizuje `line.comment` na VŠETKÝCH riadkoch s rovnakým
+  `orderId` (správne — poznámka patrí objednávke). Ale to znamená, že
+  uloženie cez RIADOK B tej istej objednávky spustí `OrderLineRow.tsx`'s
+  reset efekt AJ na RIADKU A — ktorý efekt (bez ďalšieho stráženia) nevie
+  rozlíšiť "toto sa zmenilo, lebo som si to sám uložil" od "toto sa zmenilo,
+  lebo niekto INÝ uložil poznámku tej istej objednávky odinakiaľ", a ticho
+  by prepísal riadku A ešte NEULOŽENÝ rozpísaný koncept (našlo code review
+  pred mergom, nie žiadny test — pozri `frontend-design.md`'s zodpovedajúci
+  bod pre samotnú opravu). Test na KAŽDÉ ĎALŠIE pole vlastnené OBJEDNÁVKOU
+  (nie riadkom), ktoré appka niekedy pridá s rovnakým "zobrazí sa na
+  viacerých riadkoch" tvarom: má reset efekt na to pole `isDirty` strážcu,
+  alebo len "skip prvý mount"? Ten druhý nestačí, keď zdroj resetu môže byť
+  ULOŽENIE NA INOM RIADKU, nielen vlastné prvé mountnutie.

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -3,6 +3,42 @@
 Terse per-ticket log of autopilot-worker cycles: issue(s), commit SHAs,
 RED→GREEN test names, key decisions, and the shared PR.
 
+## 2026-07-31 — #64 (order-comment write path — "Na objednanie" poznámka)
+
+- `PUT /api/orders/:id/comment` (`orders-routes.ts` + `state.ts`'s new
+  `setOrderComment`) — transaction + `FOR UPDATE` + audit, same shape as
+  sibling `setOrderLineState`/`setOrderLineOrdered`. `order.comment` column
+  pre-existed (F3, ingest never overwrites it) — no migration.
+- `OrderLineRow.tsx`'s "Komentár" cell becomes an editable input+save for
+  `canChangeState` roles; `OrdersSection.tsx`'s `changeComment` updates
+  every line sharing the edited row's `orderId` (comment is order-scoped).
+- Enabling refactor (same PR): #31 mail-preview/send state+handlers
+  mechanically extracted from `OrdersSection.tsx` into
+  `useSupplierMailActions.ts` (no behavior change) to stay under eslint
+  `max-lines: 400`.
+- Deep code review (pre-merge) found one real Important issue: a save on
+  row B of an order could silently clobber an unsaved draft on row A of
+  the SAME order (both share `orderId`). Fixed with an `isCommentDirty`
+  ref guard in `OrderLineRow.tsx`. RED regression test:
+  `OrdersSection.comment.test.tsx` "nerozostavaný koncept na riadku A
+  PREŽIJE uloženie poznámky cez riadok B" — confirmed RED against the
+  pre-fix code (`79480c6`), GREEN after (`03186ca`).
+- New backend tests: `orders-http-comment.integration.test.ts` (6). New
+  frontend tests: `ordersApi.test.ts` (+3), `OrdersSection.comment.test.tsx`
+  (5, incl. the regression test above). New e2e test in `orders.spec.ts`
+  under a fresh isolated account (`e2e-komentar@forestshop.sk` — the
+  shared `e2e@forestshop.sk` was already at `MAX_ATTEMPTS=10` across all
+  spec files) plus two pre-existing tests fixed for the new UI colliding
+  with them (`{exact:true}` on a substring-matched "Uložiť" button;
+  `toContainText`→`toHaveValue` since the comment moved from text to an
+  `<input>`).
+- PR #93, merged `6b57422e`, deployed + verified live (v0.3.0-dev.51):
+  wrote a note on order 20261228 (2 lines) via one row's input, confirmed
+  it appeared on BOTH lines before any reload, confirmed it survived a
+  reload, then cleared it back to the original empty value via the same
+  UI flow — restored state confirmed via DB query (`comment` = NULL) and a
+  second reload. 0 console errors/warnings throughout.
+
 ## 2026-07-31 — #86 (supplier-assignment write-side gaps, found by independent audit of #63)
 
 - **Finding 1**: `assignOrderLineSupplier` (`supplier-assignment.ts`) never

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.51",
+  "version": "0.3.0-dev.52",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Docs-only follow-up to PR #93 — playbook entries (`.claude/rules/orders.md`, `.claude/rules/frontend-design.md`) + `docs/autopilot-log.md` for issue 64, plus the mandatory version bump to 0.3.0-dev.52.