### PR TITLE
Pass SHOPTET_ADMIN_BASE_URL through to the production container

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -53,6 +53,13 @@ services:
       # (#21), bare kľúč preberá `/srv/forestshop/.env`, keď tam je.
       SHOPTET_ORDERS_URL:
       ORDERS_RAW_DIR: /data/orders-raw
+      # issue 65: priamy odkaz do Shoptet administrácie pri riadku objednávky
+      # — NA ROZDIEL od SHOPTET_EXPORT_URL/SHOPTET_ORDERS_URL vyššie toto
+      # NIE JE tajomstvo (žiadny prihlasovací `hash`) a `env.ts`'s zod schéma
+      # má rozumný `.default(...)`, takže appka funguje aj bez tohto riadku
+      # v `/srv/forestshop/.env` — bare kľúč tu je len na to, aby sa dala
+      # doména zmeniť BEZ nového deploy/buildu, keby to niekedy bolo treba.
+      SHOPTET_ADMIN_BASE_URL:
       # Odosielanie objednávky dodávateľovi mailom (#31) — rovnaká úvaha ako
       # SHOPTET_EXPORT_URL vyššie: `.optional()` v `env.ts`, bare kľúč
       # preberá `/srv/forestshop/.env`, keď tam je; keď nie je, appka beží

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.53",
+  "version": "0.3.0-dev.54",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Closes #65 (follow-up)

Small config-wiring fix found during post-deploy verification of PR #96:
`docker-compose.prod.yml` never listed the new `SHOPTET_ADMIN_BASE_URL`
env var, so an operator setting it in `/srv/forestshop/.env` would have
had no effect on the running container. Same bare-key pass-through
pattern as `SHOPTET_EXPORT_URL`/`SHOPTET_ORDERS_URL`.

The feature itself was already correct in production (env.ts's zod
default matches the real domain) — this only fixes configurability
without a new build.

## Test plan
- [x] CI green on dev (check, integration, e2e, docker-build, version-check)