### PR TITLE
Klikateľné číslo objednávky namiesto ikonky (issue 99)

### DIFF
--- a/apps/web/src/components/OrderLineRow.adminLink.test.tsx
+++ b/apps/web/src/components/OrderLineRow.adminLink.test.tsx
@@ -1,0 +1,70 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { OrdersSection } from "./OrdersSection.js";
+
+// issue 99: číslo objednávky sa stalo klikateľným odkazom do administrácie
+// Shoptetu namiesto samostatnej ikonky `🔗` (issue 65). Vlastný súbor —
+// `OrdersSection.test.tsx` je už na eslint `max-lines: 400` hranici
+// (`.claude/rules/frontend-design.md`'s zavedený vzor: nový tematický súbor
+// namiesto pridávania do veľkého existujúceho).
+const { fetchOpenOrders } = vi.hoisted(() => ({ fetchOpenOrders: vi.fn() }));
+
+vi.mock("../ordersApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../ordersApi.js")>();
+  return { ...actual, fetchOpenOrders };
+});
+
+const LINE = {
+  lineId: "55555555-5555-5555-5555-555555555555",
+  orderId: "cccccccc-5555-5555-5555-555555555555",
+  externalOrderId: "20261259",
+  customerName: "Zákazník Gama",
+  comment: null,
+  remark: null,
+  adminUrl: "https://www.forestshop.sk/admin/vyhladavanie/?string=20261259&src=orders",
+  placedAt: "2026-07-01T00:00:00.000Z",
+  variantCode: "C-1",
+  variantName: "Bunda FOREST 3001",
+  sizeLabel: null,
+  quantity: 1,
+  state: "objednane" as const,
+  ordered: false,
+  supplierUrl: null,
+  supplierNote: null,
+  externalCode: null,
+  supplierAssignable: false,
+  manualSupplierOverride: null,
+};
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+it("číslo objednávky je odkaz do administrácie Shoptetu so správnym href/target/rel", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Gama", lines: [LINE], email: null }]);
+
+  render(<OrdersSection role="citanie" onSessionExpired={() => {}} />);
+
+  const riadok = await screen.findByTestId(`order-line-${LINE.lineId}`);
+  const odkaz = within(riadok).getByRole<HTMLAnchorElement>("link", {
+    name: `Otvoriť objednávku ${LINE.externalOrderId} v administrácii Shoptet`,
+  });
+  expect(odkaz.href).toBe(LINE.adminUrl);
+  expect(odkaz.target).toBe("_blank");
+  expect(odkaz.rel).toBe("noreferrer noopener");
+  // Samotný text odkazu je číslo objednávky — nie prázdna ikonka.
+  expect(odkaz.textContent).toBe(LINE.externalOrderId);
+});
+
+it("v bunke objednávky neostáva žiadna samostatná ikonka odkazu (🔗)", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Gama", lines: [LINE], email: null }]);
+
+  render(<OrdersSection role="citanie" onSessionExpired={() => {}} />);
+
+  const riadok = await screen.findByTestId(`order-line-${LINE.lineId}`);
+  // issue 99: predtým bol vedľa čísla objednávky ešte SAMOSTATNÝ `<a>🔗</a>` —
+  // po zmene má bunka presne JEDEN odkaz (samotné číslo), žiadnu ikonku.
+  expect(within(riadok).getAllByRole("link", { name: /Otvoriť objednávku/ })).toHaveLength(1);
+  expect(riadok.textContent).not.toContain("🔗");
+});

--- a/apps/web/src/components/OrderLineRow.tsx
+++ b/apps/web/src/components/OrderLineRow.tsx
@@ -151,9 +151,11 @@ export function OrderLineRow({
         />
       </td>
       <td className="ord-order-cell">
-        {line.externalOrderId}
         {/* issue 65: priamy odkaz do Shoptet administrácie na TÚTO
-            objednávku (`queries.ts`'s `buildShoptetAdminOrderUrl`). */}
+            objednávku (`queries.ts`'s `buildShoptetAdminOrderUrl`).
+            issue 99: klikateľné je samotné ČÍSLO objednávky (majiteľ žiadal
+            doslovne "keď kliknem na kód objednávky") — pôvodná samostatná
+            ikonka `🔗` vedľa čísla zanikla, `line.adminUrl` sa nemení. */}
         <a
           href={line.adminUrl}
           target="_blank"
@@ -162,7 +164,7 @@ export function OrderLineRow({
           aria-label={`Otvoriť objednávku ${line.externalOrderId} v administrácii Shoptet`}
           title="Otvoriť v administrácii Shoptet"
         >
-          🔗
+          {line.externalOrderId}
         </a>
       </td>
       <td>{line.customerName}</td>

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -772,11 +772,13 @@ tr:last-child td {
   font-size: var(--fs-text-sm);
 }
 
-/* issue 65: priamy odkaz do Shoptet administrácie, malá ikonka hneď za
-   kódom objednávky — nenápadný, nezaberá miesto ako plnohodnotný text. */
+/* issue 65: priamy odkaz do Shoptet administrácie. issue 99: nesie teraz
+   samotné ČÍSLO objednávky (predtým osamotenú ikonku `🔗` vedľa neho) —
+   preto musí byť vizuálne rozpoznateľné ako odkaz (podčiarknutie + farba z
+   globálneho `a` resetu), nie ticho splynúť s okolitým textom bunky. */
 .ord-admin-link {
-  margin-left: var(--fs-space-1);
-  text-decoration: none;
+  font-weight: var(--fs-weight-medium);
+  text-decoration: underline;
 }
 /* issue 65: upozornenie na starú nevybavenú objednávku (>14 dní) — výrazná
    farba (`--fs-warning`), rovnaká sémantika ako `.orders-table tr.state-

--- a/apps/web/tests/e2e/orders.spec.ts
+++ b/apps/web/tests/e2e/orders.spec.ts
@@ -192,12 +192,20 @@ test("manažér vidí otvorené objednávky zoskupené podľa dodávateľa, konz
 
   // issue 65: zákaznícky odkaz (`remark`, read-only) + priamy odkaz do
   // Shoptet administrácie (`adminUrl`) — objednávka 9001.
+  // issue 99: klikateľné je samotné ČÍSLO objednávky (nie samostatná ikonka
+  // `🔗` vedľa neho, ktorá predtým niesla ten istý odkaz) — over href/target/
+  // rel AJ to, že viditeľný text odkazu je presne číslo objednávky a žiadna
+  // ikonka nezostala.
   await expect(riadokAlfa).toContainText("Prosím doručiť len v piatok");
   const adminOdkazAlfa = riadokAlfa.getByRole("link", { name: "Otvoriť objednávku 9001 v administrácii Shoptet" });
   await expect(adminOdkazAlfa).toHaveAttribute(
     "href",
     "https://www.forestshop.sk/admin/vyhladavanie/?string=9001&src=orders",
   );
+  await expect(adminOdkazAlfa).toHaveAttribute("target", "_blank");
+  await expect(adminOdkazAlfa).toHaveText("9001");
+  await expect(riadokAlfa.getByRole("link", { name: "Otvoriť objednávku" })).toHaveCount(1);
+  await expect(riadokAlfa).not.toContainText("🔗");
   // Objednávka 9001 je UŽ vybavená (stav "caka_sa") — upozornenie na staré
   // objednávky sa NIKDY nezobrazí pre vybavený riadok, aj keby bol starý.
   await expect(riadokAlfa.locator("[data-testid^='stale-badge-']")).toHaveCount(0);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.55",
+  "version": "0.3.0-dev.56",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Closes #99

Číslo objednávky v stĺpci OBJEDNÁVKA ("Na objednanie") je teraz samo
klikateľným odkazom do administrácie Shoptetu — namiesto samostatnej ikonky
`🔗` vedľa neho (issue 65). `target="_blank"` + `rel="noopener noreferrer"`
ostávajú, `SHOPTET_ADMIN_BASE_URL`/`adminUrl` sa nemení (len sa presúva, kam
vizuálne ukazuje). Odkaz je teraz podčiarknutý (`--fs-weight-medium` +
underline z globálneho `a` resetu), aby bol rozpoznateľný ako odkaz.

- `[red]`/`[green]` regresný pár: `OrderLineRow.adminLink.test.tsx`
- `orders.spec.ts` rozšírený o kontrolu viditeľného textu odkazu + že
  žiadna samostatná ikonka nezostala
- Design komentár s príčinou/prístupom/zamietnutou alternatívou:
  https://github.com/zbynekdrlik/forestshop-app/issues/99#issuecomment-5143231944
