### PR TITLE
Playbook: read-only prod DB check recipe (post issue 99)

### DIFF
--- a/.claude/rules/deploy.md
+++ b/.claude/rules/deploy.md
@@ -223,3 +223,22 @@ paths:
   `docker-container` drivera, nie o vždy-zlyhá chybu. Fix je jeden riadok
   (`uses: docker/setup-buildx-action@v3`), nie retry/`continue-on-error`
   okolo push kroku.
+
+- **Rýchla READ-ONLY kontrola produkčných dát po deployi (napr. "nezmenil
+  som počet riadkov/objednávok") ide cez `postgres` službu, NIE `app`** —
+  `docker compose -f docker-compose.prod.yml exec` cieli na kontajner
+  bežiaci PRIAMO Postgres, appka sama nemá `psql` nainštalované:
+  ```
+  ssh newlevel@dev2
+  cd /srv/forestshop
+  docker compose -f docker-compose.prod.yml exec -T postgres \
+    psql -U forestshop -d forestshop -t -c \
+    "select count(*) from order_line;"
+  ```
+  `"order"` je rezervované SQL kľúčové slovo (rovnaký dôvod ako
+  `.claude/rules/testing.md`'s `withCleanDb()` TRUNCATE poznámka) — v
+  priamom `-c` SQL stringu ho treba ručne uvodzovať (`"order"`), inak psql
+  ohlási syntax error. `-t` (tuples-only) vynechá hlavičku stĺpca, takže
+  výstup je priamo porovnateľné číslo. Použité pri issue 99's post-deploy
+  overení, že zmena UI odkazu nezmenila žiadny riadok v `order`/`order_line`/
+  `product_supplier_override`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.56",
+  "version": "0.3.0-dev.57",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Playbook-only follow-up to issue 99 (PR #100) — no user-facing change.

- Version bump to 0.3.0-dev.57 (dev is now equal to main after #100 merged;
  `version-bumping.md` requires the bump before any other dev commit).
- `.claude/rules/deploy.md`: documents the read-only `ssh + docker compose
  exec postgres + psql -t` recipe used to verify production data counts
  stayed unchanged post-deploy (issue 99's post-deploy verification),
  including the reserved-keyword `"order"` quoting gotcha.
