### PR TITLE
Rework "Na objednanie" into a fast, professional work screen (issue 95)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -108,7 +108,7 @@ export function App(): JSX.Element {
         >
           <ChangePasswordForm email={me.email} onSessionExpired={reload} />
         </Topbar>
-        <main>
+        <main className={tab?.wide === true ? "main-wide" : undefined}>
           {logoutError !== "" && <p role="alert">{logoutError}</p>}
           {ActiveComponent !== null && <ActiveComponent role={me.role} onSessionExpired={reload} />}
         </main>

--- a/apps/web/src/components/OrderLineRow.tsx
+++ b/apps/web/src/components/OrderLineRow.tsx
@@ -168,9 +168,14 @@ export function OrderLineRow({
         </a>
       </td>
       <td>{line.customerName}</td>
-      <td>{line.variantCode}</td>
+      {/* issue 95: KÓD + VEĽKOSŤ zlúčené (majiteľ, komentár #10: "veľkosť je
+          už súčasťou kódu") — veľkosť sa zobrazí len keď appka má samostatnú
+          `sizeLabel` hodnotu (nie každý variant ju má). */}
+      <td className="ord-code-cell">
+        {line.variantCode}
+        {line.sizeLabel !== null && <span className="ord-size-inline">{line.sizeLabel}</span>}
+      </td>
       <td>{line.variantName}</td>
-      <td>{line.sizeLabel ?? "—"}</td>
       <td className="ord-qty">
         {line.quantity} ks
         {qtyChip !== null && (
@@ -179,68 +184,74 @@ export function OrderLineRow({
           </span>
         )}
       </td>
-      <td className="ord-supplier-cell" data-testid={`supplier-link-${line.lineId}`}>
-        {line.supplierUrl !== null ? (
-          <a
-            href={line.supplierUrl}
-            target="_blank"
-            rel="noreferrer noopener"
-            className="ord-supplier-link"
-            // issue 72: variantName sám nestačí — dva riadky toho istého
-            // produktu v rôznych veľkostiach majú zhodný variantName, líšia
-            // sa len variantCode.
-            aria-label={`Odkaz na dodávateľa — ${line.variantName} (${line.variantCode})`}
-          >
-            Odkaz na dodávateľa
-          </a>
-        ) : line.supplierNote !== null ? (
-          <span className="ord-supplier-note" title={line.supplierNote}>
-            {line.supplierNote}
-          </span>
-        ) : line.externalCode === null ? (
-          "—"
-        ) : null}
-        {line.externalCode !== null && <div className="ord-supplier-code">kód {line.externalCode}</div>}
-      </td>
-      <td className="ord-supplier-assign" data-testid={`supplier-assign-cell-${line.lineId}`}>
-        {line.supplierAssignable ? (
-          <>
-            <input
-              type="text"
-              // Jeden zdieľaný `<datalist id="known-suppliers">` (rendrovaný
-              // raz v `OrdersSection.tsx`, z UŽ načítaných skupín) — žiadna
-              // nová GET trasa netreba len na našepkávanie.
-              list="known-suppliers"
-              className="ord-supplier-assign-input"
-              data-testid={`supplier-assign-input-${line.lineId}`}
-              aria-label={`Priradiť dodávateľa riadku objednávky ${line.externalOrderId} / ${line.variantCode}`}
-              placeholder="priradiť dodávateľa…"
-              value={supplierDraft}
-              disabled={supplierBusyHere}
-              onChange={(e) => {
-                setSupplierDraft(e.target.value);
-              }}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  e.preventDefault();
-                  saveSupplier();
-                }
-              }}
-            />
-            <button
-              type="button"
-              className="btn sm good"
-              data-testid={`supplier-assign-save-${line.lineId}`}
-              aria-label={`Uložiť priradenie dodávateľa riadku objednávky ${line.externalOrderId} / ${line.variantCode}`}
-              disabled={supplierBusyHere || supplierDraft.trim() === ""}
-              onClick={saveSupplier}
+      {/* issue 95: DODÁVATEĽ + PRIRADENIE DODÁVATEĽA zlúčené do jednej bunky
+          (majiteľ, komentár #1) — oba vnorené bloky nižšie sú BEZ ZMENY
+          (rovnaké testid, rovnaká logika), len vedľa seba v jednej `<td>`
+          namiesto dvoch samostatných stĺpcov. */}
+      <td className="ord-supplier-merged">
+        <div className="ord-supplier-cell" data-testid={`supplier-link-${line.lineId}`}>
+          {line.supplierUrl !== null ? (
+            <a
+              href={line.supplierUrl}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="ord-supplier-link"
+              // issue 72: variantName sám nestačí — dva riadky toho istého
+              // produktu v rôznych veľkostiach majú zhodný variantName, líšia
+              // sa len variantCode.
+              aria-label={`Odkaz na dodávateľa — ${line.variantName} (${line.variantCode})`}
             >
-              💾
-            </button>
-          </>
-        ) : (
-          "—"
-        )}
+              Odkaz na dodávateľa
+            </a>
+          ) : line.supplierNote !== null ? (
+            <span className="ord-supplier-note" title={line.supplierNote}>
+              {line.supplierNote}
+            </span>
+          ) : line.externalCode === null ? (
+            "—"
+          ) : null}
+          {line.externalCode !== null && <div className="ord-supplier-code">kód {line.externalCode}</div>}
+        </div>
+        <div className="ord-supplier-assign" data-testid={`supplier-assign-cell-${line.lineId}`}>
+          {line.supplierAssignable ? (
+            <>
+              <input
+                type="text"
+                // Jeden zdieľaný `<datalist id="known-suppliers">` (rendrovaný
+                // raz v `OrdersSection.tsx`, z UŽ načítaných skupín) — žiadna
+                // nová GET trasa netreba len na našepkávanie.
+                list="known-suppliers"
+                className="ord-supplier-assign-input"
+                data-testid={`supplier-assign-input-${line.lineId}`}
+                aria-label={`Priradiť dodávateľa riadku objednávky ${line.externalOrderId} / ${line.variantCode}`}
+                placeholder="priradiť dodávateľa…"
+                value={supplierDraft}
+                disabled={supplierBusyHere}
+                onChange={(e) => {
+                  setSupplierDraft(e.target.value);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    saveSupplier();
+                  }
+                }}
+              />
+              <button
+                type="button"
+                className="btn sm good"
+                data-testid={`supplier-assign-save-${line.lineId}`}
+                aria-label={`Uložiť priradenie dodávateľa riadku objednávky ${line.externalOrderId} / ${line.variantCode}`}
+                disabled={supplierBusyHere || supplierDraft.trim() === ""}
+                onClick={saveSupplier}
+              >
+                💾
+              </button>
+            </>
+          ) : (
+            "—"
+          )}
+        </div>
       </td>
       <td>
         {canChangeState ? (
@@ -286,54 +297,60 @@ export function OrderLineRow({
           </span>
         )}
       </td>
-      {/* issue 65: zákaznícky odkaz k objednávke — read-only, appka ho
-          nikdy needituje (na rozdiel od `comment` bunky nižšie). */}
-      <td className="ord-remark-cell" data-testid={`remark-cell-${line.lineId}`}>
-        {line.remark !== null ? (
-          <span className="ord-remark" title={line.remark}>
-            🛈 {line.remark}
-          </span>
-        ) : (
-          "—"
-        )}
-      </td>
-      <td className="ord-comment-cell" data-testid={`comment-cell-${line.lineId}`}>
-        {canChangeState ? (
-          <>
-            <input
-              type="text"
-              className="ord-comment-input"
-              data-testid={`comment-input-${line.lineId}`}
-              aria-label={`Poznámka k objednávke ${line.externalOrderId} / ${line.variantCode}`}
-              placeholder="poznámka…"
-              maxLength={2000}
-              value={commentDraft}
-              disabled={commentBusyHere}
-              onChange={(e) => {
-                isCommentDirty.current = true;
-                setCommentDraft(e.target.value);
-              }}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  e.preventDefault();
-                  saveComment();
-                }
-              }}
-            />
-            <button
-              type="button"
-              className="btn sm good"
-              data-testid={`comment-save-${line.lineId}`}
-              aria-label={`Uložiť poznámku k objednávke ${line.externalOrderId} / ${line.variantCode}`}
-              disabled={commentBusyHere}
-              onClick={saveComment}
-            >
-              💾
-            </button>
-          </>
-        ) : (
-          (line.comment ?? "—")
-        )}
+      {/* issue 95: POZNÁMKA E-SHOPU (`remark`, read-only) + KOMENTÁR zlúčené
+          do jednej bunky "Poznámky" (majiteľ, komentár #10) — oba vnorené
+          bloky nižšie sú BEZ ZMENY (rovnaké testid, rovnaká logika), len pod
+          sebou v jednej `<td>` namiesto dvoch samostatných stĺpcov. */}
+      <td className="ord-notes-merged">
+        {/* issue 65: zákaznícky odkaz k objednávke — read-only, appka ho
+            nikdy needituje (na rozdiel od `comment` bloku nižšie). */}
+        <div className="ord-remark-cell" data-testid={`remark-cell-${line.lineId}`}>
+          {line.remark !== null ? (
+            <span className="ord-remark" title={line.remark}>
+              🛈 {line.remark}
+            </span>
+          ) : (
+            "—"
+          )}
+        </div>
+        <div className="ord-comment-cell" data-testid={`comment-cell-${line.lineId}`}>
+          {canChangeState ? (
+            <>
+              <input
+                type="text"
+                className="ord-comment-input"
+                data-testid={`comment-input-${line.lineId}`}
+                aria-label={`Poznámka k objednávke ${line.externalOrderId} / ${line.variantCode}`}
+                placeholder="poznámka…"
+                maxLength={2000}
+                value={commentDraft}
+                disabled={commentBusyHere}
+                onChange={(e) => {
+                  isCommentDirty.current = true;
+                  setCommentDraft(e.target.value);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    saveComment();
+                  }
+                }}
+              />
+              <button
+                type="button"
+                className="btn sm good"
+                data-testid={`comment-save-${line.lineId}`}
+                aria-label={`Uložiť poznámku k objednávke ${line.externalOrderId} / ${line.variantCode}`}
+                disabled={commentBusyHere}
+                onClick={saveComment}
+              >
+                💾
+              </button>
+            </>
+          ) : (
+            (line.comment ?? "—")
+          )}
+        </div>
       </td>
     </tr>
   );

--- a/apps/web/src/components/OrdersSection.test.tsx
+++ b/apps/web/src/components/OrdersSection.test.tsx
@@ -156,13 +156,16 @@ it("zlúčená bunka POZNÁMKY drží poznámku e-shopu AJ komentár v tom istom
   expect(remarkBunka.closest("td")).toBe(commentBunka.closest("td"));
 });
 
-it("chýbajúcu veľkosť a komentár zobrazí ako pomlčku", async () => {
+it("chýbajúci dodávateľ zobrazí ako pomlčku (veľkosť sa pri chýbajúcej hodnote jednoducho nezobrazí)", async () => {
   fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_NOVA], email: null }]);
 
   render(<OrdersSection role="citanie" onSessionExpired={() => {}} />);
 
   const riadok = await screen.findByTestId(`order-line-${LINE_NOVA.lineId}`);
-  // LINE_NOVA má sizeLabel: null — zobrazí sa pomlčka namiesto prázdneho políčka.
+  // issue 95: `LINE_NOVA` má `sizeLabel: null` — od zlúčenia KÓD+VEĽKOSŤ sa v
+  // tom prípade jednoducho NIČ nevykreslí (žiadna pomlčka náhradou), takže
+  // pomlčka nižšie pochádza zo zlúčenej bunky DODÁVATEĽ (LINE_NOVA má aj
+  // `supplierUrl`/`supplierNote`/`externalCode` všetky `null`).
   expect(riadok.textContent).toContain("—");
 });
 

--- a/apps/web/src/components/OrdersSection.test.tsx
+++ b/apps/web/src/components/OrdersSection.test.tsx
@@ -119,6 +119,43 @@ it("zoskupí riadky podľa dodávateľa a zobrazí produkt, veľkosť, množstvo
   expect(stary.textContent).toContain("Nevybavené");
 });
 
+// issue 95: 13 pôvodných stĺpcov → 10 (VEĽKOSŤ zlúčená do KÓD, PRIRADENIE
+// DODÁVATEĽA do DODÁVATEĽ, POZNÁMKA E-SHOPU do POZNÁMOK) — regresný test
+// dokazuje, že ide o SKUTOČNÉ zlúčenie stĺpcov v DOM-e (rovnaký rodičovský
+// `<td>`), nie len premenovanie hlavičiek.
+it("hlavička tabuľky má 10 stĺpcov (zlúčené VEĽKOSŤ/PRIRADENIE DODÁVATEĽA/POZNÁMKA E-SHOPU)", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_STARA], email: null }]);
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const hlavicky = await screen.findAllByRole("columnheader");
+  expect(hlavicky).toHaveLength(10);
+  const nazvy = hlavicky.map((th) => th.textContent);
+  expect(nazvy).not.toContain("Veľkosť");
+  expect(nazvy).not.toContain("Priradenie dodávateľa");
+  expect(nazvy).not.toContain("Poznámka e-shopu");
+});
+
+it("zlúčená bunka DODÁVATEĽ drží odkaz na dodávateľa AJ priradenie v tom istom stĺpci", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_STARA], email: null }]);
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const odkazBunka = await screen.findByTestId(`supplier-link-${LINE_STARA.lineId}`);
+  const priradenieBunka = await screen.findByTestId(`supplier-assign-cell-${LINE_STARA.lineId}`);
+  expect(odkazBunka.closest("td")).toBe(priradenieBunka.closest("td"));
+});
+
+it("zlúčená bunka POZNÁMKY drží poznámku e-shopu AJ komentár v tom istom stĺpci", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_STARA], email: null }]);
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const remarkBunka = await screen.findByTestId(`remark-cell-${LINE_STARA.lineId}`);
+  const commentBunka = await screen.findByTestId(`comment-cell-${LINE_STARA.lineId}`);
+  expect(remarkBunka.closest("td")).toBe(commentBunka.closest("td"));
+});
+
 it("chýbajúcu veľkosť a komentár zobrazí ako pomlčku", async () => {
   fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_NOVA], email: null }]);
 

--- a/apps/web/src/components/SupplierOrderGroup.tsx
+++ b/apps/web/src/components/SupplierOrderGroup.tsx
@@ -111,54 +111,71 @@ export function SupplierOrderGroup({
         onClosePreview={onClosePreview}
         onConfirmSend={onConfirmSend}
       />
-      <table className="orders-table">
-        <thead>
-          <tr>
-            {/* issue 60: odškrtávacie políčko — JEDINÉ miesto na obrazovke,
-                ktoré sa smie volať "Objednané" (viď `STATE_LABELS` a stĺpec
-                dátumu nižšie, obe premenované, aby nekolidovali). */}
-            <th>Objednané</th>
-            <th>Objednávka</th>
-            <th>Zákazník</th>
-            <th>Kód</th>
-            <th>Produkt</th>
-            <th>Veľkosť</th>
-            <th>Množstvo</th>
-            <th>Dodávateľ</th>
-            {/* issue 63: ručné priradenie dodávateľa — prázdne pre riadky,
-                ktoré ho nepotrebujú (`line.supplierAssignable === false`). */}
-            <th>Priradenie dodávateľa</th>
-            <th>Stav</th>
-            <th>Dátum objednávky</th>
-            {/* issue 65: zákaznícky odkaz k objednávke (read-only, `remark`
-                stĺpec exportu — NIE naša vlastná `comment` bunka vpravo). */}
-            <th>Poznámka e-shopu</th>
-            <th>Komentár</th>
-          </tr>
-        </thead>
-        <tbody>
-          {visibleLines.map((line) => (
-            <OrderLineRow
-              key={line.lineId}
-              line={line}
-              canChangeState={canChangeState}
-              busyLineId={busyLineId}
-              busyOrderedLineId={busyOrderedLineId}
-              // Review of PR 75, finding 6: kým hromadná akcia pre TOHTO
-              // dodávateľa beží, žiadny riadok jeho skupiny sa nesmie dať
-              // meniť per-riadkovo naraz.
-              supplierBusy={busyOrderedSupplier === group.supplier}
-              variantTotal={variantTotals.get(line.variantCode)}
-              busySupplierLineId={busySupplierLineId}
-              busyCommentOrderId={busyCommentOrderId}
-              onChangeState={onChangeState}
-              onChangeOrdered={onChangeOrdered}
-              onAssignSupplier={onAssignSupplier}
-              onChangeComment={onChangeComment}
-            />
-          ))}
-        </tbody>
-      </table>
+      {/* issue 95: vlastný vodorovný posuvný obal — stránka (`.main-wide`)
+          sa sama nikdy neposúva, posúva sa (keď treba) len táto tabuľka.
+          `table-layout: fixed` + `<colgroup>` dávajú stĺpcom percentuálne
+          šírky (`app.css`'s `.col-*`) namiesto automatického rozloženia. 13
+          pôvodných stĺpcov je teraz 10 — VEĽKOSŤ zlúčená do KÓD, PRIRADENIE
+          DODÁVATEĽA do DODÁVATEĽ, POZNÁMKA E-SHOPU do POZNÁMOK (majiteľ,
+          komentár #10) — nedôležité/takmer vždy prázdne stĺpce už nedržia
+          šírku PRODUKTU, ktorý ju teraz dostáva najviac. */}
+      <div className="orders-table-wrap">
+        <table className="orders-table">
+          <colgroup>
+            <col className="col-ordered" />
+            <col className="col-order" />
+            <col className="col-customer" />
+            <col className="col-code" />
+            <col className="col-product" />
+            <col className="col-qty" />
+            <col className="col-supplier" />
+            <col className="col-state" />
+            <col className="col-date" />
+            <col className="col-notes" />
+          </colgroup>
+          <thead>
+            <tr>
+              {/* issue 60: odškrtávacie políčko — JEDINÉ miesto na obrazovke,
+                  ktoré sa smie volať "Objednané" (viď `STATE_LABELS` a stĺpec
+                  dátumu nižšie, obe premenované, aby nekolidovali). */}
+              <th>Objednané</th>
+              <th>Objednávka</th>
+              <th>Zákazník</th>
+              <th title="Kód variantu — obsahuje aj veľkosť, keď ju appka pozná">Kód</th>
+              <th>Produkt</th>
+              <th>Množstvo</th>
+              <th title="Dodávateľ z katalógu, alebo ručné priradenie pri produkte bez katalógového dodávateľa">
+                Dodávateľ
+              </th>
+              <th>Stav</th>
+              <th>Dátum objednávky</th>
+              <th title="Poznámka zákazníka z e-shopu (na čítanie) + vlastná poznámka tímu">Poznámky</th>
+            </tr>
+          </thead>
+          <tbody>
+            {visibleLines.map((line) => (
+              <OrderLineRow
+                key={line.lineId}
+                line={line}
+                canChangeState={canChangeState}
+                busyLineId={busyLineId}
+                busyOrderedLineId={busyOrderedLineId}
+                // Review of PR 75, finding 6: kým hromadná akcia pre TOHTO
+                // dodávateľa beží, žiadny riadok jeho skupiny sa nesmie dať
+                // meniť per-riadkovo naraz.
+                supplierBusy={busyOrderedSupplier === group.supplier}
+                variantTotal={variantTotals.get(line.variantCode)}
+                busySupplierLineId={busySupplierLineId}
+                busyCommentOrderId={busyCommentOrderId}
+                onChangeState={onChangeState}
+                onChangeOrdered={onChangeOrdered}
+                onAssignSupplier={onAssignSupplier}
+                onChangeComment={onChangeComment}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/nav.ts
+++ b/apps/web/src/nav.ts
@@ -17,6 +17,13 @@ export interface NavTab {
   readonly id: string;
   readonly label: string;
   readonly Component: ComponentType<SectionProps>;
+  // issue 95: `true` pre obrazovky, ktoré potrebujú viac než pohodlnú čítaciu
+  // šírku (`--fs-content-width`, 1120px) — hustá pracovná tabuľka ("Na
+  // objednanie") sa inak nikdy nerozšíri na šírku okna nad týmto stropom.
+  // `App.tsx` na základe tohto pridá `<main>`u triedu `main-wide`
+  // (`app.css`), ktorá strop zruší LEN pre túto jednu záložku — ostatné
+  // (Sync/Katalóg/Párovanie/Plánovač) ostávajú na pôvodnej čítacej šírke.
+  readonly wide?: boolean;
 }
 
 export interface NavFolder {
@@ -38,7 +45,7 @@ export const NAV: readonly NavFolder[] = [
   {
     id: "eshop",
     label: "Eshop",
-    tabs: [{ id: "orders", label: "Na objednanie", Component: OrdersSection }],
+    tabs: [{ id: "orders", label: "Na objednanie", Component: OrdersSection, wide: true }],
   },
 ];
 

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -71,11 +71,6 @@
 
   --fs-content-width: 1120px;
   --fs-sidebar-width: 250px;
-  /* issue 95: rendrovaná výška `.topbar` (sticky, top: 0) — zdieľaný token,
-     aby sticky hlavička tabuľky "Na objednanie" vedela presne, POD čím sa
-     má prilepiť, a nikdy sa s Topbarom neprekrývala. `.topbar` dostáva
-     `min-height` rovný tomuto tokenu, takže obe strany vždy sedia. */
-  --fs-topbar-height: 4.25rem;
 }
 
 /* ---------------- 2. RESET + ZÁKLADNÉ ELEMENTY ---------------- */
@@ -375,8 +370,6 @@ tr:last-child td {
   background: var(--fs-canvas);
   border-bottom: 1px solid var(--fs-border);
   padding: var(--fs-space-5) var(--fs-space-6) var(--fs-space-4);
-  min-height: var(--fs-topbar-height);
-  box-sizing: border-box;
 }
 .topbar-head h1 {
   margin: 0;
@@ -716,14 +709,17 @@ tr:last-child td {
    `.orders-table-wrap`'s `overflow-x: auto` (nutné pre bod 4, "stránka sa
    nesmie posúvať vodorovne") jedným je presne TAKÝTO predok. Keďže obal
    nemá vlastnú vertikálnu scroll oblasť (vysoký je len toľko, koľko je
-   tabuľka), sticky hlavičku posunulo o celú `--fs-topbar-height` NADOL od
-   jej prirodzenej pozície bez toho, aby si tabuľka tento posun vyhradila v
-   toku — hlavička sa tak vizuálne prekryla s prvým riadkom PORTOL a kradla
-   mu kliky ("checkbox.click() … <th>Objednané</th> … intercepts pointer
-   events", `orders.spec.ts`'s test odškrtávania). Fix by vyžadoval úplne
-   iný layout (oddelená hlavička/telo mimo jednej `<table>`) za cenu vyššieho
-   rizika pre existujúcu sadu testov — mimo rozsahu tohto (mäkko formulovaného,
-   "zvážiť") bodu. Rozhodnutie zapísané aj na ticket #95. */
+   tabuľka), sticky hlavičku posunulo o pevný offset NADOL od jej prirodzenej
+   pozície bez toho, aby si tabuľka tento posun vyhradila v toku — hlavička
+   sa tak vizuálne prekryla s prvým riadkom POD ňou a kradla mu kliky
+   ("checkbox.click() … <th>Objednané</th> … intercepts pointer events",
+   `orders.spec.ts`'s test odškrtávania). Fix by vyžadoval úplne iný layout
+   (oddelená hlavička/telo mimo jednej `<table>`) za cenu vyššieho rizika pre
+   existujúcu sadu testov — mimo rozsahu tohto (mäkko formulovaného,
+   "zvážiť") bodu. Skúšaný token (`--fs-topbar-height` + `.topbar`'s
+   `min-height`) bol pre tento účel ZBYTOČNÝ a odstránený — nemenil by nič
+   mimo tejto (zamietnutej) funkcie, len by natvrdo zväčšil výšku Topbaru na
+   VŠETKÝCH obrazovkách bez dôvodu. Rozhodnutie zapísané aj na ticket #95. */
 /* Farby stavu riadku — sémantické (čaká/skladom/nedostupné), vlastná paleta
    tejto appky (nie prevzaté hodnoty starej appky). */
 .orders-table tr.state-caka_sa {
@@ -875,6 +871,13 @@ tr:last-child td {
 }
 .ord-supplier-assign-input {
   width: 8rem;
+  /* code review (issue 95): `width` alone can force the input wider than its
+     ACTUAL column at the table's `min-width: 64rem` floor on a ~1280-1440px
+     laptop viewport (`.col-supplier` computes narrower than 8rem there) —
+     `<td>`s don't clip overflowing children by default, so without this the
+     input would visually bleed into the neighbouring column. `max-width:
+     100%` lets it shrink to whatever the column actually has. */
+  max-width: 100%;
   padding: var(--fs-space-2) var(--fs-space-2);
   border: 1px solid var(--fs-border);
   border-radius: var(--fs-radius-sm);
@@ -948,6 +951,10 @@ tr:last-child td {
 }
 .ord-comment-input {
   width: 10rem;
+  /* code review (issue 95): same overflow safeguard as
+     `.ord-supplier-assign-input` above — `.col-notes` can compute narrower
+     than 10rem at the table's `min-width` floor on a laptop viewport. */
+  max-width: 100%;
   padding: var(--fs-space-2) var(--fs-space-2);
   border: 1px solid var(--fs-border);
   border-radius: var(--fs-radius-sm);

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -71,6 +71,11 @@
 
   --fs-content-width: 1120px;
   --fs-sidebar-width: 250px;
+  /* issue 95: rendrovaná výška `.topbar` (sticky, top: 0) — zdieľaný token,
+     aby sticky hlavička tabuľky "Na objednanie" vedela presne, POD čím sa
+     má prilepiť, a nikdy sa s Topbarom neprekrývala. `.topbar` dostáva
+     `min-height` rovný tomuto tokenu, takže obe strany vždy sedia. */
+  --fs-topbar-height: 4.25rem;
 }
 
 /* ---------------- 2. RESET + ZÁKLADNÉ ELEMENTY ---------------- */
@@ -370,6 +375,8 @@ tr:last-child td {
   background: var(--fs-canvas);
   border-bottom: 1px solid var(--fs-border);
   padding: var(--fs-space-5) var(--fs-space-6) var(--fs-space-4);
+  min-height: var(--fs-topbar-height);
+  box-sizing: border-box;
 }
 .topbar-head h1 {
   margin: 0;
@@ -421,6 +428,17 @@ tr:last-child td {
   padding: var(--fs-space-5) var(--fs-space-6) var(--fs-space-7);
   max-width: var(--fs-content-width);
   width: 100%;
+}
+/* issue 95: obrazovky označené `nav.ts`'s `wide: true` (dnes len "Na
+   objednanie") strácajú čítací strop — hustá pracovná tabuľka smie využiť
+   celú šírku okna namiesto toho, aby zostala uprostred s prázdnymi bokmi aj
+   pri 1600/1920px. `overflow-x: hidden` je zámerná poistka: KAŽDÝ prvok v
+   tejto obrazovke, ktorý by mohol byť širší než dostupné miesto, musí mať
+   VLASTNÝ `overflow-x: auto` obal (`.orders-table-wrap` nižšie) — stránka
+   samotná sa nesmie posúvať vodorovne nikdy. */
+.main > main.main-wide {
+  max-width: none;
+  overflow-x: hidden;
 }
 
 /* ---------------- 4. ZDIEĽANÉ PRVKY ---------------- */
@@ -668,9 +686,44 @@ tr:last-child td {
   border-radius: var(--fs-radius-sm);
 }
 
+/* issue 95: KAŽDÁ skupina dodávateľa dostane VLASTNÝ vodorovný posuvný obal
+   okolo svojej `<table>` — stránka (`.main-wide`, vyššie) sa nikdy neposúva
+   vodorovne sama, posúva sa (keď treba) len tento obal. `min-width` na
+   tabuľke nižšie zaručuje, že stĺpce nedostanú menej miesta, než je čitateľné,
+   aj keby bolo okno naozaj úzke — vtedy sa jednoducho aktivuje toto posúvanie. */
+.orders-table-wrap {
+  overflow-x: auto;
+}
+/* issue 95: `table-layout: fixed` + percentuálne `<col>` (`SupplierOrderGroup
+   .tsx`'s `<colgroup>`) namiesto pôvodného automatického rozloženia — dôležité
+   stĺpce (PRODUKT, zlúčený DODÁVATEĽ, zlúčené POZNÁMKY) dostávajú najviac
+   miesta, prázdne/úzke stĺpce (checkbox, MNOŽSTVO) najmenej. `min-width`
+   zaručuje čitateľnú minimálnu šírku pri úzkom okne (vtedy sa posúva LEN
+   `.orders-table-wrap` vyššie, nikdy stránka). */
 .orders-table {
+  width: 100%;
+  min-width: 64rem;
+  table-layout: fixed;
   font-size: var(--fs-text-sm);
 }
+.orders-table th,
+.orders-table td {
+  overflow-wrap: break-word;
+}
+/* issue 95 bod 8 ("zvážiť prilepenú hlavičku") — VYSKÚŠANÉ a ZAMIETNUTÉ
+   (nájdené reálnym Playwright behom, nie len teoreticky): `position: sticky`
+   na `<th>` sa sticky-uje voči NAJBLIŽŠIEMU predkovi so scroll-boxom — a
+   `.orders-table-wrap`'s `overflow-x: auto` (nutné pre bod 4, "stránka sa
+   nesmie posúvať vodorovne") jedným je presne TAKÝTO predok. Keďže obal
+   nemá vlastnú vertikálnu scroll oblasť (vysoký je len toľko, koľko je
+   tabuľka), sticky hlavičku posunulo o celú `--fs-topbar-height` NADOL od
+   jej prirodzenej pozície bez toho, aby si tabuľka tento posun vyhradila v
+   toku — hlavička sa tak vizuálne prekryla s prvým riadkom PORTOL a kradla
+   mu kliky ("checkbox.click() … <th>Objednané</th> … intercepts pointer
+   events", `orders.spec.ts`'s test odškrtávania). Fix by vyžadoval úplne
+   iný layout (oddelená hlavička/telo mimo jednej `<table>`) za cenu vyššieho
+   rizika pre existujúcu sadu testov — mimo rozsahu tohto (mäkko formulovaného,
+   "zvážiť") bodu. Rozhodnutie zapísané aj na ticket #95. */
 /* Farby stavu riadku — sémantické (čaká/skladom/nedostupné), vlastná paleta
    tejto appky (nie prevzaté hodnoty starej appky). */
 .orders-table tr.state-caka_sa {
@@ -697,9 +750,40 @@ tr:last-child td {
 .orders-table tr.ordered {
   opacity: 0.55;
 }
+/* issue 95: zvislé zarovnanie hore (nie stred) — zlúčené bunky (DODÁVATEĽ,
+   POZNÁMKY) majú viac riadkov obsahu pod sebou a `top` drží prvý riadok
+   zarovnaný s ostatnými bunkami toho istého riadku tabuľky. Trocha
+   veľkorysejší zvislý padding než pôvodný globálny `td` reset (issue 95 bod
+   3: "doladiť hustotu") — stále husté, ale klikacie ciele majú dýchací
+   priestor. */
+.orders-table td {
+  vertical-align: top;
+  padding-top: var(--fs-space-3);
+  padding-bottom: var(--fs-space-3);
+}
+/* issue 95: veľké klikacie ciele (majiteľ: "veľké tlačidlá, nech sa vedia
+   zamestnanci rýchlo hýbať") — SCOPED na `.order-group`, nie globálna zmena
+   `.btn.sm`/checkboxu, ktoré používajú aj iné obrazovky (Sync/Zmena hesla)
+   mimo tohto ticketu. */
+.order-group .btn.sm {
+  padding: var(--fs-space-2) var(--fs-space-4);
+  font-size: var(--fs-text-base);
+  min-height: 2.25rem;
+}
+.order-group input[type="checkbox"] {
+  width: 1.375rem;
+  height: 1.375rem;
+  accent-color: var(--fs-brand);
+  cursor: pointer;
+}
+.order-group input[type="checkbox"]:disabled {
+  cursor: not-allowed;
+}
+/* issue 95 bod 3: zarovnanie čísiel doprava. */
 .ord-qty {
   font-weight: var(--fs-weight-semibold);
   color: var(--fs-ink);
+  text-align: right;
 }
 /* issue 62: súčet kusov toho istého produktu naprieč objednávkami dodávateľa
    — neklikateľná pilulka, zámerne odlišná od interaktívneho `.chip`
@@ -718,16 +802,41 @@ tr:last-child td {
   white-space: nowrap;
   cursor: help;
 }
+/* issue 95: KÓD + VEĽKOSŤ zlúčené do jednej bunky (majiteľ, komentár #10:
+   "veľkosť je už súčasťou kódu") — kód je hlavný text, veľkosť (keď appka má
+   samostatnú `sizeLabel` hodnotu) je vedľa neho menším, tlmeným písmom. */
+.ord-code-cell {
+  font-weight: var(--fs-weight-medium);
+}
+.ord-size-inline {
+  margin-left: var(--fs-space-1);
+  font-size: var(--fs-text-xs);
+  font-weight: var(--fs-weight-medium);
+  color: var(--fs-ink-muted);
+}
 .ord-state-select {
-  padding: var(--fs-space-1) var(--fs-space-2);
+  width: 100%;
+  padding: var(--fs-space-2) var(--fs-space-2);
   border: 1px solid var(--fs-border);
   border-radius: var(--fs-radius-sm);
   font: inherit;
-  font-size: var(--fs-text-sm);
+  font-size: var(--fs-text-base);
+  min-height: 2.25rem;
+}
+/* issue 95: DODÁVATEĽ + PRIRADENIE DODÁVATEĽA zlúčené do jednej bunky
+   (majiteľ, komentár #1: "neviem čo tam je Priradenie dodávateľa stĺpec" —
+   je vidieť len pri riadkoch bez katalógového dodávateľa, `supplierAssignable`
+   nižšie). Vnútri sú DVA pôvodné testid-ované bloky (`.ord-supplier-cell`/
+   `.ord-supplier-assign`, nezmenené) len vedľa seba v JEDNEJ bunke namiesto
+   dvoch samostatných stĺpcov. */
+.ord-supplier-merged {
+  display: flex;
+  flex-direction: column;
+  gap: var(--fs-space-1);
 }
 /* issue 67: odkaz/kód dodávateľa pri riadku objednávky. */
 .ord-supplier-cell {
-  max-width: 220px;
+  max-width: 100%;
 }
 .ord-supplier-link {
   font-weight: var(--fs-weight-medium);
@@ -752,24 +861,26 @@ tr:last-child td {
 /* issue 63: ručné priradenie dodávateľa riadku bez dodávateľa — vstup +
    uložiť, rovnaký vizuálny jazyk ako `.ord-state-select`/`.btn.sm`. `flex` +
    `flex-wrap: wrap` (NIE `white-space: nowrap`) — bez zalomenia by vstup +
-   tlačidlo pri užšom stĺpci pretiekli VIZUÁLNE do susedného stĺpca "Stav" a
-   jeho `<select>` (neskôr v DOM-e, teda navrchu) by kradol kliky mierené na
+   tlačidlo pri užšom stĺpci pretiekli VIZUÁLNE do susedného stĺpca a jeho
+   `<select>`/vstup (neskôr v DOM-e, teda navrchu) by kradol kliky mierené na
    toto tlačidlo (zistené reálnym Playwright behom — `locator.click` padalo
-   na "select ... intercepts pointer events", nie flaka). */
+   na "select ... intercepts pointer events", nie flaka). issue 95: šírka v
+   `rem` (nie natvrdo v px), o čosi širšia pre väčšie písmo/tlačidlo. */
 .ord-supplier-assign {
   display: flex;
   align-items: center;
   gap: var(--fs-space-1);
   flex-wrap: wrap;
-  max-width: 160px;
+  max-width: 100%;
 }
 .ord-supplier-assign-input {
-  width: 110px;
-  padding: var(--fs-space-1) var(--fs-space-2);
+  width: 8rem;
+  padding: var(--fs-space-2) var(--fs-space-2);
   border: 1px solid var(--fs-border);
   border-radius: var(--fs-radius-sm);
   font: inherit;
-  font-size: var(--fs-text-sm);
+  font-size: var(--fs-text-base);
+  min-height: 2.25rem;
 }
 
 /* issue 65: priamy odkaz do Shoptet administrácie. issue 99: nesie teraz
@@ -783,11 +894,13 @@ tr:last-child td {
 /* issue 65: upozornenie na starú nevybavenú objednávku (>14 dní) — výrazná
    farba (`--fs-warning`), rovnaká sémantika ako `.orders-table tr.state-
    caka_sa` vyššie, ale nezávislá od stavu riadku (môže sa zobraziť pri
-   AKOMKOĽVEK nevybavenom stave). */
+   AKOMKOĽVEK nevybavenom stave). issue 95: teraz vlastný riadok POD dátumom
+   (nie inline vedľa), aby sa v užšom zlúčenom stĺpci nezalamoval do stredu
+   textu dátumu. */
 .ord-stale-badge {
   display: inline-flex;
   align-items: center;
-  margin-left: var(--fs-space-2);
+  margin-top: var(--fs-space-1);
   padding: 0 var(--fs-space-2);
   font-size: var(--fs-text-xs);
   font-weight: var(--fs-weight-semibold);
@@ -798,10 +911,19 @@ tr:last-child td {
   white-space: nowrap;
   cursor: help;
 }
+/* issue 95: POZNÁMKA E-SHOPU (`remark`, read-only) + KOMENTÁR zlúčené do
+   jednej bunky "Poznámky" (majiteľ, komentár #10) — vnútri sú DVA pôvodné
+   testid-ované bloky (`.ord-remark-cell`/`.ord-comment-cell`, nezmenené),
+   pod sebou namiesto dvoch samostatných stĺpcov. */
+.ord-notes-merged {
+  display: flex;
+  flex-direction: column;
+  gap: var(--fs-space-2);
+}
 /* issue 65: zákaznícky odkaz k objednávke — read-only, rovnaký orezávací
    vzor ako `.ord-supplier-note` (issue 70) — voľný text neobmedzenej dĺžky. */
 .ord-remark-cell {
-  max-width: 200px;
+  max-width: 100%;
 }
 .ord-remark {
   display: inline-block;
@@ -816,22 +938,56 @@ tr:last-child td {
 /* issue 64: poznámka k CELEJ objednávke — rovnaký vizuálny jazyk ako
    `.ord-supplier-assign`/`-input` vyššie (`flex-wrap: wrap`, rovnaký dôvod:
    bez zalomenia by vstup + tlačidlo pri užšom stĺpci pretiekli do
-   susedného stĺpca). Širšie ako priradenie dodávateľa — voľný text (max
-   2000 znakov) je typicky dlhší než meno dodávateľa. */
+   susedného stĺpca). issue 95: šírka v `rem` (nie natvrdo v px). */
 .ord-comment-cell {
   display: flex;
   align-items: center;
   gap: var(--fs-space-1);
   flex-wrap: wrap;
-  max-width: 220px;
+  max-width: 100%;
 }
 .ord-comment-input {
-  width: 160px;
-  padding: var(--fs-space-1) var(--fs-space-2);
+  width: 10rem;
+  padding: var(--fs-space-2) var(--fs-space-2);
   border: 1px solid var(--fs-border);
   border-radius: var(--fs-radius-sm);
   font: inherit;
-  font-size: var(--fs-text-sm);
+  font-size: var(--fs-text-base);
+  min-height: 2.25rem;
+}
+/* issue 95: percentuálne šírky stĺpcov (`SupplierOrderGroup.tsx`'s
+   `<colgroup>`) — PRODUKT (najdôležitejší údaj, majiteľ komentár #1: "má len
+   97px na dlhý názov") a zlúčené DODÁVATEĽ/POZNÁMKY dostávajú najviac
+   miesta, checkbox/MNOŽSTVO najmenej. Súčet = 100%. */
+.col-ordered {
+  width: 4%;
+}
+.col-order {
+  width: 8%;
+}
+.col-customer {
+  width: 10%;
+}
+.col-code {
+  width: 8%;
+}
+.col-product {
+  width: 20%;
+}
+.col-qty {
+  width: 6%;
+}
+.col-supplier {
+  width: 15%;
+}
+.col-state {
+  width: 9%;
+}
+.col-date {
+  width: 8%;
+}
+.col-notes {
+  width: 12%;
 }
 
 /* issue 59: nastavenie otvorených stavov objednávok — rovnaký vizuálny

--- a/apps/web/tests/e2e/orders.spec.ts
+++ b/apps/web/tests/e2e/orders.spec.ts
@@ -84,6 +84,36 @@ test("manažér filtruje podľa dodávateľa, vidí súhrn ostáva vybaviť a sk
   await page.getByTestId("orders-hide-resolved-toggle").click();
   await expect(page.getByTestId("supplier-DODAVATEL-TEST-1")).toBeVisible();
 
+  // issue 95: stránka sa NIKDY nesmie posúvať vodorovne, na žiadnej z troch
+  // testovaných šírok — keď je tabuľka širšia než dostupné miesto, posúva sa
+  // len jej VLASTNÝ obal (`.orders-table-wrap`), nikdy `document.body`.
+  // Rovnaký účet z tohto testu ostáva prihlásený, žiadne ďalšie prihlásenie
+  // netreba (šetrí `MAX_ATTEMPTS` rozpočet — `.claude/rules/frontend-design.md`).
+  for (const width of [1280, 1600, 1920]) {
+    await page.setViewportSize({ width, height: 900 });
+    const { bodyWidth, viewportWidth } = await page.evaluate(() => ({
+      bodyWidth: document.body.scrollWidth,
+      viewportWidth: window.innerWidth,
+    }));
+    expect(bodyWidth, `šírka okna ${String(width)}px`).toBeLessThanOrEqual(viewportWidth);
+  }
+
+  // Priblíženie prehliadača (majiteľ: "ked aj scalujem tak sa ten stred
+  // nescaluje") — CSS `zoom` je Chromium's náprotivok Ctrl+/- priblíženia,
+  // `documentElement.clientWidth` sa pod ním prepočíta rovnako ako reálny
+  // prehliadačový zoom.
+  await page.evaluate(() => {
+    document.documentElement.style.zoom = "1.25";
+  });
+  const poZoome = await page.evaluate(() => ({
+    bodyWidth: document.body.scrollWidth,
+    clientWidth: document.documentElement.clientWidth,
+  }));
+  expect(poZoome.bodyWidth).toBeLessThanOrEqual(poZoome.clientWidth);
+  await page.evaluate(() => {
+    document.documentElement.style.zoom = "1";
+  });
+
   expect(chyby).toEqual([]);
 });
 

--- a/apps/web/tests/e2e/tsconfig.json
+++ b/apps/web/tests/e2e/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "noEmit": true,
+    "lib": ["ES2023", "DOM"],
+    "types": ["node"]
+  },
+  "include": ["**/*.ts"]
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,7 +12,12 @@ export default tseslint.config(
           allowDefaultProject: [
             "apps/api/*.config.ts",
             "apps/web/*.config.ts",
-            "apps/web/tests/e2e/*.ts",
+            // "apps/web/tests/e2e/*.ts" REMOVED (issue 95) — the directory now
+            // has its own real tsconfig.json (needed "DOM" lib for
+            // `page.evaluate()` callbacks referencing `document`/`window`,
+            // which the API's default project's Node-only `lib` doesn't have)
+            // wired into root `typecheck`; project service finds it on its
+            // own, same reason as the two removals below.
             // "scripts/*.ts" REMOVED (final-wave-b, item 1/issue #4) — scripts/
             // now has its own real tsconfig (`scripts/tsconfig.json`, wired into
             // `pnpm typecheck`), so typescript-eslint's project service finds it

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.57",
+  "version": "0.3.0-dev.58",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": ">=24"
   },
   "scripts": {
-    "typecheck": "tsc -b && tsc -p scripts/tsconfig.json && tsc -p apps/api/tests/tsconfig.json",
+    "typecheck": "tsc -b && tsc -p scripts/tsconfig.json && tsc -p apps/api/tests/tsconfig.json && tsc -p apps/web/tests/e2e/tsconfig.json",
     "lint": "eslint .",
     "test": "pnpm -r test",
     "test:integration": "pnpm --filter @forestshop/api test:integration",


### PR DESCRIPTION
Prerobenie záložky "Na objednanie" na rýchlu pracovnú obrazovku — šírka
obsahu, rozostupy/typografia na `--fs-*` tokenoch, zlúčenie stĺpcov
(VEĽKOSŤ→KÓD, PRIRADENIE DODÁVATEĽA→DODÁVATEĽ, POZNÁMKA E-SHOPU+KOMENTÁR→
POZNÁMKY), väčšie klikacie ciele. Detailný root-cause + zvolený prístup +
zamietnutá alternatíva: issue komentár https://github.com/zbynekdrlik/forestshop-app/issues/95#issuecomment-5143605125

Sticky hlavička (bod 8, "zvážiť") bola vyskúšaná a zámerne vynechaná —
dôvod v issue komentári https://github.com/zbynekdrlik/forestshop-app/issues/95#issuecomment-5143749019
a v `app.css`.

Closes #95
