### PR TITLE
Fix checkbox-column header mid-word wrap (issue 95 follow-up)

### DIFF
--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -699,7 +699,13 @@ tr:last-child td {
   table-layout: fixed;
   font-size: var(--fs-text-sm);
 }
-.orders-table th,
+/* Live post-deploy verification (issue 95, 1920px): `overflow-wrap:
+   break-word` on `<th>` too let a narrow single-word header (checkbox
+   column, "OBJEDNANÉ") break MID-WORD across three lines ("OBJE/DNAN/É"),
+   which reads as broken layout — multi-word headers ("Dátum objednávky")
+   still wrap fine at the natural space without it. `<td>` keeps it (needed
+   for long product names/comments in a fixed-width column); `<th>` relies
+   instead on `.col-ordered`'s widened share below to fit on one line. */
 .orders-table td {
   overflow-wrap: break-word;
 }
@@ -965,9 +971,13 @@ tr:last-child td {
 /* issue 95: percentuálne šírky stĺpcov (`SupplierOrderGroup.tsx`'s
    `<colgroup>`) — PRODUKT (najdôležitejší údaj, majiteľ komentár #1: "má len
    97px na dlhý názov") a zlúčené DODÁVATEĽ/POZNÁMKY dostávajú najviac
-   miesta, checkbox/MNOŽSTVO najmenej. Súčet = 100%. */
+   miesta. Súčet = 100%. `col-ordered` 4%→6% (živé overenie na 1920px:
+   pri 4% sa jednoslovná hlavička "OBJEDNANÉ" lámala DOPROSTRIED slova na tri
+   riadky — pozri `overflow-wrap` komentár vyššie) — rozdiel vzatý z
+   `col-qty` (6%→5%) a `col-date` (8%→7%), obe majú krátky obsah s
+   rezervou. */
 .col-ordered {
-  width: 4%;
+  width: 6%;
 }
 .col-order {
   width: 8%;
@@ -982,7 +992,7 @@ tr:last-child td {
   width: 20%;
 }
 .col-qty {
-  width: 6%;
+  width: 5%;
 }
 .col-supplier {
   width: 15%;
@@ -991,7 +1001,7 @@ tr:last-child td {
   width: 9%;
 }
 .col-date {
-  width: 8%;
+  width: 7%;
 }
 .col-notes {
   width: 12%;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.58",
+  "version": "0.3.0-dev.59",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Doplnenie k #102 (zlúčenie stĺpcov "Na objednanie") — nájdené počas
povinného živého Playwright overenia po nasadení: hlavička odškrtávacieho
stĺpca ("Objednané") sa pri 4% šírke lámala uprostred slova na tri riadky
(vyzeralo to rozbité). Oprava: `overflow-wrap: break-word` teraz platí len
na `<td>` (viacslovné hlavičky ako "Dátum objednávky" sa aj tak lámu na
prirodzenej medzere), a stĺpec dostal o niečo viac miesta (4%→6%, vzaté z
MNOŽSTVO a DÁTUM, oba mali rezervu).

Zdokumentované v `app.css`. Overené naživo na
https://forestshop-novy.newlevel.media/?tab=orders (1280/1600/1920px +
zoom, 0 console chýb) predtým aj potom.

Refs #95
