### PR TITLE
Playbook + log: document issue 95 findings (docs-only)

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -132,3 +132,47 @@ paths:
   instance's own action completed"? If yes, "skip first mount" alone is
   not enough — add the dirty guard too (see `.claude/rules/orders.md`'s
   matching entry for the full mechanism).
+- **`position: sticky` inside a wrapper that needs `overflow-x: auto` (for a
+  wide table's own horizontal scroll) does NOT stick to the viewport — it
+  sticks to that wrapper instead, and breaks.** Issue 95 tried a sticky
+  `<thead>` on the "Na objednanie" table: `.orders-table-wrap`'s required
+  `overflow-x: auto` makes the CSS engine treat the wrapper as a scroll
+  container on BOTH axes (the spec's "if one axis is non-`visible`, compute
+  the other to `auto` too" rule), which re-anchors the sticky `<th>`'s `top`
+  offset to that small, non-scrolling wrapper instead of the page — pushing
+  the header down OVER the first row without the table reserving that space
+  in its layout. Found by a REAL Playwright run, not by inspection:
+  `checkbox.click()` failed with "`<th>Objednané</th>` … intercepts pointer
+  events". Any FUTURE sticky-header attempt on a table that also needs its
+  own horizontal-scroll wrapper needs a genuinely different layout (a
+  separately-positioned header row/element outside the scrolling ancestor,
+  not `position: sticky` on `<th>`/`<thead>` inside it) — don't retry the
+  same approach.
+- **A single-word, ALL-CAPS `<th>` in a narrow `table-layout: fixed` column
+  breaks MID-WORD, not at a word boundary, if `overflow-wrap: break-word`
+  applies to `<th>`.** Issue 95's checkbox-column header "OBJEDNANÉ" (no
+  spaces) wrapped to three lines ("OBJE/DNAN/É") at a 4%-wide column —
+  found only by a LIVE post-deploy Playwright check at 1920px, not by any
+  automated test (unit tests don't render real column widths; the e2e
+  console/scroll-width checks don't inspect visual text wrapping). Fix:
+  scope `overflow-wrap: break-word` to `<td>` only (still needed there for
+  long product names/comments) — multi-word headers ("Dátum objednávky")
+  already wrap fine at their natural space without it — and widen the
+  narrow column's `<colgroup>` percentage until the single word fits on one
+  line. Any FUTURE narrow single-word column header on this table needs the
+  same check: render it at the real column width (not just skim the CSS)
+  before shipping.
+- **Merging two table columns into one WITHOUT touching any test**: keep
+  BOTH original elements (their exact `data-testid`, exact conditional
+  rendering logic) as SIBLING nested elements inside the one merged `<td>`,
+  instead of combining their JSX/conditions into new markup. Issue 95
+  merged VEĽKOSŤ→KÓD (simple inline append, no existing testid to
+  preserve), and DODÁVATEĽ+PRIRADENIE DODÁVATEĽA / POZNÁMKA E-SHOPU+KOMENTÁR
+  (both had existing `data-testid`s multiple unit/e2e tests already
+  targeted) — for the latter two, `OrderLineRow.tsx` renders the ORIGINAL
+  two `<div data-testid="...">` blocks, byte-for-byte unchanged rendering
+  logic, just nested inside one new `<td>` wrapper instead of two `<td>`s.
+  Every existing test kept passing with ZERO test edits. A regression test
+  proving a merge is a REAL DOM merge (not just relabeled headers): assert
+  the two testid'd elements' `.closest("td")` are the SAME node
+  (`OrdersSection.test.tsx`).

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -314,3 +314,23 @@ paths:
   ovládacími prvkami v jednej `<td>`: over reálnym Playwright behom (nie
   len vizuálne v prehliadači na širokej obrazovke), že klik na KAŽDÝ prvok
   skutočne trafí TEN prvok, nie souseda pod ním po pretečení.
+- **`apps/web/tests/e2e/*.ts` malo (do issue 95) žiadny VLASTNÝ
+  `tsconfig.json` — spoliehalo sa na `eslint.config.js`'s
+  `allowDefaultProject` fallback na `apps/api/tsconfig.eslint.json`
+  (Node-only `lib: ["ES2023"]`, žiadne DOM).** Kým e2e testy volali len
+  Playwright's vlastné (už typované) API (`page.click`, `expect`, …), to
+  nevadilo. Prvý test, čo volá `page.evaluate(() => document.body...)` (issue
+  95: kontrola `document.body.scrollWidth`/`window.innerWidth` proti
+  vodorovnému posúvaniu stránky), zlyhal na type-aware lint ("unsafe member
+  access .body on a type that cannot be resolved") — `document`/`window` v
+  callbacku nemali odkiaľ dostať typ. Fix: vlastný
+  `apps/web/tests/e2e/tsconfig.json` (rovnaký vzor ako
+  `apps/api/tests/tsconfig.json`/`scripts/tsconfig.json`, `.claude/rules/
+  local-dev.md`), navyše s `"lib": ["ES2023", "DOM"]`, pridaný do root
+  `typecheck` skriptu; `eslint.config.js`'s `allowDefaultProject` zoznam
+  stratil svoj `"apps/web/tests/e2e/*.ts"` riadok (project service si nový
+  reálny tsconfig nájde sám — rovnaký dôvod ako existujúce dva odstránené
+  riadky vedľa neho). Test na KAŽDÝ ďalší `page.evaluate()`/browser-context
+  kód v novom e2e súbore: over, či tento tsconfig existuje a má `DOM` v
+  `lib` — bez neho type-aware lint padne na prvom odkaze na
+  `document`/`window`/`navigator` vnútri callbacku.

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -1343,3 +1343,71 @@ nové heslo sa nikde v pushnutom obsahu nenachádza.
   export earlier). Console: 0 errors/0 warnings.
 - Shared PRs: `#96` (main implementation), `#97` (compose wiring
   follow-up).
+
+## Issue 95 — "Na objednanie" prerobené na rýchlu pracovnú obrazovku
+
+- Root cause + zvolený prístup + zamietnutá alternatíva zapísané na ticket
+  PRED prvým commitom (issue komentár
+  `#issuecomment-5143605125`): fixný `--fs-content-width` (1120px) na
+  `.main > main` capoval VŠETKY záložky vrátane hustej tabuľky; tabuľka
+  nemala vlastný `overflow-x` obal (posúvala sa celá stránka); 13 stĺpcov,
+  viaceré takmer vždy prázdne/duplicitné, kradli miesto stĺpcu PRODUKT;
+  malé klikacie ciele. Zamietnutá alternatíva: prerobenie z `<table>` na
+  kartový layout (vyššie riziko pre celú existujúcu testovú sadu, bez
+  reálneho prínosu navyše).
+- Implementácia: `nav.ts`'s `wide` príznak (len záložka "orders") →
+  `.main-wide` (ostatné obrazovky nezmenené) · `.orders-table-wrap`
+  (overflow-x: auto) + `table-layout: fixed` + `<colgroup>` na KAŽDEJ
+  skupine dodávateľa · presne tri zlúčenia stĺpcov, ktoré majiteľ sám
+  navrhol (issue komentáre #10/#11): VEĽKOSŤ→KÓD (inline), PRIRADENIE
+  DODÁVATEĽA→DODÁVATEĽ (jedna bunka, oba pôvodné testid-y zachované ako
+  vnorené prvky), POZNÁMKA E-SHOPU+KOMENTÁR→POZNÁMKY (rovnaký vzor) — 13 →
+  10 stĺpcov, nulová zmena správania/testid-ov · väčšie klikacie ciele
+  scoped cez `.order-group ...` (Sync/ZmenaHesla obrazovky nedotknuté) ·
+  zvyšné natvrdo px hodnoty prevedené na `rem`.
+- **Sticky hlavička (mäkký bod 8 "zvážiť") vyskúšaná a ZAMIETNUTÁ**:
+  `.orders-table-wrap`'s nutné `overflow-x: auto` robí z obalu scroll
+  kontajner AJ pre zvislú os (CSS overflow computed-value pravidlo), čo
+  presticky-uje `position: sticky` th voči tomuto malému obalu namiesto
+  viewportu a posunie hlavičku CEZ prvý riadok bez toho, aby si tabuľka
+  posun vyhradila v toku — reálny Playwright beh to chytil ako zlyhané
+  `checkbox.click()` ("`<th>` intercepts pointer events"), nie len
+  teoreticky. Fix by vyžadoval iný layout (mimo jednej `<table>`) za cenu
+  vyššieho rizika — mimo rozsahu mäkko formulovaného bodu. Rozhodnutie aj
+  na tickete a v `app.css` komentári.
+- Deep code review (`superpowers:requesting-code-review`, dispatched
+  subagent) našiel 2× 🟡 + 1× 🔵, všetky opravené v tej istej PR: orphaned
+  `--fs-topbar-height`/`.topbar` min-height (zostatok po zamietnutej sticky
+  funkcii, menil výšku Topbaru na VŠETKÝCH obrazovkách bezdôvodne) →
+  odstránené; `.ord-supplier-assign-input`/`.ord-comment-input` mohli pri
+  `min-width: 64rem` stropu na ~1280-1440px vizuálne pretiecť do suseda →
+  pridané `max-width: 100%`; zastaraný komentár v existujúcom teste →
+  opravený.
+- **Živé post-deploy overenie odhalilo ĎALŠÍ nález** (po prvom merge):
+  hlavička odškrtávacieho stĺpca ("OBJEDNANÉ") sa pri 4% šírke lámala
+  UPROSTRED slova na tri riadky — spôsobené globálnym `overflow-wrap:
+  break-word` aplikovaným aj na `<th>`. Fix: `overflow-wrap: break-word`
+  teraz len na `<td>`, `col-ordered` 4%→6% (vzaté z `col-qty`/`col-date`,
+  obe mali rezervu). Samostatná PR #103, samostatný CI cyklus (vrátane
+  version-bump, keďže dev sa medzičasom zrovnal s main po merge #102).
+- Testy: 3 nové vitest regresné testy (10 stĺpcov v hlavičke, zlúčené
+  bunky Dodávateľ/Poznámky zdieľajú rodičovský `<td>`) + nové e2e
+  assercie (žiadne vodorovné posúvanie stránky na 1280/1600/1920px + pod
+  1.25× zoomom, v rámci existujúceho prvého testu, bez ďalšieho
+  prihlásenia). Nový `apps/web/tests/e2e/tsconfig.json` (DOM lib) pre
+  `page.evaluate()` type-aware lint.
+- Commits: `78d7741` (bump .58) → `856dd30` (hlavná prerábka) →
+  `477d7a9` (review fixes) → `8dfc414` (merge main) → `8c8e200` (header
+  wrap fix) → `3d6f048` (bump .59). Shared PRs: `#102` (hlavná prerábka +
+  review fixy), `#103` (header-wrap doladenie).
+- CI zelené na oboch `dev` pushoch aj oboch PR (10/10 checks); main CI +
+  Deploy zelené na oboch mergoch bez retry. Live `/api/version` = verzia
+  vo footeri (`v0.3.0-dev.59`) na oboch nasadeniach.
+- Live overenie (`https://forestshop-novy.newlevel.media/?tab=orders`):
+  `document.body.scrollWidth <= window.innerWidth` na 1280/1600/1920px aj
+  pod 1.25× zoomom; 160 `<th>` (16 skupín × 10 zlúčených stĺpcov)
+  potvrdených cez DOM; 0 console chýb/varovaní. Produkčné dáta nedotknuté
+  (len čítanie): `product_supplier_override`=0, `order_line.ordered`=0,
+  `order_line`=868, objednávky s komentárom=0, `order`=528 — presne
+  zhodné s očakávanou základňou pred aj po zásahu.
+- Discord run-card odoslaný (`notify --run-card`, potvrdené doručenie).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.59",
+  "version": "0.3.0-dev.60",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Playbook + autopilot-log dokumentácia k #95 (a jej follow-upu #103) — žiadna
funkčná zmena. Zaznamenané: sticky hlavička vnútri `overflow-x: auto` obalu
sa sticky-uje voči obalu, nie viewportu (CSS gotcha nájdená reálnym
Playwright behom); jednoslovná hlavička v úzkom `table-layout: fixed`
stĺpci sa láme uprostred slova s globálnym `overflow-wrap: break-word` na
`<th>`; vzor na zlúčenie dvoch stĺpcov bez úpravy existujúcich testov
(pôvodné testid-y ako vnorené sourozenecké prvky); `apps/web/tests/e2e/`
potrebuje vlastný tsconfig s `DOM` lib pre `page.evaluate()` type-aware
lint.

Refs #95
