### PR TITLE
Na objednanie: opraviť pretekajúce hlavičky, zdvojenú veľkosť v KÓDe a príliš vysoký riadok

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -334,3 +334,12 @@ paths:
   kód v novom e2e súbore: over, či tento tsconfig existuje a má `DOM` v
   `lib` — bez neho type-aware lint padne na prvom odkaze na
   `document`/`window`/`navigator` vnútri callbacku.
+- **`"lib": ["ES2023", "DOM"]` v `apps/web/tests/e2e/tsconfig.json` (bod
+  vyššie) NESTAČÍ na `[...nodeList]` spread cez viacero prvkov** — issue 105
+  (kontrola pretekania KAŽDEJ `<th>` cez `[...document.querySelectorAll(...)]`
+  v `page.evaluate()`) narazila na `TS2488: Type 'NodeListOf<...>' must have a
+  '[Symbol.iterator]()' method`. `NodeListOf`'s iterátor žije v samostatnej
+  `DOM.Iterable` lib-e, nie v `DOM` — pridaj `"DOM.Iterable"` do `lib` poľa
+  hneď vedľa `"DOM"`. Test na KAŽDÝ ďalší e2e `page.evaluate()` kód, ktorý
+  spreadne/iteruje `querySelectorAll`/`getElementsByClassName` výsledok
+  (`[...xs]`, `for...of`): over, že tsconfig má aj `DOM.Iterable`, nielen `DOM`.

--- a/apps/web/src/components/OrderLineRow.tsx
+++ b/apps/web/src/components/OrderLineRow.tsx
@@ -1,6 +1,12 @@
 import { useEffect, useRef, useState, type JSX } from "react";
 import type { OrderLine } from "../ordersApi.js";
-import { formatVariantTotalChip, isStaleOrderLine, orderLineAgeDays, type VariantTotal } from "../ordersSummary.js";
+import {
+  formatVariantTotalChip,
+  isStaleOrderLine,
+  orderLineAgeDays,
+  shouldShowSizeLabel,
+  type VariantTotal,
+} from "../ordersSummary.js";
 
 // issue 60: `objednane` je VÝCHODISKOVÝ stav riadku (pred tým, než sa
 // čokoľvek stane), NIE potvrdenie, že manažér objednal — preto sa nazýva
@@ -170,10 +176,15 @@ export function OrderLineRow({
       <td>{line.customerName}</td>
       {/* issue 95: KÓD + VEĽKOSŤ zlúčené (majiteľ, komentár #10: "veľkosť je
           už súčasťou kódu") — veľkosť sa zobrazí len keď appka má samostatnú
-          `sizeLabel` hodnotu (nie každý variant ju má). */}
+          `sizeLabel` hodnotu (nie každý variant ju má). issue 105 bod 2:
+          `sizeLabel` je server-side odvodené ako suffix `variantCode`u, takže
+          kód ňou takmer vždy UŽ končí — pripájanie by ju zobrazilo dvakrát
+          (`shouldShowSizeLabel`, `ordersSummary.ts`). */}
       <td className="ord-code-cell">
         {line.variantCode}
-        {line.sizeLabel !== null && <span className="ord-size-inline">{line.sizeLabel}</span>}
+        {shouldShowSizeLabel(line.variantCode, line.sizeLabel) && (
+          <span className="ord-size-inline">{line.sizeLabel}</span>
+        )}
       </td>
       <td>{line.variantName}</td>
       <td className="ord-qty">

--- a/apps/web/src/components/SupplierOrderGroup.tsx
+++ b/apps/web/src/components/SupplierOrderGroup.tsx
@@ -135,20 +135,30 @@ export function SupplierOrderGroup({
           </colgroup>
           <thead>
             <tr>
-              {/* issue 60: odškrtávacie políčko — JEDINÉ miesto na obrazovke,
-                  ktoré sa smie volať "Objednané" (viď `STATE_LABELS` a stĺpec
-                  dátumu nižšie, obe premenované, aby nekolidovali). */}
-              <th>Objednané</th>
-              <th>Objednávka</th>
+              {/* issue 105 bod 1: pri 1280px (tabuľkin skutočný floor —
+                  `min-width: 64rem`) sa jednoslovné VEĽKÉ hlavičky
+                  ("OBJEDNANÉ"/"OBJEDNÁVKA"/"MNOŽSTVO"/"OBJEDNÁVKY") nezmestili
+                  do svojich úzkych stĺpcov a pretekali do suseda (zmerané
+                  `th.scrollWidth`). Namiesto širších percent (väčší diff,
+                  riziko pre PRODUKT/DODÁVATEĽ) sú 4 popisky skrátené — plný
+                  význam nesie `title`. Checkbox stĺpec: JEDINÉ miesto na
+                  obrazovke, ktoré sa smie týkať "objednané u dodávateľa" (viď
+                  `STATE_LABELS`/dátumový stĺpec nižšie, aby sa nekolidovalo). */}
+              <th title="Objednané u dodávateľa (zaškrtávacie políčko)" aria-label="Objednané u dodávateľa">
+                ✓
+              </th>
+              <th title="Číslo objednávky (klik na kód v riadku otvorí objednávku v administrácii Shoptet)">
+                Č. obj.
+              </th>
               <th>Zákazník</th>
               <th title="Kód variantu — obsahuje aj veľkosť, keď ju appka pozná">Kód</th>
               <th>Produkt</th>
-              <th>Množstvo</th>
+              <th title="Množstvo (počet kusov)">Ks</th>
               <th title="Dodávateľ z katalógu, alebo ručné priradenie pri produkte bez katalógového dodávateľa">
                 Dodávateľ
               </th>
               <th>Stav</th>
-              <th>Dátum objednávky</th>
+              <th title="Dátum objednávky">Dátum obj.</th>
               <th title="Poznámka zákazníka z e-shopu (na čítanie) + vlastná poznámka tímu">Poznámky</th>
             </tr>
           </thead>

--- a/apps/web/src/ordersSummary.test.ts
+++ b/apps/web/src/ordersSummary.test.ts
@@ -6,6 +6,7 @@ import {
   isLineResolved,
   isStaleOrderLine,
   orderLineAgeDays,
+  shouldShowSizeLabel,
   STALE_ORDER_LINE_DAYS,
   summarizeOrderLines,
 } from "./ordersSummary.js";
@@ -166,4 +167,23 @@ it("isStaleOrderLine — vybavený riadok (odškrtnutý alebo posunutý stav) NI
 
 it("isStaleOrderLine — čerstvý nevybavený riadok nedostane badge", () => {
   expect(isStaleOrderLine({ state: "objednane", ordered: false, placedAt: NOW.toISOString() }, NOW)).toBe(false);
+});
+
+// issue 105 bod 2 — `variants.sizeLabel` je odvodené priamo ako suffix
+// `variantCode`u za prvou lomkou (`apps/api/src/modules/catalog/map-row.ts`'s
+// `splitCode`), takže KÓD stĺpec pripájajúci veľkosť za kód vždy zdvojoval
+// ("62621/52" + "52" → "62621/5252"). `shouldShowSizeLabel` rozhoduje, či sa
+// veľkosť smie pripojiť: len keď kód EŠTE veľkosťou nekončí.
+it("shouldShowSizeLabel — kód UŽ končí veľkosťou (bežný prípad z katalógu) → veľkosť sa NEpripája znova", () => {
+  expect(shouldShowSizeLabel("62621/52", "52")).toBe(false);
+  expect(shouldShowSizeLabel("61759/XL", "XL")).toBe(false);
+  expect(shouldShowSizeLabel("15813/120", "120")).toBe(false);
+});
+
+it("shouldShowSizeLabel — kód veľkosťou NEkončí → veľkosť sa pripojí", () => {
+  expect(shouldShowSizeLabel("40287", "L")).toBe(true);
+});
+
+it("shouldShowSizeLabel — bez veľkosti (sizeLabel null) sa nikdy nič nepripája", () => {
+  expect(shouldShowSizeLabel("40287", null)).toBe(false);
 });

--- a/apps/web/src/ordersSummary.ts
+++ b/apps/web/src/ordersSummary.ts
@@ -129,3 +129,16 @@ export function isStaleOrderLine(
 ): boolean {
   return !isLineResolved(line) && orderLineAgeDays(line.placedAt, now) > STALE_ORDER_LINE_DAYS;
 }
+
+// issue 105 bod 2 — `variants.sizeLabel` (server) je odvodené priamo ako
+// suffix `variantCode`u za prvou lomkou (`apps/api/src/modules/catalog/
+// map-row.ts`'s `splitCode`: `sizeLabel = code.slice(code.indexOf("/") + 1)`),
+// takže KÓD stĺpec, ktorý za kódom pripája veľkosť (issue 95's zlúčenie
+// KÓD+VEĽKOSŤ), zakaždým zobrazoval veľkosť DVAKRÁT ("62621/52" + "52" →
+// "62621/5252"). Veľkosť sa smie pripojiť len vtedy, keď kód ňou ešte
+// nekončí — vždy pravdivé pre katalógové dáta dnes, ale funkcia zostáva
+// všeobecná (nezávisí od `splitCode`u), pre prípad inak odvodeného
+// `sizeLabel`u v budúcnosti.
+export function shouldShowSizeLabel(variantCode: string, sizeLabel: string | null): boolean {
+  return sizeLabel !== null && !variantCode.endsWith(sizeLabel);
+}

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -709,6 +709,18 @@ tr:last-child td {
 .orders-table td {
   overflow-wrap: break-word;
 }
+/* issue 105 bod 1: `<th>` explicitne NIKDY neláme uprostred slova — 4
+   jednoslovné/dvojslovné hlavičky boli skrátené (`SupplierOrderGroup.tsx`)
+   presne preto, aby sa zmestili na jeden riadok bez tejto potreby; tento
+   riadok dokumentuje a vynucuje invariant nezávisle od budúcej úpravy textu
+   (browser default JE `normal`, ale explicitná deklarácia bráni tichej
+   regresii, keby niekto neskôr pridal `overflow-wrap`/`word-break` na `th`
+   globálne). */
+.orders-table th {
+  overflow-wrap: normal;
+  word-break: normal;
+  hyphens: none;
+}
 /* issue 95 bod 8 ("zvážiť prilepenú hlavičku") — VYSKÚŠANÉ a ZAMIETNUTÉ
    (nájdené reálnym Playwright behom, nie len teoreticky): `position: sticky`
    na `<th>` sa sticky-uje voči NAJBLIŽŠIEMU predkovi so scroll-boxom — a
@@ -754,14 +766,17 @@ tr:last-child td {
 }
 /* issue 95: zvislé zarovnanie hore (nie stred) — zlúčené bunky (DODÁVATEĽ,
    POZNÁMKY) majú viac riadkov obsahu pod sebou a `top` drží prvý riadok
-   zarovnaný s ostatnými bunkami toho istého riadku tabuľky. Trocha
-   veľkorysejší zvislý padding než pôvodný globálny `td` reset (issue 95 bod
-   3: "doladiť hustotu") — stále husté, ale klikacie ciele majú dýchací
-   priestor. */
+   zarovnaný s ostatnými bunkami toho istého riadku tabuľky. issue 105 bod 3:
+   pôvodný `--fs-space-3` (12px) vertikálny padding tu bol o niečo
+   veľkorysejší než globálny `td` reset — teraz späť na `--fs-space-2` (8px),
+   lebo hlavný prispievateľ k 135px vysokému riadku bol zalomený vstup+
+   tlačidlo (opravené nižšie cez `flex-shrink`), nie tento padding; klikacie
+   ciele (checkbox/tlačidlá) majú explicitnú vlastnú výšku nezávislú od
+   paddingu, takže sa nezmenšujú. */
 .orders-table td {
   vertical-align: top;
-  padding-top: var(--fs-space-3);
-  padding-bottom: var(--fs-space-3);
+  padding-top: var(--fs-space-2);
+  padding-bottom: var(--fs-space-2);
 }
 /* issue 95: veľké klikacie ciele (majiteľ: "veľké tlačidlá, nech sa vedia
    zamestnanci rýchlo hýbať") — SCOPED na `.order-group`, nie globálna zmena
@@ -876,13 +891,29 @@ tr:last-child td {
   max-width: 100%;
 }
 .ord-supplier-assign-input {
-  width: 8rem;
-  /* code review (issue 95): `width` alone can force the input wider than its
-     ACTUAL column at the table's `min-width: 64rem` floor on a ~1280-1440px
-     laptop viewport (`.col-supplier` computes narrower than 8rem there) —
-     `<td>`s don't clip overflowing children by default, so without this the
-     input would visually bleed into the neighbouring column. `max-width:
-     100%` lets it shrink to whatever the column actually has. */
+  /* issue 105 bod 3: `width: 8rem` (fixed) + `max-width: 100%` still forced
+     the WHOLE row to wrap onto two lines at the table's floor width. Two
+     flexbox gotchas stacked here (found by measuring the REAL rendered
+     layout, not just reasoning about it):
+     (1) a flex item's default `flex-basis: auto` uses `width` as its basis,
+         and with no `min-width` override the browser won't shrink it below
+         its instrinsic min-content — so it never got small enough to share
+         a line with the button;
+     (2) `flex-basis` (not the post-shrink size) is what decides whether an
+         item fits on the CURRENT line under `flex-wrap: wrap` — so even
+         `flex: 1 1 8rem` (a LARGE preferred size) still wrapped, because
+         8rem alone is bigger than the whole available column at the
+         table's floor width.
+     Fix: `flex-basis: 0` (line-fit uses ~0, i.e. only `min-width` counts for
+     wrapping) + `flex-grow: 1` (it then EXPANDS to fill whatever room is
+     actually left after the button, which is generous again on wider
+     viewports) + a `min-width` small enough to still fit next to the button
+     in the WORST case (measured: ~62px free at 1280px/floor table width —
+     3rem leaves a safety margin). `flex-wrap: wrap` on `.ord-supplier-assign`
+     stays as a fallback for a genuinely narrower window than this table ever
+     reaches. */
+  flex: 1 1 0%;
+  min-width: 3rem;
   max-width: 100%;
   padding: var(--fs-space-2) var(--fs-space-2);
   border: 1px solid var(--fs-border);
@@ -890,6 +921,12 @@ tr:last-child td {
   font: inherit;
   font-size: var(--fs-text-base);
   min-height: 2.25rem;
+}
+/* issue 105 bod 3: the save button next to it must NEVER shrink — it's a
+   large tap target ("veľké tlačidlá", majiteľ) and its size is what the
+   input above is shrinking to make room for. */
+.ord-supplier-assign > button {
+  flex-shrink: 0;
 }
 
 /* issue 65: priamy odkaz do Shoptet administrácie. issue 99: nesie teraz
@@ -956,10 +993,14 @@ tr:last-child td {
   max-width: 100%;
 }
 .ord-comment-input {
-  width: 10rem;
-  /* code review (issue 95): same overflow safeguard as
-     `.ord-supplier-assign-input` above — `.col-notes` can compute narrower
-     than 10rem at the table's `min-width` floor on a laptop viewport. */
+  /* issue 105 bod 3: same fix, same TWO stacked root causes as
+     `.ord-supplier-assign-input` above (see its comment) — this was the MAIN
+     contributor to the reported 135px row height. `col-notes` is narrower
+     than `col-supplier`, so the measured worst-case budget after the button
+     is tighter (~41px at 1280px/floor table width) — `min-width: 2rem`
+     leaves a small safety margin instead of overflowing back into wrap. */
+  flex: 1 1 0%;
+  min-width: 2rem;
   max-width: 100%;
   padding: var(--fs-space-2) var(--fs-space-2);
   border: 1px solid var(--fs-border);
@@ -968,6 +1009,11 @@ tr:last-child td {
   font-size: var(--fs-text-base);
   min-height: 2.25rem;
 }
+/* issue 105 bod 3: same "button never shrinks" guarantee as the supplier
+   assign button above. */
+.ord-comment-cell > button {
+  flex-shrink: 0;
+}
 /* issue 95: percentuálne šírky stĺpcov (`SupplierOrderGroup.tsx`'s
    `<colgroup>`) — PRODUKT (najdôležitejší údaj, majiteľ komentár #1: "má len
    97px na dlhý názov") a zlúčené DODÁVATEĽ/POZNÁMKY dostávajú najviac
@@ -975,12 +1021,18 @@ tr:last-child td {
    pri 4% sa jednoslovná hlavička "OBJEDNANÉ" lámala DOPROSTRIED slova na tri
    riadky — pozri `overflow-wrap` komentár vyššie) — rozdiel vzatý z
    `col-qty` (6%→5%) a `col-date` (8%→7%), obe majú krátky obsah s
-   rezervou. */
+   rezervou.
+
+   issue 105 bod 1: aj po skrátení hlavičiek (checkbox stĺpec teraz ikona
+   "✓", `SupplierOrderGroup.tsx`) pridaná malá rezerva pre "Č. obj."/"Dátum
+   obj." — `col-order` 8%→9%, `col-date` 7%→8%, vzaté z `col-product` 20%→19%
+   a `col-supplier` 15%→14% (obe majú veľkú rezervu oproti svojmu skutočnému
+   obsahu, pozri prepočet v komentári k tomuto ticketu). Súčet ostáva 100%. */
 .col-ordered {
   width: 6%;
 }
 .col-order {
-  width: 8%;
+  width: 9%;
 }
 .col-customer {
   width: 10%;
@@ -989,19 +1041,19 @@ tr:last-child td {
   width: 8%;
 }
 .col-product {
-  width: 20%;
+  width: 19%;
 }
 .col-qty {
   width: 5%;
 }
 .col-supplier {
-  width: 15%;
+  width: 14%;
 }
 .col-state {
   width: 9%;
 }
 .col-date {
-  width: 7%;
+  width: 8%;
 }
 .col-notes {
   width: 12%;

--- a/apps/web/tests/e2e/orders.spec.ts
+++ b/apps/web/tests/e2e/orders.spec.ts
@@ -84,18 +84,30 @@ test("manažér filtruje podľa dodávateľa, vidí súhrn ostáva vybaviť a sk
   await page.getByTestId("orders-hide-resolved-toggle").click();
   await expect(page.getByTestId("supplier-DODAVATEL-TEST-1")).toBeVisible();
 
-  // issue 95: stránka sa NIKDY nesmie posúvať vodorovne, na žiadnej z troch
-  // testovaných šírok — keď je tabuľka širšia než dostupné miesto, posúva sa
-  // len jej VLASTNÝ obal (`.orders-table-wrap`), nikdy `document.body`.
-  // Rovnaký účet z tohto testu ostáva prihlásený, žiadne ďalšie prihlásenie
-  // netreba (šetrí `MAX_ATTEMPTS` rozpočet — `.claude/rules/frontend-design.md`).
-  for (const width of [1280, 1600, 1920]) {
+  // issue 95: stránka sa NIKDY nesmie posúvať vodorovne, na žiadnej zo
+  // štyroch testovaných šírok — keď je tabuľka širšia než dostupné miesto,
+  // posúva sa len jej VLASTNÝ obal (`.orders-table-wrap`), nikdy
+  // `document.body`. Rovnaký účet z tohto testu ostáva prihlásený, žiadne
+  // ďalšie prihlásenie netreba (šetrí `MAX_ATTEMPTS` rozpočet —
+  // `.claude/rules/frontend-design.md`).
+  //
+  // issue 105 bod 1: naživo namerané pretekanie hlavičiek stĺpcov
+  // (`th.scrollWidth > th.clientWidth`, napr. "OBJEDNANÉ"/"OBJEDNÁVKA" sa pri
+  // 1280px zlievali so susednou hlavičkou) sa unit testom (JSDOM nerenderuje
+  // skutočné šírky) ani doterajším 3-šírkovým behom (chýbalo 1440px)
+  // nezachytilo — teraz sa kontroluje KAŽDÁ `<th>` na VŠETKÝCH štyroch
+  // šírkach, ktoré ticket predpisuje.
+  for (const width of [1280, 1440, 1600, 1920]) {
     await page.setViewportSize({ width, height: 900 });
-    const { bodyWidth, viewportWidth } = await page.evaluate(() => ({
+    const { bodyWidth, viewportWidth, pretekajuceHlavicky } = await page.evaluate(() => ({
       bodyWidth: document.body.scrollWidth,
       viewportWidth: window.innerWidth,
+      pretekajuceHlavicky: [...document.querySelectorAll<HTMLTableCellElement>(".orders-table th")]
+        .filter((th) => th.scrollWidth > th.clientWidth)
+        .map((th) => `"${th.textContent}" (${String(th.scrollWidth)}px text vs ${String(th.clientWidth)}px bunka)`),
     }));
     expect(bodyWidth, `šírka okna ${String(width)}px`).toBeLessThanOrEqual(viewportWidth);
+    expect(pretekajuceHlavicky, `pretekajúce hlavičky pri ${String(width)}px`).toEqual([]);
   }
 
   // Priblíženie prehliadača (majiteľ: "ked aj scalujem tak sa ten stred

--- a/apps/web/tests/e2e/tsconfig.json
+++ b/apps/web/tests/e2e/tsconfig.json
@@ -4,7 +4,7 @@
     "composite": false,
     "declaration": false,
     "noEmit": true,
-    "lib": ["ES2023", "DOM"],
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "types": ["node"]
   },
   "include": ["**/*.ts"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.60",
+  "version": "0.3.0-dev.61",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Closes #105

## Čo bolo zle (naživo zmerané, nie len hádané)

1. **Hlavičky stĺpcov pretekali** (`OBJEDNANÉ`/`OBJEDNÁVKA`/`MNOŽSTVO`/`DÁTUM OBJEDNÁVKY`) — pri 1280px (tabuľkin skutočný floor, `min-width: 64rem`) boli užšie než ich text.
2. **Stĺpec KÓD zdvojoval veľkosť** (`62621/5252` namiesto `62621/52`) — `sizeLabel` je server-side odvodené priamo ako suffix `variantCode`u, takže sa vždy pripájalo niečo, čo v kóde UŽ bolo.
3. **Riadok bol 135px vysoký** — vstup+tlačidlo v stĺpci POZNÁMKY (aj DODÁVATEĽ) sa zalamovali pod seba namiesto vedľa seba (flexbox gotcha: `flex-basis` rozhoduje o zalomení, nie post-shrink veľkosť).

## Riešenie

- 4 hlavičky skrátené (checkbox stĺpec → ikona „✓“, `Č. obj.`, `Ks`, `Dátum obj.`), plný význam v `title`. Malá rezerva v `colgroup` percentách (`col-order`/`col-date` +1%, z `col-product`/`col-supplier`'s existujúceho prebytku).
- `shouldShowSizeLabel()` (`ordersSummary.ts`) — veľkosť sa pripojí len keď kód ňou EŠTE nekončí.
- `.ord-comment-input`/`.ord-supplier-assign-input`: `flex-basis: 0` + `flex-grow: 1` + malý `min-width` (namiesto fixnej `width`), sesterské tlačidlá `flex-shrink: 0`. `flex-wrap: wrap` ostáva ako poistka (issue 63), len sa v bežnom rozsahu už neaktivuje.
- `.orders-table td` vertikálny padding 12px→8px (klikacie plochy majú vlastnú explicitnú veľkosť, nezávislú od paddingu).

## Overenie (lokálne, PRED pushom)

- `pnpm test` (498), `pnpm test:integration` (229), `pnpm --filter @forestshop/web e2e` (20) — všetko zelené.
- `pnpm lint` / `pnpm typecheck` — čisto.
- RED→GREEN dokázané reálnym behom: dočasne vrátený starý CSS/TSX ukázal presne nahlásené čísla (`"Objednané" 93px text vs 61px bunka`, atď.), po vrátení opravy 0 pretečení pri 1280/1440/1600/1920px.
- Nameraná výška riadku: **135px → ~85–98px** (comment/supplier-assign kontrolky teraz na JEDNOM riadku pri všetkých 4 šírkach), checkbox 22×22px a tlačidlá ~40.5px výšky nezmenené.
