### PR TITLE
Fix STAV truncation, narrow POZNAMKY, zbytočná pomlčka v DODAVATEL (issue 107)

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -176,3 +176,40 @@ paths:
   proving a merge is a REAL DOM merge (not just relabeled headers): assert
   the two testid'd elements' `.closest("td")` are the SAME node
   (`OrdersSection.test.tsx`).
+- **A flex item's `flex-basis` — NOT its post-shrink rendered size — decides
+  whether it fits on the current line under `flex-wrap: wrap`.** Issue 105's
+  `.ord-comment-cell`/`.ord-supplier-assign` (issue 63's established pattern:
+  `display: flex; flex-wrap: wrap` on the cell so an overflowing input+button
+  wraps INSIDE the cell instead of bleeding into the neighbour column) still
+  wrapped onto two lines at the table's narrowest real width, making rows
+  135px tall — even after giving the `<input>` a `min-width` and relying on
+  `flex-shrink`. Root cause: with `width: 8rem/10rem` (fixed) and no `flex`
+  shorthand, the item's `flex-basis: auto` resolves to that `width`, and
+  **flex-basis is what the wrapping algorithm measures BEFORE any shrinking
+  happens** — a large flex-basis wraps regardless of how small `min-width`
+  allows the item to actually shrink afterward. Fix: `flex: 1 1 0%` (a ~0
+  flex-basis, so the item always "fits" for wrapping purposes) + `flex-grow:
+  1` (it then expands to fill whatever room the line actually has) + a small
+  `min-width` sized to the WORST-CASE measured column width (never guessed —
+  see below) + `flex-shrink: 0` on the sibling button so its tap target never
+  shrinks. `flex-wrap: wrap` stays on the parent as a safety net (issue 63's
+  original reason), it just stops triggering once the basis is right. Any
+  FUTURE flex-wrap cell with a shrinkable input + a fixed sibling (button/
+  icon) that still wraps unexpectedly: check whether the shrinkable item has
+  `flex: 1 1 0` — a `width`/large `flex-basis` on it is the same trap, no
+  matter how small its `min-width` is.
+- **Measure real column budgets with a throwaway Playwright script against
+  the LOCAL dev servers, never hand-derive px-per-character or eyeball a
+  screenshot, before tuning `min-width`/`colgroup` percentages.** Issue 105:
+  `pnpm --filter @forestshop/web dev` + `pnpm --filter @forestshop/api start`
+  (env `DATABASE_URL`/`SESSION_COOKIE_SECURE=false`, `.claude/rules/
+  local-dev.md`'s local DB) + a one-off Node script requiring the workspace's
+  own `apps/web/node_modules/@playwright/test` (`createRequire` from an
+  `.mjs` file) logging in as the seeded e2e user and reading real
+  `getBoundingClientRect()`/`scrollWidth`/`clientWidth` values at each target
+  viewport gave EXACT numbers (e.g. "98.33px available after the save
+  button's real 53px width") that a first `min-width` guess (3.5rem) missed
+  by enough to still wrap — the second, measured attempt (2rem/3rem) worked
+  first try. This is free (no deploy needed) and catches exactly the
+  flex-basis trap above, which pure CSS reasoning does not surface until you
+  see it render.

--- a/apps/web/src/components/OrderLineRow.supplierAssignCell.test.tsx
+++ b/apps/web/src/components/OrderLineRow.supplierAssignCell.test.tsx
@@ -1,0 +1,87 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { OrdersSection } from "./OrdersSection.js";
+
+// issue 107 bod 3: majiteľ, komentár #1: "neviem čo tam je Priradenie
+// dodávateľa stĺpec" — každý riadok BEZ ohľadu na `supplierAssignable`
+// predtým vykresľoval `.ord-supplier-assign` div, ktorý pri neradiťeľných
+// riadkoch (100 % dnešných ostrých dát) ukazoval len holú pomlčku "—". Tento
+// súbor dokazuje OBIDVE strany opravy: neradiťeľný riadok blok NEVYKRESLÍ
+// vôbec (žiadny prvok v DOM), radiťeľný riadok ho vykreslí AJ s viditeľným
+// popisom (nielen placeholderom). Vlastný súbor — rovnaký vzor ako
+// `OrderLineRow.adminLink.test.tsx` (`.claude/rules/frontend-design.md`).
+const { fetchOpenOrders } = vi.hoisted(() => ({ fetchOpenOrders: vi.fn() }));
+
+vi.mock("../ordersApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../ordersApi.js")>();
+  return { ...actual, fetchOpenOrders };
+});
+
+const ZAKLAD = {
+  orderId: "cccccccc-0000-0000-0000-000000000000",
+  externalOrderId: "20261300",
+  customerName: "Zákazník Delta",
+  comment: null,
+  remark: null,
+  adminUrl: "https://www.forestshop.sk/admin/vyhladavanie/?string=20261300&src=orders",
+  placedAt: "2026-07-01T00:00:00.000Z",
+  variantCode: "D-1",
+  variantName: "Šál FOREST 4001",
+  sizeLabel: null,
+  quantity: 1,
+  state: "objednane" as const,
+  ordered: false,
+  supplierUrl: null,
+  supplierNote: null,
+  externalCode: null,
+  manualSupplierOverride: null,
+};
+
+const RIADOK_NERADITELNY = {
+  ...ZAKLAD,
+  lineId: "11111111-0000-0000-0000-000000000001",
+  supplierAssignable: false,
+};
+
+const RIADOK_RADITELNY = {
+  ...ZAKLAD,
+  lineId: "11111111-0000-0000-0000-000000000002",
+  externalOrderId: "20261301",
+  supplierAssignable: true,
+};
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+it("neradiťeľný riadok nevykreslí blok priradenia dodávateľa vôbec (žiadna pomlčka, žiadny prázdny div)", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "(bez dodávateľa)", lines: [RIADOK_NERADITELNY], email: null }]);
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const riadok = await screen.findByTestId(`order-line-${RIADOK_NERADITELNY.lineId}`);
+  expect(within(riadok).queryByTestId(`supplier-assign-cell-${RIADOK_NERADITELNY.lineId}`)).toBeNull();
+  expect(riadok.textContent).not.toContain("—");
+});
+
+it("radiťeľný riadok vykreslí blok priradenia AJ s viditeľným popisom, nielen placeholderom", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "(bez dodávateľa)", lines: [RIADOK_RADITELNY], email: null }]);
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const riadok = await screen.findByTestId(`order-line-${RIADOK_RADITELNY.lineId}`);
+  const blok = within(riadok).getByTestId(`supplier-assign-cell-${RIADOK_RADITELNY.lineId}`);
+  // `getByLabelText`/`getByRole` už SAMY vyhodia, keď prvok nenájdu — žiadny
+  // jest-dom matcher netreba (`.claude/rules/frontend-design.md`: tento
+  // projekt nemá `@testing-library/jest-dom` zapojené).
+  within(blok).getByLabelText(
+    `Priradiť dodávateľa riadku objednávky ${RIADOK_RADITELNY.externalOrderId} / ${RIADOK_RADITELNY.variantCode}`,
+  );
+  within(blok).getByLabelText(
+    `Uložiť priradenie dodávateľa riadku objednávky ${RIADOK_RADITELNY.externalOrderId} / ${RIADOK_RADITELNY.variantCode}`,
+  );
+  // Popis viditeľný AJ mimo placeholderu (dnes to prezrádza LEN placeholder) —
+  // majiteľ, komentár #1.
+  expect(blok.textContent).toContain("Priradiť dodávateľa");
+});

--- a/apps/web/src/components/OrderLineRow.supplierAssignCell.test.tsx
+++ b/apps/web/src/components/OrderLineRow.supplierAssignCell.test.tsx
@@ -61,8 +61,12 @@ it("neradiťeľný riadok nevykreslí blok priradenia dodávateľa vôbec (žiad
   render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
 
   const riadok = await screen.findByTestId(`order-line-${RIADOK_NERADITELNY.lineId}`);
+  // Presne CIELENÁ neprítomnosť — `supplier-link-${lineId}` blok (odkaz/kód
+  // dodávateľa, NEZÁVISLÝ od tohto ticketu) legitímne vykresľuje VLASTNÚ
+  // pomlčku, keď riadok nemá ani odkaz, ani kód (`OrderLineRow.tsx:221`) —
+  // preto sa tu neoveruje "žiadna pomlčka nikde v riadku", len skutočná
+  // neprítomnosť TOHTO konkrétneho bloku.
   expect(within(riadok).queryByTestId(`supplier-assign-cell-${RIADOK_NERADITELNY.lineId}`)).toBeNull();
-  expect(riadok.textContent).not.toContain("—");
 });
 
 it("radiťeľný riadok vykreslí blok priradenia AJ s viditeľným popisom, nielen placeholderom", async () => {
@@ -81,7 +85,9 @@ it("radiťeľný riadok vykreslí blok priradenia AJ s viditeľným popisom, nie
   within(blok).getByLabelText(
     `Uložiť priradenie dodávateľa riadku objednávky ${RIADOK_RADITELNY.externalOrderId} / ${RIADOK_RADITELNY.variantCode}`,
   );
-  // Popis viditeľný AJ mimo placeholderu (dnes to prezrádza LEN placeholder) —
-  // majiteľ, komentár #1.
-  expect(blok.textContent).toContain("Priradiť dodávateľa");
+  // Popis viditeľný AJ mimo placeholderu (dnes to prezrádza LEN placeholder)
+  // — majiteľ, prvý komentár. Vykreslí sa v susednej `.ord-supplier-cell`
+  // (nie priamo v `blok`u) — žiadny extra riadok výšky navyše, pozri
+  // `OrderLineRow.tsx`'s komentár k `.ord-supplier-assign-hint`.
+  expect(riadok.textContent).toContain("Priradiť dodávateľa");
 });

--- a/apps/web/src/components/OrderLineRow.tsx
+++ b/apps/web/src/components/OrderLineRow.tsx
@@ -223,46 +223,51 @@ export function OrderLineRow({
           ) : null}
           {line.externalCode !== null && <div className="ord-supplier-code">kód {line.externalCode}</div>}
         </div>
-        <div className="ord-supplier-assign" data-testid={`supplier-assign-cell-${line.lineId}`}>
-          {line.supplierAssignable ? (
-            <>
-              <input
-                type="text"
-                // Jeden zdieľaný `<datalist id="known-suppliers">` (rendrovaný
-                // raz v `OrdersSection.tsx`, z UŽ načítaných skupín) — žiadna
-                // nová GET trasa netreba len na našepkávanie.
-                list="known-suppliers"
-                className="ord-supplier-assign-input"
-                data-testid={`supplier-assign-input-${line.lineId}`}
-                aria-label={`Priradiť dodávateľa riadku objednávky ${line.externalOrderId} / ${line.variantCode}`}
-                placeholder="priradiť dodávateľa…"
-                value={supplierDraft}
-                disabled={supplierBusyHere}
-                onChange={(e) => {
-                  setSupplierDraft(e.target.value);
-                }}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    e.preventDefault();
-                    saveSupplier();
-                  }
-                }}
-              />
-              <button
-                type="button"
-                className="btn sm good"
-                data-testid={`supplier-assign-save-${line.lineId}`}
-                aria-label={`Uložiť priradenie dodávateľa riadku objednávky ${line.externalOrderId} / ${line.variantCode}`}
-                disabled={supplierBusyHere || supplierDraft.trim() === ""}
-                onClick={saveSupplier}
-              >
-                💾
-              </button>
-            </>
-          ) : (
-            "—"
-          )}
-        </div>
+        {/* issue 107 bod 3: majiteľ, komentár #1: "neviem čo tam je Priradenie
+            dodávateľa stĺpec" — pri neradiťeľnom riadku (100 % dnešných ostrých
+            dát) sa TENTO blok predtým vykresľoval VŽDY, len s holou pomlčkou
+            "—" bez akéhokoľvek významu. Teraz sa nevykreslí VÔBEC (žiadny
+            prvok, žiadny prázdny <div>) — presne to, čo test v
+            `OrderLineRow.supplierAssignCell.test.tsx` overuje. */}
+        {line.supplierAssignable && (
+          <div className="ord-supplier-assign" data-testid={`supplier-assign-cell-${line.lineId}`}>
+            {/* Krátky viditeľný popis (nielen placeholder) — predtým účel poľa
+                prezrádzal LEN placeholder, presne na čo sa majiteľ sťažoval. */}
+            <span className="ord-supplier-assign-label">Priradiť dodávateľa:</span>
+            <input
+              type="text"
+              // Jeden zdieľaný `<datalist id="known-suppliers">` (rendrovaný
+              // raz v `OrdersSection.tsx`, z UŽ načítaných skupín) — žiadna
+              // nová GET trasa netreba len na našepkávanie.
+              list="known-suppliers"
+              className="ord-supplier-assign-input"
+              data-testid={`supplier-assign-input-${line.lineId}`}
+              aria-label={`Priradiť dodávateľa riadku objednávky ${line.externalOrderId} / ${line.variantCode}`}
+              placeholder="priradiť dodávateľa…"
+              value={supplierDraft}
+              disabled={supplierBusyHere}
+              onChange={(e) => {
+                setSupplierDraft(e.target.value);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  saveSupplier();
+                }
+              }}
+            />
+            <button
+              type="button"
+              className="btn sm good"
+              data-testid={`supplier-assign-save-${line.lineId}`}
+              aria-label={`Uložiť priradenie dodávateľa riadku objednávky ${line.externalOrderId} / ${line.variantCode}`}
+              disabled={supplierBusyHere || supplierDraft.trim() === ""}
+              onClick={saveSupplier}
+            >
+              💾
+            </button>
+          </div>
+        )}
       </td>
       <td>
         {canChangeState ? (

--- a/apps/web/src/components/OrderLineRow.tsx
+++ b/apps/web/src/components/OrderLineRow.tsx
@@ -218,22 +218,29 @@ export function OrderLineRow({
             <span className="ord-supplier-note" title={line.supplierNote}>
               {line.supplierNote}
             </span>
+          ) : line.supplierAssignable ? (
+            // issue 107 bod 3: majiteľ, komentár #1: "neviem čo tam je
+            // Priradenie dodávateľa stĺpec" — namiesto holej pomlčky (predtým
+            // aj tu, aj v `.ord-supplier-assign` nižšie — DVE pomlčky nad
+            // sebou) je tu teraz VIDITEĽNÝ popis toho, čo vstup pod ním robí.
+            // Zámerne v TEJTO, už existujúcej bunke (nie nový riadok pod
+            // vstupom) — pridanie ĎALŠIEHO riadku by pri úzkom stĺpci
+            // (input+button už zapĺňajú takmer celú šírku) posunulo výšku
+            // riadku nad issue 105's ~95px invariant (živo zmerané: 85px →
+            // 103.5px s popisom na vlastnom riadku).
+            <span className="ord-supplier-assign-hint">Priradiť dodávateľa</span>
           ) : line.externalCode === null ? (
             "—"
           ) : null}
           {line.externalCode !== null && <div className="ord-supplier-code">kód {line.externalCode}</div>}
         </div>
-        {/* issue 107 bod 3: majiteľ, komentár #1: "neviem čo tam je Priradenie
-            dodávateľa stĺpec" — pri neradiťeľnom riadku (100 % dnešných ostrých
-            dát) sa TENTO blok predtým vykresľoval VŽDY, len s holou pomlčkou
-            "—" bez akéhokoľvek významu. Teraz sa nevykreslí VÔBEC (žiadny
-            prvok, žiadny prázdny <div>) — presne to, čo test v
+        {/* pri neradiťeľnom riadku (100 % dnešných ostrých dát) sa TENTO blok
+            predtým vykresľoval VŽDY, len s holou pomlčkou "—" bez
+            akéhokoľvek významu. Teraz sa nevykreslí VÔBEC (žiadny prvok,
+            žiadny prázdny <div>) — presne to, čo test v
             `OrderLineRow.supplierAssignCell.test.tsx` overuje. */}
         {line.supplierAssignable && (
           <div className="ord-supplier-assign" data-testid={`supplier-assign-cell-${line.lineId}`}>
-            {/* Krátky viditeľný popis (nielen placeholder) — predtým účel poľa
-                prezrádzal LEN placeholder, presne na čo sa majiteľ sťažoval. */}
-            <span className="ord-supplier-assign-label">Priradiť dodávateľa:</span>
             <input
               type="text"
               // Jeden zdieľaný `<datalist id="known-suppliers">` (rendrovaný

--- a/apps/web/src/components/OrdersSection.test.tsx
+++ b/apps/web/src/components/OrdersSection.test.tsx
@@ -137,12 +137,17 @@ it("hlavička tabuľky má 10 stĺpcov (zlúčené VEĽKOSŤ/PRIRADENIE DODÁVAT
 });
 
 it("zlúčená bunka DODÁVATEĽ drží odkaz na dodávateľa AJ priradenie v tom istom stĺpci", async () => {
-  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_STARA], email: null }]);
+  // issue 107 bod 3: `.ord-supplier-assign` sa už nevykresľuje pre
+  // neradiťeľné riadky (`LINE_STARA` má `supplierAssignable: false`) —
+  // tento test overuje SKUTOČNÝ DOM zlúčenie (ten istý rodičovský `<td>`),
+  // preto potrebuje riadok, kde sa blok priradenia vôbec vykreslí.
+  const riadokRaditelny = { ...LINE_STARA, supplierAssignable: true };
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [riadokRaditelny], email: null }]);
 
   render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
 
-  const odkazBunka = await screen.findByTestId(`supplier-link-${LINE_STARA.lineId}`);
-  const priradenieBunka = await screen.findByTestId(`supplier-assign-cell-${LINE_STARA.lineId}`);
+  const odkazBunka = await screen.findByTestId(`supplier-link-${riadokRaditelny.lineId}`);
+  const priradenieBunka = await screen.findByTestId(`supplier-assign-cell-${riadokRaditelny.lineId}`);
   expect(odkazBunka.closest("td")).toBe(priradenieBunka.closest("td"));
 });
 

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -890,6 +890,16 @@ tr:last-child td {
   flex-wrap: wrap;
   max-width: 100%;
 }
+/* issue 107 bod 3: krátky viditeľný popis nad vstupom (nie vedľa) —
+   `flex-basis: 100%` ho vynúti na VLASTNÝ riadok pod `.ord-supplier-assign`'s
+   `flex-wrap: wrap`, takže nekonkuruje o horizontálny priestor s
+   vstupom/tlačidlom (presne ten priestor, ktorý si issue 105 bod 3 draho
+   zmeral pre input+button pár). */
+.ord-supplier-assign-label {
+  flex-basis: 100%;
+  font-size: var(--fs-text-xs);
+  color: var(--fs-ink-faint);
+}
 .ord-supplier-assign-input {
   /* issue 105 bod 3: `width: 8rem` (fixed) + `max-width: 100%` still forced
      the WHOLE row to wrap onto two lines at the table's floor width. Two

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -831,14 +831,29 @@ tr:last-child td {
   font-weight: var(--fs-weight-medium);
   color: var(--fs-ink-muted);
 }
+/* issue 107 bod 1: majiteľ, live nameraná chyba — natívna šípka rozbaľovača
+   sa vykresľuje VNÚTRI paddingu, ale nič v CSS s jej priestorom nepočíta
+   (`padding-right` bol celý priestor, ktorý appka "vidí"), takže reálne
+   viditeľné miesto na text bolo o ~15–20px menšie, než čokoľvek deklarované
+   — pri úzkom `col-state` stĺpci (≤1600px) sa najdlhší stav ("Nevybavené"/
+   "Nedostupné", ~83px textu) neskrátil na scrollWidth (žiadny technický
+   overflow), len sa VIZUÁLNE orezal natívnou šípkou. `appearance: none` +
+   vlastná malá SVG šípka spraví tento priestor DETERMINISTICKÝ (a teda aj
+   testovateľný) namiesto skrytého v réžii prehliadača. */
 .ord-state-select {
   width: 100%;
-  padding: var(--fs-space-2) var(--fs-space-2);
+  appearance: none;
+  padding: var(--fs-space-2) 1.25rem var(--fs-space-2) var(--fs-space-2);
   border: 1px solid var(--fs-border);
   border-radius: var(--fs-radius-sm);
   font: inherit;
   font-size: var(--fs-text-base);
   min-height: 2.25rem;
+  background-color: var(--fs-surface);
+  background-repeat: no-repeat;
+  background-position: right 0.4rem center;
+  background-size: 0.6rem 0.4rem;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 6'%3E%3Cpath d='M1 1l4 4 4-4' fill='none' stroke='%235c6b60' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
 }
 /* issue 95: DODÁVATEĽ + PRIRADENIE DODÁVATEĽA zlúčené do jednej bunky
    (majiteľ, komentár #1: "neviem čo tam je Priradenie dodávateľa stĺpec" —
@@ -1036,36 +1051,67 @@ tr:last-child td {
    "✓", `SupplierOrderGroup.tsx`) pridaná malá rezerva pre "Č. obj."/"Dátum
    obj." — `col-order` 8%→9%, `col-date` 7%→8%, vzaté z `col-product` 20%→19%
    a `col-supplier` 15%→14% (obe majú veľkú rezervu oproti svojmu skutočnému
-   obsahu, pozri prepočet v komentári k tomuto ticketu). Súčet ostáva 100%. */
+   obsahu, pozri prepočet v komentári k tomuto ticketu).
+
+   issue 107 body 1+2: majiteľ, live nameraná chyba — STAV orezaný text
+   (bod 1) a POZNÁMKY príliš úzke pole (bod 2) obe potrebovali OVEĽA väčší
+   podiel, než mala akákoľvek jednotlivá "rezerva" úprava doteraz. Živo
+   zmerané (throwaway Playwright skript proti lokálnym dev serverom, rovnaký
+   postup ako issue 105): `col-state` potrebuje aspoň ~14 % (pri tabuľkinej
+   "floor" šírke 1024px, `.ord-state-select`'s `appearance:none` vlastná
+   šípka nižšie), aby sa "Nevybavené"/"Nedostupné" (~83px textu) zmestili aj
+   s bezpečnou rezervou; `col-notes` potrebuje aspoň ~24-25 % (odvodené zo
+   `.ord-comment-input`'s reálne zmeraného vzťahu `cellWidth = inputWidth +
+   button(53px) + gap(4px)`, aby `input >= 160px`, ako žiada zadanie).
+   Financované naprieč stĺpcami, KTORÉ majú preukázateľnú rezervu (živo
+   zmerané cez skutočnú produkciu — `vychod@varos.sk` účet na
+   `forestshop-novy.newlevel.media`, nie len e2e fixtúru): `col-supplier`
+   (14%→11%, NIE agresívnejšie — prvý pokus 8% spôsobil, že "Odkaz na
+   dodávateľa" odkaz, ktorý má DNES 92 % živých riadkov, sa zalamoval o
+   ĎALŠIE riadky navyše (živo zmerané: 85px→111.5px), presný opak "efektívnej
+   práce"; 11% drží tento bežný prípad na pôvodnej výške) — bezpečné brať
+   aspoň TOĽKO, lebo issue 107 bod 3 odstránilo priradenie-dodávateľa
+   fallback pomlčku, takže stĺpec už nedrží input+tlačidlo pre 100 % dnešných
+   ostrých riadkov (tie sa vykreslia len pri zriedkavom `supplierAssignable`
+   riadku, dnes 0 z 39); `col-product` (19%→10%) — dlhé názvy produktov sa aj
+   tak zalamujú na viac riadkov bez ohľadu na % (najdlhší živý názov má >90
+   znakov, živo overené), takže miernejšie percento nemení kvalitatívne nič;
+   `col-order`/`col-code`/`col-ordered` po malých kúskoch (číslo objednávky/
+   kód variantu/checkbox potrebujú menej, než čo ich hlavička už dnes má).
+   `col-customer` len -2% (10%→8%, NIE menej — `th.scrollWidth` skutočne
+   PRETEKALO pri agresívnejšom 7% pokuse, živo zachytené existujúcim
+   regresným e2e testom). `col-qty`/`col-date` NEDOTKNUTÉ — ich obsah
+   (množstvo, dátum) je už dnes tesný, ďalšie oberanie by ich reálne
+   pretieklo. Súčet ostáva 100%. */
 .col-ordered {
-  width: 6%;
+  width: 5%;
 }
 .col-order {
-  width: 9%;
+  width: 7%;
 }
 .col-customer {
-  width: 10%;
-}
-.col-code {
   width: 8%;
 }
+.col-code {
+  width: 7%;
+}
 .col-product {
-  width: 19%;
+  width: 10%;
 }
 .col-qty {
   width: 5%;
 }
 .col-supplier {
-  width: 14%;
+  width: 11%;
 }
 .col-state {
-  width: 9%;
+  width: 14%;
 }
 .col-date {
   width: 8%;
 }
 .col-notes {
-  width: 12%;
+  width: 25%;
 }
 
 /* issue 59: nastavenie otvorených stavov objednávok — rovnaký vizuálny

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -875,6 +875,15 @@ tr:last-child td {
   font-size: var(--fs-text-xs);
   color: var(--fs-ink-faint);
 }
+/* issue 107 bod 3: majiteľ, komentár #1: "neviem čo tam je Priradenie
+   dodávateľa stĺpec" — nahrádza predtým holú pomlčku (bod vyššie v `.tsx`),
+   rovnaký vizuálny jazyk ako `.ord-supplier-code` (tichý, faint text nad
+   ovládacím prvkom pod ním), žiadny extra riadok výšky navyše — vykresľuje
+   sa v UŽ EXISTUJÚCOM mieste (`.ord-supplier-cell`), nie v novom bloku. */
+.ord-supplier-assign-hint {
+  font-size: var(--fs-text-xs);
+  color: var(--fs-ink-faint);
+}
 /* issue 63: ručné priradenie dodávateľa riadku bez dodávateľa — vstup +
    uložiť, rovnaký vizuálny jazyk ako `.ord-state-select`/`.btn.sm`. `flex` +
    `flex-wrap: wrap` (NIE `white-space: nowrap`) — bez zalomenia by vstup +
@@ -889,16 +898,6 @@ tr:last-child td {
   gap: var(--fs-space-1);
   flex-wrap: wrap;
   max-width: 100%;
-}
-/* issue 107 bod 3: krátky viditeľný popis nad vstupom (nie vedľa) —
-   `flex-basis: 100%` ho vynúti na VLASTNÝ riadok pod `.ord-supplier-assign`'s
-   `flex-wrap: wrap`, takže nekonkuruje o horizontálny priestor s
-   vstupom/tlačidlom (presne ten priestor, ktorý si issue 105 bod 3 draho
-   zmeral pre input+button pár). */
-.ord-supplier-assign-label {
-  flex-basis: 100%;
-  font-size: var(--fs-text-xs);
-  color: var(--fs-ink-faint);
 }
 .ord-supplier-assign-input {
   /* issue 105 bod 3: `width: 8rem` (fixed) + `max-width: 100%` still forced

--- a/apps/web/tests/e2e/orders-layout.spec.ts
+++ b/apps/web/tests/e2e/orders-layout.spec.ts
@@ -1,0 +1,107 @@
+import { expect, test, type ConsoleMessage } from "@playwright/test";
+
+const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
+
+// issue 107: majiteľ, live nameraná chyba po nasadení issue 105 — orezaný
+// text v STAV (bod 1), príliš úzke pole POZNÁMKY (bod 2). Vlastný súbor +
+// vlastný izolovaný účet — `orders.spec.ts` je už na eslint `max-lines: 400`
+// hranici (`.claude/rules/frontend-design.md`'s zavedený vzor), a balík
+// zdieľaného `e2e@forestshop.sk` je na hranici `MAX_ATTEMPTS`
+// (`scripts/e2e-setup.ts`'s komentár k `E2E_ROZLOZENIE_EMAIL`).
+const E2E_ROZLOZENIE_EMAIL = "e2e-rozlozenie@forestshop.sk";
+
+const jeOcakavane = (m: ConsoleMessage): boolean =>
+  m.location().url.includes("/api/me") && m.text().includes("401");
+
+test("STAV je celý čitateľný a POZNÁMKY pole je dosť široké na všetkých 4 šírkach, riadky bez priradenia dodávateľa ostávajú kompaktné, konzola je čistá", async ({
+  page,
+}) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/?tab=orders");
+  await page.getByLabel("E-mail").fill(E2E_ROZLOZENIE_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await expect(page.getByRole("heading", { name: "Na objednanie" })).toBeVisible();
+  await page.waitForSelector(".orders-table");
+
+  for (const width of [1280, 1440, 1600, 1920]) {
+    await page.setViewportSize({ width, height: 900 });
+
+    // issue 107 bod 1: KAŽDÁ <option> stavu (nie len tá aktuálne vybraná)
+    // musí byť celá viditeľná — `appearance: none` (`app.css`'s
+    // `.ord-state-select`) spravilo priestor na text DETERMINISTICKÝ
+    // (`clientWidth - padding - border`, žiadna skrytá natívna šípka), takže
+    // test už nepotrebuje hádať jej šírku.
+    const orezaneStavy = await page.evaluate(() => {
+      const select = document.querySelector<HTMLSelectElement>(".ord-state-select");
+      if (!select) return { chyba: "no select found" };
+      const rect = select.getBoundingClientRect();
+      const cs = getComputedStyle(select);
+      const dostupne =
+        rect.width -
+        parseFloat(cs.paddingLeft) -
+        parseFloat(cs.paddingRight) -
+        parseFloat(cs.borderLeftWidth) -
+        parseFloat(cs.borderRightWidth);
+      const merac = document.createElement("span");
+      merac.style.visibility = "hidden";
+      merac.style.position = "absolute";
+      merac.style.whiteSpace = "nowrap";
+      merac.style.font = cs.font;
+      document.body.appendChild(merac);
+      const orezane: string[] = [];
+      for (const option of [...select.options]) {
+        merac.textContent = option.textContent;
+        const potrebne = merac.getBoundingClientRect().width;
+        if (potrebne > dostupne) {
+          orezane.push(`"${option.textContent}" (${String(Math.ceil(potrebne))}px text vs ${String(Math.floor(dostupne))}px k dispozícii)`);
+        }
+      }
+      merac.remove();
+      return { orezane };
+    });
+    expect(orezaneStavy.orezane, `orezané stavy pri ${String(width)}px`).toEqual([]);
+
+    // issue 107 bod 2: pole na poznámku >= 160px pri 1280px, tlačidlo 💾 na
+    // TOM ISTOM riadku (nesmie sa vrátiť k zalomeniu z issue 105).
+    const poznamky = await page.evaluate(() => {
+      const input = document.querySelector<HTMLInputElement>('input[data-testid^="comment-input-"]');
+      if (!input) return { chyba: "no comment input found" };
+      const button = input.closest(".ord-comment-cell")?.querySelector("button");
+      const inputRect = input.getBoundingClientRect();
+      const buttonRect = button?.getBoundingClientRect();
+      return {
+        width: inputRect.width,
+        naTomIstomRiadku: buttonRect !== undefined && Math.abs(inputRect.top - buttonRect.top) < 3,
+      };
+    });
+    expect(poznamky.naTomIstomRiadku, `tlačidlo 💾 na inom riadku ako pole pri ${String(width)}px`).toBe(true);
+    if (width === 1280) {
+      expect(poznamky.width, "šírka poľa na poznámku pri 1280px").toBeGreaterThanOrEqual(160);
+    }
+
+    // issue 107 bod 2 (regresia issue 105): riadky BEZ bloku priradenia
+    // dodávateľa (žiadny živý riadok ho dnes nemá) ostávajú kompaktné —
+    // riadky S ním (zriedkavé, `supplierAssignable`) sú vyňaté zámerne: aj
+    // živá produkcia bežne prekračuje ~95px kvôli dlhým názvom produktov
+    // (`.claude/rules/frontend-design.md`), takže tento test overuje presne
+    // to, čo je v scope tohto ticketu — POZNÁMKY stĺpec už nespôsobuje
+    // zalomenie vstup+tlačidlo, nie univerzálny strop na VŠETKY možné riadky.
+    const vysokeKompaktneRiadky = await page.evaluate(() => {
+      return [...document.querySelectorAll(".order-row")]
+        .filter((r) => r.querySelector('[data-testid^="supplier-assign-cell-"]') === null)
+        .map((r) => r.getBoundingClientRect().height)
+        .filter((h) => h > 100);
+    });
+    expect(vysokeKompaktneRiadky, `príliš vysoké riadky pri ${String(width)}px`).toEqual([]);
+  }
+
+  expect(chyby).toEqual([]);
+});

--- a/apps/web/tests/e2e/orders.spec.ts
+++ b/apps/web/tests/e2e/orders.spec.ts
@@ -617,14 +617,16 @@ test("manažér ručne priradí dodávateľa riadku bez dodávateľa s našepká
 
   // Riadok BEZ dodávateľa (objednávka 9006, `scripts/e2e-setup.ts`) — pole na
   // priradenie je viditeľné a prázdne (kým riadok DODAVATEL-TEST-1 s
-  // katalógovým dodávateľom žiadne pole nemá, len "—").
+  // katalógovým dodávateľom nemá blok priradenia VÔBEC — issue 107 bod 3
+  // odstránilo predtým holú pomlčku, blok sa dnes nevykreslí vôbec, nie len
+  // zobrazí "—").
   const vstupL = page.getByLabel("Priradiť dodávateľa riadku objednávky 9006 / 60035/L");
   await expect(vstupL).toBeVisible();
   await expect(vstupL).toHaveValue("");
   const bunkaTest1 = page
     .getByTestId("supplier-DODAVATEL-TEST-1")
     .locator("[data-testid^='supplier-assign-cell-']");
-  await expect(bunkaTest1).toHaveText("—");
+  await expect(bunkaTest1).toHaveCount(0);
 
   // Našepkávanie: known-suppliers datalist musí ponúkať UŽ existujúceho
   // dodávateľa (dôkaz, že sa berie zo skutočne načítaných skupín, nie z

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -1411,3 +1411,42 @@ nové heslo sa nikde v pushnutom obsahu nenachádza.
   `order_line`=868, objednávky s komentárom=0, `order`=528 — presne
   zhodné s očakávanou základňou pred aj po zásahu.
 - Discord run-card odoslaný (`notify --run-card`, potvrdené doručenie).
+
+## Issue #105 — Na objednanie: hlavičky sa zlievajú, KÓD zdvojuje veľkosť, riadok 135 px vysoký
+
+- Live re-check po issue 95 (v0.3.0-dev.60) pri 1280/1600/1920px našiel 3
+  zvyškové chyby: 4 hlavičky pretekali svoje bunky (`OBJEDNANÉ`/`OBJEDNÁVKA`/
+  `MNOŽSTVO`/`DÁTUM OBJEDNÁVKY`, najhoršie pri 1280px = tabuľkin skutočný
+  floor `min-width:64rem`); KÓD stĺpec zdvojoval veľkosť (`62621/5252`);
+  riadok 135px vysoký (comment/supplier-assign vstup+tlačidlo zalomené pod
+  seba).
+- Design-rozhodnutie zapísané PRED kódom:
+  `https://github.com/zbynekdrlik/forestshop-app/issues/105#issuecomment-5144365445`.
+- RED→GREEN: `b3f006f` (red: `shouldShowSizeLabel` unit test) → `fc49f9a`
+  (green: fix v `ordersSummary.ts`/`OrderLineRow.tsx` — sizeLabel je
+  server-side literálny suffix `variantCode`u, `splitCode` v
+  `map-row.ts`, pripájanie preto vždy duplikovalo). `ae11b4e` (red:
+  rozšírený e2e width-check na 1440px + assercia na `th` pretekanie,
+  potvrdené RED reálnym behom so starým CSS/TSX) → `cc3d2ba` (green:
+  skrátené 4 hlavičky — checkbox stĺpec dostal ikonu "✓", `Č. obj.`, `Ks`,
+  `Dátum obj.`, malá rezerva v colgroup percentách; `.ord-comment-input`/
+  `.ord-supplier-assign-input` `flex-basis:0` + `flex-grow:1` + tuned
+  `min-width` namiesto fixnej `width` — flexbox gotcha: `flex-basis`
+  rozhoduje o zalomení pod `flex-wrap:wrap`, nie post-shrink veľkosť;
+  `flex-shrink:0` na susedných tlačidlách; `.orders-table td` vertikálny
+  padding 12px→8px). `8d00de2` (playbook: `DOM.Iterable` potrebné pre
+  NodeList spread v e2e tsconfig).
+- Shared PR: `#106`. CI zelené na `dev` pushi aj oboch PR CI behoch (5/5
+  jobs); main CI + Deploy zelené bez retry.
+- Nezávislý code review (general-purpose subagent na diff PR #106): 0 🔴
+  0 🟡, 2 🔵 (obe explicitne "fine as-is" — DOM.Iterable doplnené do
+  playbooku, endsWith bez case-guard zámerne ponechané pre nedosiahnuteľný
+  prípad).
+- Live overenie (`https://forestshop-novy.newlevel.media/?tab=orders`,
+  39 reálnych riadkov): 0 pretekajúcich `<th>` pri 1280/1440/1600/1920px;
+  KÓD naživo potvrdené presne uvedené príklady z ticketu ("62621/52",
+  "61759/XL", "15813/120") bez zdvojenia; 0/39 comment ciel a 0/39
+  supplier-assign ciel zalomených pri 1280px; výška riadku 84.5–116px
+  (predtým 135px); 0 console chýb/varovaní; verzia vo footeri
+  `v0.3.0-dev.61` zodpovedá `/api/version`.
+- Discord run-card odoslaný (`notify --run-card`, potvrdené doručenie).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.61",
+  "version": "0.3.0-dev.62",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.62",
+  "version": "0.3.0-dev.63",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -99,6 +99,13 @@ const E2E_PRIRADENIE_EMAIL = "e2e-priradenie@forestshop.sk"; // musí sa zhodova
 // izolovaný účet namiesto ďalšieho prihlásenia pod zdieľaným.
 const E2E_KOMENTAR_EMAIL = "e2e-komentar@forestshop.sk"; // musí sa zhodovať s hodnotou v orders.spec.ts
 
+// issue 107: rovnaký mechanizmus a dôvod ako `E2E_KOMENTAR_EMAIL` vyššie —
+// balík je UŽ na hranici `MAX_ATTEMPTS` (10), takže nový spec súbor
+// (`orders-layout.spec.ts` — vizuálna regresia STAV/POZNÁMKY/DODÁVATEĽ)
+// dostáva VLASTNÝ izolovaný účet namiesto ďalšieho prihlásenia pod
+// zdieľaným `e2e@forestshop.sk`.
+const E2E_ROZLOZENIE_EMAIL = "e2e-rozlozenie@forestshop.sk"; // musí sa zhodovať s hodnotou v orders-layout.spec.ts
+
 const { db, pool } = createDb();
 // Konštantný literál bez interpolácie — obyčajný reťazec je tu rovnako bezpečný
 // ako `sql` tagovaná šablóna (tú používa ekvivalentný apps/api/tests/helpers/db.ts),
@@ -186,6 +193,12 @@ await db.insert(users).values({
 });
 await db.insert(users).values({
   email: E2E_KOMENTAR_EMAIL,
+  passwordHash: await hashPassword(E2E_HESLO),
+  displayName: "E2E Manažér",
+  role: "manazer",
+});
+await db.insert(users).values({
+  email: E2E_ROZLOZENIE_EMAIL,
   passwordHash: await hashPassword(E2E_HESLO),
   displayName: "E2E Manažér",
   role: "manazer",


### PR DESCRIPTION
Closes #107

## Čo bolo zle (majiteľ, live nameraná chyba po nasadení issue 105)

1. **STAV** — vybraná hodnota v `<select>`e sa vizuálne orezávala (natívna šípka rozbaľovača žrala priestor, ktorý CSS vôbec nedeklarovalo) na šírkach ≤1600px.
2. **POZNÁMKY** — pole na komentár bolo len ~41-73px široké (aj vlastný placeholder bol orezaný).
3. **DODÁVATEĽ** — každý neradiťeľný riadok (100 % ostrých dát) zobrazoval zbytočnú holú pomlčku.

## Riešenie

- `.ord-state-select`: `appearance: none` + vlastná malá SVG šípka namiesto natívnej — priestor na text je teraz deterministický a testovateľný. `col-state` 9%→14%.
- `.ord-comment-input`: `col-notes` 12%→25%, komentárové pole je teraz ≥160px pri 1280px.
- `OrderLineRow.tsx`: `.ord-supplier-assign` sa vôbec nevykreslí pre neradiťeľné riadky; radiťeľné riadky (dnes 0 z 39 ostrých) dostanú viditeľný popis "Priradiť dodávateľa" namiesto spoliehania sa len na placeholder.
- Percentá stĺpcov prerozdelené naprieč tabuľkou — financované zo stĺpcov s preukázateľnou rezervou (živo zmerané aj proti skutočnej produkcii, nie len e2e fixtúre).

## Overenie

- Živo zmerané (throwaway Playwright skript) pri 1280/1440/1600/1920px — text stavu aj šírka poznámky vyhovujú s rezervou.
- Nový regresný e2e test `orders-layout.spec.ts` + nový RTL test `OrderLineRow.supplierAssignCell.test.tsx`.
- Celý balík: 226 web unit + 274 API testov, 21 e2e testov, lint, typecheck — všetko zelené.
- Žiadna regresia issue 105 (th overflow, horizontálne skrolovanie stránky) — existujúci regresný test naďalej prechádza.
