### PR TITLE
Fix column-budget regression from issue 107 (production-verified)

### DIFF
--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -1055,54 +1055,71 @@ tr:last-child td {
 
    issue 107 body 1+2: majiteľ, live nameraná chyba — STAV orezaný text
    (bod 1) a POZNÁMKY príliš úzke pole (bod 2) obe potrebovali OVEĽA väčší
-   podiel, než mala akákoľvek jednotlivá "rezerva" úprava doteraz. Živo
-   zmerané (throwaway Playwright skript proti lokálnym dev serverom, rovnaký
-   postup ako issue 105): `col-state` potrebuje aspoň ~14 % (pri tabuľkinej
-   "floor" šírke 1024px, `.ord-state-select`'s `appearance:none` vlastná
-   šípka nižšie), aby sa "Nevybavené"/"Nedostupné" (~83px textu) zmestili aj
-   s bezpečnou rezervou; `col-notes` potrebuje aspoň ~24-25 % (odvodené zo
-   `.ord-comment-input`'s reálne zmeraného vzťahu `cellWidth = inputWidth +
-   button(53px) + gap(4px)`, aby `input >= 160px`, ako žiada zadanie).
-   Financované naprieč stĺpcami, KTORÉ majú preukázateľnú rezervu (živo
-   zmerané cez skutočnú produkciu — `vychod@varos.sk` účet na
-   `forestshop-novy.newlevel.media`, nie len e2e fixtúru): `col-supplier`
-   (14%→11%, NIE agresívnejšie — prvý pokus 8% spôsobil, že "Odkaz na
-   dodávateľa" odkaz, ktorý má DNES 92 % živých riadkov, sa zalamoval o
-   ĎALŠIE riadky navyše (živo zmerané: 85px→111.5px), presný opak "efektívnej
-   práce"; 11% drží tento bežný prípad na pôvodnej výške) — bezpečné brať
-   aspoň TOĽKO, lebo issue 107 bod 3 odstránilo priradenie-dodávateľa
-   fallback pomlčku, takže stĺpec už nedrží input+tlačidlo pre 100 % dnešných
-   ostrých riadkov (tie sa vykreslia len pri zriedkavom `supplierAssignable`
-   riadku, dnes 0 z 39); `col-product` (19%→10%) — dlhé názvy produktov sa aj
-   tak zalamujú na viac riadkov bez ohľadu na % (najdlhší živý názov má >90
-   znakov, živo overené), takže miernejšie percento nemení kvalitatívne nič;
-   `col-order`/`col-code`/`col-ordered` po malých kúskoch (číslo objednávky/
-   kód variantu/checkbox potrebujú menej, než čo ich hlavička už dnes má).
-   `col-customer` len -2% (10%→8%, NIE menej — `th.scrollWidth` skutočne
-   PRETEKALO pri agresívnejšom 7% pokuse, živo zachytené existujúcim
-   regresným e2e testom). `col-qty`/`col-date` NEDOTKNUTÉ — ich obsah
-   (množstvo, dátum) je už dnes tesný, ďalšie oberanie by ich reálne
-   pretieklo. Súčet ostáva 100%. */
+   podiel, než mala akákoľvek jednotlivá "rezerva" úprava doteraz. `col-state`
+   potrebuje aspoň ~14 % (pri tabuľkinej "floor" šírke 1024px,
+   `.ord-state-select`'s `appearance:none` vlastná šípka nižšie), aby sa
+   "Nevybavené"/"Nedostupné" (~83px textu) zmestili aj s bezpečnou rezervou;
+   `col-notes` potrebuje aspoň ~24 % (odvodené zo `.ord-comment-input`'s
+   reálne zmeraného vzťahu `cellWidth = inputWidth + button(53px) +
+   gap(4px)`, aby `input >= 160px`, ako žiada zadanie).
+
+   PRVÝ pokus (nasadený, potom OPRAVENÝ v tomto istom PR) financoval túto
+   +18 percentuálnych bodov väčšinou zo `col-supplier` (14%→8%) a
+   `col-product` (19%→10-11%) — testované LEN proti lokálnej e2e fixtúre
+   (krátke, jednoduché testové dáta), nie proti skutočnej produkcii. Po
+   nasadení živé meranie (`vychod@varos.sk` na
+   `forestshop-novy.newlevel.media`, throwaway skript vkladajúci kandidátne
+   `<style>` priamo do živej stránky cez `page.addStyleTag`, žiadny ďalší
+   deploy netreba na vyskúšanie kandidáta) odhalilo REGRESIU: 92 % živých
+   riadkov má odkaz "Odkaz na dodávateľa" ČASTO AJ s "kód XXXX" pod ním
+   (dlhší obsah, než akýkoľvek e2e fixture riadok testoval), ktorý sa pri
+   zúženom `col-supplier` zalomil na viac riadkov než predtým (`maxHeight`
+   85px→212px, 17 z 39 riadkov nad 100px) — presný opak "efektívnej práce".
+   **Ponaučenie: percentuálny rozpočet stĺpca sa musí overiť proti SKUTOČNEJ
+   živej produkcii (dlhé názvy, odkazy AJ kódy súčasne), nie len proti
+   krátkej e2e fixtúre — jedna e2e-friendly hodnota môže vyzerať v poriadku a
+   pritom reálne zhoršiť väčšinu ostrých riadkov.**
+
+   OPRAVENÝ rozpočet (živo overený `page.addStyleTag` kandidátmi PRIAMO proti
+   produkcii, kým sa nenašla kombinácia bez regresie): `col-supplier` späť
+   bližšie k pôvodným 14% (na 13%) — bezpečné vziať aspoň TOĽKO menej, lebo
+   issue 107 bod 3 odstránilo priradenie-dodávateľa fallback pomlčku, takže
+   stĺpec už nedrží input+tlačidlo pre 100 % dnešných ostrých riadkov (tie sa
+   vykreslia len pri zriedkavom `supplierAssignable` riadku, dnes pár z 39);
+   `col-product` tiež späť na 13% — pri 12% či menej sa `maxHeight`
+   živo zhoršil (12%: 173px/12 riadkov nad 100px vs 13%: 134px/5 riadkov),
+   dlhé názvy (najdlhší živý má >90 znakov) potrebujú skutočnú rezervu, nie
+   len o niečo menej než pôvodných 19%. Zvyšok financovania: `col-order`/
+   `col-code`/`col-ordered` na 5% (číslo objednávky/kód variantu/checkbox
+   potrebujú menej, než čo ich hlavička už dnes má — živo overené, žiadny
+   `th` nepretiekol). `col-customer` len -2% (10%→8%, NIE menej —
+   `th.scrollWidth` skutočne PRETEKALO pri agresívnejšom 7% pokuse, živo
+   zachytené existujúcim regresným e2e testom). `col-qty`/`col-date`
+   NEDOTKNUTÉ — ich obsah (množstvo, dátum) je už dnes tesný, ďalšie
+   oberanie by ich reálne pretieklo. Výsledok živo overený proti produkcii:
+   `maxHeight` 134px (namiesto 212px), 5 z 39 riadkov nad 100px (namiesto
+   17), 0 nad 150px (namiesto 5), žiadna pretekajúca hlavička na žiadnej zo
+   4 šírok. Súčet ostáva 100%. */
 .col-ordered {
   width: 5%;
 }
 .col-order {
-  width: 7%;
+  width: 5%;
 }
 .col-customer {
   width: 8%;
 }
 .col-code {
-  width: 7%;
+  width: 5%;
 }
 .col-product {
-  width: 10%;
+  width: 13%;
 }
 .col-qty {
   width: 5%;
 }
 .col-supplier {
-  width: 11%;
+  width: 13%;
 }
 .col-state {
   width: 14%;
@@ -1111,7 +1128,7 @@ tr:last-child td {
   width: 8%;
 }
 .col-notes {
-  width: 25%;
+  width: 24%;
 }
 
 /* issue 59: nastavenie otvorených stavov objednávok — rovnaký vizuálny

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.63",
+  "version": "0.3.0-dev.64",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Follow-up to #107 / PR #108 — no new `Closes` (issue 107 already closed by #108's merge).

## Nález po nasadení #108

Percentá stĺpcov v #108 boli overené LEN proti lokálnej e2e fixtúre. Po nasadení živé meranie na `forestshop-novy.newlevel.media` (`vychod@varos.sk`) odhalilo regresiu: 92 % ostrých riadkov má odkaz "Odkaz na dodávateľa" (často aj s "kód XXXX" pod ním) — dlhší obsah, než akýkoľvek e2e fixture riadok testoval — ktorý sa v zúženom `col-supplier` (14%→8-11%) zalomil na viac riadkov (`maxHeight` 85px→212px, 17 z 39 riadkov nad 100px).

## Oprava

`col-supplier` a `col-product` späť na 13% (namiesto 8-11%), financovanie prišlo z `col-order`/`col-code`/`col-ordered` (5%) a `col-customer` (8%) — všetko živo overené priamo proti produkcii (`page.addStyleTag` kandidáty, žiadny redeploy netreba na vyskúšanie).

## Výsledok (živo overené proti produkcii)

- `maxHeight` 134px (namiesto 212px), 5 z 39 riadkov nad 100px (namiesto 17), 0 nad 150px (namiesto 5).
- STAV (~83px textu) aj POZNÁMKY (≥160px poľa) požiadavky naďalej splnené s rezervou na všetkých 4 šírkach.
- Žiadna pretekajúca hlavička.
- Celý balík testov (226 web + 274 API unit, 21 e2e) zelený, lint aj typecheck čisté.
