### PR TITLE
Playbook + log entry for issue 107 (documentation only)

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -213,3 +213,35 @@ paths:
   first try. This is free (no deploy needed) and catches exactly the
   flex-basis trap above, which pure CSS reasoning does not surface until you
   see it render.
+- **A `<colgroup>` percentage budget MUST be verified against REAL PRODUCTION
+  content shape, not just the e2e fixture — the fixture's short, simple test
+  data can hide a regression that only shows up on real rows.** Issue 107
+  bodies 1+2 needed `col-state`/`col-notes` to grow a lot (9%→14%, 12%→24%),
+  funded partly by shrinking `col-supplier` (14%→8-11%). That passed the FULL
+  e2e suite and looked fine against the seeded fixture (`orders.spec.ts`'s
+  `4859/46` row, plain "Odkaz na dodávateľa" link, no `externalCode`) — but
+  after deploying, live measurement against `forestshop-novy.newlevel.media`
+  (`vychod@varos.sk`) showed 92% of the 39 real rows carry that same link
+  text PLUS a second "kód XXXX" line under it (`OrderLineRow.tsx`'s
+  `.ord-supplier-code`, driven by `externalCode` — present on real supplier
+  data, absent from the lean fixture), which wrapped across noticeably more
+  lines once the column narrowed (`maxHeight` 85px→212px, 17/39 rows over
+  100px — the opposite of the ticket's own "efektívna práca" goal). Fixed by
+  re-verifying candidate `<colgroup>` percentages LIVE against production
+  BEFORE settling on the final numbers, using `page.addStyleTag({content:
+  ".col-x{width:Y%!important}"})` against the ALREADY-DEPLOYED page — this
+  swaps column percentages in the live DOM instantly, no redeploy needed per
+  candidate, so a wrong split (`col-product` at 12% made things worse, not
+  better — `maxHeight` 173px vs 13%'s 134px) can be caught and corrected in
+  seconds. **Two things to get right when doing this:** (1) test a COMPLETE
+  set of column percentages that sums to exactly 100 each time — overriding
+  just ONE column via `addStyleTag` while the others stay at their deployed
+  values does NOT sum to 100 and produces misleading cross-column overflow
+  (a `.col-product` override alone made `Zákazník`'s header "overflow", which
+  had nothing to do with product); (2) log into the REAL account
+  (`vychod@varos.sk`, see the `forestshop-app-login` memory note) to see the
+  REAL 39-row dataset, not an isolated e2e account — the e2e fixture's
+  fixtures are deliberately minimal and will never reproduce a real
+  content-shape regression like this one. Any FUTURE `<colgroup>` percentage
+  change needs this same live-against-production check before being called
+  done, not just a green e2e suite.

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -1450,3 +1450,36 @@ nové heslo sa nikde v pushnutom obsahu nenachádza.
   (predtým 135px); 0 console chýb/varovaní; verzia vo footeri
   `v0.3.0-dev.61` zodpovedá `/api/version`.
 - Discord run-card odoslaný (`notify --run-card`, potvrdené doručenie).
+
+## issue 107 — STAV orezaný text, úzke POZNÁMKY, zbytočná pomlčka v DODAVATEL
+
+- Commity na `dev`: `469f462` (bump 0.3.0-dev.63), `26e9e9f` ([red] test:
+  supplier-assign-cell musí zmiznúť pre neradiťeľné riadky), `74ba34c`
+  ([green] bod 3: neradiťeľný riadok nevykreslí blok priradenia dodávateľa
+  vôbec), `002d06a` ([green] popis "Priradiť dodávateľa" presunutý do
+  existujúcej `.ord-supplier-cell` — bez extra riadku výšky), `9e6ad99`
+  ([red] `orders-layout.spec.ts` — STAV orezaný text + úzke POZNÁMKY),
+  `791d78a` ([green] bod 1+2: `.ord-state-select`'s `appearance:none` +
+  vlastná šípka, `col-state` 9%→14%, `col-notes` 12%→25%, financované zo
+  `col-supplier`/`col-product`/ostatných).
+- Shared PR: `#108` (zmergnuté, `49aeb92`). Main CI + Deploy zelené,
+  v0.3.0-dev.63 nasadené.
+- **Live post-deploy overenie odhalilo regresiu** (percentá stĺpcov
+  overené LEN proti e2e fixtúre, nie proti skutočnej produkcii): 92 % z 39
+  ostrých riadkov má "Odkaz na dodávateľa" + "kód XXXX" pod ním — dlhší
+  obsah než e2e fixture testovala — ktorý sa v zúženom `col-supplier`
+  zalomil na viac riadkov (`maxHeight` 85px→212px). Follow-up PR `#109`
+  (`67b023c` bump 0.3.0-dev.64, `f4c67c4` oprava rozpočtu stĺpcov — live
+  overené priamo proti produkcii cez `page.addStyleTag`, žiadny redeploy
+  netreba na vyskúšanie kandidáta) — `col-supplier`/`col-product` späť na
+  13%, financovanie z `col-order`/`col-code`/`col-ordered` (5%) a
+  `col-customer` (8%). Zmergnuté, `69b9e0b`. Main CI + Deploy zelené,
+  v0.3.0-dev.64 nasadené.
+- Live overenie po opravnom deployi (`vychod@varos.sk`, 39 reálnych
+  riadkov, 1280/1440/1600/1920px): 0 orezaných stavov, POZNÁMKY pole
+  164–304px (≥160px), 0 pomlčiek v DODAVATEL bloku, 0 pretekajúcich `<th>`,
+  0 vodorovného skrolovania stránky, `maxHeight` 134/134/114.5/95px
+  (namiesto pôvodných 85–212px), 0 console chýb/varovaní, verzia vo
+  footeri `v0.3.0-dev.64` zodpovedá `/api/version`.
+- Playbook zápis: `.claude/rules/frontend-design.md` — overuj `<colgroup>`
+  percentá proti SKUTOČNEJ produkcii, nie len e2e fixtúre.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.64",
+  "version": "0.3.0-dev.65",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Documentation-only follow-up: playbook entry in `.claude/rules/frontend-design.md` (verify colgroup % budgets against real production content, not just e2e fixture) + `docs/autopilot-log.md` entry for issue 107. No code changes.