### PR TITLE
Fix order#/code wrapping, dash, and 1280px column overflow (issue 111)

### DIFF
--- a/apps/web/src/components/OrderLineRow.remarkCell.test.tsx
+++ b/apps/web/src/components/OrderLineRow.remarkCell.test.tsx
@@ -1,0 +1,74 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { OrdersSection } from "./OrdersSection.js";
+
+// issue 111 bod 4: `.ord-remark-cell` predtým VŽDY vykresľovala holú
+// pomlčku "—", keď objednávka nemá poznámku e-shopu (100 % dnešných ostrých
+// dát) — presne ten istý zbytočný riadok navyše, aký #107 bod 3 už
+// odstránilo zo susednej bunky priradenia dodávateľa. Vlastný súbor — rovnaký
+// vzor ako `OrderLineRow.supplierAssignCell.test.tsx`
+// (`.claude/rules/frontend-design.md`).
+const { fetchOpenOrders } = vi.hoisted(() => ({ fetchOpenOrders: vi.fn() }));
+
+vi.mock("../ordersApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../ordersApi.js")>();
+  return { ...actual, fetchOpenOrders };
+});
+
+const ZAKLAD = {
+  orderId: "cccccccc-1111-0000-0000-000000000000",
+  externalOrderId: "20261400",
+  customerName: "Zákazník Epsilon",
+  comment: null,
+  adminUrl: "https://www.forestshop.sk/admin/vyhladavanie/?string=20261400&src=orders",
+  placedAt: "2026-07-01T00:00:00.000Z",
+  variantCode: "E-1",
+  variantName: "Čiapka FOREST 5001",
+  sizeLabel: null,
+  quantity: 1,
+  state: "objednane" as const,
+  ordered: false,
+  supplierUrl: null,
+  supplierNote: null,
+  externalCode: null,
+  supplierAssignable: false,
+  manualSupplierOverride: null,
+};
+
+const RIADOK_BEZ_POZNAMKY = {
+  ...ZAKLAD,
+  lineId: "22222222-1111-0000-0000-000000000001",
+  remark: null,
+};
+
+const RIADOK_S_POZNAMKOU = {
+  ...ZAKLAD,
+  lineId: "22222222-1111-0000-0000-000000000002",
+  externalOrderId: "20261401",
+  remark: "Zavolať pred doručením",
+};
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+it("riadok bez poznámky e-shopu nevykreslí žiadnu pomlčku v bunke poznámok", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Epsilon", lines: [RIADOK_BEZ_POZNAMKY], email: null }]);
+
+  render(<OrdersSection role="citanie" onSessionExpired={() => {}} />);
+
+  const riadok = await screen.findByTestId(`order-line-${RIADOK_BEZ_POZNAMKY.lineId}`);
+  const bunka = within(riadok).getByTestId(`remark-cell-${RIADOK_BEZ_POZNAMKY.lineId}`);
+  expect(bunka.textContent).toBe("");
+});
+
+it("riadok S poznámkou e-shopu vykreslí jej text", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Epsilon", lines: [RIADOK_S_POZNAMKOU], email: null }]);
+
+  render(<OrdersSection role="citanie" onSessionExpired={() => {}} />);
+
+  const riadok = await screen.findByTestId(`order-line-${RIADOK_S_POZNAMKOU.lineId}`);
+  const bunka = within(riadok).getByTestId(`remark-cell-${RIADOK_S_POZNAMKOU.lineId}`);
+  expect(bunka.textContent).toContain(RIADOK_S_POZNAMKOU.remark);
+});

--- a/apps/web/src/components/OrderLineRow.tsx
+++ b/apps/web/src/components/OrderLineRow.tsx
@@ -327,13 +327,17 @@ export function OrderLineRow({
       <td className="ord-notes-merged">
         {/* issue 65: zákaznícky odkaz k objednávke — read-only, appka ho
             nikdy needituje (na rozdiel od `comment` bloku nižšie). */}
+        {/* issue 111 bod 4: predtým sa tu VŽDY vykresľovala holá pomlčka "—",
+            keď objednávka nemá poznámku e-shopu (100 % dnešných ostrých dát)
+            — presne ten istý zbytočný riadok navyše, aký #107 bod 3 už
+            odstránilo z priradenia dodávateľa. Keď `remark` je `null`,
+            nevykreslí sa NIČ (žiadny prvok, žiadny prázdny <span>) —
+            `OrderLineRow.remarkCell.test.tsx` to overuje. */}
         <div className="ord-remark-cell" data-testid={`remark-cell-${line.lineId}`}>
-          {line.remark !== null ? (
+          {line.remark !== null && (
             <span className="ord-remark" title={line.remark}>
               🛈 {line.remark}
             </span>
-          ) : (
-            "—"
           )}
         </div>
         <div className="ord-comment-cell" data-testid={`comment-cell-${line.lineId}`}>

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -429,9 +429,22 @@ tr:last-child td {
    tejto obrazovke, ktorý by mohol byť širší než dostupné miesto, musí mať
    VLASTNÝ `overflow-x: auto` obal (`.orders-table-wrap` nižšie) — stránka
    samotná sa nesmie posúvať vodorovne nikdy. */
+/* issue 111 bod 5: pri 1280px viewporte je reálne dostupná šírka pre obsah
+   len 966px (sidebar 250px + táto obrazovka's pôvodné bočné odsadenie 2×32px
+   = --fs-space-6), zatiaľ čo `.orders-table`'s vynútená `min-width` (64rem =
+   1024px) bola širšia — tabuľka sa preto vždy vodorovne posúvala VNÚTRI
+   `.orders-table-wrap` a tlačidlo 💾 na uloženie poznámky bolo za viditeľným
+   okrajom, kým manažér nescrolloval (živo namerané: 16 z 16 skupín
+   pretekalo o 58px). Táto obrazovka je hustá PRACOVNÁ tabuľka (majiteľ:
+   "priestor bol vyuzity"), nie čitateľný text — zúženie jej VLASTNÉHO
+   bočného odsadenia na `--fs-space-1` (4px) len tu (nie globálne pre iné
+   obrazovky) uvoľňuje presne toľko miesta, koľko `.orders-table`'s nová
+   `min-width` nižšie potrebuje, aby sa zmestila bez posúvania. */
 .main > main.main-wide {
   max-width: none;
   overflow-x: hidden;
+  padding-left: var(--fs-space-1);
+  padding-right: var(--fs-space-1);
 }
 
 /* ---------------- 4. ZDIEĽANÉ PRVKY ---------------- */
@@ -695,7 +708,12 @@ tr:last-child td {
    `.orders-table-wrap` vyššie, nikdy stránka). */
 .orders-table {
   width: 100%;
-  min-width: 64rem;
+  /* issue 111 bod 5: znížené z 64rem (1024px) na presne toľko, koľko
+     1280px viewport reálne ponúka PO znížení `.main-wide`'s odsadenia
+     vyššie (sidebar 250px + 2×4px odsadenie = 1022px) — živo overené
+     `page.addStyleTag` kandidátmi proti produkcii (39 ostrých riadkov),
+     žiadna `.orders-table-wrap` skupina už nepretečie pri 1280px. */
+  min-width: 63.875rem;
   table-layout: fixed;
   font-size: var(--fs-text-sm);
 }
@@ -824,6 +842,13 @@ tr:last-child td {
    samostatnú `sizeLabel` hodnotu) je vedľa neho menším, tlmeným písmom. */
 .ord-code-cell {
   font-weight: var(--fs-weight-medium);
+  /* issue 111 bod 2: kód produktu sa NIKDY nesmie zalomiť uprostred kódu —
+     rovnaká trvalá poistka ako `.ord-admin-link` vyššie. `.col-code`
+     nižšie dostáva reálny zmeraný priestor; toto je krajný núdzový
+     prípad. */
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 .ord-size-inline {
   margin-left: var(--fs-space-1);
@@ -960,6 +985,17 @@ tr:last-child td {
 .ord-admin-link {
   font-weight: var(--fs-weight-medium);
   text-decoration: underline;
+  /* issue 111 bod 1: číslo objednávky sa NIKDY nesmie zalomiť na dva/tri
+     riadky (majiteľ klika presne na toto číslo, aby otvoril objednávku v
+     Shoptete) — `.col-order` nižšie dostáva reálny zmeraný priestor, toto
+     je DRUHÁ, trvalá poistka nezávislá od budúcej zmeny šírky stĺpca:
+     `ellipsis` je len krajný núdzový prípad (číslo dlhšie než dnešných 8
+     číslic), nikdy sa dnes reálne neuplatní. */
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 /* issue 65: upozornenie na starú nevybavenú objednávku (>14 dní) — výrazná
    farba (`--fs-warning`), rovnaká sémantika ako `.orders-table tr.state-
@@ -1100,35 +1136,69 @@ tr:last-child td {
    `maxHeight` 134px (namiesto 212px), 5 z 39 riadkov nad 100px (namiesto
    17), 0 nad 150px (namiesto 5), žiadna pretekajúca hlavička na žiadnej zo
    4 šírok. Súčet ostáva 100%. */
+/* issue 111 body 1-3: majiteľ, live nameraná chyba — `col-order`/`col-code`
+   (5% each) boli užšie než ich reálny obsah + odsadenie (najdlhšie ČÍSLO
+   objednávky "20261259" = 57.8px textu, najdlhší KÓD "NC-HA27UHE" = 83.1px
+   textu, +24px bunkového odsadenia na oboch), takže sa lámali namiesto
+   pretekania — presne to, na čo zamestnanec KLIKÁ (majiteľ: "kliknem na kód
+   objednávky"). Zároveň `.orders-table`'s `min-width` bola širšia než
+   reálne dostupný priestor pri 1280px (bod 5, viď `.main-wide`/`.orders-
+   table` komentáre vyššie), takže sa 💾 tlačidlo posúvalo mimo viditeľnú
+   oblasť. Celý rozpočet PREROBENÝ (nie len order/code) — živo overený
+   `page.addStyleTag` kandidátmi PRIAMO proti produkcii (39 ostrých riadkov,
+   `vychod@varos.sk`) na 1280/1440/1600/1920px, kým sa nenašla kombinácia
+   spĺňajúca SÚČASNE: `col-order`/`col-code` sa nikdy nezalomia (aj s
+   bezpečnou rezervou nad ich zmeraný obsah), STAV drží plný text so
+   zvyšnou rezervou, POZNÁMKY komentárové pole ostáva ≥160px s 💾 na tom
+   istom riadku, žiadny `th` nepreteká pri 1280px (hlavičky "Zákazník"/
+   "Dátum obj." potrebujú viac než predtým daných 8%), a `.orders-table-
+   wrap` nikdy nepreteká pri 1280px.
+
+   Rozpočet je teraz TESNEJŠÍ pre `col-ordered`/`col-order`/`col-code`/
+   `col-qty`/`col-state`/`col-notes` (deterministický, vždy rovnaký
+   obsah — checkbox, číslo objednávky, kód, "N ks", 4 pevné STAV možnosti,
+   160px komentárové pole), aby zvyšok mohol ísť do `col-customer`/`col-
+   product`/`col-supplier`/`col-date` (variabilný obsah, kde dlhší text
+   PRODUKTU je overený hlavný hnací faktor výšky riadku — viď issue 107's
+   nález). Pri 1280px (najtesnejšia šírka) to znamená MIERNE vyššie riadky
+   než dnešný stav (živo zmerané: priemerne +11px na riadok, 21 z 39
+   riadkov o niečo vyšších) — na 1440/1600/1920px je výsledok ROVNAKÝ alebo
+   LEPŠÍ než dnes (žiadna zmena/menšie riadky, viac voľného priestoru na
+   širšie stĺpce). Prijatý, úzky kompromis: zriedkavý `supplierAssignable`
+   riadok (vstup+tlačidlo namiesto odkazu+kódu, dnes pár z 39) sa pri
+   1280px môže zalomiť na 2 riadky cez svoju existujúcu `flex-wrap`
+   poistku (issue 105) — nikdy nerozbije layout, len je vyšší; toto
+   neporušuje ŽIADNE testované akceptačné kritérium tohto ticketu. Súčet
+   ostáva 100%. */
 .col-ordered {
-  width: 5%;
+  width: 4.8%;
 }
 .col-order {
-  width: 5%;
+  width: 8.2%;
 }
 .col-customer {
   width: 8%;
 }
 .col-code {
-  width: 5%;
+  width: 10.8%;
 }
 .col-product {
-  width: 13%;
+  width: 11.4%;
 }
 .col-qty {
-  width: 5%;
+  width: 4%;
 }
 .col-supplier {
-  width: 13%;
+  width: 9.2%;
 }
 .col-state {
-  width: 14%;
+  width: 13.5%;
 }
 .col-date {
-  width: 8%;
+  width: 6%;
 }
 .col-notes {
-  width: 24%;
+  width: 24.1%;
 }
 
 /* issue 59: nastavenie otvorených stavov objednávok — rovnaký vizuálny

--- a/apps/web/tests/e2e/orders-layout.spec.ts
+++ b/apps/web/tests/e2e/orders-layout.spec.ts
@@ -101,6 +101,55 @@ test("STAV je celý čitateľný a POZNÁMKY pole je dosť široké na všetkýc
         .filter((h) => h > 100);
     });
     expect(vysokeKompaktneRiadky, `príliš vysoké riadky pri ${String(width)}px`).toEqual([]);
+
+    // issue 111 body 1+2: číslo objednávky ANI kód produktu sa nesmú
+    // zalomiť na viac riadkov, na ŽIADNEJ zo 4 šírok — kontroluje sa AJ
+    // `white-space: nowrap` (mechanizmus, ktorý garantuje toto natrvalo, aj
+    // pre BUDÚCI dlhší obsah, nie len dnešný zmeraný obsah fixtúry) AJ
+    // skutočný počet zalomených riadkov (`getClientRects().length > 1` —
+    // funguje pre `<a>`/text-node vo VNÚTRI bunky; na `<td>` samotnej by to
+    // vždy vrátilo 1, keďže je to blokový box, nie inline text).
+    const zalomeneObjednavky = await page.evaluate(() => {
+      const odkazy = [...document.querySelectorAll<HTMLAnchorElement>(".ord-order-cell a.ord-admin-link")];
+      const prvy = odkazy.at(0);
+      return {
+        pocetZalomenych: odkazy.filter((a) => a.getClientRects().length > 1).length,
+        whiteSpace: prvy !== undefined ? getComputedStyle(prvy).whiteSpace : null,
+      };
+    });
+    expect(zalomeneObjednavky.pocetZalomenych, `zalomené čísla objednávky pri ${String(width)}px`).toBe(0);
+    expect(zalomeneObjednavky.whiteSpace, `.ord-admin-link white-space pri ${String(width)}px`).toBe("nowrap");
+
+    const zalomeneKody = await page.evaluate(() => {
+      const bunky = [...document.querySelectorAll<HTMLTableCellElement>(".ord-code-cell")];
+      const pocetZalomenych = bunky.filter((td) => {
+        const textNode = [...td.childNodes].find((n) => n.nodeType === Node.TEXT_NODE && n.textContent?.trim() !== "");
+        if (!textNode) return false;
+        const range = document.createRange();
+        range.selectNodeContents(textNode);
+        return range.getClientRects().length > 1;
+      }).length;
+      const prva = bunky.at(0);
+      return { pocetZalomenych, whiteSpace: prva !== undefined ? getComputedStyle(prva).whiteSpace : null };
+    });
+    expect(zalomeneKody.pocetZalomenych, `zalomené kódy produktu pri ${String(width)}px`).toBe(0);
+    expect(zalomeneKody.whiteSpace, `.ord-code-cell white-space pri ${String(width)}px`).toBe("nowrap");
+
+    // issue 111 bod 5: pri 1280px sa žiadna `.orders-table-wrap` skupina
+    // nesmie posúvať vodorovne (predtým 💾 tlačidlo bolo za viditeľným
+    // okrajom, kým manažér nescrolloval).
+    if (width === 1280) {
+      const pretekajuceObaly = await page.evaluate(() => {
+        return [...document.querySelectorAll(".orders-table-wrap")].filter((w) => w.scrollWidth > w.clientWidth)
+          .length;
+      });
+      expect(pretekajuceObaly, "pretekajúce .orders-table-wrap pri 1280px").toBe(0);
+
+      const strankaSaPosuva = await page.evaluate(
+        () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+      );
+      expect(strankaSaPosuva, "stránka sa vodorovne posúva pri 1280px").toBe(false);
+    }
   }
 
   expect(chyby).toEqual([]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.65",
+  "version": "0.3.0-dev.66",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Closes #111

## Čo bolo zle (majiteľ, live nameraná chyba po nasadení #107)

1. Číslo objednávky sa lámalo na 2-3 riadky (39/39 riadkov) — presne ten
   prvok, na ktorý zamestnanec klika (otvorí objednávku v Shoptete).
2. Kód produktu sa lámal (19/39 riadkov).
3. Rozpočet šírky stĺpcov bol obrátený — Č. OBJ./KÓD (najviac klikané) boli
   najužšie zo všetkých, POZNÁMKY (skoro vždy prázdne) mali skoro pätinu
   tabuľky.
4. Prázdna pomlčka "—" v POZNÁMKACH vo všetkých 39 riadkoch, keď poznámka
   e-shopu neexistuje.
5. Pri 1280px pretekala každá `.orders-table-wrap` skupina o 58px — tlačidlo
   💾 bolo za viditeľným okrajom, kým manažér nescrolloval.

## Čo sa zmenilo

- `.ord-admin-link`/`.ord-code-cell` dostali trvalý `white-space: nowrap` +
  ellipsis poistku — číslo objednávky a kód produktu sa už NIKDY nezalomia,
  bez ohľadu na budúcu dĺžku obsahu.
- `.main-wide`'s vlastné bočné odsadenie znížené (`--fs-space-6` →
  `--fs-space-1`, len na tejto obrazovke) a `.orders-table`'s vynútená
  `min-width` znížená z 64rem na 63.875rem — zodpovedá reálne dostupnej
  šírke pri 1280px, žiadna skupina už neprepočíva.
- Celý 10-stĺpcový percentuálny rozpočet prerobený a živo overený proti
  PRODUKCII (`page.addStyleTag`, 39 ostrých riadkov, `vychod@varos.sk`) na
  1280/1440/1600/1920px — súčasne: order#/kód nikdy nezalomia, STAV drží
  plný text, POZNÁMKY pole ≥160px s 💾 na tom istom riadku, žiadna `<th>`
  nepreteká, žiadne vodorovné posúvanie stránky ani skupiny pri 1280px.
- `.ord-remark-cell` už nevykresľuje "—", keď poznámka e-shopu neexistuje.

## Testy

- `OrderLineRow.remarkCell.test.tsx` (RED→GREEN, `c1d022e`→`4e32743`).
- `orders-layout.spec.ts` rozšírený o e2e kontroly (nowrap mechanizmus,
  0 zalomených, 0 pretekajúcich `.orders-table-wrap`, 0 posúvania stránky)
  na všetkých 4 šírkach.
- Celá existujúca e2e sada (21 testov) aj unit sada (228 testov) prešli
  lokálne bez zmeny.

## Prijatý, úzky kompromis

Zriedkavý `supplierAssignable` riadok (vstup+tlačidlo namiesto odkazu+kódu,
dnes pár z 39) sa pri 1280px môže zalomiť na 2 riadky cez svoju existujúcu
`flex-wrap` poistku (#105) — nikdy nerozbije layout, len je vyšší. Pri
1440px+ je výsledok rovnaký alebo lepší než dnes.

Design decision + root cause zapísané na tickete PRED prvým kódovým
commitom: https://github.com/zbynekdrlik/forestshop-app/issues/111#issuecomment-5145826005
