### PR TITLE
Playbook + log entry for issue 111 (documentation only)

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -245,3 +245,49 @@ paths:
   content-shape regression like this one. Any FUTURE `<colgroup>` percentage
   change needs this same live-against-production check before being called
   done, not just a green e2e suite.
+- **`getClientRects().length` on a `<td>`/block element is ALWAYS 1, regardless
+  of how many lines its text wraps onto** — that method reports per-line rects
+  only for an INLINE formatting context (a `<a>`, a `<span>`, or a `Range`
+  over a text node), never for the block box itself. Issue 111's first wrap-
+  detection attempt checked `.ord-code-cell.getClientRects().length > 1` and
+  got `0` even though the text was visibly wrapping 2-3 lines — the fix was
+  `document.createRange().selectNodeContents(textNode); range.getClientRects
+  ().length`, targeting the TEXT NODE inside the cell, not the cell itself.
+  `.ord-admin-link` (an `<a>`, inline) worked fine directly. Any FUTURE "did
+  this wrap" check against a `<td>`/`<div>`/block container needs the Range-
+  over-text-node form, not a direct call on the container.
+- **A "never wraps" requirement needs BOTH a generous measured width AND a
+  permanent `white-space: nowrap` (+`overflow:hidden;text-overflow:ellipsis`
+  fallback) on the element itself** — issue 111 (order # + product code
+  breaking mid-number, the third time a `<colgroup>` budget alone was tried
+  and regressed, after #105/#107) fixed it both ways: `.col-order`/`.col-code`
+  got real measured budget AND `.ord-admin-link`/`.ord-code-cell` got
+  `white-space: nowrap`. The CSS rule is what makes the guarantee survive a
+  FUTURE longer order number or code format without another live-measurement
+  cycle — width alone is only correct until content grows past today's
+  sample.
+- **When a `<colgroup>` budget can't fit inside the viewport's real available
+  width, look at the SCREEN'S OWN padding/min-width first, not just the
+  column percentages.** Issue 111 bod 5: `.orders-table`'s `min-width: 64rem`
+  (1024px) was wider than the ACTUAL content area at 1280px (sidebar 250px +
+  `.main-wide`'s own 2×32px padding = only 966px available) — the table was
+  always horizontally scrolling inside `.orders-table-wrap`, hiding the 💾
+  save button past the visible edge. Shrinking 10 columns to fit 966px alone
+  would have starved every column that matters (measured: avg +20px/row
+  height regression across 34/39 rows). The actual fix reclaimed a few px of
+  `.main-wide`'s OWN horizontal padding (`--fs-space-6` → `--fs-space-1`,
+  scoped to this dense work screen only, not global) AND lowered
+  `.orders-table`'s `min-width` to match — turning an infeasible 966px budget
+  into a workable ~1022px one. Any FUTURE "table doesn't fit at width X" bug:
+  check `main.clientWidth` vs `.orders-table`'s `min-width` BEFORE assuming
+  the fix is purely a `<colgroup>` percentage problem.
+- **Comparing row-height min/median/max ACROSS candidate `<colgroup>`
+  percentages is misleading — the row that LANDS at the median/min RANK
+  changes per candidate**, since other columns' widths shift which rows are
+  short/tall. Issue 111: a candidate showing "median 119px" looked like a
+  disaster next to baseline's "median 85.5px" — but per-row PAIRED
+  comparison (`Map` keyed by `data-testid`, same 39 rows, old height vs new
+  height) showed the true picture: avg +11px, only specific rows changed
+  meaningfully. Always diff the SAME rows before-vs-after (keyed by
+  `data-testid`), never just compare the sorted-height array's summary
+  stats between two differently-configured runs.

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -1483,3 +1483,42 @@ nové heslo sa nikde v pushnutom obsahu nenachádza.
   footeri `v0.3.0-dev.64` zodpovedá `/api/version`.
 - Playbook zápis: `.claude/rules/frontend-design.md` — overuj `<colgroup>`
   percentá proti SKUTOČNEJ produkcii, nie len e2e fixtúre.
+
+## Issue #111 — číslo objednávky/kód sa lámu, pomlčka v poznámkach, 1280px overflow (2026-07-31)
+
+- Nález pri vlastnej kontrole naživo po nasadení #107's fixu (v0.3.0-dev.65):
+  1) číslo objednávky sa láme na 2-3 riadky (39/39 riadkov pri 1280/1600px),
+  2) kód produktu sa láme (19/39 pri 1600px), 3) rozpočet stĺpcov obrátený
+  (Č.OBJ./KÓD najužšie, POZNÁMKY skoro pätina tabuľky), 4) prázdna pomlčka
+  "—" v POZNÁMKACH (39/39), 5) pri 1280px `.orders-table-wrap` preteká o
+  58px, 💾 tlačidlo za viditeľným okrajom.
+- Design decision zapísaný na tickete PRED prvým commitom
+  (`4eb4f4d` bump 0.3.0-dev.66):
+  https://github.com/zbynekdrlik/forestshop-app/issues/111#issuecomment-5145826005
+- RED→GREEN: `OrderLineRow.remarkCell.test.tsx` (`c1d022e`→`4e32743`) —
+  bare-dash fix, rovnaký tvar ako #107 bod 3.
+- Layout fix (`525bca8`): `.ord-admin-link`/`.ord-code-cell` dostali trvalý
+  `white-space: nowrap` + ellipsis poistku; `.main-wide`'s bočné odsadenie
+  znížené (`--fs-space-6`→`--fs-space-1`, len táto obrazovka) a
+  `.orders-table`'s `min-width` znížené 64rem→63.875rem, aby sa zmestila
+  do reálne dostupnej šírky pri 1280px; celý 10-stĺpcový rozpočet prerobený
+  a živo overený proti produkcii (`page.addStyleTag`, 39 riadkov,
+  `vychod@varos.sk`) na 1280/1440/1600/1920px.
+- PR `#112` zmergnuté (`18ffdec`). Main CI zelené. Deploy job zlyhal raz na
+  tranzientný sieťový timeout (`ghcr.io` pull, `dial tcp ... i/o timeout`) —
+  `gh run rerun --failed` prešiel hneď napodruhé; nešlo o obsah image.
+- Live overenie po deployi (`vychod@varos.sk`, 39 reálnych riadkov,
+  1280/1440/1600/1920px): 0 zalomených čísiel/kódov na VŠETKÝCH šírkach,
+  0 pretekajúcich `.orders-table-wrap`/`<th>`, 0 pomlčiek v poznámkach,
+  STAV/POZNÁMKY rezervy zachované, 0 console chýb/varovaní, verzia
+  `v0.3.0-dev.66` zodpovedá živému DOM-u. Produkčné dáta nedotknuté
+  (order_line 868, ordered 0, state≠'objednane' 0,
+  product_supplier_override 0, "order" 528).
+- Prijatý kompromis: pri 1280px zriedkavý `supplierAssignable` riadok môže
+  zalomiť na 2 riadky (existujúca `flex-wrap` poistka z #105) — priemerná
+  výška riadku pri 1280px vyššia o ~11px, pri 1440px+ rovnaká/lepšia.
+- Playbook zápis: `.claude/rules/frontend-design.md` — 4 nové položky
+  (`getClientRects()` na `<td>` vždy vráti 1, `white-space:nowrap` ako
+  TRVALÁ poistka popri šírke, `.main-wide` odsadenie/`min-width` ako prvá
+  vec na kontrolu pri "tabuľka sa nezmestí", párové porovnanie výšky
+  riadkov namiesto surových min/median/max).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.66",
+  "version": "0.3.0-dev.67",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Docs-only follow-up: playbook lessons from #111 (getClientRects() on block elements, permanent white-space:nowrap alongside width budget, screen padding as a first-check for table-doesn't-fit, paired row-height comparison) + autopilot-log entry. Version bump 0.3.0-dev.67 per this repo's CI version-check job.