### PR TITLE
Simplify Na objednanie row: drop code column, hide mail actions, big supplier icon button

### DIFF
--- a/apps/web/src/components/OrderLineRow.tsx
+++ b/apps/web/src/components/OrderLineRow.tsx
@@ -1,12 +1,6 @@
 import { useEffect, useRef, useState, type JSX } from "react";
 import type { OrderLine } from "../ordersApi.js";
-import {
-  formatVariantTotalChip,
-  isStaleOrderLine,
-  orderLineAgeDays,
-  shouldShowSizeLabel,
-  type VariantTotal,
-} from "../ordersSummary.js";
+import { formatVariantTotalChip, isStaleOrderLine, orderLineAgeDays, type VariantTotal } from "../ordersSummary.js";
 
 // issue 60: `objednane` je VÝCHODISKOVÝ stav riadku (pred tým, než sa
 // čokoľvek stane), NIE potvrdenie, že manažér objednal — preto sa nazýva
@@ -174,18 +168,6 @@ export function OrderLineRow({
         </a>
       </td>
       <td>{line.customerName}</td>
-      {/* issue 95: KÓD + VEĽKOSŤ zlúčené (majiteľ, komentár #10: "veľkosť je
-          už súčasťou kódu") — veľkosť sa zobrazí len keď appka má samostatnú
-          `sizeLabel` hodnotu (nie každý variant ju má). issue 105 bod 2:
-          `sizeLabel` je server-side odvodené ako suffix `variantCode`u, takže
-          kód ňou takmer vždy UŽ končí — pripájanie by ju zobrazilo dvakrát
-          (`shouldShowSizeLabel`, `ordersSummary.ts`). */}
-      <td className="ord-code-cell">
-        {line.variantCode}
-        {shouldShowSizeLabel(line.variantCode, line.sizeLabel) && (
-          <span className="ord-size-inline">{line.sizeLabel}</span>
-        )}
-      </td>
       <td>{line.variantName}</td>
       <td className="ord-qty">
         {line.quantity} ks
@@ -202,17 +184,25 @@ export function OrderLineRow({
       <td className="ord-supplier-merged">
         <div className="ord-supplier-cell" data-testid={`supplier-link-${line.lineId}`}>
           {line.supplierUrl !== null ? (
+            // issue 119: majiteľ, doslovne "zmen na nejake tlacitko z ikonou
+            // ktore otvori na novom okne ten link, lebo teraz to je tazke
+            // stlacit" — textový odkaz nahradený veľkým ikonovým tlačidlom
+            // (`.ord-supplier-link` v `app.css` teraz štylizuje `<a>` ako
+            // tlačidlo, min. 36×36px klikacej plochy). `aria-label`/`title`
+            // nesú ten istý popis ako predtým (issue 72: variantName sám
+            // nestačí — dva riadky toho istého produktu v rôznych veľkostiach
+            // majú zhodný variantName, líšia sa len variantCode), viditeľný
+            // text je teraz len ikonka (`aria-hidden`, prístupné meno nesie
+            // výlučne `aria-label`).
             <a
               href={line.supplierUrl}
               target="_blank"
               rel="noreferrer noopener"
               className="ord-supplier-link"
-              // issue 72: variantName sám nestačí — dva riadky toho istého
-              // produktu v rôznych veľkostiach majú zhodný variantName, líšia
-              // sa len variantCode.
               aria-label={`Odkaz na dodávateľa — ${line.variantName} (${line.variantCode})`}
+              title={`Otvoriť odkaz na dodávateľa — ${line.variantName} (${line.variantCode})`}
             >
-              Odkaz na dodávateľa
+              <span aria-hidden="true">🔗</span>
             </a>
           ) : line.supplierNote !== null ? (
             <span className="ord-supplier-note" title={line.supplierNote}>
@@ -229,10 +219,17 @@ export function OrderLineRow({
             // riadku nad issue 105's ~95px invariant (živo zmerané: 85px →
             // 103.5px s popisom na vlastnom riadku).
             <span className="ord-supplier-assign-hint">Priradiť dodávateľa</span>
-          ) : line.externalCode === null ? (
+          ) : (
+            // issue 117: `externalCode` (dodávateľský kód) sa už NIKDY
+            // nezobrazuje — majiteľ ho nepoužíva ("kody produktov vobec
+            // nepouzivame"), appka používa výlučne odkaz na dodávateľa.
+            // Predtým sa táto pomlčka potláčala, keď `externalCode` bol
+            // vyplnený (zobrazoval sa namiesto nej samostatný "kód …" riadok)
+            // — bez toho riadku je terajší terminálny stav VŽDY pomlčka,
+            // keď riadok nemá ani odkaz, ani poznámku, ani priradenie
+            // (legitímny, `OrderLineRow.supplierAssignCell.test.tsx`).
             "—"
-          ) : null}
-          {line.externalCode !== null && <div className="ord-supplier-code">kód {line.externalCode}</div>}
+          )}
         </div>
         {/* pri neradiťeľnom riadku (100 % dnešných ostrých dát) sa TENTO blok
             predtým vykresľoval VŽDY, len s holou pomlčkou "—" bez

--- a/apps/web/src/components/OrdersSection.mailActions.test.tsx
+++ b/apps/web/src/components/OrdersSection.mailActions.test.tsx
@@ -1,0 +1,164 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { OrdersSection } from "./OrdersSection.js";
+
+// issue 118: majiteľ, doslovne "📋 Kopírovať objednávku ✉️ Poslať objednávku
+// e-mailom zatial skry este to nebudeme pouzivat" — appka tieto tlačidlá
+// SKRÝVA (nemaže), `orderScreenFlags.ts`'s `SHOW_ORDER_MAIL_ACTIONS`
+// (predvolene `false`, overuje `OrdersSection.test.tsx`). Tento súbor
+// prepína flag na `true`, aby zostala funkcionalita (náhľad/odoslanie mailu,
+// kopírovanie do schránky) plne otestovaná aj počas skrytia — presne testy,
+// ktoré predtým žili v `OrdersSection.test.tsx` (rovnaký "same file split"
+// vzor ako `OrdersSection.ordered.test.tsx`), len teraz s flagom natvrdo
+// zapnutým.
+vi.mock("./orderScreenFlags.js", () => ({ SHOW_ORDER_MAIL_ACTIONS: true }));
+
+const { fetchOpenOrders, setSupplierEmail, fetchSupplierOrderMailPreview, sendSupplierOrderMail } = vi.hoisted(() => ({
+  fetchOpenOrders: vi.fn(),
+  setSupplierEmail: vi.fn(),
+  fetchSupplierOrderMailPreview: vi.fn(),
+  sendSupplierOrderMail: vi.fn(),
+}));
+
+vi.mock("../ordersApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../ordersApi.js")>();
+  return {
+    ...actual,
+    fetchOpenOrders,
+    setSupplierEmail,
+    fetchSupplierOrderMailPreview,
+    sendSupplierOrderMail,
+  };
+});
+
+const LINE_STARA = {
+  lineId: "11111111-1111-1111-1111-111111111111",
+  orderId: "aaaaaaaa-1111-1111-1111-111111111111",
+  externalOrderId: "1001",
+  customerName: "Zákazník Starý",
+  comment: null,
+  remark: null,
+  adminUrl: "https://www.forestshop.sk/admin/vyhladavanie/?string=1001&src=orders",
+  placedAt: "2026-07-01T00:00:00.000Z",
+  variantCode: "A-1",
+  variantName: "Nohavice FOREST 1003",
+  sizeLabel: "3XL",
+  quantity: 2,
+  state: "objednane" as const,
+  ordered: false,
+  supplierUrl: null,
+  supplierNote: null,
+  externalCode: null,
+  supplierAssignable: false,
+  manualSupplierOverride: null,
+};
+
+// Rovnaký riadok, ale vo stave "caka_sa" (vybavený, nie "objednane") —
+// `outstandingState` v `SupplierActionsPanel.tsx` je `"objednane"`, takže
+// skupina BEZ ani jedného takého riadku nemá čo poslať, aj keď má e-mail.
+const LINE_VYBAVENA = { ...LINE_STARA, lineId: "22222222-1111-1111-1111-111111111111", state: "caka_sa" as const };
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+it("s flagom zapnutým sa tlačidlá kopírovania/odoslania mailom vykresľujú (issue 118 ich len skrýva, nemaže)", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_STARA], email: null }]);
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  await screen.findByTestId(`order-line-${LINE_STARA.lineId}`);
+  expect(screen.getByRole("button", { name: "✉️ Poslať objednávku e-mailom" })).toBeTruthy();
+  expect(screen.getByRole("button", { name: "📋 Kopírovať objednávku" })).toBeTruthy();
+});
+
+it("bez e-mailu je tlačidlo na odoslanie mailom disabled s vysvetlením", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_STARA], email: null }]);
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const tlacidlo = await screen.findByRole("button", { name: "✉️ Poslať objednávku e-mailom" });
+  expect(tlacidlo.hasAttribute("disabled")).toBe(true);
+  expect(screen.getByText("Pre odoslanie mailom treba najprv nastaviť e-mail dodávateľa.")).toBeTruthy();
+});
+
+// Predtým overené len e2e (`orders.spec.ts`) — presunuté sem, keď e2e prestal
+// vedieť kliknúť na (teraz skryté) tlačidlo naživo. Dokazuje, že disabled stav
+// sleduje SKUTOČNÝ stav riadkov ("objednane"/nevybavené), nie len prítomnosť
+// e-mailu — skupina s e-mailom, ale BEZ jediného nevybaveného riadku, musí
+// ostať disabled.
+it("s e-mailom, ale bez nevybaveného riadku, ostáva tlačidlo na odoslanie mailom disabled", async () => {
+  fetchOpenOrders.mockResolvedValue([
+    { supplier: "Dodávateľ Alfa", lines: [LINE_VYBAVENA], email: "alfa@dodavatel.example" },
+  ]);
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const tlacidlo = await screen.findByRole("button", { name: "✉️ Poslať objednávku e-mailom" });
+  expect(tlacidlo.hasAttribute("disabled")).toBe(true);
+});
+
+it("s e-mailom a otvorenou položkou manažér otvorí náhľad, potvrdí a mail sa odošle", async () => {
+  fetchOpenOrders.mockResolvedValue([
+    { supplier: "Dodávateľ Alfa", lines: [LINE_STARA], email: "alfa@dodavatel.example" },
+  ]);
+  fetchSupplierOrderMailPreview.mockResolvedValue({
+    supplier: "Dodávateľ Alfa",
+    to: "alfa@dodavatel.example",
+    subject: "Objednávka — Dodávateľ Alfa (1 položka)",
+    body: "Objednávka — Dodávateľ Alfa (1 položka)\nA-1 | 3XL | 2 ks",
+    itemCount: 1,
+  });
+  sendSupplierOrderMail.mockResolvedValue({ ok: true });
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const posluTlacidlo = await screen.findByRole("button", { name: "✉️ Poslať objednávku e-mailom" });
+  expect(posluTlacidlo.hasAttribute("disabled")).toBe(false);
+  fireEvent.click(posluTlacidlo);
+
+  await waitFor(() => {
+    expect(fetchSupplierOrderMailPreview).toHaveBeenCalledWith("Dodávateľ Alfa");
+  });
+  const nahlad = await screen.findByTestId("mail-preview-Dodávateľ Alfa");
+  expect(nahlad.textContent).toContain("alfa@dodavatel.example");
+  expect(nahlad.textContent).toContain("Objednávka — Dodávateľ Alfa (1 položka)");
+
+  fireEvent.click(screen.getByRole("button", { name: "Odoslať" }));
+
+  await waitFor(() => {
+    expect(sendSupplierOrderMail).toHaveBeenCalledWith("Dodávateľ Alfa");
+  });
+  await waitFor(() => {
+    expect(screen.getByRole("status").textContent).toContain("odoslaná");
+  });
+  expect(screen.queryByTestId("mail-preview-Dodávateľ Alfa")).toBeNull();
+});
+
+it("kopírovanie objednávky do schránky použije text náhľadu", async () => {
+  fetchOpenOrders.mockResolvedValue([
+    { supplier: "Dodávateľ Alfa", lines: [LINE_STARA], email: "alfa@dodavatel.example" },
+  ]);
+  fetchSupplierOrderMailPreview.mockResolvedValue({
+    supplier: "Dodávateľ Alfa",
+    to: "alfa@dodavatel.example",
+    subject: "Objednávka — Dodávateľ Alfa (1 položka)",
+    body: "Objednávka — Dodávateľ Alfa (1 položka)\nA-1 | 3XL | 2 ks",
+    itemCount: 1,
+  });
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  Object.assign(navigator, { clipboard: { writeText } });
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const kopirovat = await screen.findByRole("button", { name: "📋 Kopírovať objednávku" });
+  fireEvent.click(kopirovat);
+
+  await waitFor(() => {
+    expect(writeText).toHaveBeenCalledWith("Objednávka — Dodávateľ Alfa (1 položka)\nA-1 | 3XL | 2 ks");
+  });
+  await waitFor(() => {
+    expect(screen.getByRole("status").textContent).toContain("schránky");
+  });
+});

--- a/apps/web/src/components/OrdersSection.test.tsx
+++ b/apps/web/src/components/OrdersSection.test.tsx
@@ -4,19 +4,15 @@ import { OrdersSection } from "./OrdersSection.js";
 
 // `updateOrderLineOrdered`/`setSupplierLinesOrdered` mocks moved to
 // `OrdersSection.ordered.test.tsx` alongside the tests that actually
-// exercise them (review of PR 75, finding 6 — same file split).
-const {
-  fetchOpenOrders,
-  updateOrderLineState,
-  setSupplierEmail,
-  fetchSupplierOrderMailPreview,
-  sendSupplierOrderMail,
-} = vi.hoisted(() => ({
+// exercise them (review of PR 75, finding 6 — same file split). issue 118:
+// `fetchSupplierOrderMailPreview`/`sendSupplierOrderMail` mocks moved to
+// `OrdersSection.mailActions.test.tsx` the same way — this file no longer
+// has any test exercising the (now hidden-by-default) mail preview/send
+// flow.
+const { fetchOpenOrders, updateOrderLineState, setSupplierEmail } = vi.hoisted(() => ({
   fetchOpenOrders: vi.fn(),
   updateOrderLineState: vi.fn(),
   setSupplierEmail: vi.fn(),
-  fetchSupplierOrderMailPreview: vi.fn(),
-  sendSupplierOrderMail: vi.fn(),
 }));
 
 // `OrdersUnauthorizedError` ostáva SKUTOČNÁ trieda z reálneho modulu — rovnaký
@@ -29,8 +25,6 @@ vi.mock("../ordersApi.js", async (importOriginal) => {
     fetchOpenOrders,
     updateOrderLineState,
     setSupplierEmail,
-    fetchSupplierOrderMailPreview,
-    sendSupplierOrderMail,
   };
 });
 
@@ -107,13 +101,11 @@ it("zoskupí riadky podľa dodávateľa a zobrazí produkt, veľkosť, množstvo
   const novy = screen.getByTestId(`order-line-${LINE_NOVA.lineId}`);
   expect(novy.textContent).toContain("1002");
   expect(novy.textContent).toContain("Zákazník Nový");
-  expect(novy.textContent).toContain("B-1");
   expect(novy.textContent).toContain("Bunda FOREST 2001");
   expect(novy.textContent).toContain("Skladom");
   expect(novy.textContent).toContain("Zavolať pred doručením");
 
   const stary = screen.getByTestId(`order-line-${LINE_STARA.lineId}`);
-  expect(stary.textContent).toContain("3XL");
   // issue 60: východiskový stav "objednane" sa teraz volá "Nevybavené" — slovo
   // "Objednané" je odteraz VÝLUČNE nové odškrtávacie políčko, nie tento stav.
   expect(stary.textContent).toContain("Nevybavené");
@@ -122,18 +114,20 @@ it("zoskupí riadky podľa dodávateľa a zobrazí produkt, veľkosť, množstvo
 // issue 95: 13 pôvodných stĺpcov → 10 (VEĽKOSŤ zlúčená do KÓD, PRIRADENIE
 // DODÁVATEĽA do DODÁVATEĽ, POZNÁMKA E-SHOPU do POZNÁMOK) — regresný test
 // dokazuje, že ide o SKUTOČNÉ zlúčenie stĺpcov v DOM-e (rovnaký rodičovský
-// `<td>`), nie len premenovanie hlavičiek.
-it("hlavička tabuľky má 10 stĺpcov (zlúčené VEĽKOSŤ/PRIRADENIE DODÁVATEĽA/POZNÁMKA E-SHOPU)", async () => {
+// `<td>`), nie len premenovanie hlavičiek. issue 117: KÓD (variant kódu)
+// stĺpec celý zrušený (majiteľ, "kody produktov vobec nepouzivame") — 10 → 9.
+it("hlavička tabuľky má 9 stĺpcov (KÓD zrušený, zlúčené VEĽKOSŤ/PRIRADENIE DODÁVATEĽA/POZNÁMKA E-SHOPU)", async () => {
   fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_STARA], email: null }]);
 
   render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
 
   const hlavicky = await screen.findAllByRole("columnheader");
-  expect(hlavicky).toHaveLength(10);
+  expect(hlavicky).toHaveLength(9);
   const nazvy = hlavicky.map((th) => th.textContent);
   expect(nazvy).not.toContain("Veľkosť");
   expect(nazvy).not.toContain("Priradenie dodávateľa");
   expect(nazvy).not.toContain("Poznámka e-shopu");
+  expect(nazvy).not.toContain("Kód");
 });
 
 it("zlúčená bunka DODÁVATEĽ drží odkaz na dodávateľa AJ priradenie v tom istom stĺpci", async () => {
@@ -161,22 +155,20 @@ it("zlúčená bunka POZNÁMKY drží poznámku e-shopu AJ komentár v tom istom
   expect(remarkBunka.closest("td")).toBe(commentBunka.closest("td"));
 });
 
-it("chýbajúci dodávateľ zobrazí ako pomlčku (veľkosť sa pri chýbajúcej hodnote jednoducho nezobrazí)", async () => {
+it("chýbajúci dodávateľ zobrazí ako pomlčku", async () => {
   fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_NOVA], email: null }]);
 
   render(<OrdersSection role="citanie" onSessionExpired={() => {}} />);
 
   const riadok = await screen.findByTestId(`order-line-${LINE_NOVA.lineId}`);
-  // issue 95: `LINE_NOVA` má `sizeLabel: null` — od zlúčenia KÓD+VEĽKOSŤ sa v
-  // tom prípade jednoducho NIČ nevykreslí (žiadna pomlčka náhradou), takže
-  // pomlčka nižšie pochádza zo zlúčenej bunky DODÁVATEĽ (LINE_NOVA má aj
-  // `supplierUrl`/`supplierNote`/`externalCode` všetky `null`).
+  // LINE_NOVA má `supplierUrl`/`supplierNote`/`externalCode`/`supplierAssignable`
+  // všetky prázdne/false — pomlčka pochádza zo zlúčenej bunky DODÁVATEĽ.
   expect(riadok.textContent).toContain("—");
 });
 
-// issue 67: odkaz na tovar u dodávateľa a kód dodávateľa — tri tvary, aké
-// export skutočne obsahuje.
-it("riadok s odkazom na dodávateľa zobrazí klikateľný odkaz aj kód dodávateľa", async () => {
+// issue 67: odkaz na tovar u dodávateľa. issue 119: viditeľný text je odteraz
+// len ikonka (icon button), prístupné meno nesie výlučne `aria-label`.
+it("riadok s odkazom na dodávateľa zobrazí klikateľné ikonové tlačidlo, otvárajúce v novej karte", async () => {
   const riadokSOdkazom = {
     ...LINE_STARA,
     supplierUrl: "https://www.huntingshop.eu/wild-t-green-nohavice",
@@ -189,16 +181,17 @@ it("riadok s odkazom na dodávateľa zobrazí klikateľný odkaz aj kód dodáva
 
   const bunka = await screen.findByTestId(`supplier-link-${LINE_STARA.lineId}`);
   // issue 70: aria-label nesie názov produktu, aby riadky nemali rovnaké
-  // prístupné meno — viditeľný text ostáva "Odkaz na dodávateľa". issue 72:
-  // samotný variantName ešte nestačí — dva riadky toho istého produktu v
-  // rôznych veľkostiach majú rovnaký variantName, líšia sa len variantCode —
-  // preto ho aria-label musí niesť tiež.
+  // prístupné meno. issue 72: samotný variantName ešte nestačí — dva riadky
+  // toho istého produktu v rôznych veľkostiach majú rovnaký variantName,
+  // líšia sa len variantCode — preto ho aria-label musí niesť tiež.
   const odkaz = within(bunka).getByRole<HTMLAnchorElement>("link", {
     name: `Odkaz na dodávateľa — ${LINE_STARA.variantName} (${LINE_STARA.variantCode})`,
   });
   expect(odkaz.getAttribute("href")).toBe("https://www.huntingshop.eu/wild-t-green-nohavice");
   expect(odkaz.getAttribute("rel")).toBe("noreferrer noopener");
-  expect(bunka.textContent).toContain("OB832");
+  expect(odkaz.getAttribute("target")).toBe("_blank");
+  // issue 117: `externalCode` (dodávateľský kód) sa už NIKDE nezobrazuje.
+  expect(bunka.textContent).not.toContain("OB832");
 });
 
 // issue 72: dva riadky TOHO ISTÉHO produktu v DVOCH rôznych veľkostiach majú
@@ -256,19 +249,20 @@ it("riadok bez akéhokoľvek údaja o dodávateľovi zobrazí pomlčku", async (
   expect(bunka.textContent).toBe("—");
 });
 
-// issue 70 (code review nález po PR 69): pomlčka sa doteraz potláčala len
-// vtedy, keď bol vyplnený `supplierUrl` alebo `supplierNote` — riadok LEN s
-// `externalCode` (bez odkazu aj bez poznámky) dostal zbytočnú pomlčku hneď
-// vedľa kódu.
-it("riadok len s kódom dodávateľa (bez odkazu aj poznámky) nezobrazí pomlčku", async () => {
+// issue 117: `externalCode` (dodávateľský kód) sa už NIKDY nezobrazuje —
+// majiteľ ho nepoužíva. Riadok LEN s `externalCode` (bez odkazu, poznámky aj
+// priradenia) je odteraz NEROZOZNATEĽNÝ od riadku úplne bez údajov o
+// dodávateľovi — obidva zobrazia pomlčku (predtým, pred issue 117, tu kód
+// potláčal pomlčku a zobrazoval sa namiesto nej).
+it("riadok len s kódom dodávateľa (bez odkazu aj poznámky) zobrazí pomlčku, kód sa nezobrazí", async () => {
   const riadokLenSKodom = { ...LINE_STARA, supplierUrl: null, supplierNote: null, externalCode: "OB832" };
   fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [riadokLenSKodom], email: null }]);
 
   render(<OrdersSection role="citanie" onSessionExpired={() => {}} />);
 
   const bunka = await screen.findByTestId(`supplier-link-${LINE_STARA.lineId}`);
-  expect(bunka.textContent).not.toContain("—");
-  expect(bunka.textContent).toContain("OB832");
+  expect(bunka.textContent).toBe("—");
+  expect(bunka.textContent).not.toContain("OB832");
 });
 
 it("pri 401 zavolá onSessionExpired namiesto zobrazenia všeobecnej chyby", async () => {
@@ -404,76 +398,24 @@ it("manažér nastaví e-mail dodávateľa cez formulár, zobrazenie sa aktualiz
   expect(fetchOpenOrders).toHaveBeenCalledTimes(1);
 });
 
-it("bez e-mailu je tlačidlo na odoslanie mailom disabled s vysvetlením", async () => {
+// issue 118: majiteľ, doslovne "zatial skry este to nebudeme pouzivat" —
+// appka SKRÝVA (nemaže) "📋 Kopírovať objednávku"/"✉️ Poslať objednávku
+// e-mailom" + sprievodný text, `orderScreenFlags.ts`'s
+// `SHOW_ORDER_MAIL_ACTIONS` (predvolene `false`). Platí AJ pre rolu
+// "manazer" (`canChangeState: true`) — na rozdiel od testu vyššie ("rola
+// citanie…"), kde sú skryté z INÉHO dôvodu (žiadne op práva). Samotná
+// funkcionalita (náhľad/odoslanie mailu, kopírovanie) zostáva plne
+// otestovaná v `OrdersSection.mailActions.test.tsx` (flag prepnutý na
+// `true` cez `vi.mock`).
+it("issue 118: aj manažér (canChangeState) nevidí tlačidlá kopírovania/odoslania mailom ani sprievodný text, kým je appka skryje", async () => {
   fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_STARA], email: null }]);
 
   render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
 
-  const tlacidlo = await screen.findByRole("button", { name: "✉️ Poslať objednávku e-mailom" });
-  expect(tlacidlo.hasAttribute("disabled")).toBe(true);
-  expect(screen.getByText("Pre odoslanie mailom treba najprv nastaviť e-mail dodávateľa.")).toBeTruthy();
-});
-
-it("s e-mailom a otvorenou položkou manažér otvorí náhľad, potvrdí a mail sa odošle", async () => {
-  fetchOpenOrders.mockResolvedValue([
-    { supplier: "Dodávateľ Alfa", lines: [LINE_STARA], email: "alfa@dodavatel.example" },
-  ]);
-  fetchSupplierOrderMailPreview.mockResolvedValue({
-    supplier: "Dodávateľ Alfa",
-    to: "alfa@dodavatel.example",
-    subject: "Objednávka — Dodávateľ Alfa (1 položka)",
-    body: "Objednávka — Dodávateľ Alfa (1 položka)\nA-1 | 3XL | 2 ks",
-    itemCount: 1,
-  });
-  sendSupplierOrderMail.mockResolvedValue({ ok: true });
-
-  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
-
-  const posluTlacidlo = await screen.findByRole("button", { name: "✉️ Poslať objednávku e-mailom" });
-  expect(posluTlacidlo.hasAttribute("disabled")).toBe(false);
-  fireEvent.click(posluTlacidlo);
-
-  await waitFor(() => {
-    expect(fetchSupplierOrderMailPreview).toHaveBeenCalledWith("Dodávateľ Alfa");
-  });
-  const nahlad = await screen.findByTestId("mail-preview-Dodávateľ Alfa");
-  expect(nahlad.textContent).toContain("alfa@dodavatel.example");
-  expect(nahlad.textContent).toContain("Objednávka — Dodávateľ Alfa (1 položka)");
-
-  fireEvent.click(screen.getByRole("button", { name: "Odoslať" }));
-
-  await waitFor(() => {
-    expect(sendSupplierOrderMail).toHaveBeenCalledWith("Dodávateľ Alfa");
-  });
-  await waitFor(() => {
-    expect(screen.getByRole("status").textContent).toContain("odoslaná");
-  });
-  expect(screen.queryByTestId("mail-preview-Dodávateľ Alfa")).toBeNull();
-});
-
-it("kopírovanie objednávky do schránky použije text náhľadu", async () => {
-  fetchOpenOrders.mockResolvedValue([
-    { supplier: "Dodávateľ Alfa", lines: [LINE_STARA], email: "alfa@dodavatel.example" },
-  ]);
-  fetchSupplierOrderMailPreview.mockResolvedValue({
-    supplier: "Dodávateľ Alfa",
-    to: "alfa@dodavatel.example",
-    subject: "Objednávka — Dodávateľ Alfa (1 položka)",
-    body: "Objednávka — Dodávateľ Alfa (1 položka)\nA-1 | 3XL | 2 ks",
-    itemCount: 1,
-  });
-  const writeText = vi.fn().mockResolvedValue(undefined);
-  Object.assign(navigator, { clipboard: { writeText } });
-
-  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
-
-  const kopirovat = await screen.findByRole("button", { name: "📋 Kopírovať objednávku" });
-  fireEvent.click(kopirovat);
-
-  await waitFor(() => {
-    expect(writeText).toHaveBeenCalledWith("Objednávka — Dodávateľ Alfa (1 položka)\nA-1 | 3XL | 2 ks");
-  });
-  await waitFor(() => {
-    expect(screen.getByRole("status").textContent).toContain("schránky");
-  });
+  await screen.findByTestId(`order-line-${LINE_STARA.lineId}`);
+  expect(screen.queryByRole("button", { name: "✉️ Poslať objednávku e-mailom" })).toBeNull();
+  expect(screen.queryByRole("button", { name: "📋 Kopírovať objednávku" })).toBeNull();
+  expect(screen.queryByText("Pre odoslanie mailom treba najprv nastaviť e-mail dodávateľa.")).toBeNull();
+  // Hromadné tlačidlo (mimo issue 118's scope) ostáva viditeľné.
+  expect(screen.getByRole("button", { name: "✔ Označiť skupinu ako objednané" })).toBeTruthy();
 });

--- a/apps/web/src/components/SupplierActionsPanel.tsx
+++ b/apps/web/src/components/SupplierActionsPanel.tsx
@@ -1,5 +1,6 @@
 import type { JSX } from "react";
 import type { OrderMailPreview, SupplierOpenOrders } from "../ordersApi.js";
+import { SHOW_ORDER_MAIL_ACTIONS } from "./orderScreenFlags.js";
 
 // issue 61 — mechanicky vyňaté z `OrdersSection.tsx` (hlavička skupiny +
 // e-mailový kontakt (#31) + hromadné akcie + náhľad/odoslanie mailom), BEZ
@@ -138,32 +139,40 @@ export function SupplierActionsPanel({
             >
               {group.lines.every((l) => l.ordered) ? "↺ Zrušiť označenie skupiny" : "✔ Označiť skupinu ako objednané"}
             </button>
-            <button
-              type="button"
-              className="btn sm ghost"
-              onClick={() => {
-                onCopyOrderToClipboard(group.supplier);
-              }}
-            >
-              📋 Kopírovať objednávku
-            </button>
-            <button
-              type="button"
-              className="btn sm good"
-              disabled={group.email === null || !group.lines.some((l) => l.state === outstandingState)}
-              title={
-                group.email === null ? "Pre odoslanie mailom treba najprv nastaviť e-mail dodávateľa." : undefined
-              }
-              onClick={() => {
-                onOpenPreview(group.supplier);
-              }}
-            >
-              ✉️ Poslať objednávku e-mailom
-            </button>
+            {/* issue 118: majiteľ, doslovne "zatial skry este to nebudeme
+                pouzivat" — SKRYTÉ (nie zmazané), `orderScreenFlags.ts`'s
+                `SHOW_ORDER_MAIL_ACTIONS` je JEDNO miesto na vrátenie oboch
+                tlačidiel + sprievodného textu nižšie naraz. */}
+            {SHOW_ORDER_MAIL_ACTIONS && (
+              <>
+                <button
+                  type="button"
+                  className="btn sm ghost"
+                  onClick={() => {
+                    onCopyOrderToClipboard(group.supplier);
+                  }}
+                >
+                  📋 Kopírovať objednávku
+                </button>
+                <button
+                  type="button"
+                  className="btn sm good"
+                  disabled={group.email === null || !group.lines.some((l) => l.state === outstandingState)}
+                  title={
+                    group.email === null ? "Pre odoslanie mailom treba najprv nastaviť e-mail dodávateľa." : undefined
+                  }
+                  onClick={() => {
+                    onOpenPreview(group.supplier);
+                  }}
+                >
+                  ✉️ Poslať objednávku e-mailom
+                </button>
+              </>
+            )}
           </div>
         )}
       </div>
-      {canChangeState && group.email === null && (
+      {SHOW_ORDER_MAIL_ACTIONS && canChangeState && group.email === null && (
         <p className="reenote">Pre odoslanie mailom treba najprv nastaviť e-mail dodávateľa.</p>
       )}
       {sendResult?.supplier === group.supplier && <p role="status">{sendResult.message}</p>}

--- a/apps/web/src/components/SupplierOrderGroup.tsx
+++ b/apps/web/src/components/SupplierOrderGroup.tsx
@@ -115,17 +115,18 @@ export function SupplierOrderGroup({
           sa sama nikdy neposúva, posúva sa (keď treba) len táto tabuľka.
           `table-layout: fixed` + `<colgroup>` dávajú stĺpcom percentuálne
           šírky (`app.css`'s `.col-*`) namiesto automatického rozloženia. 13
-          pôvodných stĺpcov je teraz 10 — VEĽKOSŤ zlúčená do KÓD, PRIRADENIE
-          DODÁVATEĽA do DODÁVATEĽ, POZNÁMKA E-SHOPU do POZNÁMOK (majiteľ,
-          komentár #10) — nedôležité/takmer vždy prázdne stĺpce už nedržia
-          šírku PRODUKTU, ktorý ju teraz dostáva najviac. */}
+          pôvodných stĺpcov je teraz 9 — VEĽKOSŤ zlúčená do KÓD (issue 95),
+          PRIRADENIE DODÁVATEĽA do DODÁVATEĽ (issue 95), POZNÁMKA E-SHOPU do
+          POZNÁMOK (issue 95), a stĺpec KÓD celý ODSTRÁNENÝ (issue 117,
+          majiteľ: "kody produktov vobec nepouzivame ... zaberaju miesto") —
+          uvoľnená šírka ide do PRODUKTU/DODÁVATEĽA (`app.css`'s `.col-*`
+          komentár), presne kam majiteľ žiadal. */}
       <div className="orders-table-wrap">
         <table className="orders-table">
           <colgroup>
             <col className="col-ordered" />
             <col className="col-order" />
             <col className="col-customer" />
-            <col className="col-code" />
             <col className="col-product" />
             <col className="col-qty" />
             <col className="col-supplier" />
@@ -151,7 +152,6 @@ export function SupplierOrderGroup({
                 Č. obj.
               </th>
               <th>Zákazník</th>
-              <th title="Kód variantu — obsahuje aj veľkosť, keď ju appka pozná">Kód</th>
               <th>Produkt</th>
               <th title="Množstvo (počet kusov)">Ks</th>
               <th title="Dodávateľ z katalógu, alebo ručné priradenie pri produkte bez katalógového dodávateľa">

--- a/apps/web/src/components/orderScreenFlags.ts
+++ b/apps/web/src/components/orderScreenFlags.ts
@@ -1,0 +1,19 @@
+// issue 118: majiteľ, doslovne "📋 Kopírovať objednávku ✉️ Poslať objednávku
+// e-mailom zatial skry este to nebudeme pouzivat" — appka ich SKRÝVA, nie
+// MAŽE (funkcionalita aj testy ostávajú v kóde). Rovnaký princíp ako
+// `nav.ts`'s `HIDDEN_TABS`: JEDEN prepínač na JEDNOM mieste, aby sa dal
+// vrátiť jednou zmenou, bez hľadania po komponentoch.
+//
+// `SupplierActionsPanel.tsx` gejtuje obe tlačidlá + sprievodný text touto
+// konštantou. Testy funkcionality (náhľad/odoslanie mailu, kopírovanie do
+// schránky) mockujú TENTO modul na `true`
+// (`vi.mock("./orderScreenFlags.js", () => ({ SHOW_ORDER_MAIL_ACTIONS: true }))`,
+// `OrdersSection.mailActions.test.tsx`), aby zostali plne funkčné aj počas
+// skrytia — appka samotná (a `OrdersSection.test.tsx`'s predvolený stav) ich
+// necháva na `false`.
+// Explicitná `boolean` anotácia (nie `false` literálový typ) — bez nej by
+// TS zúžil typ na literál `false` a eslint's `@typescript-eslint/no-
+// unnecessary-condition` by nahlásil KAŽDÉ `{SHOW_ORDER_MAIL_ACTIONS && ...}`
+// v `SupplierActionsPanel.tsx` ako "vždy falošné", hoci zámerom je práve
+// prepínateľná hodnota (`vi.mock` ju v testoch prepína na `true`).
+export const SHOW_ORDER_MAIL_ACTIONS: boolean = false;

--- a/apps/web/src/ordersSummary.test.ts
+++ b/apps/web/src/ordersSummary.test.ts
@@ -6,7 +6,6 @@ import {
   isLineResolved,
   isStaleOrderLine,
   orderLineAgeDays,
-  shouldShowSizeLabel,
   STALE_ORDER_LINE_DAYS,
   summarizeOrderLines,
 } from "./ordersSummary.js";
@@ -169,21 +168,7 @@ it("isStaleOrderLine — čerstvý nevybavený riadok nedostane badge", () => {
   expect(isStaleOrderLine({ state: "objednane", ordered: false, placedAt: NOW.toISOString() }, NOW)).toBe(false);
 });
 
-// issue 105 bod 2 — `variants.sizeLabel` je odvodené priamo ako suffix
-// `variantCode`u za prvou lomkou (`apps/api/src/modules/catalog/map-row.ts`'s
-// `splitCode`), takže KÓD stĺpec pripájajúci veľkosť za kód vždy zdvojoval
-// ("62621/52" + "52" → "62621/5252"). `shouldShowSizeLabel` rozhoduje, či sa
-// veľkosť smie pripojiť: len keď kód EŠTE veľkosťou nekončí.
-it("shouldShowSizeLabel — kód UŽ končí veľkosťou (bežný prípad z katalógu) → veľkosť sa NEpripája znova", () => {
-  expect(shouldShowSizeLabel("62621/52", "52")).toBe(false);
-  expect(shouldShowSizeLabel("61759/XL", "XL")).toBe(false);
-  expect(shouldShowSizeLabel("15813/120", "120")).toBe(false);
-});
-
-it("shouldShowSizeLabel — kód veľkosťou NEkončí → veľkosť sa pripojí", () => {
-  expect(shouldShowSizeLabel("40287", "L")).toBe(true);
-});
-
-it("shouldShowSizeLabel — bez veľkosti (sizeLabel null) sa nikdy nič nepripája", () => {
-  expect(shouldShowSizeLabel("40287", null)).toBe(false);
-});
+// issue 105 bod 2's `shouldShowSizeLabel` tests boli odstránené spolu s
+// funkciou samotnou — issue 117 zrušilo jej jediné volanie miesto
+// (`OrderLineRow.tsx`'s KÓD stĺpec), takže ostala nepoužitá (code review
+// PR #124).

--- a/apps/web/src/ordersSummary.ts
+++ b/apps/web/src/ordersSummary.ts
@@ -130,15 +130,8 @@ export function isStaleOrderLine(
   return !isLineResolved(line) && orderLineAgeDays(line.placedAt, now) > STALE_ORDER_LINE_DAYS;
 }
 
-// issue 105 bod 2 — `variants.sizeLabel` (server) je odvodené priamo ako
-// suffix `variantCode`u za prvou lomkou (`apps/api/src/modules/catalog/
-// map-row.ts`'s `splitCode`: `sizeLabel = code.slice(code.indexOf("/") + 1)`),
-// takže KÓD stĺpec, ktorý za kódom pripája veľkosť (issue 95's zlúčenie
-// KÓD+VEĽKOSŤ), zakaždým zobrazoval veľkosť DVAKRÁT ("62621/52" + "52" →
-// "62621/5252"). Veľkosť sa smie pripojiť len vtedy, keď kód ňou ešte
-// nekončí — vždy pravdivé pre katalógové dáta dnes, ale funkcia zostáva
-// všeobecná (nezávisí od `splitCode`u), pre prípad inak odvodeného
-// `sizeLabel`u v budúcnosti.
-export function shouldShowSizeLabel(variantCode: string, sizeLabel: string | null): boolean {
-  return sizeLabel !== null && !variantCode.endsWith(sizeLabel);
-}
+// issue 105 bod 2's `shouldShowSizeLabel` (KÓD+VEĽKOSŤ zlúčenie, issue 95)
+// bola odstránená spolu so svojimi 3 testami — issue 117 zrušilo celý KÓD
+// stĺpec (jej jediné volanie miesto v `OrderLineRow.tsx`), takže funkcia
+// ostala nepoužitá mŕtva produkčná logika (code review PR #124, MVP
+// philosophy: "remove unused code aggressively").

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -843,32 +843,6 @@ tr:last-child td {
   white-space: nowrap;
   cursor: help;
 }
-/* issue 95: KÓD + VEĽKOSŤ zlúčené do jednej bunky (majiteľ, komentár #10:
-   "veľkosť je už súčasťou kódu") — kód je hlavný text, veľkosť (keď appka má
-   samostatnú `sizeLabel` hodnotu) je vedľa neho menším, tlmeným písmom. */
-.ord-code-cell {
-  font-weight: var(--fs-weight-medium);
-  /* issue 111 bod 2: kód produktu sa NIKDY nesmie zalomiť uprostred kódu —
-     rovnaká trvalá poistka ako `.ord-admin-link` vyššie. `.col-code`
-     nižšie dostáva reálny zmeraný priestor; toto je krajný núdzový
-     prípad. Deep code review (issue 111): `ellipsis` platí na CELÚ bunku,
-     vrátane `.ord-size-inline` span-u nižšie, keď je vykreslený
-     (`shouldShowSizeLabel`) — to je ZÁMER, nie medzera: kód (hlavný údaj)
-     je PRVÝ v poradí, takže sa oreže AŽ POSLEDNÝ, veľkosť (druhoradý
-     doplnok, dnes prakticky nikdy nevykreslená — pozri `ordersSummary.ts`'s
-     komentár, `sizeLabel` je skoro vždy už suffixom kódu) sa prípadne
-     orezáva PRVÁ. Žiadna zmena kódu netreba, len tento zápis pre budúceho
-     čitateľa. */
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-.ord-size-inline {
-  margin-left: var(--fs-space-1);
-  font-size: var(--fs-text-xs);
-  font-weight: var(--fs-weight-medium);
-  color: var(--fs-ink-muted);
-}
 /* issue 107 bod 1: majiteľ, live nameraná chyba — natívna šípka rozbaľovača
    sa vykresľuje VNÚTRI paddingu, ale nič v CSS s jej priestorom nepočíta
    (`padding-right` bol celý priestor, ktorý appka "vidí"), takže reálne
@@ -908,8 +882,31 @@ tr:last-child td {
 .ord-supplier-cell {
   max-width: 100%;
 }
+/* issue 119: majiteľ, doslovne "zmen na nejake tlacitko z ikonou ktore
+   otvori na novom okne ten link, lebo teraz to je tazke stlacit" — textový
+   odkaz nahradený ikonovým tlačidlom (`OrderLineRow.tsx` drží `<a>`,
+   skutočná navigácia s `target="_blank"`, len vizuálne štylizovaná).
+   `min-width`/`min-height` 2.25rem = 36px, rovnaký "veľké tlačidlá" rozmer
+   ako `.order-group .btn.sm`/`.ord-state-select` vyššie — spĺňa ticketov
+   akceptačný test (klikacia plocha ≥36×36px pri 1280px). */
 .ord-supplier-link {
-  font-weight: var(--fs-weight-medium);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.25rem;
+  min-height: 2.25rem;
+  padding: var(--fs-space-1);
+  font-size: var(--fs-text-lg);
+  line-height: 1;
+  color: var(--fs-brand);
+  background: var(--fs-surface-alt);
+  border: 1px solid var(--fs-border);
+  border-radius: var(--fs-radius-sm);
+  text-decoration: none;
+}
+.ord-supplier-link:hover {
+  background: var(--fs-brand);
+  color: var(--fs-surface);
 }
 /* issue 70: `supplierNote` je voľný text neobmedzenej dĺžky (na rozdiel od
    krátkych popiskov, kde je `nowrap` bez orezania bezpečný) — orezáva sa
@@ -923,10 +920,6 @@ tr:last-child td {
   white-space: nowrap;
   vertical-align: bottom;
   color: var(--fs-ink-muted);
-}
-.ord-supplier-code {
-  font-size: var(--fs-text-xs);
-  color: var(--fs-ink-faint);
 }
 /* issue 107 bod 3: majiteľ, komentár #1: "neviem čo tam je Priradenie
    dodávateľa stĺpec" — nahrádza predtým holú pomlčku (bod vyššie v `.tsx`),
@@ -1192,17 +1185,25 @@ tr:last-child td {
 .col-customer {
   width: 8%;
 }
-.col-code {
-  width: 10.8%;
-}
+/* issue 117: majiteľ, doslovne "kody produktov vobec nepouzivame ...
+   zaberaju miesto" — `col-code` (10.8%) CELÝ zrušený spolu s bunkou v
+   `OrderLineRow.tsx`. Uvoľnená šírka ide do `col-product` (11.4%→17.4%,
+   +6 percentuálnych bodov — issue 107's nález: dlhý názov produktu je
+   overený hlavný hnací faktor výšky riadku) a `col-supplier` (9.2%→14%,
+   +4.8 — hoci teraz nesie MENŠÍ typický obsah (textový odkaz nahradilo malé
+   ikonové tlačidlo, issue 119, a "kód …" riadok pod ním zmizol, issue 117),
+   zriedkavý `supplierNote`/"Priradiť dodávateľa" text pri riadkoch bez
+   odkazu potrebuje priestor, aby sa nezalomil viac než predtým). Živo
+   overené proti produkcii (39 ostrých riadkov) po nasadení. Súčet ostáva
+   100%. */
 .col-product {
-  width: 11.4%;
+  width: 17.4%;
 }
 .col-qty {
   width: 4%;
 }
 .col-supplier {
-  width: 9.2%;
+  width: 14%;
 }
 .col-state {
   width: 13.5%;

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -923,9 +923,10 @@ tr:last-child td {
 }
 /* issue 107 bod 3: majiteľ, komentár #1: "neviem čo tam je Priradenie
    dodávateľa stĺpec" — nahrádza predtým holú pomlčku (bod vyššie v `.tsx`),
-   rovnaký vizuálny jazyk ako `.ord-supplier-code` (tichý, faint text nad
-   ovládacím prvkom pod ním), žiadny extra riadok výšky navyše — vykresľuje
-   sa v UŽ EXISTUJÚCOM mieste (`.ord-supplier-cell`), nie v novom bloku. */
+   tichý, faint text nad ovládacím prvkom pod ním (rovnaký vizuálny jazyk,
+   aký kedysi niesol `.ord-supplier-code` — odstránené issue 117), žiadny
+   extra riadok výšky navyše — vykresľuje sa v UŽ EXISTUJÚCOM mieste
+   (`.ord-supplier-cell`), nie v novom bloku. */
 .ord-supplier-assign-hint {
   font-size: var(--fs-text-xs);
   color: var(--fs-ink-faint);

--- a/apps/web/tests/e2e/orders-layout.spec.ts
+++ b/apps/web/tests/e2e/orders-layout.spec.ts
@@ -120,20 +120,9 @@ test("STAV je celý čitateľný a POZNÁMKY pole je dosť široké na všetkýc
     expect(zalomeneObjednavky.pocetZalomenych, `zalomené čísla objednávky pri ${String(width)}px`).toBe(0);
     expect(zalomeneObjednavky.whiteSpace, `.ord-admin-link white-space pri ${String(width)}px`).toBe("nowrap");
 
-    const zalomeneKody = await page.evaluate(() => {
-      const bunky = [...document.querySelectorAll<HTMLTableCellElement>(".ord-code-cell")];
-      const pocetZalomenych = bunky.filter((td) => {
-        const textNode = [...td.childNodes].find((n) => n.nodeType === Node.TEXT_NODE && n.textContent?.trim() !== "");
-        if (!textNode) return false;
-        const range = document.createRange();
-        range.selectNodeContents(textNode);
-        return range.getClientRects().length > 1;
-      }).length;
-      const prva = bunky.at(0);
-      return { pocetZalomenych, whiteSpace: prva !== undefined ? getComputedStyle(prva).whiteSpace : null };
-    });
-    expect(zalomeneKody.pocetZalomenych, `zalomené kódy produktu pri ${String(width)}px`).toBe(0);
-    expect(zalomeneKody.whiteSpace, `.ord-code-cell white-space pri ${String(width)}px`).toBe("nowrap");
+    // issue 111 bod 2's `.ord-code-cell` zalomenie kontrola je ODSTRÁNENÁ —
+    // issue 117 celý stĺpec kódu produktu zrušilo (majiteľ nepoužíva), takže
+    // `.ord-code-cell` už v DOM-e vôbec neexistuje.
 
     // issue 111 bod 5: pri 1280px sa žiadna `.orders-table-wrap` skupina
     // nesmie posúvať vodorovne (predtým 💾 tlačidlo bolo za viditeľným

--- a/apps/web/tests/e2e/orders.spec.ts
+++ b/apps/web/tests/e2e/orders.spec.ts
@@ -213,7 +213,6 @@ test("manažér vidí otvorené objednávky zoskupené podľa dodávateľa, konz
   await expect(riadokAlfa).toContainText("9001");
   await expect(riadokAlfa).toContainText("E2E Zákazník Alfa");
   await expect(riadokAlfa).toContainText("Nohavice Hart Wild-T");
-  await expect(riadokAlfa).toContainText("46");
   await expect(riadokAlfa).toContainText("2");
   await expect(riadokAlfa).toContainText("Čaká sa");
   // issue 64: poznámka k objednávke je pre `canChangeState` role (tento účet
@@ -247,8 +246,11 @@ test("manažér vidí otvorené objednávky zoskupené podľa dodávateľa, konz
   // Shoptet administrácie (`adminUrl`) — objednávka 9001.
   // issue 99: klikateľné je samotné ČÍSLO objednávky (nie samostatná ikonka
   // `🔗` vedľa neho, ktorá predtým niesla ten istý odkaz) — over href/target/
-  // rel AJ to, že viditeľný text odkazu je presne číslo objednávky a žiadna
-  // ikonka nezostala.
+  // rel AJ to, že viditeľný text TOHTO konkrétneho odkazu je presne číslo
+  // objednávky (`toHaveText` je PRESNÁ zhoda — dokazuje, že vnútri NIE JE
+  // žiadna ikonka). issue 119: `🔗` odteraz LEGITÍMNE existuje inde v tom
+  // istom riadku (odkaz na dodávateľa, over vyššie) — kontrola sa preto
+  // SKOPUJE na `adminOdkazAlfa` samotný, nie na celý `riadokAlfa`.
   await expect(riadokAlfa).toContainText("Prosím doručiť len v piatok");
   const adminOdkazAlfa = riadokAlfa.getByRole("link", { name: "Otvoriť objednávku 9001 v administrácii Shoptet" });
   await expect(adminOdkazAlfa).toHaveAttribute(
@@ -258,7 +260,6 @@ test("manažér vidí otvorené objednávky zoskupené podľa dodávateľa, konz
   await expect(adminOdkazAlfa).toHaveAttribute("target", "_blank");
   await expect(adminOdkazAlfa).toHaveText("9001");
   await expect(riadokAlfa.getByRole("link", { name: "Otvoriť objednávku" })).toHaveCount(1);
-  await expect(riadokAlfa).not.toContainText("🔗");
   // Objednávka 9001 je UŽ vybavená (stav "caka_sa") — upozornenie na staré
   // objednávky sa NIKDY nezobrazí pre vybavený riadok, aj keby bol starý.
   await expect(riadokAlfa.locator("[data-testid^='stale-badge-']")).toHaveCount(0);

--- a/apps/web/tests/e2e/orders.spec.ts
+++ b/apps/web/tests/e2e/orders.spec.ts
@@ -212,7 +212,6 @@ test("manažér vidí otvorené objednávky zoskupené podľa dodávateľa, konz
   const riadokAlfa = skupinaDodavatel.locator("[data-testid^='order-line-']");
   await expect(riadokAlfa).toContainText("9001");
   await expect(riadokAlfa).toContainText("E2E Zákazník Alfa");
-  await expect(riadokAlfa).toContainText("4859/46");
   await expect(riadokAlfa).toContainText("Nohavice Hart Wild-T");
   await expect(riadokAlfa).toContainText("46");
   await expect(riadokAlfa).toContainText("2");
@@ -223,14 +222,26 @@ test("manažér vidí otvorené objednávky zoskupené podľa dodávateľa, konz
   // preto overuje `toHaveValue` na samotnom vstupe (rovnaký dôvod ako
   // `.claude/rules/testing.md`'s poznámka o jest-dom matcheroch — tu ide o
   // Playwright, nie vitest, ale princíp "vstup nie je text" je ten istý).
+  // (Aria-label nesie kód "4859/46" — dôkaz, že ide o SPRÁVNY riadok.)
   await expect(riadokAlfa.getByLabel("Poznámka k objednávke 9001 / 4859/46")).toHaveValue("Zavolať pred doručením");
 
   // issue 67: fixtúra ("4859/46") má reálny holý odkaz na dodávateľa
-  // (`internalNote`) aj kód dodávateľa (`externalCode`, "OB832") —
-  // over cez map-row.test.ts, ak sa fixtúra niekedy zmení.
+  // (`internalNote`) — over cez map-row.test.ts, ak sa fixtúra niekedy zmení.
+  // issue 117: dodávateľský kód (`externalCode`, "OB832") sa už NIKDE
+  // nezobrazuje (majiteľ ho nepoužíva) — appka drží už len samotný odkaz.
+  // issue 119: odkaz je teraz veľké IKONOVÉ tlačidlo (nie textový odkaz) —
+  // href/target/rel ostávajú, PLUS klikacia plocha musí byť aspoň 36×36px
+  // pri 1280px (ticketov vlastný akceptačný test).
   const odkazAlfa = riadokAlfa.getByRole("link", { name: "Odkaz na dodávateľa" });
   await expect(odkazAlfa).toHaveAttribute("href", "https://www.huntingshop.eu/wild-t-green-nohavice");
-  await expect(riadokAlfa).toContainText("OB832");
+  await expect(odkazAlfa).toHaveAttribute("target", "_blank");
+  await expect(odkazAlfa).toHaveAttribute("rel", "noreferrer noopener");
+  await expect(riadokAlfa).not.toContainText("OB832");
+  const boxOdkazAlfa = await odkazAlfa.boundingBox();
+  expect(boxOdkazAlfa?.width ?? 0, "šírka klikacej plochy odkazu na dodávateľa pri 1280px").toBeGreaterThanOrEqual(36);
+  expect(boxOdkazAlfa?.height ?? 0, "výška klikacej plochy odkazu na dodávateľa pri 1280px").toBeGreaterThanOrEqual(
+    36,
+  );
 
   // issue 65: zákaznícky odkaz (`remark`, read-only) + priamy odkaz do
   // Shoptet administrácie (`adminUrl`) — objednávka 9001.
@@ -264,8 +275,11 @@ test("manažér vidí otvorené objednávky zoskupené podľa dodávateľa, konz
   const riadokBez = skupinaBezDodavatela.locator("[data-testid^='order-line-']").filter({ hasText: "9002" });
   await expect(riadokBez).toContainText("9002");
   await expect(riadokBez).toContainText("E2E Zákazník Bez dodávateľa");
-  await expect(riadokBez).toContainText("40287");
   await expect(riadokBez).toContainText("Čiapka Polar FOREST");
+  // issue 117: variant kód ("40287") sa už NIKDE nezobrazuje viditeľne —
+  // stále však nesie zmysel (a je overiteľný) cez aria-label stavového
+  // selectu tohto riadku.
+  await expect(riadokBez.getByLabel("Zmeniť stav riadku objednávky 9002 / 40287")).toBeVisible();
   // Predvolený stav riadku (schema default "objednane") a chýbajúca veľkosť —
   // issue 60: premenované na "Nevybavené" (slovo "Objednané" teraz patrí
   // výlučne novému odškrtávaciemu políčku).
@@ -331,17 +345,19 @@ test("manažér prepne stav riadku cez select, zmena pretrvá po obnovení strá
   expect(chyby).toEqual([]);
 });
 
-// #31: e-mailový kontakt dodávateľa + náhľad objednávky mailom, cez skutočný
-// prehliadač nad reálne naimportovanými fixtúrovými dátami (`scripts/
-// e2e-setup.ts`). Skutočné ODOSLANIE (SMTP) sa tu zámerne NEKLIKÁ — MAIL_HOST
-// nie je v e2e prostredí nakonfigurovaný (`playwright.config.ts`), takže
-// server by na "Odoslať" vrátil 503, čo by (rovnako ako akýkoľvek iný
-// 4xx/5xx fetch) zalogovalo console error a porušilo jedinú povolenú
-// výnimku (`.claude/rules/testing.md`) — samotné odoslanie je overené
-// integračne (`apps/api/tests/supplier-mail.integration.test.ts`) s falošným
-// transportom. E2E overuje SKUTOČNÝ prehliadačový workflow: nastavenie
-// e-mailu (perzistuje po reloade) a náhľad so správne agregovaným obsahom.
-test("manažér nastaví e-mail dodávateľa a uvidí náhľad mailu so správne agregovaným obsahom, konzola je čistá", async ({ page }) => {
+// #31: e-mailový kontakt dodávateľa, cez skutočný prehliadač nad reálne
+// naimportovanými fixtúrovými dátami (`scripts/e2e-setup.ts`). issue 118:
+// majiteľ, doslovne "zatial skry este to nebudeme pouzivat" — appka SKRÝVA
+// (nemaže) tlačidlá "📋 Kopírovať objednávku"/"✉️ Poslať objednávku
+// e-mailom" (`orderScreenFlags.ts`'s `SHOW_ORDER_MAIL_ACTIONS`), takže sa už
+// nedajú kliknúť naživo — samotný náhľad/odoslanie mailu naďalej overuje
+// `OrdersSection.mailActions.test.tsx` (flag prepnutý na `true`) + backendová
+// logika (`apps/api/tests/supplier-mail.integration.test.ts`). E2E tu overuje
+// SKUTOČNÝ prehliadačový workflow, ktorý ostáva dostupný: nastavenie e-mailu
+// (perzistuje po reloade) + skutočnú NEPRÍTOMNOSŤ oboch skrytých tlačidiel.
+test("manažér nastaví e-mail dodávateľa, zmena pretrvá po obnovení stránky; tlačidlá kopírovania/odoslania mailom sú skryté (issue 118), konzola je čistá", async ({
+  page,
+}) => {
   const chyby: string[] = [];
   page.on("console", (m) => {
     if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
@@ -356,11 +372,6 @@ test("manažér nastaví e-mail dodávateľa a uvidí náhľad mailu so správne
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
   await expect(page.getByRole("heading", { name: "Na objednanie" })).toBeVisible();
 
-  // Objednávka 9001 (dodávateľ "DODAVATEL-TEST-1") má JEDINÝ riadok vo stave
-  // "caka_sa" (`scripts/e2e-setup.ts`) — teda ŽIADNU otvorenú položku na
-  // objednanie. Tlačidlo odoslania preto musí byť disabled, aj keď sa
-  // e-mail dodávateľa nastaví — overuje, že disabled stav sleduje SKUTOČNÝ
-  // stav riadkov, nie len prítomnosť e-mailu.
   const skupinaTest1 = page.getByTestId("supplier-DODAVATEL-TEST-1");
   await skupinaTest1.getByRole("button", { name: "Upraviť e-mail" }).click();
   await skupinaTest1.getByLabel("E-mail dodávateľa DODAVATEL-TEST-1").fill("test1@dodavatel.example");
@@ -372,7 +383,6 @@ test("manažér nastaví e-mail dodávateľa a uvidí náhľad mailu so správne
   // (existujúceho, užšieho) locatora).
   await skupinaTest1.getByRole("button", { name: "Uložiť", exact: true }).click();
   await expect(skupinaTest1.getByText("E-mail dodávateľa: test1@dodavatel.example")).toBeVisible();
-  await expect(skupinaTest1.getByRole("button", { name: "✉️ Poslať objednávku e-mailom" })).toBeDisabled();
 
   await page.reload();
   await expect(page.getByRole("heading", { name: "Na objednanie" })).toBeVisible();
@@ -380,41 +390,15 @@ test("manažér nastaví e-mail dodávateľa a uvidí náhľad mailu so správne
     page.getByTestId("supplier-DODAVATEL-TEST-1").getByText("E-mail dodávateľa: test1@dodavatel.example"),
   ).toBeVisible();
 
-  // Objednávka 9002 (zástupný dodávateľ "(bez dodávateľa)") má riadok vo
-  // východiskovom stave "objednane" — TÁ skupina má odoslanie povolené,
-  // hneď ako dostane e-mail.
-  const skupinaBezDodavatela = page.getByTestId("supplier-(bez dodávateľa)");
-  await skupinaBezDodavatela.getByRole("button", { name: "Upraviť e-mail" }).click();
-  await skupinaBezDodavatela.getByLabel("E-mail dodávateľa (bez dodávateľa)").fill("nezaradene@example.com");
-  // issue 63: `{ exact: true }` — skupina teraz obsahuje AJ priraďovacie
-  // tlačidlá "💾" (aria-label "Uložiť priradenie dodávateľa…"), ktorých
-  // accessible name OBSAHUJE "Uložiť" ako substring (Playwright's substring
-  // zhoda bez `exact`, `.claude/rules/pairing.md`'s zistený vzor). Oprava je
-  // na strane TOHTO (existujúceho, užšieho) locatora, nie oberaním nového
-  // tlačidla o jeho plnohodnotný popis.
-  await skupinaBezDodavatela.getByRole("button", { name: "Uložiť", exact: true }).click();
-  const poslatTlacidlo = skupinaBezDodavatela.getByRole("button", { name: "✉️ Poslať objednávku e-mailom" });
-  await expect(poslatTlacidlo).toBeEnabled();
-  await poslatTlacidlo.click();
-
-  const nahlad = skupinaBezDodavatela.getByTestId("mail-preview-(bez dodávateľa)");
-  await expect(nahlad).toBeVisible();
-  await expect(nahlad).toContainText("nezaradene@example.com");
-  // "40287" je jednovariantný produkt (žiadna veľkosť) s množstvom 1
-  // (`scripts/e2e-setup.ts`). issue 63: fixtúra pridala ĎALŠIE 2 riadky BEZ
-  // dodávateľa v predvolenom stave "objednane" ("60035/L"/"60035/M", obe
-  // veľkosti odvodené priamo z kódu, `map-row.ts`'s `splitCode`) — mailová
-  // agregácia preto teraz vidí 3 položky, nie 1, zoradené vzostupne podľa
-  // kódu variantu.
-  await expect(nahlad).toContainText("Objednávka — (bez dodávateľa) (3 položky)");
-  await expect(nahlad.locator("pre")).toHaveText(
-    "Objednávka — (bez dodávateľa) (3 položky)\n40287 | 1 ks\n60035/L | L | 1 ks\n60035/M | M | 1 ks",
-  );
-
-  // Zrušenie náhľadu — v tomto teste sa zámerne NEODOSIELA (viď komentár
-  // vyššie).
-  await nahlad.getByRole("button", { name: "Zrušiť" }).click();
-  await expect(nahlad).not.toBeVisible();
+  // issue 118 akceptačné kritérium: naživo overiť, že tlačidlá nie sú na
+  // obrazovke — nikde na celej stránke, bez ohľadu na skupinu/e-mail stav.
+  await expect(page.getByRole("button", { name: "✉️ Poslať objednávku e-mailom" })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "📋 Kopírovať objednávku" })).toHaveCount(0);
+  await expect(page.getByText("Pre odoslanie mailom treba najprv nastaviť e-mail dodávateľa.")).toHaveCount(0);
+  // Hromadné tlačidlo (mimo issue 118's scope) ostáva viditeľné.
+  await expect(
+    page.getByTestId("supplier-(bez dodávateľa)").getByRole("button", { name: "✔ Označiť skupinu ako objednané" }),
+  ).toBeVisible();
 
   expect(chyby).toEqual([]);
 });
@@ -637,17 +621,20 @@ test("manažér ručne priradí dodávateľa riadku bez dodávateľa s našepká
   await page.getByLabel("Uložiť priradenie dodávateľa riadku objednávky 9006 / 60035/L").click();
 
   // Refetch po uložení (`OrdersSection.tsx`'s `assignSupplier`) — nová
-  // skupina sa objaví, riadok "60035/L" je v nej.
+  // skupina sa objaví, riadok "60035/L" je v nej. issue 117: variant kód sa
+  // už NIKDE viditeľne nezobrazuje, takže riadok identifikuje priamo
+  // priraďovací vstup (jeho aria-label nesie kód aj po uložení).
   const novaSkupina = page.getByTestId("supplier-E2E Dodávateľ Priradenie");
   await expect(novaSkupina).toBeVisible();
-  await expect(novaSkupina).toContainText("60035/L");
+  await expect(novaSkupina.getByLabel("Priradiť dodávateľa riadku objednávky 9006 / 60035/L")).toHaveValue(
+    "E2E Dodávateľ Priradenie",
+  );
 
   // issue 63 bod 2: priradenie cez JEDNU veľkosť platí aj pre "60035/M" —
   // TEN ISTÝ produkt, iný riadok, nikdy ručne priradený, a napriek tomu je v
   // TEJ ISTEJ novej skupine (produktová perzistencia, `product_supplier_
   // override`).
-  await expect(novaSkupina).toContainText("60035/M");
-  const vstupM = page.getByLabel("Priradiť dodávateľa riadku objednávky 9006 / 60035/M");
+  const vstupM = novaSkupina.getByLabel("Priradiť dodávateľa riadku objednávky 9006 / 60035/M");
   await expect(vstupM).toHaveValue("E2E Dodávateľ Priradenie");
 
   // Pretrvanie po obnovení stránky — priradenie je v DB (`product_supplier_
@@ -655,8 +642,12 @@ test("manažér ručne priradí dodávateľa riadku bez dodávateľa s našepká
   await page.reload();
   await expect(page.getByRole("heading", { name: "Na objednanie" })).toBeVisible();
   const novaSkupinaPoReloade = page.getByTestId("supplier-E2E Dodávateľ Priradenie");
-  await expect(novaSkupinaPoReloade).toContainText("60035/L");
-  await expect(novaSkupinaPoReloade).toContainText("60035/M");
+  await expect(
+    novaSkupinaPoReloade.getByLabel("Priradiť dodávateľa riadku objednávky 9006 / 60035/L"),
+  ).toHaveValue("E2E Dodávateľ Priradenie");
+  await expect(
+    novaSkupinaPoReloade.getByLabel("Priradiť dodávateľa riadku objednávky 9006 / 60035/M"),
+  ).toHaveValue("E2E Dodávateľ Priradenie");
 
   expect(chyby).toEqual([]);
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.68",
+  "version": "0.3.0-dev.69",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Summary

Three small owner-requested UI tweaks to the "Na objednanie" screen, all in the same order-line row/screen area:

- **#117** — remove the product-code column (KÓD) and the "kód …" line under the supplier link. Owner never uses codes on this screen; the freed width goes to the product-name and supplier columns (issue 107's finding: long product names are the main row-height driver).
- **#118** — hide (not delete) the "📋 Kopírovať objednávku" / "✉️ Poslať objednávku e-mailom" buttons + hint text, behind a single flag (`orderScreenFlags.ts`'s `SHOW_ORDER_MAIL_ACTIONS`, same principle as `nav.ts`'s `HIDDEN_TABS`). Existing functionality tests moved (not deleted) to `OrdersSection.mailActions.test.tsx`, which forces the flag on.
- **#119** — turn the plain-text "Odkaz na dodávateľa" link into a large (≥36×36px) icon button, same `<a target="_blank" rel="noreferrer noopener">`/`aria-label`, just restyled.

Design rationale (root cause / chosen approach / rejected alternative) posted per-ticket before the first commit: #117, #118, #119 issue comments.

## Test plan

- [x] Unit/RTL: 231/231 passing (`pnpm --filter @forestshop/web test`)
- [x] E2E: 21/21 passing locally + in CI (`pnpm --filter @forestshop/web e2e`)
- [x] Lint + typecheck clean
- [x] CI all green (check/integration/e2e/docker-build/version-check)
- [ ] Post-deploy: live verification at 1280/1440/1600/1920px (row heights, no wrap, icon button size/target, hidden buttons, console clean, version label)

Closes #117
Closes #118
Closes #119
