### PR TITLE
Import objednávok beží hodinovo; sync pill už nehlási OK pri starom syncu (#115)

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -291,3 +291,25 @@ paths:
   meaningfully. Always diff the SAME rows before-vs-after (keyed by
   `data-testid`), never just compare the sorted-height array's summary
   stats between two differently-configured runs.
+- **Removing a `<colgroup>` COLUMN entirely (not just resizing it) needs a
+  grep across ALL e2e spec files for its CSS class, not just the spec file
+  you're already editing** — this table's e2e coverage is split across
+  `orders.spec.ts` (functional flows) and `orders-layout.spec.ts` (column-
+  width/wrap regressions, issue 107), and a class-specific check can live in
+  either one independently of which file you're touching. Issue 117 removed
+  `.ord-code-cell` (the whole KÓD column) — `orders.spec.ts` had several
+  `variantCode`-in-visible-text assertions (`toContainText("4859/46")`, a
+  bare `toContainText("46")` fragment, `toContainText("60035/L")`, …) that
+  silently kept passing in a first local run because they happened to sit
+  in tests unrelated to the removed cell, but `orders-layout.spec.ts` had an
+  ENTIRE dedicated check (`zalomeneKody`, issue 111's wrap-detection) built
+  directly on `document.querySelectorAll(".ord-code-cell")` that CI caught
+  failing on the first push (the local pre-push run only covered
+  `orders.spec.ts` + `orders-layout.spec.ts` together, but a leftover
+  fragment assertion — `toContainText("46")` — still slipped through both
+  local AND the first CI run, since it read as part of an unrelated
+  assertion chain; only the SECOND CI run, after fixing the first failure,
+  surfaced it). Any FUTURE full-column removal: `grep -rn
+  "<the-cells-class>" apps/web/tests/e2e/` across the WHOLE e2e directory
+  before considering the removal test-safe, not just the spec file with the
+  obviously-related test names.

--- a/.claude/rules/scheduler.md
+++ b/.claude/rules/scheduler.md
@@ -5,6 +5,8 @@ paths:
   - "apps/api/src/http/scheduler-routes.ts"
   - "apps/web/src/schedulerApi.ts"
   - "apps/web/src/components/SchedulerSection.tsx"
+  - "apps/web/src/components/SyncSection.tsx"
+  - "apps/web/src/syncStatus.ts"
 ---
 
 # Plánovač úloh (F2)
@@ -17,14 +19,21 @@ paths:
   sám žiadnu doménovú logiku nemá a nemá ju ani získať. `run()` nikdy
   nezachytáva vlastné výnimky — necháva ich prejsť, `scheduler.ts`'s
   `executeJob` ich odchytí a zapíše ako `job_run.status = "failure"`.
-- **Rozvrh je len denná hodina:minúta v UTC (`DailySchedule`), žiadny cron
-  výraz.** `isDue()` (`scheduler.ts`) je čistá funkcia — nová úloha dostáva
-  vlastný `{ hourUtc, minuteUtc }`; zvoľ ho aspoň 15 min od existujúcich, aby
-  sa neprekrývali zbytočne (nie je to tvrdá závislosť, len aby operátor v
-  logoch/`job_run` vedel odlíšiť poradie). Dnes zaregistrované: 01:00 import
-  katalógu, 01:15 mazanie surových exportov katalógu, 01:30 mazanie relácií,
-  01:45 import objednávok (`ordersImportJob`, #22), 02:00 mazanie surových
-  exportov objednávok (`pruneRawOrdersJob`, #28).
+- **Rozvrh je diskriminovaná únia `Schedule = DailySchedule | HourlySchedule`
+  (`kind: "daily" | "hourly"`, `types.ts`), žiadny cron výraz.** `isDue()`
+  (`scheduler.ts`) je čistá funkcia — periodizuje podľa `kind` (`daily`: UTC
+  kalendárny deň, `hourly`: UTC deň+hodina, #115). Nová `daily` úloha dostáva
+  vlastný `{ kind: "daily", hourUtc, minuteUtc }`; zvoľ ho aspoň 15 min od
+  existujúcich `daily` úloh, aby sa neprekrývali zbytočne (nie je to tvrdá
+  závislosť, len aby operátor v logoch/`job_run` vedel odlíšiť poradie). Nová
+  `hourly` úloha dostáva `{ kind: "hourly", minuteUtc }` — nemá `hourUtc`,
+  beží v KAŽDEJ UTC hodine. Dnes zaregistrované: 01:00 import katalógu
+  (`daily`), 01:15 mazanie surových exportov katalógu (`daily`), 01:30
+  mazanie relácií (`daily`), :45 KAŽDÚ hodinu import objednávok
+  (`ordersImportJob`, `hourly` od #115, pôvodne `daily` #22), 02:00 mazanie
+  surových exportov objednávok (`pruneRawOrdersJob`, `daily`, #28). Pridanie
+  ďalšieho `kind` (napr. "weekly") by znamenalo rozšíriť `periodKey()`
+  (`scheduler.ts`) o ďalšiu vetvu — rovnaký vzor ako `hourly`.
 - **Job NEPOTREBUJE vlastný advisory zámok, keď buď (a) volaná business
   funkcia už berie svoj vlastný vnútri seba** (`catalogImportJob`/
   `ordersImportJob` → `ingestCatalog`/`ingestOrders`), **alebo (b) sa vôbec

--- a/apps/api/src/modules/scheduler/jobs.ts
+++ b/apps/api/src/modules/scheduler/jobs.ts
@@ -97,7 +97,12 @@ export function ordersImportJob(runOrdersIngest: RunOrdersIngest | undefined): S
 export function pruneRawOrdersJob(rawDir: string, keepDays = 30): ScheduledJob {
   return {
     name: PRUNE_RAW_ORDERS_JOB_NAME,
-    // Ďalší voľný slot po `ordersImportJob` (01:45).
+    // Zostáva DENNÁ (nie hodinová) — mazanie starých surových exportov
+    // netreba spúšťať častejšie. #115: `ordersImportJob` je odteraz hodinová
+    // (:45 každú hodinu), takže tento denný beh o 02:00 sa s ním bude
+    // prekrývať KAŽDÝ deň (nie len raz), nie iba pri tomto jednom sedení —
+    // neprekáža, `pruneRawOrders` nemá žiadny DB advisory zámok (viď komentár
+    // vyššie), takže si nekonkuruje.
     schedule: { kind: "daily", hourUtc: 2, minuteUtc: 0 },
     async run(_db, now) {
       const result = await pruneRawOrders(rawDir, { keepDays, now });

--- a/apps/api/src/modules/scheduler/jobs.ts
+++ b/apps/api/src/modules/scheduler/jobs.ts
@@ -29,7 +29,7 @@ const EXPORT_URL_NOT_CONFIGURED = "Import katalógu nie je nakonfigurovaný (ch�
 export function catalogImportJob(runIngest: RunIngest | undefined): ScheduledJob {
   return {
     name: CATALOG_IMPORT_JOB_NAME,
-    schedule: { hourUtc: 1, minuteUtc: 0 },
+    schedule: { kind: "daily", hourUtc: 1, minuteUtc: 0 },
     async run(_db, now) {
       if (runIngest === undefined) throw new Error(EXPORT_URL_NOT_CONFIGURED);
       const result = await runIngest(now);
@@ -42,7 +42,7 @@ export function catalogImportJob(runIngest: RunIngest | undefined): ScheduledJob
 export function pruneRawExportsJob(keepDays = 30): ScheduledJob {
   return {
     name: PRUNE_RAW_EXPORTS_JOB_NAME,
-    schedule: { hourUtc: 1, minuteUtc: 15 },
+    schedule: { kind: "daily", hourUtc: 1, minuteUtc: 15 },
     async run(db, now) {
       const result = await pruneRawSnapshots(db, { keepDays, now });
       return { detail: result };
@@ -54,7 +54,7 @@ export function pruneRawExportsJob(keepDays = 30): ScheduledJob {
 export function sessionCleanupJob(): ScheduledJob {
   return {
     name: SESSION_CLEANUP_JOB_NAME,
-    schedule: { hourUtc: 1, minuteUtc: 30 },
+    schedule: { kind: "daily", hourUtc: 1, minuteUtc: 30 },
     async run(db, now) {
       const result = await cleanupExpiredSessions(db, now);
       return { detail: result };
@@ -63,11 +63,11 @@ export function sessionCleanupJob(): ScheduledJob {
 }
 
 /**
- * Nočný import objednávok (#22) — rovnaký vzor ako `catalogImportJob`, volá
- * EXISTUJÚCI `ingestOrders` (cez `runOrdersIngest` closure z `index.ts`),
- * nič sa nereimplementuje. Žiadny nový advisory lock na tejto úrovni —
- * `ingestOrders` (`orders/ingest.ts`) už berie svoj vlastný
- * (`INGEST_ORDERS_ADVISORY_LOCK_KEY`) vnútri seba, presne ako
+ * Import objednávok (#22, hodinová kadencia od #115) — rovnaký vzor ako
+ * `catalogImportJob`, volá EXISTUJÚCI `ingestOrders` (cez `runOrdersIngest`
+ * closure z `index.ts`), nič sa nereimplementuje. Žiadny nový advisory lock
+ * na tejto úrovni — `ingestOrders` (`orders/ingest.ts`) už berie svoj
+ * vlastný (`INGEST_ORDERS_ADVISORY_LOCK_KEY`) vnútri seba, presne ako
  * `catalogImportJob` nepridáva zámok navyše. Keď `SHOPTET_ORDERS_URL` nie je
  * nakonfigurované, job VYHODÍ — `scheduler.ts` to zapíše ako "failure" s
  * touto správou, namiesto toho, aby beh ticho preskočil bez záznamu.
@@ -75,9 +75,11 @@ export function sessionCleanupJob(): ScheduledJob {
 export function ordersImportJob(runOrdersIngest: RunOrdersIngest | undefined): ScheduledJob {
   return {
     name: ORDERS_IMPORT_JOB_NAME,
-    // Ďalší voľný 15-minútový slot v registri (01:00 import katalógu, 01:15
-    // mazanie surových exportov katalógu, 01:30 mazanie relácií).
-    schedule: { hourUtc: 1, minuteUtc: 45 },
+    // #115 (majiteľ: "sync zo shoptetu ma bezat kazdu hodinu"): predtým raz
+    // denne o 01:45 (`kind: "daily"`), teraz KAŽDÚ hodinu o :45 — `isDue()`
+    // (`scheduler.ts`) periodizuje `hourly` podľa UTC dňa+hodiny, takže sa v
+    // tej istej hodine nezopakuje, ale v ĎALŠEJ hodine áno.
+    schedule: { kind: "hourly", minuteUtc: 45 },
     async run(_db, now) {
       if (runOrdersIngest === undefined) throw new Error(ORDERS_EXPORT_URL_NOT_CONFIGURED);
       const result = await runOrdersIngest(now);
@@ -96,7 +98,7 @@ export function pruneRawOrdersJob(rawDir: string, keepDays = 30): ScheduledJob {
   return {
     name: PRUNE_RAW_ORDERS_JOB_NAME,
     // Ďalší voľný slot po `ordersImportJob` (01:45).
-    schedule: { hourUtc: 2, minuteUtc: 0 },
+    schedule: { kind: "daily", hourUtc: 2, minuteUtc: 0 },
     async run(_db, now) {
       const result = await pruneRawOrders(rawDir, { keepDays, now });
       return { detail: result };

--- a/apps/api/src/modules/scheduler/scheduler.test.ts
+++ b/apps/api/src/modules/scheduler/scheduler.test.ts
@@ -1,34 +1,71 @@
 import { expect, it } from "vitest";
 import { isDue } from "./scheduler.js";
 
-const SCHEDULE = { hourUtc: 1, minuteUtc: 0 };
+const DAILY = { kind: "daily" as const, hourUtc: 1, minuteUtc: 0 };
 
-it("nie je splatná pred naplánovanou hodinou, keď ešte dnes nebežala", () => {
-  expect(isDue(SCHEDULE, new Date("2026-07-29T00:59:00Z"), null)).toBe(false);
+it("daily: nie je splatná pred naplánovanou hodinou, keď ešte dnes nebežala", () => {
+  expect(isDue(DAILY, new Date("2026-07-29T00:59:00Z"), null)).toBe(false);
 });
 
-it("je splatná presne v naplánovanú minútu, keď ešte dnes nebežala", () => {
-  expect(isDue(SCHEDULE, new Date("2026-07-29T01:00:00Z"), null)).toBe(true);
+it("daily: je splatná presne v naplánovanú minútu, keď ešte dnes nebežala", () => {
+  expect(isDue(DAILY, new Date("2026-07-29T01:00:00Z"), null)).toBe(true);
 });
 
-it("je splatná aj neskôr v ten istý deň, keď ešte nebežala", () => {
-  expect(isDue(SCHEDULE, new Date("2026-07-29T14:00:00Z"), null)).toBe(true);
+it("daily: je splatná aj neskôr v ten istý deň, keď ešte nebežala", () => {
+  expect(isDue(DAILY, new Date("2026-07-29T14:00:00Z"), null)).toBe(true);
 });
 
-it("nie je splatná, keď už dnes bežala (bez ohľadu na hodinu posledného behu)", () => {
-  expect(isDue(SCHEDULE, new Date("2026-07-29T14:00:00Z"), { startedAt: new Date("2026-07-29T01:00:00Z") })).toBe(
+it("daily: nie je splatná, keď už dnes bežala (bez ohľadu na hodinu posledného behu)", () => {
+  expect(isDue(DAILY, new Date("2026-07-29T14:00:00Z"), { startedAt: new Date("2026-07-29T01:00:00Z") })).toBe(
     false,
   );
 });
 
-it("je znova splatná ĎALŠÍ UTC kalendárny deň, aj keď posledný beh bol len pár hodín predtým", () => {
-  expect(isDue(SCHEDULE, new Date("2026-07-30T01:00:00Z"), { startedAt: new Date("2026-07-29T23:00:00Z") })).toBe(
+it("daily: je znova splatná ĎALŠÍ UTC kalendárny deň, aj keď posledný beh bol len pár hodín predtým", () => {
+  expect(isDue(DAILY, new Date("2026-07-30T01:00:00Z"), { startedAt: new Date("2026-07-29T23:00:00Z") })).toBe(
     true,
   );
 });
 
-it("nie je splatná v ten istý UTC kalendárny deň, aj keď posledný beh bol tesne pred naplánovanou minútou", () => {
-  expect(isDue(SCHEDULE, new Date("2026-07-29T01:05:00Z"), { startedAt: new Date("2026-07-29T00:59:59Z") })).toBe(
+it("daily: nie je splatná v ten istý UTC kalendárny deň, aj keď posledný beh bol tesne pred naplánovanou minútou", () => {
+  expect(isDue(DAILY, new Date("2026-07-29T01:05:00Z"), { startedAt: new Date("2026-07-29T00:59:59Z") })).toBe(
     false,
+  );
+});
+
+// #115: hodinová kadencia (`kind: "hourly"`) — periodizuje podľa UTC dňa+
+// hodiny namiesto celého dňa, takže je splatná znova v KAŽDEJ nasledujúcej
+// hodine, nie len raz denne.
+const HOURLY = { kind: "hourly" as const, minuteUtc: 45 };
+
+it("hourly: nie je splatná pred naplánovanou minútou v tejto hodine, keď ešte v tejto hodine nebežala", () => {
+  expect(isDue(HOURLY, new Date("2026-07-29T10:44:00Z"), null)).toBe(false);
+});
+
+it("hourly: je splatná presne v naplánovanú minútu, keď ešte v tejto hodine nebežala", () => {
+  expect(isDue(HOURLY, new Date("2026-07-29T10:45:00Z"), null)).toBe(true);
+});
+
+it("hourly: nie je splatná, keď už v tejto UTC hodine bežala (bez ohľadu na minútu posledného behu)", () => {
+  expect(isDue(HOURLY, new Date("2026-07-29T10:59:00Z"), { startedAt: new Date("2026-07-29T10:45:00Z") })).toBe(
+    false,
+  );
+});
+
+it("hourly: je znova splatná v NASLEDUJÚCEJ UTC hodine, aj keď posledný beh bol len pár minút predtým", () => {
+  expect(isDue(HOURLY, new Date("2026-07-29T11:45:00Z"), { startedAt: new Date("2026-07-29T10:59:00Z") })).toBe(
+    true,
+  );
+});
+
+it("hourly: nie je splatná v tej istej UTC hodine, aj keď posledný beh bol tesne pred naplánovanou minútou", () => {
+  expect(isDue(HOURLY, new Date("2026-07-29T10:46:00Z"), { startedAt: new Date("2026-07-29T10:44:59Z") })).toBe(
+    false,
+  );
+});
+
+it("hourly: je znova splatná pri prechode cez polnoc (nová UTC hodina 00 nasledujúceho dňa)", () => {
+  expect(isDue(HOURLY, new Date("2026-07-30T00:45:00Z"), { startedAt: new Date("2026-07-29T23:45:00Z") })).toBe(
+    true,
   );
 });

--- a/apps/api/src/modules/scheduler/scheduler.ts
+++ b/apps/api/src/modules/scheduler/scheduler.ts
@@ -2,7 +2,7 @@ import { desc, eq, sql } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
 import { jobRuns } from "../../db/schema.js";
 import { log } from "../../logger.js";
-import type { DailySchedule, ScheduledJob } from "./types.js";
+import type { Schedule, ScheduledJob } from "./types.js";
 
 // Zámok naplánovaných úloh — VLASTNÝ, samostatný kľúč (advisory zámky zdieľajú
 // JEDEN priestor bez ohľadu na to, ktorá funkcia ho vzala, `.claude/rules/
@@ -14,21 +14,35 @@ function utcDateKey(d: Date): string {
   return d.toISOString().slice(0, 10);
 }
 
-// Splatná = dnešný UTC kalendárny deň ešte nemá ŽIADEN riadok (running,
-// success AJ failure sa počítajú — zlyhaný beh sa dnes už neopakuje, čaká na
-// zajtrajší tick, presne ako úspešný) A aktuálny čas dosiahol naplánovanú
-// hodinu:minútu. Prvá podmienka (nie druhá) je to, čo úlohu robí odolnou voči
+// Kľúč periódy podľa druhu rozvrhu — `daily` periodizuje podľa UTC
+// kalendárneho dňa (nezmenené), `hourly` (#115) podľa UTC dňa+hodiny, aby sa
+// tá istá hodina neopakovala dvakrát. Rovnaký beh v RÔZNYCH periódach (napr.
+// 23:00 včera vs. 01:00 dnes pri `daily`, alebo 10:xx vs. 11:xx pri `hourly`)
+// má rôzny kľúč → znova splatná.
+function periodKey(schedule: Schedule, d: Date): string {
+  if (schedule.kind === "daily") return utcDateKey(d);
+  return `${utcDateKey(d)}T${String(d.getUTCHours()).padStart(2, "0")}`;
+}
+
+// Splatná = aktuálna perióda (deň pri `daily`, deň+hodina pri `hourly`) ešte
+// nemá ŽIADEN riadok (running, success AJ failure sa počítajú — zlyhaný beh
+// sa v tejto perióde už neopakuje, čaká na ďalšiu, presne ako úspešný) A
+// aktuálny čas v rámci periódy dosiahol naplánovanú minútu (`daily` navyše aj
+// hodinu). Prvá podmienka (nie druhá) je to, čo úlohu robí odolnou voči
 // reštartu kontajnera — splatnosť sa odvodzuje z PERZISTOVANÉHO posledného
 // behu, nie z pamäte procesu.
 export function isDue(
-  schedule: DailySchedule,
+  schedule: Schedule,
   now: Date,
   lastRun: { readonly startedAt: Date } | null,
 ): boolean {
-  if (lastRun !== null && utcDateKey(lastRun.startedAt) === utcDateKey(now)) return false;
-  const targetMinuteOfDay = schedule.hourUtc * 60 + schedule.minuteUtc;
-  const nowMinuteOfDay = now.getUTCHours() * 60 + now.getUTCMinutes();
-  return nowMinuteOfDay >= targetMinuteOfDay;
+  if (lastRun !== null && periodKey(schedule, lastRun.startedAt) === periodKey(schedule, now)) return false;
+  if (schedule.kind === "daily") {
+    const targetMinuteOfDay = schedule.hourUtc * 60 + schedule.minuteUtc;
+    const nowMinuteOfDay = now.getUTCHours() * 60 + now.getUTCMinutes();
+    return nowMinuteOfDay >= targetMinuteOfDay;
+  }
+  return now.getUTCMinutes() >= schedule.minuteUtc;
 }
 
 /**

--- a/apps/api/src/modules/scheduler/types.ts
+++ b/apps/api/src/modules/scheduler/types.ts
@@ -6,9 +6,25 @@ import type { Database } from "../../db/client.js";
 // bod a dnes (podľa UTC kalendárneho dňa) ešte nebežala — viď `isDue`
 // v scheduler.ts.
 export interface DailySchedule {
+  readonly kind: "daily";
   readonly hourUtc: number;
   readonly minuteUtc: number;
 }
+
+// Hodinová schéma (#115) — rovnaký princíp ako `DailySchedule`, len s
+// jemnejšou periódou: úloha je "splatná" v danom ticku, keď aktuálna UTC
+// minúta dosiahla/prekročila `minuteUtc` A v tejto UTC hodine ešte nebežala.
+// Zámerne DISKRIMINOVANÁ ÚNIA s `DailySchedule` (spoločné pole `kind`),
+// nie jeden preťažený tvar s voliteľným flagom — vylučuje nezmyselné
+// kombinácie (napr. `everyHour` + nastavené `hourUtc` súčasne) a zodpovedá
+// existujúcemu štýlu repa (`CatalogIngestOutcome`/`OrdersIngestOutcome`
+// diskriminujú podľa `status`).
+export interface HourlySchedule {
+  readonly kind: "hourly";
+  readonly minuteUtc: number;
+}
+
+export type Schedule = DailySchedule | HourlySchedule;
 
 export interface JobOutcome {
   readonly detail?: unknown;
@@ -16,6 +32,6 @@ export interface JobOutcome {
 
 export interface ScheduledJob {
   readonly name: string;
-  readonly schedule: DailySchedule;
+  readonly schedule: Schedule;
   run(db: Database, now: Date): Promise<JobOutcome>;
 }

--- a/apps/api/tests/scheduler-http.integration.test.ts
+++ b/apps/api/tests/scheduler-http.integration.test.ts
@@ -66,7 +66,7 @@ it("manazer vidí posledný beh každej úlohy", async () => {
 
   const job: ScheduledJob = {
     name: "test-job",
-    schedule: { hourUtc: 1, minuteUtc: 0 },
+    schedule: { kind: "daily", hourUtc: 1, minuteUtc: 0 },
     run: () => Promise.resolve({ detail: { removed: 3 } }),
   };
   await tick(db, [job], NOW);

--- a/apps/api/tests/scheduler.integration.test.ts
+++ b/apps/api/tests/scheduler.integration.test.ts
@@ -19,7 +19,7 @@ const NASLEDUJUCI_DEN = new Date("2026-07-30T01:00:00Z");
 function fakeJob(overrides: Partial<ScheduledJob> = {}): ScheduledJob {
   return {
     name: "fake-job",
-    schedule: { hourUtc: 1, minuteUtc: 0 },
+    schedule: { kind: "daily", hourUtc: 1, minuteUtc: 0 },
     run: () => Promise.resolve({ detail: { ok: true } }),
     ...overrides,
   };

--- a/apps/web/src/components/SyncSection.test.tsx
+++ b/apps/web/src/components/SyncSection.test.tsx
@@ -83,6 +83,25 @@ it("zobrazí posledný beh katalógu (OK) aj objednávok (CHYBA) so slovenským 
   expect(screen.getByTestId("sync-job-orders-import").textContent).toContain("Import objednávok");
 });
 
+// #115 (majiteľ: "nemoze tam bezat ok ked posledny sync bol dni dozadu!!!") —
+// posledný ÚSPEŠNÝ beh spred 3 dní nesmie ukázať zelené "✅ OK". Dátum je
+// relatívny k reálnemu "teraz" (nie natvrdo zapísaný literál) — inak by sa
+// táto asercia sama stala časovanou bombou presne z toho istého dôvodu, pre
+// ktorý táto oprava vôbec vznikla.
+it("posledný úspešný beh spred 3 dní ukáže zastaraný/varovný stav, NIE '✅ OK'", async () => {
+  const predTromiDnami = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString();
+  fetchJobRuns.mockResolvedValue([
+    { ...CATALOG_RUN, startedAt: predTromiDnami, finishedAt: predTromiDnami },
+  ]);
+
+  render(<SyncSection role="admin" onSessionExpired={() => {}} />);
+
+  const katalog = await screen.findByTestId("sync-channel-Katalóg");
+  expect(katalog.textContent).not.toContain("✅ OK");
+  expect(katalog.textContent).toContain("Posledný úspešný sync");
+  expect(katalog.textContent).toContain("dňami");
+});
+
 it("klik na 'Stiahnuť teraz' pre katalóg spustí triggerCatalogIngest a zobrazí výsledok", async () => {
   fetchJobRuns.mockResolvedValue([]);
   triggerCatalogIngest.mockResolvedValue({ status: "accepted", snapshotId: "s1", variantCount: 35, productCount: 8, missingCount: 0, issueCount: 0 });

--- a/apps/web/src/components/SyncSection.test.tsx
+++ b/apps/web/src/components/SyncSection.test.tsx
@@ -71,7 +71,11 @@ it("keď zatiaľ žiadny beh nie je zaznamenaný, oba kanály aj história ukazu
 it("zobrazí posledný beh katalógu (OK) aj objednávok (CHYBA) so slovenským detailom v histórii", async () => {
   fetchJobRuns.mockResolvedValue([CATALOG_RUN, ORDERS_RUN]);
 
-  render(<SyncSection role="admin" onSessionExpired={() => {}} />);
+  // #115: explicitné `now` tesne PO `CATALOG_RUN.startedAt` (2026-07-30
+  // 01:00) — bez neho by sa táto asercia po zavedení staleness kontroly
+  // stala časovanou bombou (skutočné "teraz" pri behu CI je vždy neskôr než
+  // natvrdo zapísaný literál vo fixtúre).
+  render(<SyncSection role="admin" onSessionExpired={() => {}} now={new Date("2026-07-30T02:00:00Z")} />);
 
   const katalog = await screen.findByTestId("sync-channel-Katalóg");
   expect(katalog.textContent).toContain("✅ OK");
@@ -97,7 +101,10 @@ it("posledný úspešný beh spred 3 dní ukáže zastaraný/varovný stav, NIE 
   render(<SyncSection role="admin" onSessionExpired={() => {}} />);
 
   const katalog = await screen.findByTestId("sync-channel-Katalóg");
-  expect(katalog.textContent).not.toContain("✅ OK");
+  // Pill (aktuálny STAV) nesmie tvrdiť "OK" — na rozdiel od `lastRunLine`'s
+  // "Posledný beh: … — ✅ OK" nižšie, ktorá popisuje HISTORICKÝ výsledok
+  // toho konkrétneho behu (ten naozaj skončil úspešne) a ostáva nezmenená.
+  expect(katalog.querySelector(".pill")?.textContent).not.toContain("✅ OK");
   expect(katalog.textContent).toContain("Posledný úspešný sync");
   expect(katalog.textContent).toContain("dňami");
 });

--- a/apps/web/src/components/SyncSection.tsx
+++ b/apps/web/src/components/SyncSection.tsx
@@ -4,6 +4,7 @@ import { CatalogUnauthorizedError, triggerCatalogIngest, type CatalogIngestOutco
 import { OrdersUnauthorizedError, triggerOrdersIngest, type OrdersIngestOutcome } from "../ordersApi.js";
 import { fetchJobRuns, SchedulerUnauthorizedError, type JobRun } from "../schedulerApi.js";
 import { detailText, jobLabel, STATUS_LABELS } from "../schedulerLabels.js";
+import { CATALOG_STALE_AFTER_MS, computeSyncStatus, ORDERS_STALE_AFTER_MS } from "../syncStatus.js";
 
 // Rovnaké dve role, ktoré server vyžaduje pre `GET /api/scheduler/runs`
 // AJ pre obe ručné tlačidlá importu (`requireRole("admin", "manazer")`,
@@ -63,26 +64,37 @@ function IngestChannel({
   busy,
   notice,
   onRun,
+  now,
+  staleAfterMs,
 }: {
   readonly title: string;
   readonly run: JobRun | undefined;
   readonly busy: boolean;
   readonly notice: Notice | null;
   readonly onRun: () => void;
+  readonly now: Date;
+  readonly staleAfterMs: number;
 }): JSX.Element {
+  // #115: JEDINÝ zdroj pravdy pre pill — `computeSyncStatus` porovnáva vek
+  // POSLEDNÉHO úspešného behu s prahom (`staleAfterMs`), namiesto pôvodného
+  // "OK, pokiaľ posledný beh neskončil chybou" bez ohľadu na to, ako dávno.
+  const status = computeSyncStatus(run, now, staleAfterMs);
   return (
     <div className="autostatus" data-testid={`sync-channel-${title}`}>
       <div className="autohead">
         <h3>{title}</h3>
-        <span className={"pill " + (run?.status === "failure" ? "off" : "on")}>
-          {run === undefined ? "zatiaľ nič" : run.status === "failure" ? "❌ CHYBA" : "✅ OK"}
-        </span>
+        <span className={"pill " + status.pillClass}>{status.pillText}</span>
         <button type="button" className="btn sm ghost" disabled={busy} onClick={onRun}>
           {busy ? "Sťahujem…" : "⚡ Stiahnuť teraz"}
         </button>
       </div>
       <div className="autometa">{lastRunLine(run)}</div>
       {run?.status === "failure" && <div className="autoerr">❌ {run.errorMessage ?? "Beh zlyhal."}</div>}
+      {status.warningText !== null && (
+        <p role="alert" className="autostale" data-testid={`sync-stale-${title}`}>
+          {status.warningText}
+        </p>
+      )}
       {notice !== null && (
         <p role={notice.kind === "warning" ? "alert" : "status"}>{notice.text}</p>
       )}
@@ -93,9 +105,15 @@ function IngestChannel({
 export function SyncSection({
   role,
   onSessionExpired,
+  now = new Date(),
 }: {
   readonly role: Me["role"];
   readonly onSessionExpired: () => void;
+  // #115: voliteľné, na testovateľnosť staleness kontroly (bez neho by
+  // testy so ZAFIXOVANÝMI dátumami vo fixtúrach postupne "zostarli" spolu so
+  // skutočným časom behu CI — presne ten druh časovanej bomby, kvôli ktorej
+  // tento ticket vôbec vznikol).
+  readonly now?: Date;
 }): JSX.Element {
   const [runs, setRuns] = useState<readonly JobRun[]>([]);
   const [loaded, setLoaded] = useState(false);
@@ -178,8 +196,24 @@ export function SyncSection({
       {error !== "" && <p role="alert">{error}</p>}
       {loaded && (
         <>
-          <IngestChannel title="Katalóg" run={catalogRun} busy={catalogBusy} notice={catalogNotice} onRun={runCatalog} />
-          <IngestChannel title="Objednávky" run={ordersRun} busy={ordersBusy} notice={ordersNotice} onRun={runOrders} />
+          <IngestChannel
+            title="Katalóg"
+            run={catalogRun}
+            busy={catalogBusy}
+            notice={catalogNotice}
+            onRun={runCatalog}
+            now={now}
+            staleAfterMs={CATALOG_STALE_AFTER_MS}
+          />
+          <IngestChannel
+            title="Objednávky"
+            run={ordersRun}
+            busy={ordersBusy}
+            notice={ordersNotice}
+            onRun={runOrders}
+            now={now}
+            staleAfterMs={ORDERS_STALE_AFTER_MS}
+          />
 
           <h3>História behov</h3>
           {runs.length === 0 ? (

--- a/apps/web/src/syncStatus.test.ts
+++ b/apps/web/src/syncStatus.test.ts
@@ -1,0 +1,83 @@
+import { expect, it } from "vitest";
+import { computeSyncStatus, type SyncStatus } from "./syncStatus.js";
+import type { JobRun } from "./schedulerApi.js";
+
+// #115 (majiteľ: "sync zo shoptetu ma bezat kazdu hodinu, nemoze tam bezat ok
+// ked posledny sync bol dni dozadu!!!") — dnes `SyncSection.tsx`'s pill
+// rozhoduje LEN podľa `run?.status === "failure"`, vek behu sa nikde
+// nekontroluje. `computeSyncStatus` je čistá funkcia nesúca TÚTO logiku —
+// jediné miesto, ktoré rozhoduje "ok" vs. "zastaralé" vs. "chyba" vs. "nikdy".
+
+const HOUR_MS = 60 * 60 * 1000;
+const STALE_AFTER_MS = 2 * HOUR_MS; // rovnaká hranica ako issue's príklad ("~2 hodiny" pri hodinovej kadencii)
+
+function run(overrides: Partial<JobRun> = {}): JobRun {
+  return {
+    jobName: "orders-import",
+    startedAt: "2026-07-30T10:00:00.000Z",
+    finishedAt: "2026-07-30T10:00:05.000Z",
+    status: "success",
+    detail: null,
+    errorMessage: null,
+    ...overrides,
+  };
+}
+
+it("žiadny beh zatiaľ nebol → 'never', pill NIE JE 'on' (nesmie tváriť sa ako OK)", () => {
+  const status: SyncStatus = computeSyncStatus(undefined, new Date("2026-07-30T10:00:00Z"), STALE_AFTER_MS);
+  expect(status.kind).toBe("never");
+  expect(status.pillClass).toBe("off");
+  expect(status.warningText).toBeNull();
+});
+
+it("posledný beh SKONČIL CHYBOU → 'error', bez ohľadu na to, ako dávno bežal", () => {
+  const status = computeSyncStatus(
+    run({ status: "failure", errorMessage: "Import zlyhal", startedAt: "2026-07-30T09:59:00.000Z" }),
+    new Date("2026-07-30T10:00:00Z"),
+    STALE_AFTER_MS,
+  );
+  expect(status.kind).toBe("error");
+  expect(status.pillClass).toBe("off");
+});
+
+it("posledný ÚSPEŠNÝ beh presne NA prahu (2h) je ešte 'ok'", () => {
+  const now = new Date("2026-07-30T12:00:00Z");
+  const status = computeSyncStatus(run({ startedAt: "2026-07-30T10:00:00.000Z" }), now, STALE_AFTER_MS);
+  expect(status.kind).toBe("ok");
+  expect(status.pillClass).toBe("on");
+  expect(status.warningText).toBeNull();
+});
+
+it("posledný ÚSPEŠNÝ beh TESNE ZA prahom (2h + 1ms) je 'stale', nie 'ok'", () => {
+  const now = new Date("2026-07-30T12:00:00.001Z");
+  const status = computeSyncStatus(run({ startedAt: "2026-07-30T10:00:00.000Z" }), now, STALE_AFTER_MS);
+  expect(status.kind).toBe("stale");
+  expect(status.pillClass).toBe("off");
+  expect(status.warningText).not.toBeNull();
+});
+
+it("posledný úspešný sync spred 3 dní → 'stale' s textom vrátane veku v dňoch", () => {
+  const now = new Date("2026-07-30T10:00:00Z");
+  const status = computeSyncStatus(run({ startedAt: "2026-07-27T10:00:00.000Z" }), now, STALE_AFTER_MS);
+  expect(status.kind).toBe("stale");
+  expect(status.warningText).toContain("Posledný úspešný sync");
+  expect(status.warningText).toContain("3 dňami");
+  expect(status.warningText).toContain("synchronizácia nebeží");
+});
+
+it("posledný úspešný sync spred 5 hodín (ešte v ten istý deň) → text vo formáte hodín, nie dní", () => {
+  const now = new Date("2026-07-30T15:00:00Z");
+  const status = computeSyncStatus(run({ startedAt: "2026-07-30T10:00:00.000Z" }), now, STALE_AFTER_MS);
+  expect(status.kind).toBe("stale");
+  expect(status.warningText).toContain("5 hodinami");
+});
+
+it("beh, ktorý ešte BEŽÍ ('running'), sa nepovažuje za zastaraný", () => {
+  const status = computeSyncStatus(
+    run({ status: "running", startedAt: "2026-07-01T00:00:00.000Z" }),
+    new Date("2026-07-30T10:00:00Z"),
+    STALE_AFTER_MS,
+  );
+  expect(status.kind).toBe("ok");
+  expect(status.warningText).toBeNull();
+});

--- a/apps/web/src/syncStatus.ts
+++ b/apps/web/src/syncStatus.ts
@@ -1,0 +1,70 @@
+import type { JobRun } from "./schedulerApi.js";
+
+// #115 (majiteľ: "sync zo shoptetu ma bezat kazdu hodinu, nemoze tam bezat
+// ok ked posledny sync bol dni dozadu!!!") — jediné miesto, ktoré rozhoduje
+// stav "Sync zo Shoptetu" pillu. Predtým `SyncSection.tsx`'s `IngestChannel`
+// rozhodoval o zelenej VÝLUČNE podľa `run?.status === "failure"`, vek
+// posledného behu sa nikde neporovnával s ničím.
+export type SyncStatusKind = "never" | "ok" | "stale" | "error";
+
+export interface SyncStatus {
+  readonly kind: SyncStatusKind;
+  readonly pillClass: "on" | "off";
+  readonly pillText: string;
+  // Vyplnené LEN pre "stale" — samostatný varovný riadok pod pillom
+  // s vekom posledného úspešného behu ("Posledný úspešný sync: pred 3
+  // dňami — synchronizácia nebeží.").
+  readonly warningText: string | null;
+}
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+// Prah zastaranosti = 2× nakonfigurovaná kadencia danej úlohy
+// (`apps/api/src/modules/scheduler/jobs.ts`) — nie natvrdo zapísané magické
+// číslo odpojené od skutočného rozvrhu. Objednávky: hodinová kadencia (#115)
+// → 2 h (presne príklad z issue). Katalóg: zostáva denná kadencia (#115 ju
+// nemení) → 48 h. Obe "Sync zo Shoptetu" políčka zdieľajú TEN ISTÝ
+// `IngestChannel` komponent, takže rovnaký druh chyby (ignorovanie veku)
+// platil identicky pre oba kanály.
+export const ORDERS_STALE_AFTER_MS = 2 * HOUR_MS;
+export const CATALOG_STALE_AFTER_MS = 2 * DAY_MS;
+
+// Jednoduché dvojtvarové skloňovanie (1 vs. viac) — rovnaká úroveň
+// jednoduchosti, akú repo už používa pre vek objednávky
+// (`ordersSummary.ts`'s `orderLineAgeDays`, vždy len "N dní" bez ohľadu na
+// N). Formát "pred 3 dňami" doslovne zodpovedá majiteľovmu vlastnému
+// zneniu v zadaní issue.
+function formatAge(ms: number): string {
+  const hours = Math.floor(ms / HOUR_MS);
+  if (hours < 24) return hours === 1 ? "hodinou" : `${String(hours)} hodinami`;
+  const days = Math.floor(ms / DAY_MS);
+  return days === 1 ? "dňom" : `${String(days)} dňami`;
+}
+
+export function computeSyncStatus(run: JobRun | undefined, now: Date, staleAfterMs: number): SyncStatus {
+  if (run === undefined) {
+    // Nikdy nebežalo → nesmie sa tváriť ako zelené "OK" (rovnaký princíp,
+    // aký táto oprava zavádza pre zastaraný beh) — text ostáva "zatiaľ nič"
+    // (nezmenené, `lastRunLine` ukazuje detail vedľa neho).
+    return { kind: "never", pillClass: "off", pillText: "zatiaľ nič", warningText: null };
+  }
+  if (run.status === "failure") {
+    return { kind: "error", pillClass: "off", pillText: "❌ CHYBA", warningText: null };
+  }
+  if (run.status === "running") {
+    // Prebiehajúci beh nemá zmysluplný "vek" na porovnanie s prahom —
+    // ostáva "ok" ako doteraz.
+    return { kind: "ok", pillClass: "on", pillText: "✅ OK", warningText: null };
+  }
+  const ageMs = now.getTime() - new Date(run.startedAt).getTime();
+  if (ageMs <= staleAfterMs) {
+    return { kind: "ok", pillClass: "on", pillText: "✅ OK", warningText: null };
+  }
+  return {
+    kind: "stale",
+    pillClass: "off",
+    pillText: "⚠️ ZASTARANÉ",
+    warningText: `Posledný úspešný sync: pred ${formatAge(ageMs)} — synchronizácia nebeží.`,
+  };
+}

--- a/apps/web/tests/e2e/login.spec.ts
+++ b/apps/web/tests/e2e/login.spec.ts
@@ -37,11 +37,12 @@ test("manažér sa prihlási, vidí svoje meno a verziu, konzola je čistá", as
   await expect(page.getByTestId("greeting")).toContainText("E2E Manažér");
   await expect(page.getByTestId("version")).toHaveText(/^v\d+\.\d+\.\d+/);
 
-  // F2 (#12/#3): manažér vidí sekciu "Plánovač" — e2e-setup.ts nespúšťa žiaden
-  // tick, takže `job_run` je prázdna a musí sa zobraziť informačná veta, nie
-  // holá/rozbitá tabuľka.
+  // F2 (#12/#3): manažér vidí sekciu "Plánovač". `e2e-setup.ts` nespúšťa
+  // žiaden tick (#115 pridalo LEN jeden umelo zostarnutý `job_run` riadok pre
+  // katalóg, kvôli `nav.spec.ts`'s staleness testu) — tabuľka teda ukazuje
+  // PRESNE tento jeden riadok, nie je prázdna, ale ani nie je "rozbitá".
   await expect(page.getByRole("heading", { name: "Plánovač" })).toBeVisible();
-  await expect(page.getByTestId("scheduler-empty")).toHaveText("Žiadny beh zatiaľ nie je zaznamenaný.");
+  await expect(page.getByTestId("job-catalog-import")).toBeVisible();
 
   // #57: odhlásenie žije v menu používateľa v hlavičke (klik na meno ho rozbalí).
   await page.getByTestId("greeting").click();
@@ -109,7 +110,15 @@ test("zmena hesla: zlé staré heslo/nezhoda odmietnuté, úspešná zmena zruš
   await page.getByLabel("Nové heslo", { exact: true }).fill(NOVE_HESLO);
   await page.getByLabel("Nové heslo znova").fill(NOVE_HESLO);
   await page.getByRole("button", { name: "Zmeniť heslo" }).click();
-  await expect(page.getByRole("alert")).toHaveText("Nesprávne staré heslo");
+  // #115: bare `getByRole("alert")` je odteraz nejednoznačný — na predvolenej
+  // obrazovke "Sync zo Shoptetu" pod týmto panelom svieti aj `role="alert"`
+  // staleness upozornenie (`sync-stale-Katalóg`). Rovnaký vzor ako
+  // `.claude/rules/testing.md`'s existujúca kolízna poznámka pri
+  // `getByLabel`u: oprava na strane KOLÍDUJÚCEHO (existujúceho) locatora
+  // (`.filter({ hasText })`), nie odobratím `role="alert"` novému prvku.
+  await expect(page.getByRole("alert").filter({ hasText: "Nesprávne staré heslo" })).toHaveText(
+    "Nesprávne staré heslo",
+  );
 
   // Nezhodujúce sa potvrdenie nového hesla — odmietnuté klientom, server sa
   // vôbec nevolá.
@@ -117,7 +126,9 @@ test("zmena hesla: zlé staré heslo/nezhoda odmietnuté, úspešná zmena zruš
   await page.getByLabel("Nové heslo", { exact: true }).fill(NOVE_HESLO);
   await page.getByLabel("Nové heslo znova").fill("ine-heslo-nez-vyssie");
   await page.getByRole("button", { name: "Zmeniť heslo" }).click();
-  await expect(page.getByRole("alert")).toHaveText("Nové heslo a jeho potvrdenie sa nezhodujú");
+  await expect(
+    page.getByRole("alert").filter({ hasText: "Nové heslo a jeho potvrdenie sa nezhodujú" }),
+  ).toHaveText("Nové heslo a jeho potvrdenie sa nezhodujú");
 
   // Úspešná zmena.
   await page.getByLabel("Staré heslo").fill(E2E_HESLO);

--- a/apps/web/tests/e2e/nav.spec.ts
+++ b/apps/web/tests/e2e/nav.spec.ts
@@ -57,9 +57,12 @@ test("ľavé menu má presne dva priečinky s jednou záložkou každý, klik pr
 // #57: obrazovka konsoliduje "čo a kedy sa naposledy stiahlo zo Shoptetu" +
 // tlačidlo na okamžité stiahnutie — dnes roztrúsené (tlačidlo v katalógu,
 // história v plánovači). `scripts/e2e-setup.ts` nespúšťa žiaden scheduler tick
-// a katalógový snapshot pre `catalog.spec.ts` vkladá priamo (obchádza
-// scheduler), takže `job_run` je pri tomto teste prázdna — rovnaký stav ako
-// login.spec.ts's "Plánovač" prázdny zoznam.
+// pre OBJEDNÁVKY a katalógový snapshot pre `catalog.spec.ts` vkladá priamo
+// (obchádza scheduler) — kanál "Objednávky" je preto pri tomto teste stále
+// "zatiaľ nikdy". Kanál "Katalóg" ale #115 seeduje UMELO ZOSTARNUTÝM,
+// úspešným `job_run` (2020, hlboko v minulosti, produkčných dát sa to
+// netýka) — presne to, čo umožňuje overiť staleness upozornenie naživo cez
+// skutočný prehliadač, bez zásahu do reálnych dát.
 test("Sync zo Shoptetu ukazuje stav katalógu aj objednávok a tlačidlo 'Stiahnuť teraz', konzola je čistá", async ({ page }) => {
   const chyby: string[] = [];
   page.on("console", (m) => {
@@ -74,15 +77,21 @@ test("Sync zo Shoptetu ukazuje stav katalógu aj objednávok a tlačidlo 'Stiahn
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
+  // #115: katalóg má seedovaný, roky starý úspešný beh — pill NESMIE ukázať
+  // "✅ OK", musí ukázať zastaraný/varovný stav so slovenským vysvetlením
+  // (nie "zatiaľ nikdy" — ten beh SKUTOČNE prebehol, len je príliš starý).
   const katalog = page.getByTestId("sync-channel-Katalóg");
-  await expect(katalog).toContainText("Posledný beh: zatiaľ nikdy");
+  await expect(katalog.locator(".pill")).not.toHaveText("✅ OK");
+  await expect(page.getByTestId("sync-stale-Katalóg")).toContainText("Posledný úspešný sync");
   await expect(katalog.getByRole("button", { name: "⚡ Stiahnuť teraz" })).toBeVisible();
 
   const objednavky = page.getByTestId("sync-channel-Objednávky");
   await expect(objednavky).toContainText("Posledný beh: zatiaľ nikdy");
   await expect(objednavky.getByRole("button", { name: "⚡ Stiahnuť teraz" })).toBeVisible();
 
-  await expect(page.getByTestId("sync-history-empty")).toHaveText("Žiadny beh zatiaľ nie je zaznamenaný.");
+  // História už nie je prázdna (katalógový beh vyššie) — "sync-history-empty"
+  // testid sa preto už nevykresľuje; namiesto neho overíme priamo riadok.
+  await expect(page.getByTestId("sync-job-catalog-import")).toBeVisible();
 
   expect(chyby).toEqual([]);
 });

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -3,6 +3,40 @@
 Terse per-ticket log of autopilot-worker cycles: issue(s), commit SHAs,
 RED→GREEN test names, key decisions, and the shared PR.
 
+## 2026-07-31 — #115 (hourly orders sync + no more false "OK") + #116 closed obsolete
+
+- STEP 0: #116 (remark on "Na objednanie") found ALREADY IMPLEMENTED via
+  #65/#95/#111 (parser, API, `OrderLineRow.tsx`'s `.ord-remark`, truncation
+  + tooltip, all with existing tests) — closed as obsolete, evidence:
+  https://github.com/zbynekdrlik/forestshop-app/issues/116#issuecomment-5146716654
+  Dropped from the batch; #115 proceeded solo.
+- Version bump `b7e17dd` (0.3.0-dev.69→.70), first commit on `dev`.
+- Design decision posted BEFORE the feature commit:
+  https://github.com/zbynekdrlik/forestshop-app/issues/115#issuecomment-5146738208
+- `381e47f` (feat): `Schedule` becomes discriminated union
+  `DailySchedule | HourlySchedule` (`types.ts`); `isDue()`/`periodKey()`
+  (`scheduler.ts`) periodize by UTC day (daily) or UTC day+hour (hourly);
+  `ordersImportJob` → `{ kind: "hourly", minuteUtc: 45 }`. Tests:
+  `scheduler.test.ts` (12, daily unchanged + new hourly boundaries incl.
+  midnight rollover).
+- RED `c5d2706` / GREEN `5f70a36`: `syncStatus.test.ts`
+  ("posledný úspešný sync spred 3 dní…") failed against non-existent
+  `computeSyncStatus`; `SyncSection.test.tsx`'s new stale-run test failed
+  showing `✅ OK` for a 3-day-old run. Fixed via `apps/web/src/syncStatus.ts`
+  (`computeSyncStatus`, threshold = 2× each channel's own configured
+  cadence: orders 2h, catalog 48h) wired into `SyncSection.tsx`
+  (`IngestChannel` now takes `now`/`staleAfterMs`). e2e `nav.spec.ts`
+  proves it live against a seeded aged `job_run` (`scripts/e2e-setup.ts`,
+  isolated test DB, never production) — required updating
+  `login.spec.ts`'s two `getByRole("alert")` assertions with
+  `.filter({ hasText })` since the new stale banner shares that role on
+  the default "sync" tab (same collision-fix pattern as the existing
+  `getByLabel` note in `.claude/rules/testing.md`).
+- Post-review fixes (both 🔵, non-blocking, folded into the merge):
+  `jobs.ts`'s `pruneRawOrdersJob` comment updated (was still describing
+  the old daily orders cadence); this log entry itself was the second nit.
+- PR #125 (`dev` → `main`), auto-merged per default policy once all gates green.
+
 ## 2026-07-31 — #117 + #118 + #119 (bundle: drop KÓD column, hide mail actions, big supplier icon button)
 
 - Version bump `c8853bb` (0.3.0-dev.68→.69), first commit on `dev` after

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -3,6 +3,52 @@
 Terse per-ticket log of autopilot-worker cycles: issue(s), commit SHAs,
 RED→GREEN test names, key decisions, and the shared PR.
 
+## 2026-07-31 — #117 + #118 + #119 (bundle: drop KÓD column, hide mail actions, big supplier icon button)
+
+- Version bump `c8853bb` (0.3.0-dev.68→.69), first commit on `dev` after
+  main caught up.
+- Design decisions posted per-ticket BEFORE the feature commit:
+  https://github.com/zbynekdrlik/forestshop-app/issues/117#issuecomment-5146452081
+  https://github.com/zbynekdrlik/forestshop-app/issues/118#issuecomment-5146459218
+  https://github.com/zbynekdrlik/forestshop-app/issues/119#issuecomment-5146459969
+- Main feature commit `6531b04`: `col-code`/`ord-code-cell`/`.ord-size-inline`/
+  `.ord-supplier-code` removed entirely (117); `orderScreenFlags.ts`'s
+  `SHOW_ORDER_MAIL_ACTIONS` (default `false`) gates the two mail-action
+  buttons + hint in `SupplierActionsPanel.tsx` (118), existing functionality
+  tests moved intact to new `OrdersSection.mailActions.test.tsx` (flag
+  forced `true` via `vi.mock`); supplier link restyled to a 36×36px icon
+  button (`🔗`, `aria-hidden`), same `href`/`target`/`rel`/`aria-label`
+  (119). Freed colgroup width: `col-product` 11.4%→17.4%, `col-supplier`
+  9.2%→14%.
+- CI round 1 failed on e2e: two assertions in `orders.spec.ts` were made
+  stale by the diff itself — `toContainText("46")` (leftover variant-code
+  fragment) and `not.toContainText("🔗")` (issue 99's admin-link check,
+  now legitimately false since #119 adds its OWN 🔗 elsewhere in the row)
+  — fixed in `e1e4afc`, verified locally first (21/21 e2e, 231/231 unit).
+- PR #124, all gates green, `/requesting-code-review` (general-purpose
+  subagent) surfaced 2 🔵: `shouldShowSizeLabel` left as dead code
+  (its only call site was the removed KÓD cell) and a stale CSS comment
+  referencing the now-deleted `.ord-supplier-code` — both fixed in
+  `78dfb5e` (228/228 unit after removing 3 now-pointless tests).
+- Merged `ca858df`. Main CI + Deploy green.
+- Live verification (`forestshop-novy.newlevel.media`, `vychod@varos.sk`,
+  39 real rows, 16 supplier groups) at 1280/1440/1600/1920px: version
+  `v0.3.0-dev.69` read from DOM; KÓD header absent (9 columns, was 10);
+  0 rows with `variantCode`/`externalCode` text anywhere; 0 order-number
+  wraps; 0 `.orders-table-wrap`/`<th>` overflow; 0 page horizontal scroll;
+  0 copy/email buttons or hint text (16/16 bulk "✔ Označiť skupinu" buttons
+  still present); 31 supplier icon links, all ≥36×36px click target,
+  target=_blank + rel containing noopener; 0 console errors/warnings on a
+  fresh navigation. Row height at 1280px: min 79px, median 91px, **max
+  114.5px** (target was <120px; before this PR: median 95px, max 173px,
+  7/39 rows >120px) — target met. At 1440/1600/1920px max dropped to 98px.
+- Playbook: no new gotcha filed — this bundle's live-measurement/colgroup
+  method was already fully covered by existing `.claude/rules/
+  frontend-design.md` entries (issues 105/107/111); the two review findings
+  (dead code from a removed call site, a stale cross-reference comment) are
+  process learnings already covered by `no-dropped-work.md`/code-review
+  discipline, not new project-specific knowledge.
+
 ## 2026-07-31 — #64 (order-comment write path — "Na objednanie" poznámka)
 
 - `PUT /api/orders/:id/comment` (`orders-routes.ts` + `state.ts`'s new

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.69",
+  "version": "0.3.0-dev.70",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -9,7 +9,8 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { createDb } from "../apps/api/src/db/client.js";
-import { orderLines, orderOpenStatuses, orders, pairings, users } from "../apps/api/src/db/schema.js";
+import { jobRuns, orderLines, orderOpenStatuses, orders, pairings, users } from "../apps/api/src/db/schema.js";
+import { CATALOG_IMPORT_JOB_NAME } from "../apps/api/src/modules/scheduler/jobs.js";
 import { hashPassword } from "../apps/api/src/modules/auth/passwords.js";
 import { ingestCatalog } from "../apps/api/src/modules/catalog/ingest.js";
 import { DEFAULT_SNAPSHOT_LIMITS } from "../apps/api/src/modules/catalog/validation.js";
@@ -403,6 +404,23 @@ await db.insert(orderLines).values([
 await db.insert(pairings).values({
   variantCode: "40287",
   supplierUrl: "https://www.grube.sk/p/ciapka-polar-forest/1",
+});
+
+// #115 (majiteľ: "nemoze tam bezat ok ked posledny sync bol dni dozadu!!!") —
+// jeden UMELO ZOSTARNUTÝ, ÚSPEŠNÝ `job_run` pre import katalógu (nikdy sa
+// nedotýka produkčných dát — toto je izolovaná testovacia DB), aby
+// `nav.spec.ts`'s test staleness upozornenia mal čo overiť. Pevný dátum
+// hlboko v minulosti (rovnaký vzor ako `objednavkaBezDodavatela.placedAt`
+// vyššie) — zostáva "starý" navždy, bez ohľadu na to, kedy CI beh skutočne
+// prebehne. `catalog-import` (nie `orders-import`) — `nav.spec.ts`'s ostatné
+// testy neoverujú konkrétny obsah kanála "Objednávky", takže sa tu
+// nekolíduje so žiadnym existujúcim tvrdením.
+await db.insert(jobRuns).values({
+  jobName: CATALOG_IMPORT_JOB_NAME,
+  startedAt: new Date("2020-01-01T09:00:00Z"),
+  finishedAt: new Date("2020-01-01T09:00:05Z"),
+  status: "success",
+  detail: { variantCount: 1 },
 });
 
 await pool.end();


### PR DESCRIPTION
Closes #115

## Čo sa mení

1. **Import objednávok beží každú hodinu** (predtým raz denne o 01:45 UTC). `Schedule` je teraz diskriminovaná únia `DailySchedule | HourlySchedule` (`kind` pole) — `isDue()` periodizuje podľa UTC dňa (daily) alebo UTC dňa+hodiny (hourly). Katalóg a ostatné joby zostávajú denné, nezmenené.
2. **"Sync zo Shoptetu" pill už nehlási "✅ OK", keď je posledný úspešný beh starý.** Nová čistá funkcia `computeSyncStatus` (`apps/web/src/syncStatus.ts`) rozhoduje: nikdy nebežalo → nie "on"; posledný beh skončil chybou → chyba (bez ohľadu na vek); posledný ÚSPEŠNÝ beh starší než 2× nakonfigurovaná kadencia kanála (objednávky 2h, katalóg 48h) → viditeľné varovanie so slovenským textom vrátane veku ("Posledný úspešný sync: pred 3 dňami — synchronizácia nebeží.").

## Testy

- `apps/api/src/modules/scheduler/scheduler.test.ts` — hranice `isDue` pre `daily` (nezmenené) aj nové `hourly` (na prahu, tesne za, cez polnoc).
- `apps/web/src/syncStatus.test.ts` — hranice `computeSyncStatus` (nikdy/chyba/na prahu/tesne za/dni vs. hodiny/beží).
- `apps/web/src/components/SyncSection.test.tsx` — RED→GREEN regresný test (beh spred 3 dní nesmie ukázať OK).
- e2e `nav.spec.ts` — živo overuje staleness upozornenie cez seedovaný (izolovaná testovacia DB, nikdy produkcia) umelo zostarnutý `job_run`.
- Integračné testy (`scheduler.integration.test.ts`, `scheduler-http.integration.test.ts`, `scheduler-jobs.integration.test.ts`) prešli nezmenené (len pridaný `kind: "daily"` do existujúcich literálov kvôli typu).

## Poznámka k #116

Druhý ticket z pôvodnej dávky (#116 — zobraziť `order.remark` na "Na objednanie") sa pri kontrole ukázal ako už HOTOVÝ (implementované cez #65/#95/#111, vrátane testov) — zavretý priamo ako obsolete, mimo tejto PR.
