### PR TITLE
Playbook: role=alert collision + seeded job_run fixture notes (#115 follow-up)

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -188,6 +188,27 @@ paths:
   `getByLabel("Stav", { exact: true })`, nový select v `OrdersSection.tsx`
   si ponechal plnohodnotný popis (`"Zmeniť stav riadku objednávky ..."`).
   novo pridaný test.
+- **Rovnaká kolízna trieda ako vyššie platí aj pre ARIA ROLES, nielen
+  `aria-label`/`getByLabel` — konkrétne `page.getByRole("alert")` je
+  nejednoznačný v CELEJ appke, nielen v jednej sekcii.** #115 pridalo nový
+  `<p role="alert">` (staleness upozornenie na "Sync zo Shoptetu", predvolená
+  obrazovka po prihlásení) — `login.spec.ts`'s test zmeny hesla (panel v
+  hlavičke, viditeľný NAD tou istou predvolenou obrazovkou) mal bare
+  `page.getByRole("alert")` a začal padať na "strict mode violation:
+  resolved to 2 elements". Rovnaká oprava ako vyššie: `.filter({ hasText:
+  "..." })` na strane KOLÍDUJÚCEHO (existujúceho) locatora, nikdy
+  odobratím `role="alert"` novému prvku. Test pri KAŽDOM ďalšom
+  `role="alert"`/`role="status"` pridanom do zdieľanej obrazovky: spusti
+  CELÝ e2e balík (nie len nový spec súbor), presne ako pri `aria-label`
+  vyššie.
+- **`job_run` tabuľka má od #115 JEDEN GLOBÁLNY, natrvalo seedovaný riadok**
+  (`scripts/e2e-setup.ts`: umelo zostarnutý úspešný `catalog-import` beh z
+  roku 2020) — kvôli `nav.spec.ts`'s staleness testu. Dôsledok: "Sync zo
+  Shoptetu"/"Plánovač" NIE SÚ prázdne ako predtým (#22-38) — `login.spec.ts`
+  aj `nav.spec.ts` boli upravené, aby to zohľadňovali (`getByTestId("job-
+  catalog-import")` namiesto `scheduler-empty`/`sync-history-empty`). Ďalší
+  nový e2e test, ktorý by očakával PRÁZDNU `job_run`/históriu behov, treba
+  najprv skontrolovať proti tomuto seedu.
 - **Playwright s viacerými workermi (predvolený počet, ako aj CI runner)
   môže byť nestály — všetky e2e spec súbory zdieľajú JEDEN bežiaci API
   server aj JEDNU lokálnu Postgres inštanciu.** #32 (vyriešené): koreňová

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.70",
+  "version": "0.3.0-dev.71",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Docs-only follow-up to #125 (issue #115): version bump (main/dev had converged) + two playbook entries in `.claude/rules/testing.md` capturing findings from the deep code review — the new `role="alert"` staleness banner collides with `login.spec.ts`'s bare `getByRole("alert")` (same collision class as the existing `getByLabel` note, fixed with `.filter({ hasText })`), and the new permanently-seeded aged `job_run` row in `scripts/e2e-setup.ts` that future e2e tests must account for. No functional/code changes.