### PR TITLE
docs: capture Closes-N auto-close gotcha for credential-gated verification (#120)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,18 @@ nasadenie na dev2 cez GHCR a Cloudflare tunel.
 body,title,state,labels,comments` namiesto toho (žiadne Projects polia sa
 nepýtajú, takže to prejde).
 
+**`Closes #N` v tele PR zavrie ticket AUTOMATICKY v momente mergu — nie až po
+nasadení/naživo overení.** Issue 120 (2026-07-31): PR malo `Closes #120`,
+GitHub ho zavrel presne v čase merge commitu, hoci ticket mal ešte
+neoverenú (na credential čakajúcu) akceptačnú podmienku ("naživo klikni a
+over"). Keď ticket má AKÚKOĽVEK acceptančnú podmienku, ktorú nejde overiť
+PRED mergom (živý klik vyžadujúci cudzie prihlásenie, manuálne potvrdenie
+treťou stranou a pod.), NEPÍŠ `Closes #N` do tela PR — nechaj ticket
+zavrieť RUČNE (`gh issue close`) až PO skutočnom overení, alebo (ak sa
+merguje aj tak) rovno po merge over stav (`gh issue view --json state`) a
+znovu otvor (`gh issue reopen`) s vysvetľujúcim komentárom, presne ako sa
+to riešilo tu.
+
 **Airuleset's `block-sensitive-staging.sh` (globálny `git add`/`git commit`
 hook) hlási FALOŠNÝ pozitív na plný 40-znakový git SHA v ktoromkoľvek
 súbore/commit správe** — jeho "40+ char hex blob (possible key/token)"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.73",
+  "version": "0.3.0-dev.74",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Non-functional follow-up. Records in CLAUDE.md the lesson from #120: a PR body's \`Closes #N\` auto-closes the linked issue exactly at merge time, even when the issue still has an acceptance criterion that can only be verified after (e.g. a live click needing credentials not yet available). No \`Closes\` keyword here on purpose — #120 stays open pending the owner's Shoptet admin credentials.

Version bump only (0.3.0-dev.74, dev must stay ahead of main after #130's merge). No code changes.