### PR TITLE
Fix order-table badge overflow, NUL byte in queries.ts, id-backfill window (#127, #129, #132)

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -313,3 +313,36 @@ paths:
   "<the-cells-class>" apps/web/tests/e2e/` across the WHOLE e2e directory
   before considering the removal test-safe, not just the spec file with the
   obviously-related test names.
+- **When a `<colgroup>` column needs MORE width, test EVERY candidate donor
+  column live against production BEFORE picking one — not just the column
+  you'd guess has slack.** Issue 127 (stale-order badge, `.col-date`,
+  overflowing its cell): live-testing (`page.addStyleTag`, 37 real rows,
+  same methodology as issue 107/111) ruled out `col-notes` (only ~0.5
+  percentage-point slack above the tested `≥160px` comment-input floor),
+  `col-supplier` (regressed 3 REAL `supplierAssignable` rows over 120px —
+  the existing code comment "žiadny živý riadok ho dnes nemá" was STALE;
+  production had grown 3 such rows since it was written), `col-customer`
+  (customer names already wrap almost universally, zero slack),
+  `col-qty`/`col-state`/`col-order` (zero or negative slack, measured
+  directly). Only `col-product` had genuine verified slack — a candidate
+  that "should" have slack per an old design comment can be WRONG by the
+  time you need it; test the actual live donor, never assume last-known
+  slack is still there. Any FUTURE column-width increase: test the intended
+  donor's real current content (not just the % on paper) against
+  production first, and be ready to look at 2-3 candidates if the first
+  one's own established comment turns out stale.
+- **A JS-level in-memory rate limiter (`checkLoginRateLimit`,
+  `login-rate-limit.ts`) resets INSTANTLY on API process restart, but a
+  live-verification session hitting it against PRODUCTION has no such
+  reset available — you just wait out the 5-minute window.** Repeated
+  Playwright logins during local column-width measurement (issue 127) hit
+  `MAX_ATTEMPTS=10` against the LOCAL dev API within a few scripts;
+  restarting `pnpm --filter @forestshop/api start` cleared it immediately
+  (module-level singleton, no DB state). The SAME limiter applies to the
+  live production site — hit it there too during repeated
+  `vychod@varos.sk` live-verification logins, and had to wait for the
+  window to clear (no restart available on a shared prod process). Batch
+  live-verification page interactions into ONE login per script/session
+  (reuse the same `page`, just `setViewportSize` between checks) instead
+  of a fresh login per viewport/candidate, to avoid burning through the
+  10-attempt budget on read-only verification work.

--- a/apps/api/src/cli/orders-ingest.ts
+++ b/apps/api/src/cli/orders-ingest.ts
@@ -16,6 +16,7 @@
 // na $?, nie len na text výstupu (rovnaká disciplína ako `scripts/catalog-ingest.ts`).
 import { createDb } from "../db/client.js";
 import { loadEnv } from "../env.js";
+import { computeOrderIdsWindowStart } from "../modules/orders/backfill.js";
 import { computeImportWindow, createHttpOrderIdsFetcher, createHttpOrdersExportFetcher } from "../modules/orders/fetcher.js";
 import {
   DEFAULT_ORDERS_IMPORT_WINDOW_DAYS,
@@ -50,6 +51,10 @@ const ordersXmlUrl = env.SHOPTET_ORDERS_XML_URL;
 const { db, pool } = createDb(env.DATABASE_URL);
 let result: OrdersIngestResult;
 try {
+  // issue 132: pozri rovnaký komentár v `index.ts` — XML id-fetch okno sa
+  // sebaozdravujúco predĺži dozadu, keď existuje otvorená objednávka bez id
+  // staršia než predvolené okno.
+  const idsDateFrom = ordersXmlUrl === undefined ? dateFrom : await computeOrderIdsWindowStart(db, dateFrom);
   result = await ingestOrders(db, {
     fetchExport: createHttpOrdersExportFetcher({ url: env.SHOPTET_ORDERS_URL, dateFrom, dateUntil }),
     now,
@@ -58,7 +63,7 @@ try {
     windowEnd: dateUntil,
     ...(ordersXmlUrl === undefined
       ? {}
-      : { fetchOrderIds: createHttpOrderIdsFetcher({ url: ordersXmlUrl, dateFrom, dateUntil }) }),
+      : { fetchOrderIds: createHttpOrderIdsFetcher({ url: ordersXmlUrl, dateFrom: idsDateFrom, dateUntil }) }),
   });
 } finally {
   await pool.end();

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -10,6 +10,7 @@ import { log } from "./logger.js";
 import { createHttpExportFetcher } from "./modules/catalog/fetcher.js";
 import { ingestCatalog } from "./modules/catalog/ingest.js";
 import { createSmtpMailTransport } from "./modules/mail/transport.js";
+import { computeOrderIdsWindowStart } from "./modules/orders/backfill.js";
 import { computeImportWindow, createHttpOrderIdsFetcher, createHttpOrdersExportFetcher } from "./modules/orders/fetcher.js";
 import { DEFAULT_ORDERS_IMPORT_WINDOW_DAYS, ingestOrders, type RunOrdersIngest } from "./modules/orders/ingest.js";
 import {
@@ -61,11 +62,19 @@ const ordersUrl = env.SHOPTET_ORDERS_URL;
 // `runIngest`/`runOrdersIngest` vyššie) — `ingestOrders` to sama osebe berie
 // ako "id zatiaľ neznáme", nikdy ako chybu.
 const ordersXmlUrl = env.SHOPTET_ORDERS_XML_URL;
+// issue 132: XML id-fetch okno (LEN preň, nikdy pre hlavný CSV import vyššie
+// — ten má vlastnú, nezávislú akceptančnú logiku, `.claude/rules/orders.md`)
+// sa sebaozdravujúco predĺži dozadu, keď v DB existuje otvorená objednávka
+// bez `shoptet_order_id` staršia než predvolené 90-dňové okno
+// (`backfill.ts`'s `computeOrderIdsWindowStart`) — inak taká objednávka
+// (napr. 20260739/20260740) nikdy nedostane svoje id, hoci Shoptet ho má a
+// objednávka ostáva otvorená.
 const runOrdersIngest: RunOrdersIngest | undefined =
   ordersUrl === undefined
     ? undefined
-    : (now: Date) => {
+    : async (now: Date) => {
         const { dateFrom, dateUntil } = computeImportWindow(now, DEFAULT_ORDERS_IMPORT_WINDOW_DAYS);
+        const idsDateFrom = ordersXmlUrl === undefined ? dateFrom : await computeOrderIdsWindowStart(db, dateFrom);
         return ingestOrders(db, {
           fetchExport: createHttpOrdersExportFetcher({ url: ordersUrl, dateFrom, dateUntil }),
           now,
@@ -74,7 +83,7 @@ const runOrdersIngest: RunOrdersIngest | undefined =
           windowEnd: dateUntil,
           ...(ordersXmlUrl === undefined
             ? {}
-            : { fetchOrderIds: createHttpOrderIdsFetcher({ url: ordersXmlUrl, dateFrom, dateUntil }) }),
+            : { fetchOrderIds: createHttpOrderIdsFetcher({ url: ordersXmlUrl, dateFrom: idsDateFrom, dateUntil }) }),
         });
       };
 

--- a/apps/api/src/modules/orders/backfill.ts
+++ b/apps/api/src/modules/orders/backfill.ts
@@ -1,0 +1,59 @@
+import { and, inArray, isNull, sql } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { orders } from "../../db/schema.js";
+import { listOpenStatusNames } from "./open-statuses.js";
+
+// issue 132: `createHttpOrderIdsFetcher` (fetcher.ts) dostáva PEVNÉ
+// `dateFrom`/`dateUntil` z `computeImportWindow` — presne to isté posúvajúce
+// sa 90-dňové okno, aké používa aj hlavný CSV import. Keďže sa okno vždy
+// počíta od `now`, objednávka staršia než 90 dní sa do XML exportu (jediný
+// zdroj `order.shoptet_order_id`, issue 120) UŽ NIKDY nedostane — aj keď je
+// stále otvorená ("Na objednanie") a aj keď Shoptet jej id má. Funkcie nižšie
+// zisťujú, či taká objednávka existuje, a o koľko treba okno IBA pre XML
+// id-fetch (nikdy pre hlavný CSV import — ten má vlastnú, nezávislú
+// akceptančnú logiku voči `previousLineRatio`, `.claude/rules/orders.md`,
+// ktorú netreba meniť) predĺžiť dozadu, aby ju zachytil.
+
+/**
+ * Najstarší `placedAt` medzi OTVORENÝMI objednávkami (rovnaká definícia
+ * "otvorená" ako "Na objednanie" — `orders.statusName` v
+ * `listOpenStatusNames()`), ktorým chýba `shoptet_order_id`. `null`, keď
+ * žiadna taká objednávka neexistuje (nič nechýba, alebo nie je nastavený
+ * žiadny otvorený stav — rovnaký guard ako `queries.ts`'s
+ * `listOpenOrderLinesBySupplier`, `inArray` s prázdnym poľom by nemalo podľa
+ * čoho filtrovať).
+ */
+export async function findOldestOpenOrderMissingShoptetId(
+  db: Pick<Database, "select">,
+): Promise<Date | null> {
+  const openStatuses = await listOpenStatusNames(db);
+  if (openStatuses.length === 0) return null;
+
+  const [row] = await db
+    .select({ oldest: sql<string | null>`min(${orders.placedAt})` })
+    .from(orders)
+    .where(and(isNull(orders.shoptetOrderId), inArray(orders.statusName, [...openStatuses])));
+  // `min()` cez raw `sql` šablónu neprejde drizzle-ovým stĺpcovým mapperom
+  // (ten by `timestamp` normálne vrátil ako `Date`) — pg driver ho preto
+  // vracia ako ISO reťazec, nie `Date` objekt. Explicitná konverzia tu, nie
+  // spoliehanie sa na typový cast vyššie.
+  return row?.oldest === null || row?.oldest === undefined ? null : new Date(row.oldest);
+}
+
+/**
+ * Počiatok okna PRE XML id-fetch (`createHttpOrderIdsFetcher`'s
+ * `dateFrom`) — nikdy nezúži `defaultDateFrom` (predvolené 90-dňové okno,
+ * `computeImportWindow`), len ho voliteľne predĺži dozadu, aby zachytil
+ * KAŽDÚ dnes otvorenú objednávku, ktorej id ešte chýba. Sebaozdravujúce:
+ * kým je objednávka otvorená A chýba jej id, okno ju zachytáva pri každom
+ * behu; len čo id raz zistí, `ingestOrders`'s `COALESCE` zápis ho už
+ * navždy chráni a okno sa pre ňu ďalej netýka.
+ */
+export async function computeOrderIdsWindowStart(
+  db: Pick<Database, "select">,
+  defaultDateFrom: Date,
+): Promise<Date> {
+  const oldestMissing = await findOldestOpenOrderMissingShoptetId(db);
+  if (oldestMissing !== null && oldestMissing.getTime() < defaultDateFrom.getTime()) return oldestMissing;
+  return defaultDateFrom;
+}

--- a/apps/api/src/modules/orders/queries.test.ts
+++ b/apps/api/src/modules/orders/queries.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { buildShoptetAdminOrderUrl } from "./queries.js";
 
@@ -29,4 +31,20 @@ describe("buildShoptetAdminOrderUrl", () => {
       "https://admin.example.sk/admin/objednavky-detail/?id=58728",
     );
   });
+});
+
+// issue 129: `NULL_GROUP_KEY` niesol skutočný `\x00` (NUL) bajt namiesto
+// medzery pred "none" (zavedené ead8ae3, issue 63) — `git diff`/`git show`
+// preto zaobchádzali s CELÝM súborom ako s binárnym, takže žiadny reviewer
+// spoliehajúci sa na `git diff` (namiesto čítania celého obsahu) nikdy
+// neuvidel žiadnu zmenu v tomto súbore (zistené na code review PR #128).
+// Test číta RAW bajty vlastného zdrojového súboru priamo z disku (nie cez
+// import — ten by NUL bajt v reťazcovom literáli tichým spôsobom preniesol
+// ako obyčajný znak, test by nikdy nezlyhal) a overuje, že súbor neobsahuje
+// ŽIADEN NUL bajt — chráni pred rovnakou náhodou v BUDÚCNOSTI, nielen dnešný
+// jeden výskyt.
+it("zdrojový súbor queries.ts neobsahuje NUL bajt (git diff musí ostať čitateľný)", () => {
+  const cestaKSuboru = fileURLToPath(new URL("./queries.ts", import.meta.url));
+  const bajty = readFileSync(cestaKSuboru);
+  expect(bajty.includes(0)).toBe(false);
 });

--- a/apps/api/src/modules/orders/queries.ts
+++ b/apps/api/src/modules/orders/queries.ts
@@ -165,7 +165,7 @@ export async function listOpenOrderLinesBySupplier(
   // dodávateľa (buď z katalógu, alebo z ručného priradenia) padnú do JEDNEJ
   // skupiny. `spellingCounts` drží počet riadkov na KAŽDÝ videný pravopis,
   // aby sa dala zvoliť zobrazovaná forma (`pickCanonicalSupplierSpelling`).
-  const NULL_GROUP_KEY = " none";
+  const NULL_GROUP_KEY = " none";
   interface GroupAccumulator {
     readonly lines: OpenOrderLine[];
     readonly spellingCounts: Map<string, number>;

--- a/apps/api/tests/orders-id-backfill.integration.test.ts
+++ b/apps/api/tests/orders-id-backfill.integration.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, expect, it } from "vitest";
+import { orders } from "../src/db/schema.js";
+import { DEFAULT_ORDER_OPEN_STATUS } from "../src/modules/orders/open-statuses.js";
+import {
+  computeOrderIdsWindowStart,
+  findOldestOpenOrderMissingShoptetId,
+} from "../src/modules/orders/backfill.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 132: majiteľ, dve objednávky (20260739/20260740) nemali interné
+// Shoptet id, lebo `createHttpOrderIdsFetcher`'s pevné 90-dňové okno ich už
+// dávno nezachytáva (`placedAt` staršie než okno) — hoci Shoptet id MÁ a
+// objednávky sú stále otvorené ("Na objednanie"). Tieto testy overujú novú
+// `backfill.ts`'s logiku, ktorá okno PRE XML id-fetch (nikdy pre hlavný CSV
+// import) sebaozdravujúco predĺži dozadu, kým existuje otvorená objednávka
+// bez id.
+
+let close: (() => Promise<void>) | undefined;
+
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+});
+
+const DEFAULT_DATE_FROM = new Date("2026-05-03T00:00:00Z");
+
+it("findOldestOpenOrderMissingShoptetId vráti null, keď žiadnej otvorenej objednávke id nechýba", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await ctx.db.insert(orders).values({
+    externalOrderId: "9101",
+    customerName: "Zákazník A",
+    statusName: DEFAULT_ORDER_OPEN_STATUS,
+    placedAt: new Date("2026-04-01T00:00:00Z"),
+    shoptetOrderId: 12345,
+  });
+
+  const oldest = await findOldestOpenOrderMissingShoptetId(ctx.db);
+  expect(oldest).toBeNull();
+});
+
+it("findOldestOpenOrderMissingShoptetId ignoruje UZAVRETÉ objednávky bez id (nie sú v 'Na objednanie')", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await ctx.db.insert(orders).values({
+    externalOrderId: "9102",
+    customerName: "Zákazník B",
+    statusName: "Vybavená", // NIE otvorený stav — mimo listOpenStatusNames()
+    placedAt: new Date("2026-01-01T00:00:00Z"),
+    shoptetOrderId: null,
+  });
+
+  const oldest = await findOldestOpenOrderMissingShoptetId(ctx.db);
+  expect(oldest).toBeNull();
+});
+
+it("findOldestOpenOrderMissingShoptetId nájde najstaršiu OTVORENÚ objednávku bez id", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await ctx.db.insert(orders).values([
+    {
+      externalOrderId: "20260739",
+      customerName: "Zákazník C",
+      statusName: DEFAULT_ORDER_OPEN_STATUS,
+      placedAt: new Date("2026-04-30T10:00:00Z"),
+      shoptetOrderId: null,
+    },
+    {
+      externalOrderId: "20260740",
+      customerName: "Zákazník D",
+      statusName: DEFAULT_ORDER_OPEN_STATUS,
+      placedAt: new Date("2026-05-01T10:00:00Z"),
+      shoptetOrderId: null,
+    },
+  ]);
+
+  const oldest = await findOldestOpenOrderMissingShoptetId(ctx.db);
+  expect(oldest?.toISOString()).toBe(new Date("2026-04-30T10:00:00Z").toISOString());
+});
+
+it("computeOrderIdsWindowStart NEZUZUJE predvolené okno, keď nič nechýba", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+
+  const windowStart = await computeOrderIdsWindowStart(ctx.db, DEFAULT_DATE_FROM);
+  expect(windowStart).toEqual(DEFAULT_DATE_FROM);
+});
+
+it("computeOrderIdsWindowStart PREDĹŽI okno dozadu, aby zachytilo staršiu otvorenú objednávku bez id", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const staraObjednavka = new Date("2026-04-30T10:00:00Z"); // staršie než DEFAULT_DATE_FROM
+  await ctx.db.insert(orders).values({
+    externalOrderId: "20260739",
+    customerName: "Zákazník C",
+    statusName: DEFAULT_ORDER_OPEN_STATUS,
+    placedAt: staraObjednavka,
+    shoptetOrderId: null,
+  });
+
+  const windowStart = await computeOrderIdsWindowStart(ctx.db, DEFAULT_DATE_FROM);
+  expect(windowStart.toISOString()).toBe(staraObjednavka.toISOString());
+});
+
+it("computeOrderIdsWindowStart NEROZŠÍRI okno, keď chýbajúca objednávka je UŽ vnútri predvoleného okna", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const novaObjednavka = new Date("2026-06-01T10:00:00Z"); // novšie než DEFAULT_DATE_FROM
+  await ctx.db.insert(orders).values({
+    externalOrderId: "9103",
+    customerName: "Zákazník E",
+    statusName: DEFAULT_ORDER_OPEN_STATUS,
+    placedAt: novaObjednavka,
+    shoptetOrderId: null,
+  });
+
+  const windowStart = await computeOrderIdsWindowStart(ctx.db, DEFAULT_DATE_FROM);
+  expect(windowStart).toEqual(DEFAULT_DATE_FROM);
+});

--- a/apps/web/src/components/OrderLineRow.tsx
+++ b/apps/web/src/components/OrderLineRow.tsx
@@ -306,14 +306,18 @@ export function OrderLineRow({
         {new Date(line.placedAt).toLocaleDateString("sk-SK")}
         {/* issue 65: upozornenie na starú nevybavenú objednávku — priamy
             náprotivok starej appky's ⚠️ badge (`ordersSummary.ts`'s
-            `isStaleOrderLine`, hranica 14 dní). */}
+            `isStaleOrderLine`, hranica 14 dní). issue 127: viditeľný text
+            skrátený na "N d" (namiesto "N dní") — naživo nameraný odznak
+            pretŕčal svoju bunku (`.col-date`) o ~22px pri 1280px, keďže
+            stĺpec je užší než jeho vlastný obsah. Celý text ("N dní")
+            zostáva v `title` tooltipe pre prístupnosť/čitateľnosť. */}
         {isStaleOrderLine(line) && (
           <span
             className="ord-stale-badge"
             data-testid={`stale-badge-${line.lineId}`}
             title={`Nevybavená objednávka stará ${String(orderLineAgeDays(line.placedAt))} dní — pozri, nech nezapadne`}
           >
-            ⚠️ {orderLineAgeDays(line.placedAt)} dní
+            ⚠️ {orderLineAgeDays(line.placedAt)} d
           </span>
         )}
       </td>

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -1023,6 +1023,16 @@ tr:last-child td {
   border-radius: 999px;
   white-space: nowrap;
   cursor: help;
+  /* issue 127: trvalá poistka pre BUDÚCI, ešte dlhší počet dní (rovnaký vzor
+     ako `.ord-admin-link`/`.ord-code-cell`, issue 111) — `col-date`'s
+     rozšírená šírka vyššie pokrýva dnešný aj rozumne budúci (3-ciferný)
+     obsah s rezervou, ale keby ju predsa niekedy prekročil, odznak sa
+     orezáva SÁM (nikdy nepreteká vizuálne do suseda). `max-width: 100%`
+     viaže orezanie na skutočnú dostupnú šírku bunky, nie na pevné číslo.
+     `title` (naďalej celý text "N dní") ostáva jediný zdroj plnej hodnoty. */
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 /* issue 95: POZNÁMKA E-SHOPU (`remark`, read-only) + KOMENTÁR zlúčené do
    jednej bunky "Poznámky" (majiteľ, komentár #10) — vnútri sú DVA pôvodné
@@ -1197,8 +1207,24 @@ tr:last-child td {
    odkazu potrebuje priestor, aby sa nezalomil viac než predtým). Živo
    overené proti produkcii (39 ostrých riadkov) po nasadení. Súčet ostáva
    100%. */
+/* issue 127: majiteľ, live nameraná chyba — odznak veku objednávky
+   (`.ord-stale-badge`, `.col-date`) pretŕčal svoju bunku o ~22px pri
+   1280px. Skúšaní darcovia šírky (živo, `page.addStyleTag` priamo proti
+   produkcii, 37 ostrých riadkov — nie proti e2e fixtúre, rovnaká metodika
+   ako issue 107/111): `col-notes` má len ~0,5 percentuálneho bodu rezervy
+   nad testovaným prahom "komentárové pole ≥160px" (`orders-layout.spec.
+   ts`); `col-supplier` má naživo 3 riadky s ručným priradením dodávateľa
+   (`.ord-supplier-assign`, na rozdiel od staršieho — dnes už neplatného —
+   komentára "žiadny živý riadok ho dnes nemá") a zúženie ich poslalo nad
+   120px; `col-customer` sa dnes už takmer VŽDY zalamuje (mená zákazníkov),
+   `col-qty`/`col-state`/`col-order` majú nulovú/zápornú rezervu. JEDINÝ
+   stĺpec, kde zúženie o 3 body naživo NEZMENILO žiadnu výšku riadku
+   (min/median/max identické pred aj po, 0 nad 120, na 1280 aj 1920px) je
+   `col-product` — má z issue 117 veľkú rezervu (dlhé názvy produktov
+   dnešnej živej dávky sa nedostávajú na hranicu zalomenia pri tomto
+   zúžení). Súčet ostáva 100%. */
 .col-product {
-  width: 17.4%;
+  width: 14.4%;
 }
 .col-qty {
   width: 4%;
@@ -1210,7 +1236,7 @@ tr:last-child td {
   width: 13.5%;
 }
 .col-date {
-  width: 6%;
+  width: 9%;
 }
 .col-notes {
   width: 24.1%;

--- a/apps/web/tests/e2e/orders-layout.spec.ts
+++ b/apps/web/tests/e2e/orders-layout.spec.ts
@@ -124,6 +124,30 @@ test("STAV je celý čitateľný a POZNÁMKY pole je dosť široké na všetkýc
     // issue 117 celý stĺpec kódu produktu zrušilo (majiteľ nepoužíva), takže
     // `.ord-code-cell` už v DOM-e vôbec neexistuje.
 
+    // issue 127: odznak veku objednávky (`.ord-stale-badge`) sa CELOU šírkou
+    // musí zmestiť do svojej bunky (`.col-date`) — pred touto opravou
+    // pretŕčal o ~22px pri 1280px do vedľajšieho stĺpca POZNÁMKY. Objednávka
+    // 9002 (`scripts/e2e-setup.ts`) má `placedAt` hlboko v minulosti, takže
+    // odznak sa vždy vykreslí.
+    const staleOdznaky = await page.evaluate(() => {
+      return [...document.querySelectorAll<HTMLElement>("[data-testid^='stale-badge-']")].map((odznak) => {
+        const td = odznak.closest("td");
+        if (td === null) return { spill: null, scrollOverflow: null };
+        const odznakRect = odznak.getBoundingClientRect();
+        const tdRect = td.getBoundingClientRect();
+        return {
+          spill: odznakRect.right - tdRect.right,
+          scrollOverflow: td.scrollWidth > td.clientWidth,
+        };
+      });
+    });
+    expect(staleOdznaky.length, `žiadny stale-badge nájdený pri ${String(width)}px`).toBeGreaterThan(0);
+    for (const { spill, scrollOverflow } of staleOdznaky) {
+      expect(spill, `odznak pretŕča svoju bunku pri ${String(width)}px`).not.toBeNull();
+      expect(spill as number, `odznak pretŕča svoju bunku pri ${String(width)}px`).toBeLessThanOrEqual(0);
+      expect(scrollOverflow, `bunka odznaku posúva obsah pri ${String(width)}px`).toBe(false);
+    }
+
     // issue 111 bod 5: pri 1280px sa žiadna `.orders-table-wrap` skupina
     // nesmie posúvať vodorovne (predtým 💾 tlačidlo bolo za viditeľným
     // okrajom, kým manažér nescrolloval).

--- a/apps/web/tests/e2e/orders-layout.spec.ts
+++ b/apps/web/tests/e2e/orders-layout.spec.ts
@@ -88,9 +88,13 @@ test("STAV je celý čitateľný a POZNÁMKY pole je dosť široké na všetkýc
     }
 
     // issue 107 bod 2 (regresia issue 105): riadky BEZ bloku priradenia
-    // dodávateľa (žiadny živý riadok ho dnes nemá) ostávajú kompaktné —
-    // riadky S ním (zriedkavé, `supplierAssignable`) sú vyňaté zámerne: aj
-    // živá produkcia bežne prekračuje ~95px kvôli dlhým názvom produktov
+    // dodávateľa ostávajú kompaktné — riadky S ním (zriedkavé,
+    // `supplierAssignable`) sú vyňaté zámerne. AKTUALIZÁCIA (issue 127,
+    // 2026-08-01): "žiadny živý riadok ho dnes nemá" (pôvodný komentár tu)
+    // je ZASTARANÉ — produkcia má dnes 3 také riadky (naživo overené proti
+    // `vychod@varos.sk`), preto sa toto vylúčenie z výškovej kontroly stále
+    // uplatňuje aj naživo, nielen teoreticky. Aj živá produkcia bežne
+    // prekračuje ~95px kvôli dlhým názvom produktov
     // (`.claude/rules/frontend-design.md`), takže tento test overuje presne
     // to, čo je v scope tohto ticketu — POZNÁMKY stĺpec už nespôsobuje
     // zalomenie vstup+tlačidlo, nie univerzálny strop na VŠETKY možné riadky.

--- a/apps/web/tests/e2e/orders.spec.ts
+++ b/apps/web/tests/e2e/orders.spec.ts
@@ -289,10 +289,13 @@ test("manažér vidí otvorené objednávky zoskupené podľa dodávateľa, konz
   // issue 65: objednávka 9002 zámerne nesie placedAt hlboko v minulosti
   // (`scripts/e2e-setup.ts`) a zostáva NEVYBAVENÁ (predvolený stav) — presne
   // ten prípad, ktorý má dostať upozornenie ⚠️ na starú objednávku.
+  // issue 127: viditeľný text je od tohto ticketu skrátený na "N d" (nie
+  // "N dní") — plný text ostáva v `title` tooltipe, overenom nižšie.
   const staleBadgeBez = riadokBez.locator("[data-testid^='stale-badge-']");
   await expect(staleBadgeBez).toBeVisible();
   await expect(staleBadgeBez).toContainText("⚠️");
-  await expect(staleBadgeBez).toContainText("dní");
+  await expect(staleBadgeBez).toContainText("d");
+  await expect(staleBadgeBez).toHaveAttribute("title", /dní/);
 
   expect(chyby).toEqual([]);
 });

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -1647,3 +1647,43 @@ nové heslo sa nikde v pushnutom obsahu nenachádza.
 - Playbook: `.claude/rules/orders.md` updated (see above); memory
   `shoptet-export-urls.md` updated to record the XML export is now
   actively consumed, not just "supplied for later phases".
+
+## Issues 127, 129, 132 — bundled batch (2026-08-01)
+
+- Version bumped to `0.3.0-dev.75` (`c34597b`), first commit on `dev`.
+- Design-decision comments posted on all three tickets BEFORE any code
+  commit (root cause + chosen approach + rejected alternative for each).
+- **#129** (NUL byte in `queries.ts`'s `NULL_GROUP_KEY`): RED test
+  (`1ee8001`, reads raw source bytes, asserts no `\x00`) -> GREEN fix
+  (`a712df9`, replaced with a plain space). `git diff` on `queries.ts` is
+  now a normal text diff. Full 290-test unit suite + 239-test integration
+  suite unaffected.
+- **#132** (id-backfill window widening): RED integration test
+  (`a08724c`, `orders-id-backfill.integration.test.ts` -- module didn't
+  exist yet, confirmed `Cannot find module`) -> GREEN
+  (`cf9efca`, new `apps/api/src/modules/orders/backfill.ts`:
+  `findOldestOpenOrderMissingShoptetId` + `computeOrderIdsWindowStart`,
+  wired into `index.ts` + `cli/orders-ingest.ts`). Self-healing: widens
+  the XML id-fetch window (never the main CSV import's own window) only
+  while an open order is missing its id.
+- **#127** (stale-badge overflow): RED e2e test (`0b47b89`,
+  `orders-layout.spec.ts` -- measured 35.125px spill against the OLD
+  styling, matching the ticket's live-measured ~22-35px depending on day
+  count) -> GREEN (`b637050`): compact badge text ("N d", full "N dni" in
+  `title`), `col-date` 6%->9%, `col-product` 17.4%->14.4%, permanent
+  ellipsis safety net. Every other column tested live against production
+  first (`page.addStyleTag`, 37 real rows) as a candidate width donor --
+  `col-notes`/`col-supplier`/`col-customer`/`col-qty`/`col-state`/
+  `col-order` all regressed something already measured today
+  (comment-input floor, 3 real supplier-assign rows pushed over 120px,
+  near-universal customer-name wrapping, zero/negative slack) --
+  `col-product` was the only column with genuine verified slack.
+- Local full-suite verification before push: typecheck clean, lint clean,
+  API unit (290 tests) + integration (239 tests) green, web unit (236
+  tests) green, full local e2e suite (21 tests, all 6 spec files) green.
+- Pull request opened for this batch: `Closes #127`, `Closes #129`.
+  Issue #132 deliberately NOT closed by that PR -- its acceptance
+  criterion (0 rows using the search fallback once Shoptet has the id)
+  needs a real ingest run against the live XML export post-deploy, same
+  reasoning as the #120 premature-close gotcha above. Will trigger manual
+  ingest post-deploy, verify live, close #132 manually with evidence.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.74",
+  "version": "0.3.0-dev.75",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Bundle: #127, #129, #132 (verify-issue-still-valid confirmed all three still
reproducible against current `main`/live production before implementing —
see design-decision comments on each ticket, posted before any code commit).

## #127 — stale-order badge overflowed its column

`.ord-stale-badge` pretŕčal `.col-date` o ~22px pri 1280px. Live-tested every
other column as a width donor directly against production (37 real rows,
`page.addStyleTag`) before picking `col-product` as the only one with genuine
verified slack — `col-notes`/`col-supplier`/`col-customer`/`col-qty`/
`col-state`/`col-order` all regress something already measured today.
Compact badge text ("N d", full "N dní" stays in `title`) + `col-date`
6%→9%, `col-product` 17.4%→14.4% + permanent ellipsis safety net.

Live-verified against production (1280–1920px): badge no longer spills (even
simulating a future 3-digit day count), row height min/median/max unchanged
(79.5/91/114.5), 0 rows over 120px.

## #129 — stray NUL byte in `NULL_GROUP_KEY`

Replaced with a plain space. `git diff` on `queries.ts` is now a normal text
diff instead of "Binary files ... differ". No behavior change (regression
test + the full existing suite prove the "(bez dodávateľa)" grouping is
unaffected).

## #132 — id-backfill window widening

`createHttpOrderIdsFetcher`'s fixed 90-day window meant an order older than
90 days (20260739/20260740) could never get its `shoptet_order_id`
backfilled, even though it's still open and Shoptet has the id.
`computeOrderIdsWindowStart` (new `backfill.ts`) widens the id-fetch
window's `dateFrom` — only for that fetch, never the main CSV import's own
acceptance window — whenever an open order is missing its id and older than
the default window. Self-healing: once an id is found, the existing
`COALESCE` write protects it forever.

**Not closing #132 in this PR** — its acceptance criterion ("0 rows using
the search fallback when Shoptet has the id") requires an actual ingest run
against the live XML export post-deploy, which I cannot prove before merge
(same reasoning as the #120 premature-close gotcha documented in this
project's CLAUDE.md). Will trigger the manual "stiahnuť teraz" ingest after
deploy, verify live, and close #132 manually with evidence.

Closes #127
Closes #129
