### PR TITLE
Reduce col-product/col-supplier width steal after #127 post-deploy regression

### DIFF
--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -1213,24 +1213,36 @@ tr:last-child td {
    produkcii, 37 ostrých riadkov — nie proti e2e fixtúre, rovnaká metodika
    ako issue 107/111): `col-notes` má len ~0,5 percentuálneho bodu rezervy
    nad testovaným prahom "komentárové pole ≥160px" (`orders-layout.spec.
-   ts`); `col-supplier` má naživo 3 riadky s ručným priradením dodávateľa
-   (`.ord-supplier-assign`, na rozdiel od staršieho — dnes už neplatného —
-   komentára "žiadny živý riadok ho dnes nemá") a zúženie ich poslalo nad
-   120px; `col-customer` sa dnes už takmer VŽDY zalamuje (mená zákazníkov),
-   `col-qty`/`col-state`/`col-order` majú nulovú/zápornú rezervu. JEDINÝ
-   stĺpec, kde zúženie o 3 body naživo NEZMENILO žiadnu výšku riadku
-   (min/median/max identické pred aj po, 0 nad 120, na 1280 aj 1920px) je
-   `col-product` — má z issue 117 veľkú rezervu (dlhé názvy produktov
-   dnešnej živej dávky sa nedostávajú na hranicu zalomenia pri tomto
-   zúžení). Súčet ostáva 100%. */
+   ts`); `col-customer` sa dnes už takmer VŽDY zalamuje (mená zákazníkov);
+   `col-qty`/`col-state`/`col-order` majú nulovú/zápornú rezervu.
+
+   OPRAVA po prvom nasadení (ten istý deň): prvý pokus vzal celých 3 body z
+   `col-product` samotného (17.4%→14.4%) — naživo overené OK proti vtedajšej
+   živej dávke (37 riadkov), ale HNEĎ po merge/deploji prišla NOVÁ reálna
+   objednávka (20261267, extrémne dlhý názov produktu — "TETRAO šnúra na
+   čistenie guľovnice cal .30, .308 win, 30-06, ...") a jej riadok vyskočil
+   na 134px (nad 120px strop) — pri PÔVODNEJ šírke 17.4% by bol býval na
+   114.5px (tesne pod stropom, nie nad ním). Živé stĺpcové rozpočty NEMAJÚ
+   pevný strop obsahu (produktový katalóg rastie), takže "0 riadkov nad
+   120px dnes" nikdy nezaručuje totéž zajtra pri KAŽDOM možnom zúžení —
+   treba nájsť, KDE presne je hranica (nie len overiť JEDEN kandidát), a
+   nechať rezervu POD ňou, nie na nej. Opätovné živé meranie (`page.
+   addStyleTag`, tá istá produkcia) ukázalo: `col-product` znesie zúženie
+   len do 15.4% (o 2.0 bodu — 14.9% ešte OK, 14.4% už zlomí spomínaný
+   riadok na 134px, teda skutočná hranica je MEDZI 14.9% a 14.4%);
+   `col-supplier` (14%) má samostatnú rezervu do 13% (o 1.0 bod — 12.5% už
+   pošle VŠETKY 3 živé `supplierAssignable` riadky nad 120px, na 142.5px).
+   Potrebných +3 body pre `col-date` teraz idú z OBOCH darcov naraz (2.0 +
+   1.0), každý s bezpečnou rezervou POD svojou zmeranou hranicou, nie na
+   nej. Súčet ostáva 100%. */
 .col-product {
-  width: 14.4%;
+  width: 15.4%;
 }
 .col-qty {
   width: 4%;
 }
 .col-supplier {
-  width: 14%;
+  width: 13%;
 }
 .col-state {
   width: 13.5%;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.75",
+  "version": "0.3.0-dev.76",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Post-deploy live regression fix for #127 (already merged/deployed in
PR #133, then reopened after this was found). No "Closes" trailer in this
PR body on purpose — GitHub's closing-keyword scan is broad enough to
match "close" anywhere near an issue number, which is exactly what
prematurely auto-closed #132 during #133's merge. I'll close #127 manually
after this deploys and I re-verify live.

## What happened

The first #127 fix took the full +3 percentage points `col-date` needed
entirely from `col-product` (17.4% -> 14.4%), live-verified against
production's 37 rows at that moment. Right after merge+deploy, a genuinely
new real order (20261267, an exceptionally long product name) arrived and
its row jumped to 134px — over the ticket's own "0 rows over 120px" bar.
At the ORIGINAL 17.4% that row would have been 114.5px.

## Root cause

Live column-width budgets have no content ceiling — the catalog keeps
growing, so verifying ONE candidate against today's snapshot never proves
tomorrow's new order won't cross the exact same boundary the candidate
sits right on.

## Fix

Re-measured live (`page.addStyleTag` against the same production, several
candidate cuts per column to find the actual boundary, not just check one
point): `col-product` tolerates shrinking to 15.4% (2.0 points — 14.9%
still fine, 14.4% breaks), `col-supplier` has a separate 1.0-point budget
down to 13% (12.5% pushes all 3 live `supplierAssignable` rows to 142.5px).
The needed +3 points for `col-date` now come from both donors, each with
margin under its measured cliff.

Re-verified live: max row height back to 114.5px, 0 rows over 120px, badge
still fits with margin at 1280-1920px.
