### PR TITLE
Backfill shoptet_order_id for orders outside the CSV import window

### DIFF
--- a/apps/api/src/modules/orders/ingest.ts
+++ b/apps/api/src/modules/orders/ingest.ts
@@ -341,6 +341,27 @@ export async function ingestOrders(db: Database, options: OrdersIngestOptions): 
         for (const row of inserted) orderIdByExternalId.set(row.externalOrderId, row.id);
       }
 
+      // issue 132: `orderIdsByCode` (best-effort XML fetch, prípadne
+      // ROZŠÍRENÉ za CSV okno cez `backfill.ts`'s `computeOrderIdsWindowStart`
+      // — pozri `index.ts`/`cli/orders-ingest.ts`) môže poznať objednávku,
+      // ktorá v TOMTO behu CSV vôbec NIE JE (staršia než jeho vlastné,
+      // NEROZŠÍRENÉ okno — CSV okno sa zámerne nemení, aby sa nedotkla
+      // `previousLineRatio` akceptančná logika vyššie). Bez tohto kroku by
+      // upsert cyklus vyššie (ktorý ide LEN cez `orderInfo`, postavené z CSV)
+      // taký záznam nikdy nenavštívil, takže jeho `shoptetOrderId` by sa
+      // nikdy nezapísal, hoci XML mapa ho pozná. Priamy `UPDATE` namiesto
+      // upsertu — objednávka MUSÍ už v DB existovať (z predošlého importu),
+      // tento krok jej nikdy nezakladá nový riadok len z XML dát (tie
+      // nenesú `customerName` ani ostatné povinné polia). `COALESCE` chráni
+      // už zistené id rovnako ako hlavný upsert vyššie.
+      for (const [externalOrderId, shoptetOrderId] of orderIdsByCode) {
+        if (orderInfo.has(externalOrderId)) continue;
+        await tx
+          .update(orders)
+          .set({ shoptetOrderId: sql`coalesce(${orders.shoptetOrderId}, ${shoptetOrderId})` })
+          .where(eq(orders.externalOrderId, externalOrderId));
+      }
+
       // Overenie proti `variant` tabuľke je AUTORITA nad tým, čo je skutočný
       // produkt (prefix-filter v `parser.ts` je len prvé, DB-nezávislé sito) —
       // položka, ktorú Shoptet vráti, ale náš katalóg ju nepozná (napr. dávno

--- a/apps/api/tests/orders-ingest.integration.test.ts
+++ b/apps/api/tests/orders-ingest.integration.test.ts
@@ -184,6 +184,50 @@ it("uloží interné Shoptet id z fetchOrderIds vedľa CSV importu", async () =>
   expect(rows?.shoptetOrderId).toBe(58728);
 });
 
+// issue 132: `fetchOrderIds` môže byť (cez `computeOrderIdsWindowStart`,
+// `backfill.ts`) NAMERANÉ na ŠIRŠIE okno než hlavný CSV import — pozná teda
+// aj objednávky, ktoré CSV export tohto behu vôbec NENESIE (staršie než
+// jeho vlastné, nerozšírené okno). Bez samostatného backfill kroku by ich
+// `shoptetOrderId` NIKDY nedostal zápis, lebo hlavný upsert cyklus prechádza
+// LEN `orderInfo` (postavené z CSV) — `orderIdsByCode.get(externalOrderId)`
+// sa vôbec nezavolá pre id, ktorého kľúč v `orderInfo` chýba.
+it("fetchOrderIds pozná objednávku, ktorá NIE JE v tomto behu CSV (staršia než jeho okno) — id sa napriek tomu zapíše", async () => {
+  const { db, dir } = await boot();
+  await insertTestVariant(db, "40237/XL");
+
+  // Objednávka 9106 UŽ existuje v DB (predchádzajúci import), otvorená,
+  // bez interného id — presne stav 20260739 pred touto opravou.
+  await db.insert(orders).values({
+    externalOrderId: "9106",
+    customerName: "Starý zákazník",
+    statusName: "Vybavuje sa",
+    placedAt: new Date("2026-01-01T00:00:00Z"),
+    shoptetOrderId: null,
+  });
+
+  // Tento beh CSV nesie LEN inú, novšiu objednávku (9107) — 9106 v ňom
+  // vôbec nie je, presne ako keď je staršia než CSV okno.
+  const csv = buildCsv(HEADER, [
+    { code: "9107", date: "2026-07-01 10:00:00", statusName: "Vybavuje sa", billFullName: "X", itemName: "Y", itemAmount: "1", itemCode: "40237/XL" },
+  ]);
+  const result = await ingestOrders(db, {
+    fetchExport: fetcherOf(csv),
+    now: NOW,
+    rawDir: dir,
+    windowStart: WINDOW_START,
+    windowEnd: WINDOW_END,
+    // Rozšírená XML mapa (ako by ju vrátil computeOrderIdsWindowStart-om
+    // rozšírený fetch) — pozná AJ 9106, hoci CSV vyššie ju nenesie.
+    fetchOrderIds: () => Promise.resolve(new Map([["9107", 58729], ["9106", 58184]])),
+  });
+
+  expect(result.status).toBe("accepted");
+  const [stara] = await db.select().from(orders).where(eq(orders.externalOrderId, "9106"));
+  expect(stara?.shoptetOrderId).toBe(58184);
+  const [nova] = await db.select().from(orders).where(eq(orders.externalOrderId, "9107"));
+  expect(nova?.shoptetOrderId).toBe(58729);
+});
+
 it("zlyhaný fetchOrderIds NEODMIETNE import CSV — objednávka sa uloží bez id", async () => {
   const { db, dir } = await boot();
   await insertTestVariant(db, "40237/XL");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.76",
+  "version": "0.3.0-dev.77",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Followup fix for issue 132 (id-backfill window widening, first attempt
merged earlier). No auto-close trailer in this body on purpose — avoiding
even the word "close" near an issue number after two accidental premature
auto-closes on this same batch (GitHub's keyword scan is broader than the
standard `Closes #N` line).

## What happened

Post-deploy live verification of the window-widening fix (computeOrderIdsWindowStart)
found it was not sufficient on its own: after a real production ingest
run, order 20260739 still had no shoptet_order_id, even though I directly
confirmed (inside the running container) that the widened window
computation returns the correct date AND the XML export fetch with that
window correctly returns {20260739: 58184}.

## Root cause

The COALESCE write only happens inside the main upsert loop, which walks
`orderInfo` — built purely from the CSV export, which intentionally keeps
its own UNwidened 90-day window (widening it would change the
previousLineRatio acceptance gate, a separate concern). An order older
than the CSV's own window never enters `orderInfo`, so the write loop
never visits it, no matter what the separately-widened XML id map knows.

## Fix

After the main upsert, a direct UPDATE for every `orderIdsByCode` entry
whose externalOrderId is NOT in `orderInfo` — same COALESCE protection as
the main write, UPDATE only (never inserts a new order row, since XML data
lacks customerName/other required fields).

Verified locally: RED test (`e25e260`, an order outside the CSV batch with
a known XML id stayed null) -> GREEN (`5eb8a8f`). Full 240-test integration
suite + 290-test unit suite green.
