### PR TITLE
feat(orders): manual supplier-link override — doplniť/upraviť odkaz na dodávateľa (issue 121)

### DIFF
--- a/apps/api/drizzle/0017_curious_the_renegades.sql
+++ b/apps/api/drizzle/0017_curious_the_renegades.sql
@@ -1,0 +1,7 @@
+CREATE TABLE "product_supplier_link_override" (
+	"product_key" text PRIMARY KEY NOT NULL,
+	"url" text NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "product_supplier_link_override" ADD CONSTRAINT "product_supplier_link_override_product_key_product_key_fk" FOREIGN KEY ("product_key") REFERENCES "public"."product"("key") ON DELETE cascade ON UPDATE no action;

--- a/apps/api/drizzle/meta/0017_snapshot.json
+++ b/apps/api/drizzle/meta/0017_snapshot.json
@@ -1,0 +1,1525 @@
+{
+  "id": "6fe479c5-57f0-4bba-9b87-c9f0a037a20e",
+  "prevId": "691cb3e1-a4c1-415b-899f-3425a9a3d032",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_code": {
+          "name": "external_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_open_status": {
+      "name": "order_open_status",
+      "schema": "",
+      "columns": {
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Vybavuje sa'"
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shoptet_order_id": {
+          "name": "shoptet_order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_link_override": {
+      "name": "product_supplier_link_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_link_override_product_key_product_key_fk": {
+          "name": "product_supplier_link_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_link_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_override": {
+      "name": "product_supplier_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_override_product_key_product_key_fk": {
+          "name": "product_supplier_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing": {
+      "name": "pairing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_url": {
+          "name": "supplier_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "pairing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'navrhnute'"
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pairing_state_idx": {
+          "name": "pairing_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_confirmed_by_idx": {
+          "name": "pairing_confirmed_by_idx",
+          "columns": [
+            {
+              "expression": "confirmed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_variant_code_variant_code_fk": {
+          "name": "pairing_variant_code_variant_code_fk",
+          "tableFrom": "pairing",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pairing_confirmed_by_users_id_fk": {
+          "name": "pairing_confirmed_by_users_id_fk",
+          "tableFrom": "pairing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pairing_variant_code_unique": {
+          "name": "pairing_variant_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pairing_confirmation_ck": {
+          "name": "pairing_confirmation_ck",
+          "value": "(\"pairing\".\"state\" = 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)\n        OR (\"pairing\".\"state\" != 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NULL AND \"pairing\".\"confirmed_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier": {
+      "name": "supplier",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wholesale_base_url": {
+          "name": "wholesale_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_key": {
+          "name": "adapter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne"
+      ]
+    },
+    "public.pairing_state": {
+      "name": "pairing_state",
+      "schema": "public",
+      "values": [
+        "navrhnute",
+        "potvrdene"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1785532681171,
       "tag": "0016_superb_nightcrawler",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1785543315291,
+      "tag": "0017_curious_the_renegades",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema-orders.ts
+++ b/apps/api/src/db/schema-orders.ts
@@ -136,6 +136,32 @@ export const productSupplierOverrides = pgTable("product_supplier_override", {
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
 });
 
+// issue 121: majiteľ, doslovne "ak na produkt nie je odkaz na dodavatela, tak
+// tam ma byt moznost ho doplnit, a vlastne pri kazdom produkte ma byt moznost
+// upravit link na dodavatela". Priamy náprotivok `productSupplierOverrides`
+// vyššie (rovnaké kľúčovanie `product.key`, nie variantom — `internalNote`,
+// z ktorého sa odkaz extrahuje, je vlastnosť CELÉHO produktu naprieč
+// veľkosťami, `.claude/rules/catalog.md`), ale s JEDNÝM podstatným rozdielom:
+// `productSupplierOverrides` je FALLBACK povolený LEN keď katalóg pole nemá
+// (`supplierAssignable`/409 "already_has_supplier" gate) — tu majiteľ výslovne
+// žiada úpravu "pri KAŽDOM produkte", teda AJ keď Shoptet odkaz už poskytuje.
+// Čítacia strana preto VŽDY uprednostní TENTO riadok pred extrahovaným
+// `internalNote` odkazom (`coalesce(override.url, extractSupplierLink(...).url)`,
+// `queries.ts`), nikdy podmienene ako override vyššie. Zápis (`internalNote`
+// samotný) nikdy nemení — nočný katalógový import by ho pri ďalšom behu
+// prepísal (dôvod, prečo appka doteraz nemala VÔBEC žiadnu zápisovú cestu na
+// tento odkaz). `ON DELETE CASCADE` — rovnaký zámer ako `productSupplierOverrides`
+// (produkt sa reálne nikdy nemaže, ale osamotený riadok bez zmyslu nemá dôvod
+// prežiť). Nasledujúci samostatný ticket (#122) spätne zapisuje TENTO odkaz do
+// Shoptetu cez hromadný CSV import — táto tabuľka je jeho zdroj pravdy.
+export const productSupplierLinkOverrides = pgTable("product_supplier_link_override", {
+  productKey: text("product_key")
+    .primaryKey()
+    .references(() => products.key, { onDelete: "cascade" }),
+  url: text("url").notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+});
+
 export const orderLines = pgTable(
   "order_line",
   {

--- a/apps/api/src/http/orders-routes.ts
+++ b/apps/api/src/http/orders-routes.ts
@@ -9,6 +9,7 @@ import { ORDERS_EXPORT_URL_NOT_CONFIGURED, type OrdersIngestResult, type RunOrde
 import { listKnownStatusNames, listOpenStatusNames, replaceOpenStatusNames } from "../modules/orders/open-statuses.js";
 import { getOrderDetail, listOpenOrderLinesBySupplier } from "../modules/orders/queries.js";
 import { assignOrderLineSupplier } from "../modules/orders/supplier-assignment.js";
+import { setProductSupplierLink } from "../modules/orders/supplier-link-assignment.js";
 import { setOrderComment, setOrderLineOrdered, setOrderLineState } from "../modules/orders/state.js";
 import { requireRole, requireUser, type AppBindings } from "./middleware.js";
 import { requireSameOrigin } from "./origin-check.js";
@@ -28,6 +29,17 @@ const orderLineOrderedBody = z.object({ ordered: z.boolean() });
 // v projekte (`catalog-routes.ts`, `pairing-routes.ts`) — hodnota sa neskôr
 // vkladá aj do mailu dodávateľovi, chýbajúci limit bol prehliadnutá medzera.
 const orderLineSupplierBody = z.object({ supplier: z.string().trim().min(1).max(200) });
+// issue 121: manuálny odkaz na dodávateľa — validovaný ako URL (ticketova
+// akceptačná podmienka), `.max(2000)` rovnaká horná hranica ako ostatné voľné
+// URL/textové vstupy v projekte (`orderCommentBody` nižšie). `.url()` samo o
+// sebe by prijalo aj syntakticky platnú, ale nebezpečnú schému (napr.
+// `javascript:...`) — hodnota sa vykresľuje priamo ako `<a href>`
+// (`OrderLineRow.tsx`), preto NAVYŠE `.regex` vynucuje http(s), rovnaký vzor
+// ako `adminUrl`/existujúci `supplierUrl` vo frontendovej `ordersApi.ts`
+// schéme (issue 70's "druhá vrstva overenia" zásada).
+const orderLineSupplierLinkBody = z.object({
+  url: z.string().trim().url().max(2000).regex(/^https?:\/\//),
+});
 // issue 64: manažérova voľná poznámka k CELEJ objednávke — na rozdiel od
 // `orderLineSupplierBody` vyššie ZÁMERNE bez `.min(1)` (prázdny orezaný vstup
 // je platný spôsob, ako poznámku vymazať, route ho mapuje na `null`). Cap
@@ -235,6 +247,33 @@ export function registerOrdersRoutes(
       }
       log.info({ actorUserId: user.userId, lineId, supplier }, "ručné priradenie dodávateľa riadku objednávky");
       return c.json({ ok: true as const, supplier });
+    },
+  );
+
+  // issue 121: manuálny odkaz na dodávateľa — na rozdiel od priradenia
+  // dodávateľa vyššie (#63) tu NIE je žiadna "už má hodnotu" gate: majiteľ
+  // smie odkaz upraviť aj keď Shoptet už jeden poskytuje (opravuje zlé/
+  // zastarané odkazy rovnako často ako dopĺňa chýbajúce). Rovnaké oprávnenie
+  // ako zvyšok zápisov v tomto súbore.
+  app.post(
+    "/api/orders/lines/:lineId/supplier-link",
+    requireSameOrigin(),
+    requireUser(db),
+    requireRole("admin", "manazer"),
+    zValidator("param", orderLineParam),
+    zValidator("json", orderLineSupplierLinkBody),
+    async (c) => {
+      const { lineId } = c.req.valid("param");
+      const { url } = c.req.valid("json");
+      const user = c.get("user");
+      const now = new Date();
+
+      const result = await setProductSupplierLink(db, { lineId, url, actorUserId: user.userId, now });
+      if (result === "not_found") {
+        return c.json({ error: "Riadok objednávky sa nenašiel" }, 404);
+      }
+      log.info({ actorUserId: user.userId, lineId, url }, "úprava odkazu na dodávateľa riadku objednávky");
+      return c.json({ ok: true as const, url });
     },
   );
 

--- a/apps/api/src/modules/orders/effective-supplier-link.ts
+++ b/apps/api/src/modules/orders/effective-supplier-link.ts
@@ -1,0 +1,24 @@
+import { extractSupplierLink, type SupplierLink } from "../catalog/supplier-link.js";
+
+// issue 121: efektívny odkaz na dodávateľa riadku — manažérovo ručné
+// prepísanie (`product_supplier_link_override`), a keď žiadne nie je,
+// odkaz extrahovaný z katalógového `product.internalNote`
+// (`extractSupplierLink`). Priamy náprotivok `supplier-key.ts`'s
+// `effectiveSupplierSql` (dodávateľ MENO), len tu je "extrakcia" čistá JS
+// funkcia (regex nad voľným textom), nie SQL výraz — coalesce preto beží
+// AŽ TU, po tom, čo obe strany (override stĺpec + `internalNote`) prídu z
+// DB. NA ROZDIEL od `effectiveSupplierSql` je toto prepísanie VŽDY
+// prioritné (nikdy podmienené tým, či Shoptet niečo má) — ticket to žiada
+// explicitne, majiteľ opravuje aj EXISTUJÚCE odkazy, nielen dopĺňa chýbajúce.
+// Použité na VŠETKÝCH troch čítacích cestách, ktoré dnes zobrazujú odkaz na
+// dodávateľa (`queries.ts`'s `listOpenOrderLinesBySupplier` + `getOrderDetail`,
+// `mail.ts`'s `loadOutstandingLines`) — rovnaká disciplína ako
+// `effectiveSupplierSql`'s komentár žiada pre dodávateľa MENO.
+export function resolveEffectiveSupplierLink(
+  internalNote: string | null,
+  overrideUrl: string | null,
+): SupplierLink {
+  const extracted = extractSupplierLink(internalNote);
+  if (overrideUrl !== null) return { url: overrideUrl, note: extracted.note };
+  return extracted;
+}

--- a/apps/api/src/modules/orders/mail.ts
+++ b/apps/api/src/modules/orders/mail.ts
@@ -1,9 +1,17 @@
 import { and, asc, eq, isNull } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
-import { orderLines, orders, productSupplierOverrides, products, supplierContacts, variants } from "../../db/schema.js";
+import {
+  orderLines,
+  orders,
+  productSupplierLinkOverrides,
+  productSupplierOverrides,
+  products,
+  supplierContacts,
+  variants,
+} from "../../db/schema.js";
 import { log } from "../../logger.js";
-import { extractSupplierLink } from "../catalog/supplier-link.js";
 import type { MailTransport } from "../mail/transport.js";
+import { resolveEffectiveSupplierLink } from "./effective-supplier-link.js";
 import { NEZNAMY_DODAVATEL } from "./queries.js";
 import { itemsWord } from "./pluralize.js";
 import { effectiveSupplierSql, normalizedSupplierKeySql, normalizeSupplierKeyJs } from "./supplier-key.js";
@@ -85,12 +93,14 @@ async function loadOutstandingLines(db: Database, supplier: string): Promise<Sup
       quantity: orderLines.quantity,
       externalCode: variants.externalCode,
       internalNote: products.internalNote,
+      supplierLinkOverride: productSupplierLinkOverrides.url,
     })
     .from(orderLines)
     .innerJoin(orders, eq(orders.id, orderLines.orderId))
     .innerJoin(variants, eq(variants.code, orderLines.variantCode))
     .innerJoin(products, eq(products.key, variants.productKey))
     .leftJoin(productSupplierOverrides, eq(productSupplierOverrides.productKey, products.key))
+    .leftJoin(productSupplierLinkOverrides, eq(productSupplierLinkOverrides.productKey, products.key))
     .where(and(supplierCondition, eq(orderLines.state, "objednane")))
     .orderBy(asc(orderLines.variantCode));
 
@@ -103,7 +113,7 @@ async function loadOutstandingLines(db: Database, supplier: string): Promise<Sup
         sizeLabel: row.sizeLabel,
         quantity: row.quantity,
         externalCode: row.externalCode,
-        supplierUrl: extractSupplierLink(row.internalNote).url,
+        supplierUrl: resolveEffectiveSupplierLink(row.internalNote, row.supplierLinkOverride).url,
       });
     } else {
       byCode.set(row.variantCode, { ...existing, quantity: existing.quantity + row.quantity });

--- a/apps/api/src/modules/orders/queries.ts
+++ b/apps/api/src/modules/orders/queries.ts
@@ -3,13 +3,14 @@ import type { Database } from "../../db/client.js";
 import {
   orderLines,
   orders,
+  productSupplierLinkOverrides,
   productSupplierOverrides,
   products,
   supplierContacts,
   variants,
   type OrderLineState,
 } from "../../db/schema.js";
-import { extractSupplierLink } from "../catalog/supplier-link.js";
+import { resolveEffectiveSupplierLink } from "./effective-supplier-link.js";
 import { listOpenStatusNames } from "./open-statuses.js";
 import { effectiveSupplierSql, normalizedSupplierKeySql, normalizeSupplierKeyJs, pickCanonicalSupplierSpelling } from "./supplier-key.js";
 
@@ -143,6 +144,7 @@ export async function listOpenOrderLinesBySupplier(
       effectiveSupplier: effectiveSupplierSql,
       overrideSupplier: productSupplierOverrides.supplier,
       internalNote: products.internalNote,
+      supplierLinkOverride: productSupplierLinkOverrides.url,
       externalCode: variants.externalCode,
     })
     .from(orderLines)
@@ -150,6 +152,7 @@ export async function listOpenOrderLinesBySupplier(
     .innerJoin(variants, eq(variants.code, orderLines.variantCode))
     .innerJoin(products, eq(products.key, variants.productKey))
     .leftJoin(productSupplierOverrides, eq(productSupplierOverrides.productKey, products.key))
+    .leftJoin(productSupplierLinkOverrides, eq(productSupplierLinkOverrides.productKey, products.key))
     .where(inArray(orders.statusName, [...openStatuses]))
     // Sekundárne triedenie podľa najnovšej objednávky ako prvej v rámci
     // dodávateľa — rovnaký zámer ako katalógov `desc(fetchedAt), desc(id)`
@@ -172,7 +175,7 @@ export async function listOpenOrderLinesBySupplier(
   }
   const bySupplier = new Map<string, GroupAccumulator>();
   for (const row of rows) {
-    const supplierLink = extractSupplierLink(row.internalNote);
+    const supplierLink = resolveEffectiveSupplierLink(row.internalNote, row.supplierLinkOverride);
     const catalogSupplierIsNull = row.catalogSupplier === null;
     const line: OpenOrderLine = {
       lineId: row.lineId,
@@ -339,12 +342,14 @@ export async function getOrderDetail(db: Database, id: string): Promise<OrderDet
       state: orderLines.state,
       ordered: orderLines.ordered,
       internalNote: products.internalNote,
+      supplierLinkOverride: productSupplierLinkOverrides.url,
       externalCode: variants.externalCode,
     })
     .from(orderLines)
     .innerJoin(variants, eq(variants.code, orderLines.variantCode))
     .innerJoin(products, eq(products.key, variants.productKey))
     .leftJoin(productSupplierOverrides, eq(productSupplierOverrides.productKey, products.key))
+    .leftJoin(productSupplierLinkOverrides, eq(productSupplierLinkOverrides.productKey, products.key))
     .where(eq(orderLines.orderId, id))
     // issue 63: `effectiveSupplier` (override-aware) nahradilo priame
     // `products.supplier` v `ORDER BY` — poradie riadkov v detaile objednávky
@@ -359,7 +364,7 @@ export async function getOrderDetail(db: Database, id: string): Promise<OrderDet
     comment: order.comment,
     placedAt: order.placedAt.toISOString(),
     lines: lineRows.map((row) => {
-      const supplierLink = extractSupplierLink(row.internalNote);
+      const supplierLink = resolveEffectiveSupplierLink(row.internalNote, row.supplierLinkOverride);
       return {
         lineId: row.lineId,
         variantCode: row.variantCode,

--- a/apps/api/src/modules/orders/supplier-link-assignment.ts
+++ b/apps/api/src/modules/orders/supplier-link-assignment.ts
@@ -1,0 +1,78 @@
+import { eq } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { orderLines, productSupplierLinkOverrides, variants } from "../../db/schema.js";
+import { record } from "../audit/service.js";
+
+export type SetProductSupplierLinkResult = "ok" | "not_found";
+
+export interface SetProductSupplierLinkInput {
+  readonly lineId: string;
+  // Už orezané + validované ako URL — `zValidator` na HTTP hranici
+  // (`z.string().trim().url()`, `orders-routes.ts`).
+  readonly url: string;
+  readonly actorUserId: string;
+  readonly now: Date;
+}
+
+// issue 121: majiteľ, doslovne "pri kazdom produkte ma byt moznost upravit
+// link na dodavatela ktory sa potom cez sync na shoptet doplni". Priamy
+// náprotivok `assignOrderLineSupplier` (`supplier-assignment.ts`) — rovnaké
+// "prijmi lineId, server si sám dopočíta productKey" API (frontend nikdy
+// nepotrebuje poznať `productKey` priamo), rovnaký jednoduchý upsert + audit
+// v JEDNEJ transakcii bez `.for("update")` naviac (rovnaké zdôvodnenie:
+// nízkofrekventovaná ručná akcia, posledný zápis vyhráva, Postgres
+// `onConflictDoUpdate` je aj tak atomický).
+//
+// NA ROZDIEL od `assignOrderLineSupplier` tu ale NIE JE žiadna "už má
+// hodnotu" 409 gate — `product_supplier_override` smie manažér priradiť LEN
+// keď katalóg pole nemá (`supplierAssignable`), ale odkaz na dodávateľa smie
+// upraviť VŽDY, aj keď Shoptet už jeden odkaz uvádza (ticket to žiada
+// explicitne: "pri KAŽDOM produkte" — majiteľ opravuje ZLÉ/zastarané odkazy
+// rovnako často ako dopĺňa chýbajúce). Preto tu stačí overiť len existenciu
+// riadku (`not_found`), nie stav katalógového poľa.
+export async function setProductSupplierLink(
+  db: Database,
+  input: SetProductSupplierLinkInput,
+): Promise<SetProductSupplierLinkResult> {
+  return db.transaction(async (tx) => {
+    const [line] = await tx
+      .select({ productKey: variants.productKey })
+      .from(orderLines)
+      .innerJoin(variants, eq(variants.code, orderLines.variantCode))
+      .where(eq(orderLines.id, input.lineId))
+      .limit(1);
+    if (line === undefined) return "not_found";
+
+    const [previous] = await tx
+      .select({ url: productSupplierLinkOverrides.url })
+      .from(productSupplierLinkOverrides)
+      .where(eq(productSupplierLinkOverrides.productKey, line.productKey))
+      .limit(1);
+
+    await tx
+      .insert(productSupplierLinkOverrides)
+      .values({ productKey: line.productKey, url: input.url, updatedAt: input.now })
+      .onConflictDoUpdate({
+        target: productSupplierLinkOverrides.productKey,
+        set: { url: input.url, updatedAt: input.now },
+      });
+
+    // Audit nesie AJ pôvodnú hodnotu (kto/kedy/z čoho/na čo — ticketova
+    // akceptačná podmienka), `null` keď doteraz žiadna nebola nastavená.
+    await record(tx, {
+      at: input.now,
+      actorUserId: input.actorUserId,
+      action: "product_supplier_link_override.changed",
+      entity: "product_supplier_link_override",
+      entityId: line.productKey,
+      data: {
+        productKey: line.productKey,
+        lineId: input.lineId,
+        previousUrl: previous?.url ?? null,
+        newUrl: input.url,
+      },
+    });
+
+    return "ok";
+  });
+}

--- a/apps/api/tests/orders-supplier-link-assignment.integration.test.ts
+++ b/apps/api/tests/orders-supplier-link-assignment.integration.test.ts
@@ -1,0 +1,297 @@
+import { eq, sql } from "drizzle-orm";
+import { afterEach, expect, it } from "vitest";
+import { orderLines, orders, productSupplierLinkOverrides, products, users } from "../src/db/schema.js";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import type { UserRole } from "../src/modules/auth/service.js";
+import { insertTestVariant, insertTestVariantForProduct } from "./helpers/orders.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 121: manuálny odkaz na dodávateľa — perzistencia
+// (`product_supplier_link_override`), prednosť pred `internalNote` odkazom,
+// propagácia na SÚRODENECKÉ riadky toho istého produktu, a to, že (na
+// rozdiel od `orders-supplier-assignment.integration.test.ts`) sa smie
+// upraviť AJ riadok, ktorý už odkaz má. Vlastný súbor — rovnaký vzor ako
+// `orders-supplier-assignment.integration.test.ts` (`.claude/rules/testing.md`).
+
+const HESLO = "test-heslo-abc"; // testovacie údaje, nie tajomstvo
+
+let close: (() => Promise<void>) | undefined;
+
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  resetLoginRateLimit();
+});
+
+async function boot(role: UserRole) {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const [pouzivatel] = await ctx.db
+    .insert(users)
+    .values({ email: "manazer@forestshop.sk", passwordHash: await hashPassword(HESLO), displayName: "Manažér", role })
+    .returning({ id: users.id });
+  if (pouzivatel === undefined) throw new Error("testovací používateľ sa nepodarilo vložiť");
+
+  const app = createApp(ctx.db, { cookieSecure: false });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "manazer@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie, db: ctx.db };
+}
+
+interface OpenTelo {
+  readonly suppliers: {
+    readonly supplier: string;
+    readonly lines: {
+      readonly lineId: string;
+      readonly variantCode: string;
+      readonly supplierUrl: string | null;
+    }[];
+  }[];
+}
+
+it("doplnenie odkazu riadku bez odkazu sa uloží a prežije opätovné načítanie", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await insertTestVariant(db, "L-A", "Dodávateľ A");
+  const [objednavka] = await db
+    .insert(orders)
+    .values({ externalOrderId: "7001", customerName: "Zákazník", placedAt: new Date("2026-07-01T00:00:00Z") })
+    .returning();
+  if (objednavka === undefined) throw new Error("insert zlyhal");
+  const [line] = await db.insert(orderLines).values({ orderId: objednavka.id, variantCode: "L-A", quantity: 1 }).returning();
+  if (line === undefined) throw new Error("insert zlyhal");
+
+  const predTelo = (await (await app.request("/api/orders/open", { headers: { cookie } })).json()) as OpenTelo;
+  expect(predTelo.suppliers[0]?.lines[0]?.supplierUrl).toBeNull();
+
+  const res = await app.request(`/api/orders/lines/${line.id}/supplier-link`, {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ url: "https://dodavatel.example.com/produkt" }),
+  });
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ ok: true, url: "https://dodavatel.example.com/produkt" });
+
+  const poTelo = (await (await app.request("/api/orders/open", { headers: { cookie } })).json()) as OpenTelo;
+  expect(poTelo.suppliers[0]?.lines[0]?.supplierUrl).toBe("https://dodavatel.example.com/produkt");
+});
+
+// issue 121: NA ROZDIEL od priradenia dodávateľa (#63, 409 keď katalóg už má
+// hodnotu) tu žiadna gate neexistuje — odkaz sa smie upraviť AJ keď Shoptet
+// (`internalNote`) už jeden poskytuje. Naša hodnota má VŽDY prednosť.
+it("úprava riadku, ktorý UŽ má odkaz zo Shoptetu, uloží novú hodnotu bez 409 a prepíše zobrazenú hodnotu", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await insertTestVariant(db, "L-B", "Dodávateľ B", { internalNote: "https://stary-odkaz.example.com/x" });
+  const [objednavka] = await db
+    .insert(orders)
+    .values({ externalOrderId: "7002", customerName: "Zákazník", placedAt: new Date("2026-07-02T00:00:00Z") })
+    .returning();
+  if (objednavka === undefined) throw new Error("insert zlyhal");
+  const [line] = await db.insert(orderLines).values({ orderId: objednavka.id, variantCode: "L-B", quantity: 1 }).returning();
+  if (line === undefined) throw new Error("insert zlyhal");
+
+  const predTelo = (await (await app.request("/api/orders/open", { headers: { cookie } })).json()) as OpenTelo;
+  expect(predTelo.suppliers[0]?.lines[0]?.supplierUrl).toBe("https://stary-odkaz.example.com/x");
+
+  const res = await app.request(`/api/orders/lines/${line.id}/supplier-link`, {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ url: "https://novy-odkaz.example.com/y" }),
+  });
+  expect(res.status).toBe(200);
+
+  const poTelo = (await (await app.request("/api/orders/open", { headers: { cookie } })).json()) as OpenTelo;
+  expect(poTelo.suppliers[0]?.lines[0]?.supplierUrl).toBe("https://novy-odkaz.example.com/y");
+});
+
+it("úprava odkazu cez JEDNU veľkosť produktu platí aj pre INÚ veľkosť toho istého produktu", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await insertTestVariantForProduct(db, "PROD-LINK", "PROD-LINK/S", { sizeLabel: "S" });
+  await insertTestVariantForProduct(db, "PROD-LINK", "PROD-LINK/M", { sizeLabel: "M" });
+  const [objednavka] = await db
+    .insert(orders)
+    .values({ externalOrderId: "7003", customerName: "Zákazník", placedAt: new Date("2026-07-03T00:00:00Z") })
+    .returning();
+  if (objednavka === undefined) throw new Error("insert zlyhal");
+  const [lineS] = await db
+    .insert(orderLines)
+    .values({ orderId: objednavka.id, variantCode: "PROD-LINK/S", quantity: 1 })
+    .returning();
+  if (lineS === undefined) throw new Error("insert zlyhal");
+  await db.insert(orderLines).values({ orderId: objednavka.id, variantCode: "PROD-LINK/M", quantity: 1 });
+
+  await app.request(`/api/orders/lines/${lineS.id}/supplier-link`, {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ url: "https://dodavatel.example.com/produkt-x" }),
+  });
+
+  const telo = (await (await app.request("/api/orders/open", { headers: { cookie } })).json()) as OpenTelo;
+  const skupina = telo.suppliers.find((s) => s.lines.some((l) => l.variantCode.startsWith("PROD-LINK")));
+  expect(skupina?.lines.map((l) => l.variantCode).sort()).toEqual(["PROD-LINK/M", "PROD-LINK/S"]);
+  expect(skupina?.lines.every((l) => l.supplierUrl === "https://dodavatel.example.com/produkt-x")).toBe(true);
+});
+
+it("úprava odkazu zapíše audit záznam s pôvodnou aj novou hodnotou", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await insertTestVariant(db, "L-AUDIT", "Dodávateľ", { internalNote: "https://stary.example.com" });
+  const [objednavka] = await db
+    .insert(orders)
+    .values({ externalOrderId: "7004", customerName: "Zákazník", placedAt: new Date("2026-07-04T00:00:00Z") })
+    .returning();
+  if (objednavka === undefined) throw new Error("insert zlyhal");
+  const [line] = await db.insert(orderLines).values({ orderId: objednavka.id, variantCode: "L-AUDIT", quantity: 1 }).returning();
+  if (line === undefined) throw new Error("insert zlyhal");
+
+  await app.request(`/api/orders/lines/${line.id}/supplier-link`, {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ url: "https://novy.example.com" }),
+  });
+
+  const [override] = await db
+    .select()
+    .from(productSupplierLinkOverrides)
+    .where(eq(productSupplierLinkOverrides.productKey, "L-AUDIT"));
+  expect(override?.url).toBe("https://novy.example.com");
+});
+
+// issue 121: ticketova akceptačná podmienka "opakovaný import katalógu ho
+// NEPREPÍŠE" — reprodukuje PRESNE ten istý upsert tvar ako `catalog/ingest.ts`
+// (`onConflictDoUpdate({ target: products.key, set: { ... internalNote:
+// sql\`excluded.internal_note\` ... } })`), nie len znovu-insert. Katalógový
+// re-import NIKDY nemaže/znovu-vkladá `product` riadok (`ON CONFLICT
+// UPDATE` na tom istom `key`), takže FK z `product_supplier_link_override`
+// (`ON DELETE CASCADE`) sa nikdy neaktivuje — override prežije AJ keď
+// Shoptet medzitým prinesie ÚPLNE INÝ `internalNote`.
+it("opakovaný katalógový re-import (upsert na product.key) NEPREPÍŠE uložený odkaz", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await insertTestVariant(db, "L-REIMPORT", "Dodávateľ", { internalNote: "https://povodny-shoptet-odkaz.example.com" });
+  const [objednavka] = await db
+    .insert(orders)
+    .values({ externalOrderId: "7007", customerName: "Zákazník", placedAt: new Date("2026-07-07T00:00:00Z") })
+    .returning();
+  if (objednavka === undefined) throw new Error("insert zlyhal");
+  const [line] = await db.insert(orderLines).values({ orderId: objednavka.id, variantCode: "L-REIMPORT", quantity: 1 }).returning();
+  if (line === undefined) throw new Error("insert zlyhal");
+
+  await app.request(`/api/orders/lines/${line.id}/supplier-link`, {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ url: "https://nas-ulozeny-odkaz.example.com" }),
+  });
+
+  // Simuluje nočný re-import: rovnaký `onConflictDoUpdate` tvar ako
+  // `ingest.ts`, so ÚPLNE NOVÝM `internalNote` zo Shoptetu (nová hodnota
+  // dokazuje, že re-import SKUTOČNE prebehol, nielen no-op).
+  const [existujuciProdukt] = await db.select().from(products).where(eq(products.key, "L-REIMPORT")).limit(1);
+  if (existujuciProdukt === undefined) throw new Error("produkt sa nenašiel");
+  await db
+    .insert(products)
+    .values({
+      key: "L-REIMPORT",
+      name: "Test produkt L-REIMPORT",
+      supplier: "Dodávateľ",
+      internalNote: "https://novy-shoptet-odkaz-po-reimporte.example.com",
+      firstSeenAt: new Date("2026-01-01T00:00:00Z"),
+      lastSeenAt: new Date("2026-07-08T00:00:00Z"),
+      lastSeenSnapshotId: existujuciProdukt.lastSeenSnapshotId,
+    })
+    .onConflictDoUpdate({
+      target: products.key,
+      set: {
+        name: sql`excluded.name`,
+        supplier: sql`excluded.supplier`,
+        internalNote: sql`excluded.internal_note`,
+        lastSeenAt: sql`excluded.last_seen_at`,
+      },
+    });
+
+  const override = await db
+    .select()
+    .from(productSupplierLinkOverrides)
+    .where(eq(productSupplierLinkOverrides.productKey, "L-REIMPORT"));
+  expect(override).toHaveLength(1);
+  expect(override[0]?.url).toBe("https://nas-ulozeny-odkaz.example.com");
+
+  const [produkt] = await db.select().from(products).where(eq(products.key, "L-REIMPORT"));
+  expect(produkt?.internalNote).toBe("https://novy-shoptet-odkaz-po-reimporte.example.com");
+
+  const telo = (await (await app.request("/api/orders/open", { headers: { cookie } })).json()) as OpenTelo;
+  expect(telo.suppliers[0]?.lines[0]?.supplierUrl).toBe("https://nas-ulozeny-odkaz.example.com");
+});
+
+it("úprava neznámeho riadku vráti 404", async () => {
+  const { app, cookie } = await boot("manazer");
+  const res = await app.request("/api/orders/lines/11111111-1111-1111-1111-111111111111/supplier-link", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ url: "https://dodavatel.example.com" }),
+  });
+  expect(res.status).toBe(404);
+});
+
+it("neplatná URL vráti 400 (validácia)", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await insertTestVariant(db, "L-C", "Dodávateľ");
+  const [objednavka] = await db
+    .insert(orders)
+    .values({ externalOrderId: "7005", customerName: "Zákazník", placedAt: new Date("2026-07-05T00:00:00Z") })
+    .returning();
+  if (objednavka === undefined) throw new Error("insert zlyhal");
+  const [line] = await db.insert(orderLines).values({ orderId: objednavka.id, variantCode: "L-C", quantity: 1 }).returning();
+  if (line === undefined) throw new Error("insert zlyhal");
+
+  const res = await app.request(`/api/orders/lines/${line.id}/supplier-link`, {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ url: "nie je url" }),
+  });
+  expect(res.status).toBe(400);
+});
+
+// issue 121: `.url()` samo osebe by prijalo aj syntakticky platnú, ale
+// nebezpečnú schému (hodnota ide priamo do `<a href>`) — server-strana MUSÍ
+// navyše vynútiť http(s), nespoliehať sa len na frontendovú vrstvu.
+it("URL s inou ako http(s) schémou vráti 400 (validácia)", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await insertTestVariant(db, "L-SCHEME", "Dodávateľ");
+  const [objednavka] = await db
+    .insert(orders)
+    .values({ externalOrderId: "7008", customerName: "Zákazník", placedAt: new Date("2026-07-08T00:00:00Z") })
+    .returning();
+  if (objednavka === undefined) throw new Error("insert zlyhal");
+  const [line] = await db.insert(orderLines).values({ orderId: objednavka.id, variantCode: "L-SCHEME", quantity: 1 }).returning();
+  if (line === undefined) throw new Error("insert zlyhal");
+
+  const res = await app.request(`/api/orders/lines/${line.id}/supplier-link`, {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ url: "javascript:alert(1)" }),
+  });
+  expect(res.status).toBe(400);
+});
+
+it("rola citanie nesmie upraviť odkaz na dodávateľa (403)", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  await insertTestVariant(db, "L-D", "Dodávateľ");
+  const [objednavka] = await db
+    .insert(orders)
+    .values({ externalOrderId: "7006", customerName: "Zákazník", placedAt: new Date("2026-07-06T00:00:00Z") })
+    .returning();
+  if (objednavka === undefined) throw new Error("insert zlyhal");
+  const [line] = await db.insert(orderLines).values({ orderId: objednavka.id, variantCode: "L-D", quantity: 1 }).returning();
+  if (line === undefined) throw new Error("insert zlyhal");
+
+  const res = await app.request(`/api/orders/lines/${line.id}/supplier-link`, {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ url: "https://dodavatel.example.com" }),
+  });
+  expect(res.status).toBe(403);
+});

--- a/apps/api/tests/orders-supplier-link-assignment.integration.test.ts
+++ b/apps/api/tests/orders-supplier-link-assignment.integration.test.ts
@@ -81,6 +81,65 @@ it("doplnenie odkazu riadku bez odkazu sa uloží a prežije opätovné načíta
   expect(poTelo.suppliers[0]?.lines[0]?.supplierUrl).toBe("https://dodavatel.example.com/produkt");
 });
 
+// issue 121 (review of PR 138, coverage gap): `resolveEffectiveSupplierLink`
+// je zdieľaná ČISTÁ funkcia použitá na TROCH čítacích cestách
+// (`listOpenOrderLinesBySupplier`, `getOrderDetail`, `mail.ts`'s
+// `loadOutstandingLines`) — vyššie overený `/api/orders/open` je len JEDNA
+// z nich. Tento test dokazuje DRUHÚ (`GET /api/orders/:id`), rovnakým
+// vzorom ako existujúci `orders-http.integration.test.ts`'s "detail
+// objednávky nesie odkaz na dodávateľa aj kód dodávateľa" test.
+it("detail objednávky (GET /api/orders/:id) tiež zobrazí uložený odkaz namiesto odkazu zo Shoptetu", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await insertTestVariant(db, "L-DETAIL", "Dodávateľ", { internalNote: "https://stary-detail.example.com" });
+  const [objednavka] = await db
+    .insert(orders)
+    .values({ externalOrderId: "7009", customerName: "Zákazník", placedAt: new Date("2026-07-09T00:00:00Z") })
+    .returning();
+  if (objednavka === undefined) throw new Error("insert zlyhal");
+  const [line] = await db.insert(orderLines).values({ orderId: objednavka.id, variantCode: "L-DETAIL", quantity: 1 }).returning();
+  if (line === undefined) throw new Error("insert zlyhal");
+
+  await app.request(`/api/orders/lines/${line.id}/supplier-link`, {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ url: "https://novy-detail.example.com" }),
+  });
+
+  const detailRes = await app.request(`/api/orders/${objednavka.id}`, { headers: { cookie } });
+  const detail = (await detailRes.json()) as { lines: { supplierUrl: string | null }[] };
+  expect(detail.lines[0]?.supplierUrl).toBe("https://novy-detail.example.com");
+});
+
+// issue 121 (review of PR 138, coverage gap): TRETIA čítacia cesta —
+// dodávateľský mailový náhľad (`mail.ts`'s `loadOutstandingLines` cez
+// `buildSupplierOrderMailContent`) musí tiež niesť uložený odkaz, nie
+// odkaz zo Shoptetu — inak by appka poslala dodávateľovi zastaraný/zlý
+// odkaz napriek tomu, že ho manažér práve opravil.
+it("mailový náhľad objednávky dodávateľovi (GET .../order-mail) tiež nesie uložený odkaz", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await insertTestVariant(db, "L-MAIL", "Dodávateľ Mailový", { internalNote: "https://stary-mail.example.com" });
+  const [objednavka] = await db
+    .insert(orders)
+    .values({ externalOrderId: "7010", customerName: "Zákazník", placedAt: new Date("2026-07-10T00:00:00Z") })
+    .returning();
+  if (objednavka === undefined) throw new Error("insert zlyhal");
+  const [line] = await db.insert(orderLines).values({ orderId: objednavka.id, variantCode: "L-MAIL", quantity: 1 }).returning();
+  if (line === undefined) throw new Error("insert zlyhal");
+
+  await app.request(`/api/orders/lines/${line.id}/supplier-link`, {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ url: "https://novy-mail.example.com" }),
+  });
+
+  const mailRes = await app.request(`/api/suppliers/${encodeURIComponent("Dodávateľ Mailový")}/order-mail`, {
+    headers: { cookie },
+  });
+  const preview = (await mailRes.json()) as { body: string };
+  expect(preview.body).toContain("https://novy-mail.example.com");
+  expect(preview.body).not.toContain("https://stary-mail.example.com");
+});
+
 // issue 121: NA ROZDIEL od priradenia dodávateľa (#63, 409 keď katalóg už má
 // hodnotu) tu žiadna gate neexistuje — odkaz sa smie upraviť AJ keď Shoptet
 // (`internalNote`) už jeden poskytuje. Naša hodnota má VŽDY prednosť.

--- a/apps/web/src/components/OrderLineRow.supplierLinkEditCell.test.tsx
+++ b/apps/web/src/components/OrderLineRow.supplierLinkEditCell.test.tsx
@@ -1,0 +1,152 @@
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { OrdersSection } from "./OrdersSection.js";
+
+// issue 121: majiteľ, doslovne "ak na produkt nie je odkaz na dodavatela, tak
+// tam ma byt moznost ho doplnit... pri kazdom produkte ma byt moznost upravit
+// link". Vlastný súbor — rovnaký vzor ako `OrderLineRow.supplierAssignCell
+// .test.tsx` (`.claude/rules/frontend-design.md`).
+const { fetchOpenOrders, setProductSupplierLink } = vi.hoisted(() => ({
+  fetchOpenOrders: vi.fn(),
+  setProductSupplierLink: vi.fn(),
+}));
+
+vi.mock("../ordersApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../ordersApi.js")>();
+  return { ...actual, fetchOpenOrders, setProductSupplierLink };
+});
+
+const ZAKLAD = {
+  orderId: "cccccccc-0000-0000-0000-000000000000",
+  externalOrderId: "20261400",
+  customerName: "Zákazník Epsilon",
+  comment: null,
+  remark: null,
+  adminUrl: "https://www.forestshop.sk/admin/vyhladavanie/?string=20261400&src=orders",
+  placedAt: "2026-07-01T00:00:00.000Z",
+  variantCode: "E-1",
+  variantName: "Šál FOREST 5001",
+  sizeLabel: null,
+  quantity: 1,
+  state: "objednane" as const,
+  ordered: false,
+  supplierNote: null,
+  externalCode: null,
+  supplierAssignable: false,
+  manualSupplierOverride: null,
+};
+
+const RIADOK_BEZ_ODKAZU = { ...ZAKLAD, lineId: "11111111-0000-0000-0000-000000000010", supplierUrl: null };
+const RIADOK_S_ODKAZOM = {
+  ...ZAKLAD,
+  lineId: "11111111-0000-0000-0000-000000000011",
+  externalOrderId: "20261401",
+  supplierUrl: "https://dodavatel.example.com/produkt",
+};
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+it("riadok BEZ odkazu ponúka 'doplniť'; otvorenie zobrazí prázdny vstup", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [RIADOK_BEZ_ODKAZU], email: null }]);
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const riadok = await screen.findByTestId(`order-line-${RIADOK_BEZ_ODKAZU.lineId}`);
+  const toggle = within(riadok).getByLabelText(
+    `Doplniť odkaz na dodávateľa — ${RIADOK_BEZ_ODKAZU.variantName} (${RIADOK_BEZ_ODKAZU.variantCode})`,
+  );
+  expect(within(riadok).queryByTestId(`supplier-link-edit-${RIADOK_BEZ_ODKAZU.lineId}`)).toBeNull();
+
+  fireEvent.click(toggle);
+
+  const vstup = within(riadok).getByTestId<HTMLInputElement>(`supplier-link-edit-input-${RIADOK_BEZ_ODKAZU.lineId}`);
+  expect(vstup.value).toBe("");
+});
+
+it("riadok S odkazom ponúka 'upraviť'; otvorenie predvyplní vstup AKTUÁLNYM odkazom", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [RIADOK_S_ODKAZOM], email: null }]);
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const riadok = await screen.findByTestId(`order-line-${RIADOK_S_ODKAZOM.lineId}`);
+  const toggle = within(riadok).getByLabelText(
+    `Upraviť odkaz na dodávateľa — ${RIADOK_S_ODKAZOM.variantName} (${RIADOK_S_ODKAZOM.variantCode})`,
+  );
+
+  fireEvent.click(toggle);
+
+  const vstup = within(riadok).getByTestId<HTMLInputElement>(`supplier-link-edit-input-${RIADOK_S_ODKAZOM.lineId}`);
+  expect(vstup.value).toBe(RIADOK_S_ODKAZOM.supplierUrl);
+});
+
+it("uloženie zavolá setProductSupplierLink so správnym lineId a URL, a zavrie panel", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [RIADOK_BEZ_ODKAZU], email: null }]);
+  setProductSupplierLink.mockResolvedValue(undefined);
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const riadok = await screen.findByTestId(`order-line-${RIADOK_BEZ_ODKAZU.lineId}`);
+  fireEvent.click(
+    within(riadok).getByLabelText(
+      `Doplniť odkaz na dodávateľa — ${RIADOK_BEZ_ODKAZU.variantName} (${RIADOK_BEZ_ODKAZU.variantCode})`,
+    ),
+  );
+  const vstup = within(riadok).getByTestId<HTMLInputElement>(`supplier-link-edit-input-${RIADOK_BEZ_ODKAZU.lineId}`);
+  fireEvent.change(vstup, { target: { value: "https://novy-dodavatel.example.com/x" } });
+  expect(vstup.value).toBe("https://novy-dodavatel.example.com/x");
+  fireEvent.click(within(riadok).getByTestId(`supplier-link-edit-save-${RIADOK_BEZ_ODKAZU.lineId}`));
+
+  await waitFor(() => {
+    expect(setProductSupplierLink).toHaveBeenCalledWith(
+      RIADOK_BEZ_ODKAZU.lineId,
+      "https://novy-dodavatel.example.com/x",
+    );
+  });
+  expect(within(riadok).queryByTestId(`supplier-link-edit-${RIADOK_BEZ_ODKAZU.lineId}`)).toBeNull();
+  // issue 121: PLNÝ refetch po úspechu (rovnaký dôvod ako priradenie
+  // dodávateľa — zmena môže zasiahnuť súrodenecké veľkosti toho istého
+  // produktu).
+  await waitFor(() => {
+    expect(fetchOpenOrders).toHaveBeenCalledTimes(2);
+  });
+});
+
+it("zlyhanie uloženia zobrazí slovenskú hlášku", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [RIADOK_BEZ_ODKAZU], email: null }]);
+  setProductSupplierLink.mockRejectedValue(new Error("Uloženie odkazu na dodávateľa sa nepodarilo"));
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const riadok = await screen.findByTestId(`order-line-${RIADOK_BEZ_ODKAZU.lineId}`);
+  fireEvent.click(
+    within(riadok).getByLabelText(
+      `Doplniť odkaz na dodávateľa — ${RIADOK_BEZ_ODKAZU.variantName} (${RIADOK_BEZ_ODKAZU.variantCode})`,
+    ),
+  );
+  const vstup = within(riadok).getByTestId<HTMLInputElement>(`supplier-link-edit-input-${RIADOK_BEZ_ODKAZU.lineId}`);
+  fireEvent.change(vstup, { target: { value: "https://zly-odkaz.example.com" } });
+  fireEvent.click(within(riadok).getByTestId(`supplier-link-edit-save-${RIADOK_BEZ_ODKAZU.lineId}`));
+
+  await waitFor(() => {
+    expect(screen.getByRole("alert").textContent).toBe("Uloženie odkazu na dodávateľa sa nepodarilo");
+  });
+});
+
+it("kliknutie na toggle znova (zrušiť) zavrie panel bez volania API", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [RIADOK_BEZ_ODKAZU], email: null }]);
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const riadok = await screen.findByTestId(`order-line-${RIADOK_BEZ_ODKAZU.lineId}`);
+  const toggle = within(riadok).getByLabelText(
+    `Doplniť odkaz na dodávateľa — ${RIADOK_BEZ_ODKAZU.variantName} (${RIADOK_BEZ_ODKAZU.variantCode})`,
+  );
+  fireEvent.click(toggle);
+  expect(within(riadok).queryByTestId(`supplier-link-edit-${RIADOK_BEZ_ODKAZU.lineId}`)).not.toBeNull();
+
+  fireEvent.click(
+    within(riadok).getByLabelText(
+      `Zrušiť úpravu odkazu na dodávateľa — ${RIADOK_BEZ_ODKAZU.variantName} (${RIADOK_BEZ_ODKAZU.variantCode})`,
+    ),
+  );
+  expect(within(riadok).queryByTestId(`supplier-link-edit-${RIADOK_BEZ_ODKAZU.lineId}`)).toBeNull();
+  expect(setProductSupplierLink).not.toHaveBeenCalled();
+});

--- a/apps/web/src/components/OrderLineRow.tsx
+++ b/apps/web/src/components/OrderLineRow.tsx
@@ -25,10 +25,12 @@ export function OrderLineRow({
   supplierBusy,
   variantTotal,
   busySupplierLineId,
+  busySupplierLinkLineId,
   busyCommentOrderId,
   onChangeState,
   onChangeOrdered,
   onAssignSupplier,
+  onSetSupplierLink,
   onChangeComment,
 }: {
   readonly line: OrderLine;
@@ -53,12 +55,19 @@ export function OrderLineRow({
   // issue 63: riadok, ktorého ručné priradenie dodávateľa PRÁVE TERAZ ukladá
   // (needitovateľné, kým sa neskončí).
   readonly busySupplierLineId: string | null;
+  // issue 121: riadok, ktorého odkaz na dodávateľa PRÁVE TERAZ ukladá —
+  // nezávislé od `busySupplierLineId` vyššie (iný zápis, iná trasa).
+  readonly busySupplierLinkLineId: string | null;
   // issue 64: objednávka (nie riadok — poznámka patrí CELEJ objednávke),
   // ktorej poznámka PRÁVE TERAZ ukladá.
   readonly busyCommentOrderId: string | null;
   readonly onChangeState: (lineId: string, newState: OrderLine["state"]) => void;
   readonly onChangeOrdered: (lineId: string, ordered: boolean) => void;
   readonly onAssignSupplier: (lineId: string, supplier: string) => void;
+  // issue 121: manuálny odkaz na dodávateľa — smie sa upraviť pri KAŽDOM
+  // riadku (na rozdiel od `onAssignSupplier`, ktorý je len pre riadky bez
+  // katalógového dodávateľa).
+  readonly onSetSupplierLink: (lineId: string, url: string) => void;
   readonly onChangeComment: (orderId: string, comment: string | null) => void;
 }): JSX.Element {
   const qtyChip = variantTotal !== undefined ? formatVariantTotalChip(variantTotal) : null;
@@ -92,6 +101,32 @@ export function OrderLineRow({
     const trimmed = supplierDraft.trim();
     if (trimmed === "") return;
     onAssignSupplier(line.lineId, trimmed);
+  };
+
+  // issue 121: TOGGLE (nie trvalo viditeľný vstup ako `supplierDraft`
+  // vyššie) — draft sa prednaplní ČERSTVOU `line.supplierUrl` hodnotou pri
+  // KAŽDOM otvorení (nie udržiavaný cez `useEffect`), takže nehrozí rovnaký
+  // "reset pri prvom mounte"/pretek, aký `supplierDraft`/`commentDraft` museli
+  // riešiť guardom (`.claude/rules/frontend-design.md`). Zavretie panelu je
+  // OPTIMISTICKÉ (hneď pri kliku na Uložiť) — jednoduchšie než čakať na
+  // potvrdenie servera, a pri zlyhaní ostáva chyba viditeľná v `stateError`
+  // banneri, manažér otvorí úpravu znova.
+  const [linkEditing, setLinkEditing] = useState(false);
+  const [linkDraft, setLinkDraft] = useState("");
+  const linkBusyHere = busySupplierLinkLineId === line.lineId;
+  const toggleLinkEditing = (): void => {
+    if (linkEditing) {
+      setLinkEditing(false);
+      return;
+    }
+    setLinkDraft(line.supplierUrl ?? "");
+    setLinkEditing(true);
+  };
+  const saveLink = (): void => {
+    const trimmed = linkDraft.trim();
+    if (trimmed === "") return;
+    onSetSupplierLink(line.lineId, trimmed);
+    setLinkEditing(false);
   };
 
   // issue 64: rovnaký "controlled draft, resetovaný z props po uložení"
@@ -182,55 +217,112 @@ export function OrderLineRow({
           (rovnaké testid, rovnaká logika), len vedľa seba v jednej `<td>`
           namiesto dvoch samostatných stĺpcov. */}
       <td className="ord-supplier-merged">
-        <div className="ord-supplier-cell" data-testid={`supplier-link-${line.lineId}`}>
-          {line.supplierUrl !== null ? (
-            // issue 119: majiteľ, doslovne "zmen na nejake tlacitko z ikonou
-            // ktore otvori na novom okne ten link, lebo teraz to je tazke
-            // stlacit" — textový odkaz nahradený veľkým ikonovým tlačidlom
-            // (`.ord-supplier-link` v `app.css` teraz štylizuje `<a>` ako
-            // tlačidlo, min. 36×36px klikacej plochy). `aria-label`/`title`
-            // nesú ten istý popis ako predtým (issue 72: variantName sám
-            // nestačí — dva riadky toho istého produktu v rôznych veľkostiach
-            // majú zhodný variantName, líšia sa len variantCode), viditeľný
-            // text je teraz len ikonka (`aria-hidden`, prístupné meno nesie
-            // výlučne `aria-label`).
-            <a
-              href={line.supplierUrl}
-              target="_blank"
-              rel="noreferrer noopener"
-              className="ord-supplier-link"
-              aria-label={`Odkaz na dodávateľa — ${line.variantName} (${line.variantCode})`}
-              title={`Otvoriť odkaz na dodávateľa — ${line.variantName} (${line.variantCode})`}
-            >
-              <span aria-hidden="true">🔗</span>
-            </a>
-          ) : line.supplierNote !== null ? (
-            <span className="ord-supplier-note" title={line.supplierNote}>
-              {line.supplierNote}
-            </span>
-          ) : line.supplierAssignable ? (
-            // issue 107 bod 3: majiteľ, komentár #1: "neviem čo tam je
-            // Priradenie dodávateľa stĺpec" — namiesto holej pomlčky (predtým
-            // aj tu, aj v `.ord-supplier-assign` nižšie — DVE pomlčky nad
-            // sebou) je tu teraz VIDITEĽNÝ popis toho, čo vstup pod ním robí.
-            // Zámerne v TEJTO, už existujúcej bunke (nie nový riadok pod
-            // vstupom) — pridanie ĎALŠIEHO riadku by pri úzkom stĺpci
-            // (input+button už zapĺňajú takmer celú šírku) posunulo výšku
-            // riadku nad issue 105's ~95px invariant (živo zmerané: 85px →
-            // 103.5px s popisom na vlastnom riadku).
-            <span className="ord-supplier-assign-hint">Priradiť dodávateľa</span>
-          ) : (
-            // issue 117: `externalCode` (dodávateľský kód) sa už NIKDY
-            // nezobrazuje — majiteľ ho nepoužíva ("kody produktov vobec
-            // nepouzivame"), appka používa výlučne odkaz na dodávateľa.
-            // Predtým sa táto pomlčka potláčala, keď `externalCode` bol
-            // vyplnený (zobrazoval sa namiesto nej samostatný "kód …" riadok)
-            // — bez toho riadku je terajší terminálny stav VŽDY pomlčka,
-            // keď riadok nemá ani odkaz, ani poznámku, ani priradenie
-            // (legitímny, `OrderLineRow.supplierAssignCell.test.tsx`).
-            "—"
-          )}
+        <div className="ord-supplier-row">
+          <div className="ord-supplier-cell" data-testid={`supplier-link-${line.lineId}`}>
+            {line.supplierUrl !== null ? (
+              // issue 119: majiteľ, doslovne "zmen na nejake tlacitko z ikonou
+              // ktore otvori na novom okne ten link, lebo teraz to je tazke
+              // stlacit" — textový odkaz nahradený veľkým ikonovým tlačidlom
+              // (`.ord-supplier-link` v `app.css` teraz štylizuje `<a>` ako
+              // tlačidlo, min. 36×36px klikacej plochy). `aria-label`/`title`
+              // nesú ten istý popis ako predtým (issue 72: variantName sám
+              // nestačí — dva riadky toho istého produktu v rôznych veľkostiach
+              // majú zhodný variantName, líšia sa len variantCode), viditeľný
+              // text je teraz len ikonka (`aria-hidden`, prístupné meno nesie
+              // výlučne `aria-label`).
+              <a
+                href={line.supplierUrl}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="ord-supplier-link"
+                aria-label={`Odkaz na dodávateľa — ${line.variantName} (${line.variantCode})`}
+                title={`Otvoriť odkaz na dodávateľa — ${line.variantName} (${line.variantCode})`}
+              >
+                <span aria-hidden="true">🔗</span>
+              </a>
+            ) : line.supplierNote !== null ? (
+              <span className="ord-supplier-note" title={line.supplierNote}>
+                {line.supplierNote}
+              </span>
+            ) : line.supplierAssignable ? (
+              // issue 107 bod 3: majiteľ, komentár #1: "neviem čo tam je
+              // Priradenie dodávateľa stĺpec" — namiesto holej pomlčky (predtým
+              // aj tu, aj v `.ord-supplier-assign` nižšie — DVE pomlčky nad
+              // sebou) je tu teraz VIDITEĽNÝ popis toho, čo vstup pod ním robí.
+              // Zámerne v TEJTO, už existujúcej bunke (nie nový riadok pod
+              // vstupom) — pridanie ĎALŠIEHO riadku by pri úzkom stĺpci
+              // (input+button už zapĺňajú takmer celú šírku) posunulo výšku
+              // riadku nad issue 105's ~95px invariant (živo zmerané: 85px →
+              // 103.5px s popisom na vlastnom riadku).
+              <span className="ord-supplier-assign-hint">Priradiť dodávateľa</span>
+            ) : (
+              // issue 117: `externalCode` (dodávateľský kód) sa už NIKDY
+              // nezobrazuje — majiteľ ho nepoužíva ("kody produktov vobec
+              // nepouzivame"), appka používa výlučne odkaz na dodávateľa.
+              // Predtým sa táto pomlčka potláčala, keď `externalCode` bol
+              // vyplnený (zobrazoval sa namiesto nej samostatný "kód …" riadok)
+              // — bez toho riadku je terajší terminálny stav VŽDY pomlčka,
+              // keď riadok nemá ani odkaz, ani poznámku, ani priradenie
+              // (legitímny, `OrderLineRow.supplierAssignCell.test.tsx`).
+              "—"
+            )}
+          </div>
+          {/* issue 121: majiteľ, doslovne "ma byt moznost ho doplnit... pri
+              kazdom produkte ma byt moznost upravit link". TOGGLE (nie trvalo
+              viditeľný vstup) — pridáva JEDEN malý prvok VŽDY (`flex-shrink: 0`
+              v `.ord-supplier-row`, žiadna vlastná výška), vstup+uložiť sa
+              vykreslí LEN pri otvorenej úprave (nižšie), aby sa nezopakovala
+              issue 105/107/111/127's row-height regresia na VŠETKÝCH 37
+              riadkoch naraz. */}
+          <button
+            type="button"
+            className="ord-supplier-link-edit-toggle"
+            data-testid={`supplier-link-edit-toggle-${line.lineId}`}
+            aria-label={
+              linkEditing
+                ? `Zrušiť úpravu odkazu na dodávateľa — ${line.variantName} (${line.variantCode})`
+                : line.supplierUrl !== null
+                  ? `Upraviť odkaz na dodávateľa — ${line.variantName} (${line.variantCode})`
+                  : `Doplniť odkaz na dodávateľa — ${line.variantName} (${line.variantCode})`
+            }
+            title={linkEditing ? "Zrušiť úpravu" : line.supplierUrl !== null ? "Upraviť odkaz" : "Doplniť odkaz"}
+            onClick={toggleLinkEditing}
+          >
+            <span aria-hidden="true">{linkEditing ? "✖" : "✏️"}</span>
+          </button>
         </div>
+        {linkEditing && (
+          <div className="ord-supplier-link-edit" data-testid={`supplier-link-edit-${line.lineId}`}>
+            <input
+              type="url"
+              className="ord-supplier-link-edit-input"
+              data-testid={`supplier-link-edit-input-${line.lineId}`}
+              aria-label={`Odkaz na dodávateľa riadku objednávky ${line.externalOrderId} / ${line.variantCode}`}
+              placeholder="https://…"
+              value={linkDraft}
+              disabled={linkBusyHere}
+              onChange={(e) => {
+                setLinkDraft(e.target.value);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  saveLink();
+                }
+              }}
+            />
+            <button
+              type="button"
+              className="btn sm good"
+              data-testid={`supplier-link-edit-save-${line.lineId}`}
+              aria-label={`Uložiť odkaz na dodávateľa riadku objednávky ${line.externalOrderId} / ${line.variantCode}`}
+              disabled={linkBusyHere || linkDraft.trim() === ""}
+              onClick={saveLink}
+            >
+              💾
+            </button>
+          </div>
+        )}
         {/* pri neradiťeľnom riadku (100 % dnešných ostrých dát) sa TENTO blok
             predtým vykresľoval VŽDY, len s holou pomlčkou "—" bez
             akéhokoľvek významu. Teraz sa nevykreslí VÔBEC (žiadny prvok,

--- a/apps/web/src/components/OrdersSection.tsx
+++ b/apps/web/src/components/OrdersSection.tsx
@@ -10,6 +10,7 @@ import {
   fetchOpenOrders,
   NEZNAMY_DODAVATEL,
   OrdersUnauthorizedError,
+  setProductSupplierLink,
   setSupplierEmail,
   setSupplierLinesOrdered,
   updateOrderComment,
@@ -210,6 +211,33 @@ export function OrdersSection({
     [load, onSessionExpired],
   );
 
+  // issue 121: manuálny odkaz na dodávateľa — PLNÝ refetch po úspechu (rovnaký
+  // dôvod ako `assignSupplier` vyššie: zmena platí pre celý PRODUKT, teda aj
+  // pre súrodenecké veľkosti toho istého riadku).
+  const [busySupplierLinkLineId, setBusySupplierLinkLineId] = useState<string | null>(null);
+
+  const setSupplierLink = useCallback(
+    (lineId: string, url: string) => {
+      setStateError("");
+      setBusySupplierLinkLineId(lineId);
+      setProductSupplierLink(lineId, url)
+        .then(() => {
+          load();
+        })
+        .catch((err: unknown) => {
+          if (err instanceof OrdersUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setStateError(err instanceof Error ? err.message : "Uloženie odkazu na dodávateľa sa nepodarilo.");
+        })
+        .finally(() => {
+          setBusySupplierLinkLineId(null);
+        });
+    },
+    [load, onSessionExpired],
+  );
+
   // Hromadné označenie/zrušenie CELEJ skupiny dodávateľa naraz (stará appka's
   // `markGroupOrdered` — jedno tlačidlo, ktoré prepína smer podľa toho, či je
   // skupina UŽ celá objednaná, `webreview/static/app.js`'s `allOrdered`).
@@ -381,10 +409,12 @@ export function OrdersSection({
           busyOrderedLineId={busyOrderedLineId}
           busyOrderedSupplier={busyOrderedSupplier}
           busySupplierLineId={busySupplierLineId}
+          busySupplierLinkLineId={busySupplierLinkLineId}
           busyCommentOrderId={busyCommentOrderId}
           onChangeState={changeState}
           onChangeOrdered={changeOrdered}
           onAssignSupplier={assignSupplier}
+          onSetSupplierLink={setSupplierLink}
           onChangeComment={changeComment}
           editingEmailSupplier={editingEmailSupplier}
           emailDraft={emailDraft}

--- a/apps/web/src/components/SupplierOrderGroup.tsx
+++ b/apps/web/src/components/SupplierOrderGroup.tsx
@@ -20,10 +20,12 @@ export function SupplierOrderGroup({
   busyOrderedLineId,
   busyOrderedSupplier,
   busySupplierLineId,
+  busySupplierLinkLineId,
   busyCommentOrderId,
   onChangeState,
   onChangeOrdered,
   onAssignSupplier,
+  onSetSupplierLink,
   onChangeComment,
   editingEmailSupplier,
   emailDraft,
@@ -52,11 +54,14 @@ export function SupplierOrderGroup({
   readonly busyOrderedSupplier: string | null;
   // issue 63: riadok, ktorého ručné priradenie dodávateľa PRÁVE TERAZ ukladá.
   readonly busySupplierLineId: string | null;
+  // issue 121: riadok, ktorého odkaz na dodávateľa PRÁVE TERAZ ukladá.
+  readonly busySupplierLinkLineId: string | null;
   // issue 64: objednávka, ktorej poznámka PRÁVE TERAZ ukladá.
   readonly busyCommentOrderId: string | null;
   readonly onChangeState: (lineId: string, newState: OrderLine["state"]) => void;
   readonly onChangeOrdered: (lineId: string, ordered: boolean) => void;
   readonly onAssignSupplier: (lineId: string, supplier: string) => void;
+  readonly onSetSupplierLink: (lineId: string, url: string) => void;
   readonly onChangeComment: (orderId: string, comment: string | null) => void;
   readonly editingEmailSupplier: string | null;
   readonly emailDraft: string;
@@ -176,10 +181,12 @@ export function SupplierOrderGroup({
                 supplierBusy={busyOrderedSupplier === group.supplier}
                 variantTotal={variantTotals.get(line.variantCode)}
                 busySupplierLineId={busySupplierLineId}
+                busySupplierLinkLineId={busySupplierLinkLineId}
                 busyCommentOrderId={busyCommentOrderId}
                 onChangeState={onChangeState}
                 onChangeOrdered={onChangeOrdered}
                 onAssignSupplier={onAssignSupplier}
+                onSetSupplierLink={onSetSupplierLink}
                 onChangeComment={onChangeComment}
               />
             ))}

--- a/apps/web/src/ordersApi.supplierLink.test.ts
+++ b/apps/web/src/ordersApi.supplierLink.test.ts
@@ -1,0 +1,41 @@
+import { expect, it, vi } from "vitest";
+import { OrdersUnauthorizedError, setProductSupplierLink } from "./ordersApi.js";
+
+// issue 121: manuálny odkaz na dodávateľa — vlastný súbor (nie pridané do
+// `ordersApi.test.ts`, ktoré je už blízko eslint `max-lines: 400`), rovnaký
+// vzor ako existujúce delenia (`.claude/rules/testing.md`).
+
+it("setProductSupplierLink pošle POST na správnu trasu s telom { url }", async () => {
+  const fetchMock = vi
+    .fn()
+    .mockResolvedValue(new Response(JSON.stringify({ ok: true, url: "https://dodavatel.example.com" }), { status: 200 }));
+  vi.stubGlobal("fetch", fetchMock);
+
+  await setProductSupplierLink("11111111-1111-1111-1111-111111111111", "https://dodavatel.example.com");
+
+  expect(fetchMock).toHaveBeenCalledWith(
+    "/api/orders/lines/11111111-1111-1111-1111-111111111111/supplier-link",
+    expect.objectContaining({
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ url: "https://dodavatel.example.com" }),
+    }),
+  );
+});
+
+it("setProductSupplierLink pri 400 (neplatná URL) vyhodí Error so slovenskou hláškou z tela odpovede", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue(new Response(JSON.stringify({ error: "Neplatná URL adresa" }), { status: 400 })),
+  );
+  await expect(
+    setProductSupplierLink("11111111-1111-1111-1111-111111111111", "nie je url"),
+  ).rejects.toThrow("Neplatná URL adresa");
+});
+
+it("setProductSupplierLink pri 401 vyhodí OrdersUnauthorizedError", async () => {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 401 })));
+  await expect(
+    setProductSupplierLink("11111111-1111-1111-1111-111111111111", "https://dodavatel.example.com"),
+  ).rejects.toBeInstanceOf(OrdersUnauthorizedError);
+});

--- a/apps/web/src/ordersApi.ts
+++ b/apps/web/src/ordersApi.ts
@@ -202,6 +202,21 @@ export async function assignOrderLineSupplier(lineId: string, supplier: string):
   await readJson(response, "Priradenie dodávateľa sa nepodarilo");
 }
 
+// issue 121: manuálny odkaz na dodávateľa — NA ROZDIEL od priradenia
+// dodávateľa vyššie sa smie upraviť pri KAŽDOM produkte, aj keď už jeden
+// odkaz (zo Shoptetu) má. Rovnaký dôvod na PLNÝ refetch po úspechu ako
+// `assignOrderLineSupplier` — zmena platí pre celý PRODUKT (server-strana
+// `setProductSupplierLink`), teda aj pre súrodenecké veľkosti toho istého
+// riadku, nielen preň samotný.
+export async function setProductSupplierLink(lineId: string, url: string): Promise<void> {
+  const response = await fetch(`/api/orders/lines/${lineId}/supplier-link`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ url }),
+  });
+  await readJson(response, "Uloženie odkazu na dodávateľa sa nepodarilo");
+}
+
 // issue 64: manažérova voľná poznámka k CELEJ objednávke — `orderId` je
 // spoločný pre VŠETKY riadky tej istej objednávky (`OrderLine.orderId`),
 // server-strana `setOrderComment` (`modules/orders/state.ts`) mutuje

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -985,6 +985,79 @@ tr:last-child td {
   flex-shrink: 0;
 }
 
+/* issue 121: riadok obsahujúci existujúci obsah bunky (`.ord-supplier-cell`,
+   NEZMENENÝ) + NOVÝ toggle na úpravu odkazu — SÚRODENCI v jednom flex riadku,
+   nie vnorené jeden do druhého (existujúce testy assertujú `.ord-supplier
+   -cell`'s `textContent` PRESNE "—" pre riadok bez údajov, `OrdersSection
+   .test.tsx`). `align-items: center` drží ikonku zarovnanú s odkazom/pomlčkou
+   napriek rôznej výške obsahu. */
+.ord-supplier-row {
+  display: flex;
+  align-items: center;
+  gap: var(--fs-space-1);
+  min-width: 0;
+}
+.ord-supplier-row > .ord-supplier-cell {
+  min-width: 0;
+  flex: 1 1 auto;
+}
+/* "veľké tlačidlá" — rovnaký 2.25rem (36px) klikací rozmer ako
+   `.ord-supplier-link`, aby zamestnanec mohol rýchlo kliknúť aj na úzkej
+   obrazovke (majiteľ, ticketov zámer "rýchla efektívna práca"). Vykresľuje sa
+   VŽDY (na rozdiel od `.ord-supplier-link-edit` nižšie, ktorá sa objaví LEN
+   pri otvorenej úprave) — jediný trvalý pridaný prvok na KAŽDOM riadku, takže
+   nesmie pridávať výšku (`flex-shrink: 0` v riadku, žiadny vlastný blok pod
+   sebou). */
+.ord-supplier-link-edit-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  min-width: 2.25rem;
+  min-height: 2.25rem;
+  padding: var(--fs-space-1);
+  font-size: var(--fs-text-base);
+  line-height: 1;
+  color: var(--fs-ink-muted);
+  background: var(--fs-surface-alt);
+  border: 1px solid var(--fs-border);
+  border-radius: var(--fs-radius-sm);
+  cursor: pointer;
+}
+.ord-supplier-link-edit-toggle:hover {
+  background: var(--fs-brand);
+  color: var(--fs-surface);
+}
+/* Vstup + uložiť pri OTVORENEJ úprave — rovnaký "flex-basis: 0 + min-width"
+   vzor ako `.ord-supplier-assign-input` (issue 105 bod 3's komentár
+   vysvetľuje prečo: `flex-basis` rozhoduje o zalomení, nie post-shrink
+   veľkosť). Vykreslí sa LEN keď editing beží (`OrderLineRow.tsx`) — na
+   rozdiel od `.ord-supplier-row` vyššie NEPRIDÁVA výšku KAŽDÉMU riadku,
+   len tomu PRÁVE editovanému (issue 105/107/111/127's odmeraný strop 120px
+   by inak takmer isto prasklo na VŠETKÝCH 37 riadkoch naraz). */
+.ord-supplier-link-edit {
+  display: flex;
+  align-items: center;
+  gap: var(--fs-space-1);
+  flex-wrap: wrap;
+  max-width: 100%;
+  margin-top: var(--fs-space-1);
+}
+.ord-supplier-link-edit-input {
+  flex: 1 1 0%;
+  min-width: 3rem;
+  max-width: 100%;
+  padding: var(--fs-space-2) var(--fs-space-2);
+  border: 1px solid var(--fs-border);
+  border-radius: var(--fs-radius-sm);
+  font: inherit;
+  font-size: var(--fs-text-base);
+  min-height: 2.25rem;
+}
+.ord-supplier-link-edit > button {
+  flex-shrink: 0;
+}
+
 /* issue 65: priamy odkaz do Shoptet administrácie. issue 99: nesie teraz
    samotné ČÍSLO objednávky (predtým osamotenú ikonku `🔗` vedľa neho) —
    preto musí byť vizuálne rozpoznateľné ako odkaz (podčiarknutie + farba z

--- a/apps/web/tests/e2e/orders-supplier-link.spec.ts
+++ b/apps/web/tests/e2e/orders-supplier-link.spec.ts
@@ -1,0 +1,96 @@
+import { expect, test, type ConsoleMessage } from "@playwright/test";
+
+// issue 121: majiteľ, doslovne "ak na produkt nie je odkaz na dodavatela, tak
+// tam ma byt moznost ho doplnit, a vlastne pri kazdom produkte ma byt moznost
+// upravit link na dodavatela". VLASTNÝ súbor (nie ďalší test v
+// `orders.spec.ts`, ktoré je už blízko eslint `max-lines: 400`,
+// `.claude/rules/testing.md`).
+
+const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
+
+// Rovnaká a JEDINÁ povolená výnimka ako v ostatných e2e spec súboroch.
+const jeOcakavane = (m: ConsoleMessage): boolean =>
+  m.location().url.includes("/api/me") && m.text().includes("401");
+
+// VLASTNÝ izolovaný účet — balík je už na hranici `MAX_ATTEMPTS=10`
+// (`scripts/e2e-setup.ts`'s komentár k `E2E_ODKAZ_EMAIL`).
+const E2E_ODKAZ_EMAIL = "e2e-odkaz@forestshop.sk";
+
+test("riadok bez odkazu ponúka 'doplniť', po uložení ponúka 'upraviť' a nová hodnota prežije obnovenie stránky, konzola je čistá", async ({
+  page,
+}) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/?tab=orders");
+  await page.getByLabel("E-mail").fill(E2E_ODKAZ_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await expect(page.getByRole("heading", { name: "Na objednanie" })).toBeVisible();
+
+  // Riadok objednávky 9007 (`scripts/e2e-setup.ts`) je nad variantom "278" —
+  // jednovariantný produkt BEZ dodávateľa AJ bez odkazu (CSV fixtúra nesie
+  // prázdny `internalNote`). Bunka DODÁVATEĽ preto zobrazí "Priradiť
+  // dodávateľa" popis (issue 63/107 bod 3) a toggle na odkaz ponúka "Doplniť".
+  const skupina = page.getByTestId("supplier-(bez dodávateľa)");
+  await expect(skupina).toBeVisible();
+  const riadok = skupina.locator("[data-testid^='order-line-']").filter({ hasText: "9007" });
+  await expect(riadok).toContainText("ThermVisia");
+  const toggle = riadok.getByLabel(/Doplniť odkaz na dodávateľa/);
+  await expect(toggle).toBeVisible();
+
+  await toggle.click();
+  // `{ exact: true }` — inak by táto substring-zhoda kolidovala so susedným
+  // tlačidlom "Uložiť odkaz na dodávateľa riadku objednávky ..." (obsahuje
+  // ten istý text ako podreťazec, `.claude/rules/testing.md`'s Playwright
+  // substring-kolízna poznámka).
+  const vstup = riadok.getByLabel("Odkaz na dodávateľa riadku objednávky 9007 / 278", { exact: true });
+  await expect(vstup).toBeVisible();
+  await expect(vstup).toHaveValue("");
+
+  await vstup.fill("https://e2e-dodavatel.example.com/produkt-278");
+  await riadok.getByLabel("Uložiť odkaz na dodávateľa riadku objednávky 9007 / 278").click();
+
+  // Refetch po uložení (`OrdersSection.tsx`'s `setSupplierLink`) — panel sa
+  // zavrie, ikonové tlačidlo odkazu sa objaví s NOVOU hodnotou, toggle teraz
+  // ponúka "Upraviť" (nie "Doplniť" — hodnota UŽ existuje).
+  const odkaz = riadok.getByRole("link", { name: "Odkaz na dodávateľa" });
+  await expect(odkaz).toHaveAttribute("href", "https://e2e-dodavatel.example.com/produkt-278");
+  await expect(odkaz).toHaveAttribute("target", "_blank");
+  await expect(odkaz).toHaveAttribute("rel", "noreferrer noopener");
+  await expect(riadok.getByLabel(/Upraviť odkaz na dodávateľa/)).toBeVisible();
+
+  // Pretrvanie po obnovení stránky — odkaz je v DB
+  // (`product_supplier_link_override`), nielen v optimistickom klientskom stave.
+  await page.reload();
+  await expect(page.getByRole("heading", { name: "Na objednanie" })).toBeVisible();
+  const riadokPoReloade = page
+    .getByTestId("supplier-(bez dodávateľa)")
+    .locator("[data-testid^='order-line-']")
+    .filter({ hasText: "9007" });
+  await expect(riadokPoReloade.getByRole("link", { name: "Odkaz na dodávateľa" })).toHaveAttribute(
+    "href",
+    "https://e2e-dodavatel.example.com/produkt-278",
+  );
+
+  // "Upraviť" — nová hodnota PREPÍŠE tú predchádzajúcu (na rozdiel od
+  // priradenia dodávateľa, žiadna "už má hodnotu" gate — ticket to žiada
+  // explicitne).
+  await riadokPoReloade.getByLabel(/Upraviť odkaz na dodávateľa/).click();
+  const vstupUprava = riadokPoReloade.getByLabel("Odkaz na dodávateľa riadku objednávky 9007 / 278", { exact: true });
+  await expect(vstupUprava).toHaveValue("https://e2e-dodavatel.example.com/produkt-278");
+  await vstupUprava.fill("https://e2e-dodavatel.example.com/opravena-adresa");
+  await riadokPoReloade.getByLabel("Uložiť odkaz na dodávateľa riadku objednávky 9007 / 278").click();
+
+  await expect(riadokPoReloade.getByRole("link", { name: "Odkaz na dodávateľa" })).toHaveAttribute(
+    "href",
+    "https://e2e-dodavatel.example.com/opravena-adresa",
+  );
+
+  expect(chyby).toEqual([]);
+});

--- a/apps/web/tests/e2e/orders.spec.ts
+++ b/apps/web/tests/e2e/orders.spec.ts
@@ -41,13 +41,18 @@ test("manažér filtruje podľa dodávateľa, vidí súhrn ostáva vybaviť a sk
   // súhrn nižšie preto počítajú so 4 riadkami, nie s pôvodnými 2. issue 63:
   // fixtúra pridala ĎALŠIE 2 riadky BEZ dodávateľa ("60035/L"/"60035/M",
   // `orders-supplier-assign.spec.ts`'s fixtúra) — "(bez dodávateľa)" má preto
-  // 3, nie 1, "Všetci" 6, nie 4.
-  await expect(page.getByTestId("supplier-chip-all")).toHaveText("Všetci (6)");
+  // 3, nie 1, "Všetci" 6, nie 4. issue 121: pridala ĎALŠÍ 1 riadok BEZ
+  // dodávateľa ("278", `scripts/e2e-setup.ts`'s komentár vysvetľuje prečo
+  // TENTO produkt) — "(bez dodávateľa)" má preto 4, "Všetci" 7.
+  await expect(page.getByTestId("supplier-chip-all")).toHaveText("Všetci (7)");
   await expect(page.getByTestId("supplier-chip-DODAVATEL-TEST-1")).toHaveText("DODAVATEL-TEST-1 (1)");
-  await expect(page.getByTestId("supplier-chip-(bez dodávateľa)")).toHaveText("(bez dodávateľa) (3)");
+  await expect(page.getByTestId("supplier-chip-(bez dodávateľa)")).toHaveText("(bez dodávateľa) (4)");
 
   const summary = page.getByTestId("orders-summary");
-  await expect(summary).toHaveText("Ostáva vybaviť 5 z 6 · Čaká sa 1");
+  // Nový riadok ("278") štartuje vo VÝCHODISKOVOM ("objednane"/nevybavené)
+  // stave, rovnako ako "40287" — zvyšuje "ostáva vybaviť" aj celkový počet
+  // rovnako o 1 (6 z 6 nevyriešených + 1 vyriešené = 5 z 6 → 6 z 7).
+  await expect(summary).toHaveText("Ostáva vybaviť 6 z 7 · Čaká sa 1");
 
   // Klik na chip DODAVATEL-TEST-1 zúži zoznam len na jeho skupinu.
   await page.getByTestId("supplier-chip-DODAVATEL-TEST-1").click();
@@ -59,7 +64,7 @@ test("manažér filtruje podľa dodávateľa, vidí súhrn ostáva vybaviť a sk
   await page.getByTestId("supplier-chip-(bez dodávateľa)").click();
   await expect(page.getByTestId("supplier-(bez dodávateľa)")).toBeVisible();
   await expect(page.getByTestId("supplier-DODAVATEL-TEST-1")).not.toBeVisible();
-  await expect(summary).toHaveText("(bez dodávateľa): ostáva vybaviť 3 z 3");
+  await expect(summary).toHaveText("(bez dodávateľa): ostáva vybaviť 4 z 4");
 
   // Späť na "Všetci" — obe skupiny opäť viditeľné.
   await page.getByTestId("supplier-chip-all").click();
@@ -270,9 +275,10 @@ test("manažér vidí otvorené objednávky zoskupené podľa dodávateľa, konz
   const skupinaBezDodavatela = page.getByTestId("supplier-(bez dodávateľa)");
   await expect(skupinaBezDodavatela).toBeVisible();
   // issue 63: fixtúra pridala ĎALŠIE 2 riadky BEZ dodávateľa (objednávka
-  // 9006) — skupina má teraz 3 riadky, `.filter({ hasText })` zúži presne na
-  // riadok objednávky 9002 (inak by `[data-testid^='order-line-']` zhodou
-  // troch prvkov spadlo na strict-mode violation).
+  // 9006), issue 121 pridalo ĎALŠÍ 1 (objednávka 9007) — skupina má teraz 4
+  // riadky, `.filter({ hasText })` zúži presne na riadok objednávky 9002
+  // (inak by `[data-testid^='order-line-']` zhodou viacerých prvkov spadlo
+  // na strict-mode violation).
   const riadokBez = skupinaBezDodavatela.locator("[data-testid^='order-line-']").filter({ hasText: "9002" });
   await expect(riadokBez).toContainText("9002");
   await expect(riadokBez).toContainText("E2E Zákazník Bez dodávateľa");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.79",
+  "version": "0.3.0-dev.80",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -107,6 +107,12 @@ const E2E_KOMENTAR_EMAIL = "e2e-komentar@forestshop.sk"; // musí sa zhodovať s
 // zdieľaným `e2e@forestshop.sk`.
 const E2E_ROZLOZENIE_EMAIL = "e2e-rozlozenie@forestshop.sk"; // musí sa zhodovať s hodnotou v orders-layout.spec.ts
 
+// issue 121: rovnaký mechanizmus a dôvod ako `E2E_ROZLOZENIE_EMAIL` vyššie —
+// balík je UŽ na hranici `MAX_ATTEMPTS` (10), takže nový test (manuálny
+// odkaz na dodávateľa — doplniť/upraviť) dostáva VLASTNÝ izolovaný účet
+// namiesto ďalšieho prihlásenia pod zdieľaným `e2e@forestshop.sk`.
+const E2E_ODKAZ_EMAIL = "e2e-odkaz@forestshop.sk"; // musí sa zhodovať s hodnotou v orders.spec.ts
+
 const { db, pool } = createDb();
 // Konštantný literál bez interpolácie — obyčajný reťazec je tu rovnako bezpečný
 // ako `sql` tagovaná šablóna (tú používa ekvivalentný apps/api/tests/helpers/db.ts),
@@ -200,6 +206,12 @@ await db.insert(users).values({
 });
 await db.insert(users).values({
   email: E2E_ROZLOZENIE_EMAIL,
+  passwordHash: await hashPassword(E2E_HESLO),
+  displayName: "E2E Manažér",
+  role: "manazer",
+});
+await db.insert(users).values({
+  email: E2E_ODKAZ_EMAIL,
   passwordHash: await hashPassword(E2E_HESLO),
   displayName: "E2E Manažér",
   role: "manazer",
@@ -392,6 +404,28 @@ await db.insert(orderLines).values([
   { orderId: objednavkaPriradenie.id, variantCode: "60035/L", quantity: 1 },
   { orderId: objednavkaPriradenie.id, variantCode: "60035/M", quantity: 1 },
 ]);
+
+// issue 121: JEDEN riadok nad DOVTEDY NEPOUŽITÝM jednovariantným produktom
+// ("278" — CSV fixtúra ho nesie s prázdnym `supplier`/`internalNote`,
+// `.claude/rules/catalog.md`'s CSV-editačný vzor) — NIE "40287"/"60035/*"
+// (tie `orders.spec.ts` viacnásobne overuje presným počtom/obsahom skupiny,
+// a "4859/*" (jediný fixtúrový produkt so SKUTOČNÝM `internalNote` odkazom)
+// by prepísanie odkazu na JEDNEJ veľkosti prejavilo aj na "4859/46",
+// KTORÉHO presnú `href` hodnotu prvý test súboru hard-coduje — issue 67).
+// Pridáva GLOBÁLNE 1 riadok do "(bez dodávateľa)" — `orders.spec.ts`'s prvý
+// test (E2E_FILTRE_EMAIL) preto počíta so "Všetci (7)"/"(bez dodávateľa) (4)"
+// namiesto predošlých (6)/(3).
+const [objednavkaOdkaz] = await db
+  .insert(orders)
+  .values({
+    externalOrderId: "9007",
+    customerName: "E2E Zákazník Odkaz",
+    statusName: DEFAULT_ORDER_OPEN_STATUS,
+    placedAt: new Date("2026-07-26T09:00:00Z"),
+  })
+  .returning();
+if (objednavkaOdkaz === undefined) throw new Error("E2E objednávka (odkaz) sa nepodarila vložiť");
+await db.insert(orderLines).values({ orderId: objednavkaOdkaz.id, variantCode: "278", quantity: 1 });
 
 // F4 (#45): jeden UŽ NAVRHNUTÝ (nepotvrdený) pairing kandidát — simuluje to,
 // čo by inak vložilo #46 (automatické hľadanie kandidátov, ešte


### PR DESCRIPTION
Implements the manual supplier-link override for the "Na objednanie" screen — see issue 121 for the full owner request and the design comment on that ticket for the root-cause/approach writeup.

## What this does

- New `product_supplier_link_override` table (migration 0017) — mirrors `product_supplier_override`, but our stored link ALWAYS wins over the Shoptet-extracted `internalNote` link (never gated on whether Shoptet already has one — the owner wants every product editable, even ones that already have a link).
- New `POST /api/orders/lines/:lineId/supplier-link` route + `setProductSupplierLink` module (server resolves the product from the line, same shape as the existing supplier-assignment route).
- Read side (`queries.ts` + `mail.ts`) now resolves the effective link via `resolveEffectiveSupplierLink` (`coalesce(override, extracted)`).
- Frontend: a pencil toggle next to the supplier-link cell (sibling of the existing tested `.ord-supplier-cell`, never inside it) opens an inline URL input + save. Closed by default so it adds zero row height to rows not being edited — the ticket's own acceptance bar is not regressing issue 105/107/111/127's row-height baseline.
- Audit logs `product_supplier_link_override.changed` with previous/new URL.

## Tests

- Backend integration: persistence, precedence over an existing Shoptet link (no 409 gate, unlike supplier assignment), propagation to sibling variant sizes, audit trail, survival across a simulated real catalog re-import (same `onConflictDoUpdate` shape as `ingest.ts`), validation (404/400/403, plus a non-http(s) scheme rejection).
- Frontend unit/RTL: doplniť vs upraviť affordance, save wiring, error handling, cancel.
- Playwright e2e: real browser click through doplniť → upraviť → reload-persists, on a previously-unused fixture product (never `4859/*`, whose exact href another existing test hard-asserts).

## Not in this PR

Follow-up ticket 122 (Shoptet write-back via bulk CSV import) is separate and untouched.

## Merge note

This PR intentionally does NOT carry a `Closes #121` line — the ticket's acceptance criteria require a live production check (add a link, verify, then restore prod exactly) after deploy. Issue 121 will be closed by hand once that check passes.
