### PR TITLE
docs: playbook review for issue 121 (0.3.0-dev.81)

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -198,6 +198,38 @@ paths:
   icon) that still wraps unexpectedly: check whether the shrinkable item has
   `flex: 1 1 0` — a `width`/large `flex-basis` on it is the same trap, no
   matter how small its `min-width` is.
+- **A per-row toggle that opens an inline edit control (input+save) must be a
+  SIBLING of an existing tested cell div, never nested INSIDE it — and the
+  edit form itself must render ONLY while open, not always.** Issue 121
+  (manual supplier-LINK override, always-editable — unlike issue 63's
+  gated supplier-name assign): `OrderLineRow.tsx`'s existing
+  `.ord-supplier-cell` div (testid `supplier-link-${lineId}`) has a test
+  asserting its `textContent` is EXACTLY `"—"` for an empty row
+  (`OrdersSection.test.tsx`) — putting the new pencil toggle button INSIDE
+  that div would have broken it (`"—✏️"` ≠ `"—"`). Fix: wrap the existing,
+  UNCHANGED cell div together with the new toggle button in a new
+  `.ord-supplier-row` flex-row wrapper (`app.css`), so the toggle is a
+  sibling, not a child. Second half of the same fix: the toggle itself is
+  ALWAYS rendered (small, `flex-shrink: 0`, adds no height), but the actual
+  `<input>+save` block renders ONLY when `linkEditing` is true — an
+  always-visible input+button on EVERY row (the `.ord-supplier-assign`
+  pattern from issue 63, which IS always-visible but only for the minority
+  of `supplierAssignable` rows) would have added height to ALL 34+ non-gated
+  rows at once and almost certainly broken the issue 105/107/111/127
+  ~120px row-height ceiling. Any FUTURE per-row inline-edit toggle in this
+  table needs BOTH halves: sibling-not-child placement (protects existing
+  exact-textContent tests) AND conditional-render-only-when-open (protects
+  the row-height ceiling).
+- **A draft input for a TOGGLED (open/close) edit control does NOT need the
+  "skip-first-mount + reset `useEffect`" guard** that `supplierDraft`/
+  `commentDraft` (issue 63/64, both ALWAYS-visible inputs) need. Issue 121's
+  `linkDraft`: since the input only exists while `linkEditing` is true, the
+  draft is simply re-seeded FRESH from `line.supplierUrl` at the moment the
+  toggle OPENS (`onClick`), never synced continuously via an effect — there
+  is no mount-time race to guard against, because there is no persistent
+  mounted input to race with. Simpler AND correct. Only reach for the
+  effect-based reset pattern when the input is ALWAYS mounted and its
+  source prop can change while the user might be mid-edit.
 - **Measure real column budgets with a throwaway Playwright script against
   the LOCAL dev servers, never hand-derive px-per-character or eyeball a
   screenshot, before tuning `min-width`/`colgroup` percentages.** Issue 105:

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -364,3 +364,23 @@ paths:
   hneď vedľa `"DOM"`. Test na KAŽDÝ ďalší e2e `page.evaluate()` kód, ktorý
   spreadne/iteruje `querySelectorAll`/`getElementsByClassName` výsledok
   (`[...xs]`, `for...of`): over, že tsconfig má aj `DOM.Iterable`, nielen `DOM`.
+- **Fixtúrový variant pre nový e2e test PRODUKTOVO-kľúčovaného override
+  (`product_supplier_override`, `product_supplier_link_override`) sa nesmie
+  vybrať len podľa "je nepoužitý v `orders.spec.ts`" — musí sa overiť aj, či
+  na NEJAKOM SÚRODENECKOM variante (rovnaký `productKey`) INÝ test hard-
+  coduje presnú hodnotu (napr. `href`).** Issue 121 (manuálny odkaz na
+  dodávateľa): kandidát `"4859/48"` mal reálny fixtúrový `internalNote`
+  odkaz vhodný na test "upraviť EXISTUJÚCI odkaz zo Shoptetu" — ale `"4859/
+  48"` je súrodenec `"4859/46"`, ktorého PRESNÚ `href` hodnotu
+  `orders.spec.ts`'s prvý mailový/odkazový test hard-coduje
+  (`"https://www.huntingshop.eu/wild-t-green-nohavice"`). Keďže override je
+  kľúčovaný `productKey`, nie `variantCode`, prepísanie odkazu cez
+  `"4859/48"` by zmenilo EFEKTÍVNU hodnotu aj pre `"4859/46"` a ticho rozbilo
+  ten vzdialený test. Fix: použiť ÚPLNE INÝ, dovtedy nepoužitý JEDNOVARIANTNÝ
+  produkt (`"278"`) namiesto súrodenca už-testovaného produktu, a namiesto
+  testovania "upraviť EXISTUJÚCI Shoptet odkaz" cez reálne fixtúrové dáta
+  otestovať rovnaké správanie cez VLASTNÝ, práve uložený override (doplniť →
+  upraviť VLASTNÚ hodnotu) — rovnako platný dôkaz "upraviť" cesty, bez
+  rizika medzi-testovej kolízie. Pri KAŽDOM ďalšom produktovo-kľúčovanom
+  override teste: `grep` cieľový `productKey` (nie len `variantCode`) naprieč
+  CELÝM `apps/web/tests/e2e/` predtým, než ho použiješ.

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -1729,3 +1729,44 @@ nové heslo sa nikde v pushnutom obsahu nenachádza.
   use the search-fallback link (was 1/37).
 - All three per-ticket Discord cards fired after final verification
   (`v0.3.0-dev.77`).
+
+## Issue 121 — manuálny odkaz na dodávateľa (doplniť/upraviť pri každom produkte)
+
+- PR #138, merge `6b67f75`, deployed `v0.3.0-dev.80` (curl `/api/version` matches
+  merge SHA exactly).
+- Design comment posted BEFORE first commit:
+  https://github.com/zbynekdrlik/forestshop-app/issues/121#issuecomment-5148523005
+- New table `product_supplier_link_override` (migration 0017) — mirrors
+  `product_supplier_override` but the stored link ALWAYS wins over the
+  Shoptet-extracted `internalNote` link (no "already has one" 409 gate — the
+  owner wants every product editable, including ones that already have a
+  link). New pure resolver `effective-supplier-link.ts`
+  (`resolveEffectiveSupplierLink`) shared by all three read paths
+  (`queries.ts` ×2, `mail.ts`).
+- Frontend: pencil toggle SIBLING of (never inside) the existing tested
+  `.ord-supplier-cell` div — the inline edit input only renders while open,
+  so it adds zero row height to the 34+ rows not being edited (protects the
+  issue 105/107/111/127 ~120px row-height ceiling).
+- Code review (background subagent, PR 138 diff) found 2 🔵 (no 🔴/🟡):
+  coverage gap (only 1 of 3 read paths had a direct test) — fixed with 2
+  more integration tests (`getOrderDetail` + supplier mail preview); the
+  second (`SELECT` without `FOR UPDATE` on the audit "previous value" read)
+  mirrors the EXISTING accepted pattern in `assignOrderLineSupplier` — left
+  as-is, consistency with established repo convention.
+- e2e: new isolated login (`e2e-odkaz@forestshop.sk`) + seeded order 9007 on
+  previously-unused single-variant fixture product "278" — NOT `4859/*`
+  (`orders.spec.ts` hard-asserts `4859/46`'s exact href, and the override is
+  product-keyed so touching any `4859/*` variant would have broken it).
+  Bumped `orders.spec.ts`'s shared global count assertions (Všetci 6→7,
+  "(bez dodávateľa)" 3→4) — counted explicitly, not guessed.
+- Live post-deploy verification (Playwright, admin account, order 20261059 /
+  12314/3XL8): doplniť → upraviť → reload-persists all confirmed, 0 console
+  errors/warnings. Row-height baseline unchanged (38 rows, min 87.75/med
+  91.25/max 114.5px, 0 over 120px, 38/38 admin links to `objednavky-detail`,
+  0 horizontal scroll) before AND after the test. Production data restored
+  exactly: `product_supplier_link_override` back to 0 rows,
+  `product_supplier_override` unaffected at 0, `order`/`order_line` counts
+  unchanged (534/878). Audit rows (append-only) kept.
+- Issue 121 closed by hand (not via `Closes #`) — this repo's PR body
+  intentionally omits any close keyword since the ticket's acceptance needed
+  a post-deploy live check, per the CLAUDE.md gotcha from #120/#127/#132.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.80",
+  "version": "0.3.0-dev.81",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Docs-only follow-up to PR #138 (issue 121) — playbook review + autopilot log entry, no code change.

- `docs/autopilot-log.md`: entry summarizing issue 121's implementation, review findings, and live post-deploy verification (already merged/deployed in PR #138).
- `.claude/rules/frontend-design.md`: two new reusable patterns — the sibling-not-child toggle placement (protects existing exact-textContent tests while adding a new per-row control without a row-height regression), and why a toggled edit control doesn't need the skip-first-mount reset-effect guard that always-visible drafts need.
- `.claude/rules/testing.md`: the e2e fixture-selection gotcha found while writing issue 121's e2e test — a product-keyed override test must check sibling VARIANTS of its chosen product too, not just that the variant itself is unused, since another test can hard-assert an exact value on a sibling.
- Version bump to 0.3.0-dev.81 (required by the version-check CI gate on any dev commit after a merge).
