### PR TITLE
feat: spätný zápis odkazov na dodávateľa do Shoptetu cez hromadný CSV import (issue 122)

### DIFF
--- a/.claude/rules/scheduler.md
+++ b/.claude/rules/scheduler.md
@@ -31,9 +31,11 @@ paths:
   (`daily`), 01:15 mazanie surových exportov katalógu (`daily`), 01:30
   mazanie relácií (`daily`), :45 KAŽDÚ hodinu import objednávok
   (`ordersImportJob`, `hourly` od #115, pôvodne `daily` #22), 02:00 mazanie
-  surových exportov objednávok (`pruneRawOrdersJob`, `daily`, #28). Pridanie
-  ďalšieho `kind` (napr. "weekly") by znamenalo rozšíriť `periodKey()`
-  (`scheduler.ts`) o ďalšiu vetvu — rovnaký vzor ako `hourly`.
+  surových exportov objednávok (`pruneRawOrdersJob`, `daily`, #28), :50
+  KAŽDÚ hodinu spätný zápis odkazov na dodávateľa do Shoptetu
+  (`shoptetWritebackJob`, `hourly`, issue 122 — mimo kolízie s `:45`).
+  Pridanie ďalšieho `kind` (napr. "weekly") by znamenalo rozšíriť
+  `periodKey()` (`scheduler.ts`) o ďalšiu vetvu — rovnaký vzor ako `hourly`.
 - **Job NEPOTREBUJE vlastný advisory zámok, keď buď (a) volaná business
   funkcia už berie svoj vlastný vnútri seba** (`catalogImportJob`/
   `ordersImportJob` → `ingestCatalog`/`ingestOrders`), **alebo (b) sa vôbec
@@ -48,7 +50,11 @@ paths:
   `787_878_003` (`INGEST_ORDERS_ADVISORY_LOCK_KEY`, `orders/ingest.ts`, #21),
   `787_878_100` (`TEST_DB_ISOLATION_LOCK_KEY`, `tests/helpers/db.ts`).
   `ordersImportJob`/`pruneRawOrdersJob` (#22/#28) nepridali žiadny nový kľúč
-  (pozri bod vyššie).
+  (pozri bod vyššie). `shoptetWritebackJob` (issue 122) tiež žiadny nepridal
+  — v tomto tickete niet manuálneho HTTP triggeru na tú istú prácu (na
+  rozdiel od `catalogImportJob`/`ordersImportJob`, ktoré preto majú svoj
+  vlastný zámok VNÚTRI `ingestCatalog`/`ingestOrders`), takže scheduler
+  tick()'s vlastný zámok (bod nižšie) stačí.
 - **`tick()`'s zámok chráni LEN kontrolu splatnosti + vloženie "running"
   riadku, NIE celý beh úlohy.** `job.run()` beží AŽ PO commite transakcie so
   zámkom, mimo neho — dlho bežiaci job (napr. 54 MB import katalógu) tak

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,10 @@ jobs:
         with: { node-version: 24, cache: pnpm }
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter @forestshop/api db:migrate
+      # issue 122: shoptet-writeback's integration tests drive a REAL
+      # Chromium (via `playwright`) against a local fixture server (never the
+      # real Shoptet) — same install step apps/web's e2e job already uses.
+      - run: pnpm --filter @forestshop/api exec playwright install --with-deps chromium
       - run: pnpm --filter @forestshop/api test:integration
 
   e2e:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,13 @@
 FROM node:24-alpine AS build
 RUN corepack enable
 WORKDIR /app
+# issue 122: apps/api's `playwright` dependency's own postinstall would try to
+# download its bundled (glibc-only) Chromium here too — Playwright does not
+# support Alpine's musl libc for that binary at all, so the download is
+# useless in this stage (build only COMPILES, it never launches a browser)
+# and would just waste build time / risk a flaky network failure. The
+# runtime stage below installs a REAL, working Alpine chromium via apk instead.
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
 COPY apps/api/package.json apps/api/
 COPY apps/web/package.json apps/web/
@@ -14,6 +21,17 @@ FROM node:24-alpine AS runtime
 RUN corepack enable
 WORKDIR /app
 ENV NODE_ENV=production
+# Same reasoning as the build stage above — never let Playwright's postinstall
+# try (and fail) to download its own bundled Chromium on Alpine.
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+# issue 122: real, working Chromium for Alpine (musl libc) — Playwright's own
+# downloaded browser build targets glibc distros only and will not run here.
+# `playwright-import.ts`'s `resolveChromiumExecutablePath()` finds this
+# automatically at its standard apk-installed path. The extra font/NSS/
+# freetype packages are the standard set needed for headless Chromium to
+# actually render (a bare `chromium` package alone crashes on launch on
+# Alpine — documented Puppeteer/Playwright-on-Alpine requirement).
+RUN apk add --no-cache chromium nss freetype freetype-dev harfbuzz ca-certificates ttf-freefont
 # Produkčné závislosti sa inštalujú znova, nekopírujú sa z build fázy: pnpm robí
 # node_modules zo symlinkov do svojho store, a tie by po skopírovaní ukazovali do
 # prázdna. Natívny modul argon2 sa tak zároveň zostaví pre runtime obraz.

--- a/apps/api/drizzle/0018_foamy_doctor_octopus.sql
+++ b/apps/api/drizzle/0018_foamy_doctor_octopus.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "product_supplier_link_override" ADD COLUMN "synced_at" timestamp with time zone;

--- a/apps/api/drizzle/meta/0018_snapshot.json
+++ b/apps/api/drizzle/meta/0018_snapshot.json
@@ -1,0 +1,1531 @@
+{
+  "id": "cabcd70c-0743-46a8-8b90-70e066317ad4",
+  "prevId": "6fe479c5-57f0-4bba-9b87-c9f0a037a20e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_code": {
+          "name": "external_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_open_status": {
+      "name": "order_open_status",
+      "schema": "",
+      "columns": {
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Vybavuje sa'"
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shoptet_order_id": {
+          "name": "shoptet_order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_link_override": {
+      "name": "product_supplier_link_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_link_override_product_key_product_key_fk": {
+          "name": "product_supplier_link_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_link_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_override": {
+      "name": "product_supplier_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_override_product_key_product_key_fk": {
+          "name": "product_supplier_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing": {
+      "name": "pairing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_url": {
+          "name": "supplier_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "pairing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'navrhnute'"
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pairing_state_idx": {
+          "name": "pairing_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_confirmed_by_idx": {
+          "name": "pairing_confirmed_by_idx",
+          "columns": [
+            {
+              "expression": "confirmed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_variant_code_variant_code_fk": {
+          "name": "pairing_variant_code_variant_code_fk",
+          "tableFrom": "pairing",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pairing_confirmed_by_users_id_fk": {
+          "name": "pairing_confirmed_by_users_id_fk",
+          "tableFrom": "pairing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pairing_variant_code_unique": {
+          "name": "pairing_variant_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pairing_confirmation_ck": {
+          "name": "pairing_confirmation_ck",
+          "value": "(\"pairing\".\"state\" = 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)\n        OR (\"pairing\".\"state\" != 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NULL AND \"pairing\".\"confirmed_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier": {
+      "name": "supplier",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wholesale_base_url": {
+          "name": "wholesale_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_key": {
+          "name": "adapter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne"
+      ]
+    },
+    "public.pairing_state": {
+      "name": "pairing_state",
+      "schema": "public",
+      "values": [
+        "navrhnute",
+        "potvrdene"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1785543315291,
       "tag": "0017_curious_the_renegades",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1785547348333,
+      "tag": "0018_foamy_doctor_octopus",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -20,6 +20,7 @@
     "nodemailer": "^9.0.3",
     "pg": "^8.13.0",
     "pino": "^9.5.0",
+    "playwright": "^1.49.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/apps/api/src/db/schema-orders.ts
+++ b/apps/api/src/db/schema-orders.ts
@@ -160,6 +160,15 @@ export const productSupplierLinkOverrides = pgTable("product_supplier_link_overr
     .references(() => products.key, { onDelete: "cascade" }),
   url: text("url").notNull(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  // issue 122: KEDY bol tento riadok naposledy ÚSPEŠNE zapísaný späť do
+  // Shoptetu (potvrdené z Logu — nikdy len "odoslané"). `null` = ešte nikdy.
+  // "Zmenené od posledného zápisu" = `syncedAt IS NULL OR syncedAt <
+  // updatedAt` (select-changes.ts) — to je zdroj pravdy pre to, KTORÉ
+  // produkty CSV write-back nesie, nikdy celý katalóg. Zámerne SAMOSTATNÝ
+  // stĺpec, nie prepočítavaný z `job_run` — viaže sa na KONKRÉTNY riadok
+  // override, nie na "posledný beh úlohy vôbec" (ten mohol zlyhať len na
+  // INOM produkte).
+  syncedAt: timestamp("synced_at", { withTimezone: true }),
 });
 
 export const orderLines = pgTable(

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -41,6 +41,18 @@ const envSchema = z.object({
   MAIL_USER: z.string().optional(),
   MAIL_PASS: z.string().optional(),
   MAIL_FROM: z.string().optional(),
+  // issue 122: spätný zápis odkazu na dodávateľa do Shoptetu cez hromadný CSV
+  // import (Playwright). Skutočné prihlasovacie údaje — rovnaké pravidlo ako
+  // `MAIL_PASS` vyššie, nikdy do repa/commit správy/logu. Obe nepovinné:
+  // bez nich appka beží ďalej, naplánovaná úloha len zlyhá s vysvetlením
+  // "nenakonfigurované" (rovnaký vzor ako `catalogImportJob`/`ordersImportJob`).
+  SHOPTET_ADMIN_USER: z.string().min(1).optional(),
+  SHOPTET_ADMIN_PASSWORD: z.string().min(1).optional(),
+  // Alpine (produkčný Docker image) nemá Playwright's vlastný (glibc-only)
+  // stiahnutý Chromium — `playwright-import.ts`'s `resolveChromiumExecutablePath`
+  // namiesto neho použije apk-nainštalovaný systémový chromium. Nepovinné aj
+  // tu — mimo produkčného image ho netreba, Playwright použije svoj vlastný.
+  CHROMIUM_EXECUTABLE_PATH: z.string().min(1).optional(),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -19,8 +19,11 @@ import {
   pruneRawExportsJob,
   pruneRawOrdersJob,
   sessionCleanupJob,
+  shoptetWritebackJob,
 } from "./modules/scheduler/jobs.js";
 import { startScheduler } from "./modules/scheduler/scheduler.js";
+import { shoptetImportConfigFromBaseUrl } from "./modules/shoptet-writeback/config.js";
+import { runShoptetWriteback } from "./modules/shoptet-writeback/run-writeback.js";
 import { createShutdownHandler } from "./shutdown.js";
 import { appVersion } from "./version.js";
 
@@ -103,6 +106,24 @@ const sendSupplierMail =
         from: env.MAIL_FROM,
       });
 
+// issue 122: spätný zápis odkazu na dodávateľa do Shoptetu — rovnaká úvaha
+// ako `runIngest`/`runOrdersIngest`/`sendSupplierMail` vyššie:
+// `SHOPTET_ADMIN_USER`/`PASSWORD` sú nepovinné (`env.ts`), appka beží ďalej
+// bez nich, len naplánovaná úloha zaznamená "nenakonfigurované"
+// (`scheduler/jobs.ts`'s `shoptetWritebackJob`). Žiadna HTTP cesta ich
+// nepotrebuje (na rozdiel od tamtých troch) — toto je LEN scheduler.
+const shoptetAdminUser = env.SHOPTET_ADMIN_USER;
+const shoptetAdminPassword = env.SHOPTET_ADMIN_PASSWORD;
+const runShoptetWritebackFn =
+  shoptetAdminUser === undefined || shoptetAdminPassword === undefined
+    ? undefined
+    : (db2: typeof db, now: Date) =>
+        runShoptetWriteback(
+          db2,
+          shoptetImportConfigFromBaseUrl(env.SHOPTET_ADMIN_BASE_URL, shoptetAdminUser, shoptetAdminPassword),
+          now,
+        );
+
 const app = createApp(db, {
   cookieSecure: env.SESSION_COOKIE_SECURE,
   ...(runIngest === undefined ? {} : { runIngest }),
@@ -124,6 +145,7 @@ const scheduler = startScheduler(db, [
   sessionCleanupJob(),
   ordersImportJob(runOrdersIngest),
   pruneRawOrdersJob(env.ORDERS_RAW_DIR),
+  shoptetWritebackJob(runShoptetWritebackFn),
 ]);
 
 // `@hono/node-server`'s `serveStatic` prints its OWN `console.error` on every

--- a/apps/api/src/modules/scheduler/jobs.ts
+++ b/apps/api/src/modules/scheduler/jobs.ts
@@ -3,6 +3,7 @@ import type { RunIngest } from "../catalog/ingest.js";
 import { pruneRawSnapshots } from "../catalog/raw-store.js";
 import { ORDERS_EXPORT_URL_NOT_CONFIGURED, type RunOrdersIngest } from "../orders/ingest.js";
 import { pruneRawOrders } from "../orders/raw-prune.js";
+import type { WritebackRunResult } from "../shoptet-writeback/run-writeback.js";
 import type { ScheduledJob } from "./types.js";
 
 export const CATALOG_IMPORT_JOB_NAME = "catalog-import";
@@ -10,6 +11,12 @@ export const PRUNE_RAW_EXPORTS_JOB_NAME = "prune-raw-exports";
 export const SESSION_CLEANUP_JOB_NAME = "session-cleanup";
 export const ORDERS_IMPORT_JOB_NAME = "orders-import";
 export const PRUNE_RAW_ORDERS_JOB_NAME = "prune-raw-orders";
+export const SHOPTET_WRITEBACK_JOB_NAME = "shoptet-writeback";
+
+// Rovnaká hláška ako `catalogImportJob`/`ordersImportJob` vyššie — operátor
+// vidí to isté vysvetlenie, keď SHOPTET_ADMIN_USER/PASSWORD chýbajú.
+export const SHOPTET_WRITEBACK_NOT_CONFIGURED =
+  "Spätný zápis odkazov na dodávateľa do Shoptetu nie je nakonfigurovaný (chýba SHOPTET_ADMIN_USER/SHOPTET_ADMIN_PASSWORD)";
 
 // Rovnaká hláška ako `catalog-routes.ts`'s 503 pri ručnom importe bez
 // nakonfigurovaného SHOPTET_EXPORT_URL — operátor vidí to isté vysvetlenie na
@@ -106,6 +113,34 @@ export function pruneRawOrdersJob(rawDir: string, keepDays = 30): ScheduledJob {
     schedule: { kind: "daily", hourUtc: 2, minuteUtc: 0 },
     async run(_db, now) {
       const result = await pruneRawOrders(rawDir, { keepDays, now });
+      return { detail: result };
+    },
+  };
+}
+
+export type RunShoptetWriteback = (db: Parameters<ScheduledJob["run"]>[0], now: Date) => Promise<WritebackRunResult>;
+
+/**
+ * Spätný zápis odkazov na dodávateľa do Shoptetu (issue 122) — hodinovo, na
+ * :50 (mimo kolízie s `ordersImportJob`'s :45). Rovnaký vzor ako
+ * `catalogImportJob`/`ordersImportJob`: dostáva injektovanú `runWriteback`
+ * closure (môže byť `undefined`, keď `SHOPTET_ADMIN_USER`/`PASSWORD` nie sú
+ * nakonfigurované — `index.ts` ju zostaví z `runShoptetWriteback`
+ * (`shoptet-writeback/run-writeback.ts`) + `shoptetImportConfigFromBaseUrl`),
+ * nikdy si business logiku nezostavuje sama. Žiadny nový advisory lock
+ * (rovnaký dôvod ako pri tamtých dvoch: v tomto tickete niet manuálneho
+ * triggeru, teda niet s čím pretekať — `job_run` periodicita scheduler.ts
+ * sama vylučuje duplicitný beh v tej istej hodine). Keď `runWriteback` je
+ * `undefined`, job VYHODÍ — rovnaký vzor ako ostatné nepovinne-nakonfigurované
+ * joby vyššie.
+ */
+export function shoptetWritebackJob(runWriteback: RunShoptetWriteback | undefined): ScheduledJob {
+  return {
+    name: SHOPTET_WRITEBACK_JOB_NAME,
+    schedule: { kind: "hourly", minuteUtc: 50 },
+    async run(db, now) {
+      if (runWriteback === undefined) throw new Error(SHOPTET_WRITEBACK_NOT_CONFIGURED);
+      const result = await runWriteback(db, now);
       return { detail: result };
     },
   };

--- a/apps/api/src/modules/shoptet-writeback/config.test.ts
+++ b/apps/api/src/modules/shoptet-writeback/config.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { shoptetImportConfigFromBaseUrl } from "./config.js";
+
+describe("shoptetImportConfigFromBaseUrl", () => {
+  it("builds the three Shoptet admin URLs from the bare origin", () => {
+    const cfg = shoptetImportConfigFromBaseUrl("https://www.forestshop.sk", "u", "p");
+    expect(cfg.loginUrl).toBe("https://www.forestshop.sk/admin/");
+    expect(cfg.importUrl).toBe("https://www.forestshop.sk/admin/import-produktov/");
+    expect(cfg.logUrl).toBe("https://www.forestshop.sk/admin/import-produktov/log/");
+    expect(cfg.user).toBe("u");
+    expect(cfg.password).toBe("p");
+  });
+
+  it("tolerates a trailing slash on the base URL", () => {
+    const cfg = shoptetImportConfigFromBaseUrl("https://www.forestshop.sk/", "u", "p");
+    expect(cfg.loginUrl).toBe("https://www.forestshop.sk/admin/");
+  });
+});

--- a/apps/api/src/modules/shoptet-writeback/config.ts
+++ b/apps/api/src/modules/shoptet-writeback/config.ts
@@ -1,0 +1,30 @@
+/**
+ * Reálne Shoptet cesty (overené naživo proti https://www.forestshop.sk/admin/
+ * pri návrhu #122, port zo sesterského `parovanie_produktov`'s
+ * `scripts/shoptet_import.py` — `IMPORT_PATH`/`LOG_PATH` konštanty):
+ * prihlasovacia stránka JE `${adminBaseUrl}/admin/`, import formulár
+ * `${adminBaseUrl}/admin/import-produktov/`, log importov
+ * `${adminBaseUrl}/admin/import-produktov/log/`.
+ */
+export interface ShoptetImportConfig {
+  readonly loginUrl: string;
+  readonly importUrl: string;
+  readonly logUrl: string;
+  readonly user: string;
+  readonly password: string;
+}
+
+export function shoptetImportConfigFromBaseUrl(
+  adminBaseUrl: string,
+  user: string,
+  password: string,
+): ShoptetImportConfig {
+  const base = adminBaseUrl.replace(/\/+$/, "");
+  return {
+    loginUrl: `${base}/admin/`,
+    importUrl: `${base}/admin/import-produktov/`,
+    logUrl: `${base}/admin/import-produktov/log/`,
+    user,
+    password,
+  };
+}

--- a/apps/api/src/modules/shoptet-writeback/csv.test.ts
+++ b/apps/api/src/modules/shoptet-writeback/csv.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { buildWritebackCsv } from "./csv.js";
+
+describe("buildWritebackCsv", () => {
+  it("has the canonical Shoptet import header + BOM + CRLF + ';' delimiter", () => {
+    const csv = buildWritebackCsv([{ code: "123/S", pairCode: "456", internalNote: "https://dodavatel.example/x" }]);
+    const text = csv.toString("utf8");
+    expect(text.charCodeAt(0)).toBe(0xfeff); // BOM
+    const withoutBom = text.slice(1);
+    const lines = withoutBom.split("\r\n");
+    expect(lines[0]).toBe("code;pairCode;internalNote");
+    expect(lines[1]).toBe("123/S;456;https://dodavatel.example/x");
+    // trailing CRLF leaves one empty element at the end
+    expect(lines.at(-1)).toBe("");
+  });
+
+  it("emits ONE row per given variant — caller decides which variants (one per product's variants)", () => {
+    const csv = buildWritebackCsv([
+      { code: "A/S", pairCode: "1", internalNote: "https://x.example/a" },
+      { code: "A/M", pairCode: "2", internalNote: "https://x.example/a" },
+      { code: "B/S", pairCode: "", internalNote: "https://x.example/b" },
+    ]);
+    const rows = csv.toString("utf8").slice(1).split("\r\n").filter(Boolean);
+    expect(rows).toEqual([
+      "code;pairCode;internalNote",
+      "A/S;1;https://x.example/a",
+      "A/M;2;https://x.example/a",
+      "B/S;;https://x.example/b",
+    ]);
+  });
+
+  it("throws on an empty row list — never upload a file that changes nothing", () => {
+    expect(() => buildWritebackCsv([])).toThrow(/žiadne riadky/i);
+  });
+
+  it("quotes a value that itself contains the delimiter or a double quote", () => {
+    const csv = buildWritebackCsv([{ code: "A", pairCode: "", internalNote: 'note; with "quotes"' }]);
+    const rows = csv.toString("utf8").slice(1).split("\r\n").filter(Boolean);
+    expect(rows[1]).toBe('A;;"note; with ""quotes"""');
+  });
+});

--- a/apps/api/src/modules/shoptet-writeback/csv.ts
+++ b/apps/api/src/modules/shoptet-writeback/csv.ts
@@ -1,0 +1,47 @@
+/**
+ * Shoptet bulk-import CSV — presne dialekt overený naživo v sesterskom
+ * projekte `parovanie_produktov` (`src/parovanie/writer.py`'s
+ * `shoptet_writer`/`write_import`): UTF-8 s BOM, `;` oddeľovač, CRLF, hlavička
+ * `code;pairCode;internalNote`. Shoptet PREPÍŠE prítomný-ale-prázdny stĺpec
+ * (vymaže existujúcu hodnotu) — preto tento súbor nesie LEN tieto tri
+ * stĺpce, nikdy viac (issue 122's zadanie: "iba také stĺpce, ktoré chce
+ * zmeniť" + párovacie stĺpce).
+ */
+
+export interface WritebackRow {
+  readonly code: string;
+  readonly pairCode: string;
+  readonly internalNote: string;
+}
+
+const HEADER = ["code", "pairCode", "internalNote"] as const;
+
+/** Shoptet CSV field-quoting: quote only when the value needs it (contains
+ * the delimiter, a double quote, or a line break), doubling any inner quote —
+ * the standard CSV escaping rule, same as Python's csv.QUOTE_MINIMAL. */
+function quoteField(value: string): string {
+  if (/[;"\r\n]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+function rowToLine(values: readonly string[]): string {
+  return values.map(quoteField).join(";");
+}
+
+/**
+ * Builds the write-back CSV as a Buffer ready to upload — UTF-8 BOM prefix,
+ * one row per given variant (caller decides which variants: one per changed
+ * product's variant codes, `select-changes.ts`). Throws when given no rows —
+ * Shoptet's bulk import must never be invoked with a file that changes
+ * nothing.
+ */
+export function buildWritebackCsv(rows: readonly WritebackRow[]): Buffer {
+  if (rows.length === 0) {
+    throw new Error("buildWritebackCsv: žiadne riadky na zápis — CSV sa nesmie nahrať prázdne");
+  }
+  const lines = [rowToLine(HEADER), ...rows.map((r) => rowToLine([r.code, r.pairCode, r.internalNote]))];
+  const bom = "﻿";
+  return Buffer.from(bom + lines.join("\r\n") + "\r\n", "utf8");
+}

--- a/apps/api/src/modules/shoptet-writeback/log-attribution.test.ts
+++ b/apps/api/src/modules/shoptet-writeback/log-attribution.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import {
+  hasLogEntries,
+  logEntryId,
+  parseImportLog,
+  pickResultRow,
+  resultExitCode,
+} from "./log-attribution.js";
+
+describe("logEntryId", () => {
+  it("reads Shoptet's own leading '#N' entry id", () => {
+    expect(logEntryId("#12689 26.07.2026 21:00 Spracované: 4. Upravené: 1.")).toBe(12689);
+  });
+  it("returns null when the row carries no leading id", () => {
+    expect(logEntryId("Dátum Výsledok")).toBeNull();
+    expect(logEntryId("obsahuje #42 niekde vnútri, nie na začiatku")).toBeNull();
+  });
+});
+
+describe("parseImportLog", () => {
+  it("extracts processed/updated/failed counts (Slovak 'Spracované'/'Upravené'/'Zlyhanie')", () => {
+    const parsed = parseImportLog("Spracované: 4. Upravené: 1. Zlyhanie variantov: 0.");
+    expect(parsed.processed).toBe(4);
+    expect(parsed.updated).toBe(1);
+    expect(parsed.failed).toBe(0);
+    expect(parsed.errorDetail).toBeNull();
+  });
+  it("also parses the Czech 'Zpracováno' spelling", () => {
+    expect(parseImportLog("Zpracováno: 1. Upraveno: 1.").processed).toBe(1);
+  });
+  it("surfaces a hard Shoptet error with no summary at all as errorDetail", () => {
+    const parsed = parseImportLog("Chyba | Číslo riadku: 42 - Data in column code are not unique");
+    expect(parsed.processed).toBeNull();
+    expect(parsed.errorDetail).toContain("Data in column code are not unique");
+  });
+  it("does not mistake the harmless 'skončil s chybou' prose for a hard error when a summary is present", () => {
+    const parsed = parseImportLog("Import skončil s chybou. Spracované: 4. Zlyhanie variantov: 1.");
+    expect(parsed.processed).toBe(4);
+    expect(parsed.failed).toBe(1);
+    expect(parsed.errorDetail).toBeNull();
+  });
+});
+
+describe("hasLogEntries", () => {
+  it("is true when at least one row looks like a genuine log entry", () => {
+    expect(hasLogEntries(["Dátum Výsledok", "#1 Spracované: 1."])).toBe(true);
+  });
+  it("is false for header-only / empty page chrome", () => {
+    expect(hasLogEntries(["Dátum Výsledok"])).toBe(false);
+    expect(hasLogEntries([])).toBe(false);
+  });
+});
+
+describe("pickResultRow — baseline + expected-rows attribution", () => {
+  const baseline = "#100 25.07.2026 10:00 Spracované: 2. Upravené: 2.";
+  const rowsNewestFirst = (...rows: string[]) => rows;
+
+  it("returns null when nothing new appeared since the baseline", () => {
+    expect(pickResultRow(rowsNewestFirst(baseline), { baseline, expectedRows: 1 })).toBeNull();
+  });
+
+  it("picks the single new entry whose processed count matches expectedRows", () => {
+    const ours = "#101 25.07.2026 10:05 Spracované: 1. Upravené: 1.";
+    expect(pickResultRow(rowsNewestFirst(ours, baseline), { baseline, expectedRows: 1 })).toBe(ours);
+  });
+
+  it("returns null (ambiguous) when two new entries both match expectedRows", () => {
+    const a = "#101 Spracované: 1. Upravené: 1.";
+    const b = "#102 Spracované: 1. Upravené: 1.";
+    expect(pickResultRow(rowsNewestFirst(b, a, baseline), { baseline, expectedRows: 1 })).toBeNull();
+  });
+
+  it("returns null when the baseline itself was unreadable — never attribute a stale row", () => {
+    const stale = "#5 Spracované: 1.";
+    expect(pickResultRow(rowsNewestFirst(stale), { baseline: null, expectedRows: 1 })).toBeNull();
+  });
+
+  it("attributes a single new HARD-error entry (no Spracované summary) when it is the only new row", () => {
+    const err = "#101 Chyba | Číslo riadku: 3 - Data in column code are not unique";
+    expect(pickResultRow(rowsNewestFirst(err, baseline), { baseline, expectedRows: 5 })).toBe(err);
+  });
+});
+
+describe("resultExitCode", () => {
+  it("is 0 only for a clean processed count with zero failures", () => {
+    expect(resultExitCode(parseImportLog("Spracované: 3. Zlyhanie variantov: 0."))).toBe(0);
+  });
+  it("is non-zero when processed is unreadable", () => {
+    expect(resultExitCode(parseImportLog(""))).not.toBe(0);
+  });
+  it("is non-zero when any row failed", () => {
+    expect(resultExitCode(parseImportLog("Spracované: 3. Zlyhanie variantov: 1."))).not.toBe(0);
+  });
+});

--- a/apps/api/src/modules/shoptet-writeback/log-attribution.test.ts
+++ b/apps/api/src/modules/shoptet-writeback/log-attribution.test.ts
@@ -1,11 +1,21 @@
 import { describe, expect, it } from "vitest";
 import {
+  entryKey,
   hasLogEntries,
   logEntryId,
   parseImportLog,
   pickResultRow,
   resultExitCode,
 } from "./log-attribution.js";
+
+describe("entryKey", () => {
+  it("uses Shoptet's own '#id' when the row carries one", () => {
+    expect(entryKey("#12689 26.07.2026 21:00 Spracované: 4.")).toBe("12689");
+  });
+  it("falls back to the raw row text when there is no '#id'", () => {
+    expect(entryKey("bez čísla — starší formát riadku")).toBe("bez čísla — starší formát riadku");
+  });
+});
 
 describe("logEntryId", () => {
   it("reads Shoptet's own leading '#N' entry id", () => {

--- a/apps/api/src/modules/shoptet-writeback/log-attribution.ts
+++ b/apps/api/src/modules/shoptet-writeback/log-attribution.ts
@@ -62,7 +62,13 @@ export function hasLogEntries(rowTexts: readonly (string | null | undefined)[]):
   return rowTexts.some((t) => RESULT_ROW_RE.test(t ?? ""));
 }
 
-function entryKey(row: string): string {
+/** Stabilný kľúč jedného riadku Logu na "settle" kontrolu v čítacom pollingu
+ * (`playwright-import.ts`'s `pollForResult`): Shoptetovo '#id', keď ho
+ * riadok nesie, inak surový text ako záloha (ten vie tikať kvôli
+ * relatívnemu času, ale to je jediná dostupná možnosť pri staršom/inom
+ * zobrazení bez '#id' — rovnaký kompromis ako `parovanie_produktov`'s
+ * `_entry_key`). */
+export function entryKey(row: string): string {
   const id = logEntryId(row);
   return id !== null ? String(id) : row;
 }
@@ -124,13 +130,18 @@ export function pickResultRow(
 
 /** Exit-code štýl verdikt z už rozobraného výsledku — nikdy nehlási zlyhaný
  * alebo nečitateľný import ako úspech. */
+/**
+ * `parsed.failed` je `null` len keď text nemá ŽIADNU zmienku o zlyhaní
+ * (ani explicitné "Zlyhanie … N", ani "chyb(y)/chýb: N") — na reálnom
+ * Shoptet výstupe to nastáva PRÁVE pri úplne čistom importe (žiadna
+ * "Zlyhanie variantov: 0." fráza sa vôbec nevypíše, keď nie je čo hlásiť;
+ * pozorované naživo pri návrhu #122). `null` sa preto úmyselne správa ako
+ * "žiadne zlyhanie" (rovnaká sémantika ako sesterský `chunk_outcome`'s
+ * `parsed.get("failed") or 0` — falošné aj `None` aj `0`), NIE ako
+ * "nečitateľné" — tú vetvu už pokrýva `processed === null` vyššie.
+ */
 export function resultExitCode(parsed: ParsedImportLog | null | undefined): number {
   if (!parsed || parsed.processed === null) return 2;
   if (parsed.failed) return 2;
   return 0;
 }
-
-// entryKey je zámerne exportovaná až spolu s prípadným budúcim pollovacím
-// helperom (playwright-import.ts) — read-back retry loop ju potrebuje na
-// "settle" kontrolu (viď parovanie_produktov's _read_result).
-export { entryKey };

--- a/apps/api/src/modules/shoptet-writeback/log-attribution.ts
+++ b/apps/api/src/modules/shoptet-writeback/log-attribution.ts
@@ -1,0 +1,136 @@
+/**
+ * Attribúcia výsledku z Shoptet Import-Logu — čistá logika (žiadny prehliadač
+ * tu), portovaná zo sesterského projektu `parovanie_produktov`'s
+ * `src/parovanie/shoptet_import.py`, ktorý ju má overenú naživo cez viacero
+ * produkčných incidentov (#23, #196, #257 tam). Prečo je to vôbec potrebné:
+ * Shoptet nevracia žiadne API volanie s výsledkom — jediný spôsob, ako
+ * zistiť, čo sa stalo, je prečítať si TABUĽKU "Log" na
+ * `/admin/import-produktov/log/`, ktorá zobrazuje VŠETKY importy (aj cudzie,
+ * aj staršie) NAJNOVŠIE HORE. Bez baseline+expected-rows atribúcie by čítanie
+ * ľahko priradilo CUDZÍ alebo STARŠÍ riadok tomuto behu.
+ */
+
+export interface ParsedImportLog {
+  readonly raw: string;
+  readonly processed: number | null;
+  readonly updated: number | null;
+  readonly failed: number | null;
+  readonly errorDetail: string | null;
+}
+
+function numAfter(low: string, ...patterns: RegExp[]): number | null {
+  for (const re of patterns) {
+    const m = re.exec(low);
+    if (m?.[1] !== undefined) return Number.parseInt(m[1], 10);
+  }
+  return null;
+}
+
+/**
+ * Vytiahne processed/updated/failed zo Shoptet výsledkového riadku
+ * ('Spracované: 1. Zlyhanie variantov: 1.' / česky 'Zpracováno: 1. Upraveno: 1.').
+ * `failed` uprednostní explicitné 'Zlyhanie …: N' pred všeobecnou prózou
+ * 'skončil s chybou' (tá nenesie žiadne číslo) — inak by próza "chybou"
+ * omylom zachytila číslo za sebou, ktoré patrí 'processed'.
+ */
+export function parseImportLog(text: string | null | undefined): ParsedImportLog {
+  const raw = text ?? "";
+  const low = raw.toLowerCase();
+  const processed = numAfter(low, /z?pracov\w*[^0-9]{0,40}?(\d+)/);
+  const failed = numAfter(low, /zlyhan\w*[^0-9]{0,40}?(\d+)/, /ch[ýy]b\w*\s*:\s*(\d+)/);
+  const updated = numAfter(low, /uprav\w*[^0-9]{0,40}?(\d+)/);
+  const errorDetail = processed === null && low.includes("chyba") ? raw.trim() || null : null;
+  return { raw, processed, updated, failed, errorDetail };
+}
+
+const RESULT_ROW_RE = /spracov|zpracov|uprav|zlyhan|chyba|riadku/i;
+const ENTRY_ID_RE = /^\s*#(\d+)/;
+
+/** Shoptetovo vlastné rastúce číslo Log riadku ('#12689 …' → 12689), alebo
+ * `null`, keď riadok žiadne nenesie (staršie/iné zobrazenie — volajúci to
+ * musí degradovať, nikdy nespadnúť). ZAKOTVENÉ na začiatku textu — '#42'
+ * niekde vnútri (číslo objednávky, kód) nie je entry id. */
+export function logEntryId(text: string | null | undefined): number | null {
+  const m = ENTRY_ID_RE.exec(text ?? "");
+  return m?.[1] !== undefined ? Number.parseInt(m[1], 10) : null;
+}
+
+/** Videl tento čítací pokus VÔBEC log tabuľku (aspoň jeden riadok tvarom
+ * pripomínajúci skutočný import-log záznam)? Hlavičkový riadok/prázdna
+ * stránka sa nepočíta. */
+export function hasLogEntries(rowTexts: readonly (string | null | undefined)[]): boolean {
+  return rowTexts.some((t) => RESULT_ROW_RE.test(t ?? ""));
+}
+
+function entryKey(row: string): string {
+  const id = logEntryId(row);
+  return id !== null ? String(id) : row;
+}
+
+/** Log riadky napísané PO `baseline` (najvrchnejší riadok zachytený PRED
+ * odoslaním importu), najnovšie prvé. Používa Shoptetovo entry id, keď ho
+ * nesú obe strany; inak sa spolieha na poradie v tabuľke (Log sa vykresľuje
+ * najnovšie navrchu, takže všetko od `baseline` nadol je staršie). */
+function newEntries(entries: readonly string[], baseline: string | null): string[] {
+  const baseId = logEntryId(baseline);
+  const out: string[] = [];
+  for (const t of entries) {
+    if (baseline !== null && t === baseline) break;
+    const tid = logEntryId(t);
+    if (baseId !== null && tid !== null && tid <= baseId) break;
+    out.push(t);
+  }
+  return out;
+}
+
+export interface PickResultRowOptions {
+  readonly baseline: string | null;
+  readonly expectedRows: number | null;
+}
+
+/**
+ * Vyberie riadok Logu, ktorý zodpovedá PRÁVE odoslanému behu — nikdy hádanie.
+ * Vracia `null` ("naše/nečitateľné zatiaľ" — volajúci musí opakovať čítanie,
+ * a nakoniec to nahlásiť ako nečitateľný výsledok), keď: žiadny riadok
+ * nevyzerá ako log-entry, nič nové sa neobjavilo od baseline, alebo nové
+ * riadky nejde jednoznačne priradiť.
+ */
+export function pickResultRow(
+  rowTexts: readonly (string | null | undefined)[],
+  options: PickResultRowOptions,
+): string | null {
+  const { baseline, expectedRows } = options;
+  const entries = rowTexts.filter((t): t is string => RESULT_ROW_RE.test(t ?? ""));
+  if (entries.length === 0) return null;
+  if (expectedRows !== null && baseline === null) {
+    // Baseline sa nedal zachytiť (stránka Logu nečitateľná/nevykreslená) —
+    // KAŽDÝ viditeľný riadok by bol kandidát, aj dni starý so zhodným počtom.
+    // Nič sa tu nedá priradiť: fail-closed.
+    return null;
+  }
+  const candidates = newEntries(entries, baseline);
+  if (candidates.length === 0) return null;
+  if (expectedRows === null) return candidates[0] ?? null;
+  const matches = candidates.filter((c) => parseImportLog(c).processed === expectedRows);
+  if (matches.length === 1) return matches[0] ?? null;
+  if (matches.length > 1) return null; // dva rovnako veľké importy — nejednoznačné
+  if (candidates.length === 1 && parseImportLog(candidates[0]).errorDetail !== null) {
+    // tvrdý abort nenesie žiadne 'Spracované' vôbec; patrí nám, len keď je
+    // JEDINÝ nový riadok (nič iné ho nemohlo napísať)
+    return candidates[0] ?? null;
+  }
+  return null;
+}
+
+/** Exit-code štýl verdikt z už rozobraného výsledku — nikdy nehlási zlyhaný
+ * alebo nečitateľný import ako úspech. */
+export function resultExitCode(parsed: ParsedImportLog | null | undefined): number {
+  if (!parsed || parsed.processed === null) return 2;
+  if (parsed.failed) return 2;
+  return 0;
+}
+
+// entryKey je zámerne exportovaná až spolu s prípadným budúcim pollovacím
+// helperom (playwright-import.ts) — read-back retry loop ju potrebuje na
+// "settle" kontrolu (viď parovanie_produktov's _read_result).
+export { entryKey };

--- a/apps/api/src/modules/shoptet-writeback/mark-synced.ts
+++ b/apps/api/src/modules/shoptet-writeback/mark-synced.ts
@@ -1,0 +1,22 @@
+import { inArray } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { productSupplierLinkOverrides } from "../../db/schema.js";
+
+/**
+ * Označí dané `productKey`s ako úspešne zapísané do Shoptetu — voláme LEN po
+ * POTVRDENOM úspechu (Log ukázal presne toľko spracovaných riadkov, koľko
+ * sme poslali, žiadne zlyhania, `run-writeback.ts`). Nikdy inak: pri chybe/
+ * nejednoznačnom výsledku ostáva `syncedAt` nezmenené, takže nasledujúci beh
+ * tie isté produkty pošle znova. No-op pre prázdny zoznam (nič sa neposlalo).
+ */
+export async function markSuppliersLinksSynced(
+  db: Database,
+  productKeys: readonly string[],
+  now: Date,
+): Promise<void> {
+  if (productKeys.length === 0) return;
+  await db
+    .update(productSupplierLinkOverrides)
+    .set({ syncedAt: now })
+    .where(inArray(productSupplierLinkOverrides.productKey, [...productKeys]));
+}

--- a/apps/api/src/modules/shoptet-writeback/mark-synced.ts
+++ b/apps/api/src/modules/shoptet-writeback/mark-synced.ts
@@ -1,4 +1,4 @@
-import { inArray } from "drizzle-orm";
+import { and, inArray, lte } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
 import { productSupplierLinkOverrides } from "../../db/schema.js";
 
@@ -8,6 +8,16 @@ import { productSupplierLinkOverrides } from "../../db/schema.js";
  * sme poslali, žiadne zlyhania, `run-writeback.ts`). Nikdy inak: pri chybe/
  * nejednoznačnom výsledku ostáva `syncedAt` nezmenené, takže nasledujúci beh
  * tie isté produkty pošle znova. No-op pre prázdny zoznam (nič sa neposlalo).
+ *
+ * `now` je časový moment ZAČIATKU celého behu (`run-writeback.ts` ho dostáva
+ * ako parameter od schedulera, PRED `selectChangedSupplierLinks` aj PRED
+ * (potenciálne dlho bežiacim) Playwright importom) — `updatedAt <= now`
+ * podmienka chráni pred pretekaním: keby majiteľ upravil TEN ISTÝ odkaz
+ * ZNOVA niekedy MEDZI výberom riadkov a týmto zápisom (celý beh môže trvať
+ * desiatky sekúnd kvôli prehliadaču), tá novšia úprava má `updatedAt` NUTNE
+ * neskôr než `now` (mohla nastať len po štarte behu) — takto sa NEoznačí
+ * ako synchronizovaná, hoci do Shoptetu odišla len jej STARŠIA hodnota;
+ * nasledujúci beh ju pošle znova.
  */
 export async function markSuppliersLinksSynced(
   db: Database,
@@ -18,5 +28,10 @@ export async function markSuppliersLinksSynced(
   await db
     .update(productSupplierLinkOverrides)
     .set({ syncedAt: now })
-    .where(inArray(productSupplierLinkOverrides.productKey, [...productKeys]));
+    .where(
+      and(
+        inArray(productSupplierLinkOverrides.productKey, [...productKeys]),
+        lte(productSupplierLinkOverrides.updatedAt, now),
+      ),
+    );
 }

--- a/apps/api/src/modules/shoptet-writeback/playwright-import.ts
+++ b/apps/api/src/modules/shoptet-writeback/playwright-import.ts
@@ -1,0 +1,204 @@
+import { existsSync } from "node:fs";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { chromium, type Browser, type Page } from "playwright";
+import { log } from "../../logger.js";
+import type { ShoptetImportConfig } from "./config.js";
+import { hasLogEntries, parseImportLog, pickResultRow, resultExitCode } from "./log-attribution.js";
+
+/**
+ * Playwright automatizácia hromadného CSV importu do Shoptetu — port zo
+ * sesterského `parovanie_produktov`'s `scripts/shoptet_import.py`
+ * (`_login`/`_goto_import`/`_ensure_safe_settings`/`_do_import`/
+ * `_read_result`), ktorý má tento presný postup overený naživo. Nikdy sa
+ * nespolieha na to, že klik "prešiel" — bezpečné nastavenia (režim
+ * "Nemeniť mimo súboru", "Zmeniť URL podľa názvu" VYPNUTÉ) sa VŽDY čítajú
+ * READ-BACK po nastavení, a výsledok importu sa vždy overuje z Logu, nikdy
+ * len z toho, že formulár sa odoslal bez chyby.
+ */
+
+const SAFE_RADIO_NAME = "Nemeniť produkty a varianty, ktoré nie sú obsiahnuté v importovanom súbore.";
+const URL_BY_NAME_CHECKBOX = "Zmeňte adresu URL produktu podľa názvu produktu.";
+
+export interface RunShoptetImportOptions {
+  readonly config: ShoptetImportConfig;
+  readonly csv: Buffer;
+  readonly expectedRows: number;
+  readonly headless?: boolean;
+  readonly executablePath?: string;
+  readonly resultPollRetries?: number;
+  readonly resultPollWaitMs?: number;
+}
+
+export interface ShoptetImportOutcome {
+  readonly ok: boolean;
+  readonly processed: number | null;
+  readonly updated: number | null;
+  readonly failed: number | null;
+  readonly errorDetail: string | null;
+  readonly rawResultText: string | null;
+}
+
+/** Alpine-friendly default: apk-installed `chromium` v produkčnom image
+ * (Dockerfile) namiesto Playwright's vlastného (glibc-only) stiahnutého
+ * binárky, ktorá na musl-libc Alpine nikdy nenaštartuje. Mimo produkčného
+ * obrazu (CI/lokálny dev, Ubuntu) žiadna z týchto ciest neexistuje →
+ * `undefined` → Playwright použije svoj vlastný bežne nainštalovaný
+ * chromium (`playwright install chromium`). */
+export function resolveChromiumExecutablePath(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  const override = env["CHROMIUM_EXECUTABLE_PATH"];
+  if (override !== undefined && override !== "") return override;
+  for (const candidate of ["/usr/bin/chromium-browser", "/usr/bin/chromium"]) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+/** Text obsahu KAŽDÉHO `<tr>` na stránke, zbalený whitespace — cez Playwright's
+ * vlastné (typované) `locator().allTextContents()`, nikdy `page.evaluate()`
+ * s priamym `document` odkazom (apps/api's tsconfig nemá DOM lib — je to
+ * Node backend, nie browser kód — `.claude/rules/testing.md`'s poznámka o
+ * `apps/web/tests/e2e/tsconfig.json`'s DOM libu platí LEN pre e2e testy, nie
+ * pre backend automatizáciu ako túto). */
+async function rowTexts(page: Page): Promise<string[]> {
+  const raw = await page.locator("tr").allTextContents();
+  return raw.map((t) => t.replace(/\s+/g, " ").trim());
+}
+
+async function login(page: Page, config: ShoptetImportConfig): Promise<void> {
+  await page.goto(config.loginUrl, { waitUntil: "domcontentloaded" });
+  await page.getByPlaceholder("E-mail").fill(config.user);
+  await page.getByPlaceholder("Vaše heslo").fill(config.password);
+  await page.getByRole("button", { name: "Prihlásenie" }).click();
+  await page.waitForLoadState("networkidle");
+  // NIKDY substring na URL ("/login") — reálny Shoptet login pre tento obchod
+  // je na `${adminBaseUrl}/admin/` a úspešné prihlásenie sa vráti na TÚ ISTÚ
+  // URL (overené naživo pri návrhu #122: dry-run skript ukázal "[login] OK →
+  // https://www.forestshop.sk/admin/", teda nezmenenú URL). Jediný spoľahlivý
+  // signál zlyhania je, že prihlasovací formulár je STÁLE na stránke.
+  if ((await page.getByPlaceholder("E-mail").count()) > 0) {
+    throw new Error("Prihlásenie do Shoptetu zlyhalo (prihlasovací formulár stále viditeľný) — over SHOPTET_ADMIN_USER/PASSWORD");
+  }
+}
+
+async function captureBaseline(page: Page, config: ShoptetImportConfig): Promise<string | null> {
+  await page.goto(config.logUrl, { waitUntil: "domcontentloaded" });
+  await page.waitForLoadState("networkidle");
+  return pickResultRow(await rowTexts(page), { baseline: null, expectedRows: null });
+}
+
+async function ensureSafeSettings(page: Page): Promise<void> {
+  const safeRadio = page.getByRole("radio", { name: SAFE_RADIO_NAME });
+  if ((await safeRadio.count()) === 0) {
+    throw new Error(`Nenašiel som voľbu bezpečného režimu importu ("${SAFE_RADIO_NAME}") — neimportujem`);
+  }
+  await safeRadio.check();
+  const urlByName = page.getByRole("checkbox", { name: URL_BY_NAME_CHECKBOX });
+  if ((await urlByName.count()) > 0 && (await urlByName.isChecked())) {
+    await urlByName.uncheck();
+  }
+  if (!(await safeRadio.isChecked())) {
+    throw new Error("Bezpečný režim 'Nemeniť produkty mimo súboru' sa nepodarilo nastaviť — neimportujem");
+  }
+  if ((await urlByName.count()) > 0 && (await urlByName.isChecked())) {
+    throw new Error("'Zmeniť URL podľa názvu' ostáva zapnuté — neimportujem");
+  }
+}
+
+async function pollForResult(
+  page: Page,
+  config: ShoptetImportConfig,
+  baseline: string | null,
+  expectedRows: number,
+  retries: number,
+  waitMs: number,
+): Promise<string | null> {
+  const seen = new Set<string>();
+  let verdict: string | null = null;
+  let verdictIsReal = false;
+  for (let attempt = 0; attempt < retries; attempt++) {
+    const texts = await rowTexts(page);
+    const row = pickResultRow(texts, { baseline, expectedRows });
+    if (row !== null) seen.add(row);
+    if (hasLogEntries(texts)) {
+      verdict = row;
+      verdictIsReal = true;
+    }
+    if (attempt < retries - 1) {
+      await page.waitForTimeout(waitMs);
+      await page.goto(config.logUrl, { waitUntil: "networkidle" });
+    }
+  }
+  if (!verdictIsReal || verdict === null || seen.size !== 1) return null;
+  return verdict;
+}
+
+/**
+ * Spustí celý beh: prihlásenie → baseline → nahratie CSV → over bezpečné
+ * nastavenia → spustenie importu → čítanie výsledku z Logu (baseline +
+ * expectedRows atribúcia, `log-attribution.ts`). Vyhodí, keď sa NEDÁ ani
+ * prihlásiť/nájsť formulár (fail-loud, nič sa neposlalo); vráti
+ * `ok: false` s vysvetlením, keď sa CSV odoslalo, ale výsledok nemožno
+ * potvrdiť ako úspech (nejednoznačné/zlyhané/nečitateľné).
+ */
+export async function runShoptetImport(options: RunShoptetImportOptions): Promise<ShoptetImportOutcome> {
+  const { config, csv, expectedRows } = options;
+  const executablePath = options.executablePath ?? resolveChromiumExecutablePath();
+  let browser: Browser | undefined;
+  const tmpDir = await mkdtemp(join(tmpdir(), "shoptet-writeback-"));
+  const csvPath = join(tmpDir, "import.csv");
+  try {
+    await writeFile(csvPath, csv);
+    browser = await chromium.launch({
+      headless: options.headless ?? true,
+      ...(executablePath === undefined ? {} : { executablePath }),
+      // --no-sandbox/--disable-setuid-sandbox: bežíme ako non-root `node` v
+      // kontajneri bez extra capabilities, Chromiov sandbox by inak zlyhal na
+      // štarte. --disable-dev-shm-usage: kontajnerov malý /dev/shm by inak
+      // Chromium prehltol pri väčších stránkach. --disable-gpu: žiadny GPU v
+      // kontajneri — overené naživo proti apk-nainštalovanému Alpine
+      // chromiu pri návrhu #122 (bez tejto vlajky Chromium chrlí neškodné,
+      // ale hlučné ANGLE/Vulkan chybové riadky do stderr).
+      args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage", "--disable-gpu"],
+    });
+    const context = await browser.newContext({ acceptDownloads: false });
+    const page = await context.newPage();
+
+    await login(page, config);
+    const baseline = await captureBaseline(page, config);
+    log.info({ baseline: baseline === null ? null : "prítomný" }, "shoptet write-back: baseline Logu zachytený");
+
+    await page.goto(config.importUrl, { waitUntil: "domcontentloaded" });
+    await page.waitForLoadState("networkidle");
+    const fileInput = page.locator('input[type="file"][name="file"]');
+    if ((await fileInput.count()) === 0) {
+      throw new Error(`Nenašiel som import formulár (file input) na ${page.url()}`);
+    }
+    await fileInput.setInputFiles(csvPath);
+    await ensureSafeSettings(page);
+
+    await page.getByTestId("buttonImport").click();
+    await page.waitForURL(/import-produktov\/log/, { timeout: 120_000 });
+    await page.waitForLoadState("networkidle");
+
+    const resultText = await pollForResult(
+      page,
+      config,
+      baseline,
+      expectedRows,
+      options.resultPollRetries ?? 6,
+      options.resultPollWaitMs ?? 2000,
+    );
+    const parsed = parseImportLog(resultText);
+    const ok = resultText !== null && resultExitCode(parsed) === 0;
+    log.info(
+      { ok, processed: parsed.processed, updated: parsed.updated, failed: parsed.failed },
+      "shoptet write-back: výsledok importu prečítaný",
+    );
+    return { ok, processed: parsed.processed, updated: parsed.updated, failed: parsed.failed, errorDetail: parsed.errorDetail, rawResultText: resultText };
+  } finally {
+    await browser?.close();
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+}

--- a/apps/api/src/modules/shoptet-writeback/playwright-import.ts
+++ b/apps/api/src/modules/shoptet-writeback/playwright-import.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { chromium, type Browser, type Page } from "playwright";
 import { log } from "../../logger.js";
 import type { ShoptetImportConfig } from "./config.js";
-import { hasLogEntries, parseImportLog, pickResultRow, resultExitCode } from "./log-attribution.js";
+import { entryKey, hasLogEntries, parseImportLog, pickResultRow, resultExitCode } from "./log-attribution.js";
 
 /**
  * Playwright automatizácia hromadného CSV importu do Shoptetu — port zo
@@ -120,7 +120,11 @@ async function pollForResult(
   for (let attempt = 0; attempt < retries; attempt++) {
     const texts = await rowTexts(page);
     const row = pickResultRow(texts, { baseline, expectedRows });
-    if (row !== null) seen.add(row);
+    // entryKey (nie surový text riadku) — Shoptetov '#id' zostáva stabilný
+    // naprieč čítaniami, ale surový text vie tikať (relatívny čas), čo by
+    // "settle" kontrolu nižšie (seen.size !== 1) nechalo nikdy zjednotiť sa
+    // (parovanie_produktov's _read_result má rovnaký dôvod pre _entry_key).
+    if (row !== null) seen.add(entryKey(row));
     if (hasLogEntries(texts)) {
       verdict = row;
       verdictIsReal = true;

--- a/apps/api/src/modules/shoptet-writeback/run-writeback.ts
+++ b/apps/api/src/modules/shoptet-writeback/run-writeback.ts
@@ -1,0 +1,52 @@
+import type { Database } from "../../db/client.js";
+import { buildWritebackCsv } from "./csv.js";
+import type { ShoptetImportConfig } from "./config.js";
+import { markSuppliersLinksSynced } from "./mark-synced.js";
+import { runShoptetImport } from "./playwright-import.js";
+import { selectChangedSupplierLinks } from "./select-changes.js";
+
+export type WritebackRunResult =
+  | { readonly status: "nothing_changed" }
+  | { readonly status: "ok"; readonly productCount: number; readonly rowCount: number }
+  | {
+      readonly status: "failed";
+      readonly productCount: number;
+      readonly rowCount: number;
+      readonly processed: number | null;
+      readonly failed: number | null;
+      readonly errorDetail: string | null;
+    };
+
+/**
+ * Celý beh issue 122: vyber zmenené odkazy → postav CSV → nahraj cez
+ * Playwright → LEN po POTVRDENOM úspechu označ dané produkty ako
+ * synchronizované. Pri chybe/nejednoznačnom výsledku sa `syncedAt` NIKDY
+ * nezmení — nasledujúci beh (naplánovaná úloha, `scheduler/jobs.ts`) tie isté
+ * produkty pošle znova. `now` sa berie ako parameter (nie `new Date()` tu
+ * vnútri), rovnaká disciplína ako `catalogImportJob`/`ordersImportJob`.
+ */
+export async function runShoptetWriteback(
+  db: Database,
+  config: ShoptetImportConfig,
+  now: Date,
+): Promise<WritebackRunResult> {
+  const { productKeys, rows } = await selectChangedSupplierLinks(db);
+  if (rows.length === 0) return { status: "nothing_changed" };
+
+  const csv = buildWritebackCsv(rows);
+  const outcome = await runShoptetImport({ config, csv, expectedRows: rows.length });
+
+  if (!outcome.ok) {
+    return {
+      status: "failed",
+      productCount: productKeys.length,
+      rowCount: rows.length,
+      processed: outcome.processed,
+      failed: outcome.failed,
+      errorDetail: outcome.errorDetail,
+    };
+  }
+
+  await markSuppliersLinksSynced(db, productKeys, now);
+  return { status: "ok", productCount: productKeys.length, rowCount: rows.length };
+}

--- a/apps/api/src/modules/shoptet-writeback/select-changes.ts
+++ b/apps/api/src/modules/shoptet-writeback/select-changes.ts
@@ -1,0 +1,45 @@
+import { eq, isNull, lt, or } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { productSupplierLinkOverrides, variants } from "../../db/schema.js";
+import type { WritebackRow } from "./csv.js";
+
+export interface SelectedWriteback {
+  /** productKey of every override actually included below — used to mark
+   * `syncedAt` after a CONFIRMED successful import (run-writeback.ts). */
+  readonly productKeys: readonly string[];
+  /** one row per variant of every changed product, ready for buildWritebackCsv. */
+  readonly rows: readonly WritebackRow[];
+}
+
+/**
+ * "Zmenilo sa niečo od posledného úspešného zápisu?" (issue 122) — nikdy
+ * celý katalóg. `syncedAt IS NULL` = ešte nikdy odoslané; `syncedAt <
+ * updatedAt` = odoslané, ale odvtedy znova upravené (ďalšia úprava po
+ * predchádzajúcom syncu). Vracia jeden CSV riadok PER VARIANT patriaci
+ * danému produktu — `internalNote` (odkaz na dodávateľa) je produktové pole,
+ * ale Shoptet páruje import podľa variantového `code`+`pairCode`
+ * (`parovanie_produktov`'s `link_rows`, viď design komentár na #122).
+ */
+export async function selectChangedSupplierLinks(db: Database): Promise<SelectedWriteback> {
+  const rows = await db
+    .select({
+      code: variants.code,
+      pairCode: variants.pairCode,
+      internalNote: productSupplierLinkOverrides.url,
+      productKey: productSupplierLinkOverrides.productKey,
+    })
+    .from(productSupplierLinkOverrides)
+    .innerJoin(variants, eq(variants.productKey, productSupplierLinkOverrides.productKey))
+    .where(
+      or(
+        isNull(productSupplierLinkOverrides.syncedAt),
+        lt(productSupplierLinkOverrides.syncedAt, productSupplierLinkOverrides.updatedAt),
+      ),
+    );
+
+  const productKeys = [...new Set(rows.map((r) => r.productKey))];
+  return {
+    productKeys,
+    rows: rows.map((r) => ({ code: r.code, pairCode: r.pairCode ?? "", internalNote: r.internalNote })),
+  };
+}

--- a/apps/api/src/modules/shoptet-writeback/select-changes.ts
+++ b/apps/api/src/modules/shoptet-writeback/select-changes.ts
@@ -1,6 +1,7 @@
 import { eq, isNull, lt, or } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
 import { productSupplierLinkOverrides, variants } from "../../db/schema.js";
+import { log } from "../../logger.js";
 import type { WritebackRow } from "./csv.js";
 
 export interface SelectedWriteback {
@@ -21,6 +22,11 @@ export interface SelectedWriteback {
  * (`parovanie_produktov`'s `link_rows`, viď design komentár na #122).
  */
 export async function selectChangedSupplierLinks(db: Database): Promise<SelectedWriteback> {
+  const changedCondition = or(
+    isNull(productSupplierLinkOverrides.syncedAt),
+    lt(productSupplierLinkOverrides.syncedAt, productSupplierLinkOverrides.updatedAt),
+  );
+
   const rows = await db
     .select({
       code: variants.code,
@@ -30,14 +36,28 @@ export async function selectChangedSupplierLinks(db: Database): Promise<Selected
     })
     .from(productSupplierLinkOverrides)
     .innerJoin(variants, eq(variants.productKey, productSupplierLinkOverrides.productKey))
-    .where(
-      or(
-        isNull(productSupplierLinkOverrides.syncedAt),
-        lt(productSupplierLinkOverrides.syncedAt, productSupplierLinkOverrides.updatedAt),
-      ),
-    );
+    .where(changedCondition);
 
   const productKeys = [...new Set(rows.map((r) => r.productKey))];
+
+  // review of PR 140: an override for a productKey with ZERO variant rows
+  // (a data anomaly — every real product has at least one variant) would
+  // otherwise silently drop out of the innerJoin above forever, never
+  // synced and never logged. Making the gap OBSERVABLE (rather than a
+  // permanently silent no-op) is cheap — one extra id-only query, only run
+  // when there is anything changed at all to compare against.
+  const changedOverrides = await db
+    .select({ productKey: productSupplierLinkOverrides.productKey })
+    .from(productSupplierLinkOverrides)
+    .where(changedCondition);
+  const skipped = changedOverrides.map((o) => o.productKey).filter((key) => !productKeys.includes(key));
+  if (skipped.length > 0) {
+    log.warn(
+      { skippedProductKeys: skipped },
+      "shoptet write-back: preskočené zmenené odkazy na dodávateľa bez žiadneho variantu (dátová anomália)",
+    );
+  }
+
   return {
     productKeys,
     rows: rows.map((r) => ({ code: r.code, pairCode: r.pairCode ?? "", internalNote: r.internalNote })),

--- a/apps/api/tests/helpers/orders.ts
+++ b/apps/api/tests/helpers/orders.ts
@@ -77,7 +77,15 @@ export async function insertTestVariantForProduct(
   db: Database,
   productKey: string,
   code: string,
-  options: { readonly sizeLabel?: string | null; readonly supplier?: string | null; readonly productName?: string } = {},
+  options: {
+    readonly sizeLabel?: string | null;
+    readonly supplier?: string | null;
+    readonly productName?: string;
+    // issue 122: write-back CSV needs a real pairCode per variant (Shoptet's
+    // own row-matching column) — default null matches every existing call
+    // (no prior test needed one).
+    readonly pairCode?: string | null;
+  } = {},
 ): Promise<void> {
   const snapshotId = await insertTestSnapshot(db);
   await db
@@ -101,7 +109,7 @@ export async function insertTestVariantForProduct(
     productKey,
     guid: productKey,
     sizeLabel: options.sizeLabel ?? null,
-    pairCode: null,
+    pairCode: options.pairCode ?? null,
     name: options.productName ?? `Test produkt ${productKey}`,
     currency: "EUR",
     price: "10.00",

--- a/apps/api/tests/helpers/shoptet-fixture.ts
+++ b/apps/api/tests/helpers/shoptet-fixture.ts
@@ -1,0 +1,167 @@
+import { serve } from "@hono/node-server";
+import { Hono } from "hono";
+import { getCookie, setCookie } from "hono/cookie";
+import type { AddressInfo } from "node:net";
+
+/**
+ * Falošný Shoptet — imituje LEN tvar, ktorý `playwright-import.ts` naozaj
+ * ovláda (prihlásenie, import formulár, Log), aby sa dala overiť CELÁ
+ * automatizácia reálnym Chromiom bez toho, aby sa čokoľvek nahralo do
+ * skutočného Shoptetu (issue 122's testová požiadavka). Tvar stránok/
+ * selektorov zodpovedá SKUTOČNÉMU Shoptet adminu overenému naživo pri
+ * návrhu tohto ticketu (login page = "/admin/", žiadny presmerovací
+ * URL-rozdiel medzi úspechom/neúspechom — preto `playwright-import.ts`
+ * kontroluje PRÍTOMNOSŤ prihlasovacieho formulára, nie URL substring).
+ */
+
+const SAFE_RADIO_LABEL = "Nemeniť produkty a varianty, ktoré nie sú obsiahnuté v importovanom súbore.";
+const URL_BY_NAME_LABEL = "Zmeňte adresu URL produktu podľa názvu produktu.";
+const COOKIE_NAME = "sid";
+
+export type FixtureOutcomeMode = "success" | "partial" | "hard-error";
+
+export interface ShoptetFixtureOptions {
+  readonly user: string;
+  readonly password: string;
+  /** Import formulár VYNECHÁ bezpečný radio — na overenie, že
+   * `playwright-import.ts` odmietne pokračovať namiesto tichého importu bez
+   * neho (fail-closed). */
+  readonly omitSafeRadio?: boolean;
+}
+
+export interface ShoptetFixture {
+  readonly baseUrl: string;
+  setOutcome(mode: FixtureOutcomeMode): void;
+  readonly logEntryCount: () => number;
+  /** Seeds ONE pre-existing Log entry, as if a previous import already ran —
+   * a real Shoptet instance's Log is NEVER empty (this shop's own Log is
+   * already past #12000, confirmed live at #122's design), so every real
+   * write-back run captures a NON-NULL baseline. `pickResultRow`
+   * (log-attribution.ts) deliberately fail-closes on a null baseline (a
+   * genuinely unreadable Log page) — tests exercise the real, common path by
+   * seeding this, matching production instead of the never-happens "log
+   * truly empty" edge case. */
+  seedPastEntry(): void;
+  close(): Promise<void>;
+}
+
+function loginPage(failed: boolean): string {
+  return `<!doctype html><html><body>
+    ${failed ? "<p>Nesprávne prihlasovacie údaje</p>" : ""}
+    <form method="post" action="/admin/do-login">
+      <input placeholder="E-mail" name="email" />
+      <input placeholder="Vaše heslo" name="password" type="password" />
+      <button type="submit">Prihlásenie</button>
+    </form>
+  </body></html>`;
+}
+
+function dashboardPage(): string {
+  return `<!doctype html><html><body><h1>Nástenka</h1></body></html>`;
+}
+
+function importPage(omitSafeRadio: boolean): string {
+  const radio = omitSafeRadio
+    ? ""
+    : `<label><input type="radio" name="mode" value="safe" />${SAFE_RADIO_LABEL}</label>`;
+  return `<!doctype html><html><body>
+    <form method="post" action="/admin/import-produktov/do-import" enctype="multipart/form-data">
+      <input type="file" name="file" />
+      ${radio}
+      <label><input type="checkbox" name="urlByName" />${URL_BY_NAME_LABEL}</label>
+      <button type="submit" data-testid="buttonImport">Importovať</button>
+    </form>
+  </body></html>`;
+}
+
+function logPage(entries: readonly string[]): string {
+  const rows = entries.map((e) => `<tr><td>${e}</td></tr>`).join("");
+  return `<!doctype html><html><body><table><tr><td>Dátum</td><td>Výsledok</td></tr>${rows}</table></body></html>`;
+}
+
+function countCsvDataRows(csvText: string): number {
+  // strip BOM, split CRLF/LF, drop header + trailing empty line
+  const withoutBom = csvText.replace(/^\uFEFF/, "");
+  return withoutBom.split(/\r?\n/).filter((l) => l.length > 0).length - 1;
+}
+
+export async function startShoptetFixture(options: ShoptetFixtureOptions): Promise<ShoptetFixture> {
+  const app = new Hono();
+  let entries: string[] = [];
+  let nextId = 100;
+  let outcome: FixtureOutcomeMode = "success";
+
+  app.get("/admin/", (c) => {
+    const cookie = getCookie(c, COOKIE_NAME);
+    return c.html(cookie === "ok" ? dashboardPage() : loginPage(false));
+  });
+
+  app.post("/admin/do-login", async (c) => {
+    const body = await c.req.parseBody();
+    const email = body["email"];
+    const password = body["password"];
+    if (email === options.user && password === options.password) {
+      setCookie(c, COOKIE_NAME, "ok", { httpOnly: true, path: "/" });
+      return c.redirect("/admin/", 303);
+    }
+    return c.redirect("/admin/", 303);
+  });
+
+  app.get("/admin/import-produktov/", (c) => {
+    if (getCookie(c, COOKIE_NAME) !== "ok") return c.redirect("/admin/", 303);
+    return c.html(importPage(options.omitSafeRadio ?? false));
+  });
+
+  app.get("/admin/import-produktov/log/", (c) => {
+    if (getCookie(c, COOKIE_NAME) !== "ok") return c.redirect("/admin/", 303);
+    return c.html(logPage(entries));
+  });
+
+  app.post("/admin/import-produktov/do-import", async (c) => {
+    if (getCookie(c, COOKIE_NAME) !== "ok") return c.redirect("/admin/", 303);
+    const body = await c.req.parseBody();
+    const file = body["file"];
+    const text = file instanceof File ? await file.text() : "";
+    const rowCount = countCsvDataRows(text);
+    const id = nextId;
+    nextId += 1;
+    const date = "01.08.2026 10:00";
+    let resultText: string;
+    if (outcome === "success") {
+      resultText = `Spracované: ${String(rowCount)}. Upravené: ${String(rowCount)}. Zlyhanie variantov: 0.`;
+    } else if (outcome === "partial") {
+      resultText = `Spracované: ${String(rowCount)}. Upravené: ${String(rowCount - 1)}. Zlyhanie variantov: 1.`;
+    } else {
+      resultText = "Chyba | Číslo riadku: 2 - Data in column code are not unique";
+    }
+    entries = [`#${String(id)} ${date} ${resultText}`, ...entries];
+    return c.redirect("/admin/import-produktov/log/", 303);
+  });
+
+  const server = await new Promise<import("node:http").Server>((resolve) => {
+    const s = serve({ fetch: app.fetch, port: 0 }, () => {
+      resolve(s as unknown as import("node:http").Server);
+    });
+  });
+  const address = server.address() as AddressInfo;
+
+  return {
+    baseUrl: `http://127.0.0.1:${String(address.port)}`,
+    setOutcome: (mode) => {
+      outcome = mode;
+    },
+    logEntryCount: () => entries.length,
+    seedPastEntry: () => {
+      const id = nextId;
+      nextId += 1;
+      entries = [`#${String(id)} 01.08.2026 09:00 Spracované: 9. Upravené: 9. Zlyhanie variantov: 0.`, ...entries];
+    },
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      }),
+  };
+}

--- a/apps/api/tests/scheduler-jobs.integration.test.ts
+++ b/apps/api/tests/scheduler-jobs.integration.test.ts
@@ -12,11 +12,14 @@ import {
   PRUNE_RAW_EXPORTS_JOB_NAME,
   PRUNE_RAW_ORDERS_JOB_NAME,
   SESSION_CLEANUP_JOB_NAME,
+  SHOPTET_WRITEBACK_JOB_NAME,
+  SHOPTET_WRITEBACK_NOT_CONFIGURED,
   catalogImportJob,
   ordersImportJob,
   pruneRawExportsJob,
   pruneRawOrdersJob,
   sessionCleanupJob,
+  shoptetWritebackJob,
 } from "../src/modules/scheduler/jobs.js";
 import { insertTestSnapshot } from "./helpers/catalog.js";
 import { withCleanDb } from "./helpers/db.js";
@@ -150,4 +153,23 @@ it("pruneRawOrdersJob deleguje na existujúci pruneRawOrders — starý surový 
   expect(job.name).toBe(PRUNE_RAW_ORDERS_JOB_NAME);
   const outcome = await job.run({} as never, NOW);
   expect(outcome).toEqual({ detail: { removed: 1 } });
+});
+
+it("shoptetWritebackJob bez nakonfigurovaného runWriteback VYHODÍ (zachytí ho scheduler.ts, zapíše ako failure)", async () => {
+  const job = shoptetWritebackJob(undefined);
+  expect(job.name).toBe(SHOPTET_WRITEBACK_JOB_NAME);
+  await expect(job.run({} as never, NOW)).rejects.toThrow(SHOPTET_WRITEBACK_NOT_CONFIGURED);
+});
+
+it("shoptetWritebackJob s nakonfigurovaným runWriteback naň deleguje a vráti jeho výsledok ako detail", async () => {
+  const fakeResult = { status: "nothing_changed" } as const;
+  let receivedNow: Date | undefined;
+  const job = shoptetWritebackJob((_db, now) => {
+    receivedNow = now;
+    return Promise.resolve(fakeResult);
+  });
+
+  const outcome = await job.run({} as never, NOW);
+  expect(outcome).toEqual({ detail: fakeResult });
+  expect(receivedNow).toBe(NOW);
 });

--- a/apps/api/tests/shoptet-writeback-mark-synced.integration.test.ts
+++ b/apps/api/tests/shoptet-writeback-mark-synced.integration.test.ts
@@ -61,4 +61,29 @@ describe("markSuppliersLinksSynced", () => {
     await markSuppliersLinksSynced(db, [], new Date("2026-01-02T00:00:00Z"));
     expect((await selectChangedSupplierLinks(db)).productKeys).toEqual(["P4"]);
   });
+
+  it("does NOT mark a row synced if it was edited AGAIN after the run started (race window) — the next run must still pick it up", async () => {
+    await insertTestVariantForProduct(db, "P5", "P5", {});
+    // The run started at 10:00 and selected this row (updatedAt 09:00).
+    // While the (possibly slow, browser-driven) import was still in flight,
+    // the owner edited the SAME override again at 10:05 — AFTER the run's
+    // start time but BEFORE this markSuppliersLinksSynced call actually
+    // executes. Only the 09:00 value ever reached Shoptet; the 10:05 edit
+    // must NOT be silently marked as synced.
+    await db.insert(productSupplierLinkOverrides).values({
+      productKey: "P5",
+      url: "https://x.example/p5-edited-during-run",
+      updatedAt: new Date("2026-01-01T10:05:00Z"),
+    });
+
+    await markSuppliersLinksSynced(db, ["P5"], new Date("2026-01-01T10:00:00Z"));
+
+    const [row] = await db
+      .select({ syncedAt: productSupplierLinkOverrides.syncedAt })
+      .from(productSupplierLinkOverrides)
+      .where(eq(productSupplierLinkOverrides.productKey, "P5"));
+    expect(row?.syncedAt).toBeNull();
+    // and the next scheduled run's selection still includes it
+    expect((await selectChangedSupplierLinks(db)).productKeys).toEqual(["P5"]);
+  });
 });

--- a/apps/api/tests/shoptet-writeback-mark-synced.integration.test.ts
+++ b/apps/api/tests/shoptet-writeback-mark-synced.integration.test.ts
@@ -1,0 +1,64 @@
+import { eq } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Database } from "../src/db/client.js";
+import { productSupplierLinkOverrides } from "../src/db/schema.js";
+import { markSuppliersLinksSynced } from "../src/modules/shoptet-writeback/mark-synced.js";
+import { selectChangedSupplierLinks } from "../src/modules/shoptet-writeback/select-changes.js";
+import { withCleanDb } from "./helpers/db.js";
+import { insertTestVariantForProduct } from "./helpers/orders.js";
+
+describe("markSuppliersLinksSynced", () => {
+  let db: Database;
+  let close: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ db, close } = await withCleanDb());
+  });
+
+  afterEach(async () => {
+    await close();
+  });
+
+  it("sets syncedAt on exactly the given productKeys, leaving an untouched sibling row alone", async () => {
+    await insertTestVariantForProduct(db, "P1", "P1", {});
+    await insertTestVariantForProduct(db, "P2", "P2", {});
+    await db.insert(productSupplierLinkOverrides).values([
+      { productKey: "P1", url: "https://x.example/p1", updatedAt: new Date("2026-01-01T00:00:00Z") },
+      { productKey: "P2", url: "https://x.example/p2", updatedAt: new Date("2026-01-01T00:00:00Z") },
+    ]);
+
+    await markSuppliersLinksSynced(db, ["P1"], new Date("2026-02-01T00:00:00Z"));
+
+    const [p1] = await db
+      .select({ syncedAt: productSupplierLinkOverrides.syncedAt })
+      .from(productSupplierLinkOverrides)
+      .where(eq(productSupplierLinkOverrides.productKey, "P1"));
+    const [p2] = await db
+      .select({ syncedAt: productSupplierLinkOverrides.syncedAt })
+      .from(productSupplierLinkOverrides)
+      .where(eq(productSupplierLinkOverrides.productKey, "P2"));
+    expect(p1?.syncedAt?.toISOString()).toBe("2026-02-01T00:00:00.000Z");
+    expect(p2?.syncedAt).toBeNull();
+  });
+
+  it("removes the marked products from the next selectChangedSupplierLinks() result", async () => {
+    await insertTestVariantForProduct(db, "P3", "P3", {});
+    await db
+      .insert(productSupplierLinkOverrides)
+      .values({ productKey: "P3", url: "https://x.example/p3", updatedAt: new Date("2026-01-01T00:00:00Z") });
+
+    expect((await selectChangedSupplierLinks(db)).productKeys).toEqual(["P3"]);
+    await markSuppliersLinksSynced(db, ["P3"], new Date("2026-01-02T00:00:00Z"));
+    expect((await selectChangedSupplierLinks(db)).productKeys).toEqual([]);
+  });
+
+  it("is a no-op for an empty productKeys list", async () => {
+    await insertTestVariantForProduct(db, "P4", "P4", {});
+    await db
+      .insert(productSupplierLinkOverrides)
+      .values({ productKey: "P4", url: "https://x.example/p4", updatedAt: new Date("2026-01-01T00:00:00Z") });
+
+    await markSuppliersLinksSynced(db, [], new Date("2026-01-02T00:00:00Z"));
+    expect((await selectChangedSupplierLinks(db)).productKeys).toEqual(["P4"]);
+  });
+});

--- a/apps/api/tests/shoptet-writeback-playwright.integration.test.ts
+++ b/apps/api/tests/shoptet-writeback-playwright.integration.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { buildWritebackCsv } from "../src/modules/shoptet-writeback/csv.js";
+import { runShoptetImport } from "../src/modules/shoptet-writeback/playwright-import.js";
+import { startShoptetFixture, type ShoptetFixture } from "./helpers/shoptet-fixture.js";
+
+// Reálny Chromium proti LOKÁLNEJ fixture appke (nikdy proti skutočnému
+// Shoptetu — issue 122's testová požiadavka). Browser beh môže byť pomalší
+// v CI, preto vyšší timeout než ostatné integračné testy.
+const TEST_TIMEOUT_MS = 60_000;
+
+describe("runShoptetImport (proti fixture, nikdy proti reálnemu Shoptetu)", () => {
+  let fixture: ShoptetFixture | undefined;
+
+  afterEach(async () => {
+    await fixture?.close();
+    fixture = undefined;
+  });
+
+  it(
+    "prihlási sa, nahrá CSV, over bezpečné nastavenia a potvrdí úspech z Logu",
+    async () => {
+      fixture = await startShoptetFixture({ user: "manager", password: "tajneheslo" });
+      fixture.seedPastEntry();
+      const csv = buildWritebackCsv([
+        { code: "A/S", pairCode: "1", internalNote: "https://dodavatel.example/a" },
+        { code: "A/M", pairCode: "2", internalNote: "https://dodavatel.example/a" },
+      ]);
+
+      const outcome = await runShoptetImport({
+        config: {
+          loginUrl: `${fixture.baseUrl}/admin/`,
+          importUrl: `${fixture.baseUrl}/admin/import-produktov/`,
+          logUrl: `${fixture.baseUrl}/admin/import-produktov/log/`,
+          user: "manager",
+          password: "tajneheslo",
+        },
+        csv,
+        expectedRows: 2,
+        resultPollRetries: 3,
+        resultPollWaitMs: 100,
+      });
+
+      expect(outcome.ok).toBe(true);
+      expect(outcome.processed).toBe(2);
+      expect(outcome.failed).toBe(0);
+      expect(outcome.errorDetail).toBeNull();
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "throws when the credentials are wrong — never silently 'succeeds'",
+    async () => {
+      fixture = await startShoptetFixture({ user: "manager", password: "tajneheslo" });
+      fixture.seedPastEntry();
+      const csv = buildWritebackCsv([{ code: "A", pairCode: "", internalNote: "https://x.example/a" }]);
+
+      await expect(
+        runShoptetImport({
+          config: {
+            loginUrl: `${fixture.baseUrl}/admin/`,
+            importUrl: `${fixture.baseUrl}/admin/import-produktov/`,
+            logUrl: `${fixture.baseUrl}/admin/import-produktov/log/`,
+            user: "manager",
+            password: "ZLE-heslo",
+          },
+          csv,
+          expectedRows: 1,
+        }),
+      ).rejects.toThrow(/prihlásenie/i);
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "refuses to upload when the safe-mode radio is missing from the import form (fail-closed)",
+    async () => {
+      fixture = await startShoptetFixture({ user: "manager", password: "tajneheslo", omitSafeRadio: true });
+      fixture.seedPastEntry();
+      const csv = buildWritebackCsv([{ code: "A", pairCode: "", internalNote: "https://x.example/a" }]);
+
+      await expect(
+        runShoptetImport({
+          config: {
+            loginUrl: `${fixture.baseUrl}/admin/`,
+            importUrl: `${fixture.baseUrl}/admin/import-produktov/`,
+            logUrl: `${fixture.baseUrl}/admin/import-produktov/log/`,
+            user: "manager",
+            password: "tajneheslo",
+          },
+          csv,
+          expectedRows: 1,
+        }),
+      ).rejects.toThrow(/bezpečn/i);
+      // and NOTHING new was uploaded — only the pre-existing seeded entry remains
+      expect(fixture.logEntryCount()).toBe(1);
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "reports a hard Shoptet abort (no Spracované summary) as ok:false with the error detail surfaced",
+    async () => {
+      fixture = await startShoptetFixture({ user: "manager", password: "tajneheslo" });
+      fixture.seedPastEntry();
+      fixture.setOutcome("hard-error");
+      const csv = buildWritebackCsv([{ code: "A", pairCode: "", internalNote: "https://x.example/a" }]);
+
+      const outcome = await runShoptetImport({
+        config: {
+          loginUrl: `${fixture.baseUrl}/admin/`,
+          importUrl: `${fixture.baseUrl}/admin/import-produktov/`,
+          logUrl: `${fixture.baseUrl}/admin/import-produktov/log/`,
+          user: "manager",
+          password: "tajneheslo",
+        },
+        csv,
+        expectedRows: 1,
+        resultPollRetries: 3,
+        resultPollWaitMs: 100,
+      });
+
+      expect(outcome.ok).toBe(false);
+      expect(outcome.processed).toBeNull();
+      expect(outcome.errorDetail).toContain("Data in column code are not unique");
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "reports a partial failure (some rows rejected) as ok:false",
+    async () => {
+      fixture = await startShoptetFixture({ user: "manager", password: "tajneheslo" });
+      fixture.seedPastEntry();
+      fixture.setOutcome("partial");
+      const csv = buildWritebackCsv([
+        { code: "A", pairCode: "", internalNote: "https://x.example/a" },
+        { code: "B", pairCode: "", internalNote: "https://x.example/b" },
+      ]);
+
+      const outcome = await runShoptetImport({
+        config: {
+          loginUrl: `${fixture.baseUrl}/admin/`,
+          importUrl: `${fixture.baseUrl}/admin/import-produktov/`,
+          logUrl: `${fixture.baseUrl}/admin/import-produktov/log/`,
+          user: "manager",
+          password: "tajneheslo",
+        },
+        csv,
+        expectedRows: 2,
+        resultPollRetries: 3,
+        resultPollWaitMs: 100,
+      });
+
+      expect(outcome.ok).toBe(false);
+      expect(outcome.processed).toBe(2);
+      expect(outcome.failed).toBe(1);
+    },
+    TEST_TIMEOUT_MS,
+  );
+});

--- a/apps/api/tests/shoptet-writeback-run.integration.test.ts
+++ b/apps/api/tests/shoptet-writeback-run.integration.test.ts
@@ -1,0 +1,102 @@
+import { eq } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Database } from "../src/db/client.js";
+import { productSupplierLinkOverrides } from "../src/db/schema.js";
+import { runShoptetWriteback } from "../src/modules/shoptet-writeback/run-writeback.js";
+import { withCleanDb } from "./helpers/db.js";
+import { insertTestVariantForProduct } from "./helpers/orders.js";
+import { startShoptetFixture, type ShoptetFixture } from "./helpers/shoptet-fixture.js";
+
+const TEST_TIMEOUT_MS = 60_000;
+
+describe("runShoptetWriteback (end-to-end proti fixture)", () => {
+  let db: Database;
+  let closeDb: () => Promise<void>;
+  let fixture: ShoptetFixture;
+
+  beforeEach(async () => {
+    ({ db, close: closeDb } = await withCleanDb());
+    fixture = await startShoptetFixture({ user: "manager", password: "tajneheslo" });
+    fixture.seedPastEntry();
+  });
+
+  afterEach(async () => {
+    await closeDb();
+    await fixture.close();
+  });
+
+  function fixtureConfig(): {
+    loginUrl: string;
+    importUrl: string;
+    logUrl: string;
+    user: string;
+    password: string;
+  } {
+    return {
+      loginUrl: `${fixture.baseUrl}/admin/`,
+      importUrl: `${fixture.baseUrl}/admin/import-produktov/`,
+      logUrl: `${fixture.baseUrl}/admin/import-produktov/log/`,
+      user: "manager",
+      password: "tajneheslo",
+    };
+  }
+
+  it(
+    "reports 'nothing_changed' and touches nothing when there are no overrides",
+    async () => {
+      const result = await runShoptetWriteback(db, fixtureConfig(), new Date("2026-02-01T00:00:00Z"));
+      expect(result).toEqual({ status: "nothing_changed" });
+      expect(fixture.logEntryCount()).toBe(1); // only the seed — nothing uploaded
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "on a confirmed success marks the written-back products synced — a second run then reports nothing_changed",
+    async () => {
+      await insertTestVariantForProduct(db, "P1", "P1/S", { pairCode: "1" });
+      await insertTestVariantForProduct(db, "P1", "P1/M", { pairCode: "2" });
+      await db
+        .insert(productSupplierLinkOverrides)
+        .values({ productKey: "P1", url: "https://x.example/p1", updatedAt: new Date("2026-01-01T00:00:00Z") });
+
+      const result = await runShoptetWriteback(db, fixtureConfig(), new Date("2026-02-01T00:00:00Z"));
+      expect(result).toEqual({ status: "ok", productCount: 1, rowCount: 2 });
+
+      const [row] = await db
+        .select({ syncedAt: productSupplierLinkOverrides.syncedAt })
+        .from(productSupplierLinkOverrides)
+        .where(eq(productSupplierLinkOverrides.productKey, "P1"));
+      expect(row?.syncedAt?.toISOString()).toBe("2026-02-01T00:00:00.000Z");
+
+      // second run: nothing changed since the sync above
+      const second = await runShoptetWriteback(db, fixtureConfig(), new Date("2026-02-02T00:00:00Z"));
+      expect(second).toEqual({ status: "nothing_changed" });
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "on a hard Shoptet failure leaves syncedAt untouched, so the same product is retried next run",
+    async () => {
+      await insertTestVariantForProduct(db, "P2", "P2", {});
+      await db
+        .insert(productSupplierLinkOverrides)
+        .values({ productKey: "P2", url: "https://x.example/p2", updatedAt: new Date("2026-01-01T00:00:00Z") });
+      fixture.setOutcome("hard-error");
+
+      const result = await runShoptetWriteback(db, fixtureConfig(), new Date("2026-02-01T00:00:00Z"));
+      expect(result.status).toBe("failed");
+      if (result.status === "failed") {
+        expect(result.errorDetail).toContain("Data in column code are not unique");
+      }
+
+      const [row] = await db
+        .select({ syncedAt: productSupplierLinkOverrides.syncedAt })
+        .from(productSupplierLinkOverrides)
+        .where(eq(productSupplierLinkOverrides.productKey, "P2"));
+      expect(row?.syncedAt).toBeNull();
+    },
+    TEST_TIMEOUT_MS,
+  );
+});

--- a/apps/api/tests/shoptet-writeback-select.integration.test.ts
+++ b/apps/api/tests/shoptet-writeback-select.integration.test.ts
@@ -1,0 +1,106 @@
+import { eq } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Database } from "../src/db/client.js";
+import { productSupplierLinkOverrides } from "../src/db/schema.js";
+import { selectChangedSupplierLinks } from "../src/modules/shoptet-writeback/select-changes.js";
+import { withCleanDb } from "./helpers/db.js";
+import { insertTestVariantForProduct } from "./helpers/orders.js";
+
+describe("selectChangedSupplierLinks", () => {
+  let db: Database;
+  let close: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ db, close } = await withCleanDb());
+  });
+
+  afterEach(async () => {
+    await close();
+  });
+
+  it("returns no rows when there are no overrides at all", async () => {
+    const result = await selectChangedSupplierLinks(db);
+    expect(result.productKeys).toEqual([]);
+    expect(result.rows).toEqual([]);
+  });
+
+  it("emits ONE row per variant of a never-synced override, carrying code+pairCode+the override URL", async () => {
+    await insertTestVariantForProduct(db, "P1", "P1/S", { pairCode: "1001" });
+    await insertTestVariantForProduct(db, "P1", "P1/M", { pairCode: "1002" });
+    await db.insert(productSupplierLinkOverrides).values({
+      productKey: "P1",
+      url: "https://dodavatel.example/p1",
+      updatedAt: new Date("2026-01-02T00:00:00Z"),
+    });
+
+    const result = await selectChangedSupplierLinks(db);
+    expect(result.productKeys).toEqual(["P1"]);
+    expect(result.rows).toHaveLength(2);
+    expect(result.rows).toEqual(
+      expect.arrayContaining([
+        { code: "P1/S", pairCode: "1001", internalNote: "https://dodavatel.example/p1" },
+        { code: "P1/M", pairCode: "1002", internalNote: "https://dodavatel.example/p1" },
+      ]),
+    );
+  });
+
+  it("uses an empty string for a variant with no pairCode (single-variant products have none)", async () => {
+    await insertTestVariantForProduct(db, "P2", "P2", {});
+    await db.insert(productSupplierLinkOverrides).values({
+      productKey: "P2",
+      url: "https://dodavatel.example/p2",
+      updatedAt: new Date("2026-01-02T00:00:00Z"),
+    });
+
+    const result = await selectChangedSupplierLinks(db);
+    expect(result.rows).toEqual([{ code: "P2", pairCode: "", internalNote: "https://dodavatel.example/p2" }]);
+  });
+
+  it("excludes an override already synced AFTER its last update (nothing changed since)", async () => {
+    await insertTestVariantForProduct(db, "P3", "P3", {});
+    await db.insert(productSupplierLinkOverrides).values({
+      productKey: "P3",
+      url: "https://dodavatel.example/p3",
+      updatedAt: new Date("2026-01-01T00:00:00Z"),
+      syncedAt: new Date("2026-01-02T00:00:00Z"),
+    });
+
+    const result = await selectChangedSupplierLinks(db);
+    expect(result.productKeys).toEqual([]);
+  });
+
+  it("includes an override whose updatedAt moved PAST its last syncedAt (edited again after a sync)", async () => {
+    await insertTestVariantForProduct(db, "P4", "P4", {});
+    await db.insert(productSupplierLinkOverrides).values({
+      productKey: "P4",
+      url: "https://dodavatel.example/p4-new",
+      updatedAt: new Date("2026-01-03T00:00:00Z"),
+      syncedAt: new Date("2026-01-01T00:00:00Z"),
+    });
+
+    const result = await selectChangedSupplierLinks(db);
+    expect(result.productKeys).toEqual(["P4"]);
+    expect(result.rows).toEqual([{ code: "P4", pairCode: "", internalNote: "https://dodavatel.example/p4-new" }]);
+  });
+
+  it("only reports the productKeys of rows actually selected — a synced-and-unchanged sibling stays excluded", async () => {
+    await insertTestVariantForProduct(db, "P5", "P5", {});
+    await insertTestVariantForProduct(db, "P6", "P6", {});
+    await db.insert(productSupplierLinkOverrides).values([
+      {
+        productKey: "P5",
+        url: "https://dodavatel.example/p5",
+        updatedAt: new Date("2026-01-01T00:00:00Z"),
+        syncedAt: new Date("2026-01-02T00:00:00Z"),
+      },
+      { productKey: "P6", url: "https://dodavatel.example/p6", updatedAt: new Date("2026-01-02T00:00:00Z") },
+    ]);
+
+    const result = await selectChangedSupplierLinks(db);
+    expect(result.productKeys).toEqual(["P6"]);
+
+    // sanity: the fixture really has both rows in the table
+    const all = await db.select().from(productSupplierLinkOverrides).where(eq(productSupplierLinkOverrides.productKey, "P5"));
+    expect(all).toHaveLength(1);
+  });
+});

--- a/apps/api/tests/shoptet-writeback-select.integration.test.ts
+++ b/apps/api/tests/shoptet-writeback-select.integration.test.ts
@@ -1,8 +1,9 @@
 import { eq } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { Database } from "../src/db/client.js";
-import { productSupplierLinkOverrides } from "../src/db/schema.js";
+import { products, productSupplierLinkOverrides } from "../src/db/schema.js";
 import { selectChangedSupplierLinks } from "../src/modules/shoptet-writeback/select-changes.js";
+import { insertTestSnapshot } from "./helpers/catalog.js";
 import { withCleanDb } from "./helpers/db.js";
 import { insertTestVariantForProduct } from "./helpers/orders.js";
 
@@ -102,5 +103,26 @@ describe("selectChangedSupplierLinks", () => {
     // sanity: the fixture really has both rows in the table
     const all = await db.select().from(productSupplierLinkOverrides).where(eq(productSupplierLinkOverrides.productKey, "P5"));
     expect(all).toHaveLength(1);
+  });
+
+  it("skips (never crashes on) a changed override whose product has zero variants — a data anomaly, not a normal case", async () => {
+    const snapshotId = await insertTestSnapshot(db);
+    await db.insert(products).values({
+      key: "P7-NO-VARIANTS",
+      name: "Produkt bez variantu (anomália)",
+      supplier: null,
+      firstSeenAt: new Date("2026-01-01T00:00:00Z"),
+      lastSeenAt: new Date("2026-01-01T00:00:00Z"),
+      lastSeenSnapshotId: snapshotId,
+    });
+    await db.insert(productSupplierLinkOverrides).values({
+      productKey: "P7-NO-VARIANTS",
+      url: "https://dodavatel.example/p7",
+      updatedAt: new Date("2026-01-01T00:00:00Z"),
+    });
+
+    const result = await selectChangedSupplierLinks(db);
+    expect(result.productKeys).toEqual([]);
+    expect(result.rows).toEqual([]);
   });
 });

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -66,6 +66,21 @@ services:
       # v `/srv/forestshop/.env` — bare kľúč tu je len na to, aby sa dala
       # doména zmeniť BEZ nového deploy/buildu, keby to niekedy bolo treba.
       SHOPTET_ADMIN_BASE_URL:
+      # issue 122: spätný zápis odkazu na dodávateľa do Shoptetu cez hromadný
+      # CSV import (Playwright) — rovnaká úvaha ako SHOPTET_EXPORT_URL vyššie:
+      # `.optional()` v `env.ts`, bare kľúč preberá `/srv/forestshop/.env`,
+      # keď tam je; keď nie je, appka beží ďalej, len naplánovaná úloha
+      # zaznamená "nenakonfigurované" (nikdy sa netýka manuálneho HTTP
+      # requestu, na rozdiel od SHOPTET_EXPORT_URL). Skutočné prihlasovacie
+      # údaje — nikdy natvrdo, nikdy do repa.
+      SHOPTET_ADMIN_USER:
+      SHOPTET_ADMIN_PASSWORD:
+      # Alpine (base image) nemá Playwright's vlastný stiahnutý Chromium —
+      # `Dockerfile` inštaluje systémový `apk add chromium` a
+      # `playwright-import.ts`'s `resolveChromiumExecutablePath` ho nájde
+      # automaticky (pevné cesty `/usr/bin/chromium-browser`/`/usr/bin/chromium`),
+      # tento riadok je len núdzový override, keby sa cesta niekedy zmenila.
+      CHROMIUM_EXECUTABLE_PATH:
       # Odosielanie objednávky dodávateľovi mailom (#31) — rovnaká úvaha ako
       # SHOPTET_EXPORT_URL vyššie: `.optional()` v `env.ts`, bare kľúč
       # preberá `/srv/forestshop/.env`, keď tam je; keď nie je, appka beží

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.81",
+  "version": "0.3.0-dev.82",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       pino:
         specifier: ^9.5.0
         version: 9.14.0
+      playwright:
+        specifier: ^1.49.0
+        version: 1.62.0
       zod:
         specifier: ^3.24.0
         version: 3.25.76


### PR DESCRIPTION
## Súhrn

Spätný zápis odkazu na dodávateľa do Shoptetu — issue 122. Odkazy uložené
appkou (issue 121's `product_supplier_link_override`) sa teraz raz za hodinu
(`:50`) pošlú späť do Shoptetu cez jeho hromadný CSV import, automatizovaný
Playwrightom presne podľa majiteľovho zadania: CSV nesie len zmenené produkty
a len `code`/`pairCode`/`internalNote` stĺpce.

## Čo pribudlo

- `product_supplier_link_override.synced_at` (nový nullable stĺpec) — zdroj
  pravdy pre "čo sa naozaj zmenilo od posledného zápisu".
- CSV builder (`code;pairCode;internalNote`, UTF-8 BOM, `;`, CRLF — dialekt
  overený naživo v sesterskom projekte `parovanie_produktov`).
- Port pravidiel na priradenie výsledku z Shoptet Logu (baseline +
  expected-rows atribúcia) zo sesterského projektu — čistá logika, unit
  testovaná.
- Playwright automatizácia (prihlásenie → over bezpečné nastavenia (fail-
  closed) → nahrá CSV → prečíta potvrdený výsledok z Logu).
- Naplánovaná úloha `shoptetWritebackJob` (hodinovo, `:50`).
- Alpine-friendly Chromium v produkčnom Docker image (`apk add chromium` +
  `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1`) — overené naživo v throwaway
  kontajneri pred commitnutím.
- `SHOPTET_ADMIN_USER`/`SHOPTET_ADMIN_PASSWORD` doplnené do
  `docker-compose.prod.yml` (predtým chýbali, appka mala k dispozícii len
  `SHOPTET_ADMIN_BASE_URL`).

## Testy

- Unit: CSV builder, log-attribution logika, URL builder — bez DB/browsera.
- Integration: select-changes / mark-synced (reálny Postgres).
- Integration s REÁLNYM Chromiom proti lokálnej fixture appke (nikdy proti
  skutočnému Shoptetu) — happy path, zlé heslo, chýbajúci bezpečný radio
  (fail-closed), tvrdé zlyhanie Shoptetu, čiastočné zlyhanie.
- End-to-end orchestrácia (`run-writeback.ts`) proti fixture + reálnemu DB.

## Akceptančné overenie

Naživo overené PO merge/deploy (pozri komentár na issue 122) — nemení sa
`Closes #122` v tomto tele, lebo akceptancia vyžaduje živé overenie AŽ po
nasadení.
