### PR TITLE
fix: Shoptet import widget potrebuje file-chooser, nie priamy setInputFiles (nadväzuje na #140)

### DIFF
--- a/apps/api/src/modules/shoptet-writeback/playwright-import.ts
+++ b/apps/api/src/modules/shoptet-writeback/playwright-import.ts
@@ -179,7 +179,20 @@ export async function runShoptetImport(options: RunShoptetImportOptions): Promis
     if ((await fileInput.count()) === 0) {
       throw new Error(`Nenašiel som import formulár (file input) na ${page.url()}`);
     }
-    await fileInput.setInputFiles(csvPath);
+    // Priame `setInputFiles` na skrytý `<input>` NESTAČÍ — Shoptetov widget
+    // (React) drží "súbor vybraný" stav sám v sebe, naviazaný na natívny
+    // file-chooser dialóg spustený VIDITEĽNÝM tlačidlom "Vyberte súbor", nie
+    // na `change` event skrytého inputu (rovnaké zistenie ako sesterský
+    // `scripts/shoptet_import.py`'s `_do_import`: "Shoptet widget inak súbor
+    // nezaregistruje" — overené naživo pri návrhu #122: priamy
+    // `setInputFiles` nechal formulár tichoodmietnuť odoslanie, `buttonImport`
+    // klik nikdy nenavigoval na Log). Port toho istého postupu: počkaj na
+    // `filechooser` event VYVOLANÝ klikom na viditeľné tlačidlo, súbor nastav
+    // na ZACHYTENÝ chooser objekt.
+    const fileChooserPromise = page.waitForEvent("filechooser");
+    await page.locator('button:has-text("Vyberte súbor")').first().click();
+    const fileChooser = await fileChooserPromise;
+    await fileChooser.setFiles(csvPath);
     await ensureSafeSettings(page);
 
     await page.getByTestId("buttonImport").click();

--- a/apps/api/tests/helpers/shoptet-fixture.ts
+++ b/apps/api/tests/helpers/shoptet-fixture.ts
@@ -64,9 +64,15 @@ function importPage(omitSafeRadio: boolean): string {
   const radio = omitSafeRadio
     ? ""
     : `<label><input type="radio" name="mode" value="safe" />${SAFE_RADIO_LABEL}</label>`;
+  // Skrytý file input + viditeľné tlačidlo, ktoré ho programovo "kliká" —
+  // rovnaký tvar ako reálny Shoptet (overené naživo pri návrhu #122: input
+  // má `hidden`, viditeľné je len tlačidlo "Vyberte súbor"; `playwright-
+  // import.ts` preto musí ísť cez `filechooser` event, nikdy priamy
+  // `setInputFiles` na skrytý input).
   return `<!doctype html><html><body>
     <form method="post" action="/admin/import-produktov/do-import" enctype="multipart/form-data">
-      <input type="file" name="file" />
+      <input type="file" name="file" id="fileInput" hidden />
+      <button type="button" onclick="document.getElementById('fileInput').click()">Vyberte súbor</button>
       ${radio}
       <label><input type="checkbox" name="urlByName" />${URL_BY_NAME_LABEL}</label>
       <button type="submit" data-testid="buttonImport">Importovať</button>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.82",
+  "version": "0.3.0-dev.83",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Súhrn

Nadväzuje na #140 (spätný zápis odkazov na dodávateľa do Shoptetu). Pri
naživo overovaní akceptančného kritéria issue 122 sa ukázalo, že priame
`setInputFiles` na skrytý file input NEFUNGUJE proti reálnemu Shoptetu —
jeho React widget drží "súbor vybraný" stav sám v sebe, naviazaný na
natívny file-chooser dialóg z viditeľného tlačidla "Vyberte súbor", nie na
`change` event skrytého inputu. Presne rovnaké zistenie ako sesterský
`parovanie_produktov` projekt už mal zdokumentované vo svojom kóde
("Shoptet widget inak súbor nezaregistruje") — táto PR portuje jeho presný
postup (počkať na `filechooser` event vyvolaný klikom na viditeľné
tlačidlo).

## Overenie

Naživo, priamo proti produkcii (`https://www.forestshop.sk`), na PRESNE
jednom produkte (Vnadidlo Bukový decht 2,5 l, kód 60286):

1. Cez appku nastavený testovací odkaz na dodávateľa.
2. Spustený spätný zápis (ručne, cez skript v bežiacom kontajneri) —
   PRED touto opravou: prihlásenie prešlo, ale klik na "Importovať" nikdy
   nenavigoval na Log (timeout 120s), lebo widget súbor nezaregistroval.
   PO oprave: `processed=1, updated=1, ok=true`.
3. Overené priamo v Shoptet exporte (mimo repa), že `internalNote` stĺpec
   PRESNE toho jedného produktu sa zmenil na testovaciu hodnotu, žiadny iný
   riadok/stĺpec sa nedotkol.
4. Odkaz vrátený na pôvodnú hodnotu, spätný zápis spustený znova, overené,
   že Shoptet má naspäť presne pôvodnú hodnotu.
5. `product_supplier_link_override` v produkčnej DB vrátená na 0 riadkov
   (pôvodný stav pred týmto testom).

Fixture (`shoptet-fixture.ts`) upravená, aby mala rovnaký tvar (skrytý
input + viditeľné tlačidlo + natívny file-chooser) — existujúce testy tak
overujú TENTO postup, nie tvar, ktorý starý kód len náhodou tiež splnil.

Testy: 41/41 test files, 272/272 testov zelené (unit + integration,
vrátane reálneho Chromia proti fixture).
