### PR TITLE
feat(shoptet-writeback): sync order comment into Shoptet (issue 123)

### DIFF
--- a/.claude/rules/shoptet-writeback.md
+++ b/.claude/rules/shoptet-writeback.md
@@ -2,7 +2,9 @@
 paths:
   - "apps/api/src/modules/shoptet-writeback/**"
   - "apps/api/tests/shoptet-writeback-*.integration.test.ts"
+  - "apps/api/tests/order-note-*.integration.test.ts"
   - "apps/api/tests/helpers/shoptet-fixture.ts"
+  - "apps/api/tests/helpers/shoptet-order-detail-fixture.ts"
   - "Dockerfile"
 ---
 

--- a/apps/api/drizzle/0019_silky_ghost_rider.sql
+++ b/apps/api/drizzle/0019_silky_ghost_rider.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "order" ADD COLUMN "comment_updated_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "order" ADD COLUMN "comment_synced_at" timestamp with time zone;

--- a/apps/api/drizzle/meta/0019_snapshot.json
+++ b/apps/api/drizzle/meta/0019_snapshot.json
@@ -1,0 +1,1543 @@
+{
+  "id": "8e828ef4-18ee-4b7f-8c6f-e9fb1a88e88f",
+  "prevId": "cabcd70c-0743-46a8-8b90-70e066317ad4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_code": {
+          "name": "external_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_open_status": {
+      "name": "order_open_status",
+      "schema": "",
+      "columns": {
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Vybavuje sa'"
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shoptet_order_id": {
+          "name": "shoptet_order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_updated_at": {
+          "name": "comment_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_synced_at": {
+          "name": "comment_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_link_override": {
+      "name": "product_supplier_link_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_link_override_product_key_product_key_fk": {
+          "name": "product_supplier_link_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_link_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_override": {
+      "name": "product_supplier_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_override_product_key_product_key_fk": {
+          "name": "product_supplier_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing": {
+      "name": "pairing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_url": {
+          "name": "supplier_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "pairing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'navrhnute'"
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pairing_state_idx": {
+          "name": "pairing_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_confirmed_by_idx": {
+          "name": "pairing_confirmed_by_idx",
+          "columns": [
+            {
+              "expression": "confirmed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_variant_code_variant_code_fk": {
+          "name": "pairing_variant_code_variant_code_fk",
+          "tableFrom": "pairing",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pairing_confirmed_by_users_id_fk": {
+          "name": "pairing_confirmed_by_users_id_fk",
+          "tableFrom": "pairing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pairing_variant_code_unique": {
+          "name": "pairing_variant_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pairing_confirmation_ck": {
+          "name": "pairing_confirmation_ck",
+          "value": "(\"pairing\".\"state\" = 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)\n        OR (\"pairing\".\"state\" != 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NULL AND \"pairing\".\"confirmed_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier": {
+      "name": "supplier",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wholesale_base_url": {
+          "name": "wholesale_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_key": {
+          "name": "adapter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne"
+      ]
+    },
+    "public.pairing_state": {
+      "name": "pairing_state",
+      "schema": "public",
+      "values": [
+        "navrhnute",
+        "potvrdene"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1785547348333,
       "tag": "0018_foamy_doctor_octopus",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1785557152824,
+      "tag": "0019_silky_ghost_rider",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema-orders.ts
+++ b/apps/api/src/db/schema-orders.ts
@@ -80,6 +80,24 @@ export const orders = pgTable(
     shoptetOrderId: integer("shoptet_order_id"),
     placedAt: timestamp("placed_at", { withTimezone: true }).notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    // issue 123: KEDY bol `comment` (vyššie) naposledy ZMENENÝ manažérom —
+    // nastavuje VÝLUČNE `setOrderComment` (`modules/orders/state.ts`), pri
+    // KAŽDEJ zmene poľa vrátane vymazania na `null`. `null` = comment sa
+    // ešte nikdy nezmenil cez appku (nový import, žiadny manažérov zásah).
+    // Rovnaký pár ako `productSupplierLinkOverrides.updatedAt` z #122, len
+    // na úrovni objednávky (namiesto samostatnej `updatedAt` na celej
+    // `order`, ktorá by musela riešiť aj polia, čo appku vôbec nezaujímajú).
+    commentUpdatedAt: timestamp("comment_updated_at", { withTimezone: true }),
+    // issue 123: kedy bol `comment` naposledy ÚSPEŠNE zapísaný do Shoptetu
+    // (potvrdené čerstvou navigáciou na detail objednávky po uložení, nikdy
+    // len "odoslalo sa"). `null` = ešte nikdy. "Zmenené od posledného
+    // zápisu" = `commentSyncedAt IS NULL OR commentSyncedAt <
+    // commentUpdatedAt` (`order-note-select.ts`) — rovnaký vzor ako #122's
+    // `product_supplier_link_override.synced_at`, len značené PER
+    // OBJEDNÁVKA hneď po jej vlastnom úspechu (nie dávkovo na konci celého
+    // behu), lebo tento zápis je per-objednávka, nie jeden hromadný CSV
+    // import.
+    commentSyncedAt: timestamp("comment_synced_at", { withTimezone: true }),
   },
   (t) => [index("order_placed_at_idx").on(t.placedAt)],
 );

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -16,13 +16,15 @@ import { DEFAULT_ORDERS_IMPORT_WINDOW_DAYS, ingestOrders, type RunOrdersIngest }
 import {
   catalogImportJob,
   ordersImportJob,
+  orderNoteWritebackJob,
   pruneRawExportsJob,
   pruneRawOrdersJob,
   sessionCleanupJob,
   shoptetWritebackJob,
 } from "./modules/scheduler/jobs.js";
 import { startScheduler } from "./modules/scheduler/scheduler.js";
-import { shoptetImportConfigFromBaseUrl } from "./modules/shoptet-writeback/config.js";
+import { orderNoteWritebackConfigFromBaseUrl, shoptetImportConfigFromBaseUrl } from "./modules/shoptet-writeback/config.js";
+import { runOrderNoteWritebackJob } from "./modules/shoptet-writeback/run-order-note-writeback.js";
 import { runShoptetWriteback } from "./modules/shoptet-writeback/run-writeback.js";
 import { createShutdownHandler } from "./shutdown.js";
 import { appVersion } from "./version.js";
@@ -124,6 +126,19 @@ const runShoptetWritebackFn =
           now,
         );
 
+// issue 123: spätný zápis appkinej poznámky k objednávke — zdieľa TIE ISTÉ
+// nepovinné premenné ako #122 vyššie (žiadne nové), len iná Playwright
+// automatizácia (per-objednávka, nie hromadný CSV import).
+const runOrderNoteWritebackFn =
+  shoptetAdminUser === undefined || shoptetAdminPassword === undefined
+    ? undefined
+    : (db2: typeof db, now: Date) =>
+        runOrderNoteWritebackJob(
+          db2,
+          orderNoteWritebackConfigFromBaseUrl(env.SHOPTET_ADMIN_BASE_URL, shoptetAdminUser, shoptetAdminPassword),
+          now,
+        );
+
 const app = createApp(db, {
   cookieSecure: env.SESSION_COOKIE_SECURE,
   ...(runIngest === undefined ? {} : { runIngest }),
@@ -146,6 +161,7 @@ const scheduler = startScheduler(db, [
   ordersImportJob(runOrdersIngest),
   pruneRawOrdersJob(env.ORDERS_RAW_DIR),
   shoptetWritebackJob(runShoptetWritebackFn),
+  orderNoteWritebackJob(runOrderNoteWritebackFn),
 ]);
 
 // `@hono/node-server`'s `serveStatic` prints its OWN `console.error` on every

--- a/apps/api/src/modules/orders/state.ts
+++ b/apps/api/src/modules/orders/state.ts
@@ -134,7 +134,13 @@ export async function setOrderComment(
       .limit(1);
     if (order === undefined) return "not_found";
 
-    await tx.update(orders).set({ comment: input.comment }).where(eq(orders.id, input.orderId));
+    // issue 123: `commentUpdatedAt` je jediný zdroj pravdy pre "treba
+    // poznámku zapísať späť do Shoptetu" (`order-note-select.ts`) — nastaví
+    // sa pri KAŽDEJ zmene, vrátane vymazania na `null`.
+    await tx
+      .update(orders)
+      .set({ comment: input.comment, commentUpdatedAt: input.now })
+      .where(eq(orders.id, input.orderId));
 
     await record(tx, {
       at: input.now,

--- a/apps/api/src/modules/scheduler/jobs.ts
+++ b/apps/api/src/modules/scheduler/jobs.ts
@@ -3,6 +3,7 @@ import type { RunIngest } from "../catalog/ingest.js";
 import { pruneRawSnapshots } from "../catalog/raw-store.js";
 import { ORDERS_EXPORT_URL_NOT_CONFIGURED, type RunOrdersIngest } from "../orders/ingest.js";
 import { pruneRawOrders } from "../orders/raw-prune.js";
+import type { OrderNoteWritebackRunResult } from "../shoptet-writeback/run-order-note-writeback.js";
 import type { WritebackRunResult } from "../shoptet-writeback/run-writeback.js";
 import type { ScheduledJob } from "./types.js";
 
@@ -141,6 +142,40 @@ export function shoptetWritebackJob(runWriteback: RunShoptetWriteback | undefine
     async run(db, now) {
       if (runWriteback === undefined) throw new Error(SHOPTET_WRITEBACK_NOT_CONFIGURED);
       const result = await runWriteback(db, now);
+      return { detail: result };
+    },
+  };
+}
+
+export const ORDER_NOTE_WRITEBACK_JOB_NAME = "order-note-writeback";
+
+// Rovnaká hláška ako `shoptetWritebackJob` vyššie — zdieľa tú istú dvojicu
+// premenných (`SHOPTET_ADMIN_USER`/`PASSWORD`), operátor vidí to isté
+// vysvetlenie na oboch miestach.
+export const ORDER_NOTE_WRITEBACK_NOT_CONFIGURED =
+  "Spätný zápis poznámky objednávky do Shoptetu nie je nakonfigurovaný (chýba SHOPTET_ADMIN_USER/SHOPTET_ADMIN_PASSWORD)";
+
+export type RunOrderNoteWriteback = (
+  db: Parameters<ScheduledJob["run"]>[0],
+  now: Date,
+) => Promise<OrderNoteWritebackRunResult>;
+
+/**
+ * Spätný zápis appkinej poznámky (issue 123) — hodinovo, na `:55` (mimo
+ * kolízie s `:45` import objednávok aj `:50` #122's spätný zápis odkazov na
+ * dodávateľa). Rovnaký injektovaný-closure vzor ako `shoptetWritebackJob`
+ * vyššie: `runOrderNoteWriteback` môže byť `undefined`, keď
+ * `SHOPTET_ADMIN_USER`/`PASSWORD` nie sú nakonfigurované (`index.ts`).
+ * Žiadny nový advisory lock (rovnaký dôvod ako #122 — v tomto tickete niet
+ * manuálneho triggeru, teda niet s čím pretekať).
+ */
+export function orderNoteWritebackJob(runOrderNoteWriteback: RunOrderNoteWriteback | undefined): ScheduledJob {
+  return {
+    name: ORDER_NOTE_WRITEBACK_JOB_NAME,
+    schedule: { kind: "hourly", minuteUtc: 55 },
+    async run(db, now) {
+      if (runOrderNoteWriteback === undefined) throw new Error(ORDER_NOTE_WRITEBACK_NOT_CONFIGURED);
+      const result = await runOrderNoteWriteback(db, now);
       return { detail: result };
     },
   };

--- a/apps/api/src/modules/shoptet-writeback/admin-login.ts
+++ b/apps/api/src/modules/shoptet-writeback/admin-login.ts
@@ -1,0 +1,26 @@
+import type { Page } from "playwright";
+
+/** Zdieľané prihlásenie do Shoptet admina — extrahované z #122's
+ * `playwright-import.ts`'s `login()` (issue 123 potrebuje to isté, len na
+ * inej nasledujúcej stránke). Žiadna zmena správania #122 — presne ten istý
+ * postup, len pod spoločným menom oboch volajúcich. */
+export interface AdminLoginConfig {
+  readonly loginUrl: string;
+  readonly user: string;
+  readonly password: string;
+}
+
+export async function loginToShoptetAdmin(page: Page, config: AdminLoginConfig): Promise<void> {
+  await page.goto(config.loginUrl, { waitUntil: "domcontentloaded" });
+  await page.getByPlaceholder("E-mail").fill(config.user);
+  await page.getByPlaceholder("Vaše heslo").fill(config.password);
+  await page.getByRole("button", { name: "Prihlásenie" }).click();
+  await page.waitForLoadState("networkidle");
+  // NIKDY substring na URL ("/login") — reálny Shoptet login pre tento obchod
+  // je na `${adminBaseUrl}/admin/` a úspešné prihlásenie sa vráti na TÚ ISTÚ
+  // URL (overené naživo pri návrhu #122). Jediný spoľahlivý signál zlyhania
+  // je, že prihlasovací formulár je STÁLE na stránke.
+  if ((await page.getByPlaceholder("E-mail").count()) > 0) {
+    throw new Error("Prihlásenie do Shoptetu zlyhalo (prihlasovací formulár stále viditeľný) — over SHOPTET_ADMIN_USER/PASSWORD");
+  }
+}

--- a/apps/api/src/modules/shoptet-writeback/config.ts
+++ b/apps/api/src/modules/shoptet-writeback/config.ts
@@ -28,3 +28,28 @@ export function shoptetImportConfigFromBaseUrl(
     password,
   };
 }
+
+/**
+ * Konfigurácia pre issue 123's spätný zápis poznámky (per-objednávka, nie
+ * hromadný CSV import ako vyššie) — zdieľa PRIHLASOVACIU stránku aj
+ * `SHOPTET_ADMIN_USER`/`PASSWORD` s #122 (žiadne nové premenné), ale
+ * NEPOTREBUJE `importUrl`/`logUrl`. `adminBaseUrl` (bez koncového lomítka)
+ * sa navyše nesie priamo — `order-note-playwright.ts` ho potrebuje pre
+ * `buildShoptetAdminOrderUrl` (`modules/orders/queries.ts`), rovnaké
+ * URL-skladanie appka už používa na obrazovke "Na objednanie".
+ */
+export interface OrderNoteWritebackConfig {
+  readonly loginUrl: string;
+  readonly adminBaseUrl: string;
+  readonly user: string;
+  readonly password: string;
+}
+
+export function orderNoteWritebackConfigFromBaseUrl(
+  adminBaseUrl: string,
+  user: string,
+  password: string,
+): OrderNoteWritebackConfig {
+  const base = adminBaseUrl.replace(/\/+$/, "");
+  return { loginUrl: `${base}/admin/`, adminBaseUrl: base, user, password };
+}

--- a/apps/api/src/modules/shoptet-writeback/note-block.test.ts
+++ b/apps/api/src/modules/shoptet-writeback/note-block.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { hasOurBlock, mergeShopRemark, NOTE_BLOCK_END, NOTE_BLOCK_START } from "./note-block.js";
+
+describe("mergeShopRemark", () => {
+  it("appends our block to an empty field", () => {
+    const result = mergeShopRemark(null, "Zavolať zajtra");
+    expect(result).toBe(`${NOTE_BLOCK_START}\nZavolať zajtra\n${NOTE_BLOCK_END}`);
+  });
+
+  it("appends our block after existing manual text, separated by a blank line", () => {
+    const result = mergeShopRemark("Ručná poznámka predajne", "Zavolať zajtra");
+    expect(result).toBe(`Ručná poznámka predajne\n\n${NOTE_BLOCK_START}\nZavolať zajtra\n${NOTE_BLOCK_END}`);
+  });
+
+  it("replaces ONLY our block's content on a second sync, never touching manual text", () => {
+    const afterFirst = mergeShopRemark("Ručná poznámka predajne", "Zavolať zajtra");
+    const afterSecond = mergeShopRemark(afterFirst, "Nová poznámka");
+    expect(afterSecond).toBe(`Ručná poznámka predajne\n\n${NOTE_BLOCK_START}\nNová poznámka\n${NOTE_BLOCK_END}`);
+  });
+
+  it("is idempotent — merging the SAME note again changes nothing (no blank-line accumulation)", () => {
+    const afterFirst = mergeShopRemark("Ručná poznámka predajne", "Zavolať zajtra");
+    const afterSecond = mergeShopRemark(afterFirst, "Zavolať zajtra");
+    expect(afterSecond).toBe(afterFirst);
+  });
+
+  it("removes ONLY our block (and its separator) when our note is cleared, preserving manual text exactly", () => {
+    const withBlock = mergeShopRemark("Ručná poznámka predajne", "Zavolať zajtra");
+    const cleared = mergeShopRemark(withBlock, null);
+    expect(cleared).toBe("Ručná poznámka predajne");
+  });
+
+  it("clears to an empty string when the field had ONLY our block", () => {
+    const withBlock = mergeShopRemark(null, "Zavolať zajtra");
+    const cleared = mergeShopRemark(withBlock, "");
+    expect(cleared).toBe("");
+  });
+
+  it("treats a whitespace-only note the same as clearing", () => {
+    const withBlock = mergeShopRemark("Ručná poznámka", "Zavolať zajtra");
+    const cleared = mergeShopRemark(withBlock, "   \n  ");
+    expect(cleared).toBe("Ručná poznámka");
+  });
+
+  it("never touches manual text when our note stays empty and no block exists yet", () => {
+    expect(mergeShopRemark("Len ručný text, žiadny blok appky", null)).toBe("Len ručný text, žiadny blok appky");
+  });
+
+  it("hasOurBlock detects presence/absence correctly", () => {
+    expect(hasOurBlock("Len ručný text")).toBe(false);
+    expect(hasOurBlock(mergeShopRemark(null, "x"))).toBe(true);
+    expect(hasOurBlock(mergeShopRemark("Ručný text", "x"))).toBe(true);
+  });
+});

--- a/apps/api/src/modules/shoptet-writeback/note-block.ts
+++ b/apps/api/src/modules/shoptet-writeback/note-block.ts
@@ -1,0 +1,67 @@
+// issue 123: appkina poznámka k objednávke (`order.comment`) sa do Shoptetu
+// zapisuje ako VLASTNÝ ohraničený blok vnútri Shoptet-ovho "Poznámka
+// e-shopu" poľa (`textarea[name="shopRemark"]` na `/admin/objednavky-
+// detail/`, naživo overené pri návrhu tohto ticketu) — NIKDY neprepisuje
+// celé pole. Majiteľovo rozhodnutie (zadanie dispatchu): appka sa PRIPÁJA,
+// nikdy nenahrádza ručne napísaný text okolo. Toto je čisto textová funkcia
+// (žiadny DB/Playwright prístup) — jednoducho testovateľná bez fixtúry.
+
+export const NOTE_BLOCK_START = "--- poznámka z appky ---";
+export const NOTE_BLOCK_END = "--- koniec ---";
+
+function escapeForRegex(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// Zachytí AJ 1-2 prázdne riadky BEZPROSTREDNE PRED blokom, aby odstránenie
+// bloku (ourNote prázdny) nenechalo za sebou osamotené prázdne riadky —
+// `mergeShopRemark` nižšie potom sám pridáva PRESNE jeden oddeľovací
+// prázdny riadok pri opätovnom pripojení, takže výsledok je vždy
+// deterministický bez ohľadu na to, koľkokrát sa blok odstráni/pridá.
+const OUR_BLOCK_RE = new RegExp(
+  `(?:\\n{1,2})?${escapeForRegex(NOTE_BLOCK_START)}[\\s\\S]*?${escapeForRegex(NOTE_BLOCK_END)}`,
+);
+
+function buildBlock(note: string): string {
+  return `${NOTE_BLOCK_START}\n${note}\n${NOTE_BLOCK_END}`;
+}
+
+/** `true`, keď `text` obsahuje náš ohraničený blok (na hocijakom mieste). */
+export function hasOurBlock(text: string): boolean {
+  return OUR_BLOCK_RE.test(text);
+}
+
+/**
+ * Zloží novú hodnotu Shoptet-ovho "Poznámka e-shopu" poľa z jeho AKTUÁLNEHO
+ * obsahu (`existingShopRemark`, `null`/`""` keď pole zatiaľ prázdne) a
+ * appkinej poznámky (`ourNote`, `null`/prázdny reťazec po orezaní = appka
+ * nemá čo zapísať, teda ODSTRÁNI svoj blok, ak tam nejaký je).
+ *
+ * - Náš blok UŽ v texte je → nahradí sa LEN jeho obsah, ručný text okolo sa
+ *   nedotkne.
+ * - Náš blok tam NIE JE a `ourNote` má obsah → pripojí sa na koniec (za
+ *   oddeľovacím prázdnym riadkom, ak existujúci text niečo obsahuje).
+ * - `ourNote` prázdny/`null` → odstráni sa LEN náš blok (aj s prípadným
+ *   oddeľovacím prázdnym riadkom pred ním), zvyšok textu ostáva presne
+ *   taký, aký bol.
+ *
+ * Idempotentné: opätovné volanie s TOU ISTOU `ourNote` na výsledku
+ * predchádzajúceho volania vráti nezmenený reťazec (žiadne hromadenie
+ * prázdnych riadkov ani duplicitných blokov).
+ */
+export function mergeShopRemark(existingShopRemark: string | null, ourNote: string | null): string {
+  const existing = existingShopRemark ?? "";
+  const trimmedNote = ourNote?.trim() ?? "";
+
+  const withoutOurBlock = existing.replace(OUR_BLOCK_RE, "");
+
+  if (trimmedNote === "") {
+    return withoutOurBlock;
+  }
+
+  const block = buildBlock(trimmedNote);
+  if (withoutOurBlock === "") {
+    return block;
+  }
+  return `${withoutOurBlock}\n\n${block}`;
+}

--- a/apps/api/src/modules/shoptet-writeback/order-note-mark-synced.ts
+++ b/apps/api/src/modules/shoptet-writeback/order-note-mark-synced.ts
@@ -1,0 +1,26 @@
+import { and, eq, lte } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { orders } from "../../db/schema.js";
+
+/**
+ * Označí JEDNU objednávku ako úspešne zapísanú (issue 123) — voláme LEN po
+ * POTVRDENOM úspechu (fill + uloženie + čerstvá navigácia potvrdila hodnotu
+ * na strane Shoptetu, `order-note-playwright.ts`). Na rozdiel od #122
+ * (dávkové označenie na konci CELÉHO behu) sa toto volá PER OBJEDNÁVKA hneď
+ * po jej vlastnom úspechu — zápis je tu per-objednávka (nie jeden hromadný
+ * CSV import), takže zlyhanie NA JEDNEJ objednávke nesmie stratiť úspech
+ * tých pred ňou.
+ *
+ * `now` je čas ZAČIATKU CELÉHO behu (zachytený PRED výberom,
+ * `run-order-note-writeback.ts`) — `commentUpdatedAt <= now` chráni pred
+ * pretekaním presne ako #122's `mark-synced.ts`: keby manažér upravil TÚTO
+ * ISTÚ poznámku ZNOVA počas behu (Playwright môže bežať desiatky sekúnd až
+ * minúty na viac objednávok), tá novšia úprava má `commentUpdatedAt` NUTNE
+ * neskôr než `now`, takže sa neoznačí — ďalší beh ju pošle znova.
+ */
+export async function markOrderNoteSynced(db: Database, orderId: string, now: Date): Promise<void> {
+  await db
+    .update(orders)
+    .set({ commentSyncedAt: now })
+    .where(and(eq(orders.id, orderId), lte(orders.commentUpdatedAt, now)));
+}

--- a/apps/api/src/modules/shoptet-writeback/order-note-playwright.ts
+++ b/apps/api/src/modules/shoptet-writeback/order-note-playwright.ts
@@ -1,0 +1,116 @@
+import { chromium, type Browser, type Page } from "playwright";
+import { log } from "../../logger.js";
+import { buildShoptetAdminOrderUrl } from "../orders/queries.js";
+import { loginToShoptetAdmin } from "./admin-login.js";
+import type { OrderNoteWritebackConfig } from "./config.js";
+import { mergeShopRemark } from "./note-block.js";
+import type { OrderNoteToSync } from "./order-note-select.js";
+import { resolveChromiumExecutablePath } from "./playwright-import.js";
+
+export interface OrderNoteWriteResult {
+  readonly orderId: string;
+  readonly externalOrderId: string;
+  readonly ok: boolean;
+  readonly errorDetail: string | null;
+}
+
+export interface RunOrderNoteWritebackOptions {
+  readonly config: OrderNoteWritebackConfig;
+  readonly orders: readonly OrderNoteToSync[];
+  readonly headless?: boolean;
+  readonly executablePath?: string;
+}
+
+/**
+ * Issue 123: pre KAŽDÚ objednávku otvorí jej detail (priamy odkaz,
+ * `buildShoptetAdminOrderUrl` — každá tu má `shoptetOrderId`, `order-note-
+ * select.ts` už tie bez neho vylúčilo), zlúči aktuálny obsah `textarea
+ * [name=shopRemark]` s appkinou poznámkou (`mergeShopRemark`), uloží (`data-
+ * testid=buttonSaveAndStay`) a overí ČERSTVOU navigáciou, že sa zápis
+ * skutočne uplatnil na strane Shoptetu (nikdy len že sa klik odoslal) —
+ * naživo overený tvar stránky pri návrhu tohto ticketu.
+ *
+ * JEDNA prihlásená browser session pre CELÝ zoznam (rovnaký vzor ako #122's
+ * `runShoptetImport` — jedno prihlásenie, nie jedno na objednávku). Na
+ * rozdiel od #122 (jeden hromadný CSV import, všetko alebo nič) zlyhanie NA
+ * JEDNEJ objednávke NEPRERUŠÍ zvyšok zoznamu — pokračuje ďalšou, aby jedna
+ * zlá objednávka nezablokovala úspešný zápis ostatných (`run-order-note-
+ * writeback.ts` označí ako synchronizované LEN tie, čo tu vyšli `ok`).
+ */
+export async function runOrderNoteWriteback(
+  options: RunOrderNoteWritebackOptions,
+): Promise<readonly OrderNoteWriteResult[]> {
+  const { config, orders } = options;
+  const executablePath = options.executablePath ?? resolveChromiumExecutablePath();
+  let browser: Browser | undefined;
+  const results: OrderNoteWriteResult[] = [];
+  try {
+    browser = await chromium.launch({
+      headless: options.headless ?? true,
+      ...(executablePath === undefined ? {} : { executablePath }),
+      args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage", "--disable-gpu"],
+    });
+    const context = await browser.newContext({ acceptDownloads: false });
+    const page = await context.newPage();
+    await loginToShoptetAdmin(page, config);
+
+    for (const order of orders) {
+      results.push(await writeOneOrderNote(page, config.adminBaseUrl, order));
+    }
+  } finally {
+    await browser?.close();
+  }
+  return results;
+}
+
+async function writeOneOrderNote(
+  page: Page,
+  adminBaseUrl: string,
+  order: OrderNoteToSync,
+): Promise<OrderNoteWriteResult> {
+  const url = buildShoptetAdminOrderUrl(adminBaseUrl, order.externalOrderId, order.shoptetOrderId);
+  try {
+    await page.goto(url, { waitUntil: "domcontentloaded" });
+    await page.waitForLoadState("networkidle");
+
+    const textarea = page.locator('textarea[name="shopRemark"]');
+    if ((await textarea.count()) === 0) {
+      throw new Error(`Nenašiel som pole "Poznámka e-shopu" (textarea[name=shopRemark]) na ${page.url()}`);
+    }
+    const existing = await textarea.inputValue();
+    const merged = mergeShopRemark(existing, order.comment);
+    await textarea.fill(merged);
+
+    const saveButton = page.getByTestId("buttonSaveAndStay");
+    if ((await saveButton.count()) === 0) {
+      throw new Error(`Nenašiel som tlačidlo "Uložiť" (data-testid=buttonSaveAndStay) na ${page.url()}`);
+    }
+    await saveButton.click();
+    await page.waitForLoadState("networkidle");
+
+    // Read-back cez ČERSTVÚ navigáciu (nie len DOM stav hneď po uložení) —
+    // potvrdzuje SERVER-side hodnotu, presne ako #122's Log-based overenie
+    // výsledku importu, nikdy len "klik prešiel bez chyby".
+    await page.goto(url, { waitUntil: "domcontentloaded" });
+    await page.waitForLoadState("networkidle");
+    const confirmed = await page.locator('textarea[name="shopRemark"]').inputValue();
+    if (confirmed !== merged) {
+      throw new Error(
+        `Zápis poznámky sa po čerstvej navigácii nepotvrdil (očakávaných ${String(merged.length)} znakov, prečítaných ${String(confirmed.length)})`,
+      );
+    }
+
+    log.info(
+      { externalOrderId: order.externalOrderId, shoptetOrderId: order.shoptetOrderId },
+      "spätný zápis poznámky objednávky: úspech",
+    );
+    return { orderId: order.orderId, externalOrderId: order.externalOrderId, ok: true, errorDetail: null };
+  } catch (error) {
+    const errorDetail = error instanceof Error ? error.message : String(error);
+    log.error(
+      { externalOrderId: order.externalOrderId, shoptetOrderId: order.shoptetOrderId, errorDetail },
+      "spätný zápis poznámky objednávky: zlyhanie",
+    );
+    return { orderId: order.orderId, externalOrderId: order.externalOrderId, ok: false, errorDetail };
+  }
+}

--- a/apps/api/src/modules/shoptet-writeback/order-note-select.ts
+++ b/apps/api/src/modules/shoptet-writeback/order-note-select.ts
@@ -1,0 +1,69 @@
+import { and, isNotNull, isNull, lt, or } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { orders } from "../../db/schema.js";
+import { log } from "../../logger.js";
+
+export interface OrderNoteToSync {
+  readonly orderId: string;
+  readonly externalOrderId: string;
+  /** vždy prítomné — riadky bez neho sú vylúčené (viď `skippedCount` nižšie). */
+  readonly shoptetOrderId: number;
+  readonly comment: string | null;
+}
+
+export interface SelectedOrderNotes {
+  readonly toSync: readonly OrderNoteToSync[];
+  /** koľko zmenených poznámok appka PRESKOČILA, lebo objednávka (zatiaľ)
+   * nemá známe `shoptet_order_id` (žiadny priamy odkaz na detail) — nie
+   * chyba, len ešte-nedostupný stav; ďalší beh ich zoberie automaticky
+   * hneď, ako sa `shoptet_order_id` doplní (nočný XML fetch, `orders.md`). */
+  readonly skippedCount: number;
+}
+
+// issue 123: "zmenilo sa niečo od posledného úspešného zápisu?" — presne
+// ten istý vzor ako #122's `selectChangedSupplierLinks`, len na
+// `order.comment`/`commentUpdatedAt`/`commentSyncedAt` namiesto
+// `product_supplier_link_override`. `commentUpdatedAt IS NULL` (nikdy
+// zmenené cez appku) sa NEVYBERIE — `changedCondition` vyžaduje neprázdny
+// `commentUpdatedAt` implicitne (`lt`/`isNull(syncedAt)` proti stĺpcu, ktorý
+// je `null`, nikdy nevyhodnotí `true` v Postgrese), takže nový import bez
+// manažérovho zásahu sa nikdy nepokúša synchronizovať.
+export async function selectChangedOrderNotes(db: Database): Promise<SelectedOrderNotes> {
+  const changedCondition = and(
+    isNotNull(orders.commentUpdatedAt),
+    or(isNull(orders.commentSyncedAt), lt(orders.commentSyncedAt, orders.commentUpdatedAt)),
+  );
+
+  const changed = await db
+    .select({
+      orderId: orders.id,
+      externalOrderId: orders.externalOrderId,
+      shoptetOrderId: orders.shoptetOrderId,
+      comment: orders.comment,
+    })
+    .from(orders)
+    .where(changedCondition);
+
+  const toSync = changed
+    .filter((row): row is typeof row & { shoptetOrderId: number } => row.shoptetOrderId !== null)
+    .map((row) => ({
+      orderId: row.orderId,
+      externalOrderId: row.externalOrderId,
+      shoptetOrderId: row.shoptetOrderId,
+      comment: row.comment,
+    }));
+  const skippedCount = changed.length - toSync.length;
+
+  if (skippedCount > 0) {
+    log.warn(
+      {
+        skippedExternalOrderIds: changed
+          .filter((row) => row.shoptetOrderId === null)
+          .map((row) => row.externalOrderId),
+      },
+      "spätný zápis poznámky: preskočené zmenené objednávky bez známeho shoptet_order_id (zatiaľ)",
+    );
+  }
+
+  return { toSync, skippedCount };
+}

--- a/apps/api/src/modules/shoptet-writeback/playwright-import.ts
+++ b/apps/api/src/modules/shoptet-writeback/playwright-import.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { chromium, type Browser, type Page } from "playwright";
 import { log } from "../../logger.js";
+import { loginToShoptetAdmin } from "./admin-login.js";
 import type { ShoptetImportConfig } from "./config.js";
 import { entryKey, hasLogEntries, parseImportLog, pickResultRow, resultExitCode } from "./log-attribution.js";
 
@@ -64,22 +65,6 @@ export function resolveChromiumExecutablePath(env: NodeJS.ProcessEnv = process.e
 async function rowTexts(page: Page): Promise<string[]> {
   const raw = await page.locator("tr").allTextContents();
   return raw.map((t) => t.replace(/\s+/g, " ").trim());
-}
-
-async function login(page: Page, config: ShoptetImportConfig): Promise<void> {
-  await page.goto(config.loginUrl, { waitUntil: "domcontentloaded" });
-  await page.getByPlaceholder("E-mail").fill(config.user);
-  await page.getByPlaceholder("Vaše heslo").fill(config.password);
-  await page.getByRole("button", { name: "Prihlásenie" }).click();
-  await page.waitForLoadState("networkidle");
-  // NIKDY substring na URL ("/login") — reálny Shoptet login pre tento obchod
-  // je na `${adminBaseUrl}/admin/` a úspešné prihlásenie sa vráti na TÚ ISTÚ
-  // URL (overené naživo pri návrhu #122: dry-run skript ukázal "[login] OK →
-  // https://www.forestshop.sk/admin/", teda nezmenenú URL). Jediný spoľahlivý
-  // signál zlyhania je, že prihlasovací formulár je STÁLE na stránke.
-  if ((await page.getByPlaceholder("E-mail").count()) > 0) {
-    throw new Error("Prihlásenie do Shoptetu zlyhalo (prihlasovací formulár stále viditeľný) — over SHOPTET_ADMIN_USER/PASSWORD");
-  }
 }
 
 async function captureBaseline(page: Page, config: ShoptetImportConfig): Promise<string | null> {
@@ -169,7 +154,7 @@ export async function runShoptetImport(options: RunShoptetImportOptions): Promis
     const context = await browser.newContext({ acceptDownloads: false });
     const page = await context.newPage();
 
-    await login(page, config);
+    await loginToShoptetAdmin(page, config);
     const baseline = await captureBaseline(page, config);
     log.info({ baseline: baseline === null ? null : "prítomný" }, "shoptet write-back: baseline Logu zachytený");
 

--- a/apps/api/src/modules/shoptet-writeback/run-order-note-writeback.ts
+++ b/apps/api/src/modules/shoptet-writeback/run-order-note-writeback.ts
@@ -1,0 +1,50 @@
+import type { Database } from "../../db/client.js";
+import type { OrderNoteWritebackConfig } from "./config.js";
+import { markOrderNoteSynced } from "./order-note-mark-synced.js";
+import { runOrderNoteWriteback } from "./order-note-playwright.js";
+import { selectChangedOrderNotes } from "./order-note-select.js";
+
+export type OrderNoteWritebackRunResult =
+  | { readonly status: "nothing_changed"; readonly skippedCount: number }
+  | { readonly status: "ok"; readonly orderCount: number; readonly skippedCount: number }
+  | {
+      readonly status: "partial";
+      readonly orderCount: number;
+      readonly succeeded: number;
+      readonly failed: number;
+      readonly skippedCount: number;
+    };
+
+/**
+ * Celý beh issue 123: vyber objednávky so zmenenou poznámkou → pre KAŽDÚ
+ * zapíš/over cez Playwright → PER OBJEDNÁVKA (nie dávkovo) označ ako
+ * synchronizovanú LEN po jej vlastnom potvrdenom úspechu. `now` sa berie ako
+ * parameter (ZACHYTENÝ PRED výberom, `scheduler/jobs.ts`) — rovnaká
+ * disciplína ako #122's `runShoptetWriteback`, chráni pred pretekaním v
+ * `markOrderNoteSynced`.
+ */
+export async function runOrderNoteWritebackJob(
+  db: Database,
+  config: OrderNoteWritebackConfig,
+  now: Date,
+): Promise<OrderNoteWritebackRunResult> {
+  const { toSync, skippedCount } = await selectChangedOrderNotes(db);
+  if (toSync.length === 0) {
+    return { status: "nothing_changed", skippedCount };
+  }
+
+  const results = await runOrderNoteWriteback({ config, orders: toSync });
+
+  let succeeded = 0;
+  for (const result of results) {
+    if (!result.ok) continue;
+    await markOrderNoteSynced(db, result.orderId, now);
+    succeeded++;
+  }
+
+  const failed = results.length - succeeded;
+  if (failed === 0) {
+    return { status: "ok", orderCount: succeeded, skippedCount };
+  }
+  return { status: "partial", orderCount: results.length, succeeded, failed, skippedCount };
+}

--- a/apps/api/tests/helpers/shoptet-order-detail-fixture.ts
+++ b/apps/api/tests/helpers/shoptet-order-detail-fixture.ts
@@ -1,0 +1,126 @@
+import { serve } from "@hono/node-server";
+import { Hono } from "hono";
+import { getCookie, setCookie } from "hono/cookie";
+import type { AddressInfo } from "node:net";
+
+/**
+ * Falošný Shoptet objednávkový detail (issue 123) — imituje LEN tvar, ktorý
+ * `order-note-playwright.ts` naozaj ovláda: prihlásenie (rovnaké ako #122's
+ * `shoptet-fixture.ts`) a `/admin/objednavky-detail/?id=<id>` s `textarea
+ * [name="shopRemark"]` + `data-testid="buttonSaveAndStay"` uloženie. Tvar
+ * OVERENÝ naživo pri návrhu tohto ticketu (produkčná objednávka
+ * `20261273`/`shoptet_order_id=59783`) — žiadny kontakt so skutočným
+ * Shoptetom v testoch.
+ */
+
+const COOKIE_NAME = "sid";
+
+export interface OrderDetailFixtureOptions {
+  readonly user: string;
+  readonly password: string;
+}
+
+export interface OrderDetailFixture {
+  readonly baseUrl: string;
+  /** Nastaví POČIATOČNÝ obsah `shopRemark` pre dané `id` PRED behom (napr.
+   * ručne napísaný text predajne, ktorý appka nesmie prepísať). */
+  seedShopRemark(id: number, text: string): void;
+  getShopRemark(id: number): string | null;
+  close(): Promise<void>;
+}
+
+function loginPage(): string {
+  return `<!doctype html><html><body>
+    <form method="post" action="/admin/do-login">
+      <input placeholder="E-mail" name="email" />
+      <input placeholder="Vaše heslo" name="password" type="password" />
+      <button type="submit">Prihlásenie</button>
+    </form>
+  </body></html>`;
+}
+
+function dashboardPage(): string {
+  return `<!doctype html><html><body><h1>Nástenka</h1></body></html>`;
+}
+
+// Tvar VERNE kopíruje naživo overenú stránku: `<a>` (nie `<button>`) s
+// `data-testid="buttonSaveAndStay"`, formulár submitujúci CELÚ stránku (POST
+// na tú istú URL, presne ako reálny Shoptet — žiadny AJAX). Príliš
+// zhovievavá fixture (napr. skutočný `<button>` s prístupným menom) by
+// nechala prejsť ZLÚ implementáciu (`.claude/rules/shoptet-writeback.md`'s
+// upozornenie o CSV-upload widgete platí rovnako tu).
+function orderDetailPage(id: number, shopRemark: string): string {
+  return `<!doctype html><html><body>
+    <h2>Objednávka ${String(id)}</h2>
+    <form method="post" action="/admin/objednavky-detail/?id=${String(id)}">
+      <h2>Poznámka e-shopu</h2>
+      <textarea name="shopRemark">${shopRemark}</textarea>
+      <a href="#" data-testid="buttonSaveAndStay" onclick="this.closest('form').submit(); return false;">Uložiť</a>
+    </form>
+  </body></html>`;
+}
+
+export async function startOrderDetailFixture(options: OrderDetailFixtureOptions): Promise<OrderDetailFixture> {
+  const app = new Hono();
+  const shopRemarks = new Map<number, string>();
+
+  app.get("/admin/", (c) => {
+    const cookie = getCookie(c, COOKIE_NAME);
+    return c.html(cookie === "ok" ? dashboardPage() : loginPage());
+  });
+
+  app.post("/admin/do-login", async (c) => {
+    const body = await c.req.parseBody();
+    if (body["email"] === options.user && body["password"] === options.password) {
+      setCookie(c, COOKIE_NAME, "ok", { httpOnly: true, path: "/" });
+    }
+    return c.redirect("/admin/", 303);
+  });
+
+  app.get("/admin/objednavky-detail/", (c) => {
+    if (getCookie(c, COOKIE_NAME) !== "ok") return c.redirect("/admin/", 303);
+    const id = Number(c.req.query("id"));
+    return c.html(orderDetailPage(id, shopRemarks.get(id) ?? ""));
+  });
+
+  app.post("/admin/objednavky-detail/", async (c) => {
+    if (getCookie(c, COOKIE_NAME) !== "ok") return c.redirect("/admin/", 303);
+    const id = Number(c.req.query("id"));
+    const body = await c.req.parseBody();
+    const shopRemark = body["shopRemark"];
+    // Real browsers serialize a <textarea>'s value as CRLF on form submit
+    // (HTML forms spec) — naživo overený REÁLNY Shoptet už normalizuje na
+    // "\n" server-side (potvrdené pri návrhu #123: read-back po uložení
+    // cez čerstvú navigáciu vrátil čisté "\n", žiadne "\r"). Fixture musí
+    // TÚTO normalizáciu robiť tiež, inak by prešla implementácia, ktorá by
+    // proti skutočnému Shoptetu (server normalizuje) fungovala inak než
+    // proti fixture (echo bez normalizácie) — presne to `.claude/rules/
+    // shoptet-writeback.md`'s upozornenie o príliš zhovievavej fixture
+    // varuje.
+    const normalized = (typeof shopRemark === "string" ? shopRemark : "").replace(/\r\n/g, "\n");
+    shopRemarks.set(id, normalized);
+    return c.redirect(`/admin/objednavky-detail/?id=${String(id)}`, 303);
+  });
+
+  const server = await new Promise<import("node:http").Server>((resolve) => {
+    const s = serve({ fetch: app.fetch, port: 0 }, () => {
+      resolve(s as unknown as import("node:http").Server);
+    });
+  });
+  const address = server.address() as AddressInfo;
+
+  return {
+    baseUrl: `http://127.0.0.1:${String(address.port)}`,
+    seedShopRemark: (id, text) => {
+      shopRemarks.set(id, text);
+    },
+    getShopRemark: (id) => shopRemarks.get(id) ?? null,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      }),
+  };
+}

--- a/apps/api/tests/helpers/shoptet-order-detail-fixture.ts
+++ b/apps/api/tests/helpers/shoptet-order-detail-fixture.ts
@@ -26,6 +26,11 @@ export interface OrderDetailFixture {
    * ručne napísaný text predajne, ktorý appka nesmie prepísať). */
   seedShopRemark(id: number, text: string): void;
   getShopRemark(id: number): string | null;
+  /** Review of PR 143: `id` sa vráti bez `textarea[name=shopRemark]` (napr.
+   * zmazaná/nedostupná objednávka) — overuje, že `writeOneOrderNote`
+   * (`order-note-playwright.ts`) TÚTO objednávku nahlási ako `ok:false` s
+   * chybovým detailom, ale NEPRERUŠÍ zvyšok zoznamu. */
+  breakOrder(id: number): void;
   close(): Promise<void>;
 }
 
@@ -60,9 +65,17 @@ function orderDetailPage(id: number, shopRemark: string): string {
   </body></html>`;
 }
 
+// review of PR 143: simuluje objednávku, ktorá sa reálne stane nedostupnou
+// (zmazaná/inak zobrazená) — stránka BEZ `textarea[name=shopRemark]`, presne
+// tvar, na ktorý `writeOneOrderNote` reaguje vlastnou chybou.
+function brokenOrderDetailPage(id: number): string {
+  return `<!doctype html><html><body><h2>Objednávka ${String(id)} nenájdená</h2></body></html>`;
+}
+
 export async function startOrderDetailFixture(options: OrderDetailFixtureOptions): Promise<OrderDetailFixture> {
   const app = new Hono();
   const shopRemarks = new Map<number, string>();
+  const brokenIds = new Set<number>();
 
   app.get("/admin/", (c) => {
     const cookie = getCookie(c, COOKIE_NAME);
@@ -80,6 +93,7 @@ export async function startOrderDetailFixture(options: OrderDetailFixtureOptions
   app.get("/admin/objednavky-detail/", (c) => {
     if (getCookie(c, COOKIE_NAME) !== "ok") return c.redirect("/admin/", 303);
     const id = Number(c.req.query("id"));
+    if (brokenIds.has(id)) return c.html(brokenOrderDetailPage(id));
     return c.html(orderDetailPage(id, shopRemarks.get(id) ?? ""));
   });
 
@@ -115,6 +129,9 @@ export async function startOrderDetailFixture(options: OrderDetailFixtureOptions
       shopRemarks.set(id, text);
     },
     getShopRemark: (id) => shopRemarks.get(id) ?? null,
+    breakOrder: (id) => {
+      brokenIds.add(id);
+    },
     close: () =>
       new Promise<void>((resolve, reject) => {
         server.close((err) => {

--- a/apps/api/tests/order-note-mark-synced.integration.test.ts
+++ b/apps/api/tests/order-note-mark-synced.integration.test.ts
@@ -1,0 +1,71 @@
+import { eq } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Database } from "../src/db/client.js";
+import { orders } from "../src/db/schema.js";
+import { DEFAULT_ORDER_OPEN_STATUS } from "../src/modules/orders/open-statuses.js";
+import { markOrderNoteSynced } from "../src/modules/shoptet-writeback/order-note-mark-synced.js";
+import { withCleanDb } from "./helpers/db.js";
+
+async function insertOrder(db: Database, overrides: Partial<typeof orders.$inferInsert> & { externalOrderId: string }) {
+  const [row] = await db
+    .insert(orders)
+    .values({
+      customerName: "Zákazník",
+      statusName: DEFAULT_ORDER_OPEN_STATUS,
+      placedAt: new Date("2026-01-01T00:00:00Z"),
+      ...overrides,
+    })
+    .returning({ id: orders.id });
+  if (row === undefined) throw new Error("testovacia objednávka sa nepodarilo vložiť");
+  return row.id;
+}
+
+describe("markOrderNoteSynced", () => {
+  let db: Database;
+  let close: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ db, close } = await withCleanDb());
+  });
+
+  afterEach(async () => {
+    await close();
+  });
+
+  it("sets commentSyncedAt to `now` after a confirmed successful write", async () => {
+    const orderId = await insertOrder(db, {
+      externalOrderId: "2001",
+      shoptetOrderId: 111,
+      comment: "Zavolať",
+      commentUpdatedAt: new Date("2026-01-02T00:00:00Z"),
+    });
+
+    const now = new Date("2026-01-02T00:05:00Z");
+    await markOrderNoteSynced(db, orderId, now);
+
+    const [after] = await db.select({ syncedAt: orders.commentSyncedAt }).from(orders).where(eq(orders.id, orderId));
+    expect(after?.syncedAt?.toISOString()).toBe(now.toISOString());
+  });
+
+  it("does NOT mark synced when the comment was edited AGAIN after `now` (race during a long-running Playwright run)", async () => {
+    const runStartedAt = new Date("2026-01-02T00:00:00Z");
+    const orderId = await insertOrder(db, {
+      externalOrderId: "2002",
+      shoptetOrderId: 222,
+      comment: "Poznámka upravená POČAS behu",
+      // updatedAt je NESKÔR než `now` odovzdané do markOrderNoteSynced —
+      // simuluje manažérovu úpravu tesne PO tom, čo select-changes prečítal
+      // starú hodnotu, ale PRED tým, než Playwright stihol dobehnúť.
+      commentUpdatedAt: new Date("2026-01-02T00:10:00Z"),
+    });
+
+    await markOrderNoteSynced(db, orderId, runStartedAt);
+
+    const [after] = await db.select({ syncedAt: orders.commentSyncedAt }).from(orders).where(eq(orders.id, orderId));
+    expect(after?.syncedAt).toBeNull();
+  });
+
+  it("is a no-op for an unknown orderId (never throws)", async () => {
+    await expect(markOrderNoteSynced(db, "00000000-0000-0000-0000-000000000000", new Date())).resolves.toBeUndefined();
+  });
+});

--- a/apps/api/tests/order-note-playwright.integration.test.ts
+++ b/apps/api/tests/order-note-playwright.integration.test.ts
@@ -93,7 +93,7 @@ describe("runOrderNoteWriteback (proti fixture, nikdy proti reálnemu Shoptetu)"
   );
 
   it(
-    "processes MULTIPLE orders in one login session, and a failure on one does not stop the rest",
+    "processes MULTIPLE orders in one login session, all succeeding",
     async () => {
       fixture = await startOrderDetailFixture({ user: "manager", password: "tajneheslo" });
 
@@ -110,6 +110,36 @@ describe("runOrderNoteWriteback (proti fixture, nikdy proti reálnemu Shoptetu)"
         { orderId: "order-2", externalOrderId: "20261272", ok: true, errorDetail: null },
       ]);
       expect(fixture.getShopRemark(59783)).toContain("Prvá poznámka");
+      expect(fixture.getShopRemark(59780)).toContain("Druhá poznámka");
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    // review of PR 143: predchádzajúca verzia tohto testu mala obe
+    // objednávky vždy úspešné, takže NIKDY nezacvičila per-objednávkovú
+    // try/catch vetvu vo `writeOneOrderNote` — `breakOrder` teraz naozaj
+    // vráti stránku BEZ `textarea[name=shopRemark]` pre PRVÚ objednávku,
+    // aby test dokázal, že jej zlyhanie NEPRERUŠÍ zápis druhej.
+    "a GENUINE failure on one order (missing shopRemark field) does not stop the rest",
+    async () => {
+      fixture = await startOrderDetailFixture({ user: "manager", password: "tajneheslo" });
+      fixture.breakOrder(59783);
+
+      const results = await runOrderNoteWriteback({
+        config: { loginUrl: `${fixture.baseUrl}/admin/`, adminBaseUrl: fixture.baseUrl, user: "manager", password: "tajneheslo" },
+        orders: [
+          { orderId: "order-1", externalOrderId: "20261273", shoptetOrderId: 59783, comment: "Prvá poznámka" },
+          { orderId: "order-2", externalOrderId: "20261272", shoptetOrderId: 59780, comment: "Druhá poznámka" },
+        ],
+      });
+
+      expect(results).toHaveLength(2);
+      expect(results[0]?.ok).toBe(false);
+      expect(results[0]?.errorDetail).toMatch(/shopRemark/);
+      expect(results[1]).toEqual({ orderId: "order-2", externalOrderId: "20261272", ok: true, errorDetail: null });
+      // the broken order never got a value written; the healthy one did
+      expect(fixture.getShopRemark(59783)).toBeNull();
       expect(fixture.getShopRemark(59780)).toContain("Druhá poznámka");
     },
     TEST_TIMEOUT_MS,

--- a/apps/api/tests/order-note-playwright.integration.test.ts
+++ b/apps/api/tests/order-note-playwright.integration.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { runOrderNoteWriteback } from "../src/modules/shoptet-writeback/order-note-playwright.js";
+import { startOrderDetailFixture, type OrderDetailFixture } from "./helpers/shoptet-order-detail-fixture.js";
+
+// Reálny Chromium proti LOKÁLNEJ fixture appke (nikdy proti skutočnému
+// Shoptetu — rovnaká testová požiadavka ako #122). Browser beh môže byť
+// pomalší v CI, preto vyšší timeout než ostatné integračné testy.
+const TEST_TIMEOUT_MS = 60_000;
+
+describe("runOrderNoteWriteback (proti fixture, nikdy proti reálnemu Shoptetu)", () => {
+  let fixture: OrderDetailFixture | undefined;
+
+  afterEach(async () => {
+    await fixture?.close();
+    fixture = undefined;
+  });
+
+  it(
+    "appends our block to an EMPTY shopRemark and confirms via fresh navigation",
+    async () => {
+      fixture = await startOrderDetailFixture({ user: "manager", password: "tajneheslo" });
+
+      const results = await runOrderNoteWriteback({
+        config: { loginUrl: `${fixture.baseUrl}/admin/`, adminBaseUrl: fixture.baseUrl, user: "manager", password: "tajneheslo" },
+        orders: [{ orderId: "order-1", externalOrderId: "20261273", shoptetOrderId: 59783, comment: "Zavolať zajtra" }],
+      });
+
+      expect(results).toEqual([{ orderId: "order-1", externalOrderId: "20261273", ok: true, errorDetail: null }]);
+      expect(fixture.getShopRemark(59783)).toBe("--- poznámka z appky ---\nZavolať zajtra\n--- koniec ---");
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "preserves manual shop text, appending our block after it (never overwrites)",
+    async () => {
+      fixture = await startOrderDetailFixture({ user: "manager", password: "tajneheslo" });
+      fixture.seedShopRemark(59783, "Ručne napísaná poznámka predajne");
+
+      const results = await runOrderNoteWriteback({
+        config: { loginUrl: `${fixture.baseUrl}/admin/`, adminBaseUrl: fixture.baseUrl, user: "manager", password: "tajneheslo" },
+        orders: [{ orderId: "order-1", externalOrderId: "20261273", shoptetOrderId: 59783, comment: "Zavolať zajtra" }],
+      });
+
+      expect(results[0]?.ok).toBe(true);
+      expect(fixture.getShopRemark(59783)).toBe(
+        "Ručne napísaná poznámka predajne\n\n--- poznámka z appky ---\nZavolať zajtra\n--- koniec ---",
+      );
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "replaces ONLY our block on a resync, still keeping the manual text",
+    async () => {
+      fixture = await startOrderDetailFixture({ user: "manager", password: "tajneheslo" });
+      fixture.seedShopRemark(
+        59783,
+        "Ručná poznámka\n\n--- poznámka z appky ---\nStará poznámka\n--- koniec ---",
+      );
+
+      const results = await runOrderNoteWriteback({
+        config: { loginUrl: `${fixture.baseUrl}/admin/`, adminBaseUrl: fixture.baseUrl, user: "manager", password: "tajneheslo" },
+        orders: [{ orderId: "order-1", externalOrderId: "20261273", shoptetOrderId: 59783, comment: "Nová poznámka" }],
+      });
+
+      expect(results[0]?.ok).toBe(true);
+      expect(fixture.getShopRemark(59783)).toBe(
+        "Ručná poznámka\n\n--- poznámka z appky ---\nNová poznámka\n--- koniec ---",
+      );
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "removes ONLY our block when the app comment was cleared, keeping manual text",
+    async () => {
+      fixture = await startOrderDetailFixture({ user: "manager", password: "tajneheslo" });
+      fixture.seedShopRemark(
+        59783,
+        "Ručná poznámka\n\n--- poznámka z appky ---\nStará poznámka\n--- koniec ---",
+      );
+
+      const results = await runOrderNoteWriteback({
+        config: { loginUrl: `${fixture.baseUrl}/admin/`, adminBaseUrl: fixture.baseUrl, user: "manager", password: "tajneheslo" },
+        orders: [{ orderId: "order-1", externalOrderId: "20261273", shoptetOrderId: 59783, comment: null }],
+      });
+
+      expect(results[0]?.ok).toBe(true);
+      expect(fixture.getShopRemark(59783)).toBe("Ručná poznámka");
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "processes MULTIPLE orders in one login session, and a failure on one does not stop the rest",
+    async () => {
+      fixture = await startOrderDetailFixture({ user: "manager", password: "tajneheslo" });
+
+      const results = await runOrderNoteWriteback({
+        config: { loginUrl: `${fixture.baseUrl}/admin/`, adminBaseUrl: fixture.baseUrl, user: "manager", password: "tajneheslo" },
+        orders: [
+          { orderId: "order-1", externalOrderId: "20261273", shoptetOrderId: 59783, comment: "Prvá poznámka" },
+          { orderId: "order-2", externalOrderId: "20261272", shoptetOrderId: 59780, comment: "Druhá poznámka" },
+        ],
+      });
+
+      expect(results).toEqual([
+        { orderId: "order-1", externalOrderId: "20261273", ok: true, errorDetail: null },
+        { orderId: "order-2", externalOrderId: "20261272", ok: true, errorDetail: null },
+      ]);
+      expect(fixture.getShopRemark(59783)).toContain("Prvá poznámka");
+      expect(fixture.getShopRemark(59780)).toContain("Druhá poznámka");
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "reports ok:false with an error detail when login credentials are wrong — never silently succeeds",
+    async () => {
+      fixture = await startOrderDetailFixture({ user: "manager", password: "tajneheslo" });
+
+      await expect(
+        runOrderNoteWriteback({
+          config: { loginUrl: `${fixture.baseUrl}/admin/`, adminBaseUrl: fixture.baseUrl, user: "manager", password: "ZLE-heslo" },
+          orders: [{ orderId: "order-1", externalOrderId: "20261273", shoptetOrderId: 59783, comment: "x" }],
+        }),
+      ).rejects.toThrow(/prihlásenie/i);
+    },
+    TEST_TIMEOUT_MS,
+  );
+});

--- a/apps/api/tests/order-note-select.integration.test.ts
+++ b/apps/api/tests/order-note-select.integration.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Database } from "../src/db/client.js";
+import { orders } from "../src/db/schema.js";
+import { DEFAULT_ORDER_OPEN_STATUS } from "../src/modules/orders/open-statuses.js";
+import { selectChangedOrderNotes } from "../src/modules/shoptet-writeback/order-note-select.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 123: presne ten istý "zmenilo sa niečo od posledného zápisu?" vzor
+// ako #122's shoptet-writeback-select.integration.test.ts, len na
+// order.comment/commentUpdatedAt/commentSyncedAt.
+describe("selectChangedOrderNotes", () => {
+  let db: Database;
+  let close: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ db, close } = await withCleanDb());
+  });
+
+  afterEach(async () => {
+    await close();
+  });
+
+  async function insertOrder(overrides: Partial<typeof orders.$inferInsert> & { externalOrderId: string }) {
+    await db.insert(orders).values({
+      customerName: "Zákazník",
+      statusName: DEFAULT_ORDER_OPEN_STATUS,
+      placedAt: new Date("2026-01-01T00:00:00Z"),
+      ...overrides,
+    });
+  }
+
+  it("returns nothing when no order ever had its comment changed via the app", async () => {
+    await insertOrder({ externalOrderId: "1001", shoptetOrderId: 111 });
+    const result = await selectChangedOrderNotes(db);
+    expect(result.toSync).toEqual([]);
+    expect(result.skippedCount).toBe(0);
+  });
+
+  it("includes an order whose comment was changed and never synced", async () => {
+    await insertOrder({
+      externalOrderId: "1002",
+      shoptetOrderId: 222,
+      comment: "Zavolať zákazníkovi",
+      commentUpdatedAt: new Date("2026-01-02T00:00:00Z"),
+    });
+    const result = await selectChangedOrderNotes(db);
+    expect(result.toSync).toEqual([
+      { orderId: expect.any(String) as string, externalOrderId: "1002", shoptetOrderId: 222, comment: "Zavolať zákazníkovi" },
+    ]);
+    expect(result.skippedCount).toBe(0);
+  });
+
+  it("excludes an order already synced AFTER its last comment change", async () => {
+    await insertOrder({
+      externalOrderId: "1003",
+      shoptetOrderId: 333,
+      comment: "Stará poznámka",
+      commentUpdatedAt: new Date("2026-01-01T00:00:00Z"),
+      commentSyncedAt: new Date("2026-01-02T00:00:00Z"),
+    });
+    const result = await selectChangedOrderNotes(db);
+    expect(result.toSync).toEqual([]);
+  });
+
+  it("includes an order edited AGAIN after its last successful sync", async () => {
+    await insertOrder({
+      externalOrderId: "1004",
+      shoptetOrderId: 444,
+      comment: "Nová poznámka",
+      commentUpdatedAt: new Date("2026-01-03T00:00:00Z"),
+      commentSyncedAt: new Date("2026-01-01T00:00:00Z"),
+    });
+    const result = await selectChangedOrderNotes(db);
+    expect(result.toSync).toHaveLength(1);
+    expect(result.toSync[0]?.comment).toBe("Nová poznámka");
+  });
+
+  it("skips (and counts, never crashes on) a changed order without a known shoptet_order_id yet", async () => {
+    await insertOrder({
+      externalOrderId: "1005",
+      shoptetOrderId: null,
+      comment: "Zavolať",
+      commentUpdatedAt: new Date("2026-01-02T00:00:00Z"),
+    });
+    const result = await selectChangedOrderNotes(db);
+    expect(result.toSync).toEqual([]);
+    expect(result.skippedCount).toBe(1);
+  });
+
+  it("includes a CLEARED comment (commentUpdatedAt set on deletion too) — must remove our block in Shoptet", async () => {
+    await insertOrder({
+      externalOrderId: "1006",
+      shoptetOrderId: 666,
+      comment: null,
+      commentUpdatedAt: new Date("2026-01-02T00:00:00Z"),
+    });
+    const result = await selectChangedOrderNotes(db);
+    expect(result.toSync).toEqual([
+      { orderId: expect.any(String) as string, externalOrderId: "1006", shoptetOrderId: 666, comment: null },
+    ]);
+  });
+});

--- a/apps/api/tests/scheduler-jobs.integration.test.ts
+++ b/apps/api/tests/scheduler-jobs.integration.test.ts
@@ -8,6 +8,8 @@ import type { CatalogIngestResult } from "../src/modules/catalog/ingest.js";
 import { ORDERS_EXPORT_URL_NOT_CONFIGURED, type OrdersIngestResult } from "../src/modules/orders/ingest.js";
 import {
   CATALOG_IMPORT_JOB_NAME,
+  ORDER_NOTE_WRITEBACK_JOB_NAME,
+  ORDER_NOTE_WRITEBACK_NOT_CONFIGURED,
   ORDERS_IMPORT_JOB_NAME,
   PRUNE_RAW_EXPORTS_JOB_NAME,
   PRUNE_RAW_ORDERS_JOB_NAME,
@@ -15,6 +17,7 @@ import {
   SHOPTET_WRITEBACK_JOB_NAME,
   SHOPTET_WRITEBACK_NOT_CONFIGURED,
   catalogImportJob,
+  orderNoteWritebackJob,
   ordersImportJob,
   pruneRawExportsJob,
   pruneRawOrdersJob,
@@ -165,6 +168,25 @@ it("shoptetWritebackJob s nakonfigurovaným runWriteback naň deleguje a vráti 
   const fakeResult = { status: "nothing_changed" } as const;
   let receivedNow: Date | undefined;
   const job = shoptetWritebackJob((_db, now) => {
+    receivedNow = now;
+    return Promise.resolve(fakeResult);
+  });
+
+  const outcome = await job.run({} as never, NOW);
+  expect(outcome).toEqual({ detail: fakeResult });
+  expect(receivedNow).toBe(NOW);
+});
+
+it("orderNoteWritebackJob bez nakonfigurovaného runOrderNoteWriteback VYHODÍ (zachytí ho scheduler.ts, zapíše ako failure)", async () => {
+  const job = orderNoteWritebackJob(undefined);
+  expect(job.name).toBe(ORDER_NOTE_WRITEBACK_JOB_NAME);
+  await expect(job.run({} as never, NOW)).rejects.toThrow(ORDER_NOTE_WRITEBACK_NOT_CONFIGURED);
+});
+
+it("orderNoteWritebackJob s nakonfigurovaným runOrderNoteWriteback naň deleguje a vráti jeho výsledok ako detail", async () => {
+  const fakeResult = { status: "nothing_changed", skippedCount: 0 } as const;
+  let receivedNow: Date | undefined;
+  const job = orderNoteWritebackJob((_db, now) => {
     receivedNow = now;
     return Promise.resolve(fakeResult);
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.84",
+  "version": "0.3.0-dev.85",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Súvisiaci ticket

issue 123 — spätný zápis našej poznámky k objednávke do Shoptetu cez
Playwright automatizáciu.

**Táto PR NEZATVÁRA issue 123 automaticky** — ticket má akceptačnú
podmienku overiteľnú až naživo PO nasadení (over na presne jednej testovacej
objednávke, potom vrátiť pôvodný stav), takže sa zavrie ručne až po tomto
overení.

## Čo pribudlo

- Dva nové stĺpce `order.comment_updated_at` / `comment_synced_at` — presne
  ten istý "zmenilo sa niečo od posledného zápisu?" pár ako issue 122's
  `product_supplier_link_override.updated_at`/`synced_at`, len na úrovni
  objednávky.
- Nová hodinová naplánovaná úloha `:55` — pre KAŽDÚ objednávku so zmenenou
  poznámkou otvorí jej Shoptet admin detail (priamy odkaz cez existujúci
  `buildShoptetAdminOrderUrl`) a zlúči appkinu poznámku do `textarea
  [name=shopRemark]` ako VLASTNÝ ohraničený blok — nikdy neprepisuje ručne
  napísaný text okolo. Naživo overený tvar poľa aj uloženia (produkčná
  objednávka 20261273 / shoptet_order_id 59783), vrátené do pôvodného
  (prázdneho) stavu po overení.
- Objednávky bez zatiaľ známeho `shoptet_order_id` sa preskočia a zalogujú
  (automaticky sa zoberú v ďalšom behu, hneď ako sa id doplní).
- Zdieľaný login helper (`admin-login.ts`) medzi issue 122's CSV importom a
  týmto novým per-objednávkovým zápisom.

## Testy

- `note-block.test.ts` — čisto textová zlučovacia logika (pripojenie/
  nahradenie nášho bloku/vymazanie), 9 testov.
- `order-note-select.integration.test.ts` / `order-note-mark-synced
  .integration.test.ts` — výber zmenených poznámok + race-safe označenie
  synchronizácie.
- `order-note-playwright.integration.test.ts` — reálny Chromium proti
  LOKÁLNEJ fixture stránke (nikdy proti skutočnému Shoptetu), overuje
  pripojenie/nahradenie/vymazanie bloku aj spracovanie viacerých objednávok
  v jednej prihlásenej relácii.
- `scheduler-jobs.integration.test.ts` — nová úloha deleguje na injektovanú
  closure a vracia jej výsledok.

Design komentár s dôvodmi (root cause, zvolený prístup, zamietnutá
alternatíva) je na tickete pred prvým commitom.
