### PR TITLE
feat(orders): cumulative failed-write banner for "Na objednanie" (issue 66)

### DIFF
--- a/apps/web/src/components/OrderLineRow.supplierLinkEditCell.test.tsx
+++ b/apps/web/src/components/OrderLineRow.supplierLinkEditCell.test.tsx
@@ -126,8 +126,11 @@ it("zlyhanie uloženia zobrazí slovenskú hlášku", async () => {
   fireEvent.change(vstup, { target: { value: "https://zly-odkaz.example.com" } });
   fireEvent.click(within(riadok).getByTestId(`supplier-link-edit-save-${RIADOK_BEZ_ODKAZU.lineId}`));
 
+  // issue 66: kumulatívny banner nahrádza pôvodný jediný `<p role="alert">`.
   await waitFor(() => {
-    expect(screen.getByRole("alert").textContent).toBe("Uloženie odkazu na dodávateľa sa nepodarilo");
+    expect(screen.getByRole("alert").textContent).toBe(
+      "⚠️ Nepodarilo sa uložiť 1 položku×Odkaz na dodávateľa — obj. 20261400, kód E-1 (Uloženie odkazu na dodávateľa sa nepodarilo)",
+    );
   });
 });
 

--- a/apps/web/src/components/OrderWriteFailuresBanner.test.tsx
+++ b/apps/web/src/components/OrderWriteFailuresBanner.test.tsx
@@ -1,0 +1,54 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { OrderWriteFailuresBanner } from "./OrderWriteFailuresBanner.js";
+import type { OrderWriteFailure } from "../ordersWriteFailures.js";
+
+afterEach(cleanup);
+
+it("bez zlyhaní nevykreslí NIČ (žiadny prázdny alert)", () => {
+  const { container } = render(<OrderWriteFailuresBanner failures={[]} onDismiss={() => {}} />);
+  expect(container.innerHTML).toBe("");
+});
+
+it("s JEDNÝM zlyhaním ukáže nadpis v jednotnom čísle a jeho popis", () => {
+  const zlyhania: readonly OrderWriteFailure[] = [
+    { id: "state:1", what: "Zmena stavu", where: "obj. 1001, kód A-1", detail: "Riadok objednávky sa nenašiel" },
+  ];
+  render(<OrderWriteFailuresBanner failures={zlyhania} onDismiss={() => {}} />);
+  expect(screen.getByRole("alert").textContent).toBe(
+    "⚠️ Nepodarilo sa uložiť 1 položku×Zmena stavu — obj. 1001, kód A-1 (Riadok objednávky sa nenašiel)",
+  );
+});
+
+it("s VIACERÝMI NEZÁVISLÝMI zlyhaniami ukáže VŠETKY naraz, kumulatívne (jadro ticketu #66)", () => {
+  const zlyhania: readonly OrderWriteFailure[] = [
+    { id: "state:1", what: "Zmena stavu", where: "obj. 1001, kód A-1", detail: "chyba A" },
+    { id: "ordered:2", what: "Príznak objednané", where: "obj. 1002, kód B-1", detail: "chyba B" },
+  ];
+  render(<OrderWriteFailuresBanner failures={zlyhania} onDismiss={() => {}} />);
+  expect(screen.getByTestId("order-write-failures").textContent).toContain("Nepodarilo sa uložiť 2 položky");
+  expect(screen.getByTestId("order-write-failure-state:1").textContent).toBe(
+    "Zmena stavu — obj. 1001, kód A-1 (chyba A)",
+  );
+  expect(screen.getByTestId("order-write-failure-ordered:2").textContent).toBe(
+    "Príznak objednané — obj. 1002, kód B-1 (chyba B)",
+  );
+});
+
+it("kliknutie na '×' zavolá onDismiss (zavrie CELÝ banner naraz)", () => {
+  const onDismiss = vi.fn();
+  const zlyhania: readonly OrderWriteFailure[] = [
+    { id: "state:1", what: "Zmena stavu", where: "obj. 1001", detail: "chyba" },
+  ];
+  render(<OrderWriteFailuresBanner failures={zlyhania} onDismiss={onDismiss} />);
+  fireEvent.click(screen.getByRole("button", { name: "Zavrieť hlásenie o neuložených zmenách" }));
+  expect(onDismiss).toHaveBeenCalledTimes(1);
+});
+
+it("položka bez `where` (riadok medzitým zmizol zo zoznamu) vynechá pomlčku, nenechá vetu 'ohnutú'", () => {
+  const zlyhania: readonly OrderWriteFailure[] = [
+    { id: "state:1", what: "Zmena stavu", where: "", detail: "chyba" },
+  ];
+  render(<OrderWriteFailuresBanner failures={zlyhania} onDismiss={() => {}} />);
+  expect(screen.getByTestId("order-write-failure-state:1").textContent).toBe("Zmena stavu (chyba)");
+});

--- a/apps/web/src/components/OrderWriteFailuresBanner.tsx
+++ b/apps/web/src/components/OrderWriteFailuresBanner.tsx
@@ -1,0 +1,42 @@
+import type { JSX } from "react";
+import { formatWriteFailuresHeading, type OrderWriteFailure } from "../ordersWriteFailures.js";
+
+// issue 66: kumulatívny banner "⚠️ Nepodarilo sa uložiť N položiek" — vyňaté
+// do vlastného komponentu (rovnaký vzor extrakcie ako `OrderLineRow`/
+// `SupplierOrderGroup`, `.claude/rules/frontend-design.md`), aby zostal
+// jednoducho testovateľný samostatne. `role="alert"` na koreňovom prvku
+// preberá existujúci globálny reset (`app.css`'s `[role="alert"]`) —
+// farba/padding/radius appka nikde nedefinuje druhýkrát.
+export function OrderWriteFailuresBanner({
+  failures,
+  onDismiss,
+}: {
+  readonly failures: readonly OrderWriteFailure[];
+  readonly onDismiss: () => void;
+}): JSX.Element | null {
+  if (failures.length === 0) return null;
+  return (
+    <div className="order-write-failures" role="alert" data-testid="order-write-failures">
+      <div className="order-write-failures-head">
+        <span>{formatWriteFailuresHeading(failures.length)}</span>
+        <button
+          type="button"
+          className="btn sm ghost"
+          aria-label="Zavrieť hlásenie o neuložených zmenách"
+          onClick={onDismiss}
+        >
+          ×
+        </button>
+      </div>
+      <ul>
+        {failures.map((f) => (
+          <li key={f.id} data-testid={`order-write-failure-${f.id}`}>
+            {f.what}
+            {f.where !== "" ? ` — ${f.where}` : ""}
+            {f.detail !== "" ? ` (${f.detail})` : ""}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/src/components/OrdersSection.assignSupplier.test.tsx
+++ b/apps/web/src/components/OrdersSection.assignSupplier.test.tsx
@@ -108,7 +108,7 @@ it("úspešné priradenie dodávateľa spraví refetch zoznamu", async () => {
 // medzitým dostal dodávateľa inou cestou) predtým NErobilo refetch — stará
 // verzia zoznamu zostala, vstupné pole na priradenie ostalo viditeľné
 // navždy. Teraz sa zoznam obnoví AJ pri zlyhaní, a hláška (nezávislý stav
-// `stateError`) prežije refetch.
+// `writeFailures`) prežije refetch.
 it("zamietnuté priradenie (409) zobrazí slovenskú hlášku A ZÁROVEŇ spraví refetch zoznamu", async () => {
   fetchOpenOrders.mockResolvedValue([
     { supplier: "(bez dodávateľa)", lines: [LINE_BEZ_DODAVATELA], email: null },
@@ -120,9 +120,10 @@ it("zamietnuté priradenie (409) zobrazí slovenskú hlášku A ZÁROVEŇ sprav�
   render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
   await vyplnAUloz("Konkurenčný Zápis");
 
+  // issue 66: kumulatívny banner nahrádza pôvodný jediný `<p role="alert">`.
   await waitFor(() => {
     expect(screen.getByRole("alert").textContent).toBe(
-      "Produkt už má dodávateľa v katalógu — ručné priradenie nie je možné",
+      "⚠️ Nepodarilo sa uložiť 1 položku×Priradenie dodávateľa — obj. 1003, kód C-1 (Produkt už má dodávateľa v katalógu — ručné priradenie nie je možné)",
     );
   });
   // Počiatočné načítanie + refetch po zlyhaní — samo-vyliečenie stránky,
@@ -130,8 +131,8 @@ it("zamietnuté priradenie (409) zobrazí slovenskú hlášku A ZÁROVEŇ sprav�
   await waitFor(() => {
     expect(fetchOpenOrders).toHaveBeenCalledTimes(2);
   });
-  // Banner prežil refetch (`load()` nemení `stateError`, nezávislý stav).
+  // Banner prežil refetch (`load()` nemení `writeFailures`, nezávislý stav).
   expect(screen.getByRole("alert").textContent).toBe(
-    "Produkt už má dodávateľa v katalógu — ručné priradenie nie je možné",
+    "⚠️ Nepodarilo sa uložiť 1 položku×Priradenie dodávateľa — obj. 1003, kód C-1 (Produkt už má dodávateľa v katalógu — ručné priradenie nie je možné)",
   );
 });

--- a/apps/web/src/components/OrdersSection.comment.test.tsx
+++ b/apps/web/src/components/OrdersSection.comment.test.tsx
@@ -165,8 +165,11 @@ it("zlyhané uloženie poznámky zobrazí slovenskú hlášku, bez refetchu", as
     screen.getByLabelText(`Uložiť poznámku k objednávke ${RIADOK_1.externalOrderId} / ${RIADOK_1.variantCode}`),
   );
 
+  // issue 66: kumulatívny banner nahrádza pôvodný jediný `<p role="alert">`.
   await waitFor(() => {
-    expect(screen.getByRole("alert").textContent).toBe("Uloženie poznámky sa nepodarilo");
+    expect(screen.getByRole("alert").textContent).toBe(
+      "⚠️ Nepodarilo sa uložiť 1 položku×Poznámka k objednávke — obj. 1004 (Uloženie poznámky sa nepodarilo)",
+    );
   });
   expect(fetchOpenOrders).toHaveBeenCalledTimes(1);
 });

--- a/apps/web/src/components/OrdersSection.ordered.test.tsx
+++ b/apps/web/src/components/OrdersSection.ordered.test.tsx
@@ -118,8 +118,11 @@ it("zlyhaná zmena príznaku objednané zobrazí slovenskú hlášku a checkbox 
   const checkbox = await screen.findByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_STARA.lineId}`);
   fireEvent.click(checkbox);
 
+  // issue 66: kumulatívny banner nahrádza pôvodný jediný `<p role="alert">`.
   await waitFor(() => {
-    expect(screen.getByRole("alert").textContent).toBe("Zmena príznaku objednané sa nepodarila");
+    expect(screen.getByRole("alert").textContent).toBe(
+      "⚠️ Nepodarilo sa uložiť 1 položku×Príznak objednané — obj. 1001, kód A-1 (Zmena príznaku objednané sa nepodarila)",
+    );
   });
   expect(screen.getByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_STARA.lineId}`).checked).toBe(false);
 });

--- a/apps/web/src/components/OrdersSection.test.tsx
+++ b/apps/web/src/components/OrdersSection.test.tsx
@@ -332,8 +332,13 @@ it("zlyhaná zmena stavu zobrazí slovenskú hlášku zo servera a stav sa nezme
   select.value = "skladom";
   select.dispatchEvent(new Event("change", { bubbles: true }));
 
+  // issue 66: kumulatívny banner (nahrádza pôvodný jediný `<p role="alert">`
+  // so surovou serverovou hláškou) — nesie aj nadpis "N položiek"/tlačidlo
+  // "×" aj `what — where (detail)` riadok, `.claude/rules/frontend-design.md`.
   await waitFor(() => {
-    expect(screen.getByRole("alert").textContent).toBe("Riadok objednávky sa nenašiel");
+    expect(screen.getByRole("alert").textContent).toBe(
+      "⚠️ Nepodarilo sa uložiť 1 položku×Zmena stavu — obj. 1001, kód A-1 (Riadok objednávky sa nenašiel)",
+    );
   });
   expect(screen.getByTestId<HTMLSelectElement>(`state-select-${LINE_STARA.lineId}`).value).toBe("objednane");
 });

--- a/apps/web/src/components/OrdersSection.tsx
+++ b/apps/web/src/components/OrdersSection.tsx
@@ -1,9 +1,12 @@
 import { useCallback, useEffect, useState, type JSX } from "react";
 import type { Me } from "../api.js";
 import { isLineResolved } from "../ordersSummary.js";
+import { clearWriteFailure, lineWhere, orderWhere, upsertWriteFailure, type OrderWriteFailure } from "../ordersWriteFailures.js";
+import { useSupplierEmailEditing } from "../useSupplierEmailEditing.js";
 import { useSupplierMailActions } from "../useSupplierMailActions.js";
 import { OrderOpenStatusesPanel } from "./OrderOpenStatusesPanel.js";
 import { OrdersToolbar } from "./OrdersToolbar.js";
+import { OrderWriteFailuresBanner } from "./OrderWriteFailuresBanner.js";
 import { SupplierOrderGroup } from "./SupplierOrderGroup.js";
 import {
   assignOrderLineSupplier as assignOrderLineSupplierApi,
@@ -11,7 +14,6 @@ import {
   NEZNAMY_DODAVATEL,
   OrdersUnauthorizedError,
   setProductSupplierLink,
-  setSupplierEmail,
   setSupplierLinesOrdered,
   updateOrderComment,
   updateOrderLineOrdered,
@@ -52,7 +54,10 @@ export function OrdersSection({
   const [suppliers, setSuppliers] = useState<readonly SupplierOpenOrders[]>([]);
   const [loaded, setLoaded] = useState(false);
   const [error, setError] = useState("");
-  const [stateError, setStateError] = useState("");
+  // issue 66: kumulatívny zoznam zlyhaní zápisu (nahrádza pôvodný jediný
+  // `stateError` string, ktorý každé ĎALŠIE zlyhanie prepísalo — pozri
+  // `ordersWriteFailures.ts`'s modulový komentár + komentár na tickete).
+  const [writeFailures, setWriteFailures] = useState<readonly OrderWriteFailure[]>([]);
   const [busyLineId, setBusyLineId] = useState<string | null>(null);
   const canChangeState = CAN_CHANGE_STATE_ROLES.has(role);
 
@@ -74,11 +79,18 @@ export function OrdersSection({
     });
   }, []);
 
-  // #31: e-mailový kontakt dodávateľa (editovateľný priamo v zozname).
-  const [editingEmailSupplier, setEditingEmailSupplier] = useState<string | null>(null);
-  const [emailDraft, setEmailDraft] = useState("");
-  const [emailBusy, setEmailBusy] = useState(false);
-  const [emailError, setEmailError] = useState("");
+  // #31: e-mailový kontakt dodávateľa (editovateľný priamo v zozname) —
+  // vyňaté do vlastného hooku (issue 66), pozri `useSupplierEmailEditing.ts`.
+  const {
+    editingEmailSupplier,
+    emailDraft,
+    emailBusy,
+    emailError,
+    onEmailDraftChange: setEmailDraft,
+    onStartEditEmail: startEditEmail,
+    onSaveEmail: saveEmail,
+    onCancelEditEmail: cancelEditEmail,
+  } = useSupplierEmailEditing(setSuppliers, onSessionExpired);
 
   // #31: náhľad + potvrdenie pred odoslaním objednávky mailom — vyňaté do
   // vlastného hooku (issue 64), aby sa v tomto súbore uvoľnilo miesto pod
@@ -116,7 +128,7 @@ export function OrdersSection({
 
   const changeState = useCallback(
     (lineId: string, newState: OrderLine["state"]) => {
-      setStateError("");
+      const failureId = `state:${lineId}`;
       setBusyLineId(lineId);
       updateOrderLineState(lineId, newState)
         .then(() => {
@@ -128,19 +140,27 @@ export function OrdersSection({
               lines: group.lines.map((line) => (line.lineId === lineId ? { ...line, state: newState } : line)),
             })),
           );
+          setWriteFailures((current) => clearWriteFailure(current, failureId));
         })
         .catch((err: unknown) => {
           if (err instanceof OrdersUnauthorizedError) {
             onSessionExpired();
             return;
           }
-          setStateError(err instanceof Error ? err.message : "Zmena stavu sa nepodarila.");
+          setWriteFailures((current) =>
+            upsertWriteFailure(current, {
+              id: failureId,
+              what: "Zmena stavu",
+              where: lineWhere(suppliers, lineId),
+              detail: err instanceof Error ? err.message : "Zmena stavu sa nepodarila.",
+            }),
+          );
         })
         .finally(() => {
           setBusyLineId(null);
         });
     },
-    [onSessionExpired],
+    [onSessionExpired, suppliers],
   );
 
   // issue 60: odškrtávacie políčko "objednané u dodávateľa" — per riadok aj
@@ -150,7 +170,7 @@ export function OrdersSection({
 
   const changeOrdered = useCallback(
     (lineId: string, ordered: boolean) => {
-      setStateError("");
+      const failureId = `ordered:${lineId}`;
       setBusyOrderedLineId(lineId);
       updateOrderLineOrdered(lineId, ordered)
         .then(() => {
@@ -160,19 +180,27 @@ export function OrdersSection({
               lines: group.lines.map((line) => (line.lineId === lineId ? { ...line, ordered } : line)),
             })),
           );
+          setWriteFailures((current) => clearWriteFailure(current, failureId));
         })
         .catch((err: unknown) => {
           if (err instanceof OrdersUnauthorizedError) {
             onSessionExpired();
             return;
           }
-          setStateError(err instanceof Error ? err.message : "Zmena príznaku objednané sa nepodarila.");
+          setWriteFailures((current) =>
+            upsertWriteFailure(current, {
+              id: failureId,
+              what: "Príznak objednané",
+              where: lineWhere(suppliers, lineId),
+              detail: err instanceof Error ? err.message : "Zmena príznaku objednané sa nepodarila.",
+            }),
+          );
         })
         .finally(() => {
           setBusyOrderedLineId(null);
         });
     },
-    [onSessionExpired],
+    [onSessionExpired, suppliers],
   );
 
   // issue 63: ručné priradenie dodávateľa riadku bez dodávateľa. PLNÝ refetch
@@ -182,10 +210,12 @@ export function OrdersSection({
 
   const assignSupplier = useCallback(
     (lineId: string, supplier: string) => {
-      setStateError("");
+      const failureId = `supplier:${lineId}`;
+      const where = lineWhere(suppliers, lineId);
       setBusySupplierLineId(lineId);
       assignOrderLineSupplierApi(lineId, supplier)
         .then(() => {
+          setWriteFailures((current) => clearWriteFailure(current, failureId));
           load();
         })
         .catch((err: unknown) => {
@@ -193,14 +223,21 @@ export function OrdersSection({
             onSessionExpired();
             return;
           }
-          setStateError(err instanceof Error ? err.message : "Priradenie dodávateľa sa nepodarilo.");
+          setWriteFailures((current) =>
+            upsertWriteFailure(current, {
+              id: failureId,
+              what: "Priradenie dodávateľa",
+              where,
+              detail: err instanceof Error ? err.message : "Priradenie dodávateľa sa nepodarilo.",
+            }),
+          );
           // issue 89 (review PR 87): predtým sa `load()` volalo LEN v úspešnej
           // vetve vyššie — pri zamietnutí (napr. server vráti 409, lebo
           // produkt medzitým dostal dodávateľa v katalógu inou cestou, súbeh s
           // importom alebo dlho otvorená stránka iného manažéra) zoznam
           // zostal STARÝ a vstupné pole na priradenie by tak ostalo viditeľné
           // navždy — manažér by mohol skúšať donekonečna. `load()` mení len
-          // `suppliers`/`loaded`/`error`, nikdy `stateError` (nezávislý stav
+          // `suppliers`/`loaded`/`error`, nikdy `writeFailures` (nezávislý stav
           // vyššie), takže táto hláška ostáva viditeľná aj po refetchi.
           load();
         })
@@ -208,7 +245,7 @@ export function OrdersSection({
           setBusySupplierLineId(null);
         });
     },
-    [load, onSessionExpired],
+    [load, onSessionExpired, suppliers],
   );
 
   // issue 121: manuálny odkaz na dodávateľa — PLNÝ refetch po úspechu (rovnaký
@@ -218,10 +255,12 @@ export function OrdersSection({
 
   const setSupplierLink = useCallback(
     (lineId: string, url: string) => {
-      setStateError("");
+      const failureId = `supplierLink:${lineId}`;
+      const where = lineWhere(suppliers, lineId);
       setBusySupplierLinkLineId(lineId);
       setProductSupplierLink(lineId, url)
         .then(() => {
+          setWriteFailures((current) => clearWriteFailure(current, failureId));
           load();
         })
         .catch((err: unknown) => {
@@ -229,13 +268,20 @@ export function OrdersSection({
             onSessionExpired();
             return;
           }
-          setStateError(err instanceof Error ? err.message : "Uloženie odkazu na dodávateľa sa nepodarilo.");
+          setWriteFailures((current) =>
+            upsertWriteFailure(current, {
+              id: failureId,
+              what: "Odkaz na dodávateľa",
+              where,
+              detail: err instanceof Error ? err.message : "Uloženie odkazu na dodávateľa sa nepodarilo.",
+            }),
+          );
         })
         .finally(() => {
           setBusySupplierLinkLineId(null);
         });
     },
-    [load, onSessionExpired],
+    [load, onSessionExpired, suppliers],
   );
 
   // Hromadné označenie/zrušenie CELEJ skupiny dodávateľa naraz (stará appka's
@@ -243,7 +289,7 @@ export function OrdersSection({
   // skupina UŽ celá objednaná, `webreview/static/app.js`'s `allOrdered`).
   const toggleGroupOrdered = useCallback(
     (supplier: string, ordered: boolean) => {
-      setStateError("");
+      const failureId = `groupOrdered:${supplier}`;
       setBusyOrderedSupplier(supplier);
       setSupplierLinesOrdered(supplier, ordered)
         .then(() => {
@@ -254,57 +300,27 @@ export function OrdersSection({
                 : group,
             ),
           );
+          setWriteFailures((current) => clearWriteFailure(current, failureId));
         })
         .catch((err: unknown) => {
           if (err instanceof OrdersUnauthorizedError) {
             onSessionExpired();
             return;
           }
-          setStateError(err instanceof Error ? err.message : "Hromadné označenie skupiny sa nepodarilo.");
+          setWriteFailures((current) =>
+            upsertWriteFailure(current, {
+              id: failureId,
+              what: "Hromadné označenie skupiny",
+              where: `dodávateľ ${supplier}`,
+              detail: err instanceof Error ? err.message : "Hromadné označenie skupiny sa nepodarilo.",
+            }),
+          );
         })
         .finally(() => {
           setBusyOrderedSupplier(null);
         });
     },
     [onSessionExpired],
-  );
-
-  // #31: úprava e-mailu dodávateľa.
-  const startEditEmail = useCallback((group: SupplierOpenOrders) => {
-    setEditingEmailSupplier(group.supplier);
-    setEmailDraft(group.email ?? "");
-    setEmailError("");
-  }, []);
-
-  const cancelEditEmail = useCallback(() => {
-    setEditingEmailSupplier(null);
-    setEmailError("");
-  }, []);
-
-  const saveEmail = useCallback(
-    (supplier: string) => {
-      setEmailBusy(true);
-      setEmailError("");
-      const novyEmail = emailDraft.trim() === "" ? null : emailDraft.trim();
-      setSupplierEmail(supplier, novyEmail)
-        .then(() => {
-          setSuppliers((current) =>
-            current.map((group) => (group.supplier === supplier ? { ...group, email: novyEmail } : group)),
-          );
-          setEditingEmailSupplier(null);
-        })
-        .catch((err: unknown) => {
-          if (err instanceof OrdersUnauthorizedError) {
-            onSessionExpired();
-            return;
-          }
-          setEmailError(err instanceof Error ? err.message : "Nastavenie e-mailu sa nepodarilo.");
-        })
-        .finally(() => {
-          setEmailBusy(false);
-        });
-    },
-    [emailDraft, onSessionExpired],
   );
 
   // issue 64: manažérova voľná poznámka k CELEJ objednávke — NEZÁVISLÉ od
@@ -317,7 +333,7 @@ export function OrdersSection({
 
   const changeComment = useCallback(
     (orderId: string, comment: string | null) => {
-      setStateError("");
+      const failureId = `comment:${orderId}`;
       setBusyCommentOrderId(orderId);
       updateOrderComment(orderId, comment)
         .then(() => {
@@ -327,19 +343,27 @@ export function OrdersSection({
               lines: group.lines.map((line) => (line.orderId === orderId ? { ...line, comment } : line)),
             })),
           );
+          setWriteFailures((current) => clearWriteFailure(current, failureId));
         })
         .catch((err: unknown) => {
           if (err instanceof OrdersUnauthorizedError) {
             onSessionExpired();
             return;
           }
-          setStateError(err instanceof Error ? err.message : "Uloženie poznámky sa nepodarilo.");
+          setWriteFailures((current) =>
+            upsertWriteFailure(current, {
+              id: failureId,
+              what: "Poznámka k objednávke",
+              where: orderWhere(suppliers, orderId),
+              detail: err instanceof Error ? err.message : "Uloženie poznámky sa nepodarilo.",
+            }),
+          );
         })
         .finally(() => {
           setBusyCommentOrderId(null);
         });
     },
-    [onSessionExpired],
+    [onSessionExpired, suppliers],
   );
 
   // `/api/orders/open` už zoraďuje riadky presne tak, ako majú byť zobrazené
@@ -370,7 +394,12 @@ export function OrdersSection({
     <section className="orders-section">
       {!loaded && <p>Načítavam otvorené objednávky…</p>}
       {error !== "" && <p role="alert">{error}</p>}
-      {stateError !== "" && <p role="alert">{stateError}</p>}
+      <OrderWriteFailuresBanner
+        failures={writeFailures}
+        onDismiss={() => {
+          setWriteFailures([]);
+        }}
+      />
       {canChangeState && <OrderOpenStatusesPanel onSessionExpired={onSessionExpired} onSaved={load} />}
       {loaded && totalLines === 0 && (
         <p className="empty" data-testid="orders-empty">Zatiaľ nie sú žiadne otvorené objednávky.</p>

--- a/apps/web/src/components/OrdersSection.writeFailures.test.tsx
+++ b/apps/web/src/components/OrdersSection.writeFailures.test.tsx
@@ -1,0 +1,108 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { OrdersSection } from "./OrdersSection.js";
+
+// issue 66: dôkaz jadra ticketu — DVE NEZÁVISLÉ zlyhania (rôzne riadky, rôzne
+// akcie) sa musia zobraziť SÚČASNE (predtým jediný `stateError` string druhé
+// zlyhanie ÚPLNE prepísalo, prvé zmizlo z obrazovky, hoci sa nikdy neuložilo).
+// Vlastný súbor — rovnaký vzor ako existujúce `OrdersSection.ordered.test
+// .tsx`/`OrdersSection.assignSupplier.test.tsx` splity (`.claude/rules/
+// testing.md`), aby žiadny súbor nenarástol cez eslint `max-lines: 400`.
+
+const { fetchOpenOrders, updateOrderLineState, updateOrderLineOrdered } = vi.hoisted(() => ({
+  fetchOpenOrders: vi.fn(),
+  updateOrderLineState: vi.fn(),
+  updateOrderLineOrdered: vi.fn(),
+}));
+
+vi.mock("../ordersApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../ordersApi.js")>();
+  return { ...actual, fetchOpenOrders, updateOrderLineState, updateOrderLineOrdered };
+});
+
+const LINE_ALFA = {
+  lineId: "11111111-1111-1111-1111-111111111111",
+  orderId: "aaaaaaaa-1111-1111-1111-111111111111",
+  externalOrderId: "1001",
+  customerName: "Zákazník Alfa",
+  comment: null,
+  remark: null,
+  adminUrl: "https://www.forestshop.sk/admin/vyhladavanie/?string=1001&src=orders",
+  placedAt: "2026-07-01T00:00:00.000Z",
+  variantCode: "A-1",
+  variantName: "Nohavice FOREST",
+  sizeLabel: "3XL",
+  quantity: 2,
+  state: "objednane" as const,
+  ordered: false,
+  supplierUrl: null,
+  supplierNote: null,
+  externalCode: null,
+  supplierAssignable: false,
+  manualSupplierOverride: null,
+};
+
+const LINE_BETA = {
+  ...LINE_ALFA,
+  lineId: "22222222-2222-2222-2222-222222222222",
+  orderId: "bbbbbbbb-2222-2222-2222-222222222222",
+  externalOrderId: "1002",
+  customerName: "Zákazník Beta",
+  variantCode: "B-1",
+};
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+it("dve nezávislé zlyhania zápisu (iný riadok, iná akcia) sa zobrazia SÚČASNE, kumulatívne", async () => {
+  fetchOpenOrders.mockResolvedValue([
+    { supplier: "Dodávateľ Alfa", lines: [LINE_ALFA, LINE_BETA], email: null },
+  ]);
+  updateOrderLineState.mockRejectedValue(new Error("chyba stavu"));
+  updateOrderLineOrdered.mockRejectedValue(new Error("chyba príznaku"));
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const select = await screen.findByTestId<HTMLSelectElement>(`state-select-${LINE_ALFA.lineId}`);
+  select.value = "skladom";
+  select.dispatchEvent(new Event("change", { bubbles: true }));
+
+  await waitFor(() => {
+    expect(screen.getByTestId("order-write-failures").textContent).toContain("Nepodarilo sa uložiť 1 položku");
+  });
+
+  const checkbox = screen.getByTestId<HTMLInputElement>(`ordered-checkbox-${LINE_BETA.lineId}`);
+  fireEvent.click(checkbox);
+
+  // OBE zlyhania viditeľné naraz — presne to, čo predtým chýbalo.
+  await waitFor(() => {
+    expect(screen.getByTestId("order-write-failures").textContent).toContain("Nepodarilo sa uložiť 2 položky");
+  });
+  expect(screen.getByTestId(`order-write-failure-state:${LINE_ALFA.lineId}`).textContent).toBe(
+    "Zmena stavu — obj. 1001, kód A-1 (chyba stavu)",
+  );
+  expect(screen.getByTestId(`order-write-failure-ordered:${LINE_BETA.lineId}`).textContent).toBe(
+    "Príznak objednané — obj. 1002, kód B-1 (chyba príznaku)",
+  );
+  // Zamietnutá zmena sa NIKDY netvári ako uložená.
+  expect(select.value).toBe("objednane");
+  expect(checkbox.checked).toBe(false);
+
+  // Úspešný opakovaný zápis (riadok Alfa) zmaže LEN jeho položku — druhá
+  // (Beta) ostáva viditeľná (legacy `clearToOrderFail`: "drop only ITS line").
+  updateOrderLineState.mockResolvedValue(undefined);
+  select.value = "skladom";
+  select.dispatchEvent(new Event("change", { bubbles: true }));
+
+  await waitFor(() => {
+    expect(screen.getByTestId("order-write-failures").textContent).toContain("Nepodarilo sa uložiť 1 položku");
+  });
+  expect(screen.queryByTestId(`order-write-failure-state:${LINE_ALFA.lineId}`)).toBeNull();
+  expect(screen.getByTestId(`order-write-failure-ordered:${LINE_BETA.lineId}`)).toBeTruthy();
+
+  // Zatvorenie bannera zmaže VŠETKY zostávajúce položky naraz.
+  fireEvent.click(screen.getByRole("button", { name: "Zavrieť hlásenie o neuložených zmenách" }));
+  expect(screen.queryByTestId("order-write-failures")).toBeNull();
+});

--- a/apps/web/src/ordersWriteFailures.test.ts
+++ b/apps/web/src/ordersWriteFailures.test.ts
@@ -1,0 +1,107 @@
+import { expect, it } from "vitest";
+import {
+  clearWriteFailure,
+  formatWriteFailuresHeading,
+  lineWhere,
+  orderWhere,
+  upsertWriteFailure,
+  type OrderWriteFailure,
+} from "./ordersWriteFailures.js";
+import type { OrderLine, SupplierOpenOrders } from "./ordersApi.js";
+
+const LINE: OrderLine = {
+  lineId: "11111111-1111-1111-1111-111111111111",
+  orderId: "aaaaaaaa-1111-1111-1111-111111111111",
+  externalOrderId: "1001",
+  customerName: "Zákazník",
+  comment: null,
+  remark: null,
+  adminUrl: "https://www.forestshop.sk/admin/vyhladavanie/?string=1001&src=orders",
+  placedAt: "2026-07-01T00:00:00.000Z",
+  variantCode: "A-1",
+  variantName: "Nohavice FOREST",
+  sizeLabel: "3XL",
+  quantity: 2,
+  state: "objednane",
+  ordered: false,
+  supplierUrl: null,
+  supplierNote: null,
+  externalCode: null,
+  supplierAssignable: false,
+  manualSupplierOverride: null,
+};
+
+const SUPPLIERS: readonly SupplierOpenOrders[] = [{ supplier: "Dodávateľ Alfa", lines: [LINE], email: null }];
+
+it("upsertWriteFailure pridá novú položku", () => {
+  const result = upsertWriteFailure([], { id: "state:1", what: "Zmena stavu", where: "obj. 1001", detail: "chyba" });
+  expect(result).toEqual([{ id: "state:1", what: "Zmena stavu", where: "obj. 1001", detail: "chyba" }]);
+});
+
+it("upsertWriteFailure s ROVNAKÝM id NAHRADÍ predchádzajúcu položku, nikdy ju neduplikuje", () => {
+  const puvodny: readonly OrderWriteFailure[] = [
+    { id: "state:1", what: "Zmena stavu", where: "obj. 1001", detail: "prvá chyba" },
+  ];
+  const result = upsertWriteFailure(puvodny, {
+    id: "state:1",
+    what: "Zmena stavu",
+    where: "obj. 1001",
+    detail: "druhá chyba",
+  });
+  expect(result).toHaveLength(1);
+  expect(result[0]?.detail).toBe("druhá chyba");
+});
+
+it("upsertWriteFailure s INÝM id PRIDÁ NEZÁVISLÚ položku (kumulatívne, nikdy neprepíše cudziu)", () => {
+  const puvodny: readonly OrderWriteFailure[] = [
+    { id: "state:1", what: "Zmena stavu", where: "obj. 1001", detail: "chyba A" },
+  ];
+  const result = upsertWriteFailure(puvodny, {
+    id: "ordered:2",
+    what: "Príznak objednané",
+    where: "obj. 1002",
+    detail: "chyba B",
+  });
+  expect(result).toHaveLength(2);
+  expect(result.map((f) => f.id)).toEqual(["state:1", "ordered:2"]);
+});
+
+it("clearWriteFailure zmaže LEN položku so zhodným id, ostatné nechá bez zmeny", () => {
+  const puvodny: readonly OrderWriteFailure[] = [
+    { id: "state:1", what: "Zmena stavu", where: "obj. 1001", detail: "chyba A" },
+    { id: "ordered:2", what: "Príznak objednané", where: "obj. 1002", detail: "chyba B" },
+  ];
+  const result = clearWriteFailure(puvodny, "state:1");
+  expect(result).toEqual([{ id: "ordered:2", what: "Príznak objednané", where: "obj. 1002", detail: "chyba B" }]);
+});
+
+it("clearWriteFailure na chýbajúce id je no-op", () => {
+  const puvodny: readonly OrderWriteFailure[] = [
+    { id: "state:1", what: "Zmena stavu", where: "obj. 1001", detail: "chyba" },
+  ];
+  expect(clearWriteFailure(puvodny, "neznáme")).toEqual(puvodny);
+});
+
+it("formatWriteFailuresHeading skloňuje po slovensky (1/2-4/5+)", () => {
+  expect(formatWriteFailuresHeading(1)).toBe("⚠️ Nepodarilo sa uložiť 1 položku");
+  expect(formatWriteFailuresHeading(2)).toBe("⚠️ Nepodarilo sa uložiť 2 položky");
+  expect(formatWriteFailuresHeading(4)).toBe("⚠️ Nepodarilo sa uložiť 4 položky");
+  expect(formatWriteFailuresHeading(5)).toBe("⚠️ Nepodarilo sa uložiť 5 položiek");
+  expect(formatWriteFailuresHeading(0)).toBe("⚠️ Nepodarilo sa uložiť 0 položiek");
+});
+
+it("lineWhere nájde riadok podľa lineId naprieč skupinami dodávateľov", () => {
+  expect(lineWhere(SUPPLIERS, LINE.lineId)).toBe("obj. 1001, kód A-1");
+});
+
+it("lineWhere na neznámy lineId vráti prázdny reťazec (riadok medzitým zmizol zo zoznamu)", () => {
+  expect(lineWhere(SUPPLIERS, "neznámy")).toBe("");
+});
+
+it("orderWhere nájde PRVÝ riadok s daným orderId (poznámka patrí objednávke, nie riadku)", () => {
+  expect(orderWhere(SUPPLIERS, LINE.orderId)).toBe("obj. 1001");
+});
+
+it("orderWhere na neznámy orderId vráti prázdny reťazec", () => {
+  expect(orderWhere(SUPPLIERS, "neznáme")).toBe("");
+});

--- a/apps/web/src/ordersWriteFailures.ts
+++ b/apps/web/src/ordersWriteFailures.ts
@@ -1,0 +1,74 @@
+import type { OrderLine, SupplierOpenOrders } from "./ordersApi.js";
+
+// issue 66: predtým mala "Na objednanie" JEDEN zdieľaný string (`stateError`
+// v `OrdersSection.tsx`) pre VŠETKÝCH 6 zápisových akcií tabu — každé ďalšie
+// zlyhanie ho PREPÍSALO, takže manažér pri viacerých zlyhaniach za sebou
+// (typický obraz krátkeho výpadku siete) videl vždy len POSLEDNÚ príčinu.
+// Tento modul nahrádza jeden string ZOZNAMOM zlyhaní, kľúčovaným `id`
+// (`<akcia>:<cieľ>`) — kumulatívne, kým sa položka buď znova neuloží úspešne,
+// alebo ju manažér ručne nezavrie. Žiadna optimistická reconciliation
+// (commitSeq a pod., ako legacy `app.js:1093-1240`) tu netreba — appka nikdy
+// nezobrazí zápis ako uložený skôr, než ho server potvrdí (`checked={line
+// .ordered}`/`<select value={line.state}>` v `OrderLineRow.tsx` sú viazané
+// priamo na potvrdenú hodnotu z props, viď komentár na tickete #66).
+export interface OrderWriteFailure {
+  readonly id: string;
+  readonly what: string;
+  readonly where: string;
+  readonly detail: string;
+}
+
+/** Pridá zlyhanie — rovnaké `id` NAHRADÍ predchádzajúcu položku (aktualizuje
+ * dôvod), nikdy ju nezduplikuje. */
+export function upsertWriteFailure(
+  failures: readonly OrderWriteFailure[],
+  failure: OrderWriteFailure,
+): readonly OrderWriteFailure[] {
+  return [...failures.filter((f) => f.id !== failure.id), failure];
+}
+
+/** Jeden zápis prišiel úspešne — zmaž LEN jeho položku (legacy `app.js`'s
+ * `clearToOrderFail`: "ONE write landed — drop only ITS line"). */
+export function clearWriteFailure(
+  failures: readonly OrderWriteFailure[],
+  id: string,
+): readonly OrderWriteFailure[] {
+  return failures.filter((f) => f.id !== id);
+}
+
+function pluralWord(n: number, one: string, few: string, many: string): string {
+  if (n === 1) return one;
+  return n >= 2 && n <= 4 ? few : many;
+}
+
+export function formatWriteFailuresHeading(count: number): string {
+  return `⚠️ Nepodarilo sa uložiť ${String(count)} ${pluralWord(count, "položku", "položky", "položiek")}`;
+}
+
+function findLine(suppliers: readonly SupplierOpenOrders[], lineId: string): OrderLine | undefined {
+  for (const group of suppliers) {
+    const found = group.lines.find((l) => l.lineId === lineId);
+    if (found !== undefined) return found;
+  }
+  return undefined;
+}
+
+// "obj. 20260910, kód 4859/46" — priamy náprotivok legacy `toOrderRowLabel`.
+// Prázdny reťazec, keď riadok medzitým zmizol zo zoznamu (napr. iný manažér
+// medzitým priradil dodávateľa a appka spravila refetch) — banner ukáže
+// aspoň `what`, nikdy nespadne na chýbajúcom riadku.
+export function lineWhere(suppliers: readonly SupplierOpenOrders[], lineId: string): string {
+  const line = findLine(suppliers, lineId);
+  return line === undefined ? "" : `obj. ${line.externalOrderId}, kód ${line.variantCode}`;
+}
+
+// Poznámka je vlastníctvom CELEJ objednávky (`orderId`), nie jedného riadku
+// — stačí nájsť PRVÝ riadok s tým `orderId` (rovnaký vzor ako `OrdersSection
+// .tsx`'s `changeComment`, ktoré tiež mutuje všetky riadky rovnakej objednávky).
+export function orderWhere(suppliers: readonly SupplierOpenOrders[], orderId: string): string {
+  for (const group of suppliers) {
+    const found = group.lines.find((l) => l.orderId === orderId);
+    if (found !== undefined) return `obj. ${found.externalOrderId}`;
+  }
+  return "";
+}

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -591,6 +591,29 @@ tr:last-child td {
   margin-bottom: var(--fs-space-6);
 }
 
+/* issue 66: kumulatívny banner "Nepodarilo sa uložiť N položiek" —
+   `[role="alert"]` (sekcia 2) už dáva farbu/padding/radius, tu len rozloženie
+   hlavičky (nadpis + zatváracie tlačidlo) a odstup zoznamu položiek. */
+.order-write-failures {
+  display: flex;
+  flex-direction: column;
+  gap: var(--fs-space-2);
+}
+.order-write-failures-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--fs-space-3);
+  font-weight: var(--fs-weight-semibold);
+}
+.order-write-failures ul {
+  margin: 0;
+  padding-left: var(--fs-space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--fs-space-1);
+}
+
 /* issue 61: filtrovacie štítky dodávateľov + súhrn "ostáva vybaviť" +
    prepínač "skryť vybavené" — vlastný jazyk tejto appky (issue výslovne
    žiada dizajn podľa NOVEJ appky, nie prevzaté farby starej). */

--- a/apps/web/src/useSupplierEmailEditing.ts
+++ b/apps/web/src/useSupplierEmailEditing.ts
@@ -1,0 +1,79 @@
+import { useCallback, useState } from "react";
+import { OrdersUnauthorizedError, setSupplierEmail, type SupplierOpenOrders } from "./ordersApi.js";
+
+// issue 66: mechanicky vyňaté z `OrdersSection.tsx` (#31 — úprava e-mailového
+// kontaktu dodávateľa), BEZ ZMENY SPRÁVANIA — rovnaký zámer a vzor ako
+// `useSupplierMailActions.ts`'s komentár vysvetľuje (issue 64): vlastný HOOK
+// namiesto komponenty, lebo tento blok nemá vlastný markup, len stav + tri
+// handlery, ktoré `SupplierActionsPanel` dostáva ako props. Extrakcia
+// uvoľnila v `OrdersSection.tsx` miesto (eslint `max-lines: 400`) pre
+// kumulatívne hlásenie o neuložených zmenách (tento ticket), bez zmeny
+// e-mailovej logiky.
+export interface SupplierEmailEditing {
+  readonly editingEmailSupplier: string | null;
+  readonly emailDraft: string;
+  readonly emailBusy: boolean;
+  readonly emailError: string;
+  readonly onEmailDraftChange: (value: string) => void;
+  readonly onStartEditEmail: (group: SupplierOpenOrders) => void;
+  readonly onSaveEmail: (supplier: string) => void;
+  readonly onCancelEditEmail: () => void;
+}
+
+export function useSupplierEmailEditing(
+  setSuppliers: (updater: (current: readonly SupplierOpenOrders[]) => readonly SupplierOpenOrders[]) => void,
+  onSessionExpired: () => void,
+): SupplierEmailEditing {
+  const [editingEmailSupplier, setEditingEmailSupplier] = useState<string | null>(null);
+  const [emailDraft, setEmailDraft] = useState("");
+  const [emailBusy, setEmailBusy] = useState(false);
+  const [emailError, setEmailError] = useState("");
+
+  const onStartEditEmail = useCallback((group: SupplierOpenOrders) => {
+    setEditingEmailSupplier(group.supplier);
+    setEmailDraft(group.email ?? "");
+    setEmailError("");
+  }, []);
+
+  const onCancelEditEmail = useCallback(() => {
+    setEditingEmailSupplier(null);
+    setEmailError("");
+  }, []);
+
+  const onSaveEmail = useCallback(
+    (supplier: string) => {
+      setEmailBusy(true);
+      setEmailError("");
+      const novyEmail = emailDraft.trim() === "" ? null : emailDraft.trim();
+      setSupplierEmail(supplier, novyEmail)
+        .then(() => {
+          setSuppliers((current) =>
+            current.map((group) => (group.supplier === supplier ? { ...group, email: novyEmail } : group)),
+          );
+          setEditingEmailSupplier(null);
+        })
+        .catch((err: unknown) => {
+          if (err instanceof OrdersUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setEmailError(err instanceof Error ? err.message : "Nastavenie e-mailu sa nepodarilo.");
+        })
+        .finally(() => {
+          setEmailBusy(false);
+        });
+    },
+    [emailDraft, onSessionExpired, setSuppliers],
+  );
+
+  return {
+    editingEmailSupplier,
+    emailDraft,
+    emailBusy,
+    emailError,
+    onEmailDraftChange: setEmailDraft,
+    onStartEditEmail,
+    onSaveEmail,
+    onCancelEditEmail,
+  };
+}

--- a/apps/web/tests/e2e/orders-write-failures.spec.ts
+++ b/apps/web/tests/e2e/orders-write-failures.spec.ts
@@ -1,0 +1,130 @@
+import { expect, test, type ConsoleMessage } from "@playwright/test";
+
+const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
+const E2E_ZAPISY_EMAIL = "e2e-zapisy@forestshop.sk";
+
+// Rovnaká a JEDINÁ povolená výnimka ako v login.spec.ts/orders.spec.ts.
+const jeOcakavane = (m: ConsoleMessage): boolean =>
+  m.location().url.includes("/api/me") && m.text().includes("401");
+
+// issue 66: predtým appka zobrazovala len JEDNU (poslednú) chybovú hlášku pri
+// zápise do "Na objednanie" — zlyhanie STARŠIEHO riadku úplne zmizlo z
+// obrazovky, hoci sa nikdy neuložilo (naživo overené na produkcii PRED
+// implementáciou, pozri komentár na tickete #66). Test simuluje DVE
+// NEZÁVISLÉ zlyhania zápisu (rôzne riadky, rôzne akcie) cez prepichnutý
+// `window.fetch` — injektovaný `addInitScript`om PRED akýmkoľvek appkovým
+// kódom, nikdy cez `page.route().abort()`/`.fulfill({status:5xx})`, ktoré by
+// zalogovali skutočné "Failed to load resource" do konzoly a porušili
+// `.claude/rules/testing.md`'s zákaz rozširovania JEDINEJ povolenej
+// konzolovej výnimky (401 na `/api/me`). Žiadny reálny zápis na server preto
+// nikdy neodíde — appka naživo nič nemutuje, žiadna nová fixtúra netreba.
+test("kumulatívne hlásenie o neuložených zmenách drží VIAC zlyhaní naraz, mizne po úspešnom zápise/zavretí, konzola je čistá", async ({
+  page,
+}) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  // Musí bežať PRED appkovým kódom — prvý render volá `fetchOpenOrders` hneď
+  // pri mounte. `addInitScript` sa vykoná pred KAŽDÝM ďalším skriptom na
+  // stránke.
+  await page.addInitScript(() => {
+    const puvodny = window.fetch.bind(window);
+    const zlyhaj = new Set<string>();
+    const uspej = new Set<string>();
+    Object.assign(window, { __zlyhajUrl: zlyhaj, __uspejUrl: uspej });
+    window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      const method = init?.method;
+      if (method !== undefined && method !== "GET") {
+        for (const frag of zlyhaj) {
+          if (url.includes(frag)) return Promise.reject(new TypeError("Failed to fetch (simulovaný výpadok siete)"));
+        }
+        for (const frag of uspej) {
+          if (url.includes(frag)) {
+            return Promise.resolve(
+              new Response(JSON.stringify({}), { status: 200, headers: { "content-type": "application/json" } }),
+            );
+          }
+        }
+      }
+      return puvodny(input, init);
+    };
+  });
+
+  await page.goto("/?tab=orders");
+  await page.getByLabel("E-mail").fill(E2E_ZAPISY_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await expect(page.getByRole("heading", { name: "Na objednanie" })).toBeVisible();
+
+  const riadokAlfa = page
+    .getByTestId("supplier-DODAVATEL-TEST-1")
+    .locator("[data-testid^='order-line-']")
+    .filter({ hasText: "9001" });
+  const selectAlfa = riadokAlfa.locator("select");
+
+  const riadokBez = page
+    .getByTestId("supplier-(bez dodávateľa)")
+    .locator("[data-testid^='order-line-']")
+    .filter({ hasText: "9002" });
+  const checkboxBez = riadokBez.locator("input[type='checkbox']");
+
+  const alfaTestId = await selectAlfa.getAttribute("data-testid");
+  const alfaLineId = (alfaTestId ?? "").replace("state-select-", "");
+  const bezTestId = await checkboxBez.getAttribute("data-testid");
+  const bezLineId = (bezTestId ?? "").replace("ordered-checkbox-", "");
+  expect(alfaLineId).not.toBe("");
+  expect(bezLineId).not.toBe("");
+
+  const banner = page.getByTestId("order-write-failures");
+
+  // `scripts/e2e-setup.ts`: riadok Alfa (obj. 9001) štartuje v stave
+  // "caka_sa" (vybavený), nie vo východiskovom "objednane".
+  await expect(selectAlfa).toHaveValue("caka_sa");
+
+  // 1. zlyhanie: zmena stavu na riadku Alfa (DODAVATEL-TEST-1, obj. 9001).
+  await page.evaluate((frag) => {
+    (window as unknown as { __zlyhajUrl: Set<string> }).__zlyhajUrl.add(frag);
+  }, `/api/orders/lines/${alfaLineId}/state`);
+  await selectAlfa.selectOption("skladom");
+  await expect(banner).toContainText("Nepodarilo sa uložiť 1 položku");
+  await expect(banner).toContainText("obj. 9001");
+  // Zamietnutá zmena sa NIKDY netvári ako uložená.
+  await expect(selectAlfa).toHaveValue("caka_sa");
+
+  // 2. NEZÁVISLÉ zlyhanie: iný riadok (obj. 9002, "(bez dodávateľa)"), iná
+  // akcia (checkbox "objednané").
+  await page.evaluate((frag) => {
+    (window as unknown as { __zlyhajUrl: Set<string> }).__zlyhajUrl.add(frag);
+  }, `/api/orders/lines/${bezLineId}/ordered`);
+  await checkboxBez.click();
+  await expect(banner).toContainText("Nepodarilo sa uložiť 2 položky");
+  // PRVÉ zlyhanie stále vidieť — presne to, čo ticket #66 vyžaduje (predtým
+  // by ho toto druhé zlyhanie ÚPLNE prepísalo).
+  await expect(banner).toContainText("obj. 9001");
+  await expect(banner).toContainText("obj. 9002");
+  await expect(checkboxBez).not.toBeChecked();
+
+  // Úspešný opakovaný zápis (riadok Alfa, mockovaná 200 odpoveď — žiadny
+  // reálny zápis na server) zmaže LEN jeho položku z bannera.
+  await page.evaluate((frag) => {
+    const w = window as unknown as { __zlyhajUrl: Set<string>; __uspejUrl: Set<string> };
+    w.__zlyhajUrl.delete(frag);
+    w.__uspejUrl.add(frag);
+  }, `/api/orders/lines/${alfaLineId}/state`);
+  await selectAlfa.selectOption("skladom");
+  await expect(banner).toContainText("Nepodarilo sa uložiť 1 položku");
+  await expect(banner).not.toContainText("obj. 9001");
+  await expect(banner).toContainText("obj. 9002");
+
+  // Zatvorenie bannera zmaže VŠETKY zostávajúce položky naraz.
+  await page.getByRole("button", { name: "Zavrieť hlásenie o neuložených zmenách" }).click();
+  await expect(banner).toHaveCount(0);
+
+  expect(chyby).toEqual([]);
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.86",
+  "version": "0.3.0-dev.87",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -113,6 +113,13 @@ const E2E_ROZLOZENIE_EMAIL = "e2e-rozlozenie@forestshop.sk"; // musí sa zhodova
 // namiesto ďalšieho prihlásenia pod zdieľaným `e2e@forestshop.sk`.
 const E2E_ODKAZ_EMAIL = "e2e-odkaz@forestshop.sk"; // musí sa zhodovať s hodnotou v orders.spec.ts
 
+// issue 66: rovnaký mechanizmus a dôvod ako `E2E_ODKAZ_EMAIL` vyššie — balík
+// je UŽ na hranici `MAX_ATTEMPTS` (10), takže nový spec súbor (`orders-
+// write-failures.spec.ts` — kumulatívny banner o neuložených zmenách)
+// dostáva VLASTNÝ izolovaný účet namiesto ďalšieho prihlásenia pod
+// zdieľaným `e2e@forestshop.sk`.
+const E2E_ZAPISY_EMAIL = "e2e-zapisy@forestshop.sk"; // musí sa zhodovať s hodnotou v orders-write-failures.spec.ts
+
 const { db, pool } = createDb();
 // Konštantný literál bez interpolácie — obyčajný reťazec je tu rovnako bezpečný
 // ako `sql` tagovaná šablóna (tú používa ekvivalentný apps/api/tests/helpers/db.ts),
@@ -212,6 +219,12 @@ await db.insert(users).values({
 });
 await db.insert(users).values({
   email: E2E_ODKAZ_EMAIL,
+  passwordHash: await hashPassword(E2E_HESLO),
+  displayName: "E2E Manažér",
+  role: "manazer",
+});
+await db.insert(users).values({
+  email: E2E_ZAPISY_EMAIL,
   passwordHash: await hashPassword(E2E_HESLO),
   displayName: "E2E Manažér",
   role: "manazer",


### PR DESCRIPTION
## Summary

Adds a cumulative "failed write" banner to the "Na objednanie" (orders) screen. Previously, when a write to the server failed (e.g. a brief network drop), OrdersSection.tsx showed the error in a single shared string that the NEXT failing write immediately overwrote — a manager working through several failing rows only ever saw the last one; earlier failures vanished from the screen even though they were never saved.

- New `ordersWriteFailures.ts`: a small keyed list (`id = <action>:<target>`) replacing the single `stateError` string — `upsertWriteFailure`/`clearWriteFailure`, Slovak plural heading, `lineWhere`/`orderWhere` label lookups.
- New `OrderWriteFailuresBanner.tsx`: renders "Nepodarilo sa uložiť N položiek/položku" + one line per failed item + a single "x" to dismiss the whole banner.
- All 6 order-write actions in `OrdersSection.tsx` (state, ordered flag, supplier assign, supplier link, order comment, group-ordered toggle) now upsert/clear their own entry instead of overwriting one shared string.
- No optimistic-write reconciliation was ported from the legacy app (`app.js:1093-1240`) — this app's writes are already confirm-then-render (`checked={line.ordered}` / `<select value={line.state}>` bind directly to server-confirmed props), so a rejected write already never displays as saved; see the design rationale posted on the issue before implementation.
- Extracted supplier-email editing into `useSupplierEmailEditing.ts` (same pattern as the existing `useSupplierMailActions.ts`) to keep `OrdersSection.tsx` under the eslint `max-lines: 400` cap.

## Test plan

- [x] `apps/web/src/ordersWriteFailures.test.ts` — pure logic (upsert/clear/pluralization/label lookups)
- [x] `apps/web/src/components/OrderWriteFailuresBanner.test.tsx` — component rendering + dismiss
- [x] `apps/web/src/components/OrdersSection.writeFailures.test.tsx` — TWO independent failures (different rows/actions) shown at once, one clears on retry success, dismiss clears all
- [x] Updated 5 existing tests whose `role="alert"` assertions changed shape (banner text instead of a bare string)
- [x] New Playwright e2e `orders-write-failures.spec.ts` — simulates two independent write failures via a `window.fetch` override injected through `addInitScript` (never `page.route().abort()`/`.fulfill(5xx)`, which would log a real "Failed to load resource" console error and break this repo's single-exception console-zero-errors rule), verifies cumulative banner, that a rejected write never displays as saved, that a successful retry clears only its own entry, and that dismiss clears everything — zero console errors
- [x] Full unit suite green (`pnpm test`: 323 API + 260 web), full local e2e suite green (23/23), lint clean, typecheck clean
- [x] CI green: version-check, check, integration, e2e, docker-build

Not marked `Closes #66` — the ticket's acceptance needs live post-deploy verification (real browser click-through on production), so it is closed manually after that, per this repo's own documented incident (issue 120) about premature auto-close.

Design rationale posted before implementation: https://github.com/zbynekdrlik/forestshop-app/issues/66#issuecomment-5150002362
