### PR TITLE
chore: bump version to 0.3.0-dev.88; docs: playbook review for issue 66

### DIFF
--- a/.claude/rules/orders.md
+++ b/.claude/rules/orders.md
@@ -370,3 +370,19 @@ paths:
   riadky, uprav cieľové polia, potom RUČNE zlož každý riadok
   (`";".join(esc(v) for v in row[:-1]) + ";"`, `esc` obaľuje úvodzovkami +
   zdvojuje vnútorné), NIE `csv.writer` nad celým súborom.
+- **Kumulatívne hlásenie o neuložených zápisoch (issue 66) je
+  `apps/web/src/ordersWriteFailures.ts`** — nahradilo pôvodný jediný
+  `stateError` string v `OrdersSection.tsx` (každé ďalšie zlyhanie ho
+  prepísalo, staršie zlyhanie zmizlo z obrazovky). Zoznam kľúčovaný `id =
+  <akcia>:<cieľ>` (napr. `state:<lineId>`, `comment:<orderId>`,
+  `groupOrdered:<supplier>`) — zhodné `id` NAHRADÍ starú položku (aktualizuje
+  dôvod), cudzie `id` PRIDÁ nezávislú položku vedľa nej. KAŽDÁ ĎALŠIA nová
+  zápisová akcia na tomto tabe (7. write handler) musí rovnako
+  upsert/clear-núť VLASTNÝ `id` do `writeFailures`, nikdy nezaviesť nový
+  samostatný `useState` error string vedľa neho — to by obnovilo presne ten
+  istý "posledné zlyhanie prepíše predchádzajúce" bug pre tú JEDNU akciu.
+  Žiadna optimistická reconciliation (legacy `app.js:1093-1240`'s
+  commitSeq) tu nie je potrebná — `checked={line.ordered}`/`<select
+  value={line.state}>` (`OrderLineRow.tsx`) sú viazané PRIAMO na
+  server-potvrdenú hodnotu z props, takže zamietnutý zápis sa NIKDY netvári
+  ako uložený už len vďaka existujúcemu dizajnu.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -384,3 +384,25 @@ paths:
   rizika medzi-testovej kolízie. Pri KAŽDOM ďalšom produktovo-kľúčovanom
   override teste: `grep` cieľový `productKey` (nie len `variantCode`) naprieč
   CELÝM `apps/web/tests/e2e/` predtým, než ho použiješ.
+- **E2E test, ktorý potrebuje simulovať ZLYHANÝ zápis na server (výpadok
+  siete, 5xx), MUSÍ prepichnúť `window.fetch` cez `addInitScript` — NIKDY
+  `page.route().abort()`/`.fulfill({status: 4xx/5xx})`.** Issue 66
+  (kumulatívny banner o neuložených zmenách): `page.route` ide cez
+  SKUTOČNÚ sieťovú vrstvu prehliadača, takže Chromium zaloguje reálne
+  "Failed to load resource" do konzoly — presne to, čo vyššie uvedený
+  zákaz rozširovania JEDINEJ povolenej konzolovej výnimky (401 na
+  `/api/me`) zakazuje. Naživo overené (Playwright MCP proti produkcii aj v
+  tomto e2e súbore): prepichnutý `window.fetch` (JS-level override, nikdy
+  sa nedotkne skutočnej siete pre zhodné URL) pri REJECTNUTÍ aj pri fake
+  200 `Response` vracia NULOVÉ console správy. Vzor (`orders-write-
+  failures.spec.ts`): `addInitScript` nahradí `window.fetch` funkciou, čo
+  pre NE-GET požiadavky na URL fragmenty v `Set`e buď rejectne
+  (`Promise.reject(new TypeError(...))` — simuluje výpadok siete) alebo
+  vráti fake `new Response(...)` (simuluje úspech BEZ reálneho zápisu),
+  inak zavolá originálny `fetch`. Musí bežať `addInitScript`om (pred
+  KAŽDÝM appkovým skriptom), nie neskorším `page.evaluate` — appka volá
+  zápisové funkcie hneď pri mounte/interakcii. Bonus: keďže reálny zápis
+  nikdy neodíde na server, test nepotrebuje VLASTNÚ fixtúrovú objednávku
+  ani obavu o kolíziu s inými spec súbormi bežiacimi súbežne — smie
+  bezpečne použiť UŽ existujúce fixtúrové riadky (napr. `orders.spec.ts`'s
+  DODAVATEL-TEST-1/"(bez dodávateľa)" riadky).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,11 +28,22 @@ GitHub ho zavrel presne v čase merge commitu, hoci ticket mal ešte
 neoverenú (na credential čakajúcu) akceptačnú podmienku ("naživo klikni a
 over"). Keď ticket má AKÚKOĽVEK acceptančnú podmienku, ktorú nejde overiť
 PRED mergom (živý klik vyžadujúci cudzie prihlásenie, manuálne potvrdenie
-treťou stranou a pod.), NEPÍŠ `Closes #N` do tela PR — nechaj ticket
+treťou stranou a pod. — vrátane BEŽNÉHO post-deploy naživo overenia, ktoré
+príde AŽ PO merge/deploy), NEPÍŠ `Closes #N` do tela PR — nechaj ticket
 zavrieť RUČNE (`gh issue close`) až PO skutočnom overení, alebo (ak sa
 merguje aj tak) rovno po merge over stav (`gh issue view --json state`) a
 znovu otvor (`gh issue reopen`) s vysvetľujúcim komentárom, presne ako sa
 to riešilo tu.
+
+**Rovnaké riziko platí aj pre COMMIT SPRÁVY, nielen telo PR** (issue 66,
+2026-08-01) — tento repo merguje dev→main VŽDY merge commitom (nikdy
+squash), takže jednotlivé commit správy z `dev` ostávajú NEDOTKNUTÉ v
+histórii `main` po merge; GitHub-ova detekcia zatváracích kľúčových slov
+sa spúšťa aj z commit správy, keď taký commit skončí na predvolenej vetve.
+`Closes #66`/`Fixes #66` v samotnej commit správe (nie len v tele PR) by
+teda tickét zavrelo AJ BEZ akéhokoľvek riadku v tele PR. Fix: pri tickete s
+odloženým overením napíš do commit správy PLAIN referenciu bez zatváracieho
+slovesa (`issue 66`, nie `Closes #66`/`Fixes #66`), presne ako v tele PR.
 
 **GitHub-ova detekcia zatváracích kľúčových slov chytá tvary slovies
 zavrieť/opraviť/vyriešiť (v angličtine) BEZPROSTREDNE pred `#N` KDEKOĽVEK

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -1872,3 +1872,42 @@ nové heslo sa nikde v pushnutom obsahu nenachádza.
   odkaz), CRLF→LF normalizácia real Shoptetu (fixture musí kopírovať),
   per-objednávkové mark-synced zdôvodnenie, docker-cp postup potvrdený aj
   pre tento druhý modul.
+
+## Issue 66 — kumulatívne hlásenie o neuložených zmenách ("Na objednanie")
+
+- Design comment PRED prvým kódovým commitom:
+  https://github.com/zbynekdrlik/forestshop-app/issues/66#issuecomment-5150002362
+  (root cause: jediný `stateError` string zdieľaný 6 zápisovými akciami,
+  každé ďalšie zlyhanie prepísalo predchádzajúce; zvolený prístup: keyed
+  zoznam zlyhaní `ordersWriteFailures.ts`; zamietnutá alternatíva: portovanie
+  legacy `app.js:1093-1240`'s commitSeq optimistickej reconciliation — tento
+  app nikdy nezobrazuje zápis ako uložený pred potvrdením servera, takže ten
+  pretek tu vôbec neexistuje).
+- Nové: `ordersWriteFailures.ts` (RED/GREEN nebolo relevantné — feature, nie
+  bug fix, testy pridané v tej istej práci), `OrderWriteFailuresBanner.tsx`,
+  `useSupplierEmailEditing.ts` (extrakcia kvôli eslint `max-lines: 400`,
+  rovnaký vzor ako `useSupplierMailActions.ts`).
+- Testy: `ordersWriteFailures.test.ts` (10), `OrderWriteFailuresBanner
+  .test.tsx` (5), `OrdersSection.writeFailures.test.tsx` (1 — dôkaz DVOCH
+  nezávislých zlyhaní naraz), 5 existujúcich testov upravených (nová tvar
+  bannera namiesto holého stringu), nový Playwright e2e `orders-write-
+  failures.spec.ts` (`window.fetch` override cez `addInitScript`, nikdy
+  `page.route`, kvôli konzolovej výnimke — zdokumentované v
+  `.claude/rules/testing.md`).
+- PR #145 (merge 8b17c5c, v0.3.0-dev.87). NEobsahovalo `Closes #66` v
+  commit správe ani v tele PR (post-deploy naživo overenie príde AŽ po
+  merge) — issue 66 zavreté ručne po overení.
+- Naživo overené na produkcii (`forestshop-novy.newlevel.media`) cez
+  prepichnutý `window.fetch` (nikdy sa nedotkol reálneho servera): DVE
+  nezávislé zlyhania (zmena stavu na dvoch rôznych riadkoch, obj. 20261249 +
+  obj. 20261203) sa zobrazili SÚČASNE v banneri ("2 položky"), zamietnuté
+  zmeny sa netvárili ako uložené, zatvorenie bannera zmazalo obe naraz,
+  konzola bez chýb. Baseline po teste nedotknutý (nič sa reálne neuložilo):
+  `product_supplier_link_override|product_supplier_override|order|order_line`
+  = `0|0|534|878`, presne pôvodná hodnota.
+- Playbook rozšírený: `.claude/rules/orders.md` (kumulatívny zoznam zlyhaní,
+  `id` konvencia pre budúce zápisové akcie), `.claude/rules/testing.md`
+  (fetch-override technika pre simuláciu zlyhaného zápisu v e2e testoch bez
+  porušenia jedinej povolenej konzolovej výnimky), `CLAUDE.md` (rozšírenie
+  existujúcej `Closes #N` poznámky — riziko platí aj pre COMMIT správy,
+  nielen telo PR, keďže tento repo merguje merge commitom).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.87",
+  "version": "0.3.0-dev.88",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Summary

Playbook-review follow-up after issue 66 (PR #145) — no code change, docs/version bump only.

- Extend CLAUDE.md's existing `Closes #N` auto-close warning to also cover commit messages (this repo merges via merge commit, so individual `dev` commits land on `main` unchanged and GitHub's closing-keyword scan applies to them too).
- Document the `window.fetch` `addInitScript` override technique for simulating a failed write in a Playwright e2e test without tripping the console-zero-errors exception (`.claude/rules/testing.md`).
- Document `ordersWriteFailures.ts`'s `id` keying convention for the next order-write action (`.claude/rules/orders.md`).
- `docs/autopilot-log.md` entry for issue 66.

## Test plan

- [x] Docs-only + version bump; `pnpm run lint` / `pnpm run typecheck` clean (no source changed)
- [x] CI green: version-check, check, integration, e2e, docker-build
