### PR TITLE
Bundle: nav badge + supplier persistence + hide-resolved editor guard + multiline comment (issues 147/148/149/150)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, type JSX } from "react";
+import { useCallback, useEffect, useMemo, useState, type JSX } from "react";
 import { fetchMe, postLogout, type Me } from "./api.js";
 import { ChangePasswordForm } from "./components/ChangePasswordForm.js";
 import { Footer } from "./components/Footer.js";
@@ -6,6 +6,7 @@ import { LoginForm } from "./components/LoginForm.js";
 import { Sidebar } from "./components/Sidebar.js";
 import { Topbar } from "./components/Topbar.js";
 import { DEFAULT_TAB_ID, NAV, findTab, isVisibleTabId } from "./nav.js";
+import { OrdersRemainingCountContext } from "./ordersRemainingCountContext.js";
 
 // Prvá záložka z URL-u (`?tab=<id>`), keď existuje a je platná — inak
 // predvolená ("Sync zo Shoptetu"). Umožňuje priamy odkaz aj na SKRYTÉ
@@ -25,6 +26,20 @@ export function App(): JSX.Element {
   const [logoutError, setLogoutError] = useState("");
   const [activeTabId, setActiveTabId] = useState<string>(initialTabId);
   const [passwordPanelOpen, setPasswordPanelOpen] = useState(false);
+  // issue 147: odznak počtu nevybavených riadkov "Na objednanie" v ľavom menu
+  // — `OrdersSection` (kdekoľvek je práve zmountnutá) ho publikuje cez
+  // `OrdersRemainingCountContext`, App.tsx (spoločný predok Sidebar-u aj
+  // aktívnej záložky) drží poslednú známú hodnotu a posiela ju do `Sidebar`
+  // generickým `badgeCounts` prop-om — žiadne "if tab === orders" tu.
+  const [ordersRemainingCount, setOrdersRemainingCount] = useState<number | null>(null);
+  const ordersRemainingCountContextValue = useMemo(
+    () => ({ count: ordersRemainingCount, setCount: setOrdersRemainingCount }),
+    [ordersRemainingCount],
+  );
+  const badgeCounts = useMemo<Readonly<Record<string, number>>>(
+    () => (ordersRemainingCount !== null ? { orders: ordersRemainingCount } : {}),
+    [ordersRemainingCount],
+  );
 
   const reload = useCallback(() => {
     setMeUnreachable(false);
@@ -94,25 +109,27 @@ export function App(): JSX.Element {
   }
 
   return (
-    <div className="app-shell">
-      <Sidebar folders={NAV} activeTabId={activeTabId} onSelectTab={selectTab} />
-      <div className="main">
-        <Topbar
-          title={isVisibleTabId(activeTabId) ? (tab?.label ?? null) : null}
-          greeting={`Prihlásený: ${me.displayName} (${me.role})`}
-          onLogout={logout}
-          passwordPanelOpen={passwordPanelOpen}
-          onTogglePasswordPanel={() => {
-            setPasswordPanelOpen((open) => !open);
-          }}
-        >
-          <ChangePasswordForm email={me.email} onSessionExpired={reload} />
-        </Topbar>
-        <main className={tab?.wide === true ? "main-wide" : undefined}>
-          {logoutError !== "" && <p role="alert">{logoutError}</p>}
-          {ActiveComponent !== null && <ActiveComponent role={me.role} onSessionExpired={reload} />}
-        </main>
+    <OrdersRemainingCountContext.Provider value={ordersRemainingCountContextValue}>
+      <div className="app-shell">
+        <Sidebar folders={NAV} activeTabId={activeTabId} onSelectTab={selectTab} badgeCounts={badgeCounts} />
+        <div className="main">
+          <Topbar
+            title={isVisibleTabId(activeTabId) ? (tab?.label ?? null) : null}
+            greeting={`Prihlásený: ${me.displayName} (${me.role})`}
+            onLogout={logout}
+            passwordPanelOpen={passwordPanelOpen}
+            onTogglePasswordPanel={() => {
+              setPasswordPanelOpen((open) => !open);
+            }}
+          >
+            <ChangePasswordForm email={me.email} onSessionExpired={reload} />
+          </Topbar>
+          <main className={tab?.wide === true ? "main-wide" : undefined}>
+            {logoutError !== "" && <p role="alert">{logoutError}</p>}
+            {ActiveComponent !== null && <ActiveComponent role={me.role} onSessionExpired={reload} />}
+          </main>
+        </div>
       </div>
-    </div>
+    </OrdersRemainingCountContext.Provider>
   );
 }

--- a/apps/web/src/components/OrderLineRow.tsx
+++ b/apps/web/src/components/OrderLineRow.tsx
@@ -32,6 +32,7 @@ export function OrderLineRow({
   onAssignSupplier,
   onSetSupplierLink,
   onChangeComment,
+  onEditorActivityChange,
 }: {
   readonly line: OrderLine;
   readonly canChangeState: boolean;
@@ -69,6 +70,11 @@ export function OrderLineRow({
   // katalógového dodávateľa).
   readonly onSetSupplierLink: (lineId: string, url: string) => void;
   readonly onChangeComment: (orderId: string, comment: string | null) => void;
+  // issue 149: hlási RODIČOVI (`OrdersSection.tsx`'s `dirtyEditorLineIds`),
+  // či tento riadok PRÁVE TERAZ drží otvorenú/rozpísanú úpravu — výnimka z
+  // "skryť vybavené" filtra, aby riadok nezmizol spod rúk. Nesie len boolean,
+  // nikdy samotný rozpísaný text (ten ostáva výlučne tu, v tomto komponente).
+  readonly onEditorActivityChange: (lineId: string, active: boolean) => void;
 }): JSX.Element {
   const qtyChip = variantTotal !== undefined ? formatVariantTotalChip(variantTotal) : null;
 
@@ -167,6 +173,21 @@ export function OrderLineRow({
     isCommentDirty.current = false;
     onChangeComment(line.orderId, trimmed === "" ? null : trimmed);
   };
+
+  // issue 149: "má tento riadok otvorenú/rozpísanú úpravu" — presne tie tri
+  // editory, ktoré ticket menuje. `linkEditing` počíta ako aktívny hneď pri
+  // OTVORENÍ (bez ohľadu na obsah, rovnaký zámer ako stará appka's "opened
+  // counts as his"); `supplierDraft`/komentár počítajú len keď sa SKUTOČNE
+  // líšia od uloženej hodnoty (nemajú vlastný toggle open/close).
+  const supplierDraftDirty = line.supplierAssignable && supplierDraft.trim() !== "" && supplierDraft.trim() !== (line.manualSupplierOverride ?? "");
+  const commentDirtyNow = isCommentDirty.current;
+  const hasOpenEditor = linkEditing || supplierDraftDirty || commentDirtyNow;
+  useEffect(() => {
+    onEditorActivityChange(line.lineId, hasOpenEditor);
+    return () => {
+      onEditorActivityChange(line.lineId, false);
+    };
+  }, [line.lineId, hasOpenEditor, onEditorActivityChange]);
 
   return (
     <tr

--- a/apps/web/src/components/OrderLineRow.tsx
+++ b/apps/web/src/components/OrderLineRow.tsx
@@ -179,7 +179,18 @@ export function OrderLineRow({
   // OTVORENÍ (bez ohľadu na obsah, rovnaký zámer ako stará appka's "opened
   // counts as his"); `supplierDraft`/komentár počítajú len keď sa SKUTOČNE
   // líšia od uloženej hodnoty (nemajú vlastný toggle open/close).
-  const supplierDraftDirty = line.supplierAssignable && supplierDraft.trim() !== "" && supplierDraft.trim() !== (line.manualSupplierOverride ?? "");
+  const trimmedSupplierDraft = supplierDraft.trim();
+  const supplierDraftDirty =
+    line.supplierAssignable && trimmedSupplierDraft !== "" && trimmedSupplierDraft !== (line.manualSupplierOverride ?? "");
+  // Code review (PR 154): `isCommentDirty.current` je REF, nie state — jeho
+  // čítanie tu funguje len preto, že KAŽDÁ jeho mutácia (`onChange` nižšie →
+  // `true`, `saveComment` vyššie → `false`) je v TEJ ISTEJ tikni sprevádzaná
+  // state zmenou, ktorá tento komponent aj tak prekreslí (lokálny
+  // `setCommentDraft`, alebo rodičovský `setBusyCommentOrderId` cez props) —
+  // a nič v tomto strome dnes nie je `React.memo`. Ak by niekedy pribudol
+  // `React.memo` na `OrderLineRow`/`SupplierOrderGroup` (perf krok kvôli
+  // `dirtyEditorLineIds` nižšie), TENTO odvodený signál by mohol prestať
+  // reagovať na správnom tiku bez chyby/varovania — over najprv toto miesto.
   const commentDirtyNow = isCommentDirty.current;
   const hasOpenEditor = linkEditing || supplierDraftDirty || commentDirtyNow;
   useEffect(() => {

--- a/apps/web/src/components/OrderLineRow.tsx
+++ b/apps/web/src/components/OrderLineRow.tsx
@@ -457,13 +457,20 @@ export function OrderLineRow({
         <div className="ord-comment-cell" data-testid={`comment-cell-${line.lineId}`}>
           {canChangeState ? (
             <>
-              <input
-                type="text"
+              {/* issue 150: `<textarea>` (nie `<input>`) — Enter vkladá nový
+                  riadok defaultne (žiadny `preventDefault`), uloží LEN
+                  Ctrl/⌘+Enter. Poznámka býva viacriadková (dohoda so
+                  zákazníkom/dodávateľom) a spätne sa zapisuje do Shoptetu,
+                  takže formátovanie má význam — `<input>` by nový riadok
+                  nikdy vizuálne nezobrazil, bez ohľadu na to, čo je v jeho
+                  hodnote uložené. */}
+              <textarea
                 className="ord-comment-input"
                 data-testid={`comment-input-${line.lineId}`}
                 aria-label={`Poznámka k objednávke ${line.externalOrderId} / ${line.variantCode}`}
                 placeholder="poznámka…"
                 maxLength={2000}
+                rows={1}
                 value={commentDraft}
                 disabled={commentBusyHere}
                 onChange={(e) => {
@@ -471,7 +478,7 @@ export function OrderLineRow({
                   setCommentDraft(e.target.value);
                 }}
                 onKeyDown={(e) => {
-                  if (e.key === "Enter") {
+                  if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
                     e.preventDefault();
                     saveComment();
                   }
@@ -482,6 +489,7 @@ export function OrderLineRow({
                 className="btn sm good"
                 data-testid={`comment-save-${line.lineId}`}
                 aria-label={`Uložiť poznámku k objednávke ${line.externalOrderId} / ${line.variantCode}`}
+                title="Uložiť poznámku (Ctrl+Enter)"
                 disabled={commentBusyHere}
                 onClick={saveComment}
               >
@@ -489,7 +497,10 @@ export function OrderLineRow({
               </button>
             </>
           ) : (
-            (line.comment ?? "—")
+            // issue 150: `.ord-comment-display` (CSS `white-space: pre-wrap`)
+            // — už uložený viacriadkový komentár zobrazí svoje zalomenia aj
+            // na čítanie, nielen počas úpravy.
+            <span className="ord-comment-display">{line.comment ?? "—"}</span>
           )}
         </div>
       </td>

--- a/apps/web/src/components/OrdersSection.comment.test.tsx
+++ b/apps/web/src/components/OrdersSection.comment.test.tsx
@@ -186,3 +186,38 @@ it("rola citanie vidí poznámku len na čítanie, bez vstupného poľa", async 
     screen.queryByLabelText(`Poznámka k objednávke ${RIADOK_1.externalOrderId} / ${RIADOK_1.variantCode}`),
   ).toBeNull();
 });
+
+// issue 150: pole je odteraz `<textarea>` — obyčajný Enter musí vložiť nový
+// riadok (nesmie uložiť), uloží len Ctrl/⌘+Enter.
+it("Enter v poznámke vloží nový riadok a NEUloží (žiadne volanie updateOrderComment)", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "(bez dodávateľa)", lines: [RIADOK_1], email: null }]);
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const vstup = await screen.findByLabelText<HTMLTextAreaElement>(
+    `Poznámka k objednávke ${RIADOK_1.externalOrderId} / ${RIADOK_1.variantCode}`,
+  );
+  expect(vstup.tagName).toBe("TEXTAREA");
+  fireEvent.change(vstup, { target: { value: "prvý riadok\ndruhý riadok" } });
+  fireEvent.keyDown(vstup, { key: "Enter" });
+
+  expect(vstup.value).toBe("prvý riadok\ndruhý riadok");
+  expect(updateOrderComment).not.toHaveBeenCalled();
+});
+
+it("Ctrl+Enter v poznámke uloží viacriadkový text", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "(bez dodávateľa)", lines: [RIADOK_1], email: null }]);
+  updateOrderComment.mockResolvedValue(undefined);
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const vstup = await screen.findByLabelText<HTMLTextAreaElement>(
+    `Poznámka k objednávke ${RIADOK_1.externalOrderId} / ${RIADOK_1.variantCode}`,
+  );
+  fireEvent.change(vstup, { target: { value: "prvý riadok\ndruhý riadok" } });
+  fireEvent.keyDown(vstup, { key: "Enter", ctrlKey: true });
+
+  await waitFor(() => {
+    expect(updateOrderComment).toHaveBeenCalledWith(ORDER_ID, "prvý riadok\ndruhý riadok");
+  });
+});

--- a/apps/web/src/components/OrdersSection.hideResolvedEditorGuard.test.tsx
+++ b/apps/web/src/components/OrdersSection.hideResolvedEditorGuard.test.tsx
@@ -1,0 +1,113 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { OrdersSection } from "./OrdersSection.js";
+
+// issue 149 — riadok s otvorenou/rozpísanou úpravou (komentár alebo ručné
+// priradenie mena dodávateľa) nesmie zmiznúť spod rúk, keď sa medzitým
+// označí za vybavené a "skryť vybavené" je zapnuté. Vlastný súbor (rovnaký
+// vzor ako existujúce `OrdersSection.ordered.test.tsx`/`.comment.test.tsx`
+// splity, `.claude/rules/testing.md`) — Playwright e2e (`orders-hidden-
+// editor.spec.ts`) pokrýva TRETÍ editor (odkaz na dodávateľa, toggle
+// open/close) end-to-end cez skutočný prehliadač.
+
+const { fetchOpenOrders, updateOrderComment, updateOrderLineOrdered } = vi.hoisted(() => ({
+  fetchOpenOrders: vi.fn(),
+  updateOrderComment: vi.fn(),
+  updateOrderLineOrdered: vi.fn(),
+}));
+
+vi.mock("../ordersApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../ordersApi.js")>();
+  return { ...actual, fetchOpenOrders, updateOrderComment, updateOrderLineOrdered };
+});
+
+const LINE = {
+  lineId: "11111111-1111-1111-1111-111111111149",
+  orderId: "aaaaaaaa-1111-1111-1111-111111111149",
+  externalOrderId: "4001",
+  customerName: "Zákazník Rozpísaný",
+  comment: "pôvodná poznámka",
+  remark: null,
+  adminUrl: "https://www.forestshop.sk/admin/vyhladavanie/?string=4001&src=orders",
+  placedAt: "2026-07-01T00:00:00.000Z",
+  variantCode: "R-1",
+  variantName: "Produkt Rozpísaný",
+  sizeLabel: null,
+  quantity: 1,
+  state: "objednane" as const,
+  ordered: false,
+  supplierUrl: null,
+  supplierNote: null,
+  externalCode: null,
+  supplierAssignable: false,
+  manualSupplierOverride: null,
+};
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+  window.localStorage.clear();
+});
+
+it("riadok s rozpísaným (neuloženým) komentárom ostáva viditeľný, keď sa medzitým označí za vybavené pri zapnutom 'skryť vybavené' — a zmizne až po uložení", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE], email: null }]);
+  updateOrderLineOrdered.mockResolvedValue(undefined);
+  updateOrderComment.mockResolvedValue(undefined);
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  // Zapnúť "skryť vybavené" — riadok je zatiaľ NEVYBAVENÝ, ostáva viditeľný.
+  fireEvent.click(await screen.findByTestId("orders-hide-resolved-toggle"));
+  await screen.findByTestId(`order-line-${LINE.lineId}`);
+
+  // Manažér rozpíše komentár, ale ešte ho NEULOŽÍ.
+  const komentar = screen.getByTestId<HTMLTextAreaElement>(`comment-input-${LINE.lineId}`);
+  fireEvent.change(komentar, { target: { value: "rozpísaný, ešte neuložený text" } });
+
+  // Medzitým sa riadok označí za vybavené ("objednané u dodávateľa").
+  fireEvent.click(screen.getByTestId<HTMLInputElement>(`ordered-checkbox-${LINE.lineId}`));
+  await waitFor(() => {
+    expect(screen.getByTestId<HTMLInputElement>(`ordered-checkbox-${LINE.lineId}`).checked).toBe(true);
+  });
+
+  // Riadok je TERAZ vybavený + "skryť vybavené" je zapnuté — bez výnimky by
+  // zmizol. Musí ostať viditeľný, kým editor drží rozpísaný text.
+  expect(screen.queryByTestId(`order-line-${LINE.lineId}`)).not.toBeNull();
+  expect(komentar.value).toBe("rozpísaný, ešte neuložený text");
+
+  // Uloženie komentára vyčistí "dirty" príznak — riadok teraz zmizne.
+  fireEvent.click(screen.getByTestId(`comment-save-${LINE.lineId}`));
+  await waitFor(() => {
+    expect(updateOrderComment).toHaveBeenCalledWith(LINE.orderId, "rozpísaný, ešte neuložený text");
+  });
+  await waitFor(() => {
+    expect(screen.queryByTestId(`order-line-${LINE.lineId}`)).toBeNull();
+  });
+});
+
+it("riadok s rozpísaným (neuloženým) ručným priradením dodávateľa ostáva viditeľný pri zapnutom 'skryť vybavené'", async () => {
+  const riadokPriraditelny = { ...LINE, supplierAssignable: true };
+  fetchOpenOrders.mockResolvedValue([{ supplier: "(bez dodávateľa)", lines: [riadokPriraditelny], email: null }]);
+  updateOrderLineOrdered.mockResolvedValue(undefined);
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  fireEvent.click(await screen.findByTestId("orders-hide-resolved-toggle"));
+  await screen.findByTestId(`order-line-${riadokPriraditelny.lineId}`);
+
+  const priradenieVstup = screen.getByTestId<HTMLInputElement>(`supplier-assign-input-${riadokPriraditelny.lineId}`);
+  fireEvent.change(priradenieVstup, { target: { value: "Nový Dodávateľ" } });
+
+  fireEvent.click(screen.getByTestId<HTMLInputElement>(`ordered-checkbox-${riadokPriraditelny.lineId}`));
+  await waitFor(() => {
+    expect(screen.getByTestId<HTMLInputElement>(`ordered-checkbox-${riadokPriraditelny.lineId}`).checked).toBe(true);
+  });
+
+  expect(screen.queryByTestId(`order-line-${riadokPriraditelny.lineId}`)).not.toBeNull();
+
+  // Vyprázdnenie konceptu (zhoda s prázdnym/uloženým stavom) vyčistí "dirty".
+  fireEvent.change(priradenieVstup, { target: { value: "" } });
+  await waitFor(() => {
+    expect(screen.queryByTestId(`order-line-${riadokPriraditelny.lineId}`)).toBeNull();
+  });
+});

--- a/apps/web/src/components/OrdersSection.remainingCount.test.tsx
+++ b/apps/web/src/components/OrdersSection.remainingCount.test.tsx
@@ -1,0 +1,97 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { useCallback, useMemo, useState, type JSX } from "react";
+import { afterEach, expect, it, vi } from "vitest";
+import { OrdersRemainingCountContext } from "../ordersRemainingCountContext.js";
+import { OrdersSection } from "./OrdersSection.js";
+
+// issue 147 — overuje, že `OrdersSection` PUBLIKUJE počet nevybavených
+// riadkov do `OrdersRemainingCountContext` (spotrebiteľ v produkčnom kóde je
+// `App.tsx`/`Sidebar.tsx`, tu ho nahrádza tenký testovací "harness", ktorý
+// prečítanú hodnotu vypíše do DOM-u, aby sa dala assertovať).
+
+const { fetchOpenOrders, updateOrderLineState } = vi.hoisted(() => ({
+  fetchOpenOrders: vi.fn(),
+  updateOrderLineState: vi.fn(),
+}));
+
+vi.mock("../ordersApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../ordersApi.js")>();
+  return { ...actual, fetchOpenOrders, updateOrderLineState };
+});
+
+function Harness(): JSX.Element {
+  const [count, setCount] = useState<number | null>(null);
+  // `onSessionExpired` MUSÍ mať stabilnú identitu naprieč re-renderami tohto
+  // harness-u (Harness sa znova vykreslí zakaždým, keď `OrdersSection`
+  // zavolá `setCount`) — inak by nová `() => {}` funkcia pri každom
+  // re-rendri zneplatnila `OrdersSection.tsx`'s `useCallback(load, …)` a
+  // spôsobila ĎALŠÍ (zbytočný) `fetchOpenOrders` refetch, čo by tento test
+  // hlásil ako falošný regresný nález namiesto skutočného správania appky.
+  const onSessionExpired = useCallback(() => {}, []);
+  const contextValue = useMemo(() => ({ count, setCount }), [count]);
+  return (
+    <OrdersRemainingCountContext.Provider value={contextValue}>
+      <span data-testid="remaining-count">{count === null ? "null" : count}</span>
+      <OrdersSection role="manazer" onSessionExpired={onSessionExpired} />
+    </OrdersRemainingCountContext.Provider>
+  );
+}
+
+const LINE_NEVYBAVENY = {
+  lineId: "11111111-1111-1111-1111-111111111147",
+  orderId: "aaaaaaaa-1111-1111-1111-111111111147",
+  externalOrderId: "3001",
+  customerName: "Zákazník Nevybavený",
+  comment: null,
+  remark: null,
+  adminUrl: "https://www.forestshop.sk/admin/vyhladavanie/?string=3001&src=orders",
+  placedAt: "2026-07-01T00:00:00.000Z",
+  variantCode: "N-1",
+  variantName: "Produkt Nevybavený",
+  sizeLabel: null,
+  quantity: 1,
+  state: "objednane" as const,
+  ordered: false,
+  supplierUrl: null,
+  supplierNote: null,
+  externalCode: null,
+  supplierAssignable: false,
+  manualSupplierOverride: null,
+};
+
+const LINE_VYBAVENY = { ...LINE_NEVYBAVENY, lineId: "22222222-2222-2222-2222-222222222147", ordered: true };
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+it("po načítaní publikuje počet nevybavených riadkov (nie celkový počet)", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_NEVYBAVENY, LINE_VYBAVENY], email: null }]);
+
+  render(<Harness />);
+
+  expect(screen.getByTestId("remaining-count").textContent).toBe("null");
+  await waitFor(() => {
+    expect(screen.getByTestId("remaining-count").textContent).toBe("1");
+  });
+});
+
+it("po zmene stavu posledného nevybaveného riadku odznak klesne na 0, bez nového refetchu", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_NEVYBAVENY, LINE_VYBAVENY], email: null }]);
+  updateOrderLineState.mockResolvedValue(undefined);
+
+  render(<Harness />);
+  await waitFor(() => {
+    expect(screen.getByTestId("remaining-count").textContent).toBe("1");
+  });
+
+  const select = await screen.findByTestId<HTMLSelectElement>(`state-select-${LINE_NEVYBAVENY.lineId}`);
+  select.value = "skladom";
+  select.dispatchEvent(new Event("change", { bubbles: true }));
+
+  await waitFor(() => {
+    expect(screen.getByTestId("remaining-count").textContent).toBe("0");
+  });
+  expect(fetchOpenOrders).toHaveBeenCalledTimes(1);
+});

--- a/apps/web/src/components/OrdersSection.selectedSupplierPersistence.test.tsx
+++ b/apps/web/src/components/OrdersSection.selectedSupplierPersistence.test.tsx
@@ -1,0 +1,86 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { OrdersSection } from "./OrdersSection.js";
+
+// issue 148 — vyňaté do vlastného súboru (rovnaký vzor ako existujúce
+// `OrdersSection.ordered.test.tsx`/`OrdersSection.assignSupplier.test.tsx`
+// splity, `.claude/rules/testing.md`). Overuje PRESNE tú istú perzistenciu,
+// akú `hideResolved` (issue 61) už má, ale pre `selectedSupplier` —
+// `hideResolved` nemá vlastný vitest test na localStorage vôbec (jediné
+// pokrytie je `orders.spec.ts`'s e2e reload test), takže toto je prvý takýto
+// unit test v tomto súbore — zámerne priamo cez skutočnú jsdom
+// `window.localStorage`, nie mock, aby overil SKUTOČNÝ read/write cyklus.
+
+const { fetchOpenOrders } = vi.hoisted(() => ({ fetchOpenOrders: vi.fn() }));
+
+vi.mock("../ordersApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../ordersApi.js")>();
+  return { ...actual, fetchOpenOrders };
+});
+
+const STORAGE_KEY = "forestshop.orders.selectedSupplier";
+
+const LINE_ALFA = {
+  lineId: "11111111-1111-1111-1111-111111111148",
+  orderId: "aaaaaaaa-1111-1111-1111-111111111148",
+  externalOrderId: "2001",
+  customerName: "Zákazník Alfa",
+  comment: null,
+  remark: null,
+  adminUrl: "https://www.forestshop.sk/admin/vyhladavanie/?string=2001&src=orders",
+  placedAt: "2026-07-01T00:00:00.000Z",
+  variantCode: "P-1",
+  variantName: "Produkt Alfa",
+  sizeLabel: null,
+  quantity: 1,
+  state: "objednane" as const,
+  ordered: false,
+  supplierUrl: null,
+  supplierNote: null,
+  externalCode: null,
+  supplierAssignable: false,
+  manualSupplierOverride: null,
+};
+
+const LINE_BETA = { ...LINE_ALFA, lineId: "22222222-2222-2222-2222-222222222148", variantCode: "P-2" };
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+  window.localStorage.clear();
+});
+
+it("vybraný dodávateľ prežije novú inštanciu appky (localStorage) — rovnaký chip je aktívny hneď po načítaní", async () => {
+  fetchOpenOrders.mockResolvedValue([
+    { supplier: "Dodávateľ Alfa", lines: [LINE_ALFA], email: null },
+    { supplier: "Dodávateľ Beta", lines: [LINE_BETA], email: null },
+  ]);
+
+  const prveVykreslenie = render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+  const chipBeta = await screen.findByTestId("supplier-chip-Dodávateľ Beta");
+  fireEvent.click(chipBeta);
+  expect(chipBeta.className).toContain("active");
+  expect(window.localStorage.getItem(STORAGE_KEY)).toBe("Dodávateľ Beta");
+  prveVykreslenie.unmount();
+
+  // "Obnovenie stránky" = nová inštancia komponentu nad TOU ISTOU localStorage.
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+  const chipBetaPoObnoveni = await screen.findByTestId("supplier-chip-Dodávateľ Beta");
+  await waitFor(() => {
+    expect(chipBetaPoObnoveni.className).toContain("active");
+  });
+  expect(screen.getByTestId("supplier-chip-all").className).not.toContain("active");
+});
+
+it("keď dodávateľ z localStorage medzi PRÁVE načítanými skupinami už nefiguruje, výber spadne na 'Všetci'", async () => {
+  window.localStorage.setItem(STORAGE_KEY, "Dodávateľ Zaniknutý");
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_ALFA], email: null }]);
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  await waitFor(() => {
+    expect(screen.getByTestId("supplier-chip-all").className).toContain("active");
+  });
+  expect(screen.getByTestId("supplier-chip-Dodávateľ Alfa").className).not.toContain("active");
+  expect(window.localStorage.getItem(STORAGE_KEY)).toBe("");
+});

--- a/apps/web/src/components/OrdersSection.tsx
+++ b/apps/web/src/components/OrdersSection.tsx
@@ -1,7 +1,15 @@
-import { useCallback, useEffect, useState, type JSX } from "react";
+import { useCallback, useContext, useEffect, useState, type JSX } from "react";
 import type { Me } from "../api.js";
-import { isLineResolved } from "../ordersSummary.js";
+import {
+  persistHideResolvedPreference,
+  persistSelectedSupplier,
+  readHideResolvedPreference,
+  readSelectedSupplierPreference,
+} from "../ordersDisplayPreferences.js";
+import { OrdersRemainingCountContext } from "../ordersRemainingCountContext.js";
+import { isLineHiddenByFilter, summarizeOrderLines } from "../ordersSummary.js";
 import { clearWriteFailure, lineWhere, orderWhere, upsertWriteFailure, type OrderWriteFailure } from "../ordersWriteFailures.js";
+import { useDirtyEditorLineIds } from "../useDirtyEditorLineIds.js";
 import { useSupplierEmailEditing } from "../useSupplierEmailEditing.js";
 import { useSupplierMailActions } from "../useSupplierMailActions.js";
 import { OrderOpenStatusesPanel } from "./OrderOpenStatusesPanel.js";
@@ -29,21 +37,6 @@ import {
 // `CatalogPage`'s `IMPORT_ROLES`/`SchedulerSection`'s `SCHEDULER_ROLES`).
 const CAN_CHANGE_STATE_ROLES: ReadonlySet<Me["role"]> = new Set(["admin", "manazer"]);
 
-// issue 61: kľúč pre prepínač "skryť vybavené riadky" — jediný stav, ktorý
-// má prežiť obnovenie stránky (issue to pýta výslovne LEN preň, výber
-// dodávateľa/chipu ostáva zámerne len klientský stav bez perzistencie).
-const HIDE_RESOLVED_STORAGE_KEY = "forestshop.orders.hideResolved";
-
-function readHideResolvedPreference(): boolean {
-  try {
-    return window.localStorage.getItem(HIDE_RESOLVED_STORAGE_KEY) === "1";
-  } catch {
-    // localStorage nedostupné (napr. prehliadač so zakázaným úložiskom) —
-    // prepínač jednoducho nezačne predvyplnený, nič nespadne.
-    return false;
-  }
-}
-
 export function OrdersSection({
   role,
   onSessionExpired,
@@ -61,20 +54,24 @@ export function OrdersSection({
   const [busyLineId, setBusyLineId] = useState<string | null>(null);
   const canChangeState = CAN_CHANGE_STATE_ROLES.has(role);
 
-  // issue 61: vybraný dodávateľ (chip) — `null` = "Všetci". Prepínač "skryť
-  // vybavené" sa naopak číta raz pri mount-e priamo z localStorage (lazy
-  // init), aby appka po reloade neblikla najprv nefiltrovaný zoznam.
-  const [selectedSupplier, setSelectedSupplier] = useState<string | null>(null);
+  // issue 61/148: vybraný dodávateľ (chip) aj prepínač "skryť vybavené" sa
+  // OBA čítajú raz pri mount-e priamo z localStorage (lazy init), aby appka
+  // po reloade neblikla najprv nefiltrovaný/nezúžený zoznam.
+  const [selectedSupplier, setSelectedSupplierState] = useState<string | null>(readSelectedSupplierPreference);
   const [hideResolved, setHideResolved] = useState<boolean>(readHideResolvedPreference);
+
+  // issue 148: jediné miesto, ktoré mení `selectedSupplier` — VŽDY aj
+  // persistuje, takže žiadne volajúce miesto (manuálny klik na chip AJ
+  // automatický fallback nižšie) nemôže zabudnúť na jednu z dvoch strán.
+  const selectSupplier = useCallback((next: string | null) => {
+    setSelectedSupplierState(next);
+    persistSelectedSupplier(next);
+  }, []);
 
   const toggleHideResolved = useCallback(() => {
     setHideResolved((current) => {
       const next = !current;
-      try {
-        window.localStorage.setItem(HIDE_RESOLVED_STORAGE_KEY, next ? "1" : "0");
-      } catch {
-        // localStorage nedostupné — voľba ostáva platná len pre túto reláciu.
-      }
+      persistHideResolvedPreference(next);
       return next;
     });
   }, []);
@@ -125,6 +122,31 @@ export function OrdersSection({
   }, [onSessionExpired]);
 
   useEffect(load, [load]);
+
+  // issue 147: publikuje počet NEVYBAVENÝCH riadkov (naprieč VŠETKÝMI
+  // dodávateľmi) do ľavého menu cez `OrdersRemainingCountContext` — po KAŽDEJ
+  // zmene `suppliers`, takže odznak je vždy aktuálny. Pred prvým úspešným
+  // načítaním sa nevolá vôbec — Sidebar dovtedy odznak nevykreslí.
+  const { setCount: setOrdersRemainingCount } = useContext(OrdersRemainingCountContext);
+  useEffect(() => {
+    if (!loaded) return;
+    const allLines = suppliers.flatMap((group) => group.lines);
+    setOrdersRemainingCount(summarizeOrderLines(allLines).remaining);
+  }, [loaded, suppliers, setOrdersRemainingCount]);
+
+  // issue 148 — priamy náprotivok starej appky's fallback (`app.js:2677-2680`):
+  // keď je dodávateľ vybraný z PREDCHÁDZAJÚCEJ relácie/dňa (localStorage) a
+  // medzi PRÁVE načítanými skupinami už vôbec nefiguruje, výber spadne späť
+  // na "Všetci" — namiesto toho, aby zobrazil prázdny zoznam s aktívnym
+  // chipom, ktorý nikde nie je. `suppliers.length === 0` sa zámerne
+  // VYNECHÁVA (rovnako ako stará appka) — prechodné zlyhanie fetchu nesmie
+  // zahodiť platný výber.
+  useEffect(() => {
+    if (!loaded || selectedSupplier === null || suppliers.length === 0) return;
+    if (!suppliers.some((group) => group.supplier === selectedSupplier)) {
+      selectSupplier(null);
+    }
+  }, [loaded, suppliers, selectedSupplier, selectSupplier]);
 
   const changeState = useCallback(
     (lineId: string, newState: OrderLine["state"]) => {
@@ -366,6 +388,10 @@ export function OrdersSection({
     [onSessionExpired, suppliers],
   );
 
+  // issue 149: `useDirtyEditorLineIds.ts` — riadky s PRÁVE TERAZ otvorenou
+  // úpravou, výnimka z "skryť vybavené" filtra nižšie.
+  const { dirtyEditorLineIds, setActive: onEditorActivityChange } = useDirtyEditorLineIds();
+
   // `/api/orders/open` už zoraďuje riadky presne tak, ako majú byť zobrazené
   // (dodávateľ vzostupne, potom najnovšia objednávka prvá) — žiadne ďalšie
   // preskupovanie na klientovi.
@@ -379,7 +405,7 @@ export function OrdersSection({
     (group) => selectedSupplier === null || group.supplier === selectedSupplier,
   );
   const visibleLinesCount = filteredGroups.reduce(
-    (sum, group) => sum + (hideResolved ? group.lines.filter((line) => !isLineResolved(line)).length : group.lines.length),
+    (sum, group) => sum + group.lines.filter((line) => !isLineHiddenByFilter(line, hideResolved, dirtyEditorLineIds)).length,
     0,
   );
 
@@ -408,7 +434,7 @@ export function OrdersSection({
         <OrdersToolbar
           suppliers={suppliers}
           selectedSupplier={selectedSupplier}
-          onSelectSupplier={setSelectedSupplier}
+          onSelectSupplier={selectSupplier}
           hideResolved={hideResolved}
           onToggleHideResolved={toggleHideResolved}
         />
@@ -433,6 +459,8 @@ export function OrdersSection({
           key={group.supplier}
           group={group}
           hideResolved={hideResolved}
+          dirtyEditorLineIds={dirtyEditorLineIds}
+          onEditorActivityChange={onEditorActivityChange}
           canChangeState={canChangeState}
           busyLineId={busyLineId}
           busyOrderedLineId={busyOrderedLineId}

--- a/apps/web/src/components/Sidebar.test.tsx
+++ b/apps/web/src/components/Sidebar.test.tsx
@@ -36,3 +36,19 @@ it("klik na hlavičku priečinka ho zbalí (folder-chev sa otočí cez triedu 'c
   fireEvent.click(folderBtn);
   expect(folderBtn.getAttribute("aria-expanded")).toBe("false");
 });
+
+// issue 147: `badgeCounts` je generický (kľúčovaný `tab.id`), nielen pre
+// "Na objednanie" — test preto overuje aj že tab BEZ kľúča v `badgeCounts`
+// odznak nedostane vôbec (nie odznak s "0").
+it("vykreslí odznak len pre záložku s kľúčom v badgeCounts, ostatné bez odznaku", () => {
+  render(<Sidebar folders={FOLDERS} activeTabId="sync" onSelectTab={() => {}} badgeCounts={{ orders: 3 }} />);
+
+  expect(screen.getByTestId("nav-badge-orders").textContent).toBe("3");
+  expect(screen.queryByTestId("nav-badge-sync")).toBeNull();
+});
+
+it("bez badgeCounts (prop vôbec chýba) sa nevykreslí žiadny odznak", () => {
+  render(<Sidebar folders={FOLDERS} activeTabId="sync" onSelectTab={() => {}} />);
+
+  expect(screen.queryByTestId("nav-badge-orders")).toBeNull();
+});

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -71,10 +71,16 @@ export function Sidebar({
                       >
                         <span className="tlabel">{tab.label}</span>
                         {badgeCount !== undefined && (
+                          // Code review (PR 154): `aria-label` NESMIE niesť
+                          // doménovo špecifické slovo ("nevybavených") — táto
+                          // komponenta je zámerne generická pre AKÚKOĽVEK
+                          // budúcu záložku (viď `badgeCounts` prop vyššie),
+                          // takže popis smie použiť len to, čo Sidebar sám
+                          // pozná: číslo + názov TEJTO záložky.
                           <span
                             className="tab-badge"
                             data-testid={`nav-badge-${tab.id}`}
-                            aria-label={`${String(badgeCount)} nevybavených`}
+                            aria-label={`${tab.label}: ${String(badgeCount)}`}
                           >
                             {badgeCount}
                           </span>

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -13,10 +13,16 @@ export function Sidebar({
   folders,
   activeTabId,
   onSelectTab,
+  badgeCounts,
 }: {
   readonly folders: readonly NavFolder[];
   readonly activeTabId: string;
   readonly onSelectTab: (id: string) => void;
+  // issue 147: voliteľný odznak (počet) per záložka, kľúčovaný `tab.id` — dnes
+  // ho posiela len "Na objednanie" (`App.tsx`), ale Sidebar zostáva generický,
+  // aby AKÁKOĽVEK budúca záložka mohla dostať odznak bez zásahu sem. Chýbajúci
+  // kľúč = žiadny odznak (nie "0" — appka ešte nevie, nie "isté nula").
+  readonly badgeCounts?: Readonly<Record<string, number>>;
 }): JSX.Element {
   const [collapsed, setCollapsed] = useState<Readonly<Record<string, boolean>>>({});
 
@@ -51,19 +57,27 @@ export function Sidebar({
               </button>
               <div className="folder-body">
                 <div className="tabs">
-                  {folder.tabs.map((tab) => (
-                    <button
-                      key={tab.id}
-                      type="button"
-                      className={"tab" + (tab.id === activeTabId ? " active" : "")}
-                      aria-current={tab.id === activeTabId ? "page" : undefined}
-                      onClick={() => {
-                        onSelectTab(tab.id);
-                      }}
-                    >
-                      <span className="tlabel">{tab.label}</span>
-                    </button>
-                  ))}
+                  {folder.tabs.map((tab) => {
+                    const badgeCount = badgeCounts?.[tab.id];
+                    return (
+                      <button
+                        key={tab.id}
+                        type="button"
+                        className={"tab" + (tab.id === activeTabId ? " active" : "")}
+                        aria-current={tab.id === activeTabId ? "page" : undefined}
+                        onClick={() => {
+                          onSelectTab(tab.id);
+                        }}
+                      >
+                        <span className="tlabel">{tab.label}</span>
+                        {badgeCount !== undefined && (
+                          <span className="tab-badge" data-testid={`nav-badge-${tab.id}`}>
+                            {badgeCount}
+                          </span>
+                        )}
+                      </button>
+                    );
+                  })}
                 </div>
               </div>
             </div>

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -71,7 +71,11 @@ export function Sidebar({
                       >
                         <span className="tlabel">{tab.label}</span>
                         {badgeCount !== undefined && (
-                          <span className="tab-badge" data-testid={`nav-badge-${tab.id}`}>
+                          <span
+                            className="tab-badge"
+                            data-testid={`nav-badge-${tab.id}`}
+                            aria-label={`${String(badgeCount)} nevybavených`}
+                          >
                             {badgeCount}
                           </span>
                         )}

--- a/apps/web/src/components/SupplierOrderGroup.tsx
+++ b/apps/web/src/components/SupplierOrderGroup.tsx
@@ -1,5 +1,5 @@
 import type { JSX } from "react";
-import { computeVariantTotals, isLineResolved } from "../ordersSummary.js";
+import { computeVariantTotals, isLineHiddenByFilter } from "../ordersSummary.js";
 import { OrderLineRow } from "./OrderLineRow.js";
 import { SupplierActionsPanel } from "./SupplierActionsPanel.js";
 import type { OrderLine, OrderMailPreview, SupplierOpenOrders } from "../ordersApi.js";
@@ -15,6 +15,8 @@ import type { OrderLine, OrderMailPreview, SupplierOpenOrders } from "../ordersA
 export function SupplierOrderGroup({
   group,
   hideResolved,
+  dirtyEditorLineIds,
+  onEditorActivityChange,
   canChangeState,
   busyLineId,
   busyOrderedLineId,
@@ -48,6 +50,11 @@ export function SupplierOrderGroup({
 }: {
   readonly group: SupplierOpenOrders;
   readonly hideResolved: boolean;
+  // issue 149: riadky s PRÁVE TERAZ otvorenou/rozpísanou úpravou — výnimka z
+  // `hideResolved` filtra nižšie, aby vybavený riadok nezmizol spod rúk
+  // manažérovi, ktorý doň ešte niečo píše (`OrdersSection.tsx`'s komentár).
+  readonly dirtyEditorLineIds: ReadonlySet<string>;
+  readonly onEditorActivityChange: (lineId: string, active: boolean) => void;
   readonly canChangeState: boolean;
   readonly busyLineId: string | null;
   readonly busyOrderedLineId: string | null;
@@ -82,7 +89,7 @@ export function SupplierOrderGroup({
   readonly onClosePreview: () => void;
   readonly onConfirmSend: (supplier: string) => void;
 }): JSX.Element | null {
-  const visibleLines = hideResolved ? group.lines.filter((line) => !isLineResolved(line)) : group.lines;
+  const visibleLines = group.lines.filter((line) => !isLineHiddenByFilter(line, hideResolved, dirtyEditorLineIds));
   if (visibleLines.length === 0) return null;
   // issue 62: súčty sa počítajú nad CELOU (nefiltrovanou) skupinou
   // dodávateľa, nikdy nad `visibleLines` — chip nesmie zmiznúť/zmeniť
@@ -188,6 +195,7 @@ export function SupplierOrderGroup({
                 onAssignSupplier={onAssignSupplier}
                 onSetSupplierLink={onSetSupplierLink}
                 onChangeComment={onChangeComment}
+                onEditorActivityChange={onEditorActivityChange}
               />
             ))}
           </tbody>

--- a/apps/web/src/ordersDisplayPreferences.ts
+++ b/apps/web/src/ordersDisplayPreferences.ts
@@ -1,0 +1,51 @@
+// issue 61/148 — vyňaté z `OrdersSection.tsx` (rovnaký dôvod ako existujúce
+// hook-extrakcie `useSupplierEmailEditing.ts`/`useSupplierMailActions.ts`,
+// `.claude/rules/frontend-design.md`): pridanie perzistencie vybraného
+// dodávateľa (issue 148) poslalo `OrdersSection.tsx` cez eslint `max-lines:
+// 400` — tieto ČISTÉ funkcie (žiadny React state/hook) sú najsamostatnejší
+// vyňateľný blok.
+//
+// issue 61: kľúč pre prepínač "skryť vybavené riadky" — perzistovaný do
+// localStorage. issue 148: vybraný dodávateľ (chip) dostáva PRESNE ten istý
+// mechanizmus (predtým bol zámerne len klientský, komentár na tickete
+// vysvetľuje zmenu).
+const HIDE_RESOLVED_STORAGE_KEY = "forestshop.orders.hideResolved";
+const SELECTED_SUPPLIER_STORAGE_KEY = "forestshop.orders.selectedSupplier";
+
+export function readHideResolvedPreference(): boolean {
+  try {
+    return window.localStorage.getItem(HIDE_RESOLVED_STORAGE_KEY) === "1";
+  } catch {
+    // localStorage nedostupné (napr. prehliadač so zakázaným úložiskom) —
+    // prepínač jednoducho nezačne predvyplnený, nič nespadne.
+    return false;
+  }
+}
+
+export function persistHideResolvedPreference(next: boolean): void {
+  try {
+    window.localStorage.setItem(HIDE_RESOLVED_STORAGE_KEY, next ? "1" : "0");
+  } catch {
+    // localStorage nedostupné — voľba ostáva platná len pre túto reláciu.
+  }
+}
+
+// issue 148: `null` (chýbajúci kľúč AJ prázdny reťazec) = "Všetci" — dodávateľ
+// nikdy nemá prázdne meno, takže "" je bezpečný zástupný zápis pre "explicitne
+// Všetci" bez potreby JSON parsovania jedného reťazca.
+export function readSelectedSupplierPreference(): string | null {
+  try {
+    const stored = window.localStorage.getItem(SELECTED_SUPPLIER_STORAGE_KEY);
+    return stored === null || stored === "" ? null : stored;
+  } catch {
+    return null;
+  }
+}
+
+export function persistSelectedSupplier(next: string | null): void {
+  try {
+    window.localStorage.setItem(SELECTED_SUPPLIER_STORAGE_KEY, next ?? "");
+  } catch {
+    // localStorage nedostupné — voľba ostáva platná len pre túto reláciu.
+  }
+}

--- a/apps/web/src/ordersRemainingCountContext.ts
+++ b/apps/web/src/ordersRemainingCountContext.ts
@@ -1,0 +1,22 @@
+import { createContext } from "react";
+
+// issue 147 — most jednoduchý mostík medzi `OrdersSection` (vlastník dát) a
+// `Sidebar`/`App.tsx` (potrebujú len ODVODENÝ počet, nie celé dáta). Provider
+// žije raz v `App.tsx` (spoločný predok Sidebar-u aj `ActiveComponent`-u), takže
+// hodnota PREŽIJE prepnutie na inú záložku (na rozdiel od stavu vnútri
+// `OrdersSection`, ktorý sa pri odmountovaní stratí) — odznak tak ukazuje
+// poslednú známu hodnotu, nie "zmizne, kým sa tab znova nenavštívi".
+// `count === null` = appka ešte nevie (OrdersSection ešte nikdy nenačítala
+// dáta v tejto relácii) — Sidebar vtedy odznak vôbec nevykreslí.
+export interface OrdersRemainingCountContextValue {
+  readonly count: number | null;
+  readonly setCount: (count: number | null) => void;
+}
+
+export const OrdersRemainingCountContext = createContext<OrdersRemainingCountContextValue>({
+  count: null,
+  setCount: () => {
+    // Predvolená hodnota mimo Provider-a (napr. v teste, ktorý OrdersSection
+    // rendruje samostatne) — bezpečné no-op, nikdy nespadne.
+  },
+});

--- a/apps/web/src/ordersSummary.test.ts
+++ b/apps/web/src/ordersSummary.test.ts
@@ -3,6 +3,7 @@ import {
   computeVariantTotals,
   formatOrderSummaryText,
   formatVariantTotalChip,
+  isLineHiddenByFilter,
   isLineResolved,
   isStaleOrderLine,
   orderLineAgeDays,
@@ -34,6 +35,29 @@ it("riadok posunutý za predvolený stav je vybavený, aj bez odškrtnutia", () 
   expect(isLineResolved(line("caka_sa", false))).toBe(true);
   expect(isLineResolved(line("skladom", false))).toBe(true);
   expect(isLineResolved(line("nedostupne", false))).toBe(true);
+});
+
+// issue 149 — priame testy jediného zdieľaného predikátu (`OrdersSection.tsx`'s
+// `visibleLinesCount` a `SupplierOrderGroup.tsx`'s `visibleLines` naň oba
+// spoliehajú), review nález (code review na PR 154): predtým bol overený len
+// nepriamo cez komponentové/e2e testy.
+it("isLineHiddenByFilter: hideResolved=false nikdy nič neskryje, bez ohľadu na stav/dirty", () => {
+  expect(isLineHiddenByFilter({ ...line("caka_sa", false), lineId: "x" }, false, new Set())).toBe(false);
+  expect(isLineHiddenByFilter({ ...line("objednane", false), lineId: "x" }, false, new Set())).toBe(false);
+});
+
+it("isLineHiddenByFilter: hideResolved=true skryje vybavený riadok BEZ otvorenej úpravy", () => {
+  expect(isLineHiddenByFilter({ ...line("caka_sa", false), lineId: "x" }, true, new Set())).toBe(true);
+});
+
+it("isLineHiddenByFilter: hideResolved=true NEVYBAVENÝ riadok nikdy neskryje", () => {
+  expect(isLineHiddenByFilter({ ...line("objednane", false), lineId: "x" }, true, new Set())).toBe(false);
+});
+
+it("isLineHiddenByFilter: vybavený riadok s otvorenou úpravou (dirtyEditorLineIds) ostáva viditeľný", () => {
+  expect(isLineHiddenByFilter({ ...line("caka_sa", false), lineId: "x" }, true, new Set(["x"]))).toBe(false);
+  // Iný riadok v tom istom sete zostáva skrytý — výnimka je per-lineId, nie globálna.
+  expect(isLineHiddenByFilter({ ...line("caka_sa", false), lineId: "y" }, true, new Set(["x"]))).toBe(true);
 });
 
 it("summarizeOrderLines spočíta total/remaining a rozpis podľa stavov/odškrtnutia", () => {

--- a/apps/web/src/ordersSummary.ts
+++ b/apps/web/src/ordersSummary.ts
@@ -11,6 +11,20 @@ export function isLineResolved(line: Pick<OrderLine, "ordered" | "state">): bool
   return line.ordered || line.state !== "objednane";
 }
 
+// issue 149 — jediné miesto rozhodujúce, či "skryť vybavené" riadok SKUTOČNE
+// skryje. Zdieľané medzi `OrdersSection.tsx`'s `visibleLinesCount` (hláška
+// "Všetko vybavené") a `SupplierOrderGroup.tsx`'s `visibleLines` (skutočné
+// vykreslenie) — výnimka je rovnaká na oboch miestach: vybavený riadok s
+// PRÁVE TERAZ otvorenou/rozpísanou úpravou (`dirtyEditorLineIds`,
+// `useDirtyEditorLineIds.ts`) ostáva viditeľný, kým sa úprava nezavrie.
+export function isLineHiddenByFilter(
+  line: Pick<OrderLine, "ordered" | "state" | "lineId">,
+  hideResolved: boolean,
+  dirtyEditorLineIds: ReadonlySet<string>,
+): boolean {
+  return hideResolved && isLineResolved(line) && !dirtyEditorLineIds.has(line.lineId);
+}
+
 export interface OrderLinesSummary {
   readonly total: number;
   readonly remaining: number;

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -312,6 +312,29 @@ tr:last-child td {
   color: var(--fs-brand-strong);
   font-weight: var(--fs-weight-semibold);
 }
+.tlabel {
+  flex: 1;
+}
+/* issue 147: odznak počtu nevybavených riadkov (dnes len "Na objednanie",
+   ale generický pre AKÚKOĽVEK budúcu záložku — `Sidebar.tsx`'s `badgeCounts`
+   prop). Vlastný dizajn tejto appky (nikdy prevzatý zo starej appky, viď
+   `.claude/rules/frontend-design.md`) — malá guľatá pilulka v brand farbe,
+   `flex-shrink: 0` aby ju dlhší popisok záložky nikdy nestlačil. */
+.tab-badge {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.25rem;
+  height: 1.25rem;
+  padding: 0 var(--fs-space-1);
+  border-radius: var(--fs-radius-lg);
+  background: var(--fs-brand);
+  color: #fff;
+  font-size: var(--fs-text-xs);
+  font-weight: var(--fs-weight-semibold);
+  line-height: 1.25rem;
+}
 
 .sidefoot {
   border-top: 1px solid var(--fs-border);

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -1204,11 +1204,29 @@ tr:last-child td {
   font: inherit;
   font-size: var(--fs-text-base);
   min-height: 2.25rem;
+  /* issue 150: `<textarea>` (predtým `<input>`) — `line-height`/`min-height`
+     nezmenené (rovnaká predvolená výška riadku ako predtým), `resize:
+     vertical` + `max-height` dovolia manažérovi pole podľa potreby zväčšiť
+     na viac riadkov, bez toho, aby to natrvalo nafúklo výšku VŠETKÝCH
+     riadkov tabuľky (rovnaký ~row-height rozpočet, aký #105/#107/#111/#127
+     doladili) — presiahnutý obsah pri predvolenej výške sa interne posúva
+     (`overflow-y: auto`), nikdy nepretečie do suseda. */
+  line-height: 1.4;
+  resize: vertical;
+  max-height: 6rem;
+  overflow-y: auto;
 }
 /* issue 105 bod 3: same "button never shrinks" guarantee as the supplier
    assign button above. */
 .ord-comment-cell > button {
   flex-shrink: 0;
+}
+/* issue 150: read-only vetva (rola bez `canChangeState`) — zalomenia
+   uloženého viacriadkového komentára musia prežiť aj na čítanie, nielen
+   počas úpravy vo `<textarea>` vyššie. */
+.ord-comment-display {
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 /* issue 95: percentuálne šírky stĺpcov (`SupplierOrderGroup.tsx`'s
    `<colgroup>`) — PRODUKT (najdôležitejší údaj, majiteľ komentár #1: "má len

--- a/apps/web/src/useDirtyEditorLineIds.ts
+++ b/apps/web/src/useDirtyEditorLineIds.ts
@@ -10,6 +10,17 @@ import { useCallback, useState } from "react";
 // (`SupplierOrderGroup.tsx`'s `visibleLines`) aj `OrdersSection.tsx`'s
 // `visibleLinesCount` použijú výsledný set ako VÝNIMKU: vybavený riadok s
 // otvorenou úpravou ostáva viditeľný, kým sa úprava nezavrie/neuloží.
+//
+// Code review (PR 154): `dirtyEditorLineIds` je NOVÝ `Set` pri KAŽDEJ zmene
+// (immutable update vyššie), takže KAŽDÝ `SupplierOrderGroup`/`OrderLineRow`
+// na celej obrazovke sa prekreslí pri otvorení/zavretí ktoréhokoľvek JEDNÉHO
+// riadku — nič v tomto strome dnes nie je `React.memo`. Pri dnešných
+// desiatkach riadkov ("Na objednanie") je to zanedbateľné; ak by objem
+// objednávok narástol natoľko, že by to bolo merateľne pomalé, riešenie je
+// `React.memo` na `SupplierOrderGroup`/`OrderLineRow` s vlastným
+// porovnávačom (len `dirtyEditorLineIds.has(line.lineId)`, nie celý set) —
+// pozri aj `OrderLineRow.tsx`'s komentár pri `commentDirtyNow` predtým, než
+// taký `React.memo` krok urobíš.
 export function useDirtyEditorLineIds(): {
   readonly dirtyEditorLineIds: ReadonlySet<string>;
   readonly setActive: (lineId: string, active: boolean) => void;

--- a/apps/web/src/useDirtyEditorLineIds.ts
+++ b/apps/web/src/useDirtyEditorLineIds.ts
@@ -1,0 +1,29 @@
+import { useCallback, useState } from "react";
+
+// issue 149 — vyňaté z `OrdersSection.tsx` (rovnaký dôvod ako existujúce hook-
+// extrakcie `useSupplierEmailEditing.ts`/`useSupplierMailActions.ts`,
+// `.claude/rules/frontend-design.md`): riadky, ktoré PRÁVE TERAZ držia
+// rozpísanú/otvorenú úpravu (odkaz na dodávateľa, ručné priradenie mena
+// dodávateľa, komentár — `OrderLineRow.tsx` hlási zmenu cez `setActive`).
+// Nesie len ĽAHKÝ boolean signál per `lineId`, NIE samotný rozpísaný text —
+// ten ostáva výlučne vnútri `OrderLineRow`. Filter "skryť vybavené"
+// (`SupplierOrderGroup.tsx`'s `visibleLines`) aj `OrdersSection.tsx`'s
+// `visibleLinesCount` použijú výsledný set ako VÝNIMKU: vybavený riadok s
+// otvorenou úpravou ostáva viditeľný, kým sa úprava nezavrie/neuloží.
+export function useDirtyEditorLineIds(): {
+  readonly dirtyEditorLineIds: ReadonlySet<string>;
+  readonly setActive: (lineId: string, active: boolean) => void;
+} {
+  const [dirtyEditorLineIds, setDirtyEditorLineIds] = useState<ReadonlySet<string>>(new Set());
+  const setActive = useCallback((lineId: string, active: boolean) => {
+    setDirtyEditorLineIds((current) => {
+      const alreadyActive = current.has(lineId);
+      if (active === alreadyActive) return current;
+      const next = new Set(current);
+      if (active) next.add(lineId);
+      else next.delete(lineId);
+      return next;
+    });
+  }, []);
+  return { dirtyEditorLineIds, setActive };
+}

--- a/apps/web/tests/e2e/nav.spec.ts
+++ b/apps/web/tests/e2e/nav.spec.ts
@@ -51,6 +51,18 @@ test("ľavé menu má presne dva priečinky s jednou záložkou každý, klik pr
   await expect(page.getByRole("heading", { name: "Na objednanie" })).toBeVisible();
   await expect(page.getByTestId("supplier-DODAVATEL-TEST-1")).toBeVisible();
 
+  // issue 147: odznak počtu nevybavených riadkov v ľavom menu — musí ostať
+  // viditeľný AJ po prepnutí SPÄŤ na inú záložku (odznak žije v `App.tsx`
+  // koreni cez `OrdersRemainingCountContext`, nie vnútri "Na objednanie",
+  // ktorá sa pri prepnutí odmountuje). Presné číslo sa zámerne neoveruje
+  // (zdieľaná globálna DB, iné súbežne bežiace e2e súbory menia stavy
+  // riadkov) — len že odznak existuje a nesie platné celé číslo.
+  await page.getByRole("button", { name: "Sync zo Shoptetu" }).click();
+  await expect(page.getByRole("heading", { name: "Sync zo Shoptetu" })).toBeVisible();
+  const odznak = page.getByTestId("nav-badge-orders");
+  await expect(odznak).toBeVisible();
+  await expect(odznak).toHaveText(/^\d+$/);
+
   expect(chyby).toEqual([]);
 });
 

--- a/apps/web/tests/e2e/orders-hidden-editor.spec.ts
+++ b/apps/web/tests/e2e/orders-hidden-editor.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test, type ConsoleMessage } from "@playwright/test";
+
+const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
+// Vlastný, IZOLOVANÝ účet (`scripts/e2e-setup.ts`'s komentár vysvetľuje dôvod
+// aj mechanizmus — balík je už na hranici `MAX_ATTEMPTS`).
+const E2E_SKRYTY_EDITOR_EMAIL = "e2e-skryty-editor@forestshop.sk";
+
+const jeOcakavane = (m: ConsoleMessage): boolean =>
+  m.location().url.includes("/api/me") && m.text().includes("401");
+
+// issue 149: riadok s otvorenou (neuloženou) úpravou odkazu na dodávateľa
+// nesmie zmiznúť pri zapnutom "skryť vybavené", aj keď je riadok už
+// vybavený — kým sa úprava nezavrie. Používa DODAVATEL-TEST-1's jediný
+// riadok ("4859/46", stav "caka_sa" = už vybavený, `scripts/e2e-setup.ts`).
+// Test len OTVÁRA/ZAVIERA edit panel, nikdy neukladá (žiadny klik na 💾) —
+// nemení žiadnu zdieľanú fixtúrovú hodnotu (vrátane hardcodovaného
+// `supplierUrl`, ktorý `orders.spec.ts`'s mailový/odkazový test overuje),
+// takže je bezpečné bežať súbežne s ostatnými spec súbormi.
+test("riadok s otvoreným editorom odkazu na dodávateľa ostáva viditeľný pri 'skryť vybavené', zmizne po zavretí editora, konzola je čistá", async ({
+  page,
+}) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/?tab=orders");
+  await page.getByLabel("E-mail").fill(E2E_SKRYTY_EDITOR_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await expect(page.getByRole("heading", { name: "Na objednanie" })).toBeVisible();
+
+  const skupina = page.getByTestId("supplier-DODAVATEL-TEST-1");
+  const riadok = skupina.locator("[data-testid^='order-line-']");
+  await expect(riadok).toBeVisible();
+
+  // Bez otvoreného editora "skryť vybavené" skryje CELÚ skupinu (jediný
+  // riadok je vybavený, "caka_sa") — presne existujúce správanie z issue 61.
+  const toggle = page.getByTestId("orders-hide-resolved-toggle");
+  await toggle.click();
+  await expect(skupina).not.toBeVisible();
+
+  // Vypnúť naspäť, otvoriť edit panel odkazu na dodávateľa (toggle, NEUKLADÁ).
+  await toggle.click();
+  await expect(skupina).toBeVisible();
+  await riadok.getByRole("button", { name: /odkaz na dodávateľa/i }).click();
+  await expect(riadok.locator("input[type='url']")).toBeVisible();
+
+  // Zapnúť "skryť vybavené" znova — riadok TERAZ ostáva viditeľný, lebo má
+  // otvorený editor (issue 149's akceptačná podmienka).
+  await toggle.click();
+  await expect(skupina).toBeVisible();
+  await expect(riadok).toBeVisible();
+  await expect(riadok.locator("input[type='url']")).toBeVisible();
+
+  // Zavretie editora (✖, bez uloženia) — riadok teraz zmizne.
+  await riadok.getByRole("button", { name: /zrušiť úpravu odkazu na dodávateľa/i }).click();
+  await expect(skupina).not.toBeVisible();
+
+  expect(chyby).toEqual([]);
+});

--- a/apps/web/tests/e2e/orders-layout.spec.ts
+++ b/apps/web/tests/e2e/orders-layout.spec.ts
@@ -72,7 +72,9 @@ test("STAV je celý čitateľný a POZNÁMKY pole je dosť široké na všetkýc
     // issue 107 bod 2: pole na poznámku >= 160px pri 1280px, tlačidlo 💾 na
     // TOM ISTOM riadku (nesmie sa vrátiť k zalomeniu z issue 105).
     const poznamky = await page.evaluate(() => {
-      const input = document.querySelector<HTMLInputElement>('input[data-testid^="comment-input-"]');
+      // issue 150: pole je odteraz `<textarea>` (predtým `<input>`) —
+      // selektor bez tagu, aby fungoval po zmene elementu bez ďalšej úpravy.
+      const input = document.querySelector<HTMLTextAreaElement>('[data-testid^="comment-input-"]');
       if (!input) return { chyba: "no comment input found" };
       const button = input.closest(".ord-comment-cell")?.querySelector("button");
       const inputRect = input.getBoundingClientRect();

--- a/apps/web/tests/e2e/orders.spec.ts
+++ b/apps/web/tests/e2e/orders.spec.ts
@@ -89,6 +89,20 @@ test("manažér filtruje podľa dodávateľa, vidí súhrn ostáva vybaviť a sk
   await page.getByTestId("orders-hide-resolved-toggle").click();
   await expect(page.getByTestId("supplier-DODAVATEL-TEST-1")).toBeVisible();
 
+  // issue 148: vybraný dodávateľ prežije obnovenie stránky (localStorage) —
+  // rovnaký mechanizmus, aký `hideResolved` má už od issue 61 vyššie.
+  await page.getByTestId("supplier-chip-(bez dodávateľa)").click();
+  await expect(page.getByTestId("supplier-chip-(bez dodávateľa)")).toHaveClass(/active/);
+  await page.reload();
+  await expect(page.getByRole("heading", { name: "Na objednanie" })).toBeVisible();
+  await expect(page.getByTestId("supplier-chip-(bez dodávateľa)")).toHaveClass(/active/);
+  await expect(page.getByTestId("supplier-(bez dodávateľa)")).toBeVisible();
+  await expect(page.getByTestId("supplier-DODAVATEL-TEST-1")).not.toBeVisible();
+
+  // Späť na "Všetci" — zvyšok testu (šírkové kontroly nižšie) potrebuje OBE skupiny.
+  await page.getByTestId("supplier-chip-all").click();
+  await expect(page.getByTestId("supplier-DODAVATEL-TEST-1")).toBeVisible();
+
   // issue 95: stránka sa NIKDY nesmie posúvať vodorovne, na žiadnej zo
   // štyroch testovaných šírok — keď je tabuľka širšia než dostupné miesto,
   // posúva sa len jej VLASTNÝ obal (`.orders-table-wrap`), nikdy

--- a/apps/web/tests/e2e/orders.spec.ts
+++ b/apps/web/tests/e2e/orders.spec.ts
@@ -585,10 +585,31 @@ test("manažér napíše a upraví poznámku k objednávke, zmena pretrvá po ob
   await expect(vstup).toHaveValue("Vyzdvihnúť v sklade do piatku");
   await expect(page.getByRole("alert")).toHaveCount(0);
 
+  // issue 150: pole je odteraz `<textarea>` — Enter vloží nový riadok a
+  // NEULOŽÍ (na rozdiel od predošlého jednoriadkového `<input>`, kde Enter
+  // rovno uložil). Skutočné stláčanie klávesov (`pressSequentially`/`press`),
+  // nie `.fill()`, aby sa overilo reálne správanie klávesnice.
+  await vstup.fill("");
+  await vstup.pressSequentially("prvý riadok");
+  await vstup.press("Enter");
+  await vstup.pressSequentially("druhý riadok (neuložený koncept)");
+  await expect(vstup).toHaveValue("prvý riadok\ndruhý riadok (neuložený koncept)");
+
   await page.reload();
   await expect(page.getByRole("heading", { name: "Na objednanie" })).toBeVisible();
   const vstupPoReloade = page.getByLabel("Poznámka k objednávke 9001 / 4859/46");
+  // Dôkaz, že obyčajný Enter vyššie NEuložil — po obnovení stránky je tam
+  // stále posledná SKUTOČNE uložená hodnota, nie neuložený viacriadkový koncept.
   await expect(vstupPoReloade).toHaveValue("Vyzdvihnúť v sklade do piatku");
+
+  // Ctrl+Enter ULOŽÍ viacriadkový text.
+  await vstupPoReloade.fill("");
+  await vstupPoReloade.pressSequentially("riadok jeden");
+  await vstupPoReloade.press("Enter");
+  await vstupPoReloade.pressSequentially("riadok dva");
+  await vstupPoReloade.press("Control+Enter");
+  await expect(vstupPoReloade).toHaveValue("riadok jeden\nriadok dva");
+  await expect(page.getByRole("alert")).toHaveCount(0);
 
   // Vrátenie na pôvodnú hodnotu (hygiena zdieľaných fixtúrových dát).
   await vstupPoReloade.fill("Zavolať pred doručením");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.88",
+  "version": "0.3.0-dev.89",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -120,6 +120,12 @@ const E2E_ODKAZ_EMAIL = "e2e-odkaz@forestshop.sk"; // musí sa zhodovať s hodno
 // zdieľaným `e2e@forestshop.sk`.
 const E2E_ZAPISY_EMAIL = "e2e-zapisy@forestshop.sk"; // musí sa zhodovať s hodnotou v orders-write-failures.spec.ts
 
+// issue 149: rovnaký mechanizmus a dôvod ako `E2E_ZAPISY_EMAIL` vyššie —
+// nový spec súbor (`orders-hidden-editor.spec.ts` — riadok s otvoreným
+// editorom nesmie zmiznúť pri "skryť vybavené") dostáva VLASTNÝ izolovaný
+// účet namiesto ďalšieho prihlásenia pod zdieľaným `e2e@forestshop.sk`.
+const E2E_SKRYTY_EDITOR_EMAIL = "e2e-skryty-editor@forestshop.sk"; // musí sa zhodovať s hodnotou v orders-hidden-editor.spec.ts
+
 const { db, pool } = createDb();
 // Konštantný literál bez interpolácie — obyčajný reťazec je tu rovnako bezpečný
 // ako `sql` tagovaná šablóna (tú používa ekvivalentný apps/api/tests/helpers/db.ts),
@@ -225,6 +231,12 @@ await db.insert(users).values({
 });
 await db.insert(users).values({
   email: E2E_ZAPISY_EMAIL,
+  passwordHash: await hashPassword(E2E_HESLO),
+  displayName: "E2E Manažér",
+  role: "manazer",
+});
+await db.insert(users).values({
+  email: E2E_SKRYTY_EDITOR_EMAIL,
   passwordHash: await hashPassword(E2E_HESLO),
   displayName: "E2E Manažér",
   role: "manazer",


### PR DESCRIPTION
Bundled parity fixes for the "Na objednanie" screen — issue 147, issue 148, issue 149, issue 150.

## issue 147 — unresolved-lines badge in left nav
Nav item "Na objednanie" now carries a live badge with the count of unresolved order lines, published via a small `OrdersRemainingCountContext` so the value survives switching to another tab (unlike the tab's own local state, which unmounts).

## issue 148 — persist selected supplier filter across reload
The supplier-chip selection now persists to localStorage (same mechanism `hideResolved` already uses since issue 61) and falls back to "Vsetci" when the persisted supplier no longer exists among the fetched groups — mirrors the legacy app's exact fallback logic.

## issue 149 — row with an open editor must not disappear under "Skryt vybavene"
A resolved line whose supplier-link / manual-supplier-name / comment editor is still open (unsaved) is no longer unmounted when "Skryt vybavene" is on. A lightweight per-line "has open editor" signal (not the draft text itself) bubbles up from `OrderLineRow` to the hide-resolved filter.

## issue 150 — order comment is multi-line
The comment field is now a `<textarea>`: Enter inserts a newline, Ctrl/Cmd+Enter saves. The read-only display path preserves line breaks for already-saved multi-line comments.

## Validation
Each issue's design (root cause, chosen approach, rejected alternative) is posted as a `gh issue comment` before its first code commit — see issue 147, issue 148, issue 149, issue 150.

## Testing
- 274 web unit tests (vitest) pass, including new coverage for all four issues.
- 24/24 Playwright e2e tests pass locally (login, catalog, nav, orders*, orders-hidden-editor [new], orders-layout, orders-supplier-link, orders-write-failures, pairing).
- 290 API integration tests pass (untouched by this change, run as a regression check).
- CI (check/version-check/integration/e2e/docker-build) all green: run 30689747384.

## Post-merge
Each issue will be closed manually via `gh issue close` after live post-deploy verification on `forestshop-novy.newlevel.media` (per the project's Closes-#N auto-close footgun — see project CLAUDE.md), not via this PR body.
