### PR TITLE
docs: playbook review + autopilot log for issues 147/148/149/150 (0.3.0-dev.90)

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -378,3 +378,51 @@ paths:
   (reuse the same `page`, just `setViewportSize` between checks) instead
   of a fresh login per viewport/candidate, to avoid burning through the
   10-attempt budget on read-only verification work.
+- **A React wrapper/harness component that owns state AND is re-rendered
+  BY that state must memoize (`useCallback`) any inline prop function it
+  passes down, or a downstream `useCallback`-memoized effect will refire
+  on every wrapper re-render.** Issue 147's `OrdersRemainingCountContext`
+  test harness (`OrdersSection.remainingCount.test.tsx`) initially passed
+  `onSessionExpired={() => {}}` as a fresh arrow literal on every render —
+  since the harness itself re-renders every time `OrdersSection` calls
+  `setCount` (the exact thing being tested), this broke `OrdersSection
+  .tsx`'s own `useCallback(load, [onSessionExpired])` memoization and
+  caused `fetchOpenOrders` to fire 3× instead of once, ONLY when wrapped
+  in this test's specific harness (not reproducible by rendering
+  `OrdersSection` directly, which is why every other existing test never
+  hit it). Fix: `const onSessionExpired = useCallback(() => {}, [])` (and
+  `useMemo` the Context Provider's `value` object) in the harness itself.
+  Any FUTURE test harness/wrapper that re-renders in response to the
+  thing under test needs the same treatment for every prop it passes down.
+- **A value that must SURVIVE a tab switching away (unmounting the owning
+  component) needs a React Context Provider living ABOVE the nav-switch
+  point (`App.tsx`), not state lifted only as far as the tab's own
+  parent.** Issue 147's nav badge: `OrdersSection` (the data owner) is
+  unmounted the instant the user picks a different tab (`App.tsx` renders
+  only `ActiveComponent`) — a naive "lift state to `App.tsx` via a
+  callback prop" would still need `App.tsx` itself to special-case which
+  tab gets the callback, breaking `nav.ts`'s "no `App.tsx` change to
+  add/move a tab" invariant. The Context (`ordersRemainingCountContext.ts`)
+  decouples "who PUBLISHES" from "who CONSUMES" — `OrdersSection` publishes
+  whenever mounted, `Sidebar` consumes via a generic `badgeCounts` prop
+  keyed by `tab.id`, and the value persists at its LAST KNOWN state once
+  `OrdersSection` unmounts. Any FUTURE cross-tab-surviving value (a
+  pending-count badge, a sync-status dot) should reach for this same
+  shape rather than threading a new prop through `App.tsx`.
+- **A filter/hide rule that can unmount a component mid-edit needs the
+  "has open edit" signal lifted as a LIGHTWEIGHT boolean per item, never
+  the draft text itself.** Issue 149: the naive fix would be lifting the
+  full draft state (`supplierDraft`/`linkDraft`/`commentDraft`) out of
+  `OrderLineRow` into `OrdersSection` so the filter could inspect it —
+  rejected because it would break every existing "controlled draft +
+  skip-first-mount + dirty guard" pattern already established per editor
+  (this file's own earlier entries) for no benefit. Instead
+  `useDirtyEditorLineIds.ts` carries ONLY `Set<lineId>` (open/not), and
+  `OrderLineRow` reports it via a `useEffect([...deps])` whose cleanup ALSO
+  reports `false` (handles both "closed" and "genuinely unmounted for an
+  unrelated reason" in one code path). The single shared predicate
+  (`ordersSummary.ts`'s `isLineHiddenByFilter`) is then the ONE place both
+  the render-filter (`SupplierOrderGroup.tsx`) and the count
+  (`OrdersSection.tsx`) apply the exception — never duplicate the
+  three-way boolean logic (`hideResolved && resolved && !dirty`) inline in
+  two files, they will drift.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -406,3 +406,28 @@ paths:
   ani obavu o kolíziu s inými spec súbormi bežiacimi súbežne — smie
   bezpečne použiť UŽ existujúce fixtúrové riadky (napr. `orders.spec.ts`'s
   DODAVATEL-TEST-1/"(bez dodávateľa)" riadky).
+- **Changing an existing form element's TAG (e.g. `<input>` → `<textarea>`,
+  issue 150's multi-line comment) silently breaks any e2e test that
+  queries it with a TAG-SCOPED selector, even though `data-testid`/
+  `aria-label` are unchanged.** `orders-layout.spec.ts`'s row-height check
+  used `document.querySelector<HTMLInputElement>('input[data-testid^=
+  "comment-input-"]')` — after the tag change this silently returned
+  `null` (not a type error, since `querySelector` always types-as-cast),
+  so a DOWNSTREAM property read on `undefined` failed with a confusing
+  "expected true, got undefined" instead of "element not found". Local
+  full e2e run caught it (CI would have too) — the fix is to drop the tag
+  from the selector (`'[data-testid^="comment-input-"]'`) so it survives
+  future tag changes on the same element. Any FUTURE element-tag change
+  (input↔textarea↔select) needs a `grep -rn '<oldtag>\[data-testid'
+  apps/web/tests/e2e/` across the WHOLE e2e directory, not just the spec
+  file that already covers the element's own behaviour.
+- **A `<textarea>`'s Enter-vs-Ctrl+Enter split needs REAL keystrokes in
+  both vitest (`fireEvent.keyDown(el, {key:"Enter", ctrlKey:true})`) and
+  Playwright (`locator.press("Control+Enter")`), never `.fill()`/
+  `fireEvent.change()` alone** — issue 150: `.fill()` only sets the DOM
+  `.value` and fires a synthetic `input`/`change` event, it never
+  dispatches a `keydown`, so a test using only `.fill()` would pass
+  whether the Enter-vs-Ctrl+Enter branching logic was implemented
+  correctly OR removed entirely. `pressSequentially`/`.press()`
+  (Playwright) and `fireEvent.keyDown` (vitest) are the only two APIs that
+  actually exercise the `onKeyDown` handler being tested.

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -1911,3 +1911,40 @@ nové heslo sa nikde v pushnutom obsahu nenachádza.
   porušenia jedinej povolenej konzolovej výnimky), `CLAUDE.md` (rozšírenie
   existujúcej `Closes #N` poznámky — riziko platí aj pre COMMIT správy,
   nielen telo PR, keďže tento repo merguje merge commitom).
+
+- **Bundle: issues 147+148+149+150 — nav odznak / perzistencia dodávateľa /
+  ochrana rozpísaného editora / viacriadkový komentár** (PR #154, merge
+  `e6cdf94`, v0.3.0-dev.89). Commity `e05995e` (#147: `OrdersRemainingCount
+  Context` + `Sidebar`'s generický `badgeCounts` prop), `f3d47c3` (#148:
+  `ordersDisplayPreferences.ts` extrahované z `hideResolved`'s existujúceho
+  localStorage vzoru), `0e52ee7` (#149: `useDirtyEditorLineIds.ts` +
+  `ordersSummary.ts`'s zdieľaný `isLineHiddenByFilter`), `5e7b627` (#150:
+  `<input>`→`<textarea>`), `5315fe1` (spojenie do `OrdersSection.tsx`),
+  plus testovacie commity `48b8703`/`60a4417`/`2918af5`/`5c5fc99` a
+  review-fix commity `62e677e`/`de80851` (deep code review nálezy — 3 🟡 +
+  2 🔵, opravené: priamy unit test `isLineHiddenByFilter`, odznak-ov
+  `aria-label` prestal niesť doménovo špecifické slovo, dva dokumentačné
+  komentáre pre budúci `React.memo` krok).
+- Design komentáre PRED prvým kódovým commitom na každom ticket-e:
+  issue-comment-5150251505 (#147), -5150253019 (#148), -5150255070 (#149),
+  -5150256490 (#150).
+- Naživo overené na produkcii (`forestshop-novy.newlevel.media`,
+  `vychod@varos.sk`): odznak "Na objednanie: 38" sa objavil po prvej
+  návšteve a PREŽIL prepnutie na "Sync zo Shoptetu" (#147); chip
+  "BETALOV" ostal aktívny po SKUTOČNOM obnovení stránky (#148); riadok
+  (obj. 20261249 / variant 62312) s otvoreným edit panelom odkazu na
+  dodávateľa OSTAL viditeľný pri zapnutom "Skryť vybavené", zmizol až po
+  zavretí editora (#149); Enter vložil nový riadok bez uloženia (obnovenie
+  potvrdilo), Ctrl+Enter uložil viacriadkový text (obnovenie potvrdilo
+  perzistenciu) (#150). Všetko vrátené do pôvodného stavu, baseline po
+  teste nedotknutý: `product_supplier_override|product_supplier_link_
+  override|order|order_line|order_line kde ordered` = `0|0|534|878|0`,
+  presne pôvodná hodnota. Všetky 4 tickety zavreté RUČNE (nie cez PR
+  `Closes #N`) až PO naživo overení, presne podľa `CLAUDE.md`'s
+  poznámky.
+- Playbook rozšírený: `.claude/rules/frontend-design.md` (dva NOVÉ
+  architektonické vzory — Context pre hodnotu prežívajúcu prepnutie
+  záložky; ľahký per-riadkový boolean signál namiesto zdvihnutia celého
+  draftu — plus wrapper-harness `useCallback` gotcha), `.claude/rules/
+  testing.md` (tag-scoped selector sa rozbije pri zmene tagu prvku;
+  Enter-vs-Ctrl+Enter potrebuje SKUTOČNÉ stláčanie klávesov, nie `.fill()`).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.89",
+  "version": "0.3.0-dev.90",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Docs-only follow-up to PR #154 (issue 147, issue 148, issue 149, issue 150) — version bump + playbook review, per the standard post-merge autopilot-log/playbook mandate.

- `docs/autopilot-log.md`: records the bundle's commits, design-decision comment links, and the live post-deploy verification evidence (nav badge, supplier persistence, dirty-editor guard, multiline comment) already used to close all four issues manually.
- `.claude/rules/frontend-design.md`: two reusable architecture patterns — a Context for a value that must survive a tab switch (unlike component-local state), and lifting a lightweight per-row boolean signal instead of the full draft state when a filter can unmount a mid-edit row.
- `.claude/rules/testing.md`: two e2e/vitest gotchas — a tag-scoped selector silently breaking when an element's tag changes, and why Enter-vs-Ctrl+Enter branching needs real keystrokes (`.press()`/`fireEvent.keyDown`), never `.fill()`.

No feature code changed. CI green on dev: see the push run for `290e239`.
