### PR TITLE
Bundle: dodávateľský koncept prežije refetch + triedenie skupín podľa dátumu (issue 151, issue 152)

### DIFF
--- a/apps/api/src/modules/orders/queries.ts
+++ b/apps/api/src/modules/orders/queries.ts
@@ -219,14 +219,24 @@ export async function listOpenOrderLinesBySupplier(
     const supplier = groupKey === NULL_GROUP_KEY ? NEZNAMY_DODAVATEL : pickCanonicalSupplierSpelling(acc.spellingCounts);
     return { supplier, lines: acc.lines, email: emailBySupplier.get(supplier) ?? null };
   });
-  // "(bez dodávateľa)" vždy naposledy (rovnaké správanie ako predtým — Postgres
-  // `ASC` triedenie `products.supplier` malo default `NULLS LAST`), zvyšok
-  // abecedne — nič v appke sa nespolieha na presné poradie skupín, ale
-  // deterministický výstup je jednoduchšie testovateľný a menej prekvapivý.
+  // issue 152: skupiny podľa NAJNOVŠEJ objednávky (najčerstvejšia prvá),
+  // pri zhode abecedne — priamy náprotivok starej appky (`app.js:2470-2476`,
+  // `2671-2672`). "(bez dodávateľa)" vždy naposledy (rovnaké správanie ako
+  // predtým — Postgres `ASC` triedenie `products.supplier` malo default
+  // `NULLS LAST`), bez ohľadu na jej vlastnú najnovšiu objednávku.
+  // `acc.lines[0]` je zaručene najnovší riadok DANEJ skupiny — riadky vyššie
+  // (`.orderBy(desc(orders.placedAt), desc(orderLines.id))`) sú UŽ zoradené
+  // najnovšie-prvé PRED zoskupením, takže prvý riadok, aký ktorákoľvek
+  // skupina pri iterácii dostane, je vždy jej najnovší (žiadny ďalší dopyt
+  // ani prepočet netreba). `placedAt` je už ISO 8601 reťazec, takže
+  // reťazcové porovnanie zodpovedá chronologickému poradiu bez parsovania.
   groups.sort((a, b) => {
     const aNull = a.supplier === NEZNAMY_DODAVATEL;
     const bNull = b.supplier === NEZNAMY_DODAVATEL;
     if (aNull !== bNull) return aNull ? 1 : -1;
+    const aNewest = a.lines[0]?.placedAt ?? "";
+    const bNewest = b.lines[0]?.placedAt ?? "";
+    if (aNewest !== bNewest) return aNewest > bNewest ? -1 : 1;
     return a.supplier < b.supplier ? -1 : a.supplier > b.supplier ? 1 : 0;
   });
   return groups;

--- a/apps/api/tests/orders-http-supplier-order.integration.test.ts
+++ b/apps/api/tests/orders-http-supplier-order.integration.test.ts
@@ -1,0 +1,139 @@
+import { expect, it } from "vitest";
+import { afterEach } from "vitest";
+import { orderLines, orders, users } from "../src/db/schema.js";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import type { UserRole } from "../src/modules/auth/service.js";
+import { insertTestVariant } from "./helpers/orders.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 152: dodávateľské skupiny (aj chipy hore, aj sekcie na stránke) sa
+// teraz zoraďujú podľa NAJNOVŠEJ objednávky (najčerstvejšia prvá), nie
+// abecedne — priamy náprotivok starej appky (`app.js:2470-2476`, `2671-
+// 2672`). VLASTNÝ súbor, rovnaký dôvod ako `orders-http-annotations
+// .integration.test.ts`/`orders-http-comment.integration.test.ts`: `orders-
+// http.integration.test.ts` je už na hranici eslint `max-lines: 400`
+// (`.claude/rules/testing.md`).
+
+const HESLO = "test-heslo-abc"; // testovacie údaje, nie tajomstvo
+
+let close: (() => Promise<void>) | undefined;
+
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  resetLoginRateLimit();
+});
+
+async function boot(role: UserRole) {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const [pouzivatel] = await ctx.db
+    .insert(users)
+    .values({
+      email: "manazer@forestshop.sk",
+      passwordHash: await hashPassword(HESLO),
+      displayName: "Manažér",
+      role,
+    })
+    .returning({ id: users.id });
+  if (pouzivatel === undefined) throw new Error("testovací používateľ sa nepodarilo vložiť");
+
+  const app = createApp(ctx.db, { cookieSecure: false });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "manazer@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie, db: ctx.db };
+}
+
+it("skupiny dodávateľov sú zoradené podľa NAJNOVŠEJ objednávky (najčerstvejšia prvá), nie abecedne", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  // Zámerne abecedne OPAČNÉ poradie, než aké má vzniknúť podľa dátumu —
+  // "Alfa" (najstaršia objednávka) by abecedne bola prvá, ale podľa dátumu
+  // musí skončiť POSLEDNÁ; "Zeta" (najnovšia) musí skončiť PRVÁ.
+  await insertTestVariant(db, "SUP-ALFA", "Dodávateľ Alfa");
+  await insertTestVariant(db, "SUP-STRED", "Dodávateľ Stred");
+  await insertTestVariant(db, "SUP-ZETA", "Dodávateľ Zeta");
+
+  const [najstarsia] = await db
+    .insert(orders)
+    .values({ externalOrderId: "9001", customerName: "Zákazník 1", placedAt: new Date("2026-07-01T00:00:00Z") })
+    .returning();
+  const [stredna] = await db
+    .insert(orders)
+    .values({ externalOrderId: "9002", customerName: "Zákazník 2", placedAt: new Date("2026-07-15T00:00:00Z") })
+    .returning();
+  const [najnovsia] = await db
+    .insert(orders)
+    .values({ externalOrderId: "9003", customerName: "Zákazník 3", placedAt: new Date("2026-07-20T00:00:00Z") })
+    .returning();
+  if (najstarsia === undefined || stredna === undefined || najnovsia === undefined) throw new Error("insert zlyhal");
+
+  await db.insert(orderLines).values([
+    { orderId: najstarsia.id, variantCode: "SUP-ALFA", quantity: 1 },
+    { orderId: stredna.id, variantCode: "SUP-STRED", quantity: 1 },
+    { orderId: najnovsia.id, variantCode: "SUP-ZETA", quantity: 1 },
+  ]);
+
+  const res = await app.request("/api/orders/open", { headers: { cookie } });
+  expect(res.status).toBe(200);
+  const telo = (await res.json()) as { suppliers: { supplier: string }[] };
+
+  expect(telo.suppliers.map((s) => s.supplier)).toEqual(["Dodávateľ Zeta", "Dodávateľ Stred", "Dodávateľ Alfa"]);
+});
+
+// Pri REMÍZE (rovnaký čas najnovšej objednávky oboch skupín) sa rozhoduje
+// abecedne — priamy náprotivok existujúcej `supplier-key.test.ts`'s "remíza
+// sa rozhodne abecedne" pravidla pre pravopis v rámci JEDNEJ skupiny,
+// tentokrát na úrovni PORADIA SAMOTNÝCH SKUPÍN.
+it("pri zhodnom čase najnovšej objednávky sa poradie skupín rozhodne abecedne", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  await insertTestVariant(db, "SUP-BETA", "Dodávateľ Beta");
+  await insertTestVariant(db, "SUP-CENTRUM", "Dodávateľ Centrum");
+
+  const [zdielanaObjednavka] = await db
+    .insert(orders)
+    .values({ externalOrderId: "9010", customerName: "Zákazník", placedAt: new Date("2026-07-18T00:00:00Z") })
+    .returning();
+  if (zdielanaObjednavka === undefined) throw new Error("insert zlyhal");
+  await db.insert(orderLines).values([
+    { orderId: zdielanaObjednavka.id, variantCode: "SUP-BETA", quantity: 1 },
+    { orderId: zdielanaObjednavka.id, variantCode: "SUP-CENTRUM", quantity: 1 },
+  ]);
+
+  const res = await app.request("/api/orders/open", { headers: { cookie } });
+  const telo = (await res.json()) as { suppliers: { supplier: string }[] };
+  expect(telo.suppliers.map((s) => s.supplier)).toEqual(["Dodávateľ Beta", "Dodávateľ Centrum"]);
+});
+
+// "(bez dodávateľa)" ostáva VŽDY posledný, aj keď má ONA NAJNOVŠIU
+// objednávku zo všetkých skupín — akceptačná podmienka to žiada výslovne.
+it("'(bez dodávateľa)' ostáva vždy posledný, aj keď má najnovšiu objednávku spomedzi všetkých skupín", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  await insertTestVariant(db, "SUP-STARY", "Dodávateľ Starý");
+  await insertTestVariant(db, "SUP-BEZ", null);
+
+  const [starsiaObjednavka] = await db
+    .insert(orders)
+    .values({ externalOrderId: "9020", customerName: "Zákazník 1", placedAt: new Date("2026-07-01T00:00:00Z") })
+    .returning();
+  const [najnovsiaObjednavka] = await db
+    .insert(orders)
+    .values({ externalOrderId: "9021", customerName: "Zákazník 2", placedAt: new Date("2026-07-25T00:00:00Z") })
+    .returning();
+  if (starsiaObjednavka === undefined || najnovsiaObjednavka === undefined) throw new Error("insert zlyhal");
+
+  await db.insert(orderLines).values([
+    { orderId: starsiaObjednavka.id, variantCode: "SUP-STARY", quantity: 1 },
+    // Najnovšia objednávka zo VŠETKÝCH ide práve na riadok BEZ dodávateľa.
+    { orderId: najnovsiaObjednavka.id, variantCode: "SUP-BEZ", quantity: 1 },
+  ]);
+
+  const res = await app.request("/api/orders/open", { headers: { cookie } });
+  const telo = (await res.json()) as { suppliers: { supplier: string }[] };
+  expect(telo.suppliers.map((s) => s.supplier)).toEqual(["Dodávateľ Starý", "(bez dodávateľa)"]);
+});

--- a/apps/web/src/components/OrderLineRow.tsx
+++ b/apps/web/src/components/OrderLineRow.tsx
@@ -27,12 +27,14 @@ export function OrderLineRow({
   busySupplierLineId,
   busySupplierLinkLineId,
   busyCommentOrderId,
+  pendingSupplierDraft,
   onChangeState,
   onChangeOrdered,
   onAssignSupplier,
   onSetSupplierLink,
   onChangeComment,
   onEditorActivityChange,
+  onSupplierDraftChange,
 }: {
   readonly line: OrderLine;
   readonly canChangeState: boolean;
@@ -62,6 +64,13 @@ export function OrderLineRow({
   // issue 64: objednávka (nie riadok — poznámka patrí CELEJ objednávke),
   // ktorej poznámka PRÁVE TERAZ ukladá.
   readonly busyCommentOrderId: string | null;
+  // issue 151: rozpísaný, ešte neuložený koncept priradenia dodávateľa —
+  // žije v `OrdersSection.tsx`'s `useSupplierDrafts.ts`, NIE lokálne tu
+  // (`useSupplierDrafts.ts` vysvetľuje prečo: priradenie mení SKUPINU
+  // riadku, takže lokálny stav v tejto komponente presun medzi skupinami
+  // neprežije). `undefined`, keď tento riadok nemá rozpísaný koncept —
+  // vtedy sa zobrazuje priamo `line.manualSupplierOverride`.
+  readonly pendingSupplierDraft: string | undefined;
   readonly onChangeState: (lineId: string, newState: OrderLine["state"]) => void;
   readonly onChangeOrdered: (lineId: string, ordered: boolean) => void;
   readonly onAssignSupplier: (lineId: string, supplier: string) => void;
@@ -75,33 +84,23 @@ export function OrderLineRow({
   // "skryť vybavené" filtra, aby riadok nezmizol spod rúk. Nesie len boolean,
   // nikdy samotný rozpísaný text (ten ostáva výlučne tu, v tomto komponente).
   readonly onEditorActivityChange: (lineId: string, active: boolean) => void;
+  // issue 151: hlási RODIČOVI (`OrdersSection.tsx`'s `useSupplierDrafts.ts`)
+  // KAŽDÚ zmenu rozpísaného konceptu priradenia dodávateľa — na rozdiel od
+  // `onEditorActivityChange` vyššie (len boolean) tu ide o SAMOTNÝ TEXT,
+  // lebo ten musí prežiť aj presun riadku medzi skupinami (remount).
+  readonly onSupplierDraftChange: (lineId: string, value: string) => void;
 }): JSX.Element {
   const qtyChip = variantTotal !== undefined ? formatVariantTotalChip(variantTotal) : null;
 
-  // issue 63: lokálny koncept vstupu — controlled, ale RESETOVANÝ z props
-  // vždy, keď server potvrdí novú hodnotu (`line.manualSupplierOverride`
-  // sa zmení po úspešnom uložení + refetchi, `OrdersSection.tsx`'s
-  // `assignSupplier`). Bez tohto by po uložení zostal v poli VIDIEŤ starý
-  // koncept, keď riadok NEZMENÍ skupinu (rovnaký pravopis po normalizácii).
-  const [supplierDraft, setSupplierDraft] = useState(line.manualSupplierOverride ?? "");
-  // issue 89 (nezávislý audit, objavené novým testom `OrdersSection
-  // .assignSupplier.test.tsx`): tento efekt PREDTÝM bežal aj pri PRVOM
-  // mountnutí (React spúšťa `useEffect` vždy po prvom commite, bez ohľadu
-  // na to, či sa "závislosť skutočne zmenila"), čo bolo úplne zbytočné
-  // (`useState` vyššie už štartuje s TOU ISTOU hodnotou) — a navyše
-  // pretekové: rýchla interakcia hneď po mounte (presne to, čo nový test
-  // robí) mohla zachytiť tento oneskorený "reset na ''" AŽ PO tom, čo
-  // manažér už stihol napísať koncept, a ticho ho vymazať (~1 z ~150
-  // lokálnych behov). Skip na prvom mounte odstraňuje pretek — efekt teraz
-  // reaguje len na SKUTOČNÚ zmenu `manualSupplierOverride` po uložení.
-  const isFirstMount = useRef(true);
-  useEffect(() => {
-    if (isFirstMount.current) {
-      isFirstMount.current = false;
-      return;
-    }
-    setSupplierDraft(line.manualSupplierOverride ?? "");
-  }, [line.manualSupplierOverride]);
+  // issue 63 + issue 151: zobrazovaná hodnota je ODVODENÁ z props, nie
+  // lokálny stav — `pendingSupplierDraft` (rodičovská mapa, prežije presun
+  // riadku medzi skupinami) má prednosť pred potvrdenou hodnotou zo servera.
+  // Žiadny `useState`/reset `useEffect`/dirty ref tu netreba: keď rodič
+  // nedrží rozpísaný koncept (`undefined`), zobrazí sa priamo
+  // `line.manualSupplierOverride`; keď drží, zobrazí sa TEN, bez ohľadu na
+  // to, či ide o re-render TEJ ISTEJ inštancie, alebo o čerstvo namontovanú
+  // (rodič zosúlaďuje/čistí mapu sám, `useSupplierDrafts.ts`'s `reconcile`).
+  const supplierDraft = pendingSupplierDraft ?? (line.manualSupplierOverride ?? "");
   const supplierBusyHere = busySupplierLineId === line.lineId;
   const saveSupplier = (): void => {
     const trimmed = supplierDraft.trim();
@@ -375,7 +374,7 @@ export function OrderLineRow({
               value={supplierDraft}
               disabled={supplierBusyHere}
               onChange={(e) => {
-                setSupplierDraft(e.target.value);
+                onSupplierDraftChange(line.lineId, e.target.value);
               }}
               onKeyDown={(e) => {
                 if (e.key === "Enter") {

--- a/apps/web/src/components/OrdersSection.assignSupplier.test.tsx
+++ b/apps/web/src/components/OrdersSection.assignSupplier.test.tsx
@@ -136,3 +136,83 @@ it("zamietnuté priradenie (409) zobrazí slovenskú hlášku A ZÁROVEŇ sprav�
     "⚠️ Nepodarilo sa uložiť 1 položku×Priradenie dodávateľa — obj. 1003, kód C-1 (Produkt už má dodávateľa v katalógu — ručné priradenie nie je možné)",
   );
 });
+
+// issue 151: priradenie dodávateľa platí pre CELÝ PRODUKT
+// (`supplier-assignment.ts`'s `productSupplierOverrides` kľúčovaná
+// `productKey`), takže po uložení cez JEDEN riadok server vráti novú
+// `manualSupplierOverride` hodnotu aj pre KAŽDÝ SÚRODENECKÝ riadok toho
+// istého produktu (iná veľkosť/objednávka) — nielen pre riadok, čo reálne
+// uložil. `assignSupplier` robí PLNÝ refetch po úspechu, takže simulujeme to
+// isté: druhý `fetchOpenOrders` návrat nesie NOVÚ `manualSupplierOverride`
+// hodnotu na OBOCH riadkoch (presne to, čo by server vrátil pre dva riadky
+// toho istého produktu), zatiaľ čo riadok A má stále rozpísaný, ešte
+// NEULOŽENÝ koncept.
+const LINE_A_SUROD = {
+  ...LINE_BEZ_DODAVATELA,
+  lineId: "44444444-4444-4444-4444-444444444444",
+  orderId: "cccccccc-4444-4444-4444-444444444444",
+  externalOrderId: "1004",
+  variantCode: "C-2",
+};
+
+it("rozpísaný, ešte neuložený koncept priradenia dodávateľa na riadku A PREŽIJE uloženie dodávateľa cez SÚRODENECKÝ riadok B (rovnaký produkt)", async () => {
+  fetchOpenOrders.mockResolvedValueOnce([
+    {
+      supplier: "(bez dodávateľa)",
+      lines: [LINE_A_SUROD, LINE_BEZ_DODAVATELA],
+      email: null,
+    },
+  ]);
+  assignOrderLineSupplier.mockResolvedValue(undefined);
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  // Manažér rozpíše koncept na riadku A, ale NEULOŽÍ ho.
+  const vstupA = await screen.findByLabelText<HTMLInputElement>(
+    `Priradiť dodávateľa riadku objednávky ${LINE_A_SUROD.externalOrderId} / ${LINE_A_SUROD.variantCode}`,
+  );
+  fireEvent.change(vstupA, { target: { value: "Rozpísaný, ešte neuložený dodávateľ" } });
+  expect(vstupA.value).toBe("Rozpísaný, ešte neuložený dodávateľ");
+
+  // Server (po úspešnom uložení cez riadok B) vráti OBIDVA riadky s NOVOU
+  // `manualSupplierOverride` hodnotou — presne tak, ako by to spravil
+  // skutočný per-produktový override.
+  fetchOpenOrders.mockResolvedValueOnce([
+    {
+      supplier: "Dodávateľ XYZ",
+      lines: [
+        { ...LINE_A_SUROD, manualSupplierOverride: "Dodávateľ XYZ" },
+        { ...LINE_BEZ_DODAVATELA, manualSupplierOverride: "Dodávateľ XYZ" },
+      ],
+      email: null,
+    },
+  ]);
+  await vyplnAUloz("Dodávateľ XYZ");
+
+  await waitFor(() => {
+    expect(assignOrderLineSupplier).toHaveBeenCalledWith(LINE_BEZ_DODAVATELA.lineId, "Dodávateľ XYZ");
+  });
+  await waitFor(() => {
+    expect(fetchOpenOrders).toHaveBeenCalledTimes(2);
+  });
+
+  // Riadok A NEBOL uložený — jeho rozpísaný koncept musí PREŽIŤ, nesmie sa
+  // ticho prepísať na hodnotu, ktorú práve dostal z refetchu (rovnaký
+  // produkt, teda rovnaká `manualSupplierOverride`, ako riadok B, čo reálne
+  // uložil).
+  //
+  // Priradenie dodávateľa MENÍ SKUPINU riadku (`effectiveSupplier` sa zmení
+  // z "(bez dodávateľa)" na "Dodávateľ XYZ") — `OrdersSection.tsx`'s
+  // `SupplierOrderGroup` má `key={group.supplier}`, takže pôvodná inštancia
+  // `OrderLineRow` pre riadok A sa ODMONTUJE a NAMONTUJE sa nová pod novou
+  // skupinou. Držať sa STAREJ (`vstupA`) referencie by test urobilo FALOŠNE
+  // ZELENÝM — stará, odpojená referencia si ticho drží svoju poslednú
+  // hodnotu bez ohľadu na to, čo je aktuálne v DOM-e. Preto sa hodnota číta
+  // ZNOVA, cez čerstvý dotaz PO refetchi.
+  await waitFor(() => {
+    const vstupAPoRefetchi = screen.getByLabelText<HTMLInputElement>(
+      `Priradiť dodávateľa riadku objednávky ${LINE_A_SUROD.externalOrderId} / ${LINE_A_SUROD.variantCode}`,
+    );
+    expect(vstupAPoRefetchi.value).toBe("Rozpísaný, ešte neuložený dodávateľ");
+  });
+});

--- a/apps/web/src/components/OrdersSection.tsx
+++ b/apps/web/src/components/OrdersSection.tsx
@@ -10,6 +10,8 @@ import { OrdersRemainingCountContext } from "../ordersRemainingCountContext.js";
 import { isLineHiddenByFilter, summarizeOrderLines } from "../ordersSummary.js";
 import { clearWriteFailure, lineWhere, orderWhere, upsertWriteFailure, type OrderWriteFailure } from "../ordersWriteFailures.js";
 import { useDirtyEditorLineIds } from "../useDirtyEditorLineIds.js";
+import { useSelectedSupplierFallback } from "../useSelectedSupplierFallback.js";
+import { useSupplierDrafts } from "../useSupplierDrafts.js";
 import { useSupplierEmailEditing } from "../useSupplierEmailEditing.js";
 import { useSupplierMailActions } from "../useSupplierMailActions.js";
 import { OrderOpenStatusesPanel } from "./OrderOpenStatusesPanel.js";
@@ -105,6 +107,11 @@ export function OrdersSection({
     copyOrderToClipboard,
   } = useSupplierMailActions(onSessionExpired);
 
+  // issue 151: rozpísaný koncept priradenia dodávateľa — musí žiť TU, nie
+  // lokálne v `OrderLineRow` (`useSupplierDrafts.ts` vysvetľuje prečo).
+  // Zosúlaďuje sa SAMO, vnútri hooku, po každej zmene `suppliers`.
+  const supplierDrafts = useSupplierDrafts(suppliers);
+
   const load = useCallback(() => {
     fetchOpenOrders()
       .then((items) => {
@@ -134,19 +141,9 @@ export function OrdersSection({
     setOrdersRemainingCount(summarizeOrderLines(allLines).remaining);
   }, [loaded, suppliers, setOrdersRemainingCount]);
 
-  // issue 148 — priamy náprotivok starej appky's fallback (`app.js:2677-2680`):
-  // keď je dodávateľ vybraný z PREDCHÁDZAJÚCEJ relácie/dňa (localStorage) a
-  // medzi PRÁVE načítanými skupinami už vôbec nefiguruje, výber spadne späť
-  // na "Všetci" — namiesto toho, aby zobrazil prázdny zoznam s aktívnym
-  // chipom, ktorý nikde nie je. `suppliers.length === 0` sa zámerne
-  // VYNECHÁVA (rovnako ako stará appka) — prechodné zlyhanie fetchu nesmie
-  // zahodiť platný výber.
-  useEffect(() => {
-    if (!loaded || selectedSupplier === null || suppliers.length === 0) return;
-    if (!suppliers.some((group) => group.supplier === selectedSupplier)) {
-      selectSupplier(null);
-    }
-  }, [loaded, suppliers, selectedSupplier, selectSupplier]);
+  // issue 148 (vyňaté do `useSelectedSupplierFallback.ts`, issue 151 —
+  // uvoľnenie miesta pod eslint `max-lines`, BEZ zmeny správania).
+  useSelectedSupplierFallback(loaded, suppliers, selectedSupplier, selectSupplier);
 
   const changeState = useCallback(
     (lineId: string, newState: OrderLine["state"]) => {
@@ -461,6 +458,7 @@ export function OrdersSection({
           hideResolved={hideResolved}
           dirtyEditorLineIds={dirtyEditorLineIds}
           onEditorActivityChange={onEditorActivityChange}
+          supplierDrafts={supplierDrafts}
           canChangeState={canChangeState}
           busyLineId={busyLineId}
           busyOrderedLineId={busyOrderedLineId}

--- a/apps/web/src/components/SupplierOrderGroup.tsx
+++ b/apps/web/src/components/SupplierOrderGroup.tsx
@@ -1,5 +1,6 @@
 import type { JSX } from "react";
 import { computeVariantTotals, isLineHiddenByFilter } from "../ordersSummary.js";
+import type { SupplierDraftsApi } from "../useSupplierDrafts.js";
 import { OrderLineRow } from "./OrderLineRow.js";
 import { SupplierActionsPanel } from "./SupplierActionsPanel.js";
 import type { OrderLine, OrderMailPreview, SupplierOpenOrders } from "../ordersApi.js";
@@ -17,6 +18,7 @@ export function SupplierOrderGroup({
   hideResolved,
   dirtyEditorLineIds,
   onEditorActivityChange,
+  supplierDrafts,
   canChangeState,
   busyLineId,
   busyOrderedLineId,
@@ -55,6 +57,11 @@ export function SupplierOrderGroup({
   // manažérovi, ktorý doň ešte niečo píše (`OrdersSection.tsx`'s komentár).
   readonly dirtyEditorLineIds: ReadonlySet<string>;
   readonly onEditorActivityChange: (lineId: string, active: boolean) => void;
+  // issue 151: rozpísaný, ešte neuložený koncept priradenia dodávateľa,
+  // zdvihnutý na úroveň `OrdersSection` (`useSupplierDrafts.ts` vysvetľuje
+  // prečo — prežije presun riadku medzi skupinami, čo lokálny stav v
+  // `OrderLineRow` neprežije).
+  readonly supplierDrafts: SupplierDraftsApi;
   readonly canChangeState: boolean;
   readonly busyLineId: string | null;
   readonly busyOrderedLineId: string | null;
@@ -190,12 +197,14 @@ export function SupplierOrderGroup({
                 busySupplierLineId={busySupplierLineId}
                 busySupplierLinkLineId={busySupplierLinkLineId}
                 busyCommentOrderId={busyCommentOrderId}
+                pendingSupplierDraft={supplierDrafts.draftByLineId.get(line.lineId)}
                 onChangeState={onChangeState}
                 onChangeOrdered={onChangeOrdered}
                 onAssignSupplier={onAssignSupplier}
                 onSetSupplierLink={onSetSupplierLink}
                 onChangeComment={onChangeComment}
                 onEditorActivityChange={onEditorActivityChange}
+                onSupplierDraftChange={supplierDrafts.setDraft}
               />
             ))}
           </tbody>

--- a/apps/web/src/useSelectedSupplierFallback.ts
+++ b/apps/web/src/useSelectedSupplierFallback.ts
@@ -1,0 +1,27 @@
+import { useEffect } from "react";
+import type { SupplierOpenOrders } from "./ordersApi.js";
+
+// issue 148 — priamy náprotivok starej appky's fallback (`app.js:2677-2680`):
+// keď je dodávateľ vybraný z PREDCHÁDZAJÚCEJ relácie/dňa (localStorage) a
+// medzi PRÁVE načítanými skupinami už vôbec nefiguruje, výber spadne späť
+// na "Všetci" — namiesto toho, aby zobrazil prázdny zoznam s aktívnym
+// chipom, ktorý nikde nie je. `suppliers.length === 0` sa zámerne
+// VYNECHÁVA (rovnako ako stará appka) — prechodné zlyhanie fetchu nesmie
+// zahodiť platný výber.
+//
+// Vyňaté z `OrdersSection.tsx` (issue 151 — uvoľnenie miesta pod eslint
+// `max-lines` pre `useSupplierDrafts`, rovnaký dôvod ako existujúce hook-
+// extrakcie, `.claude/rules/frontend-design.md`), BEZ zmeny správania.
+export function useSelectedSupplierFallback(
+  loaded: boolean,
+  suppliers: readonly SupplierOpenOrders[],
+  selectedSupplier: string | null,
+  selectSupplier: (next: string | null) => void,
+): void {
+  useEffect(() => {
+    if (!loaded || selectedSupplier === null || suppliers.length === 0) return;
+    if (!suppliers.some((group) => group.supplier === selectedSupplier)) {
+      selectSupplier(null);
+    }
+  }, [loaded, suppliers, selectedSupplier, selectSupplier]);
+}

--- a/apps/web/src/useSupplierDrafts.ts
+++ b/apps/web/src/useSupplierDrafts.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useState } from "react";
+import type { SupplierOpenOrders } from "./ordersApi.js";
+
+// issue 151 — vyňaté z `OrdersSection.tsx`, rovnaký princíp ako existujúce
+// `useDirtyEditorLineIds.ts` (issue 149), tentokrát nesúci SAMOTNÝ ROZPÍSANÝ
+// TEXT namiesto len ľahkého boolean signálu.
+//
+// Prečo to nestačí držať lokálne v `OrderLineRow` (`isSupplierDirty` ref by
+// bola prirodzená prvá voľba, presne ako `isCommentDirty` pri komentári):
+// priradenie dodávateľa platí pre CELÝ PRODUKT (`supplier-assignment.ts`),
+// takže po uložení sa `effectiveSupplier` (teda aj SKUPINA riadku,
+// `OrdersSection.tsx`'s `SupplierOrderGroup key={group.supplier}`) zmení pre
+// KAŽDÝ riadok toho istého produktu — nielen ten, čo reálne uložil. Zmena
+// skupiny znamená, že `OrderLineRow` danej inštancie sa NEPREKRESLÍ so
+// zmenenými props — ODMONTUJE sa (starý strom pod starou skupinou) a NOVÁ
+// inštancia sa NAMONTUJE pod novou skupinou (empiricky overené priamym
+// behom, nie len čítaním kódu — `document.contains()` na starý DOM uzol
+// vrátil `false`). Žiadny lokálny `useState`/`useEffect`/`ref` neprežije
+// tento prechod — musí žiť tu, na úrovni `OrdersSection`, ktorá sa
+// presúvaním riadkov medzi skupinami NIKDY neodmontuje.
+//
+// `OrderLineRow` odvodí zobrazovanú hodnotu ako `pendingDraft ??
+// (line.manualSupplierOverride ?? "")` — pri remounte tak automaticky
+// dostane SPRÁVNU, ešte neuloženú hodnotu z tejto mapy namiesto čerstvo
+// inicializovaného stavu.
+export interface SupplierDraftsApi {
+  readonly draftByLineId: ReadonlyMap<string, string>;
+  readonly setDraft: (lineId: string, value: string) => void;
+}
+
+// `groups` je `OrdersSection.tsx`'s `suppliers` stav — zosúladenie beží
+// SAMO po KAŽDEJ jeho zmene (teda po KAŽDOM refetchi), takže volajúci
+// nemusí na nič zvlášť myslieť. Čistí záznam, keď potvrdená
+// `manualSupplierOverride` (zo servera) už zodpovedá rozpísanému konceptu
+// (uloženie sa potvrdilo), a záznamy, ktorých riadok medzičasom vôbec
+// zmizol zo zoznamu otvorených objednávok (vybavené/zmenený stav). Bez
+// tohto by mapa raz uložený koncept držala NAVŽDY a blokovala by
+// akúkoľvek budúcu legitímnu externú zmenu (napr. kolegom).
+export function useSupplierDrafts(groups: readonly SupplierOpenOrders[]): SupplierDraftsApi {
+  const [draftByLineId, setDraftByLineId] = useState<ReadonlyMap<string, string>>(new Map());
+
+  const setDraft = useCallback((lineId: string, value: string) => {
+    setDraftByLineId((current) => {
+      const next = new Map(current);
+      next.set(lineId, value);
+      return next;
+    });
+  }, []);
+
+  useEffect(() => {
+    setDraftByLineId((current) => {
+      if (current.size === 0) return current;
+      const overrideByLineId = new Map(
+        groups.flatMap((group) => group.lines).map((line) => [line.lineId, line.manualSupplierOverride ?? ""]),
+      );
+      let changed = false;
+      const next = new Map(current);
+      for (const [lineId, draft] of current) {
+        const confirmed = overrideByLineId.get(lineId);
+        if (confirmed === undefined || draft.trim() === confirmed) {
+          next.delete(lineId);
+          changed = true;
+        }
+      }
+      return changed ? next : current;
+    });
+  }, [groups]);
+
+  return { draftByLineId, setDraft };
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.90",
+  "version": "0.3.0-dev.91",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Bundle: rozpísaný koncept dodávateľa prežije refetch + zoradenie skupín podľa najnovšej objednávky (issue 151, issue 152)

## issue 151 (bug): rozpísané meno dodávateľa sa stratilo pri obnovení zoznamu

Priradenie dodávateľa platí pre CELÝ produkt, takže uloženie cez jeden
riadok mení skupinu (`SupplierOrderGroup key={group.supplier}`) pre
KAŽDÝ riadok toho istého produktu — nielen ten, čo reálne uložil.
Empiricky overené priamym behom (nie len čítaním kódu): zmena skupiny
je pre React REMOUNT, nie re-render, takže žiadny lokálny stav v
`OrderLineRow` túto zmenu neprežije.

Fix zdvíha rozpísaný koncept na úroveň `OrdersSection` (nový
`useSupplierDrafts.ts` hook, rovnaký princíp ako existujúce
`useDirtyEditorLineIds.ts` z issue 149) — táto komponenta sa presúvaním
riadkov medzi skupinami nikdy neodmontuje. `OrderLineRow` teraz
ODVODZUJE zobrazovanú hodnotu z props namiesto vlastného stavu; rodič
zosúlaďuje mapu po každej zmene zoznamu.

Regresný test (RED→GREEN, samostatné commity) simuluje presne opísaný
scenár a číta hodnotu cez ČERSTVÝ DOM dotaz po refetchi (nie starú
odpojenú referenciu, ktorá by dala falošne zelený výsledok).

## issue 152 (feature): zoradiť dodávateľov podľa najnovšej objednávky, nie abecedne

Priamy náprotivok starej appky — skupina s najčerstvejšou objednávkou
je prvá, pri zhode abecedne, "(bez dodávateľa)" ostáva vždy posledný.
Nový integračný test pokrýva triedenie podľa dátumu, tie-break pri
zhode a "(bez dodávateľa)" vždy posledný aj s najnovšou objednávkou.

## Overenie

- `pnpm typecheck` / `pnpm lint` — čisté
- `pnpm --filter @forestshop/web test` — 275/275
- `pnpm --filter @forestshop/api test` — 323/323
- `pnpm --filter @forestshop/api test:integration` — 293/293 (45 súborov)
- `pnpm --filter @forestshop/web e2e` — 24/24, nulová konzola
- CI (dev push): version-check, check, integration, docker-build, e2e — všetko zelené
