### PR TITLE
docs(orders): clarify reconcile compares by value, not write identity (0.3.0-dev.93)

### DIFF
--- a/apps/web/src/useSupplierDrafts.ts
+++ b/apps/web/src/useSupplierDrafts.ts
@@ -57,6 +57,11 @@ export function useSupplierDrafts(groups: readonly SupplierOpenOrders[]): Suppli
       const next = new Map(current);
       for (const [lineId, draft] of current) {
         const confirmed = overrideByLineId.get(lineId);
+        // Code review (post-merge): toto porovnáva HODNOTU, nie totožnosť
+        // zápisu — nevie rozlíšiť "toto je MOJE uloženie, čo sa práve
+        // potvrdilo" od "niekto iný náhodou nastavil rovnaký text na tomto
+        // produkte inou cestou". V praxi je výsledok vizuálne identický v
+        // oboch prípadoch (koncept == potvrdená hodnota), takže to nevadí.
         if (confirmed === undefined || draft.trim() === confirmed) {
           next.delete(lineId);
           changed = true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.92",
+  "version": "0.3.0-dev.93",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Tiny follow-up from an independent post-merge code review of #156/#157 (0 critical/0 warning findings) — adds a one-line clarifying comment in useSupplierDrafts.ts's reconcile effect. No behavior change.