### PR TITLE
Na objednanie: okamžitá kontrola odkazu + ochrana pred vzorcom v hodnote (issue 153)

### DIFF
--- a/apps/api/src/http/orders-routes.ts
+++ b/apps/api/src/http/orders-routes.ts
@@ -10,6 +10,7 @@ import { listKnownStatusNames, listOpenStatusNames, replaceOpenStatusNames } fro
 import { getOrderDetail, listOpenOrderLinesBySupplier } from "../modules/orders/queries.js";
 import { assignOrderLineSupplier } from "../modules/orders/supplier-assignment.js";
 import { setProductSupplierLink } from "../modules/orders/supplier-link-assignment.js";
+import { startsWithFormulaChar } from "../modules/shoptet-writeback/formula-guard.js";
 import { setOrderComment, setOrderLineOrdered, setOrderLineState } from "../modules/orders/state.js";
 import { requireRole, requireUser, type AppBindings } from "./middleware.js";
 import { requireSameOrigin } from "./origin-check.js";
@@ -37,8 +38,24 @@ const orderLineSupplierBody = z.object({ supplier: z.string().trim().min(1).max(
 // (`OrderLineRow.tsx`), preto NAVYŠE `.regex` vynucuje http(s), rovnaký vzor
 // ako `adminUrl`/existujúci `supplierUrl` vo frontendovej `ordersApi.ts`
 // schéme (issue 70's "druhá vrstva overenia" zásada).
+// issue 153: `.refine` navyše — samostatná, POMENOVANÁ formula-injection
+// kontrola (`formula-guard.ts`, zdieľaná s CSV-sink ochranou v `csv.ts`).
+// Pre TOTO pole je dnes logicky prekrytá `.regex`om nižšie (hodnota
+// začínajúca `=`/`+`/`-`/`@` nikdy nemôže zároveň začínať `http`), ale ide o
+// obranu do hĺbky: chráni pred budúcim uvoľnením http(s) pravidla, ktoré by
+// inak potichu znovu otvorilo CSV-injection dieru (`internalNote` v
+// generovanom CSV, `select-changes.ts`) bez toho, aby si to niekto všimol —
+// viď ticketov design komentár.
 const orderLineSupplierLinkBody = z.object({
-  url: z.string().trim().url().max(2000).regex(/^https?:\/\//),
+  url: z
+    .string()
+    .trim()
+    .url()
+    .max(2000)
+    .regex(/^https?:\/\//)
+    .refine((v) => !startsWithFormulaChar(v), {
+      message: "odkaz nesmie začínať znakom vzorca (=, +, -, @) — možný pokus o CSV-injection",
+    }),
 });
 // issue 64: manažérova voľná poznámka k CELEJ objednávke — na rozdiel od
 // `orderLineSupplierBody` vyššie ZÁMERNE bez `.min(1)` (prázdny orezaný vstup

--- a/apps/api/src/modules/shoptet-writeback/csv.test.ts
+++ b/apps/api/src/modules/shoptet-writeback/csv.test.ts
@@ -38,4 +38,22 @@ describe("buildWritebackCsv", () => {
     const rows = csv.toString("utf8").slice(1).split("\r\n").filter(Boolean);
     expect(rows[1]).toBe('A;;"note; with ""quotes"""');
   });
+
+  // issue 153: CSV-injection ochrana — KAŽDÁ bunka (nielen `internalNote`,
+  // ktoré prechádza cez URL-tvarovú validáciu, ale aj `code`/`pairCode`,
+  // ktoré prichádzajú z katalógového importu bez akejkoľvek inej kontroly)
+  // začínajúca znakom vzorca sa neutralizuje priamo pri zápise CSV
+  // (`formula-guard.ts`'s `csvSafe`, rovnaký mechanizmus ako referenčná
+  // appka's `_csv_safe`).
+  it("neutralizuje bunku začínajúcu znakom vzorca v KTOROMKOĽVEK stĺpci (CSV-injection ochrana)", () => {
+    const csv = buildWritebackCsv([{ code: "=SUM(A1:A9)", pairCode: "+1", internalNote: "-2+3" }]);
+    const rows = csv.toString("utf8").slice(1).split("\r\n").filter(Boolean);
+    expect(rows[1]).toBe("'=SUM(A1:A9);'+1;'-2+3");
+  });
+
+  it("neutralizácia vzorca funguje aj SÚČASNE s uvodzovaním kvôli oddeľovaču", () => {
+    const csv = buildWritebackCsv([{ code: "A", pairCode: "", internalNote: "=cmd|'/c calc'!A1;X" }]);
+    const rows = csv.toString("utf8").slice(1).split("\r\n").filter(Boolean);
+    expect(rows[1]).toBe(`A;;"'=cmd|'/c calc'!A1;X"`);
+  });
 });

--- a/apps/api/src/modules/shoptet-writeback/csv.ts
+++ b/apps/api/src/modules/shoptet-writeback/csv.ts
@@ -8,6 +8,8 @@
  * zmeniť" + párovacie stĺpce).
  */
 
+import { csvSafe } from "./formula-guard.js";
+
 export interface WritebackRow {
   readonly code: string;
   readonly pairCode: string;
@@ -30,6 +32,17 @@ function rowToLine(values: readonly string[]): string {
   return values.map(quoteField).join(";");
 }
 
+// issue 153: CSV-injection ochrana PRI ZÁPISE — `csvSafe` sa aplikuje na
+// KAŽDÚ bunku DÁTOVÉHO riadku (nie na hlavičku, tá je statická), bez ohľadu
+// na to, čo už overila validácia vyššie (`code`/`pairCode` prichádzajú z
+// katalógového importu, ktorý ŽIADNU takú kontrolu nerobí). Poradie MUSÍ byť
+// `csvSafe` PRED `quoteField` — pridaná úvodná `'` sama osebe nikdy
+// nevyžaduje CSV-uvodzovanie, ale pôvodná hodnota môže, takže `quoteField`
+// beží AŽ na výslednom (už neutralizovanom) reťazci.
+function dataRowToLine(values: readonly string[]): string {
+  return values.map(csvSafe).map(quoteField).join(";");
+}
+
 /**
  * Builds the write-back CSV as a Buffer ready to upload — UTF-8 BOM prefix,
  * one row per given variant (caller decides which variants: one per changed
@@ -41,7 +54,7 @@ export function buildWritebackCsv(rows: readonly WritebackRow[]): Buffer {
   if (rows.length === 0) {
     throw new Error("buildWritebackCsv: žiadne riadky na zápis — CSV sa nesmie nahrať prázdne");
   }
-  const lines = [rowToLine(HEADER), ...rows.map((r) => rowToLine([r.code, r.pairCode, r.internalNote]))];
+  const lines = [rowToLine(HEADER), ...rows.map((r) => dataRowToLine([r.code, r.pairCode, r.internalNote]))];
   const bom = "﻿";
   return Buffer.from(bom + lines.join("\r\n") + "\r\n", "utf8");
 }

--- a/apps/api/src/modules/shoptet-writeback/formula-guard.test.ts
+++ b/apps/api/src/modules/shoptet-writeback/formula-guard.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { csvSafe, FORMULA_LEAD_CHARS, startsWithFormulaChar } from "./formula-guard.js";
+
+// issue 153: ochrana pred CSV-injection (hodnota začínajúca znakom vzorca).
+// Vlastný súbor — čistá funkcia, žiadna DB/HTTP závislosť, `.claude/rules/
+// testing.md`'s vzor (jednoduchá logika sa testuje samostatne, unit test).
+
+describe("startsWithFormulaChar", () => {
+  it.each(["=", "+", "-", "@"])("vráti true pre hodnotu začínajúcu '%s'", (znak) => {
+    expect(startsWithFormulaChar(`${znak}cmd|'/c calc'!A1`)).toBe(true);
+  });
+
+  it("vráti false pre bežnú hodnotu (URL, kód)", () => {
+    expect(startsWithFormulaChar("https://dodavatel.example.com/produkt")).toBe(false);
+    expect(startsWithFormulaChar("4859/46")).toBe(false);
+  });
+
+  it("vráti false pre prázdny reťazec", () => {
+    expect(startsWithFormulaChar("")).toBe(false);
+  });
+
+  it("FORMULA_LEAD_CHARS nesie presne štyri znaky z akceptačnej podmienky tiketu", () => {
+    expect(FORMULA_LEAD_CHARS).toEqual(["=", "+", "-", "@"]);
+  });
+});
+
+describe("csvSafe", () => {
+  it("neutralizuje hodnotu začínajúcu znakom vzorca — predsadí jednoduchú úvodzovku", () => {
+    expect(csvSafe("=SUM(A1:A9)")).toBe("'=SUM(A1:A9)");
+    expect(csvSafe("+1+1")).toBe("'+1+1");
+    expect(csvSafe("-2+3")).toBe("'-2+3");
+    expect(csvSafe("@SUM(1)")).toBe("'@SUM(1)");
+  });
+
+  it("nechá bežnú hodnotu bezo zmeny", () => {
+    expect(csvSafe("https://dodavatel.example.com/x")).toBe("https://dodavatel.example.com/x");
+    expect(csvSafe("4859/46")).toBe("4859/46");
+    expect(csvSafe("")).toBe("");
+  });
+});

--- a/apps/api/src/modules/shoptet-writeback/formula-guard.ts
+++ b/apps/api/src/modules/shoptet-writeback/formula-guard.ts
@@ -1,0 +1,31 @@
+/**
+ * CSV/spreadsheet formula-injection guard (issue 153). A cell beginning with
+ * one of these four characters is interpreted as a LIVE FORMULA by Excel/
+ * LibreOffice/Google Sheets when the CSV is opened — real forestshop values
+ * (URLs, product/pairing codes) never start with them. Same four characters
+ * as the sibling `parovanie_produktov` app's `_FORMULA_LEAD`/`_csv_safe`
+ * (`webreview/app.py`) — this is a direct behavioural port, see issue 153's
+ * design comment for why the reference app's OWN URL fields never needed a
+ * separate reject (the `^https?:\/\//` shape rule already excludes them) and
+ * where it DOES add one (its supplier-name field, which has no other shape
+ * rule).
+ */
+export const FORMULA_LEAD_CHARS = ["=", "+", "-", "@"] as const;
+
+export function startsWithFormulaChar(value: string): boolean {
+  const first = value.slice(0, 1);
+  return (FORMULA_LEAD_CHARS as readonly string[]).includes(first);
+}
+
+/**
+ * Neutralizes a formula-leading CSV cell value — prefixes a single quote so
+ * spreadsheet software renders it as inert text instead of evaluating it as
+ * a formula (identical mechanism to the reference app's `_csv_safe`).
+ * Applied at the CSV SINK (`csv.ts`) to EVERY emitted cell, independent of
+ * whatever upstream validation already did — belt-and-braces, since `code`/
+ * `pairCode` come from the Shoptet catalog import (`variants` table), not
+ * from a form validated anywhere in this app.
+ */
+export function csvSafe(value: string): string {
+  return startsWithFormulaChar(value) ? `'${value}` : value;
+}

--- a/apps/api/tests/orders-supplier-link-assignment.integration.test.ts
+++ b/apps/api/tests/orders-supplier-link-assignment.integration.test.ts
@@ -314,6 +314,35 @@ it("neplatná URL vráti 400 (validácia)", async () => {
   expect(res.status).toBe(400);
 });
 
+// issue 153: samostatná, POMENOVANÁ kontrola pred CSV-injection — nezávislá
+// od http(s)-tvarovej validácie vyššie (tá by KAŽDÚ hodnotu začínajúcu
+// znakom vzorca zamietla aj sama, keďže žiadna z nich nemôže zároveň začínať
+// na "http"). Test dokazuje, že sa v odpovedi objaví SAMOSTATNÁ hláška o
+// vzorci, nie len všeobecná "neplatná URL" — teda že formula-guard skutočne
+// BEŽÍ, nie je len teoreticky prekrytý iným pravidlom (design komentár na
+// tickete vysvetľuje, prečo je to napriek tomu potrebné: obrana do hĺbky
+// proti budúcemu uvoľneniu http(s) regexu).
+it("odkaz začínajúci znakom vzorca (napr. '=') vráti 400 so samostatnou hláškou o vzorci", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await insertTestVariant(db, "L-FORMULA", "Dodávateľ");
+  const [objednavka] = await db
+    .insert(orders)
+    .values({ externalOrderId: "7011", customerName: "Zákazník", placedAt: new Date("2026-07-11T00:00:00Z") })
+    .returning();
+  if (objednavka === undefined) throw new Error("insert zlyhal");
+  const [line] = await db.insert(orderLines).values({ orderId: objednavka.id, variantCode: "L-FORMULA", quantity: 1 }).returning();
+  if (line === undefined) throw new Error("insert zlyhal");
+
+  const res = await app.request(`/api/orders/lines/${line.id}/supplier-link`, {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ url: "=cmd|'/c calc'!A1" }),
+  });
+  expect(res.status).toBe(400);
+  const telo = (await res.json()) as { error: { issues: { message: string }[] } };
+  expect(telo.error.issues.some((i) => /vzorc/i.test(i.message))).toBe(true);
+});
+
 // issue 121: `.url()` samo osebe by prijalo aj syntakticky platnú, ale
 // nebezpečnú schému (hodnota ide priamo do `<a href>`) — server-strana MUSÍ
 // navyše vynútiť http(s), nespoliehať sa len na frontendovú vrstvu.

--- a/apps/web/src/components/OrdersSection.supplierLinkValidation.test.tsx
+++ b/apps/web/src/components/OrdersSection.supplierLinkValidation.test.tsx
@@ -1,0 +1,64 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { OrdersSection } from "./OrdersSection.js";
+
+// issue 153: OKAMŽITÁ kontrola odkazu v prehliadači — PRED akýmkoľvek
+// zápisom na server. Vlastný súbor — rovnaký vzor ako existujúce
+// `OrdersSection.writeFailures.test.tsx`/`OrdersSection.assignSupplier.test
+// .tsx` splity (`.claude/rules/testing.md`).
+
+const { fetchOpenOrders, setProductSupplierLink } = vi.hoisted(() => ({
+  fetchOpenOrders: vi.fn(),
+  setProductSupplierLink: vi.fn(),
+}));
+
+vi.mock("../ordersApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../ordersApi.js")>();
+  return { ...actual, fetchOpenOrders, setProductSupplierLink };
+});
+
+const LINE_ALFA = {
+  lineId: "11111111-1111-1111-1111-111111111111",
+  orderId: "aaaaaaaa-1111-1111-1111-111111111111",
+  externalOrderId: "1001",
+  customerName: "Zákazník Alfa",
+  comment: null,
+  remark: null,
+  adminUrl: "https://www.forestshop.sk/admin/vyhladavanie/?string=1001&src=orders",
+  placedAt: "2026-07-01T00:00:00.000Z",
+  variantCode: "A-1",
+  variantName: "Nohavice FOREST",
+  sizeLabel: "3XL",
+  quantity: 2,
+  state: "objednane" as const,
+  ordered: false,
+  supplierUrl: null,
+  supplierNote: null,
+  externalCode: null,
+  supplierAssignable: false,
+  manualSupplierOverride: null,
+};
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+it("neplatný odkaz na dodávateľa sa odmietne OKAMŽITE v prehliadači — bez volania API", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_ALFA], email: null }]);
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const toggle = await screen.findByTestId(`supplier-link-edit-toggle-${LINE_ALFA.lineId}`);
+  fireEvent.click(toggle);
+  const input = screen.getByTestId(`supplier-link-edit-input-${LINE_ALFA.lineId}`);
+  fireEvent.change(input, { target: { value: "nieje-url" } });
+  fireEvent.click(screen.getByTestId(`supplier-link-edit-save-${LINE_ALFA.lineId}`));
+
+  await waitFor(() => {
+    expect(screen.getByTestId(`order-write-failure-supplierLink:${LINE_ALFA.lineId}`).textContent).toBe(
+      "Odkaz na dodávateľa — obj. 1001, kód A-1 (Odkaz musí byť platná adresa začínajúca http:// alebo https://.)",
+    );
+  });
+  expect(setProductSupplierLink).not.toHaveBeenCalled();
+});

--- a/apps/web/src/components/OrdersSection.tsx
+++ b/apps/web/src/components/OrdersSection.tsx
@@ -13,6 +13,7 @@ import { useDirtyEditorLineIds } from "../useDirtyEditorLineIds.js";
 import { useSelectedSupplierFallback } from "../useSelectedSupplierFallback.js";
 import { useSupplierDrafts } from "../useSupplierDrafts.js";
 import { useSupplierEmailEditing } from "../useSupplierEmailEditing.js";
+import { useSupplierLinkSave } from "../useSupplierLinkSave.js";
 import { useSupplierMailActions } from "../useSupplierMailActions.js";
 import { OrderOpenStatusesPanel } from "./OrderOpenStatusesPanel.js";
 import { OrdersToolbar } from "./OrdersToolbar.js";
@@ -23,12 +24,10 @@ import {
   fetchOpenOrders,
   NEZNAMY_DODAVATEL,
   OrdersUnauthorizedError,
-  setProductSupplierLink,
   setSupplierLinesOrdered,
   updateOrderComment,
   updateOrderLineOrdered,
   updateOrderLineState,
-  validateSupplierLinkUrl,
   type OrderLine,
   type SupplierOpenOrders,
 } from "../ordersApi.js";
@@ -270,52 +269,11 @@ export function OrdersSection({
 
   // issue 121: manuálny odkaz na dodávateľa — PLNÝ refetch po úspechu (rovnaký
   // dôvod ako `assignSupplier` vyššie: zmena platí pre celý PRODUKT, teda aj
-  // pre súrodenecké veľkosti toho istého riadku).
-  const [busySupplierLinkLineId, setBusySupplierLinkLineId] = useState<string | null>(null);
-
-  const setSupplierLink = useCallback(
-    (lineId: string, url: string) => {
-      const failureId = `supplierLink:${lineId}`;
-      const where = lineWhere(suppliers, lineId);
-      // issue 153: OKAMŽITÁ kontrola V PREHLIADAČI, PRED akýmkoľvek zápisom
-      // na server — zrkadlí presne server-strany pravidlo
-      // (`validateSupplierLinkUrl`, `ordersApi.ts`). Neplatná hodnota sa
-      // ukáže v tom istom kumulatívnom `writeFailures` banneri (issue 66)
-      // ako každé iné zlyhanie zápisu na tejto obrazovke — žiadny nový,
-      // samostatný chybový vzor.
-      const validationError = validateSupplierLinkUrl(url);
-      if (validationError !== null) {
-        setWriteFailures((current) =>
-          upsertWriteFailure(current, { id: failureId, what: "Odkaz na dodávateľa", where, detail: validationError }),
-        );
-        return;
-      }
-      setBusySupplierLinkLineId(lineId);
-      setProductSupplierLink(lineId, url)
-        .then(() => {
-          setWriteFailures((current) => clearWriteFailure(current, failureId));
-          load();
-        })
-        .catch((err: unknown) => {
-          if (err instanceof OrdersUnauthorizedError) {
-            onSessionExpired();
-            return;
-          }
-          setWriteFailures((current) =>
-            upsertWriteFailure(current, {
-              id: failureId,
-              what: "Odkaz na dodávateľa",
-              where,
-              detail: err instanceof Error ? err.message : "Uloženie odkazu na dodávateľa sa nepodarilo.",
-            }),
-          );
-        })
-        .finally(() => {
-          setBusySupplierLinkLineId(null);
-        });
-    },
-    [load, onSessionExpired, suppliers],
-  );
+  // pre súrodenecké veľkosti toho istého riadku). issue 153: vyňaté do
+  // `useSupplierLinkSave.ts` (pridalo okamžitú klientsku validáciu, čo
+  // poslalo tento súbor cez eslint `max-lines: 400` — rovnaký dôvod/vzor ako
+  // `useSupplierEmailEditing.ts`).
+  const { busySupplierLinkLineId, setSupplierLink } = useSupplierLinkSave(suppliers, setWriteFailures, load, onSessionExpired);
 
   // Hromadné označenie/zrušenie CELEJ skupiny dodávateľa naraz (stará appka's
   // `markGroupOrdered` — jedno tlačidlo, ktoré prepína smer podľa toho, či je

--- a/apps/web/src/components/OrdersSection.tsx
+++ b/apps/web/src/components/OrdersSection.tsx
@@ -28,6 +28,7 @@ import {
   updateOrderComment,
   updateOrderLineOrdered,
   updateOrderLineState,
+  validateSupplierLinkUrl,
   type OrderLine,
   type SupplierOpenOrders,
 } from "../ordersApi.js";
@@ -276,6 +277,19 @@ export function OrdersSection({
     (lineId: string, url: string) => {
       const failureId = `supplierLink:${lineId}`;
       const where = lineWhere(suppliers, lineId);
+      // issue 153: OKAMŽITÁ kontrola V PREHLIADAČI, PRED akýmkoľvek zápisom
+      // na server — zrkadlí presne server-strany pravidlo
+      // (`validateSupplierLinkUrl`, `ordersApi.ts`). Neplatná hodnota sa
+      // ukáže v tom istom kumulatívnom `writeFailures` banneri (issue 66)
+      // ako každé iné zlyhanie zápisu na tejto obrazovke — žiadny nový,
+      // samostatný chybový vzor.
+      const validationError = validateSupplierLinkUrl(url);
+      if (validationError !== null) {
+        setWriteFailures((current) =>
+          upsertWriteFailure(current, { id: failureId, what: "Odkaz na dodávateľa", where, detail: validationError }),
+        );
+        return;
+      }
       setBusySupplierLinkLineId(lineId);
       setProductSupplierLink(lineId, url)
         .then(() => {

--- a/apps/web/src/ordersApi.supplierLink.test.ts
+++ b/apps/web/src/ordersApi.supplierLink.test.ts
@@ -1,5 +1,5 @@
 import { expect, it, vi } from "vitest";
-import { OrdersUnauthorizedError, setProductSupplierLink } from "./ordersApi.js";
+import { OrdersUnauthorizedError, setProductSupplierLink, validateSupplierLinkUrl } from "./ordersApi.js";
 
 // issue 121: manuálny odkaz na dodávateľa — vlastný súbor (nie pridané do
 // `ordersApi.test.ts`, ktoré je už blízko eslint `max-lines: 400`), rovnaký
@@ -38,4 +38,27 @@ it("setProductSupplierLink pri 401 vyhodí OrdersUnauthorizedError", async () =>
   await expect(
     setProductSupplierLink("11111111-1111-1111-1111-111111111111", "https://dodavatel.example.com"),
   ).rejects.toBeInstanceOf(OrdersUnauthorizedError);
+});
+
+// issue 153: OKAMŽITÁ kontrola v prehliadači — zrkadlí presne rovnaké
+// pravidlo ako server (`orderLineSupplierLinkBody`, `orders-routes.ts`), aby
+// zamestnanec videl chybu HNEĎ, bez zbytočného round-tripu na server.
+it("validateSupplierLinkUrl vráti null pre platnú http(s) adresu", () => {
+  expect(validateSupplierLinkUrl("https://dodavatel.example.com/produkt")).toBeNull();
+  expect(validateSupplierLinkUrl("http://dodavatel.example.com")).toBeNull();
+});
+
+it("validateSupplierLinkUrl vráti zrozumiteľnú slovenskú hlášku pre hodnotu, ktorá nie je platná URL", () => {
+  expect(validateSupplierLinkUrl("nieje-url")).toBe("Odkaz musí byť platná adresa začínajúca http:// alebo https://.");
+});
+
+it("validateSupplierLinkUrl odmietne inú schému než http(s) (napr. javascript:)", () => {
+  expect(validateSupplierLinkUrl("javascript:alert(1)")).toBe(
+    "Odkaz musí byť platná adresa začínajúca http:// alebo https://.",
+  );
+});
+
+it("validateSupplierLinkUrl odmietne adresu dlhšiu ako 2000 znakov (rovnaký strop ako server)", () => {
+  const dlha = "https://example.com/" + "a".repeat(2000);
+  expect(validateSupplierLinkUrl(dlha)).toBe("Odkaz musí byť platná adresa začínajúca http:// alebo https://.");
 });

--- a/apps/web/src/ordersApi.ts
+++ b/apps/web/src/ordersApi.ts
@@ -202,6 +202,26 @@ export async function assignOrderLineSupplier(lineId: string, supplier: string):
   await readJson(response, "Priradenie dodávateľa sa nepodarilo");
 }
 
+// issue 153: zrkadlí `orderLineSupplierLinkBody` (`apps/api/src/http/
+// orders-routes.ts`) DO ZNAKU — trim, tvar URL, dĺžkový strop, http(s)
+// schéma. NEODVODZUJE sa od žiadnej existujúcej schémy vyššie (tie parsujú
+// ODPOVEĎ zo servera; táto validuje VSTUP PRED odoslaním) — rovnaký duálny
+// vzor ako `adminUrl`/`supplierUrl` (issue 70), zámerne nezdieľaný typový
+// balík (žiadny medzi web/api zatiaľ neexistuje, viď modulový komentár
+// vyššie). Formula-guard (CSV-injection ochrana) sa tu ZÁMERNE neopakuje —
+// je to server-side/CSV-sink kontrola (issue 153's design komentár), nie
+// niečo, čo by zamestnanec pri písaní odkazu mal vidieť ako "chybu vstupu".
+const supplierLinkUrlInput = z.string().trim().max(2000).url().regex(/^https?:\/\//);
+
+/** `null`, keď je `url` (po orezaní) platná — inak zrozumiteľná slovenská
+ * hláška na OKAMŽITÉ odmietnutie V PREHLIADAČI, bez čakania na round-trip
+ * na server (issue 153 — predtým appka kontrolovala len neprázdnosť). */
+export function validateSupplierLinkUrl(url: string): string | null {
+  return supplierLinkUrlInput.safeParse(url).success
+    ? null
+    : "Odkaz musí byť platná adresa začínajúca http:// alebo https://.";
+}
+
 // issue 121: manuálny odkaz na dodávateľa — NA ROZDIEL od priradenia
 // dodávateľa vyššie sa smie upraviť pri KAŽDOM produkte, aj keď už jeden
 // odkaz (zo Shoptetu) má. Rovnaký dôvod na PLNÝ refetch po úspechu ako

--- a/apps/web/src/useSupplierLinkSave.ts
+++ b/apps/web/src/useSupplierLinkSave.ts
@@ -1,0 +1,74 @@
+import { useCallback, useState } from "react";
+import {
+  OrdersUnauthorizedError,
+  setProductSupplierLink,
+  validateSupplierLinkUrl,
+  type SupplierOpenOrders,
+} from "./ordersApi.js";
+import { clearWriteFailure, lineWhere, upsertWriteFailure, type OrderWriteFailure } from "./ordersWriteFailures.js";
+
+// issue 121: manuálny odkaz na dodávateľa — mechanicky vyňaté z
+// `OrdersSection.tsx` (issue 153, ktoré pridalo okamžitú klientsku validáciu
+// a poslalo súbor cez eslint `max-lines: 400`), BEZ ZMENY SPRÁVANIA — rovnaký
+// zámer a vzor ako `useSupplierEmailEditing.ts`'s komentár vysvetľuje: vlastný
+// HOOK namiesto komponenty, lebo tento blok nemá vlastný markup, len stav +
+// jeden handler.
+export interface SupplierLinkSave {
+  readonly busySupplierLinkLineId: string | null;
+  readonly setSupplierLink: (lineId: string, url: string) => void;
+}
+
+export function useSupplierLinkSave(
+  suppliers: readonly SupplierOpenOrders[],
+  setWriteFailures: (updater: (current: readonly OrderWriteFailure[]) => readonly OrderWriteFailure[]) => void,
+  load: () => void,
+  onSessionExpired: () => void,
+): SupplierLinkSave {
+  const [busySupplierLinkLineId, setBusySupplierLinkLineId] = useState<string | null>(null);
+
+  const setSupplierLink = useCallback(
+    (lineId: string, url: string) => {
+      const failureId = `supplierLink:${lineId}`;
+      const where = lineWhere(suppliers, lineId);
+      // issue 153: OKAMŽITÁ kontrola V PREHLIADAČI, PRED akýmkoľvek zápisom
+      // na server — zrkadlí presne server-strany pravidlo
+      // (`validateSupplierLinkUrl`, `ordersApi.ts`). Neplatná hodnota sa
+      // ukáže v tom istom kumulatívnom `writeFailures` banneri (issue 66)
+      // ako každé iné zlyhanie zápisu na tejto obrazovke — žiadny nový,
+      // samostatný chybový vzor.
+      const validationError = validateSupplierLinkUrl(url);
+      if (validationError !== null) {
+        setWriteFailures((current) =>
+          upsertWriteFailure(current, { id: failureId, what: "Odkaz na dodávateľa", where, detail: validationError }),
+        );
+        return;
+      }
+      setBusySupplierLinkLineId(lineId);
+      setProductSupplierLink(lineId, url)
+        .then(() => {
+          setWriteFailures((current) => clearWriteFailure(current, failureId));
+          load();
+        })
+        .catch((err: unknown) => {
+          if (err instanceof OrdersUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setWriteFailures((current) =>
+            upsertWriteFailure(current, {
+              id: failureId,
+              what: "Odkaz na dodávateľa",
+              where,
+              detail: err instanceof Error ? err.message : "Uloženie odkazu na dodávateľa sa nepodarilo.",
+            }),
+          );
+        })
+        .finally(() => {
+          setBusySupplierLinkLineId(null);
+        });
+    },
+    [load, onSessionExpired, setWriteFailures, suppliers],
+  );
+
+  return { busySupplierLinkLineId, setSupplierLink };
+}

--- a/apps/web/tests/e2e/orders-supplier-link.spec.ts
+++ b/apps/web/tests/e2e/orders-supplier-link.spec.ts
@@ -94,3 +94,47 @@ test("riadok bez odkazu ponúka 'doplniť', po uložení ponúka 'upraviť' a no
 
   expect(chyby).toEqual([]);
 });
+
+// issue 153: neplatný odkaz sa odmietne HNEĎ v prehliadači — konzola musí
+// zostať čistá, čo je zároveň dôkaz, že sa NIKDY neodoslal skutočný
+// request na server (server 400 by sa v Chromiu zalogoval ako "Failed to
+// load resource", `.claude/rules/testing.md`). Riadok 9007/278 už má
+// uložený odkaz z PREDCHÁDZAJÚCEHO testu tohto súboru (spoločný účet,
+// sekvenčný beh v rámci jedného spec súboru) — toggle preto ponúka
+// "Upraviť", nie "Doplniť".
+test("neplatný odkaz na dodávateľa sa odmietne HNEĎ, bez zápisu na server (konzola čistá)", async ({ page }) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/?tab=orders");
+  await page.getByLabel("E-mail").fill(E2E_ODKAZ_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await expect(page.getByRole("heading", { name: "Na objednanie" })).toBeVisible();
+
+  const riadok = page
+    .getByTestId("supplier-(bez dodávateľa)")
+    .locator("[data-testid^='order-line-']")
+    .filter({ hasText: "9007" });
+  await riadok.getByLabel(/Upraviť odkaz na dodávateľa/).click();
+  const vstup = riadok.getByLabel("Odkaz na dodávateľa riadku objednávky 9007 / 278", { exact: true });
+  await expect(vstup).toHaveValue("https://e2e-dodavatel.example.com/opravena-adresa");
+
+  await vstup.fill("nieje-url");
+  await riadok.getByLabel("Uložiť odkaz na dodávateľa riadku objednávky 9007 / 278").click();
+
+  await expect(page.getByTestId("order-write-failures")).toContainText(
+    "Odkaz musí byť platná adresa začínajúca http:// alebo https://.",
+  );
+
+  // Pôvodná hodnota ZOSTALA nezmenená — neplatný pokus sa neuložil.
+  const odkaz = riadok.getByRole("link", { name: "Odkaz na dodávateľa" });
+  await expect(odkaz).toHaveAttribute("href", "https://e2e-dodavatel.example.com/opravena-adresa");
+
+  expect(chyby).toEqual([]);
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.93",
+  "version": "0.3.0-dev.94",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Čo tento PR rieši

issue 153: dve chýbajúce kontroly vstupu na obrazovke "Na objednanie".

1. **Odkaz na dodávateľa sa teraz odmieta HNEĎ v prehliadači** — nová
   `validateSupplierLinkUrl` (`ordersApi.ts`) zrkadlí presne server-strany
   pravidlo (`orderLineSupplierLinkBody`), volaná v `useSupplierLinkSave.ts`
   (vyňaté z `OrdersSection.tsx` kvôli eslint `max-lines`) PRED akýmkoľvek
   zápisom na server. Neplatná hodnota sa zobrazí v už existujúcom
   kumulatívnom `writeFailures` banneri (issue 66), bez network round-tripu.

2. **Ochrana pred CSV-injection (formula-lead znaky `=`, `+`, `-`, `@`).**
   Vysledoval som celú cestu do generovaného CSV (`select-changes.ts` →
   `csv.ts`) — jediná ručne zadaná hodnota, ktorá tam ide, je odkaz na
   dodávateľa (`internalNote`); `code`/`pairCode` prichádzajú z katalógového
   importu. Nový `formula-guard.ts` (`csvSafe`) neutralizuje KAŽDÚ bunku
   začínajúcu znakom vzorca priamo pri zápise CSV (rovnaký mechanizmus ako
   sesterská appka's `_csv_safe`) — chráni aj `code`/`pairCode`, ktoré dnes
   nemajú žiadnu inú kontrolu. Navyše `orderLineSupplierLinkBody` dostal
   samostatný `.refine()` formula-reject — obrana do hĺbky pre prípad, že sa
   http(s) tvarová podmienka v budúcnosti uvoľní.

Design komentár (root cause + zvolený prístup + zamietnuté alternatívy),
napísaný PRED prvým kódovým commitom:
https://github.com/zbynekdrlik/forestshop-app/issues/153#issuecomment-5151009096

## Testy (RED→GREEN, security ticket)

- `formula-guard.test.ts` (nový, 9 testov) + `csv.test.ts` (+2 testy) —
  CSV-sink neutralizácia v ktoromkoľvek stĺpci.
- `orders-supplier-link-assignment.integration.test.ts` (+1 test) —
  samostatná formula-guard hláška v 400 odpovedi.
- `ordersApi.supplierLink.test.ts` (+4 testy) — `validateSupplierLinkUrl`.
- `OrdersSection.supplierLinkValidation.test.tsx` (nový) — API sa NEVOLÁ pri
  neplatnom vstupe.
- `orders-supplier-link.spec.ts` (nový e2e test) — neplatný odkaz sa
  odmietne v reálnom prehliadači, konzola čistá (dôkaz, že request naozaj
  nikdy neodišiel — server 400 by sa v Chromiu zalogoval).

Lokálne overené: `pnpm lint`, `pnpm typecheck`, `pnpm test` (API 334 +
web 280), `pnpm test:integration` (294), `pnpm --filter @forestshop/web e2e`
(25) — všetko zelené.
