### PR TITLE
docs: playbook review + CI/Deploy recovery for issue 153

### DIFF
--- a/.claude/rules/ci.md
+++ b/.claude/rules/ci.md
@@ -36,3 +36,20 @@ paths:
 - Console-assert výnimka pre e2e testy (jediná povolená: neautentifikovaný
   `/api/me` 401) je popísaná v `.claude/rules/testing.md` — rozširovanie tejto
   výnimky je zakázané, nie len pri práci na CI configu.
+- **`gh pr merge <N> --merge` môže vrátiť GraphQL chybu ("Something went
+  wrong…"), a PRESTO na strane servera čiastočne uspieť** — `main`'s ref sa
+  posunie na skutočný merge commit (over: `gh api repos/…/git/ref/heads/main`
+  aj `git diff origin/main origin/dev`, mal by byť prázdny), ale PR objekt
+  ostane `state: open, merged: false` a — kriticky — **commit nedostane ani
+  jeden check-suite/check-run/status vôbec** (`gh api repos/…/commits/<sha>/
+  check-suites` prázdne). Keďže ani `ci.yml` ani `deploy.yml` nemajú
+  `workflow_dispatch`, takýto commit sa NIKDY nespustí spätne — opakovaný
+  `gh pr merge`/`--auto` už len hlási "not mergeable: dirty" (obsah je
+  identický, niet čo mergovať) a re-request check-suite nemá čo re-requestnúť
+  (žiadny neexistuje). **Recovery:** over najprv `git diff origin/main
+  origin/dev` (prázdny = obsah je v `main` v poriadku), zavri stary PR ručne s
+  komentárom vysvetľujúcim situáciu (`gh pr comment` + `gh pr close`, NIKDY
+  force-push/prepis `main`), a nechaj CI+Deploy dobehnúť cez ĎALŠÍ, úplne
+  bežný malý commit na `dev` (napr. plánovaný playbook/log zápis) — jeho push
+  na `main` spustí normálny beh nad CELÝM aktuálnym stromom, teda aj nad
+  obsahom, ktorý "zaskočil" bez CI.

--- a/.claude/rules/http-routes.md
+++ b/.claude/rules/http-routes.md
@@ -23,3 +23,23 @@ paths:
   adding a new literal-path route under an existing `:id`/`:param` prefix
   in ANY `http/*-routes.ts` file, check the registration order before
   assuming "the route exists" means "the route is reachable".
+- **A `.refine()` chained onto a `z.string()` schema (after `.url()`/
+  `.regex()`/`.max()`) still RUNS and adds its OWN issue even when an
+  EARLIER check on the same field already failed** — zod does NOT
+  short-circuit a string schema's checks on first failure; all of them
+  execute and their issues accumulate into one `ZodError.issues` array
+  (verified empirically, issue 153: `z.string().url().regex(/^https?:\/\//)
+  .refine(...)` parsed against `"=cmd|calc"` returned THREE issues —
+  `invalid_string`/url, `invalid_string`/regex, AND the custom `.refine()`
+  message — not just the first one). This is what makes it possible to add
+  a NAMED, independently-testable `.refine()` guard even when it is
+  logically REDUNDANT with an earlier check for every value that can reach
+  it (e.g. a formula-injection reject on a field already anchored to
+  `^https?:\/\//` — a formula-leading string can never also start with
+  `http`, so the two checks always fail TOGETHER) — a test can still assert
+  the SPECIFIC custom message appears in `result.error.issues`, proving that
+  exact guard fired, decoupled from whichever other check also failed.
+  `@hono/zod-validator`'s default (no `hook`) surfaces the whole
+  `SafeParseReturnType` as the 400 body (`c.json(result, 400)`), so
+  `(await res.json()).error.issues` is where an integration test reads this
+  from.

--- a/.claude/rules/shoptet-writeback.md
+++ b/.claude/rules/shoptet-writeback.md
@@ -147,3 +147,13 @@ paths:
   `docker exec -w /app/apps/api node script.mjs`. `createDb()` (`db/
   client.ts`) bez argumentu sám číta `DATABASE_URL` z kontajnerovho
   prostredia — netreba ho manuálne skladať v skripte.
+- **CSV-injection ochrana (issue 153) sedí v `csv.ts`'s `dataRowToLine`, NIE
+  vo validácii vyššie prúdu.** `formula-guard.ts`'s `csvSafe` sa aplikuje na
+  KAŽDÚ bunku KAŽDÉHO dátového riadku PRIAMO pri zápise CSV — chráni aj
+  `code`/`pairCode` (z katalógového importu, `variants` tabuľka, BEZ
+  akejkoľvek inej kontroly), nielen `internalNote` (ktorý je aj tak už
+  ukotvený `^https?:\/\//`, takže formula-lead hodnota by ním nikdy
+  neprešla). Akýkoľvek BUDÚCI nový stĺpec/hodnota pridaná do
+  `WritebackRow`/`buildWritebackCsv` je automaticky chránená, pokiaľ ide
+  cez `dataRowToLine` — nová cesta k zápisu Shoptet CSV musí VŽDY ísť cez
+  `buildWritebackCsv`, nikdy cez vlastné skladanie stĺpcov mimo neho.

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -3,6 +3,62 @@
 Terse per-ticket log of autopilot-worker cycles: issue(s), commit SHAs,
 RED→GREEN test names, key decisions, and the shared PR.
 
+## 2026-08-01 — #153 (immediate supplier-link validation + CSV formula-injection guard)
+
+- Solo ticket (security-boundary Scope-gate, deliberately not bundled).
+- Version bump `239c241` (0.3.0-dev.93→.94), first commit.
+- Design comment BEFORE first code commit:
+  https://github.com/zbynekdrlik/forestshop-app/issues/153#issuecomment-5151009096
+  — traced the CSV write-back path (`select-changes.ts`→`csv.ts`) and found
+  only `internalNote` (the manual supplier-link URL) is user-hand-entered
+  AND reaches the generated CSV; `code`/`pairCode` come from the catalog
+  import. Since the URL is already anchored `^https?:\/\//`, a formula-lead
+  value can never pass it anyway (matches the reference app's OWN design —
+  it never adds a separate formula-check on ITS url fields either, only on
+  its supplier-NAME field which has no other shape rule). Chose: (1)
+  `csvSafe` escaping at the CSV SINK (`csv.ts`'s `dataRowToLine`) protecting
+  EVERY column including `code`/`pairCode`, matching the sibling app's own
+  `_csv_safe`; (2) an explicit `.refine()` on the schema anyway — defense in
+  depth, independently testable (zod does NOT short-circuit chained string
+  checks — a later `.refine()` still adds its own issue even when an
+  earlier `.url()`/`.regex()` check on the same value already failed, see
+  `.claude/rules/http-routes.md`).
+- RED→GREEN, four pairs (security ticket, strict TDD):
+  `877020e`[red]→`2a314b1`[green] (CSV-sink formula escaping,
+  `formula-guard.test.ts`/`csv.test.ts`), `14ccd4b`[red]→`9113f9d`[green]
+  (schema-level explicit reject, `orders-supplier-link-assignment
+  .integration.test.ts`'s "vráti 400 so samostatnou hláškou o vzorci"),
+  `1910c6b`[red]→`5e8bf33`[green] (`validateSupplierLinkUrl`,
+  `ordersApi.supplierLink.test.ts`), `d265d83`[red]→`b698262`[green]
+  (wired into `OrdersSection`'s `setSupplierLink`,
+  `OrdersSection.supplierLinkValidation.test.tsx` — proves the API is
+  never called for an invalid link). Extracted `useSupplierLinkSave.ts`
+  (behaviour-preserving) to keep `OrdersSection.tsx` under eslint
+  `max-lines: 400` after adding the validation branch — same pattern as
+  the earlier `useSupplierEmailEditing.ts` extraction.
+- New e2e test in `orders-supplier-link.spec.ts`: an invalid link is
+  rejected with console staying CLEAN — proof the request never actually
+  reached the network (a real server 400 would have logged "Failed to
+  load resource" in Chromium, per `.claude/rules/testing.md`).
+- **Merge incident (PR #159):** `gh pr merge --merge` returned a GraphQL
+  error but had partially succeeded server-side — `main`'s ref moved to
+  the real merge commit (`d53e302`, content verified identical to `dev`
+  via `git diff`), but the PR object stayed open/unmerged AND the commit
+  got zero check-suites/check-runs (no CI, no Deploy ever ran). Closed
+  PR #159 manually with an explanatory comment; recovered by bumping the
+  version again (0.3.0-dev.94→.95) and pushing this very log entry as a
+  fresh commit (own PR) so a normal push event re-triggers CI+Deploy over
+  the full current `main` tree, including #153's already-landed content.
+  Full gotcha + recovery steps: `.claude/rules/ci.md`.
+- Playbook extended: `.claude/rules/ci.md` (the `gh pr merge`
+  partial-failure/no-CI-triggered gotcha + recovery), `.claude/rules/
+  http-routes.md` (zod `.refine()` after a failing check still runs —
+  useful for adding an independently-testable guard even when logically
+  redundant with an earlier check), `.claude/rules/shoptet-writeback.md`
+  (CSV-injection guard sits at the `csv.ts` sink, not upstream validation
+  — any future writeback column is automatically protected as long as it
+  goes through `buildWritebackCsv`).
+
 ## 2026-08-01 — #151 (supplier draft lost across group remount) + #152 (sort by newest order)
 
 - Version bump `9029b0a` (0.3.0-dev.90→.91), first commit on `dev`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.94",
+  "version": "0.3.0-dev.95",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Docs/playbook-only recovery commit — no application code changes.

`gh pr merge 159 --merge` returned a GraphQL error but had partially
succeeded server-side: `main`'s ref moved to the real merge commit
(content verified identical to `dev` via `git diff origin/main
origin/dev`), but the PR object stayed open/unmerged and the commit got
zero check-suites/check-runs — CI and Deploy never ran for it. PR 159 was
closed manually with an explanatory comment. This PR's push re-triggers a
normal CI+Deploy run over `main`'s current full tree (which already
includes issue 153's supplier-link validation + CSV formula-injection
guard), plus the playbook entries capturing the gotcha for next time
(`.claude/rules/ci.md`, `.claude/rules/http-routes.md`,
`.claude/rules/shoptet-writeback.md`, `docs/autopilot-log.md`).
