### PR TITLE
Na objednanie: state buttons, wider supplier-link editor, fixed row divider

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -466,3 +466,81 @@ paths:
   "does X survive a re-render/refetch/remount" test in this codebase:
   re-query fresh at assertion time, never trust an element handle captured
   before the change under test.
+- **`display:flex` set DIRECTLY on a `<td>` breaks its participation in
+  normal table-cell height matching** — issue 163 (deliaca čiara nelícuje
+  pod bunkou s odkazom na dodávateľa): `td.ord-supplier-merged` had
+  `display:flex; flex-direction:column; gap` for years (issue 95) with no
+  visible problem, until a taller SIBLING cell in the same row (long
+  product name/notes) made the row genuinely tall — the flex `<td>` sized
+  to its OWN (shorter) content instead of stretching to the row's real
+  height like every other (`display: table-cell`) sibling, so its
+  `border-bottom` sat up to ~44px above the row's actual bottom edge (live
+  measured: `td.getBoundingClientRect().height` 53px vs
+  `tr.getBoundingClientRect().height` 91.5px). This is invisible in a
+  short/uniform-height fixture and only shows up once ANY sibling cell in
+  the row is genuinely taller — exactly why it went unnoticed for 68
+  issues. Fix: never put `display:flex` straight on a `<td>` that needs to
+  match the row's height; wrap its children in an inner `<div>` and put
+  the flex styling there instead (or, if the only purpose was a gap
+  between two always-stacked block children, replace it with `margin-top`
+  on the second child — no wrapper element needed at all, as done here).
+  Regression test for this class of bug: assert `td.getBoundingClientRect
+  ().bottom` equals `tr.getBoundingClientRect().bottom` (±1px) for every
+  row, not just "does it look OK in one screenshot" — a short/uniform e2e
+  fixture will pass a screenshot check while still carrying the bug.
+- **CSS Grid items default to `min-width: auto`, which respects the
+  intrinsic (unwrapped) width of a single unbreakable WORD — the flex
+  `flex-basis`-vs-`min-width` trap issue 105 documented above has a Grid
+  analog, and it bit in the exact same "looks fine in the CSS, breaks only
+  when actually rendered" way.** Issue 161's 2×2 state-button grid
+  (`.ord-state-btn-group { display:grid; grid-template-columns: 1fr 1fr }`)
+  visually overflowed into the NEXT column at 1280px — found ONLY by a
+  live Playwright screenshot + `getBoundingClientRect()` diff against a
+  local dev build (not by reading the CSS, not by the unit tests, which
+  don't render real widths): the group's `scrollWidth` (161px) exceeded
+  its rendered `width` (114px) because Slovak labels ("Nevybavené",
+  "Nedostupné") are single words with no natural break point, and a grid
+  item won't shrink below that intrinsic minimum unless told to. Fix:
+  `min-width: 0` on the grid item + `overflow-wrap: break-word` (letting
+  the label actually wrap inside the button instead of forcing the grid
+  wider); `hyphens: auto` (with `lang="sk"` on `<html>`, already set) is a
+  cheap improvement but not load-bearing — Chromium's Slovak hyphenation
+  dictionary support didn't visibly change the render in this repo's test
+  environment, only `min-width:0` + `overflow-wrap` actually fixed the
+  overflow. Any FUTURE `display:grid`/`display:flex` layout in this app
+  holding short, single-word (especially Slovak) labels in a narrow
+  column needs a REAL rendered-width check (Playwright against a local
+  dev server, not just CSS review) before shipping — this exact overflow
+  is invisible in vitest/jsdom (no real layout) and easy to miss by eye on
+  a wide monitor where the neighboring column happens to have slack.
+- **Moving DOM content out of an existing `<tr>` into a NEW conditional
+  sibling `<tr>` (an "expand row" pattern) breaks any e2e/unit test that
+  scoped its query to the ORIGINAL row (`within(riadok)`,
+  `riadok.getByLabel(...)`), even though the moved content's own testid
+  never changed.** Issue 162 (supplier-link edit input too narrow — moved
+  from inside `td.ord-supplier-merged` into `<tr colSpan={9}>` rendered as
+  a sibling of the main `order-line-<lineId>` row, only while editing):
+  fix in TWO places per affected test file — (1) vitest/testing-library:
+  replace `within(riadok).getByTestId(...)` with plain `screen
+  .getByTestId(...)` (safe when the test renders exactly ONE line, unsafe
+  otherwise — check test fixture size first); (2) Playwright e2e: define
+  `const editRiadok = riadok.locator("xpath=./following-sibling::tr[1]")`
+  and query THAT instead of `riadok` for anything living in the moved
+  content. The xpath locator is lazy (Playwright locators resolve at
+  assertion time, not at `.locator()` call time), so defining it BEFORE
+  the row is even open (before the sibling exists in the DOM) is safe —
+  it only needs to resolve correctly at the point you actually use it.
+- **A NEW row/element's testid must NOT share a `^='...'`-style PREFIX
+  already used elsewhere to find a DIFFERENT element, even if the new
+  element is semantically related.** Issue 162's first attempt named the
+  new expand-row `order-line-<lineId>-link-edit` (seemed natural — it's
+  "the edit row FOR that order line") — but several existing e2e tests use
+  `[data-testid^='order-line-']` to find the MAIN row, and that prefix
+  selector matched the NEW row too the instant it rendered, causing a
+  Playwright strict-mode violation ("resolved to 2 elements") the moment
+  any test opened the editor. Fix: renamed to `link-edit-row-<lineId>`
+  (no shared prefix). Before naming a new sibling/child element with a
+  testid that semantically extends an existing one, `grep -rn
+  "data-testid\^='<prefix>'"` (or the exact base string) across
+  `apps/web/tests/e2e/` to check whether a prefix-match query already
+  exists that the new element would also satisfy.

--- a/apps/web/src/components/OrderLineRow.supplierLinkEditCell.test.tsx
+++ b/apps/web/src/components/OrderLineRow.supplierLinkEditCell.test.tsx
@@ -57,11 +57,15 @@ it("riadok BEZ odkazu ponúka 'doplniť'; otvorenie zobrazí prázdny vstup", as
   const toggle = within(riadok).getByLabelText(
     `Doplniť odkaz na dodávateľa — ${RIADOK_BEZ_ODKAZU.variantName} (${RIADOK_BEZ_ODKAZU.variantCode})`,
   );
-  expect(within(riadok).queryByTestId(`supplier-link-edit-${RIADOK_BEZ_ODKAZU.lineId}`)).toBeNull();
+  // issue 162: vstup teraz žije vo VLASTNOM rozbaľovacom riadku POD týmto
+  // riadkom (`colSpan` cez celú tabuľku), nie ako potomok `riadok`u — nájde
+  // sa cez `screen` (testid je jedinečný na `lineId`, žiadna kolízia v tomto
+  // teste s jedným riadkom).
+  expect(screen.queryByTestId(`supplier-link-edit-${RIADOK_BEZ_ODKAZU.lineId}`)).toBeNull();
 
   fireEvent.click(toggle);
 
-  const vstup = within(riadok).getByTestId<HTMLInputElement>(`supplier-link-edit-input-${RIADOK_BEZ_ODKAZU.lineId}`);
+  const vstup = screen.getByTestId<HTMLInputElement>(`supplier-link-edit-input-${RIADOK_BEZ_ODKAZU.lineId}`);
   expect(vstup.value).toBe("");
 });
 
@@ -76,7 +80,7 @@ it("riadok S odkazom ponúka 'upraviť'; otvorenie predvyplní vstup AKTUÁLNYM 
 
   fireEvent.click(toggle);
 
-  const vstup = within(riadok).getByTestId<HTMLInputElement>(`supplier-link-edit-input-${RIADOK_S_ODKAZOM.lineId}`);
+  const vstup = screen.getByTestId<HTMLInputElement>(`supplier-link-edit-input-${RIADOK_S_ODKAZOM.lineId}`);
   expect(vstup.value).toBe(RIADOK_S_ODKAZOM.supplierUrl);
 });
 
@@ -91,10 +95,10 @@ it("uloženie zavolá setProductSupplierLink so správnym lineId a URL, a zavrie
       `Doplniť odkaz na dodávateľa — ${RIADOK_BEZ_ODKAZU.variantName} (${RIADOK_BEZ_ODKAZU.variantCode})`,
     ),
   );
-  const vstup = within(riadok).getByTestId<HTMLInputElement>(`supplier-link-edit-input-${RIADOK_BEZ_ODKAZU.lineId}`);
+  const vstup = screen.getByTestId<HTMLInputElement>(`supplier-link-edit-input-${RIADOK_BEZ_ODKAZU.lineId}`);
   fireEvent.change(vstup, { target: { value: "https://novy-dodavatel.example.com/x" } });
   expect(vstup.value).toBe("https://novy-dodavatel.example.com/x");
-  fireEvent.click(within(riadok).getByTestId(`supplier-link-edit-save-${RIADOK_BEZ_ODKAZU.lineId}`));
+  fireEvent.click(screen.getByTestId(`supplier-link-edit-save-${RIADOK_BEZ_ODKAZU.lineId}`));
 
   await waitFor(() => {
     expect(setProductSupplierLink).toHaveBeenCalledWith(
@@ -102,7 +106,7 @@ it("uloženie zavolá setProductSupplierLink so správnym lineId a URL, a zavrie
       "https://novy-dodavatel.example.com/x",
     );
   });
-  expect(within(riadok).queryByTestId(`supplier-link-edit-${RIADOK_BEZ_ODKAZU.lineId}`)).toBeNull();
+  expect(screen.queryByTestId(`supplier-link-edit-${RIADOK_BEZ_ODKAZU.lineId}`)).toBeNull();
   // issue 121: PLNÝ refetch po úspechu (rovnaký dôvod ako priradenie
   // dodávateľa — zmena môže zasiahnuť súrodenecké veľkosti toho istého
   // produktu).
@@ -122,9 +126,9 @@ it("zlyhanie uloženia zobrazí slovenskú hlášku", async () => {
       `Doplniť odkaz na dodávateľa — ${RIADOK_BEZ_ODKAZU.variantName} (${RIADOK_BEZ_ODKAZU.variantCode})`,
     ),
   );
-  const vstup = within(riadok).getByTestId<HTMLInputElement>(`supplier-link-edit-input-${RIADOK_BEZ_ODKAZU.lineId}`);
+  const vstup = screen.getByTestId<HTMLInputElement>(`supplier-link-edit-input-${RIADOK_BEZ_ODKAZU.lineId}`);
   fireEvent.change(vstup, { target: { value: "https://zly-odkaz.example.com" } });
-  fireEvent.click(within(riadok).getByTestId(`supplier-link-edit-save-${RIADOK_BEZ_ODKAZU.lineId}`));
+  fireEvent.click(screen.getByTestId(`supplier-link-edit-save-${RIADOK_BEZ_ODKAZU.lineId}`));
 
   // issue 66: kumulatívny banner nahrádza pôvodný jediný `<p role="alert">`.
   await waitFor(() => {
@@ -143,13 +147,13 @@ it("kliknutie na toggle znova (zrušiť) zavrie panel bez volania API", async ()
     `Doplniť odkaz na dodávateľa — ${RIADOK_BEZ_ODKAZU.variantName} (${RIADOK_BEZ_ODKAZU.variantCode})`,
   );
   fireEvent.click(toggle);
-  expect(within(riadok).queryByTestId(`supplier-link-edit-${RIADOK_BEZ_ODKAZU.lineId}`)).not.toBeNull();
+  expect(screen.queryByTestId(`supplier-link-edit-${RIADOK_BEZ_ODKAZU.lineId}`)).not.toBeNull();
 
   fireEvent.click(
     within(riadok).getByLabelText(
       `Zrušiť úpravu odkazu na dodávateľa — ${RIADOK_BEZ_ODKAZU.variantName} (${RIADOK_BEZ_ODKAZU.variantCode})`,
     ),
   );
-  expect(within(riadok).queryByTestId(`supplier-link-edit-${RIADOK_BEZ_ODKAZU.lineId}`)).toBeNull();
+  expect(screen.queryByTestId(`supplier-link-edit-${RIADOK_BEZ_ODKAZU.lineId}`)).toBeNull();
   expect(setProductSupplierLink).not.toHaveBeenCalled();
 });

--- a/apps/web/src/components/OrderLineRow.supplierLinkEditCell.test.tsx
+++ b/apps/web/src/components/OrderLineRow.supplierLinkEditCell.test.tsx
@@ -157,3 +157,26 @@ it("kliknutie na toggle znova (zrušiť) zavrie panel bez volania API", async ()
   expect(screen.queryByTestId(`supplier-link-edit-${RIADOK_BEZ_ODKAZU.lineId}`)).toBeNull();
   expect(setProductSupplierLink).not.toHaveBeenCalled();
 });
+
+// issue 162 (code review finding): `OrderLineRow.tsx`'s `ORDERS_TABLE_COLUMN_
+// COUNT` je RUČNE udržiavaná konštanta, ktorá musí sedieť s počtom <col> v
+// `SupplierOrderGroup.tsx`'s <colgroup> — žiadny automatický zdroj pravdy.
+// Bez tohto testu by budúca zmena počtu stĺpcov (pridanie/odstránenie <col>)
+// bez aktualizácie konštanty prešla ticho — rozbaľovací riadok by len bol o
+// stĺpec užší/širší než celá tabuľka, nič by nezlyhalo.
+it("colSpan rozbaľovacieho riadku sedí s reálnym počtom <col> v <colgroup>", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [RIADOK_BEZ_ODKAZU], email: null }]);
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const riadok = await screen.findByTestId(`order-line-${RIADOK_BEZ_ODKAZU.lineId}`);
+  fireEvent.click(
+    within(riadok).getByLabelText(
+      `Doplniť odkaz na dodávateľa — ${RIADOK_BEZ_ODKAZU.variantName} (${RIADOK_BEZ_ODKAZU.variantCode})`,
+    ),
+  );
+
+  const skutocnyPocetStlpcov = document.querySelectorAll(".orders-table colgroup col").length;
+  const rozbalovaciRiadokTd = screen.getByTestId(`supplier-link-edit-${RIADOK_BEZ_ODKAZU.lineId}`).closest("td");
+  expect(rozbalovaciRiadokTd).not.toBeNull();
+  expect((rozbalovaciRiadokTd as HTMLTableCellElement).colSpan).toBe(skutocnyPocetStlpcov);
+});

--- a/apps/web/src/components/OrderLineRow.tsx
+++ b/apps/web/src/components/OrderLineRow.tsx
@@ -14,6 +14,14 @@ export const STATE_LABELS: Record<OrderLine["state"], string> = {
   nedostupne: "Nedostupné",
 };
 
+// issue 162: počet stĺpcov "Na objednanie" tabuľky — MUSÍ sedieť s počtom
+// `<col>` v `SupplierOrderGroup.tsx`'s `<colgroup>` (9). Vlastný rozbaľovací
+// riadok pod týmto riadkom (odkaz na dodávateľa, nižšie) potrebuje `colSpan`
+// cez CELÚ šírku tabuľky — ak niekedy pribudne/ubudne stĺpec v tamojšom
+// `<colgroup>`, toto číslo treba zmeniť s ním (žiadny automatický zdroj
+// pravdy, len tento komentár + grep na `colSpan`).
+const ORDERS_TABLE_COLUMN_COUNT = 9;
+
 // Jeden riadok tabuľky "Na objednanie" — vyčlenené z `OrdersSection.tsx`
 // (issue 60 pridalo odškrtávacie políčko + premenovaný stĺpec dátumu, čo
 // poslalo pôvodný súbor cez eslint `max-lines: 400`, `.claude/rules/testing.md`).
@@ -200,320 +208,353 @@ export function OrderLineRow({
   }, [line.lineId, hasOpenEditor, onEditorActivityChange]);
 
   return (
-    <tr
-      className={"order-row state-" + line.state + (line.ordered ? " ordered" : "")}
-      data-testid={`order-line-${line.lineId}`}
-    >
-      <td>
-        <input
-          type="checkbox"
-          data-testid={`ordered-checkbox-${line.lineId}`}
-          aria-label={`Označiť riadok objednávky ${line.externalOrderId} / ${line.variantCode} ako objednané u dodávateľa`}
-          checked={line.ordered}
-          disabled={!canChangeState || busyOrderedLineId === line.lineId || supplierBusy}
-          onChange={(e) => {
-            onChangeOrdered(line.lineId, e.target.checked);
-          }}
-        />
-      </td>
-      <td className="ord-order-cell">
-        {/* issue 65: priamy odkaz do Shoptet administrácie na TÚTO
-            objednávku (`queries.ts`'s `buildShoptetAdminOrderUrl`).
-            issue 99: klikateľné je samotné ČÍSLO objednávky (majiteľ žiadal
-            doslovne "keď kliknem na kód objednávky") — pôvodná samostatná
-            ikonka `🔗` vedľa čísla zanikla, `line.adminUrl` sa nemení. */}
-        <a
-          href={line.adminUrl}
-          target="_blank"
-          rel="noreferrer noopener"
-          className="ord-admin-link"
-          aria-label={`Otvoriť objednávku ${line.externalOrderId} v administrácii Shoptet`}
-          title="Otvoriť v administrácii Shoptet"
-        >
-          {line.externalOrderId}
-        </a>
-      </td>
-      <td>{line.customerName}</td>
-      <td>{line.variantName}</td>
-      <td className="ord-qty">
-        {line.quantity} ks
-        {qtyChip !== null && (
-          <span className="qty-total-chip" data-testid={`qty-total-${line.lineId}`} title={qtyChip.title}>
-            {qtyChip.text}
-          </span>
-        )}
-      </td>
-      {/* issue 95: DODÁVATEĽ + PRIRADENIE DODÁVATEĽA zlúčené do jednej bunky
-          (majiteľ, komentár #1) — oba vnorené bloky nižšie sú BEZ ZMENY
-          (rovnaké testid, rovnaká logika), len vedľa seba v jednej `<td>`
-          namiesto dvoch samostatných stĺpcov. */}
-      <td className="ord-supplier-merged">
-        <div className="ord-supplier-row">
-          <div className="ord-supplier-cell" data-testid={`supplier-link-${line.lineId}`}>
-            {line.supplierUrl !== null ? (
-              // issue 119: majiteľ, doslovne "zmen na nejake tlacitko z ikonou
-              // ktore otvori na novom okne ten link, lebo teraz to je tazke
-              // stlacit" — textový odkaz nahradený veľkým ikonovým tlačidlom
-              // (`.ord-supplier-link` v `app.css` teraz štylizuje `<a>` ako
-              // tlačidlo, min. 36×36px klikacej plochy). `aria-label`/`title`
-              // nesú ten istý popis ako predtým (issue 72: variantName sám
-              // nestačí — dva riadky toho istého produktu v rôznych veľkostiach
-              // majú zhodný variantName, líšia sa len variantCode), viditeľný
-              // text je teraz len ikonka (`aria-hidden`, prístupné meno nesie
-              // výlučne `aria-label`).
-              <a
-                href={line.supplierUrl}
-                target="_blank"
-                rel="noreferrer noopener"
-                className="ord-supplier-link"
-                aria-label={`Odkaz na dodávateľa — ${line.variantName} (${line.variantCode})`}
-                title={`Otvoriť odkaz na dodávateľa — ${line.variantName} (${line.variantCode})`}
-              >
-                <span aria-hidden="true">🔗</span>
-              </a>
-            ) : line.supplierNote !== null ? (
-              <span className="ord-supplier-note" title={line.supplierNote}>
-                {line.supplierNote}
-              </span>
-            ) : line.supplierAssignable ? (
-              // issue 107 bod 3: majiteľ, komentár #1: "neviem čo tam je
-              // Priradenie dodávateľa stĺpec" — namiesto holej pomlčky (predtým
-              // aj tu, aj v `.ord-supplier-assign` nižšie — DVE pomlčky nad
-              // sebou) je tu teraz VIDITEĽNÝ popis toho, čo vstup pod ním robí.
-              // Zámerne v TEJTO, už existujúcej bunke (nie nový riadok pod
-              // vstupom) — pridanie ĎALŠIEHO riadku by pri úzkom stĺpci
-              // (input+button už zapĺňajú takmer celú šírku) posunulo výšku
-              // riadku nad issue 105's ~95px invariant (živo zmerané: 85px →
-              // 103.5px s popisom na vlastnom riadku).
-              <span className="ord-supplier-assign-hint">Priradiť dodávateľa</span>
-            ) : (
-              // issue 117: `externalCode` (dodávateľský kód) sa už NIKDY
-              // nezobrazuje — majiteľ ho nepoužíva ("kody produktov vobec
-              // nepouzivame"), appka používa výlučne odkaz na dodávateľa.
-              // Predtým sa táto pomlčka potláčala, keď `externalCode` bol
-              // vyplnený (zobrazoval sa namiesto nej samostatný "kód …" riadok)
-              // — bez toho riadku je terajší terminálny stav VŽDY pomlčka,
-              // keď riadok nemá ani odkaz, ani poznámku, ani priradenie
-              // (legitímny, `OrderLineRow.supplierAssignCell.test.tsx`).
-              "—"
-            )}
-          </div>
-          {/* issue 121: majiteľ, doslovne "ma byt moznost ho doplnit... pri
-              kazdom produkte ma byt moznost upravit link". TOGGLE (nie trvalo
-              viditeľný vstup) — pridáva JEDEN malý prvok VŽDY (`flex-shrink: 0`
-              v `.ord-supplier-row`, žiadna vlastná výška), vstup+uložiť sa
-              vykreslí LEN pri otvorenej úprave (nižšie), aby sa nezopakovala
-              issue 105/107/111/127's row-height regresia na VŠETKÝCH 37
-              riadkoch naraz. */}
-          <button
-            type="button"
-            className="ord-supplier-link-edit-toggle"
-            data-testid={`supplier-link-edit-toggle-${line.lineId}`}
-            aria-label={
-              linkEditing
-                ? `Zrušiť úpravu odkazu na dodávateľa — ${line.variantName} (${line.variantCode})`
-                : line.supplierUrl !== null
-                  ? `Upraviť odkaz na dodávateľa — ${line.variantName} (${line.variantCode})`
-                  : `Doplniť odkaz na dodávateľa — ${line.variantName} (${line.variantCode})`
-            }
-            title={linkEditing ? "Zrušiť úpravu" : line.supplierUrl !== null ? "Upraviť odkaz" : "Doplniť odkaz"}
-            onClick={toggleLinkEditing}
-          >
-            <span aria-hidden="true">{linkEditing ? "✖" : "✏️"}</span>
-          </button>
-        </div>
-        {linkEditing && (
-          <div className="ord-supplier-link-edit" data-testid={`supplier-link-edit-${line.lineId}`}>
-            <input
-              type="url"
-              className="ord-supplier-link-edit-input"
-              data-testid={`supplier-link-edit-input-${line.lineId}`}
-              aria-label={`Odkaz na dodávateľa riadku objednávky ${line.externalOrderId} / ${line.variantCode}`}
-              placeholder="https://…"
-              value={linkDraft}
-              disabled={linkBusyHere}
-              onChange={(e) => {
-                setLinkDraft(e.target.value);
-              }}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  e.preventDefault();
-                  saveLink();
-                }
-              }}
-            />
-            <button
-              type="button"
-              className="btn sm good"
-              data-testid={`supplier-link-edit-save-${line.lineId}`}
-              aria-label={`Uložiť odkaz na dodávateľa riadku objednávky ${line.externalOrderId} / ${line.variantCode}`}
-              disabled={linkBusyHere || linkDraft.trim() === ""}
-              onClick={saveLink}
-            >
-              💾
-            </button>
-          </div>
-        )}
-        {/* pri neradiťeľnom riadku (100 % dnešných ostrých dát) sa TENTO blok
-            predtým vykresľoval VŽDY, len s holou pomlčkou "—" bez
-            akéhokoľvek významu. Teraz sa nevykreslí VÔBEC (žiadny prvok,
-            žiadny prázdny <div>) — presne to, čo test v
-            `OrderLineRow.supplierAssignCell.test.tsx` overuje. */}
-        {line.supplierAssignable && (
-          <div className="ord-supplier-assign" data-testid={`supplier-assign-cell-${line.lineId}`}>
-            <input
-              type="text"
-              // Jeden zdieľaný `<datalist id="known-suppliers">` (rendrovaný
-              // raz v `OrdersSection.tsx`, z UŽ načítaných skupín) — žiadna
-              // nová GET trasa netreba len na našepkávanie.
-              list="known-suppliers"
-              className="ord-supplier-assign-input"
-              data-testid={`supplier-assign-input-${line.lineId}`}
-              aria-label={`Priradiť dodávateľa riadku objednávky ${line.externalOrderId} / ${line.variantCode}`}
-              placeholder="priradiť dodávateľa…"
-              value={supplierDraft}
-              disabled={supplierBusyHere}
-              onChange={(e) => {
-                onSupplierDraftChange(line.lineId, e.target.value);
-              }}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  e.preventDefault();
-                  saveSupplier();
-                }
-              }}
-            />
-            <button
-              type="button"
-              className="btn sm good"
-              data-testid={`supplier-assign-save-${line.lineId}`}
-              aria-label={`Uložiť priradenie dodávateľa riadku objednávky ${line.externalOrderId} / ${line.variantCode}`}
-              disabled={supplierBusyHere || supplierDraft.trim() === ""}
-              onClick={saveSupplier}
-            >
-              💾
-            </button>
-          </div>
-        )}
-      </td>
-      <td>
-        {canChangeState ? (
-          <select
-            // Code review finding (#25): pôvodne bez slova "stav" v
-            // aria-labeli (obchádzka Playwright's substring
-            // `getByLabel("Stav")` kolízie s katalógovým filtrom), čo by
-            // čítačke obrazovky neoznámilo, čo tento prvok robí. Skutočná
-            // oprava patrí na stranu KOLÍDUJÚCEHO testu (`catalog.spec.ts`
-            // teraz používa `{ exact: true }`), nie na obetovanie
-            // prístupnosti tu — tento select smie mať plnohodnotný popis.
-            aria-label={`Zmeniť stav riadku objednávky ${line.externalOrderId} / ${line.variantCode}`}
-            data-testid={`state-select-${line.lineId}`}
-            className="ord-state-select"
-            value={line.state}
-            disabled={busyLineId === line.lineId}
+    <>
+      <tr
+        className={"order-row state-" + line.state + (line.ordered ? " ordered" : "")}
+        data-testid={`order-line-${line.lineId}`}
+      >
+        <td>
+          <input
+            type="checkbox"
+            data-testid={`ordered-checkbox-${line.lineId}`}
+            aria-label={`Označiť riadok objednávky ${line.externalOrderId} / ${line.variantCode} ako objednané u dodávateľa`}
+            checked={line.ordered}
+            disabled={!canChangeState || busyOrderedLineId === line.lineId || supplierBusy}
             onChange={(e) => {
-              onChangeState(line.lineId, e.target.value as OrderLine["state"]);
+              onChangeOrdered(line.lineId, e.target.checked);
             }}
+          />
+        </td>
+        <td className="ord-order-cell">
+          {/* issue 65: priamy odkaz do Shoptet administrácie na TÚTO
+              objednávku (`queries.ts`'s `buildShoptetAdminOrderUrl`).
+              issue 99: klikateľné je samotné ČÍSLO objednávky (majiteľ žiadal
+              doslovne "keď kliknem na kód objednávky") — pôvodná samostatná
+              ikonka `🔗` vedľa čísla zanikla, `line.adminUrl` sa nemení. */}
+          <a
+            href={line.adminUrl}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="ord-admin-link"
+            aria-label={`Otvoriť objednávku ${line.externalOrderId} v administrácii Shoptet`}
+            title="Otvoriť v administrácii Shoptet"
           >
-            {(Object.keys(STATE_LABELS) as OrderLine["state"][]).map((s) => (
-              <option key={s} value={s}>
-                {STATE_LABELS[s]}
-              </option>
-            ))}
-          </select>
-        ) : (
-          STATE_LABELS[line.state]
-        )}
-      </td>
-      <td className="ord-date-cell">
-        {new Date(line.placedAt).toLocaleDateString("sk-SK")}
-        {/* issue 65: upozornenie na starú nevybavenú objednávku — priamy
-            náprotivok starej appky's ⚠️ badge (`ordersSummary.ts`'s
-            `isStaleOrderLine`, hranica 14 dní). issue 127: viditeľný text
-            skrátený na "N d" (namiesto "N dní") — naživo nameraný odznak
-            pretŕčal svoju bunku (`.col-date`) o ~22px pri 1280px, keďže
-            stĺpec je užší než jeho vlastný obsah. Celý text ("N dní")
-            zostáva v `title` tooltipe pre prístupnosť/čitateľnosť. */}
-        {isStaleOrderLine(line) && (
-          <span
-            className="ord-stale-badge"
-            data-testid={`stale-badge-${line.lineId}`}
-            title={`Nevybavená objednávka stará ${String(orderLineAgeDays(line.placedAt))} dní — pozri, nech nezapadne`}
-          >
-            ⚠️ {orderLineAgeDays(line.placedAt)} d
-          </span>
-        )}
-      </td>
-      {/* issue 95: POZNÁMKA E-SHOPU (`remark`, read-only) + KOMENTÁR zlúčené
-          do jednej bunky "Poznámky" (majiteľ, komentár #10) — oba vnorené
-          bloky nižšie sú BEZ ZMENY (rovnaké testid, rovnaká logika), len pod
-          sebou v jednej `<td>` namiesto dvoch samostatných stĺpcov. */}
-      <td className="ord-notes-merged">
-        {/* issue 65: zákaznícky odkaz k objednávke — read-only, appka ho
-            nikdy needituje (na rozdiel od `comment` bloku nižšie). */}
-        {/* issue 111 bod 4: predtým sa tu VŽDY vykresľovala holá pomlčka "—",
-            keď objednávka nemá poznámku e-shopu (100 % dnešných ostrých dát)
-            — presne ten istý zbytočný riadok navyše, aký #107 bod 3 už
-            odstránilo z priradenia dodávateľa. Keď `remark` je `null`,
-            nevykreslí sa NIČ (žiadny prvok, žiadny prázdny <span>) —
-            `OrderLineRow.remarkCell.test.tsx` to overuje. */}
-        <div className="ord-remark-cell" data-testid={`remark-cell-${line.lineId}`}>
-          {line.remark !== null && (
-            <span className="ord-remark" title={line.remark}>
-              🛈 {line.remark}
+            {line.externalOrderId}
+          </a>
+        </td>
+        <td>{line.customerName}</td>
+        <td>{line.variantName}</td>
+        <td className="ord-qty">
+          {line.quantity} ks
+          {qtyChip !== null && (
+            <span className="qty-total-chip" data-testid={`qty-total-${line.lineId}`} title={qtyChip.title}>
+              {qtyChip.text}
             </span>
           )}
-        </div>
-        <div className="ord-comment-cell" data-testid={`comment-cell-${line.lineId}`}>
-          {canChangeState ? (
-            <>
-              {/* issue 150: `<textarea>` (nie `<input>`) — Enter vkladá nový
-                  riadok defaultne (žiadny `preventDefault`), uloží LEN
-                  Ctrl/⌘+Enter. Poznámka býva viacriadková (dohoda so
-                  zákazníkom/dodávateľom) a spätne sa zapisuje do Shoptetu,
-                  takže formátovanie má význam — `<input>` by nový riadok
-                  nikdy vizuálne nezobrazil, bez ohľadu na to, čo je v jeho
-                  hodnote uložené. */}
-              <textarea
-                className="ord-comment-input"
-                data-testid={`comment-input-${line.lineId}`}
-                aria-label={`Poznámka k objednávke ${line.externalOrderId} / ${line.variantCode}`}
-                placeholder="poznámka…"
-                maxLength={2000}
-                rows={1}
-                value={commentDraft}
-                disabled={commentBusyHere}
+        </td>
+        {/* issue 95: DODÁVATEĽ + PRIRADENIE DODÁVATEĽA zlúčené do jednej bunky
+            (majiteľ, komentár #1) — oba vnorené bloky nižšie sú BEZ ZMENY
+            (rovnaké testid, rovnaká logika), len vedľa seba v jednej `<td>`
+            namiesto dvoch samostatných stĺpcov. */}
+        <td className="ord-supplier-merged">
+          <div className="ord-supplier-row">
+            <div className="ord-supplier-cell" data-testid={`supplier-link-${line.lineId}`}>
+              {line.supplierUrl !== null ? (
+                // issue 119: majiteľ, doslovne "zmen na nejake tlacitko z ikonou
+                // ktore otvori na novom okne ten link, lebo teraz to je tazke
+                // stlacit" — textový odkaz nahradený veľkým ikonovým tlačidlom
+                // (`.ord-supplier-link` v `app.css` teraz štylizuje `<a>` ako
+                // tlačidlo, min. 36×36px klikacej plochy). `aria-label`/`title`
+                // nesú ten istý popis ako predtým (issue 72: variantName sám
+                // nestačí — dva riadky toho istého produktu v rôznych veľkostiach
+                // majú zhodný variantName, líšia sa len variantCode), viditeľný
+                // text je teraz len ikonka (`aria-hidden`, prístupné meno nesie
+                // výlučne `aria-label`).
+                <a
+                  href={line.supplierUrl}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  className="ord-supplier-link"
+                  aria-label={`Odkaz na dodávateľa — ${line.variantName} (${line.variantCode})`}
+                  title={`Otvoriť odkaz na dodávateľa — ${line.variantName} (${line.variantCode})`}
+                >
+                  <span aria-hidden="true">🔗</span>
+                </a>
+              ) : line.supplierNote !== null ? (
+                <span className="ord-supplier-note" title={line.supplierNote}>
+                  {line.supplierNote}
+                </span>
+              ) : line.supplierAssignable ? (
+                // issue 107 bod 3: majiteľ, komentár #1: "neviem čo tam je
+                // Priradenie dodávateľa stĺpec" — namiesto holej pomlčky (predtým
+                // aj tu, aj v `.ord-supplier-assign` nižšie — DVE pomlčky nad
+                // sebou) je tu teraz VIDITEĽNÝ popis toho, čo vstup pod ním robí.
+                // Zámerne v TEJTO, už existujúcej bunke (nie nový riadok pod
+                // vstupom) — pridanie ĎALŠIEHO riadku by pri úzkom stĺpci
+                // (input+button už zapĺňajú takmer celú šírku) posunulo výšku
+                // riadku nad issue 105's ~95px invariant (živo zmerané: 85px →
+                // 103.5px s popisom na vlastnom riadku).
+                <span className="ord-supplier-assign-hint">Priradiť dodávateľa</span>
+              ) : (
+                // issue 117: `externalCode` (dodávateľský kód) sa už NIKDY
+                // nezobrazuje — majiteľ ho nepoužíva ("kody produktov vobec
+                // nepouzivame"), appka používa výlučne odkaz na dodávateľa.
+                // Predtým sa táto pomlčka potláčala, keď `externalCode` bol
+                // vyplnený (zobrazoval sa namiesto nej samostatný "kód …" riadok)
+                // — bez toho riadku je terajší terminálny stav VŽDY pomlčka,
+                // keď riadok nemá ani odkaz, ani poznámku, ani priradenie
+                // (legitímny, `OrderLineRow.supplierAssignCell.test.tsx`).
+                "—"
+              )}
+            </div>
+            {/* issue 121: majiteľ, doslovne "ma byt moznost ho doplnit... pri
+                kazdom produkte ma byt moznost upravit link". TOGGLE (nie trvalo
+                viditeľný vstup) — pridáva JEDEN malý prvok VŽDY (`flex-shrink: 0`
+                v `.ord-supplier-row`, žiadna vlastná výška), vstup+uložiť sa
+                vykreslí LEN pri otvorenej úprave (nižšie), aby sa nezopakovala
+                issue 105/107/111/127's row-height regresia na VŠETKÝCH 37
+                riadkoch naraz. */}
+            <button
+              type="button"
+              className="ord-supplier-link-edit-toggle"
+              data-testid={`supplier-link-edit-toggle-${line.lineId}`}
+              aria-label={
+                linkEditing
+                  ? `Zrušiť úpravu odkazu na dodávateľa — ${line.variantName} (${line.variantCode})`
+                  : line.supplierUrl !== null
+                    ? `Upraviť odkaz na dodávateľa — ${line.variantName} (${line.variantCode})`
+                    : `Doplniť odkaz na dodávateľa — ${line.variantName} (${line.variantCode})`
+              }
+              title={linkEditing ? "Zrušiť úpravu" : line.supplierUrl !== null ? "Upraviť odkaz" : "Doplniť odkaz"}
+              onClick={toggleLinkEditing}
+            >
+              <span aria-hidden="true">{linkEditing ? "✖" : "✏️"}</span>
+            </button>
+          </div>
+          {/* pri neradiťeľnom riadku (100 % dnešných ostrých dát) sa TENTO blok
+              predtým vykresľoval VŽDY, len s holou pomlčkou "—" bez
+              akéhokoľvek významu. Teraz sa nevykreslí VÔBEC (žiadny prvok,
+              žiadny prázdny <div>) — presne to, čo test v
+              `OrderLineRow.supplierAssignCell.test.tsx` overuje. */}
+          {line.supplierAssignable && (
+            <div className="ord-supplier-assign" data-testid={`supplier-assign-cell-${line.lineId}`}>
+              <input
+                type="text"
+                // Jeden zdieľaný `<datalist id="known-suppliers">` (rendrovaný
+                // raz v `OrdersSection.tsx`, z UŽ načítaných skupín) — žiadna
+                // nová GET trasa netreba len na našepkávanie.
+                list="known-suppliers"
+                className="ord-supplier-assign-input"
+                data-testid={`supplier-assign-input-${line.lineId}`}
+                aria-label={`Priradiť dodávateľa riadku objednávky ${line.externalOrderId} / ${line.variantCode}`}
+                placeholder="priradiť dodávateľa…"
+                value={supplierDraft}
+                disabled={supplierBusyHere}
                 onChange={(e) => {
-                  isCommentDirty.current = true;
-                  setCommentDraft(e.target.value);
+                  onSupplierDraftChange(line.lineId, e.target.value);
                 }}
                 onKeyDown={(e) => {
-                  if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
+                  if (e.key === "Enter") {
                     e.preventDefault();
-                    saveComment();
+                    saveSupplier();
                   }
                 }}
               />
               <button
                 type="button"
                 className="btn sm good"
-                data-testid={`comment-save-${line.lineId}`}
-                aria-label={`Uložiť poznámku k objednávke ${line.externalOrderId} / ${line.variantCode}`}
-                title="Uložiť poznámku (Ctrl+Enter)"
-                disabled={commentBusyHere}
-                onClick={saveComment}
+                data-testid={`supplier-assign-save-${line.lineId}`}
+                aria-label={`Uložiť priradenie dodávateľa riadku objednávky ${line.externalOrderId} / ${line.variantCode}`}
+                disabled={supplierBusyHere || supplierDraft.trim() === ""}
+                onClick={saveSupplier}
               >
                 💾
               </button>
-            </>
-          ) : (
-            // issue 150: `.ord-comment-display` (CSS `white-space: pre-wrap`)
-            // — už uložený viacriadkový komentár zobrazí svoje zalomenia aj
-            // na čítanie, nielen počas úpravy.
-            <span className="ord-comment-display">{line.comment ?? "—"}</span>
+            </div>
           )}
-        </div>
-      </td>
-    </tr>
+        </td>
+        <td>
+          {canChangeState ? (
+            <select
+              // Code review finding (#25): pôvodne bez slova "stav" v
+              // aria-labeli (obchádzka Playwright's substring
+              // `getByLabel("Stav")` kolízie s katalógovým filtrom), čo by
+              // čítačke obrazovky neoznámilo, čo tento prvok robí. Skutočná
+              // oprava patrí na stranu KOLÍDUJÚCEHO testu (`catalog.spec.ts`
+              // teraz používa `{ exact: true }`), nie na obetovanie
+              // prístupnosti tu — tento select smie mať plnohodnotný popis.
+              aria-label={`Zmeniť stav riadku objednávky ${line.externalOrderId} / ${line.variantCode}`}
+              data-testid={`state-select-${line.lineId}`}
+              className="ord-state-select"
+              value={line.state}
+              disabled={busyLineId === line.lineId}
+              onChange={(e) => {
+                onChangeState(line.lineId, e.target.value as OrderLine["state"]);
+              }}
+            >
+              {(Object.keys(STATE_LABELS) as OrderLine["state"][]).map((s) => (
+                <option key={s} value={s}>
+                  {STATE_LABELS[s]}
+                </option>
+              ))}
+            </select>
+          ) : (
+            STATE_LABELS[line.state]
+          )}
+        </td>
+        <td className="ord-date-cell">
+          {new Date(line.placedAt).toLocaleDateString("sk-SK")}
+          {/* issue 65: upozornenie na starú nevybavenú objednávku — priamy
+              náprotivok starej appky's ⚠️ badge (`ordersSummary.ts`'s
+              `isStaleOrderLine`, hranica 14 dní). issue 127: viditeľný text
+              skrátený na "N d" (namiesto "N dní") — naživo nameraný odznak
+              pretŕčal svoju bunku (`.col-date`) o ~22px pri 1280px, keďže
+              stĺpec je užší než jeho vlastný obsah. Celý text ("N dní")
+              zostáva v `title` tooltipe pre prístupnosť/čitateľnosť. */}
+          {isStaleOrderLine(line) && (
+            <span
+              className="ord-stale-badge"
+              data-testid={`stale-badge-${line.lineId}`}
+              title={`Nevybavená objednávka stará ${String(orderLineAgeDays(line.placedAt))} dní — pozri, nech nezapadne`}
+            >
+              ⚠️ {orderLineAgeDays(line.placedAt)} d
+            </span>
+          )}
+        </td>
+        {/* issue 95: POZNÁMKA E-SHOPU (`remark`, read-only) + KOMENTÁR zlúčené
+            do jednej bunky "Poznámky" (majiteľ, komentár #10) — oba vnorené
+            bloky nižšie sú BEZ ZMENY (rovnaké testid, rovnaká logika), len pod
+            sebou v jednej `<td>` namiesto dvoch samostatných stĺpcov. */}
+        <td className="ord-notes-merged">
+          {/* issue 65: zákaznícky odkaz k objednávke — read-only, appka ho
+              nikdy needituje (na rozdiel od `comment` bloku nižšie). */}
+          {/* issue 111 bod 4: predtým sa tu VŽDY vykresľovala holá pomlčka "—",
+              keď objednávka nemá poznámku e-shopu (100 % dnešných ostrých dát)
+              — presne ten istý zbytočný riadok navyše, aký #107 bod 3 už
+              odstránilo z priradenia dodávateľa. Keď `remark` je `null`,
+              nevykreslí sa NIČ (žiadny prvok, žiadny prázdny <span>) —
+              `OrderLineRow.remarkCell.test.tsx` to overuje. */}
+          <div className="ord-remark-cell" data-testid={`remark-cell-${line.lineId}`}>
+            {line.remark !== null && (
+              <span className="ord-remark" title={line.remark}>
+                🛈 {line.remark}
+              </span>
+            )}
+          </div>
+          <div className="ord-comment-cell" data-testid={`comment-cell-${line.lineId}`}>
+            {canChangeState ? (
+              <>
+                {/* issue 150: `<textarea>` (nie `<input>`) — Enter vkladá nový
+                    riadok defaultne (žiadny `preventDefault`), uloží LEN
+                    Ctrl/⌘+Enter. Poznámka býva viacriadková (dohoda so
+                    zákazníkom/dodávateľom) a spätne sa zapisuje do Shoptetu,
+                    takže formátovanie má význam — `<input>` by nový riadok
+                    nikdy vizuálne nezobrazil, bez ohľadu na to, čo je v jeho
+                    hodnote uložené. */}
+                <textarea
+                  className="ord-comment-input"
+                  data-testid={`comment-input-${line.lineId}`}
+                  aria-label={`Poznámka k objednávke ${line.externalOrderId} / ${line.variantCode}`}
+                  placeholder="poznámka…"
+                  maxLength={2000}
+                  rows={1}
+                  value={commentDraft}
+                  disabled={commentBusyHere}
+                  onChange={(e) => {
+                    isCommentDirty.current = true;
+                    setCommentDraft(e.target.value);
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
+                      e.preventDefault();
+                      saveComment();
+                    }
+                  }}
+                />
+                <button
+                  type="button"
+                  className="btn sm good"
+                  data-testid={`comment-save-${line.lineId}`}
+                  aria-label={`Uložiť poznámku k objednávke ${line.externalOrderId} / ${line.variantCode}`}
+                  title="Uložiť poznámku (Ctrl+Enter)"
+                  disabled={commentBusyHere}
+                  onClick={saveComment}
+                >
+                  💾
+                </button>
+              </>
+            ) : (
+              // issue 150: `.ord-comment-display` (CSS `white-space: pre-wrap`)
+              // — už uložený viacriadkový komentár zobrazí svoje zalomenia aj
+              // na čítanie, nielen počas úpravy.
+              <span className="ord-comment-display">{line.comment ?? "—"}</span>
+            )}
+          </div>
+        </td>
+      </tr>
+      {/* issue 162: majiteľ, políčko na úpravu odkazu na dodávateľa bolo v
+          úzkej bunke DODÁVATEĽ (~94px) príliš malé na to, aby bolo vidno
+          reálny odkaz. Namiesto rozširovania úzkeho stĺpca (rozbilo by
+          starostlivo odmerané `<colgroup>` rozpočty z issue 107/111/127) sa
+          úprava rozbaľuje do VLASTNÉHO riadku POD daným riadkom, cez celú
+          šírku tabuľky (`colSpan={ORDERS_TABLE_COLUMN_COUNT}`) — ticketov
+          vlastný odporúčaný prístup. Vnútri je PRESNE ten istý, nezmenený
+          `<div data-testid="supplier-link-edit-<lineId>">` blok ako predtým
+          (rovnaké testid vstupu/uloženia) — `.ord-supplier-link-edit-input`
+          už dnes má `flex: 1 1 0%; max-width: 100%` (`app.css`), takže sa
+          prirodzene roztiahne na šírku tohto oveľa širšieho rodiča bez
+          akejkoľvek zmeny CSS triedy, len zmenou DOM umiestnenia. Testid
+          tohto riadku ZÁMERNE nezačína "order-line-" — viacero e2e testov v
+          appke používa `[data-testid^='order-line-']` na nájdenie
+          HLAVNÉHO riadku (napr. `orders-hidden-editor.spec.ts`); prefix
+          zhodný s hlavným riadkom by spôsobil Playwright strict-mode
+          koliziu (2 zhodné prvky) hneď, ako by editor bol otvorený. */}
+      {linkEditing && (
+        <tr className="ord-supplier-link-edit-row" data-testid={`link-edit-row-${line.lineId}`}>
+          <td colSpan={ORDERS_TABLE_COLUMN_COUNT}>
+            <div className="ord-supplier-link-edit" data-testid={`supplier-link-edit-${line.lineId}`}>
+              <input
+                type="url"
+                className="ord-supplier-link-edit-input"
+                data-testid={`supplier-link-edit-input-${line.lineId}`}
+                aria-label={`Odkaz na dodávateľa riadku objednávky ${line.externalOrderId} / ${line.variantCode}`}
+                placeholder="https://…"
+                value={linkDraft}
+                disabled={linkBusyHere}
+                autoFocus
+                onChange={(e) => {
+                  setLinkDraft(e.target.value);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    saveLink();
+                    return;
+                  }
+                  // issue 162: majiteľ žiada explicitne "zrušenie (Escape)" —
+                  // predtým NEEXISTOVALO na tomto ani žiadnom inom editore v
+                  // appke (zrušiť sa dalo len klikom na ✖ toggle); lacné
+                  // pridať na presne ten istý vstup, ktorý sa práve presúva.
+                  if (e.key === "Escape") {
+                    e.preventDefault();
+                    toggleLinkEditing();
+                  }
+                }}
+              />
+              <button
+                type="button"
+                className="btn sm good"
+                data-testid={`supplier-link-edit-save-${line.lineId}`}
+                aria-label={`Uložiť odkaz na dodávateľa riadku objednávky ${line.externalOrderId} / ${line.variantCode}`}
+                disabled={linkBusyHere || linkDraft.trim() === ""}
+                onClick={saveLink}
+              >
+                💾
+              </button>
+            </div>
+          </td>
+        </tr>
+      )}
+    </>
   );
 }

--- a/apps/web/src/components/OrderLineRow.tsx
+++ b/apps/web/src/components/OrderLineRow.tsx
@@ -1,18 +1,8 @@
 import { useEffect, useRef, useState, type JSX } from "react";
 import type { OrderLine } from "../ordersApi.js";
+import { STATE_LABELS } from "../orderLineStateLabels.js";
 import { formatVariantTotalChip, isStaleOrderLine, orderLineAgeDays, type VariantTotal } from "../ordersSummary.js";
-
-// issue 60: `objednane` je VÝCHODISKOVÝ stav riadku (pred tým, než sa
-// čokoľvek stane), NIE potvrdenie, že manažér objednal — preto sa nazýva
-// "Nevybavené", nie "Objednané" (to slovo teraz patrí VÝLUČNE odškrtávaciemu
-// políčku v tomto riadku, `OrderLine["ordered"]`, aby appka nemala na jednej
-// obrazovke tri rôzne veci s tým istým názvom).
-export const STATE_LABELS: Record<OrderLine["state"], string> = {
-  objednane: "Nevybavené",
-  caka_sa: "Čaká sa",
-  skladom: "Skladom",
-  nedostupne: "Nedostupné",
-};
+import { OrderLineStateButtons } from "./OrderLineStateButtons.js";
 
 // issue 162: počet stĺpcov "Na objednanie" tabuľky — MUSÍ sedieť s počtom
 // `<col>` v `SupplierOrderGroup.tsx`'s `<colgroup>` (9). Vlastný rozbaľovací
@@ -375,29 +365,7 @@ export function OrderLineRow({
         </td>
         <td>
           {canChangeState ? (
-            <select
-              // Code review finding (#25): pôvodne bez slova "stav" v
-              // aria-labeli (obchádzka Playwright's substring
-              // `getByLabel("Stav")` kolízie s katalógovým filtrom), čo by
-              // čítačke obrazovky neoznámilo, čo tento prvok robí. Skutočná
-              // oprava patrí na stranu KOLÍDUJÚCEHO testu (`catalog.spec.ts`
-              // teraz používa `{ exact: true }`), nie na obetovanie
-              // prístupnosti tu — tento select smie mať plnohodnotný popis.
-              aria-label={`Zmeniť stav riadku objednávky ${line.externalOrderId} / ${line.variantCode}`}
-              data-testid={`state-select-${line.lineId}`}
-              className="ord-state-select"
-              value={line.state}
-              disabled={busyLineId === line.lineId}
-              onChange={(e) => {
-                onChangeState(line.lineId, e.target.value as OrderLine["state"]);
-              }}
-            >
-              {(Object.keys(STATE_LABELS) as OrderLine["state"][]).map((s) => (
-                <option key={s} value={s}>
-                  {STATE_LABELS[s]}
-                </option>
-              ))}
-            </select>
+            <OrderLineStateButtons line={line} busyLineId={busyLineId} onChangeState={onChangeState} />
           ) : (
             STATE_LABELS[line.state]
           )}

--- a/apps/web/src/components/OrderLineStateButtons.tsx
+++ b/apps/web/src/components/OrderLineStateButtons.tsx
@@ -1,0 +1,56 @@
+import type { JSX } from "react";
+import type { OrderLine } from "../ordersApi.js";
+import { STATE_LABELS } from "../orderLineStateLabels.js";
+
+// issue 161: majiteľ, doslovne "na stav nechcem mat selektor ale 4
+// tlacitka" — nahrádza pôvodný `<select>` (`OrderLineRow.tsx`) segmentovaným
+// prepínačom so 4 tlačidlami, vyňaté do vlastného súboru (`OrderLineRow.tsx`
+// je už na eslint `max-lines: 400` hranici, rovnaký vzor ako existujúce
+// `SupplierOrderGroup.tsx`/`OrderLineRow.tsx` extrakcie, `.claude/rules/
+// frontend-design.md`). Obal nesie PÔVODNÝ testid (`state-select-<lineId>`)
+// aj PÔVODNÝ `aria-label`, aby existujúci e2e `getByLabel(...)` test naďalej
+// nachádzal ten istý prvok — len teraz `role="radiogroup"` namiesto
+// `<select>`. Rovnaké volanie na server (`onChangeState`) a rovnaká
+// optimistická logika ako predtým — mení sa LEN ovládací prvok.
+export function OrderLineStateButtons({
+  line,
+  busyLineId,
+  onChangeState,
+}: {
+  readonly line: OrderLine;
+  readonly busyLineId: string | null;
+  readonly onChangeState: (lineId: string, newState: OrderLine["state"]) => void;
+}): JSX.Element {
+  const busy = busyLineId === line.lineId;
+  return (
+    <div
+      className="ord-state-btn-group"
+      role="radiogroup"
+      aria-label={`Zmeniť stav riadku objednávky ${line.externalOrderId} / ${line.variantCode}`}
+      data-testid={`state-select-${line.lineId}`}
+    >
+      {(Object.keys(STATE_LABELS) as OrderLine["state"][]).map((s) => {
+        const active = line.state === s;
+        return (
+          <button
+            key={s}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            className={"ord-state-btn ord-state-btn-" + s + (active ? " active" : "")}
+            data-testid={`state-btn-${s}-${line.lineId}`}
+            disabled={busy}
+            onClick={() => {
+              // issue 161: klik na UŽ aktívne tlačidlo nepošle zbytočný
+              // zápis na server — presne to, čo `<select>` prirodzene robil
+              // (výber tej istej `<option>` nikdy nevyvolal `onChange`).
+              if (!active) onChangeState(line.lineId, s);
+            }}
+          >
+            {STATE_LABELS[s]}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/OrdersSection.remainingCount.test.tsx
+++ b/apps/web/src/components/OrdersSection.remainingCount.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { useCallback, useMemo, useState, type JSX } from "react";
 import { afterEach, expect, it, vi } from "vitest";
 import { OrdersRemainingCountContext } from "../ordersRemainingCountContext.js";
@@ -86,9 +86,9 @@ it("po zmene stavu posledného nevybaveného riadku odznak klesne na 0, bez nov�
     expect(screen.getByTestId("remaining-count").textContent).toBe("1");
   });
 
-  const select = await screen.findByTestId<HTMLSelectElement>(`state-select-${LINE_NEVYBAVENY.lineId}`);
-  select.value = "skladom";
-  select.dispatchEvent(new Event("change", { bubbles: true }));
+  // issue 161: `<select>` nahradili 4 tlačidlá.
+  await screen.findByTestId(`state-select-${LINE_NEVYBAVENY.lineId}`);
+  fireEvent.click(screen.getByTestId(`state-btn-skladom-${LINE_NEVYBAVENY.lineId}`));
 
   await waitFor(() => {
     expect(screen.getByTestId("remaining-count").textContent).toBe("0");

--- a/apps/web/src/components/OrdersSection.test.tsx
+++ b/apps/web/src/components/OrdersSection.test.tsx
@@ -298,24 +298,26 @@ it("rola sef nevidí select na zmenu stavu, len text", async () => {
   expect(screen.queryByTestId(`state-select-${LINE_STARA.lineId}`)).toBeNull();
 });
 
-it("rola manazer vidí select a zmena stavu sa prejaví lokálne bez nového načítania", async () => {
+it("rola manazer vidí 4 tlačidlá a zmena stavu sa prejaví lokálne bez nového načítania", async () => {
   fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_STARA], email: null }]);
   updateOrderLineState.mockResolvedValue(undefined);
 
   render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
 
-  const select = await screen.findByTestId<HTMLSelectElement>(`state-select-${LINE_STARA.lineId}`);
-  expect(select.value).toBe("objednane");
+  await screen.findByTestId(`state-select-${LINE_STARA.lineId}`);
+  // issue 161: `<select>`'s jedna vybraná `<option>` nahradilo `aria-checked`
+  // na PRÁVE aktívnom z 4 tlačidiel.
+  expect(screen.getByTestId(`state-btn-objednane-${LINE_STARA.lineId}`).getAttribute("aria-checked")).toBe("true");
 
-  select.value = "skladom";
-  select.dispatchEvent(new Event("change", { bubbles: true }));
+  fireEvent.click(screen.getByTestId(`state-btn-skladom-${LINE_STARA.lineId}`));
 
   await waitFor(() => {
     expect(updateOrderLineState).toHaveBeenCalledWith(LINE_STARA.lineId, "skladom");
   });
   await waitFor(() => {
-    expect(screen.getByTestId<HTMLSelectElement>(`state-select-${LINE_STARA.lineId}`).value).toBe("skladom");
+    expect(screen.getByTestId(`state-btn-skladom-${LINE_STARA.lineId}`).getAttribute("aria-checked")).toBe("true");
   });
+  expect(screen.getByTestId(`state-btn-objednane-${LINE_STARA.lineId}`).getAttribute("aria-checked")).toBe("false");
   // Presne JEDNO volanie fetchOpenOrders (počiatočné načítanie) — úspešná
   // zmena aktualizuje lokálny stav, netreba refetch.
   expect(fetchOpenOrders).toHaveBeenCalledTimes(1);
@@ -328,9 +330,8 @@ it("zlyhaná zmena stavu zobrazí slovenskú hlášku zo servera a stav sa nezme
 
   render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
 
-  const select = await screen.findByTestId<HTMLSelectElement>(`state-select-${LINE_STARA.lineId}`);
-  select.value = "skladom";
-  select.dispatchEvent(new Event("change", { bubbles: true }));
+  await screen.findByTestId(`state-select-${LINE_STARA.lineId}`);
+  fireEvent.click(screen.getByTestId(`state-btn-skladom-${LINE_STARA.lineId}`));
 
   // issue 66: kumulatívny banner (nahrádza pôvodný jediný `<p role="alert">`
   // so surovou serverovou hláškou) — nesie aj nadpis "N položiek"/tlačidlo
@@ -340,7 +341,7 @@ it("zlyhaná zmena stavu zobrazí slovenskú hlášku zo servera a stav sa nezme
       "⚠️ Nepodarilo sa uložiť 1 položku×Zmena stavu — obj. 1001, kód A-1 (Riadok objednávky sa nenašiel)",
     );
   });
-  expect(screen.getByTestId<HTMLSelectElement>(`state-select-${LINE_STARA.lineId}`).value).toBe("objednane");
+  expect(screen.getByTestId(`state-btn-objednane-${LINE_STARA.lineId}`).getAttribute("aria-checked")).toBe("true");
 });
 
 it("zmena stavu pri 401 zavolá onSessionExpired namiesto zobrazenia chyby", async () => {
@@ -350,9 +351,8 @@ it("zmena stavu pri 401 zavolá onSessionExpired namiesto zobrazenia chyby", asy
 
   render(<OrdersSection role="manazer" onSessionExpired={onSessionExpired} />);
 
-  const select = await screen.findByTestId<HTMLSelectElement>(`state-select-${LINE_STARA.lineId}`);
-  select.value = "skladom";
-  select.dispatchEvent(new Event("change", { bubbles: true }));
+  await screen.findByTestId(`state-select-${LINE_STARA.lineId}`);
+  fireEvent.click(screen.getByTestId(`state-btn-skladom-${LINE_STARA.lineId}`));
 
   await waitFor(() => {
     expect(onSessionExpired).toHaveBeenCalledTimes(1);

--- a/apps/web/src/components/OrdersSection.test.tsx
+++ b/apps/web/src/components/OrdersSection.test.tsx
@@ -324,6 +324,25 @@ it("rola manazer vidí 4 tlačidlá a zmena stavu sa prejaví lokálne bez nové
   expect(screen.queryByRole("alert")).toBeNull();
 });
 
+// issue 161 (code review finding): klik na UŽ aktívne tlačidlo nesmie poslať
+// zbytočný zápis na server — presne to, čo pôvodný `<select>` robil (výber
+// TEJ ISTEJ `<option>` nikdy nevyvolal `onChange`). Bez tohto testu by
+// budúca zmena `OrderLineStateButtons.tsx`'s `if (!active)` guardu mohla
+// ticho pridať zbytočné PATCH volania a nič by to nezachytilo.
+it("klik na už aktívne stavové tlačidlo nezavolá updateOrderLineState", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_STARA], email: null }]);
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  await screen.findByTestId(`state-select-${LINE_STARA.lineId}`);
+  const aktivne = screen.getByTestId(`state-btn-objednane-${LINE_STARA.lineId}`);
+  expect(aktivne.getAttribute("aria-checked")).toBe("true");
+
+  fireEvent.click(aktivne);
+
+  expect(updateOrderLineState).not.toHaveBeenCalled();
+});
+
 it("zlyhaná zmena stavu zobrazí slovenskú hlášku zo servera a stav sa nezmení", async () => {
   fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_STARA], email: null }]);
   updateOrderLineState.mockRejectedValue(new Error("Riadok objednávky sa nenašiel"));

--- a/apps/web/src/components/OrdersSection.writeFailures.test.tsx
+++ b/apps/web/src/components/OrdersSection.writeFailures.test.tsx
@@ -65,9 +65,11 @@ it("dve nezávislé zlyhania zápisu (iný riadok, iná akcia) sa zobrazia SÚČ
 
   render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
 
-  const select = await screen.findByTestId<HTMLSelectElement>(`state-select-${LINE_ALFA.lineId}`);
-  select.value = "skladom";
-  select.dispatchEvent(new Event("change", { bubbles: true }));
+  // issue 161: `<select>` nahradili 4 tlačidlá — `state-select-<lineId>` je
+  // teraz `role="radiogroup"` obal, konkrétny stav sa mení klikom na
+  // `state-btn-<hodnota>-<lineId>`.
+  await screen.findByTestId(`state-select-${LINE_ALFA.lineId}`);
+  fireEvent.click(screen.getByTestId(`state-btn-skladom-${LINE_ALFA.lineId}`));
 
   await waitFor(() => {
     expect(screen.getByTestId("order-write-failures").textContent).toContain("Nepodarilo sa uložiť 1 položku");
@@ -87,14 +89,13 @@ it("dve nezávislé zlyhania zápisu (iný riadok, iná akcia) sa zobrazia SÚČ
     "Príznak objednané — obj. 1002, kód B-1 (chyba príznaku)",
   );
   // Zamietnutá zmena sa NIKDY netvári ako uložená.
-  expect(select.value).toBe("objednane");
+  expect(screen.getByTestId(`state-btn-objednane-${LINE_ALFA.lineId}`).getAttribute("aria-checked")).toBe("true");
   expect(checkbox.checked).toBe(false);
 
   // Úspešný opakovaný zápis (riadok Alfa) zmaže LEN jeho položku — druhá
   // (Beta) ostáva viditeľná (legacy `clearToOrderFail`: "drop only ITS line").
   updateOrderLineState.mockResolvedValue(undefined);
-  select.value = "skladom";
-  select.dispatchEvent(new Event("change", { bubbles: true }));
+  fireEvent.click(screen.getByTestId(`state-btn-skladom-${LINE_ALFA.lineId}`));
 
   await waitFor(() => {
     expect(screen.getByTestId("order-write-failures").textContent).toContain("Nepodarilo sa uložiť 1 položku");

--- a/apps/web/src/orderLineStateLabels.ts
+++ b/apps/web/src/orderLineStateLabels.ts
@@ -1,0 +1,18 @@
+import type { OrderLine } from "./ordersApi.js";
+
+// issue 60: `objednane` je VÝCHODISKOVÝ stav riadku (pred tým, než sa
+// čokoľvek stane), NIE potvrdenie, že manažér objednal — preto sa nazýva
+// "Nevybavené", nie "Objednané" (to slovo teraz patrí VÝLUČNE odškrtávaciemu
+// políčku v tomto riadku, `OrderLine["ordered"]`, aby appka nemala na jednej
+// obrazovke tri rôzne veci s tým istým názvom).
+//
+// issue 161: vyňaté z `OrderLineRow.tsx` do vlastného modulu — `<select>`
+// nahradili 4 tlačidlá (`OrderLineStateButtons.tsx`), ktoré tento zoznam
+// potrebujú TIEŽ; `OrderLineRow.tsx` sám importuje `OrderLineStateButtons`,
+// takže zdieľaná hodnota nesmie žiť ani v jednom z nich (cyklický import).
+export const STATE_LABELS: Record<OrderLine["state"], string> = {
+  objednane: "Nevybavené",
+  caka_sa: "Čaká sa",
+  skladom: "Skladom",
+  nedostupne: "Nedostupné",
+};

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -1086,20 +1086,21 @@ tr:last-child td {
   background: var(--fs-brand);
   color: var(--fs-surface);
 }
-/* Vstup + uložiť pri OTVORENEJ úprave — rovnaký "flex-basis: 0 + min-width"
-   vzor ako `.ord-supplier-assign-input` (issue 105 bod 3's komentár
-   vysvetľuje prečo: `flex-basis` rozhoduje o zalomení, nie post-shrink
-   veľkosť). Vykreslí sa LEN keď editing beží (`OrderLineRow.tsx`) — na
-   rozdiel od `.ord-supplier-row` vyššie NEPRIDÁVA výšku KAŽDÉMU riadku,
-   len tomu PRÁVE editovanému (issue 105/107/111/127's odmeraný strop 120px
-   by inak takmer isto prasklo na VŠETKÝCH 37 riadkoch naraz). */
+/* issue 162: majiteľ, políčko na úpravu odkazu bolo v úzkej bunke DODÁVATEĽ
+   (~94px) príliš malé na to, aby bolo vidno reálny odkaz. Tento blok teraz
+   žije vo VLASTNOM rozbaľovacom riadku pod daným riadkom (`colSpan` cez
+   celú tabuľku, `OrderLineRow.tsx`), nie v úzkej bunke ako predtým —
+   `flex-basis: 0` vzor (issue 105 bod 3's komentár vysvetľuje prečo) sa
+   nemení, len rodičovský priestor je teraz oveľa širší, takže vstup sa
+   roztiahne naozaj široko. `max-width` obmedzuje len HORNÚ hranicu na
+   extrémne širokých obrazovkách (ticketov akceptačný test žiada aspoň 3×
+   pôvodných 94px = ≥282px — 40rem = 640px má veľkú rezervu). */
 .ord-supplier-link-edit {
   display: flex;
   align-items: center;
-  gap: var(--fs-space-1);
+  gap: var(--fs-space-2);
   flex-wrap: wrap;
-  max-width: 100%;
-  margin-top: var(--fs-space-1);
+  max-width: 40rem;
 }
 .ord-supplier-link-edit-input {
   flex: 1 1 0%;
@@ -1114,6 +1115,14 @@ tr:last-child td {
 }
 .ord-supplier-link-edit > button {
   flex-shrink: 0;
+}
+/* issue 162: bunka rozbaľovacieho riadku — jemne odlíšené pozadie (signál
+   "toto je vysunutá úprava", nie ďalší bežný riadok dát), rovnaký vodorovný
+   padding ako ostatné bunky (`.orders-table td`'s `--fs-space-3`). */
+.ord-supplier-link-edit-row > td {
+  background: var(--fs-surface-alt);
+  padding-left: var(--fs-space-3);
+  padding-right: var(--fs-space-3);
 }
 
 /* issue 65: priamy odkaz do Shoptet administrácie. issue 99: nesie teraz

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -919,10 +919,18 @@ tr:last-child td {
    nižšie). Vnútri sú DVA pôvodné testid-ované bloky (`.ord-supplier-cell`/
    `.ord-supplier-assign`, nezmenené) len vedľa seba v JEDNEJ bunke namiesto
    dvoch samostatných stĺpcov. */
+/* issue 163: majiteľ, deliaca čiara riadku nelícuje pod touto bunkou —
+   príčina bola `display:flex` PRIAMO na `<td>` (odstránené), ktorý menil box
+   tejto bunky z `table-cell` na flex kontajner nerešpektujúci skutočnú výšku
+   riadku (naživo namerané: 53px vs. riadok 91.5px), takže jej border-bottom
+   sedel vyššie než rám ostatných buniek. `<td>` je teraz normálna tabuľková
+   bunka — jej výška sa riadi rovnakým mechanizmom ako pri VŠETKÝCH ostatných
+   stĺpcoch (max naprieč bunkami riadku), takže border-bottom vždy lícuje, na
+   KAŽDEJ výške obsahu (rôzny zoom/šírka, "skryť vybavené"). Zvislý gap medzi
+   `.ord-supplier-row`/`.ord-supplier-assign` (predtým rodičovský flex `gap`)
+   nesie teraz `.ord-supplier-assign`'s vlastný `margin-top` nižšie. */
 .ord-supplier-merged {
-  display: flex;
-  flex-direction: column;
-  gap: var(--fs-space-1);
+  max-width: 100%;
 }
 /* issue 67: odkaz/kód dodávateľa pri riadku objednávky. */
 .ord-supplier-cell {
@@ -991,6 +999,10 @@ tr:last-child td {
   gap: var(--fs-space-1);
   flex-wrap: wrap;
   max-width: 100%;
+  /* issue 163: nahrádza rodičovský `.ord-supplier-merged`'s bývalý flex
+     `gap` (odstránené — pozri jeho komentár) — tento blok sa vykresľuje VŽDY
+     AŽ za `.ord-supplier-row`, takže `margin-top` dáva identickú medzeru. */
+  margin-top: var(--fs-space-1);
 }
 .ord-supplier-assign-input {
   /* issue 105 bod 3: `width: 8rem` (fixed) + `max-width: 100%` still forced

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -889,29 +889,86 @@ tr:last-child td {
   white-space: nowrap;
   cursor: help;
 }
-/* issue 107 bod 1: majiteľ, live nameraná chyba — natívna šípka rozbaľovača
-   sa vykresľuje VNÚTRI paddingu, ale nič v CSS s jej priestorom nepočíta
-   (`padding-right` bol celý priestor, ktorý appka "vidí"), takže reálne
-   viditeľné miesto na text bolo o ~15–20px menšie, než čokoľvek deklarované
-   — pri úzkom `col-state` stĺpci (≤1600px) sa najdlhší stav ("Nevybavené"/
-   "Nedostupné", ~83px textu) neskrátil na scrollWidth (žiadny technický
-   overflow), len sa VIZUÁLNE orezal natívnou šípkou. `appearance: none` +
-   vlastná malá SVG šípka spraví tento priestor DETERMINISTICKÝ (a teda aj
-   testovateľný) namiesto skrytého v réžii prehliadača. */
-.ord-state-select {
+/* issue 161: majiteľ, doslovne "na stav nechcem mat selektor ale 4
+   tlacitka" — `<select>` (bývalá `.ord-state-select`, teraz odstránená;
+   issue 107 bod 1's šípkový problém, ktorý riešila, so selectom zmizol
+   celý) nahradil segmentovaný prepínač so 4 tlačidlami
+   (`OrderLineStateButtons.tsx`). 2×2 mriežka (nie 4 v rade) — `col-state` je
+   len ~138px (13.5 % z ~1022px `min-width`), 4 tlačidlá v jednom rade by
+   boli príliš úzke na čitateľný text aj klik; 2×2 udrží tlačidlá dosť veľké
+   ("veľké tlačidlá", majiteľova stála požiadavka) a nezväčší výšku riadku
+   nad existujúci ~100px strop (issue 105/107/111/127/163,
+   `orders-layout.spec.ts`'s `vysokeKompaktneRiadky`). */
+.ord-state-btn-group {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--fs-space-1);
   width: 100%;
-  appearance: none;
-  padding: var(--fs-space-2) 1.25rem var(--fs-space-2) var(--fs-space-2);
+}
+.ord-state-btn {
+  /* Živo overené proti lokálnemu dev serveru (Playwright, 1280px): CSS Grid
+     položky majú PREDVOLENÉ `min-width: auto`, ktoré rešpektuje intrinzitnú
+     min-content šírku obsahu — jednoslovné popisky ("Nevybavené",
+     "Nedostupné") sa bez explicitného `overflow-wrap` nemajú kde zalomiť,
+     takže ich min-content šírka (~80px) roztiahla `.ord-state-btn-group`
+     (161px scrollWidth) nad reálnu šírku stĺpca (114px) a tlačidlá VIZUÁLNE
+     pretiekli do susedného stĺpca DÁTUM. `min-width: 0` dovolí položke
+     zmenšiť sa POD jej intrinzitnú šírku, `overflow-wrap: break-word`
+     zaručí, že sa dlhší popisok skutočne ZALOMÍ vnútri tlačidla (2 riadky),
+     nikdy neprepíše/nepretečie susedný stĺpec. */
+  min-width: 0;
+  overflow-wrap: break-word;
+  /* `lang="sk"` na `<html>` (`index.html`) dáva Chromiu slovenský slovník
+     delenia slov — namiesto zalomenia uprostred slova na ľubovoľnom mieste
+     (napr. "Nevyba/vené") sa preferuje delenie pri slabike ("Ne-vy-ba-
+     vené"), čitateľnejšie pri tomto úzkom stĺpci. */
+  hyphens: auto;
+  padding: var(--fs-space-1);
+  min-height: 2rem;
   border: 1px solid var(--fs-border);
   border-radius: var(--fs-radius-sm);
+  background: var(--fs-surface);
+  color: var(--fs-ink-muted);
   font: inherit;
-  font-size: var(--fs-text-base);
-  min-height: 2.25rem;
-  background-color: var(--fs-surface);
-  background-repeat: no-repeat;
-  background-position: right 0.4rem center;
-  background-size: 0.6rem 0.4rem;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 6'%3E%3Cpath d='M1 1l4 4 4-4' fill='none' stroke='%235c6b60' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  font-size: var(--fs-text-xs);
+  font-weight: var(--fs-weight-medium);
+  line-height: 1.15;
+  text-align: center;
+  cursor: pointer;
+}
+.ord-state-btn:hover:not(:disabled) {
+  border-color: var(--fs-brand);
+}
+.ord-state-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+/* Aktívny stav NIKDY len farbou (kontrast/farbosleposť, ticketov explicitný
+   akceptačný bod) — plná výplň + hrubší rám + tučné písmo, tri nezávislé
+   signály naraz. */
+.ord-state-btn.active {
+  border-width: 2px;
+  font-weight: var(--fs-weight-bold);
+}
+.ord-state-btn-objednane.active {
+  background: var(--fs-surface-alt);
+  border-color: var(--fs-ink-muted);
+  color: var(--fs-ink);
+}
+.ord-state-btn-caka_sa.active {
+  background: var(--fs-warning-bg);
+  border-color: var(--fs-warning);
+  color: var(--fs-warning);
+}
+.ord-state-btn-skladom.active {
+  background: var(--fs-success-bg);
+  border-color: var(--fs-success);
+  color: var(--fs-success);
+}
+.ord-state-btn-nedostupne.active {
+  background: var(--fs-danger-bg);
+  border-color: var(--fs-danger);
+  color: var(--fs-danger);
 }
 /* issue 95: DODÁVATEĽ + PRIRADENIE DODÁVATEĽA zlúčené do jednej bunky
    (majiteľ, komentár #1: "neviem čo tam je Priradenie dodávateľa stĺpec" —

--- a/apps/web/tests/e2e/orders-hidden-editor.spec.ts
+++ b/apps/web/tests/e2e/orders-hidden-editor.spec.ts
@@ -36,6 +36,10 @@ test("riadok s otvoreným editorom odkazu na dodávateľa ostáva viditeľný pr
   const skupina = page.getByTestId("supplier-DODAVATEL-TEST-1");
   const riadok = skupina.locator("[data-testid^='order-line-']");
   await expect(riadok).toBeVisible();
+  // issue 162: vstup na úpravu odkazu žije teraz vo VLASTNOM rozbaľovacom
+  // riadku POD `riadok`om (`colSpan` cez celú tabuľku), nie ako jeho
+  // potomok — nájde sa cez najbližšieho súrodenca za `riadok`om.
+  const editRiadok = riadok.locator("xpath=./following-sibling::tr[1]");
 
   // Bez otvoreného editora "skryť vybavené" skryje CELÚ skupinu (jediný
   // riadok je vybavený, "caka_sa") — presne existujúce správanie z issue 61.
@@ -47,14 +51,14 @@ test("riadok s otvoreným editorom odkazu na dodávateľa ostáva viditeľný pr
   await toggle.click();
   await expect(skupina).toBeVisible();
   await riadok.getByRole("button", { name: /odkaz na dodávateľa/i }).click();
-  await expect(riadok.locator("input[type='url']")).toBeVisible();
+  await expect(editRiadok.locator("input[type='url']")).toBeVisible();
 
   // Zapnúť "skryť vybavené" znova — riadok TERAZ ostáva viditeľný, lebo má
   // otvorený editor (issue 149's akceptačná podmienka).
   await toggle.click();
   await expect(skupina).toBeVisible();
   await expect(riadok).toBeVisible();
-  await expect(riadok.locator("input[type='url']")).toBeVisible();
+  await expect(editRiadok.locator("input[type='url']")).toBeVisible();
 
   // Zavretie editora (✖, bez uloženia) — riadok teraz zmizne.
   await riadok.getByRole("button", { name: /zrušiť úpravu odkazu na dodávateľa/i }).click();

--- a/apps/web/tests/e2e/orders-layout.spec.ts
+++ b/apps/web/tests/e2e/orders-layout.spec.ts
@@ -108,6 +108,25 @@ test("STAV je celý čitateľný a POZNÁMKY pole je dosť široké na všetkýc
     });
     expect(vysokeKompaktneRiadky, `príliš vysoké riadky pri ${String(width)}px`).toEqual([]);
 
+    // issue 163: majiteľ, deliaca čiara riadku nelícuje pod bunkou s
+    // odkazom na dodávateľa — `td.ord-supplier-merged` má vlastný
+    // `display:flex`, ktorý ju v tabuľkovom layoute zmenšuje na výšku
+    // VLASTNÉHO obsahu namiesto skutočnej výšky riadku (tú si vynucujú iné,
+    // vyššie bunky), takže jej border-bottom sedí vyššie než u susedných
+    // buniek. Kontrola: PRE KAŽDÝ viditeľný riadok musí spodný okraj tejto
+    // bunky lícovať so spodným okrajom riadku (±1px, subpixelové
+    // zaokrúhlenie pri neceločíselnom zoome/DPR).
+    const nezarovnaneDelice = await page.evaluate(() => {
+      return [...document.querySelectorAll<HTMLElement>("tr[data-testid^='order-line-']")]
+        .map((riadok) => {
+          const bunka = riadok.querySelector<HTMLElement>("td.ord-supplier-merged");
+          if (bunka === null) return null;
+          return Math.abs(bunka.getBoundingClientRect().bottom - riadok.getBoundingClientRect().bottom);
+        })
+        .filter((rozdiel): rozdiel is number => rozdiel !== null && rozdiel > 1);
+    });
+    expect(nezarovnaneDelice, `nezarovnané deliace čiary pod bunkou dodávateľa pri ${String(width)}px`).toEqual([]);
+
     // issue 111 body 1+2: číslo objednávky ANI kód produktu sa nesmú
     // zalomiť na viac riadkov, na ŽIADNEJ zo 4 šírok — kontroluje sa AJ
     // `white-space: nowrap` (mechanizmus, ktorý garantuje toto natrvalo, aj
@@ -170,6 +189,25 @@ test("STAV je celý čitateľný a POZNÁMKY pole je dosť široké na všetkýc
       expect(strankaSaPosuva, "stránka sa vodorovne posúva pri 1280px").toBe(false);
     }
   }
+
+  // issue 163: rovnaká deliaca-čiara kontrola aj pri ZAPNUTOM prepínači
+  // "skryť vybavené" — fix je štrukturálny (CSS na `<td>`), nie závislý od
+  // POČTU vykreslených riadkov, ale ticket to explicitne žiada overiť oboma
+  // stavmi prepínača.
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.getByTestId("orders-hide-resolved-toggle").click();
+  const nezarovnaneDeliceSkryte = await page.evaluate(() => {
+    return [...document.querySelectorAll<HTMLElement>("tr[data-testid^='order-line-']")]
+      .map((riadok) => {
+        const bunka = riadok.querySelector<HTMLElement>("td.ord-supplier-merged");
+        if (bunka === null) return null;
+        return Math.abs(bunka.getBoundingClientRect().bottom - riadok.getBoundingClientRect().bottom);
+      })
+      .filter((rozdiel): rozdiel is number => rozdiel !== null && rozdiel > 1);
+  });
+  expect(nezarovnaneDeliceSkryte, "nezarovnané deliace čiary pri zapnutom 'skryť vybavené'").toEqual([]);
+  // Vrátiť prepínač do pôvodného stavu.
+  await page.getByTestId("orders-hide-resolved-toggle").click();
 
   expect(chyby).toEqual([]);
 });

--- a/apps/web/tests/e2e/orders-layout.spec.ts
+++ b/apps/web/tests/e2e/orders-layout.spec.ts
@@ -34,40 +34,19 @@ test("STAV je celý čitateľný a POZNÁMKY pole je dosť široké na všetkýc
   for (const width of [1280, 1440, 1600, 1920]) {
     await page.setViewportSize({ width, height: 900 });
 
-    // issue 107 bod 1: KAŽDÁ <option> stavu (nie len tá aktuálne vybraná)
-    // musí byť celá viditeľná — `appearance: none` (`app.css`'s
-    // `.ord-state-select`) spravilo priestor na text DETERMINISTICKÝ
-    // (`clientWidth - padding - border`, žiadna skrytá natívna šípka), takže
-    // test už nepotrebuje hádať jej šírku.
+    // issue 161: `<select>` (a issue 107 bod 1's šípkový problém, ktorý
+    // riešila) nahradili 4 tlačidlá — KAŽDÉ musí zobraziť svoj CELÝ text
+    // (zalomenie na 2 riadky je OK, orezanie/vodorovné pretečenie nie).
     const orezaneStavy = await page.evaluate(() => {
-      const select = document.querySelector<HTMLSelectElement>(".ord-state-select");
-      if (!select) return { chyba: "no select found" };
-      const rect = select.getBoundingClientRect();
-      const cs = getComputedStyle(select);
-      const dostupne =
-        rect.width -
-        parseFloat(cs.paddingLeft) -
-        parseFloat(cs.paddingRight) -
-        parseFloat(cs.borderLeftWidth) -
-        parseFloat(cs.borderRightWidth);
-      const merac = document.createElement("span");
-      merac.style.visibility = "hidden";
-      merac.style.position = "absolute";
-      merac.style.whiteSpace = "nowrap";
-      merac.style.font = cs.font;
-      document.body.appendChild(merac);
       const orezane: string[] = [];
-      for (const option of [...select.options]) {
-        merac.textContent = option.textContent;
-        const potrebne = merac.getBoundingClientRect().width;
-        if (potrebne > dostupne) {
-          orezane.push(`"${option.textContent}" (${String(Math.ceil(potrebne))}px text vs ${String(Math.floor(dostupne))}px k dispozícii)`);
+      for (const btn of document.querySelectorAll<HTMLElement>(".ord-state-btn")) {
+        if (btn.scrollWidth > btn.clientWidth + 1) {
+          orezane.push(`"${btn.textContent}" (scrollWidth ${String(btn.scrollWidth)}px vs clientWidth ${String(btn.clientWidth)}px)`);
         }
       }
-      merac.remove();
-      return { orezane };
+      return orezane;
     });
-    expect(orezaneStavy.orezane, `orezané stavy pri ${String(width)}px`).toEqual([]);
+    expect(orezaneStavy, `orezané stavové tlačidlá pri ${String(width)}px`).toEqual([]);
 
     // issue 107 bod 2: pole na poznámku >= 160px pri 1280px, tlačidlo 💾 na
     // TOM ISTOM riadku (nesmie sa vrátiť k zalomeniu z issue 105).
@@ -109,13 +88,13 @@ test("STAV je celý čitateľný a POZNÁMKY pole je dosť široké na všetkýc
     expect(vysokeKompaktneRiadky, `príliš vysoké riadky pri ${String(width)}px`).toEqual([]);
 
     // issue 163: majiteľ, deliaca čiara riadku nelícuje pod bunkou s
-    // odkazom na dodávateľa — `td.ord-supplier-merged` má vlastný
-    // `display:flex`, ktorý ju v tabuľkovom layoute zmenšuje na výšku
-    // VLASTNÉHO obsahu namiesto skutočnej výšky riadku (tú si vynucujú iné,
-    // vyššie bunky), takže jej border-bottom sedí vyššie než u susedných
-    // buniek. Kontrola: PRE KAŽDÝ viditeľný riadok musí spodný okraj tejto
-    // bunky lícovať so spodným okrajom riadku (±1px, subpixelové
-    // zaokrúhlenie pri neceločíselnom zoome/DPR).
+    // odkazom na dodávateľa — príčina bola `display:flex` priamo na
+    // `td.ord-supplier-merged` (odstránené, `app.css`), ktorý bunku
+    // zmenšoval na výšku VLASTNÉHO obsahu namiesto skutočnej výšky riadku
+    // (tú si vynucujú iné, vyššie bunky), takže jej border-bottom sedel
+    // vyššie než u susedných buniek. Kontrola: PRE KAŽDÝ viditeľný riadok
+    // musí spodný okraj tejto bunky lícovať so spodným okrajom riadku
+    // (±1px, subpixelové zaokrúhlenie pri neceločíselnom zoome/DPR).
     const nezarovnaneDelice = await page.evaluate(() => {
       return [...document.querySelectorAll<HTMLElement>("tr[data-testid^='order-line-']")]
         .map((riadok) => {
@@ -206,7 +185,9 @@ test("STAV je celý čitateľný a POZNÁMKY pole je dosť široké na všetkýc
       .filter((rozdiel): rozdiel is number => rozdiel !== null && rozdiel > 1);
   });
   expect(nezarovnaneDeliceSkryte, "nezarovnané deliace čiary pri zapnutom 'skryť vybavené'").toEqual([]);
-  // Vrátiť prepínač do pôvodného stavu.
+  // Vrátiť prepínač do pôvodného stavu — iné súbežne bežiace e2e spec súbory
+  // (`.claude/rules/testing.md`'s "skryť vybavené" je GLOBÁLNY localStorage
+  // preferencia) nespoliehajú na tento konkrétny účet, ale je to čistejšie.
   await page.getByTestId("orders-hide-resolved-toggle").click();
 
   expect(chyby).toEqual([]);

--- a/apps/web/tests/e2e/orders-supplier-link.spec.ts
+++ b/apps/web/tests/e2e/orders-supplier-link.spec.ts
@@ -52,6 +52,10 @@ test("riadok bez odkazu ponúka 'doplniť', po uložení ponúka 'upraviť' a no
   const vstup = riadok.getByLabel("Odkaz na dodávateľa riadku objednávky 9007 / 278", { exact: true });
   await expect(vstup).toBeVisible();
   await expect(vstup).toHaveValue("");
+  // issue 162: majiteľ, políčko na úpravu odkazu je príliš malé na to, aby
+  // bolo vidno, čo sa edituje — naživo namerané 94px. Ticketov akceptačný
+  // test žiada aspoň 3× = ≥282px.
+  expect((await vstup.boundingBox())?.width ?? 0).toBeGreaterThanOrEqual(282);
 
   await vstup.fill("https://e2e-dodavatel.example.com/produkt-278");
   await riadok.getByLabel("Uložiť odkaz na dodávateľa riadku objednávky 9007 / 278").click();

--- a/apps/web/tests/e2e/orders-supplier-link.spec.ts
+++ b/apps/web/tests/e2e/orders-supplier-link.spec.ts
@@ -41,6 +41,11 @@ test("riadok bez odkazu ponúka 'doplniť', po uložení ponúka 'upraviť' a no
   await expect(skupina).toBeVisible();
   const riadok = skupina.locator("[data-testid^='order-line-']").filter({ hasText: "9007" });
   await expect(riadok).toContainText("ThermVisia");
+  // issue 162: vstup+uloženie žijú teraz vo VLASTNOM rozbaľovacom riadku POD
+  // `riadok`om (`colSpan` cez celú tabuľku), nie ako jeho potomok — nájde sa
+  // cez najbližšieho súrodenca za `riadok`om (toggle tlačidlo OSTÁVA v
+  // `riadok`u, nezmenené).
+  const editRiadok = riadok.locator("xpath=./following-sibling::tr[1]");
   const toggle = riadok.getByLabel(/Doplniť odkaz na dodávateľa/);
   await expect(toggle).toBeVisible();
 
@@ -49,7 +54,7 @@ test("riadok bez odkazu ponúka 'doplniť', po uložení ponúka 'upraviť' a no
   // tlačidlom "Uložiť odkaz na dodávateľa riadku objednávky ..." (obsahuje
   // ten istý text ako podreťazec, `.claude/rules/testing.md`'s Playwright
   // substring-kolízna poznámka).
-  const vstup = riadok.getByLabel("Odkaz na dodávateľa riadku objednávky 9007 / 278", { exact: true });
+  const vstup = editRiadok.getByLabel("Odkaz na dodávateľa riadku objednávky 9007 / 278", { exact: true });
   await expect(vstup).toBeVisible();
   await expect(vstup).toHaveValue("");
   // issue 162: majiteľ, políčko na úpravu odkazu je príliš malé na to, aby
@@ -58,7 +63,7 @@ test("riadok bez odkazu ponúka 'doplniť', po uložení ponúka 'upraviť' a no
   expect((await vstup.boundingBox())?.width ?? 0).toBeGreaterThanOrEqual(282);
 
   await vstup.fill("https://e2e-dodavatel.example.com/produkt-278");
-  await riadok.getByLabel("Uložiť odkaz na dodávateľa riadku objednávky 9007 / 278").click();
+  await editRiadok.getByLabel("Uložiť odkaz na dodávateľa riadku objednávky 9007 / 278").click();
 
   // Refetch po uložení (`OrdersSection.tsx`'s `setSupplierLink`) — panel sa
   // zavrie, ikonové tlačidlo odkazu sa objaví s NOVOU hodnotou, toggle teraz
@@ -77,6 +82,7 @@ test("riadok bez odkazu ponúka 'doplniť', po uložení ponúka 'upraviť' a no
     .getByTestId("supplier-(bez dodávateľa)")
     .locator("[data-testid^='order-line-']")
     .filter({ hasText: "9007" });
+  const editRiadokPoReloade = riadokPoReloade.locator("xpath=./following-sibling::tr[1]");
   await expect(riadokPoReloade.getByRole("link", { name: "Odkaz na dodávateľa" })).toHaveAttribute(
     "href",
     "https://e2e-dodavatel.example.com/produkt-278",
@@ -86,10 +92,12 @@ test("riadok bez odkazu ponúka 'doplniť', po uložení ponúka 'upraviť' a no
   // priradenia dodávateľa, žiadna "už má hodnotu" gate — ticket to žiada
   // explicitne).
   await riadokPoReloade.getByLabel(/Upraviť odkaz na dodávateľa/).click();
-  const vstupUprava = riadokPoReloade.getByLabel("Odkaz na dodávateľa riadku objednávky 9007 / 278", { exact: true });
+  const vstupUprava = editRiadokPoReloade.getByLabel("Odkaz na dodávateľa riadku objednávky 9007 / 278", {
+    exact: true,
+  });
   await expect(vstupUprava).toHaveValue("https://e2e-dodavatel.example.com/produkt-278");
   await vstupUprava.fill("https://e2e-dodavatel.example.com/opravena-adresa");
-  await riadokPoReloade.getByLabel("Uložiť odkaz na dodávateľa riadku objednávky 9007 / 278").click();
+  await editRiadokPoReloade.getByLabel("Uložiť odkaz na dodávateľa riadku objednávky 9007 / 278").click();
 
   await expect(riadokPoReloade.getByRole("link", { name: "Odkaz na dodávateľa" })).toHaveAttribute(
     "href",
@@ -125,12 +133,14 @@ test("neplatný odkaz na dodávateľa sa odmietne HNEĎ, bez zápisu na server (
     .getByTestId("supplier-(bez dodávateľa)")
     .locator("[data-testid^='order-line-']")
     .filter({ hasText: "9007" });
+  // issue 162: vstup+uloženie žijú teraz v samostatnom rozbaľovacom riadku.
+  const editRiadok = riadok.locator("xpath=./following-sibling::tr[1]");
   await riadok.getByLabel(/Upraviť odkaz na dodávateľa/).click();
-  const vstup = riadok.getByLabel("Odkaz na dodávateľa riadku objednávky 9007 / 278", { exact: true });
+  const vstup = editRiadok.getByLabel("Odkaz na dodávateľa riadku objednávky 9007 / 278", { exact: true });
   await expect(vstup).toHaveValue("https://e2e-dodavatel.example.com/opravena-adresa");
 
   await vstup.fill("nieje-url");
-  await riadok.getByLabel("Uložiť odkaz na dodávateľa riadku objednávky 9007 / 278").click();
+  await editRiadok.getByLabel("Uložiť odkaz na dodávateľa riadku objednávky 9007 / 278").click();
 
   await expect(page.getByTestId("order-write-failures")).toContainText(
     "Odkaz musí byť platná adresa začínajúca http:// alebo https://.",

--- a/apps/web/tests/e2e/orders-write-failures.spec.ts
+++ b/apps/web/tests/e2e/orders-write-failures.spec.ts
@@ -66,7 +66,12 @@ test("kumulatívne hlásenie o neuložených zmenách drží VIAC zlyhaní naraz
     .getByTestId("supplier-DODAVATEL-TEST-1")
     .locator("[data-testid^='order-line-']")
     .filter({ hasText: "9001" });
-  const selectAlfa = riadokAlfa.locator("select");
+  // issue 161: `<select>` nahradili 4 tlačidlá — obal so skupinovým testid
+  // (`state-select-<lineId>`, teraz `role="radiogroup"`) sa použije LEN na
+  // vyčítanie `lineId`, samotná zmena ide cez konkrétne `role="radio"` tlačidlo.
+  const stavGroupAlfa = riadokAlfa.locator("[data-testid^='state-select-']");
+  const tlacidloCakaSaAlfa = riadokAlfa.getByRole("radio", { name: "Čaká sa" });
+  const tlacidloSkladomAlfa = riadokAlfa.getByRole("radio", { name: "Skladom" });
 
   const riadokBez = page
     .getByTestId("supplier-(bez dodávateľa)")
@@ -74,7 +79,7 @@ test("kumulatívne hlásenie o neuložených zmenách drží VIAC zlyhaní naraz
     .filter({ hasText: "9002" });
   const checkboxBez = riadokBez.locator("input[type='checkbox']");
 
-  const alfaTestId = await selectAlfa.getAttribute("data-testid");
+  const alfaTestId = await stavGroupAlfa.getAttribute("data-testid");
   const alfaLineId = (alfaTestId ?? "").replace("state-select-", "");
   const bezTestId = await checkboxBez.getAttribute("data-testid");
   const bezLineId = (bezTestId ?? "").replace("ordered-checkbox-", "");
@@ -85,17 +90,17 @@ test("kumulatívne hlásenie o neuložených zmenách drží VIAC zlyhaní naraz
 
   // `scripts/e2e-setup.ts`: riadok Alfa (obj. 9001) štartuje v stave
   // "caka_sa" (vybavený), nie vo východiskovom "objednane".
-  await expect(selectAlfa).toHaveValue("caka_sa");
+  await expect(tlacidloCakaSaAlfa).toHaveAttribute("aria-checked", "true");
 
   // 1. zlyhanie: zmena stavu na riadku Alfa (DODAVATEL-TEST-1, obj. 9001).
   await page.evaluate((frag) => {
     (window as unknown as { __zlyhajUrl: Set<string> }).__zlyhajUrl.add(frag);
   }, `/api/orders/lines/${alfaLineId}/state`);
-  await selectAlfa.selectOption("skladom");
+  await tlacidloSkladomAlfa.click();
   await expect(banner).toContainText("Nepodarilo sa uložiť 1 položku");
   await expect(banner).toContainText("obj. 9001");
   // Zamietnutá zmena sa NIKDY netvári ako uložená.
-  await expect(selectAlfa).toHaveValue("caka_sa");
+  await expect(tlacidloCakaSaAlfa).toHaveAttribute("aria-checked", "true");
 
   // 2. NEZÁVISLÉ zlyhanie: iný riadok (obj. 9002, "(bez dodávateľa)"), iná
   // akcia (checkbox "objednané").
@@ -117,7 +122,7 @@ test("kumulatívne hlásenie o neuložených zmenách drží VIAC zlyhaní naraz
     w.__zlyhajUrl.delete(frag);
     w.__uspejUrl.add(frag);
   }, `/api/orders/lines/${alfaLineId}/state`);
-  await selectAlfa.selectOption("skladom");
+  await tlacidloSkladomAlfa.click();
   await expect(banner).toContainText("Nepodarilo sa uložiť 1 položku");
   await expect(banner).not.toContainText("obj. 9001");
   await expect(banner).toContainText("obj. 9002");

--- a/apps/web/tests/e2e/orders.spec.ts
+++ b/apps/web/tests/e2e/orders.spec.ts
@@ -298,8 +298,9 @@ test("manažér vidí otvorené objednávky zoskupené podľa dodávateľa, konz
   await expect(riadokBez).toContainText("E2E Zákazník Bez dodávateľa");
   await expect(riadokBez).toContainText("Čiapka Polar FOREST");
   // issue 117: variant kód ("40287") sa už NIKDE nezobrazuje viditeľne —
-  // stále však nesie zmysel (a je overiteľný) cez aria-label stavového
-  // selectu tohto riadku.
+  // stále však nesie zmysel (a je overiteľný) cez aria-label na obale
+  // stavových tlačidiel tohto riadku (issue 161: predtým `<select>`, ten
+  // istý `aria-label` ostal zachovaný na `role="radiogroup"` obale).
   await expect(riadokBez.getByLabel("Zmeniť stav riadku objednávky 9002 / 40287")).toBeVisible();
   // Predvolený stav riadku (schema default "objednane") a chýbajúca veľkosť —
   // issue 60: premenované na "Nevybavené" (slovo "Objednané" teraz patrí
@@ -320,14 +321,17 @@ test("manažér vidí otvorené objednávky zoskupené podľa dodávateľa, konz
   expect(chyby).toEqual([]);
 });
 
-// #25: manažér prepne stav riadku cez select v UI a zmena PRETRVÁ po obnovení
-// stránky. Zápis stavu a audit bežia v JEDNEJ transakcii (`modules/orders/
-// state.ts`) — pretrvanie po reloade je teda dôkazom, že transakcia skutočne
-// commitla (audit zápis neyhodil výnimku, ktorá by ju bola vrátila späť).
-// Samotný obsah auditového riadku (kto, kedy, z akého stavu do akého) overuje
+// #25: manažér prepne stav riadku cez tlačidlá v UI (issue 161: predtým
+// `<select>`, majiteľ ho odmietol) a zmena PRETRVÁ po obnovení stránky. Zápis
+// stavu a audit bežia v JEDNEJ transakcii (`modules/orders/state.ts`) —
+// pretrvanie po reloade je teda dôkazom, že transakcia skutočne commitla
+// (audit zápis neyhodil výnimku, ktorá by ju bola vrátila späť). Samotný
+// obsah auditového riadku (kto, kedy, z akého stavu do akého) overuje
 // integračný test (`apps/api/tests/orders-http.integration.test.ts`) priamo
 // nad databázou — tam patrí kontrola stĺpcov DB riadku, nie do e2e.
-test("manažér prepne stav riadku cez select, zmena pretrvá po obnovení stránky, konzola je čistá", async ({ page }) => {
+test("manažér prepne stav riadku klikom na tlačidlo, zmena pretrvá po obnovení stránky, konzola je čistá", async ({
+  page,
+}) => {
   const chyby: string[] = [];
   page.on("console", (m) => {
     if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
@@ -345,26 +349,25 @@ test("manažér prepne stav riadku cez select, zmena pretrvá po obnovení strá
   // Objednávka 9001 (dodávateľ "DODAVATEL-TEST-1") má riadok so stavom
   // "caka_sa" (`scripts/e2e-setup.ts`).
   const riadok = page.getByTestId("supplier-DODAVATEL-TEST-1").locator("[data-testid^='order-line-']");
-  const select = riadok.locator("select");
-  await expect(select).toHaveValue("caka_sa");
+  const tlacidloCakaSa = riadok.getByRole("radio", { name: "Čaká sa" });
+  const tlacidloSkladom = riadok.getByRole("radio", { name: "Skladom" });
+  await expect(tlacidloCakaSa).toHaveAttribute("aria-checked", "true");
 
-  await select.selectOption("skladom");
-  // Nie `toContainText("Skladom")` — VŠETKY štyri `STATE_LABELS` sú vždy
-  // vykreslené ako `<option>` deti selectu bez ohľadu na to, ktorý je
-  // vybraný, takže taká kontrola textu je tautológia (vždy prejde, aj keď sa
-  // zápis nikdy nedokončí). `toHaveValue` na SAMOTNOM selecte skutočne čaká,
-  // kým lokálny optimistický update prebehne (deje sa AŽ po úspešnom
-  // vyriešení PATCH promisu, `OrdersSection.tsx`'s `changeState`), čím
-  // zaručuje, že zápis je na serveri potvrdený PRED nasledujúcim reloadom —
-  // bez tejto zmeny mohol pod pomalším CI behom `page.reload()` predbehnúť
-  // ešte neuzavretý zápis a nasledujúca kontrola po reloade náhodne zlyhala.
-  await expect(select).toHaveValue("skladom");
+  await tlacidloSkladom.click();
+  // `aria-checked` na KONKRÉTNOM tlačidle skutočne čaká, kým lokálny
+  // optimistický update prebehne (deje sa AŽ po úspešnom vyriešení PATCH
+  // promisu, `OrdersSection.tsx`'s `changeState`), čím zaručuje, že zápis je
+  // na serveri potvrdený PRED nasledujúcim reloadom — bez tejto zmeny mohol
+  // pod pomalším CI behom `page.reload()` predbehnúť ešte neuzavretý zápis a
+  // nasledujúca kontrola po reloade náhodne zlyhala.
+  await expect(tlacidloSkladom).toHaveAttribute("aria-checked", "true");
+  await expect(tlacidloCakaSa).toHaveAttribute("aria-checked", "false");
   await expect(page.getByRole("alert")).toHaveCount(0);
 
   await page.reload();
   await expect(page.getByRole("heading", { name: "Na objednanie" })).toBeVisible();
   const riadokPoReloade = page.getByTestId("supplier-DODAVATEL-TEST-1").locator("[data-testid^='order-line-']");
-  await expect(riadokPoReloade.locator("select")).toHaveValue("skladom");
+  await expect(riadokPoReloade.getByRole("radio", { name: "Skladom" })).toHaveAttribute("aria-checked", "true");
 
   expect(chyby).toEqual([]);
 });

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -2074,3 +2074,40 @@ nové heslo sa nikde v pushnutom obsahu nenachádza.
   draftu — plus wrapper-harness `useCallback` gotcha), `.claude/rules/
   testing.md` (tag-scoped selector sa rozbije pri zmene tagu prvku;
   Enter-vs-Ctrl+Enter potrebuje SKUTOČNÉ stláčanie klávesov, nie `.fill()`).
+
+## Issues 161, 162, 163 — Na objednanie: stavové tlačidlá, širší editor odkazu, opravená deliaca čiara
+
+Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.css`).
+
+- Verzia: `0.3.0-dev.96` (`175895d`).
+- **#163** (deliaca čiara nelícuje pod bunkou dodávateľa): RED
+  `b4f3c0f` (`orders-layout.spec.ts`'s `nezarovnaneDelice` — zlyhalo až
+  44px pri 1280px), GREEN `22224fe` (`app.css`: odstránené `display:flex`
+  z `.ord-supplier-merged`, medzera presunutá na `.ord-supplier-assign`'s
+  `margin-top`). Skutočná príčina: `display:flex` priamo na `<td>` menilo
+  jej box-typ tak, že sa nerozťahovala na výšku riadku ako ostatné bunky.
+- **#162** (editor odkazu na dodávateľa príliš úzky, ~94px): RED `5537bbb`
+  (`orders-supplier-link.spec.ts` — 51.7px < požadovaných 282px), GREEN
+  `6e52339` (`OrderLineRow.tsx`: presunutý do vlastného rozbaľovacieho
+  riadku pod hlavným riadkom, `colSpan={9}`; pridané Escape-to-zrušiť).
+  Naživo overené: input po fixe 579px.
+- **#161** (stav ako 4 tlačidlá namiesto `<select>`u — majiteľova
+  explicitná požiadavka): `822c5d6` (feature, jeden commit — nový súbor
+  `OrderLineStateButtons.tsx` + `orderLineStateLabels.ts`, 2×2 mriežka
+  tlačidiel). Naživo (Playwright proti lokálnemu dev buildu) odhalený a
+  opravený CSS Grid `min-width:auto` overflow bug (tlačidlá pretekali do
+  susedného stĺpca) — pridané `min-width:0`/`overflow-wrap:break-word`.
+- Design komentáre PRED prvým kódovým commitom: issue-comment-5152316395
+  (#161), -5152318281 (#162), -5152320251 (#163).
+- Validačné komentáre (STEP 0, naživo overené proti v0.3.0-dev.95):
+  issue-comment-5152313107 (#161), -5152313661 (#162), -5152314911 (#163).
+- CI (`dev` push `822c5d6`): docker-build/version-check/integration/e2e/
+  check všetky `success` (run 30710242413). PR #165 mergeable/CLEAN.
+- Tickety NEZATVORENÉ cez `Closes #N` — čakajú na živé overenie na
+  produkcii, presne podľa `CLAUDE.md`'s poznámky pre tento repo.
+- Playbook rozšírený: `.claude/rules/frontend-design.md` — `display:flex`
+  priamo na `<td>` rozbíja zarovnanie výšky riadku; CSS Grid `min-width:
+  auto` analog k už zdokumentovanej flex `flex-basis` pasci (issue 105);
+  presun obsahu do NOVÉHO súrodeneckého `<tr>` rozbíja `within(riadok)`-
+  scoped testy (fix: `screen.getByTestId`/Playwright `xpath=./following-
+  sibling::tr[1]`); nový testid nesmie zdieľať existujúci `^='...'` prefix.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.95",
+  "version": "0.3.0-dev.96",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Summary

Bundle of three owner-reported "Na objednanie" screen defects, all touching `OrderLineRow.tsx`/`app.css`:

- issue 161 — state control changed from a `<select>` to 4 big segmented buttons (owner: "na stav nechcem mat selektor ale 4 tlacitka").
- issue 162 — supplier-link edit input was too narrow (~94px) to see a real URL; now expands into a full-width row below the line.
- issue 163 — the row divider misaligned under the DODÁVATEĽ cell; root cause was `display:flex` directly on that `<td>` breaking normal table-cell height.

## Commits (RED before GREEN per defect; 161 is a control change, single commit)

1. Version bump to 0.3.0-dev.96
2. `[red]`/`[green]` for issue 163 (divider misalignment)
3. `[red]`/`[green]` for issue 162 (narrow supplier-link input)
4. Feature commit for issue 161 (state buttons)

## Verification

- `pnpm typecheck` / `pnpm lint`: clean
- Unit tests: 280/280 (`apps/web`), 334/334 (`apps/api`)
- Integration tests: 294/294 (`apps/api`)
- E2E: 25/25, including new regression checks (divider alignment at 4 widths + both "skryť vybavené" states, supplier-link input width >= 282px, state-button text never clipped)
- Live-measured against a local dev build with Playwright before finalizing the button grid (caught and fixed a CSS Grid min-width overflow bug this way)
- CI on `dev`: docker-build/version-check/integration/e2e/check all green (run 30710242413)

## Note on closing the tickets

None of these three tickets are closed by this PR body on purpose — each still needs a live post-deploy check on the real production data/screen before being marked done (repo convention, see `CLAUDE.md`). They will be closed by hand after that verification.

Plain references only: issue 161, issue 162, issue 163.
