### PR TITLE
Fix notes-column row divider (issue 163) + link-editor silent close on invalid input (issue 166)

### DIFF
--- a/apps/web/src/components/OrderLineRow.tsx
+++ b/apps/web/src/components/OrderLineRow.tsx
@@ -74,8 +74,10 @@ export function OrderLineRow({
   readonly onAssignSupplier: (lineId: string, supplier: string) => void;
   // issue 121: manuálny odkaz na dodávateľa — smie sa upraviť pri KAŽDOM
   // riadku (na rozdiel od `onAssignSupplier`, ktorý je len pre riadky bez
-  // katalógového dodávateľa).
-  readonly onSetSupplierLink: (lineId: string, url: string) => void;
+  // katalógového dodávateľa). issue 166: vracia `boolean` — `true` keď vstup
+  // prešiel validáciou a zápis sa spustil, `false` keď bol okamžite
+  // odmietnutý (`saveLink` nižšie podľa toho rozhoduje, či zavrieť editor).
+  readonly onSetSupplierLink: (lineId: string, url: string) => boolean;
   readonly onChangeComment: (orderId: string, comment: string | null) => void;
   // issue 149: hlási RODIČOVI (`OrdersSection.tsx`'s `dirtyEditorLineIds`),
   // či tento riadok PRÁVE TERAZ drží otvorenú/rozpísanú úpravu — výnimka z
@@ -111,9 +113,13 @@ export function OrderLineRow({
   // KAŽDOM otvorení (nie udržiavaný cez `useEffect`), takže nehrozí rovnaký
   // "reset pri prvom mounte"/pretek, aký `supplierDraft`/`commentDraft` museli
   // riešiť guardom (`.claude/rules/frontend-design.md`). Zavretie panelu je
-  // OPTIMISTICKÉ (hneď pri kliku na Uložiť) — jednoduchšie než čakať na
-  // potvrdenie servera, a pri zlyhaní ostáva chyba viditeľná v `stateError`
-  // banneri, manažér otvorí úpravu znova.
+  // OPTIMISTICKÉ len voči ASYNC zlyhaniu zápisu na server (nemožno vedieť
+  // vopred) — vtedy ostáva chyba viditeľná v kumulatívnom `writeFailures`
+  // banneri, manažér otvorí úpravu znova. issue 166: voči SYNCHRÓNNEJ
+  // klientskej validácii (`onSetSupplierLink`'s návratová hodnota) sa
+  // NEZATVÁRA — jej výsledok je známy ešte PRED zavretím, takže `saveLink`
+  // zatvára editor LEN keď bol vstup prijatý; pri odmietnutí ostáva otvorený
+  // so zachovaným textom (predtým sa zatváral vždy, bez ohľadu na výsledok).
   const [linkEditing, setLinkEditing] = useState(false);
   const [linkDraft, setLinkDraft] = useState("");
   const linkBusyHere = busySupplierLinkLineId === line.lineId;
@@ -128,8 +134,10 @@ export function OrderLineRow({
   const saveLink = (): void => {
     const trimmed = linkDraft.trim();
     if (trimmed === "") return;
-    onSetSupplierLink(line.lineId, trimmed);
-    setLinkEditing(false);
+    const accepted = onSetSupplierLink(line.lineId, trimmed);
+    if (accepted) {
+      setLinkEditing(false);
+    }
   };
 
   // issue 64: rovnaký "controlled draft, resetovaný z props po uložení"

--- a/apps/web/src/components/OrdersSection.supplierLinkValidation.test.tsx
+++ b/apps/web/src/components/OrdersSection.supplierLinkValidation.test.tsx
@@ -85,9 +85,9 @@ it("neplatný odkaz na dodávateľa necháva editor OTVORENÝ so zachovaným tex
   });
   // Editor musí ostať OTVORENÝ (RED pred opravou: getByTestId tu nič nenájde,
   // lebo editor sa medzitým ticho zavrel) s presne tým textom, čo bol zadaný.
-  const inputPoNeplatnomUlozeni = screen.getByTestId(
+  const inputPoNeplatnomUlozeni = screen.getByTestId<HTMLInputElement>(
     `supplier-link-edit-input-${LINE_ALFA.lineId}`,
-  ) as HTMLInputElement;
+  );
   expect(inputPoNeplatnomUlozeni.value).toBe("toto-nie-je-odkaz");
   expect(setProductSupplierLink).not.toHaveBeenCalled();
 });

--- a/apps/web/src/components/OrdersSection.supplierLinkValidation.test.tsx
+++ b/apps/web/src/components/OrdersSection.supplierLinkValidation.test.tsx
@@ -62,3 +62,32 @@ it("neplatný odkaz na dodávateľa sa odmietne OKAMŽITE v prehliadači — bez
   });
   expect(setProductSupplierLink).not.toHaveBeenCalled();
 });
+
+// issue 166: `saveLink` (`OrderLineRow.tsx`) predtým zatváral editor
+// NEPODMIENENE, bez ohľadu na to, či `onSetSupplierLink` (= `useSupplierLinkSave
+// .ts`'s `setSupplierLink`) vstup prijal alebo ho synchrónne odmietol — napísaný
+// text sa tak ticho zahodil, hoci hláška vyššie sa aj tak zobrazila v banneri.
+it("neplatný odkaz na dodávateľa necháva editor OTVORENÝ so zachovaným textom, nezavrie ho", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_ALFA], email: null }]);
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const toggle = await screen.findByTestId(`supplier-link-edit-toggle-${LINE_ALFA.lineId}`);
+  fireEvent.click(toggle);
+  const input = screen.getByTestId(`supplier-link-edit-input-${LINE_ALFA.lineId}`);
+  fireEvent.change(input, { target: { value: "toto-nie-je-odkaz" } });
+  fireEvent.click(screen.getByTestId(`supplier-link-edit-save-${LINE_ALFA.lineId}`));
+
+  await waitFor(() => {
+    expect(screen.getByTestId(`order-write-failure-supplierLink:${LINE_ALFA.lineId}`).textContent).toBe(
+      "Odkaz na dodávateľa — obj. 1001, kód A-1 (Odkaz musí byť platná adresa začínajúca http:// alebo https://.)",
+    );
+  });
+  // Editor musí ostať OTVORENÝ (RED pred opravou: getByTestId tu nič nenájde,
+  // lebo editor sa medzitým ticho zavrel) s presne tým textom, čo bol zadaný.
+  const inputPoNeplatnomUlozeni = screen.getByTestId(
+    `supplier-link-edit-input-${LINE_ALFA.lineId}`,
+  ) as HTMLInputElement;
+  expect(inputPoNeplatnomUlozeni.value).toBe("toto-nie-je-odkaz");
+  expect(setProductSupplierLink).not.toHaveBeenCalled();
+});

--- a/apps/web/src/components/SupplierOrderGroup.tsx
+++ b/apps/web/src/components/SupplierOrderGroup.tsx
@@ -75,7 +75,8 @@ export function SupplierOrderGroup({
   readonly onChangeState: (lineId: string, newState: OrderLine["state"]) => void;
   readonly onChangeOrdered: (lineId: string, ordered: boolean) => void;
   readonly onAssignSupplier: (lineId: string, supplier: string) => void;
-  readonly onSetSupplierLink: (lineId: string, url: string) => void;
+  // issue 166: `boolean` návratová hodnota — pozri `OrderLineRow.tsx`'s komentár.
+  readonly onSetSupplierLink: (lineId: string, url: string) => boolean;
   readonly onChangeComment: (orderId: string, comment: string | null) => void;
   readonly editingEmailSupplier: string | null;
   readonly emailDraft: string;

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -1235,10 +1235,18 @@ tr:last-child td {
    jednej bunky "Poznámky" (majiteľ, komentár #10) — vnútri sú DVA pôvodné
    testid-ované bloky (`.ord-remark-cell`/`.ord-comment-cell`, nezmenené),
    pod sebou namiesto dvoch samostatných stĺpcov. */
+/* issue 163 (znovu otvorené — chyba sa presunula do POSLEDNÉHO stĺpca po
+   oprave dodávateľského): rovnaká príčina ako `.ord-supplier-merged` mala
+   pred PR #165 — `display:flex` PRIAMO na `<td>` mení jej box z
+   `table-cell` na flex kontajner nerešpektujúci skutočnú výšku riadku
+   (naživo namerané: rozdiel 19-20.5px naprieč 6 riadkami). `<td>` je teraz
+   normálna tabuľková bunka — jej dvaja potomkovia (`.ord-remark-cell`,
+   `.ord-comment-cell`) sú OBAJA VŽDY vykreslené block-level `<div>`y, takže
+   sa aj bez rodičovského `flex-direction:column` prirodzene poukladajú pod
+   seba; pôvodný `gap` medzi nimi nesie teraz `.ord-comment-cell`'s vlastný
+   `margin-top` nižšie. */
 .ord-notes-merged {
-  display: flex;
-  flex-direction: column;
-  gap: var(--fs-space-2);
+  max-width: 100%;
 }
 /* issue 65: zákaznícky odkaz k objednávke — read-only, rovnaký orezávací
    vzor ako `.ord-supplier-note` (issue 70) — voľný text neobmedzenej dĺžky. */
@@ -1265,6 +1273,10 @@ tr:last-child td {
   gap: var(--fs-space-1);
   flex-wrap: wrap;
   max-width: 100%;
+  /* issue 163: nahrádza rodičovský `.ord-notes-merged`'s bývalý flex `gap`
+     (odstránené, pozri jeho komentár) — tento blok sa vykresľuje VŽDY AŽ za
+     `.ord-remark-cell`, takže `margin-top` dáva identickú medzeru. */
+  margin-top: var(--fs-space-2);
 }
 .ord-comment-input {
   /* issue 105 bod 3: same fix, same TWO stacked root causes as

--- a/apps/web/src/useSupplierLinkSave.ts
+++ b/apps/web/src/useSupplierLinkSave.ts
@@ -15,7 +15,11 @@ import { clearWriteFailure, lineWhere, upsertWriteFailure, type OrderWriteFailur
 // jeden handler.
 export interface SupplierLinkSave {
   readonly busySupplierLinkLineId: string | null;
-  readonly setSupplierLink: (lineId: string, url: string) => void;
+  // issue 166: vracia `boolean` (predtým `void`) — `true` keď vstup prešiel
+  // synchrónnou klientskou validáciou a zápis sa spustil, `false` keď bol
+  // okamžite odmietnutý (žiadny sieťový zápis). Volajúci (`OrderLineRow.tsx`)
+  // to používa na rozhodnutie, či zavrieť editor — pozri jeho komentár.
+  readonly setSupplierLink: (lineId: string, url: string) => boolean;
 }
 
 export function useSupplierLinkSave(
@@ -27,7 +31,7 @@ export function useSupplierLinkSave(
   const [busySupplierLinkLineId, setBusySupplierLinkLineId] = useState<string | null>(null);
 
   const setSupplierLink = useCallback(
-    (lineId: string, url: string) => {
+    (lineId: string, url: string): boolean => {
       const failureId = `supplierLink:${lineId}`;
       const where = lineWhere(suppliers, lineId);
       // issue 153: OKAMŽITÁ kontrola V PREHLIADAČI, PRED akýmkoľvek zápisom
@@ -35,13 +39,15 @@ export function useSupplierLinkSave(
       // (`validateSupplierLinkUrl`, `ordersApi.ts`). Neplatná hodnota sa
       // ukáže v tom istom kumulatívnom `writeFailures` banneri (issue 66)
       // ako každé iné zlyhanie zápisu na tejto obrazovke — žiadny nový,
-      // samostatný chybový vzor.
+      // samostatný chybový vzor. issue 166: `false` návratová hodnota tu je
+      // presne to, čo `OrderLineRow.tsx`'s `saveLink()` potrebuje, aby
+      // vedel, že editor NEMÁ zavrieť (predtým sa zatváral nepodmienene).
       const validationError = validateSupplierLinkUrl(url);
       if (validationError !== null) {
         setWriteFailures((current) =>
           upsertWriteFailure(current, { id: failureId, what: "Odkaz na dodávateľa", where, detail: validationError }),
         );
-        return;
+        return false;
       }
       setBusySupplierLinkLineId(lineId);
       setProductSupplierLink(lineId, url)
@@ -66,6 +72,7 @@ export function useSupplierLinkSave(
         .finally(() => {
           setBusySupplierLinkLineId(null);
         });
+      return true;
     },
     [load, onSessionExpired, setWriteFailures, suppliers],
   );

--- a/apps/web/tests/e2e/orders-layout.spec.ts
+++ b/apps/web/tests/e2e/orders-layout.spec.ts
@@ -88,23 +88,28 @@ test("STAV je celý čitateľný a POZNÁMKY pole je dosť široké na všetkýc
     expect(vysokeKompaktneRiadky, `príliš vysoké riadky pri ${String(width)}px`).toEqual([]);
 
     // issue 163: majiteľ, deliaca čiara riadku nelícuje pod bunkou s
-    // odkazom na dodávateľa — príčina bola `display:flex` priamo na
-    // `td.ord-supplier-merged` (odstránené, `app.css`), ktorý bunku
-    // zmenšoval na výšku VLASTNÉHO obsahu namiesto skutočnej výšky riadku
-    // (tú si vynucujú iné, vyššie bunky), takže jej border-bottom sedel
-    // vyššie než u susedných buniek. Kontrola: PRE KAŽDÝ viditeľný riadok
-    // musí spodný okraj tejto bunky lícovať so spodným okrajom riadku
-    // (±1px, subpixelové zaokrúhlenie pri neceločíselnom zoome/DPR).
+    // odkazom na dodávateľa (opravené) a NESKÔR (znovu otvorené) aj pod
+    // bunkou poznámok — obe mali rovnakú príčinu: `display:flex` priamo na
+    // `<td>` (odstránené, `app.css`), ktorý bunku zmenšoval na výšku
+    // VLASTNÉHO obsahu namiesto skutočnej výšky riadku (tú si vynucujú iné,
+    // vyššie bunky), takže jej border-bottom sedel vyššie než u susedných
+    // buniek. Kontrola je ZOVŠEOBECNENÁ na VŠETKY `<td>` v riadku (nie len
+    // konkrétnu triedu) — presne to, čo ticket žiada ("all td of a row share
+    // the same getBoundingClientRect().bottom") a čo je future-proof pre
+    // AKÝKOĽVEK ďalší stĺpec, čo by túto chybu v budúcnosti zopakoval.
+    // Tolerancia ±1px, subpixelové zaokrúhlenie pri neceločíselnom zoome/DPR.
     const nezarovnaneDelice = await page.evaluate(() => {
-      return [...document.querySelectorAll<HTMLElement>("tr[data-testid^='order-line-']")]
-        .map((riadok) => {
-          const bunka = riadok.querySelector<HTMLElement>("td.ord-supplier-merged");
-          if (bunka === null) return null;
-          return Math.abs(bunka.getBoundingClientRect().bottom - riadok.getBoundingClientRect().bottom);
-        })
-        .filter((rozdiel): rozdiel is number => rozdiel !== null && rozdiel > 1);
+      const rozdiely: number[] = [];
+      for (const riadok of document.querySelectorAll<HTMLElement>("tr[data-testid^='order-line-']")) {
+        const riadokBottom = riadok.getBoundingClientRect().bottom;
+        for (const bunka of riadok.querySelectorAll<HTMLElement>("td")) {
+          const rozdiel = Math.abs(bunka.getBoundingClientRect().bottom - riadokBottom);
+          if (rozdiel > 1) rozdiely.push(rozdiel);
+        }
+      }
+      return rozdiely;
     });
-    expect(nezarovnaneDelice, `nezarovnané deliace čiary pod bunkou dodávateľa pri ${String(width)}px`).toEqual([]);
+    expect(nezarovnaneDelice, `nezarovnané deliace čiary v riadku pri ${String(width)}px`).toEqual([]);
 
     // issue 111 body 1+2: číslo objednávky ANI kód produktu sa nesmú
     // zalomiť na viac riadkov, na ŽIADNEJ zo 4 šírok — kontroluje sa AJ
@@ -169,20 +174,22 @@ test("STAV je celý čitateľný a POZNÁMKY pole je dosť široké na všetkýc
     }
   }
 
-  // issue 163: rovnaká deliaca-čiara kontrola aj pri ZAPNUTOM prepínači
-  // "skryť vybavené" — fix je štrukturálny (CSS na `<td>`), nie závislý od
-  // POČTU vykreslených riadkov, ale ticket to explicitne žiada overiť oboma
-  // stavmi prepínača.
+  // issue 163: rovnaká (zovšeobecnená, VŠETKY `<td>`) deliace-čiary kontrola
+  // aj pri ZAPNUTOM prepínači "skryť vybavené" — fix je štrukturálny (CSS na
+  // `<td>`), nie závislý od POČTU vykreslených riadkov, ale ticket to
+  // explicitne žiada overiť oboma stavmi prepínača.
   await page.setViewportSize({ width: 1280, height: 900 });
   await page.getByTestId("orders-hide-resolved-toggle").click();
   const nezarovnaneDeliceSkryte = await page.evaluate(() => {
-    return [...document.querySelectorAll<HTMLElement>("tr[data-testid^='order-line-']")]
-      .map((riadok) => {
-        const bunka = riadok.querySelector<HTMLElement>("td.ord-supplier-merged");
-        if (bunka === null) return null;
-        return Math.abs(bunka.getBoundingClientRect().bottom - riadok.getBoundingClientRect().bottom);
-      })
-      .filter((rozdiel): rozdiel is number => rozdiel !== null && rozdiel > 1);
+    const rozdiely: number[] = [];
+    for (const riadok of document.querySelectorAll<HTMLElement>("tr[data-testid^='order-line-']")) {
+      const riadokBottom = riadok.getBoundingClientRect().bottom;
+      for (const bunka of riadok.querySelectorAll<HTMLElement>("td")) {
+        const rozdiel = Math.abs(bunka.getBoundingClientRect().bottom - riadokBottom);
+        if (rozdiel > 1) rozdiely.push(rozdiel);
+      }
+    }
+    return rozdiely;
   });
   expect(nezarovnaneDeliceSkryte, "nezarovnané deliace čiary pri zapnutom 'skryť vybavené'").toEqual([]);
   // Vrátiť prepínač do pôvodného stavu — iné súbežne bežiace e2e spec súbory

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.96",
+  "version": "0.3.0-dev.97",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Bundle: issue 163 (notes-column divider) + issue 166 (link-editor validation)

Both are small frontend defects in the same files (`OrderLineRow.tsx`/`app.css`) — bundled per the batch-issue-development gate, not split.

### issue 163 — row divider still broken (notes column)

The supplier-link cell divider was fixed by PR #165, but the SAME `display:flex`-directly-on-`<td>` bug remained in the notes column (`td.ord-notes-merged`), live-measured at ~19-20.5px off. Fixed the same way: dropped `display:flex` from the `<td>`, moved its gap to `margin-top` on the always-rendered second child (`.ord-comment-cell`).

Regression test generalized from checking one hardcoded cell class to ALL `<td>` in a row (future-proof against any other column repeating this).

### issue 166 — invalid supplier link silently discarded, no message

`saveLink()` (`OrderLineRow.tsx`) closed the editor unconditionally right after calling `onSetSupplierLink`, even though that call already ran `validateSupplierLinkUrl` synchronously and rejected the value — the typed text was discarded and the editor closed with no visible feedback near the input (the shared `writeFailures` banner DID show the message, just easy to miss while the editor vanishes).

Fix: `setSupplierLink` now returns a `boolean` (accepted / rejected); `saveLink` only closes the editor when it comes back `true`. No duplicate validation logic, single source of truth kept in `useSupplierLinkSave.ts`.

### Notes

- Version bumped to 0.3.0-dev.97.
- Design + STEP-0 validation comments posted to issue 163 and issue 166 before the first code commit.
- Neither issue's acceptance criterion can be verified before deploy (both require live post-deploy DOM/interaction checks) — deliberately did NOT write `Closes #163`/`Closes #166` here; both get closed by hand after live post-deploy verification, per this repo's CLAUDE.md note on the auto-close trap (issue 120/issue 66/issue 127/issue 132).

issue 163
issue 166
