### PR TITLE
fix: OUR_BLOCK_RE strips all occurrences + CRLF separators (issue 169)

### DIFF
--- a/apps/api/src/modules/shoptet-writeback/note-block.test.ts
+++ b/apps/api/src/modules/shoptet-writeback/note-block.test.ts
@@ -51,6 +51,27 @@ describe("mergeShopRemark", () => {
     expect(hasOurBlock(mergeShopRemark(null, "x"))).toBe(true);
     expect(hasOurBlock(mergeShopRemark("Ručný text", "x"))).toBe(true);
   });
+
+  // issue 169: OUR_BLOCK_RE bez /g flagu odstráni pri clear-e (ourNote=null)
+  // len PRVÝ výskyt nášho bloku — druhý by unikol do "cudzej" časti.
+  it("removes BOTH occurrences of our block when the field somehow has two, not just the first", () => {
+    const raw =
+      `Ručná poznámka\n\n` +
+      `${NOTE_BLOCK_START}\nStará poznámka\n${NOTE_BLOCK_END}` +
+      `\n\n` +
+      `${NOTE_BLOCK_START}\nDuplicitná poznámka\n${NOTE_BLOCK_END}`;
+    const cleared = mergeShopRemark(raw, null);
+    expect(cleared).toBe("Ručná poznámka");
+  });
+
+  // issue 169: voliteľný oddeľovací prefix zachytával len `\n{1,2}`, nie
+  // `\r\n` — CRLF-oddelený blok by po odstránení nechal osamotený prázdny
+  // riadok (CR) za sebou.
+  it("removes the block AND its CRLF-style separator, not just LF", () => {
+    const raw = `Ručná poznámka\r\n\r\n${NOTE_BLOCK_START}\r\nZavolať\r\n${NOTE_BLOCK_END}`;
+    const cleared = mergeShopRemark(raw, null);
+    expect(cleared).toBe("Ručná poznámka");
+  });
 });
 
 // issue 164: čítacia strana (import) — z RAW importovanej hodnoty vytiahne
@@ -74,5 +95,17 @@ describe("extractForeignShopRemark", () => {
   it("vráti null, keď v poli je LEN náš blok (žiadny cudzí text)", () => {
     const raw = mergeShopRemark(null, "Naša poznámka");
     expect(extractForeignShopRemark(raw)).toBeNull();
+  });
+
+  // issue 169: DVA naše bloky v raw hodnote (napr. starý bug/ručná
+  // duplikácia priamo v Shoptete) — druhý sa nesmie zobraziť ako cudzí text.
+  it("odstráni OBA naše bloky, druhý nikdy neunikne ako cudzí text", () => {
+    const raw =
+      `Foreign PRED\n\n` +
+      `${NOTE_BLOCK_START}\nStará\n${NOTE_BLOCK_END}` +
+      `\n\n` +
+      `${NOTE_BLOCK_START}\nDuplicitná\n${NOTE_BLOCK_END}` +
+      `\n\nForeign ZA`;
+    expect(extractForeignShopRemark(raw)).toBe("Foreign PRED\n\nForeign ZA");
   });
 });

--- a/apps/api/src/modules/shoptet-writeback/note-block.ts
+++ b/apps/api/src/modules/shoptet-writeback/note-block.ts
@@ -13,14 +13,29 @@ function escapeForRegex(literal: string): string {
   return literal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-// Zachytí AJ 1-2 prázdne riadky BEZPROSTREDNE PRED blokom, aby odstránenie
-// bloku (ourNote prázdny) nenechalo za sebou osamotené prázdne riadky —
-// `mergeShopRemark` nižšie potom sám pridáva PRESNE jeden oddeľovací
-// prázdny riadok pri opätovnom pripojení, takže výsledok je vždy
-// deterministický bez ohľadu na to, koľkokrát sa blok odstráni/pridá.
-const OUR_BLOCK_RE = new RegExp(
-  `(?:\\n{1,2})?${escapeForRegex(NOTE_BLOCK_START)}[\\s\\S]*?${escapeForRegex(NOTE_BLOCK_END)}`,
-);
+// Zachytí AJ 1-2 prázdne riadky BEZPROSTREDNE PRED blokom (LF aj CRLF, issue
+// 169 — pôvodné `\n{1,2}` chytalo len LF), aby odstránenie bloku (ourNote
+// prázdny) nenechalo za sebou osamotené prázdne riadky — `mergeShopRemark`
+// nižšie potom sám pridáva PRESNE jeden oddeľovací prázdny riadok pri
+// opätovnom pripojení, takže výsledok je vždy deterministický bez ohľadu na
+// to, koľkokrát sa blok odstráni/pridá.
+const OUR_BLOCK_PATTERN = `(?:(?:\\r?\\n){1,2})?${escapeForRegex(NOTE_BLOCK_START)}[\\s\\S]*?${escapeForRegex(NOTE_BLOCK_END)}`;
+
+// Bez `/g` flagu — používaný VÝHRADNE pre `.test()` (`hasOurBlock`). Global
+// regexy sú stavové (`lastIndex` prežíva medzi volaniami na TOM ISTOM
+// objekte) — opakované `.test()` volania na rôznych reťazcoch (presne
+// vzor v teste nižšie) by so zdieľaným globálnym objektom mohli tichým
+// spôsobom vrátiť `false` napriek reálnej zhode. Preto zámerne SAMOSTATNÝ
+// objekt od toho, čo používa `.replace()` nižšie.
+const OUR_BLOCK_RE = new RegExp(OUR_BLOCK_PATTERN);
+
+// S `/g` flagom — používaný VÝHRADNE pre `.replace()` (issue 169: bez `/g`
+// `String.prototype.replace()` odstráni len PRVÝ výskyt nášho bloku, druhý
+// by unikol do "cudzej" časti). `.replace()` s globálnym regexom si sám
+// resetuje `lastIndex` na 0 pred aj po behu, takže je bezpečný aj pri
+// opakovanom volaní `mergeShopRemark` — na rozdiel od `.test()` vyššie preto
+// zostáva zámerne oddelený objekt, nikdy zdieľaný s `OUR_BLOCK_RE`.
+const OUR_BLOCK_RE_GLOBAL = new RegExp(OUR_BLOCK_PATTERN, "g");
 
 function buildBlock(note: string): string {
   return `${NOTE_BLOCK_START}\n${note}\n${NOTE_BLOCK_END}`;
@@ -53,7 +68,7 @@ export function mergeShopRemark(existingShopRemark: string | null, ourNote: stri
   const existing = existingShopRemark ?? "";
   const trimmedNote = ourNote?.trim() ?? "";
 
-  const withoutOurBlock = existing.replace(OUR_BLOCK_RE, "");
+  const withoutOurBlock = existing.replace(OUR_BLOCK_RE_GLOBAL, "");
 
   if (trimmedNote === "") {
     return withoutOurBlock;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.98",
+  "version": "0.3.0-dev.99",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Čo a prečo

Code review na PR 168 (issue 164) upozornil, že `note-block.ts`'s
`OUR_BLOCK_RE` (zavedené issue 123) má dve preventívne slabiny — teraz na
priesečníku dvoch ciest (writeback `mergeShopRemark` aj import/zobrazenie
`extractForeignShopRemark`, obe volajú tú istú funkciu):

1. Bez `/g` flagu `existing.replace(OUR_BLOCK_RE, "")` odstráni len PRVÝ
   výskyt nášho ohraničeného bloku — druhý by unikol do "cudzej" časti a
   zobrazil by sa používateľovi ako cudzí text.
2. Voliteľný oddeľovací prefix chytal len `\n{1,2}` (LF), nie `\r\n` (CRLF)
   — CRLF-oddelený blok by po odstránení nechal osamotený riadok za sebou.

## Riešenie

- Samostatný `OUR_BLOCK_RE_GLOBAL` (s `/g`) používaný VÝHRADNE v
  `.replace()` — pôvodný `OUR_BLOCK_RE` (bez `/g`) ostáva pre `hasOurBlock`'s
  `.test()`, aby sa vyhlo klasickej JS pasci: zdieľaný globálny regex má
  stavový `lastIndex`, takže opakované `.test()` volania na rôznych
  reťazcoch (presne vzor v existujúcom teste) by mohli tichým spôsobom
  vrátiť `false` napriek reálnej zhode.
- Oddeľovací prefix rozšírený na `(?:\r?\n){1,2}` — chytí LF aj CRLF.
- 3 nové unit testy: dva naše bloky odstránené OBIDVA (nielen prvý), CRLF
  separátor odstránený spolu s blokom, a `extractForeignShopRemark` s dvomi
  blokmi nikdy nezobrazí druhý ako cudzí text.

Návrh (root cause + zvažovaná alternatíva) zaznamenaný pred kódom:
https://github.com/zbynekdrlik/forestshop-app/issues/169#issuecomment-5153199372

Žiadny živý dôkaz reprodukovaného bugu (naživo overené dáta majú vždy
najviac jeden náš blok, LF) — preventívne zosilnenie, nie oprava
reprodukovanej chyby naživo.

Closes #169

## Test plan

- [x] `pnpm --filter @forestshop/api test` — 345/345 (16 v `note-block.test.ts`, 3 nové)
- [x] `pnpm --filter @forestshop/web test` — 285/285
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] RED→GREEN overené: nové testy zlyhali proti pôvodnému kódu, prešli po oprave
