### PR TITLE
feat(orders): presunúť poznámku zákazníka pod meno produktu (issue 171)

### DIFF
--- a/.claude/rules/deploy.md
+++ b/.claude/rules/deploy.md
@@ -173,6 +173,21 @@ paths:
   --failed` — čerstvý pull znova stiahne vrstvu od nuly. Ak sa to isté zopakuje
   DRUHÝKRÁT za sebou, už to nie je transientný jav — over `docker system df`
   (miesto na disku) a zváž reštart `containerd`/`docker` služby na dev2.
+  **Ďalší pozorovaný spúšťač TEJ ISTEJ triedy (issue 169, 2026-08-01): SÚBEŽNÝ
+  CI job na tom istom self-hosted dev2 runneri, ktorý si sám ťahá/spúšťa
+  Docker image (integration/e2e job's efemérne `postgres` service kontajnery)
+  presne v okamihu, keď `deploy` job extrahuje appkin image.** Potvrdené
+  koreláciou časových pečiatok — `ssh newlevel@dev2 "journalctl -u docker
+  --since '10 min ago'"` ukázal `image pulled ... postgres:16` tesne PRED aj
+  PO zlyhanom `deploy`'s `failed to Lchown ...` v tej istej sekunde, a
+  `gh run list --json databaseId,name,event,createdAt` potvrdil, že `CI`
+  (push na `main`) a `Deploy` (push na `main`) z toho istého merge commitu
+  bežali SÚČASNE. Rovnaká liečba (jeden `gh run rerun <run-id> --failed`) —
+  pri rerune over `gh run list --json databaseId,name,status -q '.[] |
+  select(.status!="completed")'` a `docker ps`, že žiadny INÝ CI job práve
+  nebeží, aby sa race nezopakoval. Diagnostický vzor pre budúci podobný
+  nález: koreluj `journalctl -u docker --since "<čas zlyhania>"` s `gh run
+  list` časovými pečiatkami PRED tým, než sa dôvod hľadá v obsahu image.
 - **OPRAVA k nižšie zdokumentovanému nálezu z #25 — NEBOL to transientný
   containerd jav, bol to skutočný, DETERMINISTICKÝ bug appky (issue 78,
   vyriešené).** Pôvodný záznam (nižšie, ponechaný pre históriu) priradil

--- a/apps/web/src/components/OrderLineRow.remarkCell.test.tsx
+++ b/apps/web/src/components/OrderLineRow.remarkCell.test.tsx
@@ -74,3 +74,17 @@ it("riadok S poznámkou e-shopu vykreslí jej text", async () => {
   const bunka = within(riadok).getByTestId(`remark-cell-${RIADOK_S_POZNAMKOU.lineId}`);
   expect(bunka.textContent).toContain(RIADOK_S_POZNAMKOU.remark);
 });
+
+// issue 171: majiteľ, "poznamka zakaznika daj pod text produktu" — bunka
+// poznámky zákazníka je teraz VNÚTRI toho istého `<td>` ako meno produktu
+// (druhý block-level div pod ním), nie v samostatnej bunke.
+it("bunka poznámky zákazníka je v tom istom stĺpci ako meno produktu", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Epsilon", lines: [RIADOK_S_POZNAMKOU], email: null }]);
+
+  render(<OrdersSection role="citanie" onSessionExpired={() => {}} />);
+
+  const riadok = await screen.findByTestId(`order-line-${RIADOK_S_POZNAMKOU.lineId}`);
+  const bunka = within(riadok).getByTestId(`remark-cell-${RIADOK_S_POZNAMKOU.lineId}`);
+  const nazovProduktu = within(riadok).getByText(RIADOK_S_POZNAMKOU.variantName);
+  expect(bunka.closest("td")).toBe(nazovProduktu.closest("td"));
+});

--- a/apps/web/src/components/OrderLineRow.tsx
+++ b/apps/web/src/components/OrderLineRow.tsx
@@ -241,7 +241,27 @@ export function OrderLineRow({
           </a>
         </td>
         <td>{line.customerName}</td>
-        <td>{line.variantName}</td>
+        {/* issue 171: majiteľ, doslovne "poznamka zakaznika daj pod text
+            produktu" — zákaznícka poznámka (🛈, `remark`) sa vzťahuje na
+            TENTO produkt, nie na "poznámky" všeobecne, takže sa presunula
+            sem z bývalej zlúčenej `td.ord-notes-merged` (issue 95/164) do
+            VLASTNEJ bunky produktu, ako druhý block-level `<div>` pod menom.
+            Rovnaký `<div data-testid="remark-cell-<id>">` (beze zmeny
+            testid/logiky — obalový div VŽDY, vnútorný `<span>` len keď
+            `remark` nie je `null`, presne vzor issue 111 bod 4/issue 164) —
+            len iný rodič. Žiadny `display:flex` na `<td>` (issue 163's
+            poučenie, `.claude/rules/frontend-design.md`) — dva stackované
+            block divy sa prirodzene poukladajú pod seba bez toho. */}
+        <td>
+          <div className="ord-product-name">{line.variantName}</div>
+          <div className="ord-remark-cell" data-testid={`remark-cell-${line.lineId}`}>
+            {line.remark !== null && (
+              <span className="ord-remark" title={line.remark}>
+                🛈 {line.remark}
+              </span>
+            )}
+          </div>
+        </td>
         <td className="ord-qty">
           {line.quantity} ks
           {qtyChip !== null && (
@@ -397,32 +417,22 @@ export function OrderLineRow({
             </span>
           )}
         </td>
-        {/* issue 95: POZNÁMKA E-SHOPU (`remark`, read-only) + KOMENTÁR zlúčené
-            do jednej bunky "Poznámky" (majiteľ, komentár #10) — oba vnorené
-            bloky nižšie sú BEZ ZMENY (rovnaké testid, rovnaká logika), len pod
-            sebou v jednej `<td>` namiesto dvoch samostatných stĺpcov. */}
+        {/* issue 95: POZNÁMKA E-SHOPU (`shopRemark`, read-only) + KOMENTÁR
+            zlúčené do jednej bunky "Poznámky" (majiteľ, komentár #10) — oba
+            vnorené bloky nižšie sú BEZ ZMENY (rovnaké testid, rovnaká
+            logika), len pod sebou v jednej `<td>` namiesto dvoch
+            samostatných stĺpcov. issue 171: zákaznícka poznámka (`remark`)
+            sa TU už nevykresľuje — presunula sa do bunky produktu, viď
+            komentár tam. */}
         <td className="ord-notes-merged">
-          {/* issue 65: zákaznícky odkaz k objednávke — read-only, appka ho
-              nikdy needituje (na rozdiel od `comment` bloku nižšie). */}
-          {/* issue 111 bod 4: predtým sa tu VŽDY vykresľovala holá pomlčka "—",
-              keď objednávka nemá poznámku e-shopu (100 % dnešných ostrých dát)
-              — presne ten istý zbytočný riadok navyše, aký #107 bod 3 už
-              odstránilo z priradenia dodávateľa. Keď `remark` je `null`,
-              nevykreslí sa NIČ (žiadny prvok, žiadny prázdny <span>) —
-              `OrderLineRow.remarkCell.test.tsx` to overuje. */}
-          <div className="ord-remark-cell" data-testid={`remark-cell-${line.lineId}`}>
-            {line.remark !== null && (
-              <span className="ord-remark" title={line.remark}>
-                🛈 {line.remark}
-              </span>
-            )}
-          </div>
           {/* issue 164: INTERNÁ poznámka e-shopu — LEN cudzí text (appkin
               vlastný blok už odstránený na strane servera), read-only, nikdy
               needitovateľná — appka na ňu nemá žiadnu zápisovú cestu vôbec.
-              Rovnaký vzor ako `.ord-remark-cell` vyššie (issue 111 bod 4):
-              obalový <div> sa vykresľuje VŽDY, vnútorný <span> len keď je
-              poznámka vyplnená — žiadna holá pomlčka. */}
+              issue 111 bod 4's vzor (obalový <div> sa vykresľuje VŽDY,
+              vnútorný <span> len keď je poznámka vyplnená — žiadna holá
+              pomlčka). issue 171: teraz PRVÝ blok v tejto bunke (predtým
+              druhý, za zákazníckou poznámkou, ktorá sa odsťahovala) —
+              stráca svoj bývalý `margin-top` (`app.css`). */}
           <div className="ord-shop-remark-cell" data-testid={`shop-remark-cell-${line.lineId}`}>
             {line.shopRemark != null && line.shopRemark !== "" && (
               <span className="ord-shop-remark" title={line.shopRemark}>

--- a/apps/web/src/components/OrdersSection.test.tsx
+++ b/apps/web/src/components/OrdersSection.test.tsx
@@ -152,9 +152,25 @@ it("zlúčená bunka POZNÁMKY drží poznámku e-shopu AJ komentár v tom istom
 
   render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
 
-  const remarkBunka = await screen.findByTestId(`remark-cell-${LINE_STARA.lineId}`);
+  const shopRemarkBunka = await screen.findByTestId(`shop-remark-cell-${LINE_STARA.lineId}`);
   const commentBunka = await screen.findByTestId(`comment-cell-${LINE_STARA.lineId}`);
-  expect(remarkBunka.closest("td")).toBe(commentBunka.closest("td"));
+  expect(shopRemarkBunka.closest("td")).toBe(commentBunka.closest("td"));
+});
+
+// issue 171: zákaznícka poznámka (🛈, `remark`) sa presunula do bunky
+// PRODUKTU — táto bunka NIE JE tá istá ako zlúčená bunka POZNÁMKY (`shop-
+// remark-cell`/`comment-cell` vyššie), na rozdiel od pôvodného stavu, kde
+// bola treťou v tom istom `td.ord-notes-merged`.
+it("poznámka zákazníka je v bunke produktu, NIE v zlúčenej bunke POZNÁMKY", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_STARA], email: null }]);
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const remarkBunka = await screen.findByTestId(`remark-cell-${LINE_STARA.lineId}`);
+  const nazovProduktu = await screen.findByText(LINE_STARA.variantName);
+  const commentBunka = await screen.findByTestId(`comment-cell-${LINE_STARA.lineId}`);
+  expect(remarkBunka.closest("td")).toBe(nazovProduktu.closest("td"));
+  expect(remarkBunka.closest("td")).not.toBe(commentBunka.closest("td"));
 });
 
 it("chýbajúci dodávateľ zobrazí ako pomlčku", async () => {

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -1231,27 +1231,44 @@ tr:last-child td {
   overflow: hidden;
   text-overflow: ellipsis;
 }
-/* issue 95: POZNÁMKA E-SHOPU (`remark`, read-only) + KOMENTÁR zlúčené do
+/* issue 95: POZNÁMKA E-SHOPU (`shopRemark`, read-only) + KOMENTÁR zlúčené do
    jednej bunky "Poznámky" (majiteľ, komentár #10) — vnútri sú DVA pôvodné
-   testid-ované bloky (`.ord-remark-cell`/`.ord-comment-cell`, nezmenené),
-   pod sebou namiesto dvoch samostatných stĺpcov. */
+   testid-ované bloky (`.ord-shop-remark-cell`/`.ord-comment-cell`,
+   nezmenené), pod sebou namiesto dvoch samostatných stĺpcov. issue 171:
+   zákaznícka poznámka (`.ord-remark-cell`) sa PRESŤAHOVALA do bunky
+   produktu (nižšie) — už tu nie je. */
 /* issue 163 (znovu otvorené — chyba sa presunula do POSLEDNÉHO stĺpca po
    oprave dodávateľského): rovnaká príčina ako `.ord-supplier-merged` mala
    pred PR #165 — `display:flex` PRIAMO na `<td>` mení jej box z
    `table-cell` na flex kontajner nerešpektujúci skutočnú výšku riadku
    (naživo namerané: rozdiel 19-20.5px naprieč 6 riadkami). `<td>` je teraz
-   normálna tabuľková bunka — jej dvaja potomkovia (`.ord-remark-cell`,
+   normálna tabuľková bunka — jej dvaja potomkovia (`.ord-shop-remark-cell`,
    `.ord-comment-cell`) sú OBAJA VŽDY vykreslené block-level `<div>`y, takže
    sa aj bez rodičovského `flex-direction:column` prirodzene poukladajú pod
-   seba; pôvodný `gap` medzi nimi nesie teraz `.ord-comment-cell`'s vlastný
-   `margin-top` nižšie. */
+   seba; medzeru medzi nimi nesie `.ord-comment-cell`'s vlastný `margin-top`
+   nižšie. */
 .ord-notes-merged {
   max-width: 100%;
 }
+
+/* issue 171: majiteľ, "poznamka zakaznika daj pod text produktu" — meno
+   produktu je teraz obalené v tomto bloku (predtým holý text priamo v
+   `<td>`), aby zákaznícka poznámka (`.ord-remark-cell` nižšie) mohla byť
+   jeho SIBLING block-level div a prirodzene sa poukladať pod neho (rovnaký
+   "žiadny display:flex na td" princíp ako notes-merged vyššie, issue 163).
+   Žiadny vlastný orezávací štýl netreba — `.orders-table td { overflow-wrap:
+   break-word }` (vyššie) sa dedí aj sem beze zmeny správania. */
+.ord-product-name {
+  max-width: 100%;
+}
 /* issue 65: zákaznícky odkaz k objednávke — read-only, rovnaký orezávací
-   vzor ako `.ord-supplier-note` (issue 70) — voľný text neobmedzenej dĺžky. */
+   vzor ako `.ord-supplier-note` (issue 70) — voľný text neobmedzenej dĺžky.
+   issue 171: presunuté z bývalej zlúčenej bunky POZNÁMKY sem, pod meno
+   produktu — testid/logika bez zmeny, len `margin-top` navyše (predtým
+   prvý blok bez potreby medzery, teraz druhý pod `.ord-product-name`). */
 .ord-remark-cell {
   max-width: 100%;
+  margin-top: var(--fs-space-1);
 }
 .ord-remark {
   display: inline-block;
@@ -1261,14 +1278,19 @@ tr:last-child td {
   white-space: nowrap;
   vertical-align: bottom;
   color: var(--fs-ink-muted);
+  /* issue 171: akceptačná podmienka — vizuálne odlíšená od názvu produktu
+     (menšie/tlmenejšie písmo). Tlmená farba už bola, veľkosť je nová. */
+  font-size: var(--fs-text-xs);
 }
 
 /* issue 164: INTERNÁ poznámka e-shopu (LEN cudzí text, appkin vlastný blok
    nikdy neobsahuje) — rovnaký orezávací vzor ako `.ord-remark-cell`/
-   `.ord-remark` vyššie, len na vlastnom riadku pod ňou (`margin-top`). */
+   `.ord-remark` vyššie. issue 171: teraz PRVÝ blok v `td.ord-notes-merged`
+   (predtým druhý, za zákazníckou poznámkou, ktorá sa odsťahovala) — stráca
+   svoj bývalý `margin-top` (medzeru pod ňou dnes dáva `.ord-comment-cell`'s
+   vlastný `margin-top` nižšie). */
 .ord-shop-remark-cell {
   max-width: 100%;
-  margin-top: var(--fs-space-1);
 }
 .ord-shop-remark {
   display: inline-block;

--- a/apps/web/tests/e2e/orders-layout.spec.ts
+++ b/apps/web/tests/e2e/orders-layout.spec.ts
@@ -79,20 +79,24 @@ test("STAV je celý čitateľný a POZNÁMKY pole je dosť široké na všetkýc
     // (`.claude/rules/frontend-design.md`), takže tento test overuje presne
     // to, čo je v scope tohto ticketu — POZNÁMKY stĺpec už nespôsobuje
     // zalomenie vstup+tlačidlo, nie univerzálny strop na VŠETKY možné riadky.
-    // AKTUALIZÁCIA (issue 164, 2026-08-01): strop 100px→115px — pribudol
-    // TRETÍ voliteľný riadok v bunke "Poznámky" (interná poznámka e-shopu,
-    // `.ord-shop-remark-cell`, nad zákazníckym `remark` a appkiným
-    // `comment`). Riadok, čo naozaj nesie VŠETKY TRI naraz (fixtúra 9001,
-    // `scripts/e2e-setup.ts`), teraz legitímne meria ~108.5px pri 1280px —
-    // to NIE JE regresia zalomenia vstup+tlačidlo (tá je overená vyššie,
-    // `naTomIstomRiadku`), len skutočný obsah navyše. 115px necháva malú
-    // rezervu nad nameraným 108.5px bez toho, aby maskoval skutočné
-    // zalomenie (to by prehodilo strop o desiatky px, nie jednotky).
+    // AKTUALIZÁCIA (issue 171, 2026-08-02): strop 115px→105px — zákaznícka
+    // poznámka (`remark`) sa presunula z bunky POZNÁMKY do bunky PRODUKTU
+    // (pod meno produktu), takže bunka POZNÁMKY teraz nesie len DVA
+    // stackované riadky (`.ord-shop-remark-cell`/`.ord-comment-cell`)
+    // namiesto pôvodných troch. Riadok, čo nesie VŠETKY TRI poznámky naraz
+    // (fixtúra 9001, `scripts/e2e-setup.ts`), teraz naživo meria ~98.19px
+    // pri 1280px (predtým ~108.5px, keď boli všetky tri v jednej bunke) —
+    // znovu zmerané throwaway skriptom (`page.evaluate` logujúci reálne
+    // `getBoundingClientRect().height` proti lokálnym dev serverom, rovnaká
+    // metodika ako issue 105/107/111/127/164), NIE len odhadnuté. 105px
+    // necháva malú rezervu nad nameraným 98.19px bez toho, aby maskoval
+    // skutočné zalomenie (to by strop prehodilo o desiatky px, nie
+    // jednotky).
     const vysokeKompaktneRiadky = await page.evaluate(() => {
       return [...document.querySelectorAll(".order-row")]
         .filter((r) => r.querySelector('[data-testid^="supplier-assign-cell-"]') === null)
         .map((r) => r.getBoundingClientRect().height)
-        .filter((h) => h > 115);
+        .filter((h) => h > 105);
     });
     expect(vysokeKompaktneRiadky, `príliš vysoké riadky pri ${String(width)}px`).toEqual([]);
 
@@ -182,6 +186,45 @@ test("STAV je celý čitateľný a POZNÁMKY pole je dosť široké na všetkýc
       expect(strankaSaPosuva, "stránka sa vodorovne posúva pri 1280px").toBe(false);
     }
   }
+
+  // issue 171: majiteľ, "poznamka zakaznika daj pod text produktu" —
+  // zákaznícka poznámka (🛈) objednávky 9001 (`scripts/e2e-setup.ts`, variant
+  // "4859/46" pod dodávateľom DODAVATEL-TEST-1) musí byť v TOM ISTOM `<td>`
+  // ako meno produktu, NIE v zlúčenej bunke POZNÁMKY (`shop-remark-cell`/
+  // `comment-cell`), a vizuálne odlíšená (menšie písmo než meno produktu).
+  await page.setViewportSize({ width: 1280, height: 900 });
+  const umiestnenie = await page.evaluate(() => {
+    // `scripts/e2e-setup.ts`'s objednávka 9001 má JEDINÚ zákaznícku poznámku
+    // ("Prosím doručiť len v piatok") — hľadať podľa OBSAHU, nie podľa
+    // prvého `[data-testid^='remark-cell-']` v DOM poradí (ten obalový div sa
+    // vykresľuje na KAŽDOM riadku, aj bez poznámky, takže prvý v poradí by
+    // nemusel patriť riadku 9001).
+    const remarkBunka = [...document.querySelectorAll('[data-testid^="remark-cell-"]')].find((el) =>
+      el.textContent.includes("Prosím doručiť len v piatok"),
+    );
+    const produktBunka =
+      [...document.querySelectorAll("td")].find((td) => td.textContent.includes("Nohavice Hart Wild-T")) ?? null;
+    const poznamkyBunka = [...document.querySelectorAll('[data-testid^="shop-remark-cell-"]')].find((el) =>
+      el.textContent.includes("Sklad potvrdil, pripravené na vyzdvihnutie"),
+    );
+    const najdeneVsetky = remarkBunka !== undefined && produktBunka !== null && poznamkyBunka !== undefined;
+    const remarkTd = najdeneVsetky ? remarkBunka.closest("td") : null;
+    return {
+      najdeneVsetky,
+      vProduktovejBunke: najdeneVsetky && remarkTd === produktBunka,
+      vPoznamkovejBunke: najdeneVsetky && remarkTd === poznamkyBunka.closest("td"),
+      fontSizeRemark: najdeneVsetky
+        ? getComputedStyle(remarkBunka.querySelector(".ord-remark") ?? remarkBunka).fontSize
+        : null,
+      fontSizeProdukt: najdeneVsetky ? getComputedStyle(produktBunka).fontSize : null,
+    };
+  });
+  expect(umiestnenie.najdeneVsetky, "chýbajúci prvok pri kontrole umiestnenia poznámky zákazníka").toBe(true);
+  expect(umiestnenie.vProduktovejBunke, "poznámka zákazníka nie je v bunke produktu").toBe(true);
+  expect(umiestnenie.vPoznamkovejBunke, "poznámka zákazníka je stále v zlúčenej bunke POZNÁMKY").toBe(false);
+  expect(umiestnenie.fontSizeRemark, "poznámka zákazníka nie je vizuálne menšia než meno produktu").not.toBe(
+    umiestnenie.fontSizeProdukt,
+  );
 
   // issue 163: rovnaká (zovšeobecnená, VŠETKY `<td>`) deliace-čiary kontrola
   // aj pri ZAPNUTOM prepínači "skryť vybavené" — fix je štrukturálny (CSS na

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -2187,3 +2187,40 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   pridávaní ĎALŠIEHO poľa na `OpenOrderLine` (surové+odvodené polia,
   17-súborová fixtúrová konvencia, row-height strop treba pri KAŽDOM
   ďalšom stĺpcovanom riadku v "Poznámky" bunke naživo premerať).
+
+## 2026-08-01 — #169 (OUR_BLOCK_RE — druhý výskyt bloku + CRLF separátor)
+
+- Solo ticket (Scope-gate: cross-cutting), version bump `4113e34`
+  (0.3.0-dev.98→.99), first commit.
+- Design comment BEFORE first code commit: issue-comment-5153199372 — root
+  cause (`OUR_BLOCK_RE` bez `/g`, `.replace()` odstráni len prvý výskyt;
+  prefix `\n{1,2}` nesedí na `\r\n`), zvolený prístup (samostatný
+  `OUR_BLOCK_RE_GLOBAL` len pre `.replace()`, pôvodný `OUR_BLOCK_RE` bez
+  `/g` ostáva pre `hasOurBlock`'s `.test()`), zamietnutá alternatíva
+  (pridať `/g` na zdieľaný objekt použitý aj v `.test()` — zamietnuté pre
+  stavový `lastIndex` globálnych regexov, ktorý by ticho zaviedol nový bug
+  do opakovaných `hasOurBlock` volaní).
+- STEP 0 validation comment: issue-comment-5153200250 (obe slabiny
+  reprodukované priamo v Node REPL proti kódu na `dev` `4113e34`).
+- RED→GREEN: 3 nové testy v `note-block.test.ts` (dva bloky odstránené
+  OBIDVA cez `mergeShopRemark`, CRLF separátor odstránený spolu s blokom,
+  `extractForeignShopRemark` s dvomi blokmi nikdy nezobrazí druhý ako
+  cudzí text) — RED overené proti pôvodnému kódu (`b8c0cc1`), GREEN po
+  fixe (`a47582b`). Review comment: issue-comment-5153237481 (0🔴 0🟡 0🔵).
+- PR #170, CI (push aj pull_request) zelené, mergeable+clean → merged
+  `21a5a3d`.
+- Main CI aj Deploy monitorované po merge — Deploy prvýkrát zlyhal
+  (`failed to Lchown ... no such file or directory` počas extrakcie
+  vrstvy), diagnostikované ako TRANSIENTNÝ race so súbežným CI jobom na
+  tom istom self-hosted dev2 runneri (potvrdené koreláciou
+  `journalctl -u docker` časových pečiatok s `gh run list`) — nie
+  obsahová chyba image. `gh run rerun --failed` prešiel na prvý pokus,
+  žiadny iný job vtedy nebežal. Detail pridaný do `.claude/rules/deploy.md`.
+- Live overené: `/api/version` = `0.3.0-dev.99`/`21a5a3d`, dashboard DOM
+  `v0.3.0-dev.99`, objednávky (`?tab=orders`) vykreslené 41 riadkov, 0
+  console errors/warnings. DB baseline nezmenený (`0|0|535|881`).
+- Playbook: nový bod v `.claude/rules/deploy.md` — súbežný CI job na tom
+  istom self-hosted runneri ako `deploy` job je ĎALŠÍ pozorovaný spúšťač
+  tej istej "failed to extract layer" triedy chýb; diagnostický vzor
+  (korelácia `journalctl -u docker` s `gh run list` časovými pečiatkami)
+  pridaný pre budúci podobný nález.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.99",
+  "version": "0.3.0-dev.100",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Súhrn

Majiteľ, doslova: "poznamka zakaznika daj pod text produktu". Zákaznícka
poznámka (🛈, `remark-cell-<lineId>`) sa presunula zo zlúčenej bunky
POZNÁMKY do bunky produktu, ako druhý riadok pod jeho menom — vizuálne
odlíšená (menšie, tlmené písmo) od názvu. Zlúčená bunka POZNÁMKY teraz
nesie len internú poznámku e-shopu (🏪) a editovateľný komentár, ako pred
issue 164.

issue 171

## Zmeny

- `OrderLineRow.tsx`: produktová `<td>` obaľuje meno do `.ord-product-name`
  a vedľa neho vykresľuje NEZMENENÝ `remark-cell-<id>` div (rovnaké
  testid/logika, len iný rodič). Bunka POZNÁMKY stráca svoj bývalý prvý
  blok.
- `app.css`: `.ord-remark` dostáva `font-size: var(--fs-text-xs)`
  (akceptačná podmienka na vizuálne odlíšenie); `margin-top` sa presúva
  z `.ord-shop-remark-cell` (teraz prvý blok) na `.ord-remark-cell` (teraz
  druhý, pod menom produktu).
- Testy: nové assercie v `OrderLineRow.remarkCell.test.tsx` +
  `OrdersSection.test.tsx` overujú nové umiestnenie (rovnaká `<td>` ako meno
  produktu, iná ako zlúčená POZNÁMKY bunka). `orders-layout.spec.ts`
  živo prehodnotilo strop výšky kompaktného riadku — nameraných 98.19px
  (predtým ~108.5px), strop znížený 115px→105px — a pridalo kontrolu
  správneho umiestnenia + vizuálneho odlíšenia (font-size).

## Overenie

- `pnpm --filter @forestshop/web test` — 39 súborov, 289 testov (vrátane
  nových), zelené.
- `pnpm --filter @forestshop/api test` — 22 súborov, 345 testov, zelené
  (backend nedotknutý).
- `pnpm --filter @forestshop/web e2e` — 25/25 zelené, vrátane
  `orders-layout.spec.ts` s novým stropom + placement assertions.
- `pnpm lint` + `pnpm typecheck` — čisté.
- CI (run 30753998616): version-check, check, integration, docker-build,
  e2e — všetko `success`.

Naživo overenie na `forestshop-novy.newlevel.media` prebehne PO merge +
nasadení (post-deploy verification) — ticket preto ostáva otvorený, kým sa
to nepotvrdí (`.claude/rules/CLAUDE.md`'s auto-close poučenie).
