### PR TITLE
docs: playbook + autopilot log for issue 171 (0.3.0-dev.101)

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -561,3 +561,36 @@ paths:
   clean under both `tsc -b` and eslint. Any FUTURE
   `getByTestId`/`getByLabelText`/etc. result that needs a narrower element
   type in THIS codebase: use the generic argument, not `as`.
+- **UN-merging one sibling OUT of an existing merged `<td>` (the inverse of
+  the "merge two columns" pattern above) uses the SAME technique in
+  reverse: move the existing testid'd `<div>` verbatim (no change to its
+  `data-testid`/conditional-render logic) into its new parent `<td>` as a
+  plain block-level sibling — never wrap the OLD OR NEW parent `<td>` in
+  `display:flex` (issue 163's lesson stays true in both directions).**
+  Issue 171 pulled `.ord-remark-cell` (customer note) out of
+  `td.ord-notes-merged` into the product-name `<td>`, which meant that
+  `<td>` needed its own text wrapped in a new `.ord-product-name` div
+  first (a bare `{line.variantName}` text node can't be a "sibling" of
+  anything) — any future un-merge into a `<td>` that currently holds only
+  bare text needs that same one-time wrap.
+- **A `<colgroup>`/row-height ceiling based on a `page.addStyleTag`
+  candidate measurement (issue 105/107/111/127's methodology, run against
+  a THROWAWAY Node script) can also be re-measured MUCH more cheaply by
+  temporarily instrumenting the EXISTING e2e spec with a `console.log` of
+  the real heights, running it once via `playwright test`, reading the
+  logged numbers from stdout, then reverting the instrumentation before
+  committing.** Issue 171 needed to know whether moving `remark` OUT of
+  the row's tallest cell lowered the measured max height enough to justify
+  tightening `orders-layout.spec.ts`'s ceiling — no throwaway script or
+  live-production access needed, since the existing spec already logs in
+  and asserts against the same seeded fixture (9001) that drives the
+  ceiling. Pattern: copy the spec file to scratch first (`cp` for an easy
+  revert), replace the `.filter((h) => h > N)` line with an unfiltered
+  `console.log(JSON.stringify(heights))`, run `playwright test <file>
+  --reporter=line 2>&1 | grep DEBUG`, restore the original file from the
+  scratch copy, then apply the real (measured, justified) ceiling change.
+  Cheaper than the full live-production methodology when the existing e2e
+  fixture already reproduces the row shape in question — reach for the
+  live-production `addStyleTag` script only when the e2e fixture's content
+  shape doesn't match real production data (as issue 107 found out the
+  hard way).

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -2224,3 +2224,52 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   tej istej "failed to extract layer" triedy chýb; diagnostický vzor
   (korelácia `journalctl -u docker` s `gh run list` časovými pečiatkami)
   pridaný pre budúci podobný nález.
+
+## Issue 171 — poznámku zákazníka pod text produktu (2026-08-02)
+
+- Design comment (issue-comment-5158732415) PRED prvým commitom: koreň
+  problému (`remark` v zlúčenej `td.ord-notes-merged`, ďaleko od produktu,
+  ktorého sa týka), zvolený prístup (presunúť LEN `remark-cell` div do
+  produktovej `<td>` ako sibling `<div>` pod obaleným menom, žiadny
+  `display:flex` na `<td>`, issue 163's poučenie), zamietnutá alternatíva
+  (len vizuálne prepojiť, nechať v POZNÁMKY — zamietnuté, ticket žiada
+  fyzické premiestnenie).
+- STILL-VALID komentár (issue-comment-5158733610): overené proti `dev`
+  (`df4e607`), remark stále v `ord-notes-merged`, žiadny neskorší PR to
+  nepresunul.
+- Implementácia: `OrderLineRow.tsx` (produktová `<td>` obalí meno do
+  `.ord-product-name` + rovnaký `remark-cell-<id>` div ako sibling; POZNÁMKY
+  `<td>` stráca svoj bývalý prvý blok), `app.css` (`.ord-remark` dostáva
+  `font-size: var(--fs-text-xs)`, `margin-top` presunutý z
+  `.ord-shop-remark-cell` na `.ord-remark-cell`).
+- Testy: `OrderLineRow.remarkCell.test.tsx` + `OrdersSection.test.tsx` —
+  nové assercie na DOM umiestnenie (remark v tej istej `<td>` ako meno
+  produktu, inej než POZNÁMKY). `orders-layout.spec.ts` živo prehodnotilo
+  strop výšky kompaktného riadku — throwaway debug meranie (`console.log`
+  vyskok, revertnuté) ukázalo 98.19px (predtým ~108.5px so všetkými tromi
+  poznámkami v jednej bunke) — strop znížený 115px→105px, plus nová
+  kontrola placement + font-size odlíšenia. Commit `991f7c1`.
+- Lokálne overené PRED pushom: web unit 39/39 súborov (287→289 testov po
+  pridaní), api unit 22/22 (345 testov, backend nedotknutý), web e2e
+  25/25 (vrátane `orders-layout.spec.ts`), `pnpm lint` + `pnpm typecheck`
+  čisté.
+- Review comment (issue-comment-5158838610): vlastný /review pass, 0🔴 0🟡,
+  1 drobný 🔵 self-note (empty `remark-cell` div nesie `margin-top` aj bez
+  obsahu — rovnaký ustálený vzor ako mala `.ord-shop-remark-cell` predtým,
+  živo zmeraná výška riadku ho nepreukazuje ako problém).
+- PR #174 — `Closes #171` ZÁMERNE nepoužité (ticket má live post-deploy
+  overenie ako akceptačnú podmienku, `.claude/rules/CLAUDE.md`'s auto-close
+  poučenie) — CI (push run 30753998616 aj PR-triggered run 30754149804)
+  všetko `success`, PR `MERGEABLE`+`CLEAN` → merged `d5ccd06` (merge
+  commit).
+- Main CI (run 30754277925) aj Deploy (run 30754277901) monitorované po
+  merge — obe `success`.
+- Live overené (Playwright MCP): `/api/version` = `0.3.0-dev.100`/
+  `d5ccd06`. Riadok "Nabíjačka NITECORE UM4" (objednávka 20261063) —
+  `remark-cell.closest('td') === productDiv.closest('td')` → `true`;
+  `.ord-notes-merged` (35 živých riadkov) neobsahuje žiadny `remark-cell`;
+  font-size 12px (poznámka) vs 13px (meno produktu); zmeraná výška riadku
+  85px. Konzola: 0 chýb/varovaní. DB baseline nezmenený (overrides 0|0,
+  order/order_line 535→536 / 881→882 normálnym importom).
+- Issue #171 zavretý s dôkazom (issue-comment-5158877599). Discord karta
+  odoslaná (`notify --run-card`, `sent`).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.100",
+  "version": "0.3.0-dev.101",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Version bump + `docs/autopilot-log.md` entry + `.claude/rules/frontend-design.md` playbook entry for issue 171 (customer-note relocation). No functional code change — issue 171 itself already merged/deployed/verified via PR #174.