### PR TITLE
feat: Nevyzdvihnute zasielky automation (issue 172)

### DIFF
--- a/.claude/rules/scheduler.md
+++ b/.claude/rules/scheduler.md
@@ -48,13 +48,29 @@ paths:
   obsadené: `787_878_001` (`INGEST_ADVISORY_LOCK_KEY`, `catalog/ingest.ts`),
   `787_878_002` (`SCHEDULER_ADVISORY_LOCK_KEY`, `scheduler.ts`),
   `787_878_003` (`INGEST_ORDERS_ADVISORY_LOCK_KEY`, `orders/ingest.ts`, #21),
-  `787_878_100` (`TEST_DB_ISOLATION_LOCK_KEY`, `tests/helpers/db.ts`).
+  `787_878_100` (`TEST_DB_ISOLATION_LOCK_KEY`, `tests/helpers/db.ts`),
+  `787_878_004` (`POSTA_UNCOLLECTED_RUN_LOCK_KEY`, `posta-uncollected/run.ts`,
+  issue 172 — pozri nižšie).
   `ordersImportJob`/`pruneRawOrdersJob` (#22/#28) nepridali žiadny nový kľúč
   (pozri bod vyššie). `shoptetWritebackJob` (issue 122) tiež žiadny nepridal
   — v tomto tickete niet manuálneho HTTP triggeru na tú istú prácu (na
   rozdiel od `catalogImportJob`/`ordersImportJob`, ktoré preto majú svoj
   vlastný zámok VNÚTRI `ingestCatalog`/`ingestOrders`), takže scheduler
   tick()'s vlastný zámok (bod nižšie) stačí.
+- **`postaUncollectedJob` (issue 172) MÁ manuálny HTTP trigger ("Spustiť
+  teraz") na TÚ ISTÚ prácu ako naplánovaný denný beh — presne ako
+  `catalogImportJob`/`ordersImportJob`, dostáva preto VLASTNÝ zámok VNÚTRI
+  `runPostaUncollected` (`POSTA_UNCOLLECTED_RUN_LOCK_KEY`).** Na rozdiel od
+  tamtých dvoch je to `pg_advisory_lock` (session-scoped, na vlastnom
+  vyhradenom pripojení z poolu, `db.$client.connect()`) — nie
+  `pg_advisory_xact_lock` v transakcii: beh robí desiatky sekvenčných
+  sieťových volaní na posta.sk (per zásielka), a držať jednu DB transakciu
+  otvorenú počas nich by zbytočne zaťažovalo connection pool. Bez tohto
+  zámku by dva prekrývajúce sa behy (dvaja manažéri klikli "Spustiť teraz"
+  súčasne, alebo ručný klik sa prekryl s 07:00 UTC naplánovaným behom) mohli
+  OBA prečítať ten istý predošlý `notifyCount` pred zápisom a poslať
+  DUPLICITNÝ eskalačný e-mail zákazníkovi (review na PR 177 — nájdené pred
+  mergom, nie testom).
 - **`tick()`'s zámok chráni LEN kontrolu splatnosti + vloženie "running"
   riadku, NIE celý beh úlohy.** `job.run()` beží AŽ PO commite transakcie so
   zámkom, mimo neho — dlho bežiaci job (napr. 54 MB import katalógu) tak

--- a/apps/api/drizzle/0021_bouncy_shockwave.sql
+++ b/apps/api/drizzle/0021_bouncy_shockwave.sql
@@ -1,0 +1,26 @@
+CREATE TABLE "posta_uncollected_settings" (
+	"id" text PRIMARY KEY DEFAULT 'default' NOT NULL,
+	"enabled" boolean DEFAULT false NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "posta_uncollected_state" (
+	"order_code" text PRIMARY KEY NOT NULL,
+	"notify_count" integer DEFAULT 0 NOT NULL,
+	"last_sent_at" date,
+	"terminal_state" text,
+	"terminal_at" date,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "order" ADD COLUMN "email" text;--> statement-breakpoint
+ALTER TABLE "order" ADD COLUMN "phone" text;--> statement-breakpoint
+ALTER TABLE "order" ADD COLUMN "package_number" text;--> statement-breakpoint
+ALTER TABLE "order" ADD COLUMN "shipping_carrier_name" text;--> statement-breakpoint
+-- issue 172: singleton riadok MUSÍ existovať hneď po nasadení — appka
+-- kontroluje "enabled" pri KAŽDOM naplánovanom behu, žiadny riadok by
+-- znamenal, že kontrola nemá čo prečítať. `enabled = false` je jediná
+-- bezpečná predvolená hodnota (žiadny e-mail bez ručného zapnutia
+-- majiteľom) — DEFAULT stĺpca to zaisťuje aj tu. "ON CONFLICT DO NOTHING"
+-- robí migráciu bezpečne opakovateľnou.
+INSERT INTO "posta_uncollected_settings" ("id", "enabled") VALUES ('default', false) ON CONFLICT ("id") DO NOTHING;

--- a/apps/api/drizzle/meta/0021_snapshot.json
+++ b/apps/api/drizzle/meta/0021_snapshot.json
@@ -1,0 +1,1658 @@
+{
+  "id": "079b201d-c649-4e45-9249-f80d5caf2743",
+  "prevId": "d6889a56-f2b7-4c66-9ae3-e2034e95e976",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_code": {
+          "name": "external_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_open_status": {
+      "name": "order_open_status",
+      "schema": "",
+      "columns": {
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Vybavuje sa'"
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop_remark": {
+          "name": "shop_remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shoptet_order_id": {
+          "name": "shoptet_order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_updated_at": {
+          "name": "comment_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_synced_at": {
+          "name": "comment_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_carrier_name": {
+          "name": "shipping_carrier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_link_override": {
+      "name": "product_supplier_link_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_link_override_product_key_product_key_fk": {
+          "name": "product_supplier_link_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_link_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_override": {
+      "name": "product_supplier_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_override_product_key_product_key_fk": {
+          "name": "product_supplier_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing": {
+      "name": "pairing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_url": {
+          "name": "supplier_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "pairing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'navrhnute'"
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pairing_state_idx": {
+          "name": "pairing_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_confirmed_by_idx": {
+          "name": "pairing_confirmed_by_idx",
+          "columns": [
+            {
+              "expression": "confirmed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_variant_code_variant_code_fk": {
+          "name": "pairing_variant_code_variant_code_fk",
+          "tableFrom": "pairing",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pairing_confirmed_by_users_id_fk": {
+          "name": "pairing_confirmed_by_users_id_fk",
+          "tableFrom": "pairing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pairing_variant_code_unique": {
+          "name": "pairing_variant_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pairing_confirmation_ck": {
+          "name": "pairing_confirmation_ck",
+          "value": "(\"pairing\".\"state\" = 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)\n        OR (\"pairing\".\"state\" != 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NULL AND \"pairing\".\"confirmed_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier": {
+      "name": "supplier",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wholesale_base_url": {
+          "name": "wholesale_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_key": {
+          "name": "adapter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_settings": {
+      "name": "posta_uncollected_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_state": {
+      "name": "posta_uncollected_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notify_count": {
+          "name": "notify_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_state": {
+          "name": "terminal_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne"
+      ]
+    },
+    "public.pairing_state": {
+      "name": "pairing_state",
+      "schema": "public",
+      "values": [
+        "navrhnute",
+        "potvrdene"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1785611459422,
       "tag": "0020_lean_meteorite",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1785693949589,
+      "tag": "0021_bouncy_shockwave",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema-orders.ts
+++ b/apps/api/src/db/schema-orders.ts
@@ -109,6 +109,21 @@ export const orders = pgTable(
     // behu), lebo tento zápis je per-objednávka, nie jeden hromadný CSV
     // import.
     commentSyncedAt: timestamp("comment_synced_at", { withTimezone: true }),
+    // issue 172: štyri nové Shoptet-ove polia pre automatizáciu "Nevyzdvihnuté
+    // zásielky" — rovnaká rodina ako `statusName`/`remark`/`shopRemark` vyššie
+    // (VŽDY Shoptetovo pole, `ingest.ts` ho pri re-importe OSVIEŽI), ale na
+    // rozdiel od nich sa extrahujú NEZÁVISLE od `mapOrderRow`'s
+    // item-validácie (`parser.ts`'s `extractOrderLevelExtra`) — `email`/
+    // `phone`/`packageNumber` sú na KAŽDOM riadku objednávky vrátane pseudo-
+    // položiek (doprava/platba/zľava), a `shippingCarrierName` je práve na
+    // SHIPPING pseudo-riadku, ktorý `mapOrderRow` inak celý zahodí
+    // (`.claude/rules/orders.md`'s "itemCode nie je vždy skutočný produkt").
+    // Nullable — nepovinné stĺpce exportu, chýbajúca hodnota sa mapuje na
+    // `null`, nikdy na prázdny reťazec (rovnaký vzor ako `remark`).
+    email: text("email"),
+    phone: text("phone"),
+    packageNumber: text("package_number"),
+    shippingCarrierName: text("shipping_carrier_name"),
   },
   (t) => [index("order_placed_at_idx").on(t.placedAt)],
 );

--- a/apps/api/src/db/schema-posta-uncollected.ts
+++ b/apps/api/src/db/schema-posta-uncollected.ts
@@ -1,0 +1,37 @@
+import { boolean, date, integer, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+// issue 172: "Nevyzdvihnuté zásielky" (Pošta SK) — Štart/Stop prepínač.
+// JEDEN singleton riadok (pevné `id = 'default'`, nikdy druhý riadok), aby
+// appka mala presne jedno miesto pravdy "je táto automatizácia zapnutá".
+// Migrácia seeduje tento riadok s `enabled = false` — nasadenie preto
+// FYZICKY nemôže poslať e-mail, kým ho majiteľ sám ručne nezapne (ticket's
+// jediná bezpečnostná podmienka, `.claude/rules/…`'s "žiadny e-mail bez
+// zásahu človeka"). Tento flag gate-uje LEN naplánovaný denný beh
+// (`scheduler/jobs.ts`'s `postaUncollectedJob` ho skontroluje PRED behom
+// business logiky) — "Spustiť teraz" volá tú istú funkciu priamo, bez
+// ohľadu na tento flag, presne ako stará appka (`automation_runner.py`'s
+// `run_now`: "runs even when disabled — an explicit manager action").
+export const postaUncollectedSettings = pgTable("posta_uncollected_settings", {
+  id: text("id").primaryKey().default("default"),
+  enabled: boolean("enabled").notNull().default(false),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+});
+
+// Eskalačný stav PER OBJEDNÁVKA (nahrádza starej appky `posta_uncollected
+// .json`) — koľko e-mailov už bolo poslaných, kedy naposledy, a cache
+// TERMINÁLNEHO stavu sledovania (#222 v starej appke: "doručené"/"prevzaté
+// na pošte" sa už nemení, netreba ho znova pýtať 7 dní, viď
+// `modules/posta-uncollected/logic.ts`'s `TERMINAL_STATE_CODES`). Kľúčované
+// KÓDOM OBJEDNÁVKY (nie číslom zásielky) — rovnaký kľúč, aký stará appka's
+// JSON store používala (`evaluate_shipment`'s `esc.get(s["code"], "")`),
+// lebo jedna objednávka nesie jedno číslo zásielky. Riadky mimo 30-dňové
+// okno sa pri každom behu VYMAŽÚ (rovnaký zámer ako stará appka's krok
+// "Vyčistí staré záznamy… ktoré už vypadli z 30-dňového okna").
+export const postaUncollectedState = pgTable("posta_uncollected_state", {
+  orderCode: text("order_code").primaryKey(),
+  notifyCount: integer("notify_count").notNull().default(0),
+  lastSentAt: date("last_sent_at"),
+  terminalState: text("terminal_state"),
+  terminalAt: date("terminal_at"),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+});

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -3,3 +3,4 @@ export * from "./schema-catalog.js";
 export * from "./schema-scheduler.js";
 export * from "./schema-orders.js";
 export * from "./schema-pairing.js";
+export * from "./schema-posta-uncollected.js";

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -53,6 +53,13 @@ const envSchema = z.object({
   // namiesto neho použije apk-nainštalovaný systémový chromium. Nepovinné aj
   // tu — mimo produkčného image ho netreba, Playwright použije svoj vlastný.
   CHROMIUM_EXECUTABLE_PATH: z.string().min(1).optional(),
+  // issue 172: skrytá kópia (BCC) majiteľovi pre "Nevyzdvihnuté zásielky" —
+  // NEZÁVISLÁ, vyhradená premenná (nie všeobecné `MAIL_BCC`, `.claude/rules/
+  // orders.md`'s poznámka o tom, prečo appka doteraz BCC vôbec nepodporuje).
+  // Chýbajúca = automatizácia NEPOŠLE ani jeden e-mail zákazníkovi (fail-
+  // closed, ticket's jediná bezpečnostná podmienka) — nikdy sa nedotýka
+  // existujúceho odosielania objednávky dodávateľovi.
+  POSTA_UNCOLLECTED_BCC_EMAIL: z.string().email().optional(),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/apps/api/src/http/app.ts
+++ b/apps/api/src/http/app.ts
@@ -15,6 +15,7 @@ import { SESSION_COOKIE, requireUser, type AppBindings } from "./middleware.js";
 import { registerOrdersRoutes, type RunOrdersIngest } from "./orders-routes.js";
 import { requireSameOrigin } from "./origin-check.js";
 import { registerPairingRoutes } from "./pairing-routes.js";
+import { registerPostaUncollectedRoutes, type PostaUncollectedRunDeps } from "./posta-uncollected-routes.js";
 import { registerSchedulerRoutes } from "./scheduler-routes.js";
 import { registerSupplierRoutes } from "./supplier-routes.js";
 
@@ -40,6 +41,12 @@ export function createApp(
     // `?:` ako `runIngest`/ostatné (tie chýbajú, keď zodpovedajúca URL nie
     // je nastavená; toto vždy JE nastavené, aspoň na predvolenú hodnotu).
     readonly adminBaseUrl?: string;
+    // issue 172: "Spustiť teraz" + náhľad — voliteľné (rovnaký dôvod ako
+    // `adminBaseUrl` vyššie: existujúce testy/lokálny vývoj bez explicitne
+    // odovzdanej hodnoty dostanú rozumný default nižšie, nikdy nemusia
+    // meniť svoje volanie `createApp`). `index.ts` ho v produkcii VŽDY
+    // zostavuje s reálnym tracking klientom.
+    readonly postaUncollected?: PostaUncollectedRunDeps;
   },
 ): Hono<AppBindings> {
   const app = new Hono<AppBindings>();
@@ -136,6 +143,21 @@ export function createApp(
   registerSchedulerRoutes(app, db);
   registerSupplierRoutes(app, db, options.sendSupplierMail);
   registerPairingRoutes(app, db);
+  registerPostaUncollectedRoutes(
+    app,
+    db,
+    options.postaUncollected ?? {
+      // Bezpečný default pre testy/lokálny vývoj bez explicitne dodaných
+      // dependencies — NIKDY nekontaktuje skutočné api.posta.sk (vracia
+      // `null`, "zlyhalo", presne ako sieťový výpadok), nikdy neposiela
+      // mail (`mailTransport` chýba). Produkcia (`index.ts`) toto VŽDY
+      // nahradí reálnym tracking klientom.
+      trackingClient: () => Promise.resolve(null),
+      mailTransport: undefined,
+      bccEmail: undefined,
+      adminBaseUrl: options.adminBaseUrl ?? "https://www.forestshop.sk",
+    },
+  );
 
   // Musí byť registrovaný AŽ PO všetkých skutočných /api/* trasách vyššie — Hono
   // vyberá presnejšiu zhodu, takže tie majú prednosť a sem sa dostane len to, čo

--- a/apps/api/src/http/posta-uncollected-routes.ts
+++ b/apps/api/src/http/posta-uncollected-routes.ts
@@ -1,0 +1,185 @@
+import { zValidator } from "@hono/zod-validator";
+import type { Hono } from "hono";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+import type { Database } from "../db/client.js";
+import { jobRuns } from "../db/schema.js";
+import { log } from "../logger.js";
+import { record } from "../modules/audit/service.js";
+import { MAX_EMAILS } from "../modules/posta-uncollected/constants.js";
+import { buildEmail } from "../modules/posta-uncollected/logic.js";
+import { POSTA_UNCOLLECTED_JOB_NAME } from "../modules/scheduler/jobs.js";
+import { getLatestJobRun } from "../modules/scheduler/queries.js";
+import type { PostaUncollectedRunResult, RunPostaUncollectedOptions } from "../modules/posta-uncollected/run.js";
+import { runPostaUncollected } from "../modules/posta-uncollected/run.js";
+import { isPostaUncollectedEnabled, setPostaUncollectedEnabled } from "../modules/posta-uncollected/settings.js";
+import { requireRole, requireUser, type AppBindings } from "./middleware.js";
+import { requireSameOrigin } from "./origin-check.js";
+
+const setEnabledBody = z.object({ enabled: z.boolean() });
+const packageParam = z.object({ packageNumber: z.string().min(1) });
+
+// `Omit<..., "db" | "now">` — HTTP vrstva len dodá `db`/`now`, business
+// dependencies (tracking klient, mail transport, BCC adresa, admin base url)
+// zostavuje `index.ts` presne raz pri štarte procesu (rovnaký vzor ako
+// `runIngest`/`runOrdersIngest`).
+export type PostaUncollectedRunDeps = Omit<RunPostaUncollectedOptions, "db" | "now">;
+
+function isRunResult(detail: unknown): detail is PostaUncollectedRunResult {
+  return typeof detail === "object" && detail !== null && "uncollected" in detail;
+}
+
+/**
+ * Manuálne "Spustiť teraz" aj naplánovaný beh zapisujú job_run TÝM ISTÝM
+ * vzorom, aký `scheduler.ts`'s `executeJob` používa interne — tá funkcia nie
+ * je exportovaná (scheduler-interná), takže táto malá kópia zapisuje
+ * rovnaký tvar riadku priamo, aby `GET /api/posta-uncollected` videl
+ * manuálny beh HNEĎ, nielen po ďalšom pravidelnom ticku.
+ */
+async function runAndRecord(db: Database, deps: PostaUncollectedRunDeps, now: Date): Promise<PostaUncollectedRunResult> {
+  const [inserted] = await db
+    .insert(jobRuns)
+    .values({ jobName: POSTA_UNCOLLECTED_JOB_NAME, startedAt: now, status: "running" })
+    .returning({ id: jobRuns.id });
+  const runId = inserted?.id;
+  try {
+    const result = await runPostaUncollected({ db, now, ...deps });
+    if (runId !== undefined) {
+      await db.update(jobRuns).set({ status: "success", finishedAt: new Date(), detail: result }).where(eq(jobRuns.id, runId));
+    }
+    return result;
+  } catch (error) {
+    const rawErrorMessage = error instanceof Error ? error.message : String(error);
+    log.error({ rawErrorMessage }, "Nevyzdvihnuté zásielky: ručný beh zlyhal");
+    if (runId !== undefined) {
+      await db.update(jobRuns).set({ status: "failure", finishedAt: new Date(), errorMessage: rawErrorMessage }).where(eq(jobRuns.id, runId));
+    }
+    throw error;
+  }
+}
+
+export function registerPostaUncollectedRoutes(app: Hono<AppBindings>, db: Database, deps: PostaUncollectedRunDeps): void {
+  // Čítanie — každý prihlásený zamestnanec (rovnaká úroveň ako "Sync zo
+  // Shoptetu"/"Na objednanie", žiadny mutujúci vedľajší efekt).
+  app.get("/api/posta-uncollected", requireUser(db), async (c) => {
+    const [enabled, lastRun] = await Promise.all([isPostaUncollectedEnabled(db), getLatestJobRun(db, POSTA_UNCOLLECTED_JOB_NAME)]);
+    return c.json({
+      enabled,
+      lastRun:
+        lastRun === null
+          ? null
+          : {
+              startedAt: lastRun.startedAt,
+              finishedAt: lastRun.finishedAt,
+              status: lastRun.status,
+              errorMessage: lastRun.errorMessage,
+              result: isRunResult(lastRun.detail) ? lastRun.detail : null,
+              skippedReason:
+                typeof lastRun.detail === "object" &&
+                lastRun.detail !== null &&
+                "skipped" in lastRun.detail &&
+                (lastRun.detail as { readonly skipped?: unknown }).skipped === true
+                  ? ((lastRun.detail as { readonly reason?: unknown }).reason ?? "")
+                  : null,
+            },
+    });
+  });
+
+  // Štart/Stop — gate-uje LEN naplánovaný denný beh (`scheduler/jobs.ts`'s
+  // `postaUncollectedJob`), nikdy "Spustiť teraz" nižšie (návrhový komentár
+  // na issue 172).
+  app.put(
+    "/api/posta-uncollected/enabled",
+    requireSameOrigin(),
+    requireUser(db),
+    requireRole("admin", "manazer"),
+    zValidator("json", setEnabledBody),
+    async (c) => {
+      const { enabled } = c.req.valid("json");
+      const user = c.get("user");
+      const now = new Date();
+      await setPostaUncollectedEnabled(db, enabled, now);
+      await record(db, {
+        at: now,
+        actorUserId: user.userId,
+        action: "posta_uncollected.enabled.set",
+        entity: "posta_uncollected_settings",
+        data: { enabled },
+      });
+      log.info({ actorUserId: user.userId, enabled }, "Nevyzdvihnuté zásielky: Štart/Stop");
+      return c.json({ ok: true as const, enabled });
+    },
+  );
+
+  // "Spustiť teraz" — VŽDY beží, bez ohľadu na `enabled` (explicitná ľudská
+  // akcia, presne ako stará appka's `run_now`). Skutočné odoslanie e-mailu je
+  // AJ TAK fail-closed na BCC/SMTP vnútri `runPostaUncollected` samotnej.
+  app.post(
+    "/api/posta-uncollected/run-now",
+    requireSameOrigin(),
+    requireUser(db),
+    requireRole("admin", "manazer"),
+    async (c) => {
+      const user = c.get("user");
+      const now = new Date();
+      let result: PostaUncollectedRunResult;
+      try {
+        result = await runAndRecord(db, deps, now);
+      } catch {
+        return c.json({ error: "Beh zlyhal — skúste to znova o chvíľu." }, 502);
+      }
+      await record(db, {
+        at: now,
+        actorUserId: user.userId,
+        action: "posta_uncollected.run_now",
+        entity: "job_run",
+        data: { stats: result.stats },
+      });
+      log.info({ actorUserId: user.userId, stats: result.stats }, "Nevyzdvihnuté zásielky: ručné spustenie");
+      return c.json({ ok: true as const, result });
+    },
+  );
+
+  // Náhľad — číta VÝHRADNE z POSLEDNÉHO uloženého behu (nikdy znova nehýta
+  // posta.sk), presne ako stará appka's `/api/posta-uncollected/preview`.
+  // Číslo e-mailu je NASLEDUJÚCI (už poslané + 1); po vyčerpaní kadencie
+  // ukáže POSLEDNÝ odoslaný a označí `maxReached` — vymýšľať 5. e-mail, ktorý
+  // sa nikdy nepošle, by bola lož.
+  app.get(
+    "/api/posta-uncollected/preview/:packageNumber",
+    requireUser(db),
+    zValidator("param", packageParam),
+    async (c) => {
+      const { packageNumber } = c.req.valid("param");
+      const lastRun = await getLatestJobRun(db, POSTA_UNCOLLECTED_JOB_NAME);
+      const result = lastRun !== null && isRunResult(lastRun.detail) ? lastRun.detail : null;
+      const row = result?.uncollected.find((r) => r.packageNumber === packageNumber);
+      if (row === undefined) {
+        // 200 (nikdy 404) — rovnaká disciplína ako `/api/catalog/ingest`'s
+        // "busy"/rejected a `sendSupplierOrderMail`'s "no_email"/"no_items":
+        // toto je bežný, OČAKÁVANÝ doménový výsledok (zásielka medzičasom
+        // vypadla z tabuľky), nikdy HTTP-úrovňová chyba — Chromium by inak
+        // zalogoval "Failed to load resource" pri ktoromkoľvek e2e teste,
+        // čo by porušilo jedinú povolenú konzolovú výnimku (`.claude/rules/
+        // testing.md`).
+        return c.json({ ok: false as const, error: "Zásielka sa v aktuálnom zozname nenašla." });
+      }
+      const already = row.count;
+      const maxReached = already >= MAX_EMAILS;
+      const count = Math.min(already + 1, MAX_EMAILS);
+      const built = buildEmail(count, row.name, packageNumber, row.officeName, row.officeAddr, row.retainedTill, new Date());
+      return c.json({
+        ok: true as const,
+        subject: built.subject,
+        html: built.html,
+        recipient: row.email,
+        name: row.name,
+        packageNumber,
+        orderCode: row.orderCode,
+        count,
+        alreadySent: already,
+        maxReached,
+      });
+    },
+  );
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -13,10 +13,13 @@ import { createSmtpMailTransport } from "./modules/mail/transport.js";
 import { computeOrderIdsWindowStart } from "./modules/orders/backfill.js";
 import { computeImportWindow, createHttpOrderIdsFetcher, createHttpOrdersExportFetcher } from "./modules/orders/fetcher.js";
 import { DEFAULT_ORDERS_IMPORT_WINDOW_DAYS, ingestOrders, type RunOrdersIngest } from "./modules/orders/ingest.js";
+import { createHttpTrackingClient } from "./modules/posta-uncollected/tracking-client.js";
+import { runPostaUncollected } from "./modules/posta-uncollected/run.js";
 import {
   catalogImportJob,
   ordersImportJob,
   orderNoteWritebackJob,
+  postaUncollectedJob,
   pruneRawExportsJob,
   pruneRawOrdersJob,
   sessionCleanupJob,
@@ -139,12 +142,25 @@ const runOrderNoteWritebackFn =
           now,
         );
 
+// issue 172: "Nevyzdvihnuté zásielky" — tracking klient je VŽDY reálny
+// (žiadna URL na nakonfigurovanie, tretia strana má fixnú adresu,
+// `constants.ts`); mail transport a BCC adresa môžu chýbať (rovnaká úvaha
+// ako `sendSupplierMail` vyššie) — `runPostaUncollected` to sama rieši
+// fail-closed (nikdy nepošle bez oboch), nikdy nevyhadzuje.
+const postaUncollectedDeps = {
+  trackingClient: createHttpTrackingClient(),
+  mailTransport: sendSupplierMail,
+  bccEmail: env.POSTA_UNCOLLECTED_BCC_EMAIL,
+  adminBaseUrl: env.SHOPTET_ADMIN_BASE_URL,
+};
+
 const app = createApp(db, {
   cookieSecure: env.SESSION_COOKIE_SECURE,
   ...(runIngest === undefined ? {} : { runIngest }),
   ...(runOrdersIngest === undefined ? {} : { runOrdersIngest }),
   ...(sendSupplierMail === undefined ? {} : { sendSupplierMail }),
   adminBaseUrl: env.SHOPTET_ADMIN_BASE_URL,
+  postaUncollected: postaUncollectedDeps,
 });
 
 // F2 (#12/#3) + F3 (#22/#28): nočný import katalógu/objednávok, mazanie
@@ -162,6 +178,7 @@ const scheduler = startScheduler(db, [
   pruneRawOrdersJob(env.ORDERS_RAW_DIR),
   shoptetWritebackJob(runShoptetWritebackFn),
   orderNoteWritebackJob(runOrderNoteWritebackFn),
+  postaUncollectedJob((db2, now) => runPostaUncollected({ db: db2, now, ...postaUncollectedDeps })),
 ]);
 
 // `@hono/node-server`'s `serveStatic` prints its OWN `console.error` on every

--- a/apps/api/src/modules/mail/transport.ts
+++ b/apps/api/src/modules/mail/transport.ts
@@ -9,6 +9,15 @@ export interface MailMessage {
   readonly to: string;
   readonly subject: string;
   readonly text: string;
+  // issue 172: voliteľné HTML telo — "Nevyzdvihnuté zásielky" posiela
+  // formátovaný e-mail zákazníkovi (`text` zostáva jednoduchý fallback,
+  // rovnaký ako predtým). Existujúci `sendSupplierOrderMail` ho nikdy
+  // nepošle (zostáva čistý text), spätne kompatibilné.
+  readonly html?: string;
+  // issue 172: skrytá kópia — automatizácia ju posiela VŽDY majiteľovi
+  // (fail-closed kontrola žije v `run.ts`, nie tu). Voliteľné, aby existujúce
+  // volania (dodávateľská mail) ostali nezmenené.
+  readonly bcc?: string;
 }
 
 export type MailTransport = (message: MailMessage) => Promise<void>;
@@ -44,6 +53,8 @@ export function createSmtpMailTransport(config: SmtpMailConfig): MailTransport {
       to: message.to,
       subject: message.subject,
       text: message.text,
+      ...(message.html === undefined ? {} : { html: message.html }),
+      ...(message.bcc === undefined ? {} : { bcc: message.bcc }),
     });
   };
 }

--- a/apps/api/src/modules/orders/ingest.ts
+++ b/apps/api/src/modules/orders/ingest.ts
@@ -7,9 +7,13 @@ import { storeRawSnapshot } from "../catalog/raw-store.js";
 import { redactSourceLabel, type OrderIdsFetcher } from "./fetcher.js";
 import {
   decodeCp1250,
+  EMPTY_ORDER_LEVEL_EXTRA,
+  extractOrderLevelExtra,
   mapOrderRow,
+  mergeOrderLevelExtra,
   parseDelimited,
   REQUIRED_ORDER_COLUMNS,
+  type OrderLevelExtra,
   type OrderLineCandidate,
   type OrderRowIssue,
 } from "./parser.js";
@@ -171,6 +175,12 @@ export async function ingestOrders(db: Database, options: OrdersIngestOptions): 
   const issues: OrderRowIssue[] = [];
   let pseudoItemCount = 0;
   let parseErrorMessage: string | null = null;
+  // issue 172: `email`/`phone`/`packageNumber`/meno dopravcu sú OBJEDNÁVKOVÉ
+  // polia (opakované na KAŽDOM riadku vrátane pseudo-položiek), preto sa
+  // zbierajú z KAŽDÉHO riadku s neprázdnym `code` — nezávisle od toho, či
+  // `mapOrderRow` ten istý riadok prijme alebo zahodí (pozri `parser.ts`'s
+  // `extractOrderLevelExtra`/`mergeOrderLevelExtra`).
+  const orderExtraByCode = new Map<string, OrderLevelExtra>();
 
   try {
     let isHeaderRow = true;
@@ -189,6 +199,11 @@ export async function ingestOrders(db: Database, options: OrdersIngestOptions): 
         const name = columns[i] ?? "";
         if (name === "") continue;
         row[name] = values[i] ?? "";
+      }
+      const externalOrderIdOfRow = (row["code"] ?? "").trim();
+      if (externalOrderIdOfRow !== "") {
+        const previous = orderExtraByCode.get(externalOrderIdOfRow) ?? EMPTY_ORDER_LEVEL_EXTRA;
+        orderExtraByCode.set(externalOrderIdOfRow, mergeOrderLevelExtra(previous, extractOrderLevelExtra(row)));
       }
       const mapped = mapOrderRow(row);
       if (mapped.record !== null) {
@@ -304,15 +319,22 @@ export async function ingestOrders(db: Database, options: OrdersIngestOptions): 
         const inserted = await tx
           .insert(orders)
           .values(
-            batch.map(([externalOrderId, info]) => ({
-              externalOrderId,
-              customerName: info.customerName,
-              statusName: info.statusName,
-              remark: info.remark,
-              shopRemark: info.shopRemark,
-              placedAt: info.placedAt,
-              shoptetOrderId: orderIdsByCode.get(externalOrderId) ?? null,
-            })),
+            batch.map(([externalOrderId, info]) => {
+              const extra = orderExtraByCode.get(externalOrderId) ?? EMPTY_ORDER_LEVEL_EXTRA;
+              return {
+                externalOrderId,
+                customerName: info.customerName,
+                statusName: info.statusName,
+                remark: info.remark,
+                shopRemark: info.shopRemark,
+                placedAt: info.placedAt,
+                shoptetOrderId: orderIdsByCode.get(externalOrderId) ?? null,
+                email: extra.email,
+                phone: extra.phone,
+                packageNumber: extra.packageNumber,
+                shippingCarrierName: extra.shippingCarrierName,
+              };
+            }),
           )
           .onConflictDoUpdate({
             target: orders.externalOrderId,
@@ -328,13 +350,16 @@ export async function ingestOrders(db: Database, options: OrdersIngestOptions): 
             // VŽDY Shoptetovo pole, ukladá sa SUROVO (rozdelenie na naše/cudzie
             // sa robí až na čítacej strane, `queries.ts`) — appka pri IMPORTE
             // do neho nikdy nezapisuje, takže tu niet čo stratiť/prepísať.
-            // `shoptet_order_id` (issue 120) je NAVYŠE COALESCE-ovaný, nie priamo
-            // prepísaný ako predošlé — na rozdiel od nich pochádza z
-            // BEST-EFFORT XML fetchu, ktorý tento konkrétny beh môže
-            // zlyhať/chýbať (premenná nenastavená), a re-import bez neho
-            // nesmie vynulovať predtým zistené id (`"order"."shoptet_order_
-            // id"` = hodnota RIADKU PRED týmto UPDATE-om — presne to, čo
-            // `coalesce` potrebuje ako záchrannú sieť).
+            // `email`/`phone`/`package_number`/`shipping_carrier_name` (issue
+            // 172) sú TIEŽ tá istá rodina — VŽDY Shoptetovo pole, re-import ich
+            // osvieži (zásielka môže dostať číslo AŽ po prvom importe
+            // objednávky). `shoptet_order_id` (issue 120) je NAVYŠE
+            // COALESCE-ovaný, nie priamo prepísaný ako predošlé — na rozdiel
+            // od nich pochádza z BEST-EFFORT XML fetchu, ktorý tento konkrétny
+            // beh môže zlyhať/chýbať (premenná nenastavená), a re-import bez
+            // neho nesmie vynulovať predtým zistené id (`"order"."shoptet_
+            // order_id"` = hodnota RIADKU PRED týmto UPDATE-om — presne to,
+            // čo `coalesce` potrebuje ako záchrannú sieť).
             set: {
               customerName: sql`excluded.customer_name`,
               statusName: sql`excluded.status_name`,
@@ -342,6 +367,10 @@ export async function ingestOrders(db: Database, options: OrdersIngestOptions): 
               shopRemark: sql`excluded.shop_remark`,
               placedAt: sql`excluded.placed_at`,
               shoptetOrderId: sql`coalesce(excluded.shoptet_order_id, "order"."shoptet_order_id")`,
+              email: sql`excluded.email`,
+              phone: sql`excluded.phone`,
+              packageNumber: sql`excluded.package_number`,
+              shippingCarrierName: sql`excluded.shipping_carrier_name`,
             },
           })
           .returning({ id: orders.id, externalOrderId: orders.externalOrderId });

--- a/apps/api/src/modules/orders/ingest.ts
+++ b/apps/api/src/modules/orders/ingest.ts
@@ -351,15 +351,19 @@ export async function ingestOrders(db: Database, options: OrdersIngestOptions): 
             // sa robí až na čítacej strane, `queries.ts`) — appka pri IMPORTE
             // do neho nikdy nezapisuje, takže tu niet čo stratiť/prepísať.
             // `email`/`phone`/`package_number`/`shipping_carrier_name` (issue
-            // 172) sú TIEŽ tá istá rodina — VŽDY Shoptetovo pole, re-import ich
-            // osvieži (zásielka môže dostať číslo AŽ po prvom importe
-            // objednávky). `shoptet_order_id` (issue 120) je NAVYŠE
-            // COALESCE-ovaný, nie priamo prepísaný ako predošlé — na rozdiel
-            // od nich pochádza z BEST-EFFORT XML fetchu, ktorý tento konkrétny
-            // beh môže zlyhať/chýbať (premenná nenastavená), a re-import bez
-            // neho nesmie vynulovať predtým zistené id (`"order"."shoptet_
-            // order_id"` = hodnota RIADKU PRED týmto UPDATE-om — presne to,
-            // čo `coalesce` potrebuje ako záchrannú sieť).
+            // 172) sú Shoptetove polia, ale na rozdiel od `status_name`/
+            // `remark`/`shop_remark` vyššie sú NAVYŠE COALESCE-ované — rovnaký
+            // dôvod ako `shoptet_order_id` (review, PR 177): extrahujú sa z
+            // KAŽDÉHO riadku objednávky (`extractOrderLevelExtra`), takže
+            // jeden pokazený/inak tvarovaný export cyklus, kde niektorý z
+            // týchto stĺpcov na VŠETKÝCH riadkoch danej objednávky vyjde
+            // prázdny, by priamym prepísaním TICHO vynuloval už zistenú
+            // hodnotu — a "Nevyzdvihnuté zásielky" (`posta-uncollected/
+            // orders-source.ts`) by tú objednávku odvtedy prestalo sledovať
+            // bez akéhokoľvek varovania. `coalesce` necháva predtým zistenú
+            // hodnotu prežiť presne taký výpadok, zatiaľ čo skutočná NOVÁ
+            // hodnota (bežný prípad — zásielka dostane číslo AŽ po prvom
+            // importe) sa aj tak zapíše normálne.
             set: {
               customerName: sql`excluded.customer_name`,
               statusName: sql`excluded.status_name`,
@@ -367,10 +371,10 @@ export async function ingestOrders(db: Database, options: OrdersIngestOptions): 
               shopRemark: sql`excluded.shop_remark`,
               placedAt: sql`excluded.placed_at`,
               shoptetOrderId: sql`coalesce(excluded.shoptet_order_id, "order"."shoptet_order_id")`,
-              email: sql`excluded.email`,
-              phone: sql`excluded.phone`,
-              packageNumber: sql`excluded.package_number`,
-              shippingCarrierName: sql`excluded.shipping_carrier_name`,
+              email: sql`coalesce(excluded.email, "order"."email")`,
+              phone: sql`coalesce(excluded.phone, "order"."phone")`,
+              packageNumber: sql`coalesce(excluded.package_number, "order"."package_number")`,
+              shippingCarrierName: sql`coalesce(excluded.shipping_carrier_name, "order"."shipping_carrier_name")`,
             },
           })
           .returning({ id: orders.id, externalOrderId: orders.externalOrderId });

--- a/apps/api/src/modules/orders/parser.test.ts
+++ b/apps/api/src/modules/orders/parser.test.ts
@@ -3,8 +3,11 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
   decodeCp1250,
+  EMPTY_ORDER_LEVEL_EXTRA,
   extractOrderIdsFromXml,
+  extractOrderLevelExtra,
   mapOrderRow,
+  mergeOrderLevelExtra,
   normalizeStatusName,
   parseDelimited,
   parseShopLocalDateTime,
@@ -336,5 +339,73 @@ describe("extractOrderIdsFromXml", () => {
 
   it("prázdny XML vráti prázdnu mapu", () => {
     expect(extractOrderIdsFromXml("<ORDERS></ORDERS>").size).toBe(0);
+  });
+});
+
+// issue 172: "Nevyzdvihnuté zásielky" potrebuje email/telefón/číslo zásielky
+// (objednávkové polia) a meno dopravcu (LEN zo SHIPPING pseudo-riadku).
+describe("extractOrderLevelExtra", () => {
+  it("vytiahne email/phone/packageNumber z bežného produktového riadku", () => {
+    const extra = extractOrderLevelExtra({
+      code: "20300001",
+      email: "jan@example.sk",
+      phone: "+421900123456",
+      packageNumber: "EF123456789SK",
+      itemCode: "40237/XL",
+      itemName: "Nohavice FOREST 1003",
+    });
+    expect(extra).toEqual({
+      email: "jan@example.sk",
+      phone: "+421900123456",
+      packageNumber: "EF123456789SK",
+      shippingCarrierName: null,
+    });
+  });
+
+  it("vytiahne meno dopravcu LEN keď itemCode začína SHIPPING (case-insensitive)", () => {
+    const extra = extractOrderLevelExtra({
+      code: "20300001",
+      itemCode: "shipping6",
+      itemName: "Kuriér",
+    });
+    expect(extra.shippingCarrierName).toBe("Kuriér");
+  });
+
+  it("nezoberie itemName ako dopravcu pri BILLING/DISCOUNT pseudo-riadku", () => {
+    expect(extractOrderLevelExtra({ itemCode: "BILLING2", itemName: "Dobierka" }).shippingCarrierName).toBeNull();
+    expect(extractOrderLevelExtra({ itemCode: "DISCOUNT", itemName: "Zľava" }).shippingCarrierName).toBeNull();
+  });
+
+  it("prázdne/chýbajúce polia sa mapujú na null, nikdy na prázdny reťazec", () => {
+    expect(extractOrderLevelExtra({})).toEqual(EMPTY_ORDER_LEVEL_EXTRA);
+    expect(extractOrderLevelExtra({ email: "  ", phone: "" })).toEqual(EMPTY_ORDER_LEVEL_EXTRA);
+  });
+});
+
+describe("mergeOrderLevelExtra", () => {
+  it("PRVÁ neprázdna hodnota KAŽDÉHO poľa vyhráva nezávisle od ostatných polí", () => {
+    const fromProductRow = extractOrderLevelExtra({
+      email: "jan@example.sk",
+      itemCode: "40237/XL",
+      itemName: "Nohavice",
+    });
+    const fromShippingRow = extractOrderLevelExtra({
+      packageNumber: "EF123456789SK",
+      itemCode: "SHIPPING6",
+      itemName: "Kuriér",
+    });
+    const merged = mergeOrderLevelExtra(mergeOrderLevelExtra(EMPTY_ORDER_LEVEL_EXTRA, fromProductRow), fromShippingRow);
+    expect(merged).toEqual({
+      email: "jan@example.sk",
+      phone: null,
+      packageNumber: "EF123456789SK",
+      shippingCarrierName: "Kuriér",
+    });
+  });
+
+  it("neskoršia hodnota NIKDY neprepíše už zistenú (prvá vyhráva, nie posledná)", () => {
+    const first = extractOrderLevelExtra({ email: "prvy@example.sk" });
+    const second = extractOrderLevelExtra({ email: "druhy@example.sk" });
+    expect(mergeOrderLevelExtra(first, second).email).toBe("prvy@example.sk");
   });
 });

--- a/apps/api/src/modules/orders/parser.ts
+++ b/apps/api/src/modules/orders/parser.ts
@@ -220,6 +220,65 @@ export function extractOrderIdsFromXml(xml: string): Map<string, number> {
   return map;
 }
 
+// issue 172: rovnaký prefix-test ako `PSEUDO_ITEM_CODE_RE` vyššie, ale
+// zúžený LEN na dopravu — `extractOrderLevelExtra` potrebuje presne
+// rozoznať TENTO jeden pseudo-riadok (jeho `itemName` je meno dopravcu),
+// nie celú rodinu (BILLING/DISCOUNT/…).
+const SHIPPING_ITEM_CODE_RE = /^SHIPPING/i;
+
+function trimOrNull(value: string | undefined): string | null {
+  const trimmed = (value ?? "").trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+// issue 172: "Nevyzdvihnuté zásielky" potrebuje `email`/`phone`/
+// `packageNumber` (objednávkové polia, opakované na KAŽDOM riadku exportu
+// vrátane pseudo-položiek) a meno dopravcu (LEN na SHIPPING pseudo-riadku).
+// Zámerne SAMOSTATNÁ funkcia od `mapOrderRow` vyššie — tá zahadzuje CELÝ
+// pseudo-riadok (nemá zmysel ako POLOŽKA objednávky), ale tieto štyri polia
+// sú OBJEDNÁVKOVÉ, nie položkové, a existujú aj na riadkoch, ktoré
+// `mapOrderRow` zahodí. Nikdy nevyhadzuje/neoznamuje issue — chýbajúca
+// hodnota je legitímny, bežný stav (nie každá objednávka má vyplnené
+// telefónne číslo), mapuje sa jednoducho na `null`.
+export interface OrderLevelExtra {
+  readonly email: string | null;
+  readonly phone: string | null;
+  readonly packageNumber: string | null;
+  readonly shippingCarrierName: string | null;
+}
+
+export function extractOrderLevelExtra(row: Readonly<Record<string, string>>): OrderLevelExtra {
+  const itemCode = (row["itemCode"] ?? "").trim();
+  return {
+    email: trimOrNull(row["email"]),
+    phone: trimOrNull(row["phone"]),
+    packageNumber: trimOrNull(row["packageNumber"]),
+    shippingCarrierName: SHIPPING_ITEM_CODE_RE.test(itemCode) ? trimOrNull(row["itemName"]) : null,
+  };
+}
+
+// Skladá viac riadkov TEJ ISTEJ objednávky do jedného `OrderLevelExtra` —
+// PRVÁ nájdená neprázdna hodnota KAŽDÉHO POĽA vyhráva nezávisle (nie "prvý
+// riadok vyhráva celý objekt", ako `orderInfo` v `ingest.ts` robí pre
+// customerName/placedAt/…) — `shippingCarrierName` je totiž takmer vždy
+// PRÁZDNE na bežných produktových riadkoch a NEPRÁZDNE len na jednom
+// konkrétnom SHIPPING riadku, ktorý môže byť ktorýkoľvek v poradí.
+export function mergeOrderLevelExtra(existing: OrderLevelExtra, incoming: OrderLevelExtra): OrderLevelExtra {
+  return {
+    email: existing.email ?? incoming.email,
+    phone: existing.phone ?? incoming.phone,
+    packageNumber: existing.packageNumber ?? incoming.packageNumber,
+    shippingCarrierName: existing.shippingCarrierName ?? incoming.shippingCarrierName,
+  };
+}
+
+export const EMPTY_ORDER_LEVEL_EXTRA: OrderLevelExtra = Object.freeze({
+  email: null,
+  phone: null,
+  packageNumber: null,
+  shippingCarrierName: null,
+});
+
 export type OrderRowIssueKind =
   | "empty_order_code"
   | "empty_item_code"

--- a/apps/api/src/modules/posta-uncollected/constants.ts
+++ b/apps/api/src/modules/posta-uncollected/constants.ts
@@ -1,0 +1,68 @@
+// issue 172: "Nevyzdvihnuté zásielky" — verné konštanty prevzaté zo starej
+// appky (`parovanie_produktov/src/parovanie/posta_uncollected.py`), preto
+// komentáre na viacerých miestach cituju presne odtiaľ (číselné prahy sú tam
+// kalibrované na reálnej histórii, nie hádané — pozri ten súbor pre plné
+// odôvodnenie).
+
+// Netreba env premennú — tretia strana (Slovenská pošta), fixná adresa,
+// nikdy sa nemení (rovnaký zámer, aký mala stará appka).
+export const TRACKING_API_URL_TEMPLATE = "https://api.posta.sk/tracking?q={q}&l=sk&p=1";
+export const TRACKING_LINK_TEMPLATE = "https://www.posta.sk/sledovanie-zasielok#parcel={q}";
+
+export function trackingApiUrl(packageNumber: string): string {
+  return TRACKING_API_URL_TEMPLATE.replace("{q}", encodeURIComponent(packageNumber));
+}
+
+export function trackingLink(packageNumber: string): string {
+  return TRACKING_LINK_TEMPLATE.replace("{q}", encodeURIComponent(packageNumber));
+}
+
+export const SOURCE_WINDOW_DAYS = 30;
+export const MAX_EMAILS = 4;
+
+// Non-Pošta dopravcovia rozpoznaní v mene SHIPPING pseudo-položky
+// (case-insensitive substring zhoda) — DPD je jediný naživo potvrdený
+// (stará appka #126), zvyšok je defenzívne pridaný podľa ticketu ("DPD a
+// ďalší kuriéri"). Osobný odber je na tomto zozname tiež, hoci to nie je
+// kuriér — jednoducho tam nie je žiadna zásielka na sledovanie.
+export const NON_POSTA_CARRIER_KEYWORDS: readonly string[] = Object.freeze([
+  "dpd",
+  "gls",
+  "packeta",
+  "zásielkov",
+  "zasielkov",
+  "in time",
+  "intime",
+  "wedo",
+  "spservis",
+  "osobný odber",
+  "osobny odber",
+]);
+
+// Predvolené (zámerne NEnastaviteľné v tomto tickete — pozri návrhový
+// komentár na tickete, "Zamietnuté alternatívy") zoznamy stavov objednávky.
+export const DISPATCHED_STATUSES: ReadonlySet<string> = new Set(["Vybavená"]);
+export const CANCELLED_STATUSES: ReadonlySet<string> = new Set(["Stornovaná"]);
+
+// Coverage/blind-spot poistka (#282/#298 v starej appke) — kalibrované
+// prahy, viď `posta_uncollected.py`'s obšírny komentár pri týchto
+// konštantách pre plné odôvodnenie čísel.
+export const MIN_PACKAGE_COVERAGE = 0.5;
+export const MAX_PACKAGE_GAP_DAYS = 7;
+export const MIN_DISPATCHED_FOR_ALARM = 5;
+export const MIN_ELIGIBLE_FOR_BLIND_SPOT = 20;
+
+// Terminálne (už sa nemenia) stavy sledovania — `notified` je ZÁMERNE
+// CHÝBAJÚCI (to je stav, ktorý táto automatizácia práve sleduje). "returned"
+// nebol nikdy naživo pozorovaný, preto sa NEDÔVERUJE (stará appka #226) —
+// akýkoľvek nerozpoznaný kód sa berie ako "ešte sa môže zmeniť".
+export const TERMINAL_STATE_CODES: ReadonlySet<string> = new Set(["delivered"]);
+
+// Koľko dní sa terminálny stav nechá "zapamätaný" bez opätovného overenia
+// (stará appka #222 — výkon, nesledovanie už doručených zásielok).
+export const TERMINAL_CACHE_DAYS = 7;
+
+// Cadence e-mailov (deň 0 → +3 → +3 → +7).
+export function daysNeededForNextEmail(sentCount: number): number {
+  return sentCount < 3 ? 3 : 7;
+}

--- a/apps/api/src/modules/posta-uncollected/logic.test.ts
+++ b/apps/api/src/modules/posta-uncollected/logic.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildEmail,
+  classifyTracking,
+  isEligibleOrder,
+  isNonPostaCarrier,
+  shouldSend,
+  sourceCoverage,
+  terminalState,
+  type EligibleOrder,
+} from "./logic.js";
+
+const TODAY = new Date("2026-08-02T00:00:00Z");
+
+function order(overrides: Partial<EligibleOrder> = {}): EligibleOrder {
+  return {
+    externalOrderId: "20300001",
+    placedAt: new Date("2026-07-20T00:00:00Z"),
+    statusName: "Vybavená",
+    shippingCarrierName: "Kuriér",
+    packageNumber: "EF123456789SK",
+    email: "jan@example.sk",
+    phone: "+421900000000",
+    customerName: "Ján Novák",
+    shoptetOrderId: null,
+    ...overrides,
+  };
+}
+
+describe("isNonPostaCarrier", () => {
+  it("rozpozná DPD a osobný odber, nikdy Kuriér (Pošta SK domáce doručenie)", () => {
+    expect(isNonPostaCarrier("DPD doručenie na adresu")).toBe(true);
+    expect(isNonPostaCarrier("Osobný odber - len na predajni")).toBe(true);
+    expect(isNonPostaCarrier("Kuriér")).toBe(false);
+    expect(isNonPostaCarrier(null)).toBe(false);
+  });
+
+  it("case-insensitive zhoda", () => {
+    expect(isNonPostaCarrier("dpd doručenie")).toBe(true);
+  });
+});
+
+describe("isEligibleOrder", () => {
+  it("vylúči stornovanú objednávku", () => {
+    expect(isEligibleOrder(order({ statusName: "Stornovaná" }), TODAY)).toBe(false);
+  });
+
+  it("vylúči iného dopravcu než poštu", () => {
+    expect(isEligibleOrder(order({ shippingCarrierName: "DPD kuriér" }), TODAY)).toBe(false);
+  });
+
+  it("vylúči objednávku staršiu než 30 dní", () => {
+    expect(isEligibleOrder(order({ placedAt: new Date("2026-06-01T00:00:00Z") }), TODAY)).toBe(false);
+  });
+
+  it("ponechá objednávku bez SHIPPING riadku (neznámy dopravca — fail-open)", () => {
+    expect(isEligibleOrder(order({ shippingCarrierName: null }), TODAY)).toBe(true);
+  });
+
+  it("ponechá bežnú objednávku v okne", () => {
+    expect(isEligibleOrder(order(), TODAY)).toBe(true);
+  });
+});
+
+describe("sourceCoverage", () => {
+  it("degraded=false pod hranicou MIN_DISPATCHED_FOR_ALARM (málo dôkazov)", () => {
+    const eligible = [order({ externalOrderId: "1", packageNumber: null })];
+    const cov = sourceCoverage(eligible, TODAY);
+    expect(cov.degraded).toBe(false);
+  });
+
+  it("degraded=true keď málo dispatched objednávok má číslo zásielky (coverage < 50%)", () => {
+    const eligible = Array.from({ length: 6 }, (_, i) =>
+      order({ externalOrderId: `d${String(i)}`, packageNumber: i < 1 ? "EF1SK" : null }),
+    );
+    const cov = sourceCoverage(eligible, TODAY);
+    expect(cov.dispatchedOrders).toBe(6);
+    expect(cov.dispatchedWithPackage).toBe(1);
+    expect(cov.degraded).toBe(true);
+  });
+
+  it("degraded=false keď coverage je zdravá", () => {
+    const eligible = Array.from({ length: 6 }, (_, i) => order({ externalOrderId: `h${String(i)}`, packageNumber: "EF1SK" }));
+    expect(sourceCoverage(eligible, TODAY).degraded).toBe(false);
+  });
+
+  it("dispatchedStatusUnknown keď dosť eligible objednávok, ale takmer žiadna nie je rozpoznaná ako dispatched", () => {
+    const eligible = Array.from({ length: 20 }, (_, i) => order({ externalOrderId: `u${String(i)}`, statusName: "Vybavuje sa" }));
+    const cov = sourceCoverage(eligible, TODAY);
+    expect(cov.dispatchedOrders).toBe(0);
+    expect(cov.dispatchedStatusUnknown).toBe(true);
+  });
+});
+
+describe("classifyTracking", () => {
+  it("uncollected=true pre notified + ZNP kód", () => {
+    const cls = classifyTracking(
+      {
+        results: [
+          {
+            status: "ok",
+            retainedTill: "2026-08-10",
+            events: [{ stateCode: "notified", detailCode: "ZNP1AN", localDate: "2026-07-30", postOffice: { name: "Pošta 1", street: "Hlavná 1", postcode: "01001", city: "Žilina" } }],
+          },
+        ],
+      },
+      TODAY,
+    );
+    expect(cls.uncollected).toBe(true);
+    expect(cls.officeName).toBe("Pošta 1");
+    expect(cls.officeAddr).toBe("Hlavná 1, 01001 Žilina");
+    expect(cls.retainedTill).toBe("2026-08-10");
+    expect(cls.daysAtPost).toBe(3);
+  });
+
+  it("invalid_format status prejde bez udalostí", () => {
+    const cls = classifyTracking({ results: [{ status: "invalid_format" }] }, TODAY);
+    expect(cls.status).toBe("invalid_format");
+    expect(cls.uncollected).toBe(false);
+  });
+
+  it("žiadne výsledky → no_results", () => {
+    expect(classifyTracking({ results: [] }, TODAY).status).toBe("no_results");
+    expect(classifyTracking(null, TODAY).status).toBe("no_results");
+  });
+
+  it("ok status bez udalostí → no_events", () => {
+    expect(classifyTracking({ results: [{ status: "ok", events: [] }] }, TODAY).status).toBe("no_events");
+  });
+
+  it("posledná udalosť iná než notified/ZNP → uncollected=false", () => {
+    const cls = classifyTracking({ results: [{ status: "ok", events: [{ stateCode: "transit", detailCode: "X" }] }] }, TODAY);
+    expect(cls.uncollected).toBe(false);
+  });
+});
+
+describe("terminalState", () => {
+  it("'delivered' je terminálny", () => {
+    expect(terminalState({ results: [{ status: "ok", events: [{ stateCode: "delivered" }] }] })).toBe("delivered");
+  });
+
+  it("'notified' NIE JE terminálny (to je stav, ktorý sledujeme)", () => {
+    expect(terminalState({ results: [{ status: "ok", events: [{ stateCode: "notified" }] }] })).toBe("");
+  });
+
+  it("nerozpoznaný kód (napr. hypotetické 'returned') sa NEDÔVERUJE — nikdy terminálny", () => {
+    expect(terminalState({ results: [{ status: "ok", events: [{ stateCode: "returned" }] }] })).toBe("");
+  });
+
+  it("invalid_format nemá terminálny stav", () => {
+    expect(terminalState({ results: [{ status: "invalid_format" }] })).toBe("");
+  });
+});
+
+describe("shouldSend — kadencia 0 → +3 → +3 → +7", () => {
+  it("prvý e-mail (count=0) sa pošle vždy", () => {
+    expect(shouldSend(0, null, TODAY)).toBe(true);
+  });
+
+  it("2. e-mail čaká presne 3 dni od 1.", () => {
+    const lastSent = new Date("2026-07-30T00:00:00Z");
+    expect(shouldSend(1, lastSent, new Date("2026-08-01T00:00:00Z"))).toBe(false);
+    expect(shouldSend(1, lastSent, new Date("2026-08-02T00:00:00Z"))).toBe(true);
+  });
+
+  it("4. e-mail čaká 7 dní od 3.", () => {
+    const lastSent = new Date("2026-07-26T00:00:00Z");
+    expect(shouldSend(3, lastSent, new Date("2026-08-01T00:00:00Z"))).toBe(false);
+    expect(shouldSend(3, lastSent, new Date("2026-08-02T00:00:00Z"))).toBe(true);
+  });
+
+  it("po 4. e-maile sa už nikdy nepošle ďalší (MAX_EMAILS)", () => {
+    expect(shouldSend(4, new Date("2020-01-01T00:00:00Z"), TODAY)).toBe(false);
+  });
+});
+
+describe("buildEmail", () => {
+  it("prvý e-mail — predmet a HTML podľa starej appky doslovne", () => {
+    const built = buildEmail(1, "Ján Novák", "EF123456789SK", "Pošta 1", "Hlavná 1, Žilina", "2026-08-10", TODAY);
+    expect(built.subject).toBe("Vaša zásielka čaká na vyzdvihnutie | EF123456789SK");
+    expect(built.html).toContain("Ján Novák");
+    expect(built.html).toContain("10. 8. 2026"); // 2026-08-10 vs today 2026-08-02 → future, teda zobrazí sa
+    expect(built.html).not.toContain("<script>");
+  });
+
+  it("4. e-mail žiada priamy kontakt na eshop@forestshop.sk", () => {
+    const built = buildEmail(4, "Ján Novák", "EF1SK", "Pošta 1", "", "", TODAY);
+    expect(built.subject).toBe("Posledná výzva: zásielka bude vrátená | EF1SK");
+    expect(built.html).toContain("eshop@forestshop.sk");
+  });
+
+  it("dátum vyzdvihnutia, ktorý už PREŠIEL, sa nezobrazí (dateless 'čo najskôr')", () => {
+    const built = buildEmail(1, "Ján", "EF1SK", "Pošta 1", "", "2026-01-01", TODAY);
+    expect(built.html).toContain("čo najskôr");
+    expect(built.html).not.toContain("2026-01-01");
+  });
+
+  it("HTML escapuje meno zákazníka (žiadny injected tag)", () => {
+    const built = buildEmail(1, "<script>alert(1)</script>", "EF1SK", "Pošta 1", "", "", TODAY);
+    expect(built.html).not.toContain("<script>alert(1)</script>");
+    expect(built.html).toContain("&lt;script&gt;");
+  });
+});

--- a/apps/api/src/modules/posta-uncollected/logic.ts
+++ b/apps/api/src/modules/posta-uncollected/logic.ts
@@ -1,0 +1,338 @@
+import {
+  CANCELLED_STATUSES,
+  daysNeededForNextEmail,
+  DISPATCHED_STATUSES,
+  MAX_EMAILS,
+  MAX_PACKAGE_GAP_DAYS,
+  MIN_DISPATCHED_FOR_ALARM,
+  MIN_ELIGIBLE_FOR_BLIND_SPOT,
+  MIN_PACKAGE_COVERAGE,
+  NON_POSTA_CARRIER_KEYWORDS,
+  TERMINAL_STATE_CODES,
+  trackingLink,
+} from "./constants.js";
+
+// Čistá logika (žiadna DB, žiadna sieť) — verný port `posta_uncollected.py`,
+// prispôsobený TAK, aby čítal priamo z `order` riadkov (nie z CSV), viď
+// návrhový komentár na issue 172.
+
+export interface EligibleOrder {
+  readonly externalOrderId: string;
+  readonly placedAt: Date;
+  readonly statusName: string;
+  readonly shippingCarrierName: string | null;
+  readonly packageNumber: string | null;
+  readonly email: string | null;
+  readonly phone: string | null;
+  readonly customerName: string;
+  // issue 120: keď je známe, `queries.ts`'s `buildShoptetAdminOrderUrl` dá
+  // priamy odkaz na detail objednávky namiesto vyhľadávania.
+  readonly shoptetOrderId: number | null;
+}
+
+export function isNonPostaCarrier(name: string | null): boolean {
+  const n = (name ?? "").toLowerCase();
+  return NON_POSTA_CARRIER_KEYWORDS.some((k) => n.includes(k));
+}
+
+/** Objednávka, za ktorú je táto automatizácia zodpovedná — BEZ filtra na
+ * vyplnené číslo zásielky (rovnaký zámer ako stará appka's `_eligible_orders`,
+ * zdieľané aj s `sourceCoverage` nižšie, aby poistka nikdy nepočítala INÚ
+ * množinu objednávok než tá, ktorú automatizácia reálne naháňa). */
+export function isEligibleOrder(
+  order: EligibleOrder,
+  today: Date,
+  cancelledStatuses: ReadonlySet<string> = CANCELLED_STATUSES,
+): boolean {
+  if (cancelledStatuses.has(order.statusName)) return false;
+  if (isNonPostaCarrier(order.shippingCarrierName)) return false;
+  const cutoff = new Date(today);
+  cutoff.setUTCDate(cutoff.getUTCDate() - 30);
+  return order.placedAt >= cutoff;
+}
+
+export interface SourceCoverage {
+  readonly eligibleOrders: number;
+  readonly dispatchedOrders: number;
+  readonly dispatchedWithPackage: number;
+  readonly dispatchedWithoutPackage: number;
+  readonly missingPackage: number;
+  readonly daysSinceLastPackage: number | null;
+  readonly dispatchedStatusUnknown: boolean;
+  readonly degraded: boolean;
+}
+
+/** Coverage/blind-spot poistka (#282/#298 starej appky) — pozri
+ * `constants.ts` pre plné odôvodnenie prahov. */
+export function sourceCoverage(
+  eligible: readonly EligibleOrder[],
+  today: Date,
+  dispatchedStatuses: ReadonlySet<string> = DISPATCHED_STATUSES,
+): SourceCoverage {
+  const dispatched = eligible.filter((o) => dispatchedStatuses.has(o.statusName));
+  const withPkg = dispatched.filter((o) => (o.packageNumber ?? "") !== "");
+  const pkgDates = eligible
+    .filter((o) => (o.packageNumber ?? "") !== "" && o.placedAt <= today)
+    .map((o) => o.placedAt);
+  const lastPkg = pkgDates.length > 0 ? new Date(Math.max(...pkgDates.map((d) => d.getTime()))) : null;
+  const dispDates = dispatched.filter((o) => o.placedAt <= today).map((o) => o.placedAt);
+  const lastDispatch = dispDates.length > 0 ? new Date(Math.max(...dispDates.map((d) => d.getTime()))) : null;
+
+  const dispatchedStatusUnknown =
+    dispatched.length < MIN_DISPATCHED_FOR_ALARM &&
+    (eligible.length >= MIN_ELIGIBLE_FOR_BLIND_SPOT ||
+      (dispatched.length === 0 && eligible.length >= MIN_DISPATCHED_FOR_ALARM));
+
+  let degraded = false;
+  if (dispatched.length >= MIN_DISPATCHED_FOR_ALARM) {
+    const thin = withPkg.length / dispatched.length < MIN_PACKAGE_COVERAGE;
+    const stale =
+      lastPkg !== null &&
+      lastDispatch !== null &&
+      Math.floor((lastDispatch.getTime() - lastPkg.getTime()) / 86_400_000) >= MAX_PACKAGE_GAP_DAYS;
+    degraded = thin || stale;
+  }
+
+  return {
+    eligibleOrders: eligible.length,
+    dispatchedOrders: dispatched.length,
+    dispatchedWithPackage: withPkg.length,
+    dispatchedWithoutPackage: dispatched.length - withPkg.length,
+    missingPackage: eligible.filter((o) => (o.packageNumber ?? "") === "").length,
+    daysSinceLastPackage: lastPkg === null ? null : Math.floor((today.getTime() - lastPkg.getTime()) / 86_400_000),
+    dispatchedStatusUnknown,
+    degraded,
+  };
+}
+
+export interface TrackingClassification {
+  readonly status: string;
+  readonly uncollected: boolean;
+  readonly officeName: string;
+  readonly officeAddr: string;
+  readonly retainedTill: string;
+  readonly notifiedSince: string;
+  readonly daysAtPost: number;
+}
+
+// `String(unknown ?? "")` je zakázané (`no-base-to-string` — nevie dokázať,
+// že `unknown` hodnota nie je objekt, ktorý by sa vypísal ako
+// "[object Object]"). API odpoveď je nedôveryhodná (tretia strana), preto
+// KAŽDÉ pole z nej ide cez toto: `string` sa vezme, čokoľvek iné (číslo,
+// objekt, `undefined`) sa stane prázdnym reťazcom.
+function asString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function parseIsoDatePrefix(value: unknown): Date | null {
+  const s = asString(value).trim().slice(0, 10);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(s)) return null;
+  const d = new Date(`${s}T00:00:00Z`);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+interface TrackingEvent {
+  readonly stateCode?: unknown;
+  readonly detailCode?: unknown;
+  readonly localDate?: unknown;
+  readonly retainedTill?: unknown;
+  readonly postOffice?: { readonly name?: unknown; readonly street?: unknown; readonly postcode?: unknown; readonly city?: unknown };
+}
+
+interface TrackingResult {
+  readonly status?: unknown;
+  readonly events?: readonly TrackingEvent[];
+  readonly retainedTill?: unknown;
+}
+
+interface TrackingApiResponse {
+  readonly results?: readonly TrackingResult[];
+}
+
+/** Pošta SK tracking odpoveď → klasifikácia — port `classify_tracking`
+ * (Code node starej appky). `status`: 'ok' | 'invalid_format' | 'no_results'
+ * | 'no_events' | čokoľvek API vráti. */
+export function classifyTracking(apiJson: unknown, today: Date): TrackingClassification {
+  const out: {
+    status: string;
+    uncollected: boolean;
+    officeName: string;
+    officeAddr: string;
+    retainedTill: string;
+    notifiedSince: string;
+    daysAtPost: number;
+  } = {
+    status: "no_results",
+    uncollected: false,
+    officeName: "",
+    officeAddr: "",
+    retainedTill: "",
+    notifiedSince: "",
+    daysAtPost: 1,
+  };
+  const results = (apiJson as TrackingApiResponse | null)?.results ?? [];
+  const p = results[0];
+  if (p === undefined) return out;
+  out.status = typeof p.status === "string" && p.status !== "" ? p.status : "no_results";
+  if (out.status !== "ok") return out; // invalid_format a pod. — žiadne udalosti
+  const events = p.events ?? [];
+  const last = events[events.length - 1];
+  if (last === undefined) {
+    out.status = "no_events";
+    return out;
+  }
+  const state = asString(last.stateCode).toLowerCase();
+  const detail = asString(last.detailCode).toUpperCase();
+  if (state === "notified" && detail.startsWith("ZNP")) {
+    out.uncollected = true;
+    const po = last.postOffice ?? {};
+    out.officeName = asString(po.name);
+    const street = asString(po.street);
+    if (street !== "") {
+      out.officeAddr = `${street}, ${asString(po.postcode)} ${asString(po.city)}`.trim();
+    }
+    const ld = asString(last.localDate).slice(0, 10);
+    out.notifiedSince = ld;
+    const nd = parseIsoDatePrefix(ld);
+    if (nd !== null) {
+      out.daysAtPost = Math.max(1, Math.floor((today.getTime() - nd.getTime()) / 86_400_000));
+    }
+    // Termín vyzdvihnutia — živé api.posta.sk ho vracia na RESULT úrovni
+    // (stará appka #283), event je len záložný tvar.
+    const rawTill = p.retainedTill ?? events.find((e) => e.retainedTill !== undefined)?.retainedTill;
+    if (rawTill !== undefined && rawTill !== null && rawTill !== "") {
+      const d = parseIsoDatePrefix(rawTill);
+      out.retainedTill = d !== null ? d.toISOString().slice(0, 10) : "";
+    }
+  }
+  return out;
+}
+
+export function terminalState(apiJson: unknown): string {
+  const results = (apiJson as TrackingApiResponse | null)?.results ?? [];
+  const p = results[0];
+  if (p === undefined || (typeof p.status === "string" ? p.status : "") !== "ok") return "";
+  const events = p.events ?? [];
+  const last = events[events.length - 1];
+  if (last === undefined) return "";
+  const state = asString(last.stateCode).trim().toLowerCase();
+  return TERMINAL_STATE_CODES.has(state) ? state : "";
+}
+
+export function shouldSend(count: number, lastSent: Date | null, today: Date): boolean {
+  if (count >= MAX_EMAILS) return false;
+  if (count === 0) return true;
+  if (lastSent === null) return false;
+  const needed = daysNeededForNextEmail(count);
+  const days = Math.floor((today.getTime() - lastSent.getTime()) / 86_400_000);
+  return days >= needed;
+}
+
+function htmlEscape(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+export interface BuiltEmail {
+  readonly subject: string;
+  readonly html: string;
+  readonly text: string;
+}
+
+/** (subject, html, text) pre e-mail #count — doslovné znenie zo starej
+ * appky. Dátum, ktorý už PREŠIEL (alebo sa nedá prečítať), sa berie ako
+ * žiadny — mail dostane dateless "čo najskôr" formuláciu (rovnaký zámer ako
+ * stará appka's `build_email`). */
+export function buildEmail(
+  count: number,
+  name: string,
+  trackNum: string,
+  officeName: string,
+  officeAddr: string,
+  retainedTill: string,
+  today: Date,
+): BuiltEmail {
+  const d = retainedTill !== "" ? parseIsoDatePrefix(retainedTill) : null;
+  const retainedTillDisplay =
+    d !== null && d >= today ? `${String(d.getUTCDate())}. ${String(d.getUTCMonth() + 1)}. ${String(d.getUTCFullYear())}` : "";
+  const link = trackingLink(trackNum);
+  const nameH = htmlEscape(name);
+  const numH = `<strong>${htmlEscape(trackNum)}</strong>`;
+  const officeH = `<strong>${htmlEscape(officeName)}</strong>${officeAddr !== "" ? ` (${htmlEscape(officeAddr)})` : ""}`;
+  const tillH = `<strong>${htmlEscape(retainedTillDisplay)}</strong>`;
+
+  let subject: string;
+  let intro: string;
+  let urgency: string;
+  if (count === 1) {
+    subject = `Vaša zásielka čaká na vyzdvihnutie | ${trackNum}`;
+    intro = `vaša zásielka č. ${numH} je uložená na pošte ${officeH} a čaká na vyzdvihnutie.`;
+    urgency =
+      retainedTillDisplay !== ""
+        ? `Prosím vyzdvihnite si ju do ${tillH}, aby nebola vrátená späť odosielateľovi.`
+        : "Prosím vyzdvihnite si ju čo najskôr, aby nebola vrátená späť odosielateľovi.";
+  } else if (count === 2) {
+    subject = `Pripomienka: zásielka stále čaká | ${trackNum}`;
+    intro = `opätovne vás upozorňujeme, že vaša zásielka č. ${numH} je stále uložená na pošte ${officeH} a zatiaľ nebola vyzdvihnutá.`;
+    urgency =
+      retainedTillDisplay !== ""
+        ? `Termín na vyzdvihnutie sa blíži: ${tillH}. Po tomto dátume bude zásielka vrátená.`
+        : "Prosím vyzdvihnite si ju čo najskôr. Zásielka bude čoskoro vrátená odosielateľovi.";
+  } else if (count === 3) {
+    subject = `Posledné upozornenie: zásielka bude vrátená | ${trackNum}`;
+    intro = `toto je naše posledné upozornenie — vaša zásielka č. ${numH} je stále na pošte ${officeH}.`;
+    urgency =
+      retainedTillDisplay !== ""
+        ? `Ak si ju nevyzdvihnete do ${tillH}, bude vrátená späť odosielateľovi.`
+        : "Ak si ju čoskoro nevyzdvihnete, bude vrátená späť odosielateľovi.";
+  } else {
+    subject = `Posledná výzva: zásielka bude vrátená | ${trackNum}`;
+    intro = `napriek opakovaným upozorneniam vaša zásielka č. ${numH} je stále nevyzdvihnutá na pošte ${officeH}.`;
+    urgency =
+      "Zásielka bude v najbližších dňoch vrátená späť. Ak ju stále chcete, prosím kontaktujte nás čo najskôr na " +
+      '<a href="mailto:eshop@forestshop.sk">eshop@forestshop.sk</a> alebo telefonicky.';
+  }
+
+  const html = [
+    "<!DOCTYPE html>",
+    "<html>",
+    '  <body style="font-family: Arial, sans-serif; font-size: 16px; color: #333;">',
+    `    <p>Dobrý deň, <strong>${nameH}</strong>,</p>`,
+    "",
+    `    <p>${intro}</p>`,
+    "",
+    `    <p>${urgency}</p>`,
+    "",
+    `    <p>👉 Stav zásielky môžete sledovať tu: <a href="${link}">${link}</a></p>`,
+    "",
+    "    <p>",
+    "      Ak máte akékoľvek otázky, pokojne nás kontaktujte na",
+    '      <a href="mailto:eshop@forestshop.sk">eshop@forestshop.sk</a>.',
+    "    </p>",
+    "",
+    '    <p style="margin-top: 30px;">',
+    "      S pozdravom,<br>",
+    "      <strong>Tím Forestshop.sk</strong><br>",
+    '      <a href="https://www.forestshop.sk" target="_blank">www.forestshop.sk</a>',
+    "    </p>",
+    "  </body>",
+    "</html>",
+  ].join("\n");
+
+  const text = [
+    `Dobrý deň, ${name},`,
+    "",
+    intro.replaceAll(/<[^>]+>/g, ""),
+    urgency.replaceAll(/<[^>]+>/g, ""),
+    "",
+    `Stav zásielky môžete sledovať tu: ${link}`,
+    "",
+    "S pozdravom, Tím Forestshop.sk",
+  ].join("\n");
+
+  return { subject, html, text };
+}

--- a/apps/api/src/modules/posta-uncollected/orders-source.ts
+++ b/apps/api/src/modules/posta-uncollected/orders-source.ts
@@ -1,0 +1,34 @@
+import { gte } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { orders } from "../../db/schema.js";
+import { isEligibleOrder, type EligibleOrder } from "./logic.js";
+
+// O pár dní širšie než 30-dňové okno, aby SQL filter nikdy neorezal riadok,
+// ktorý `isEligibleOrder` (presná hranica, počítaná od `today`) ešte považuje
+// za eligible — JS strana je AUTORITA nad presnou hranicou, toto je len
+// hrubší, lacnejší predfilter na úrovni dopytu.
+const SQL_PREFILTER_MARGIN_DAYS = 35;
+
+/** Všetky objednávky, za ktoré je táto automatizácia zodpovedná (30-dňové
+ * okno, nie stornované, nie iný dopravca než pošta) — BEZ filtra na
+ * vyplnené číslo zásielky (to si `run.ts` robí samostatne, presne ako stará
+ * appka: `_eligible_orders` vs. `shipments_from_orders_csv`). */
+export async function loadEligibleOrders(db: Database, today: Date): Promise<readonly EligibleOrder[]> {
+  const cutoff = new Date(today);
+  cutoff.setUTCDate(cutoff.getUTCDate() - SQL_PREFILTER_MARGIN_DAYS);
+  const rows = await db
+    .select({
+      externalOrderId: orders.externalOrderId,
+      placedAt: orders.placedAt,
+      statusName: orders.statusName,
+      shippingCarrierName: orders.shippingCarrierName,
+      packageNumber: orders.packageNumber,
+      email: orders.email,
+      phone: orders.phone,
+      customerName: orders.customerName,
+      shoptetOrderId: orders.shoptetOrderId,
+    })
+    .from(orders)
+    .where(gte(orders.placedAt, cutoff));
+  return rows.filter((row) => isEligibleOrder(row, today));
+}

--- a/apps/api/src/modules/posta-uncollected/run.ts
+++ b/apps/api/src/modules/posta-uncollected/run.ts
@@ -67,13 +67,46 @@ export interface RunPostaUncollectedOptions {
   readonly adminBaseUrl: string;
 }
 
+// Ďalší voľný kľúč v registri `.claude/rules/scheduler.md` (787_878_001/002/
+// 003/100 sú obsadené) — review na PR 177 upozornila, že manuálne "Spustiť
+// teraz" (HTTP) a naplánovaný denný beh majú PRESNE rovnaký tvar súbehu ako
+// `catalogImportJob`/`ordersImportJob` (ktoré preto majú svoj VLASTNÝ
+// advisory zámok vnútri `ingestCatalog`/`ingestOrders`), ale tento modul ho
+// pôvodne nemal vôbec: dva prekrývajúce sa behy (dvaja manažéri klikli
+// "Spustiť teraz" súčasne, alebo ručný klik sa prekryl s 07:00 UTC
+// naplánovaným behom) by mohli OBA prečítať ten istý predošlý `notifyCount`/
+// `lastSentAt` PRED tým, než ktorýkoľvek zapíše — a OBA by tak mohli poslať
+// ten istý eskalačný e-mail zákazníkovi duplicitne, presne to, čomu má
+// 4-emailová kadencia zabrániť. `pg_advisory_lock` (SESSION-scoped, nie
+// `pg_advisory_xact_lock` v transakcii) beží na VLASTNOM vyhradenom
+// pripojení z poolu (rovnaký vzor ako `tests/helpers/db.ts`'s
+// `withCleanDb()`) — nie transakcia okolo celého behu, lebo beh robí desiatky
+// sekvenčných sieťových volaní na posta.sk a držať jednu DB transakciu otvorenú
+// počas nich by zbytočne zaťažovalo connection pool.
+export const POSTA_UNCOLLECTED_RUN_LOCK_KEY = 787_878_004;
+
 /** Core beh (jedno vyhodnotenie): eligible objednávky → tracking na
  * poste.sk → eskalačné e-maily → nový stav → coverage poistka. Volá sa PRIAMO
  * z HTTP "Spustiť teraz" (vždy, bez ohľadu na `enabled`) aj z naplánovaného
  * jobu (`scheduler/jobs.ts`'s `postaUncollectedJob`, ktorý PRED volaním
  * kontroluje `enabled` — pozri návrhový komentár na issue 172, "Spustiť
- * teraz" je explicitná ľudská akcia presne ako stará appka's `run_now`). */
+ * teraz" je explicitná ľudská akcia presne ako stará appka's `run_now`).
+ * Serializovaný `POSTA_UNCOLLECTED_RUN_LOCK_KEY`-om — druhý súbežný beh
+ * (iný manažér, alebo prekryv s naplánovaným behom) počká, kým prvý celý
+ * doskončí, namiesto toho, aby mohol poslať duplicitný e-mail. */
 export async function runPostaUncollected(options: RunPostaUncollectedOptions): Promise<PostaUncollectedRunResult> {
+  const { db, now, trackingClient, mailTransport, bccEmail, adminBaseUrl } = options;
+  const lockClient = await db.$client.connect();
+  try {
+    await lockClient.query("select pg_advisory_lock($1)", [POSTA_UNCOLLECTED_RUN_LOCK_KEY]);
+    return await runPostaUncollectedLocked({ db, now, trackingClient, mailTransport, bccEmail, adminBaseUrl });
+  } finally {
+    await lockClient.query("select pg_advisory_unlock($1)", [POSTA_UNCOLLECTED_RUN_LOCK_KEY]);
+    lockClient.release();
+  }
+}
+
+async function runPostaUncollectedLocked(options: RunPostaUncollectedOptions): Promise<PostaUncollectedRunResult> {
   const { db, now, trackingClient, mailTransport, bccEmail, adminBaseUrl } = options;
   const adminOrderUrl = (order: { readonly externalOrderId: string; readonly shoptetOrderId: number | null }): string =>
     buildShoptetAdminOrderUrl(adminBaseUrl, order.externalOrderId, order.shoptetOrderId);

--- a/apps/api/src/modules/posta-uncollected/run.ts
+++ b/apps/api/src/modules/posta-uncollected/run.ts
@@ -1,0 +1,267 @@
+import type { Database } from "../../db/client.js";
+import { log } from "../../logger.js";
+import type { MailTransport } from "../mail/transport.js";
+import { buildShoptetAdminOrderUrl } from "../orders/queries.js";
+import { buildEmail, classifyTracking, shouldSend, sourceCoverage, terminalState, type SourceCoverage } from "./logic.js";
+import { loadEligibleOrders } from "./orders-source.js";
+import { loadPostaUncollectedState, prunePostaUncollectedState, upsertPostaUncollectedState } from "./state.js";
+import { TERMINAL_CACHE_DAYS, trackingLink } from "./constants.js";
+import type { TrackingClient } from "./tracking-client.js";
+
+export interface PostaUncollectedShipmentRow {
+  readonly orderCode: string;
+  readonly packageNumber: string;
+  readonly name: string;
+  readonly email: string;
+  readonly phone: string;
+  readonly officeName: string;
+  readonly officeAddr: string;
+  readonly retainedTill: string;
+  readonly notifiedSince: string;
+  readonly daysAtPost: number;
+  readonly count: number;
+  readonly lastSentAt: string;
+  readonly callNeeded: boolean;
+  readonly trackingLink: string;
+  readonly adminLink: string;
+}
+
+export interface PostaUncollectedInvalidRow {
+  readonly orderCode: string;
+  readonly packageNumber: string;
+  readonly name: string;
+  readonly adminLink: string;
+}
+
+export interface PostaUncollectedErrorRow {
+  readonly orderCode: string;
+  readonly packageNumber: string;
+  readonly message: string;
+}
+
+export interface PostaUncollectedRunResult {
+  readonly checkedAt: string;
+  readonly uncollected: readonly PostaUncollectedShipmentRow[];
+  readonly invalid: readonly PostaUncollectedInvalidRow[];
+  readonly errors: readonly PostaUncollectedErrorRow[];
+  readonly coverage: SourceCoverage;
+  readonly bccMissing: boolean;
+  readonly mailNotConfigured: boolean;
+  readonly stats: {
+    readonly checked: number;
+    readonly uncollectedCount: number;
+    readonly invalidCount: number;
+    readonly errorCount: number;
+    readonly apiSkipped: number;
+    readonly emailsSent: number;
+    readonly emailsBlocked: number;
+  };
+}
+
+export interface RunPostaUncollectedOptions {
+  readonly db: Database;
+  readonly now: Date;
+  readonly trackingClient: TrackingClient;
+  readonly mailTransport: MailTransport | undefined;
+  readonly bccEmail: string | undefined;
+  readonly adminBaseUrl: string;
+}
+
+/** Core beh (jedno vyhodnotenie): eligible objednávky → tracking na
+ * poste.sk → eskalačné e-maily → nový stav → coverage poistka. Volá sa PRIAMO
+ * z HTTP "Spustiť teraz" (vždy, bez ohľadu na `enabled`) aj z naplánovaného
+ * jobu (`scheduler/jobs.ts`'s `postaUncollectedJob`, ktorý PRED volaním
+ * kontroluje `enabled` — pozri návrhový komentár na issue 172, "Spustiť
+ * teraz" je explicitná ľudská akcia presne ako stará appka's `run_now`). */
+export async function runPostaUncollected(options: RunPostaUncollectedOptions): Promise<PostaUncollectedRunResult> {
+  const { db, now, trackingClient, mailTransport, bccEmail, adminBaseUrl } = options;
+  const adminOrderUrl = (order: { readonly externalOrderId: string; readonly shoptetOrderId: number | null }): string =>
+    buildShoptetAdminOrderUrl(adminBaseUrl, order.externalOrderId, order.shoptetOrderId);
+
+  const eligible = await loadEligibleOrders(db, now);
+  const coverage = sourceCoverage(eligible, now);
+  const shipments = eligible.filter((o) => (o.packageNumber ?? "") !== "");
+  const orderCodes = shipments.map((s) => s.externalOrderId);
+  const stateMap = await loadPostaUncollectedState(db, orderCodes);
+
+  const uncollected: PostaUncollectedShipmentRow[] = [];
+  const invalid: PostaUncollectedInvalidRow[] = [];
+  const errors: PostaUncollectedErrorRow[] = [];
+  let apiSkipped = 0;
+  let emailsSent = 0;
+  let emailsBlocked = 0;
+  const bccMissing = bccEmail === undefined || bccEmail.trim() === "";
+  const mailNotConfigured = mailTransport === undefined;
+
+  for (const shipment of shipments) {
+    const packageNumber = shipment.packageNumber ?? "";
+    const existing = stateMap.get(shipment.externalOrderId);
+
+    // #222 (stará appka) — už raz zistený TERMINÁLNY stav (doručené/prevzaté)
+    // sa `TERMINAL_CACHE_DAYS` dní nepýta znova. Bezpečnostná hranica: keby
+    // sa číslo zásielky na objednávke medzičasom ručne PRETYPOVALO, cache
+    // sa síce chvíľu nesprávne drží starého záveru, ale sama vyprší najviac
+    // za `TERMINAL_CACHE_DAYS` dní — nikdy nezostane zaseknutá naveky.
+    if (existing?.terminalState !== null && existing?.terminalState !== undefined && existing.terminalAt !== null) {
+      const ageDays = Math.floor((now.getTime() - existing.terminalAt.getTime()) / 86_400_000);
+      if (ageDays < TERMINAL_CACHE_DAYS) {
+        apiSkipped += 1;
+        continue;
+      }
+    }
+
+    const trackingJson = await trackingClient(packageNumber);
+    if (trackingJson === null) {
+      errors.push({
+        orderCode: shipment.externalOrderId,
+        packageNumber,
+        message: "Overenie stavu na Pošte SK zlyhalo (výpadok/timeout) — skúsi sa znova nabudúce.",
+      });
+      continue;
+    }
+
+    const final = terminalState(trackingJson);
+    if (final !== "") {
+      await upsertPostaUncollectedState(
+        db,
+        {
+          orderCode: shipment.externalOrderId,
+          notifyCount: existing?.notifyCount ?? 0,
+          lastSentAt: existing?.lastSentAt ?? null,
+          terminalState: final,
+          terminalAt: now,
+        },
+        now,
+      );
+      continue;
+    }
+
+    const cls = classifyTracking(trackingJson, now);
+    if (cls.status === "invalid_format") {
+      invalid.push({
+        orderCode: shipment.externalOrderId,
+        packageNumber,
+        name: shipment.customerName,
+        adminLink: adminOrderUrl(shipment),
+      });
+      continue;
+    }
+
+    const priorCount = existing?.notifyCount ?? 0;
+    const priorLastSent = existing?.lastSentAt ?? null;
+    const wantsSend = cls.uncollected && shouldSend(priorCount, priorLastSent, now);
+
+    let effectiveCount = priorCount;
+    let effectiveLastSent = priorLastSent;
+    if (wantsSend) {
+      const nextCount = priorCount + 1;
+      const recipient = (shipment.email ?? "").trim();
+      if (bccMissing || mailNotConfigured || recipient === "") {
+        emailsBlocked += 1;
+        if (recipient === "" && !bccMissing && !mailNotConfigured) {
+          log.error(
+            { orderCode: shipment.externalOrderId, packageNumber },
+            "nevyzdvihnutá zásielka nemá e-mail zákazníka — upozornenie sa nedá poslať",
+          );
+        }
+      } else {
+        const built = buildEmail(nextCount, shipment.customerName, packageNumber, cls.officeName, cls.officeAddr, cls.retainedTill, now);
+        try {
+          // BCC je pre TENTO mail ZÁVÄZNÁ (ticket's jediná bezpečnostná
+          // podmienka) — `bccMissing` vyššie to už vylúčilo, `bccEmail` je
+          // tu vždy definovaný neprázdny reťazec.
+          await mailTransport({
+            to: recipient,
+            subject: built.subject,
+            text: built.text,
+            html: built.html,
+            bcc: bccEmail,
+          });
+          effectiveCount = nextCount;
+          effectiveLastSent = now;
+          emailsSent += 1;
+          // Zápis IHNEĎ po odoslaní (nie na konci celého behu) — pád appky
+          // neskôr v behu nesmie stratiť dôkaz o už odoslanom e-maile
+          // (rovnaká disciplína ako stará appka).
+          await upsertPostaUncollectedState(
+            db,
+            {
+              orderCode: shipment.externalOrderId,
+              notifyCount: effectiveCount,
+              lastSentAt: effectiveLastSent,
+              terminalState: null,
+              terminalAt: null,
+            },
+            now,
+          );
+        } catch (error) {
+          const rawErrorMessage = error instanceof Error ? error.message : String(error);
+          log.error(
+            { orderCode: shipment.externalOrderId, packageNumber, rawErrorMessage },
+            "odoslanie e-mailu (Nevyzdvihnuté zásielky) zlyhalo — skúsi sa znova nabudúce",
+          );
+        }
+      }
+    } else if (existing?.terminalState !== null && existing?.terminalState !== undefined) {
+      // Predtým cachovaný terminálny stav, teraz opätovne overený a NIE je
+      // finálny — zahodiť ho, nenechať zavádzajúci "doručené" zápis ležať
+      // (rovnaký zámer ako stará appka).
+      await upsertPostaUncollectedState(
+        db,
+        { orderCode: shipment.externalOrderId, notifyCount: priorCount, lastSentAt: priorLastSent, terminalState: null, terminalAt: null },
+        now,
+      );
+    }
+
+    if (cls.uncollected) {
+      uncollected.push({
+        orderCode: shipment.externalOrderId,
+        packageNumber,
+        name: shipment.customerName,
+        email: shipment.email ?? "",
+        phone: shipment.phone ?? "",
+        officeName: cls.officeName,
+        officeAddr: cls.officeAddr,
+        retainedTill: cls.retainedTill,
+        notifiedSince: cls.notifiedSince,
+        daysAtPost: cls.daysAtPost,
+        count: effectiveCount,
+        lastSentAt: effectiveLastSent === null ? "" : effectiveLastSent.toISOString().slice(0, 10),
+        callNeeded: effectiveCount >= 4,
+        trackingLink: trackingLink(packageNumber),
+        adminLink: adminOrderUrl(shipment),
+      });
+    }
+  }
+
+  const prunedCount = await prunePostaUncollectedState(db, orderCodes);
+  if (prunedCount > 0) {
+    log.info({ prunedCount }, "Nevyzdvihnuté zásielky: vyčistené záznamy mimo 30-dňové okno");
+  }
+
+  if (coverage.dispatchedStatusUnknown) {
+    log.error({ coverage }, "Nevyzdvihnuté zásielky: nerozpoznané stavy objednávok — poistka proti oslepnutiu");
+  }
+  if (coverage.degraded) {
+    log.error({ coverage }, "Nevyzdvihnuté zásielky: zdroj zásielok je DEGRADOVANÝ (chýbajúce čísla zásielok)");
+  }
+
+  return {
+    checkedAt: now.toISOString(),
+    uncollected,
+    invalid,
+    errors,
+    coverage,
+    bccMissing,
+    mailNotConfigured,
+    stats: {
+      checked: shipments.length,
+      uncollectedCount: uncollected.length,
+      invalidCount: invalid.length,
+      errorCount: errors.length,
+      apiSkipped,
+      emailsSent,
+      emailsBlocked,
+    },
+  };
+}

--- a/apps/api/src/modules/posta-uncollected/settings.ts
+++ b/apps/api/src/modules/posta-uncollected/settings.ts
@@ -1,0 +1,28 @@
+import { eq } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { postaUncollectedSettings } from "../../db/schema.js";
+
+// Singleton riadok (`schema-posta-uncollected.ts`) — jediný, pevný `id`.
+export const POSTA_UNCOLLECTED_SETTINGS_ID = "default";
+
+/** `true` len keď riadok existuje A `enabled = true` — chýbajúci riadok
+ * (stav pred prvou migráciou/testom, ktorý zabudol reseed) sa berie ako
+ * VYPNUTÉ, nikdy ako zapnuté (bezpečnostná disciplína ticketu: chýbajúci
+ * dôkaz nikdy neznamená "pošli mail"). */
+export async function isPostaUncollectedEnabled(db: Database): Promise<boolean> {
+  const [row] = await db
+    .select({ enabled: postaUncollectedSettings.enabled })
+    .from(postaUncollectedSettings)
+    .where(eq(postaUncollectedSettings.id, POSTA_UNCOLLECTED_SETTINGS_ID));
+  return row?.enabled ?? false;
+}
+
+export async function setPostaUncollectedEnabled(db: Database, enabled: boolean, now: Date): Promise<void> {
+  await db
+    .insert(postaUncollectedSettings)
+    .values({ id: POSTA_UNCOLLECTED_SETTINGS_ID, enabled, updatedAt: now })
+    .onConflictDoUpdate({
+      target: postaUncollectedSettings.id,
+      set: { enabled, updatedAt: now },
+    });
+}

--- a/apps/api/src/modules/posta-uncollected/state.ts
+++ b/apps/api/src/modules/posta-uncollected/state.ts
@@ -1,0 +1,89 @@
+import { inArray, notInArray, sql } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { postaUncollectedState } from "../../db/schema.js";
+
+export interface PostaUncollectedStateRow {
+  readonly orderCode: string;
+  readonly notifyCount: number;
+  readonly lastSentAt: Date | null;
+  readonly terminalState: string | null;
+  readonly terminalAt: Date | null;
+}
+
+function toDate(value: string | null): Date | null {
+  return value === null ? null : new Date(`${value}T00:00:00Z`);
+}
+
+/** Eskalačný stav pre presne tie kódy objednávok, ktoré tento beh potrebuje —
+ * chýbajúci riadok = ešte nikdy neevidovaná objednávka (count 0, nikdy
+ * neposlané, žiadny terminálny cache). */
+export async function loadPostaUncollectedState(
+  db: Database,
+  orderCodes: readonly string[],
+): Promise<ReadonlyMap<string, PostaUncollectedStateRow>> {
+  if (orderCodes.length === 0) return new Map();
+  const rows = await db
+    .select()
+    .from(postaUncollectedState)
+    .where(inArray(postaUncollectedState.orderCode, [...orderCodes]));
+  const out = new Map<string, PostaUncollectedStateRow>();
+  for (const row of rows) {
+    out.set(row.orderCode, {
+      orderCode: row.orderCode,
+      notifyCount: row.notifyCount,
+      lastSentAt: toDate(row.lastSentAt),
+      terminalState: row.terminalState,
+      terminalAt: toDate(row.terminalAt),
+    });
+  }
+  return out;
+}
+
+export interface PostaUncollectedStateUpdate {
+  readonly orderCode: string;
+  readonly notifyCount: number;
+  readonly lastSentAt: Date | null;
+  readonly terminalState: string | null;
+  readonly terminalAt: Date | null;
+}
+
+export async function upsertPostaUncollectedState(
+  db: Database,
+  update: PostaUncollectedStateUpdate,
+  now: Date,
+): Promise<void> {
+  const lastSentAt = update.lastSentAt === null ? null : update.lastSentAt.toISOString().slice(0, 10);
+  const terminalAt = update.terminalAt === null ? null : update.terminalAt.toISOString().slice(0, 10);
+  await db
+    .insert(postaUncollectedState)
+    .values({
+      orderCode: update.orderCode,
+      notifyCount: update.notifyCount,
+      lastSentAt,
+      terminalState: update.terminalState,
+      terminalAt,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: postaUncollectedState.orderCode,
+      set: {
+        notifyCount: sql`excluded.notify_count`,
+        lastSentAt: sql`excluded.last_sent_at`,
+        terminalState: sql`excluded.terminal_state`,
+        terminalAt: sql`excluded.terminal_at`,
+        updatedAt: sql`excluded.updated_at`,
+      },
+    });
+}
+
+/** Vymaže staré záznamy stavu pre objednávky, ktoré už vypadli z 30-dňového
+ * okna (rovnaký zámer ako stará appka's krok "Vyčistí staré záznamy…") —
+ * `keepOrderCodes` je presne množina objednávok, ktoré TENTO beh považuje za
+ * stále eligible. */
+export async function prunePostaUncollectedState(db: Database, keepOrderCodes: readonly string[]): Promise<number> {
+  const result =
+    keepOrderCodes.length === 0
+      ? await db.delete(postaUncollectedState)
+      : await db.delete(postaUncollectedState).where(notInArray(postaUncollectedState.orderCode, [...keepOrderCodes]));
+  return result.rowCount ?? 0;
+}

--- a/apps/api/src/modules/posta-uncollected/tracking-client.ts
+++ b/apps/api/src/modules/posta-uncollected/tracking-client.ts
@@ -1,0 +1,31 @@
+import { log } from "../../logger.js";
+import { trackingApiUrl } from "./constants.js";
+
+/** Vstrekované rozhranie (rovnaký zámer ako `MailTransport`/`OrdersExportFetcher`
+ * — testy dodávajú falošný klient, NIKDY nekontaktujú skutočné api.posta.sk,
+ * per ticketu). Vrátené `unknown` je buď surový JSON tela odpovede, alebo
+ * doslovne `null` — `null` = zlyhanie (timeout, sieť, ne-2xx, nevalidný
+ * JSON), volajúci (`run.ts`) to zaznamená ako per-shipment chybu, nikdy
+ * nespadne. (`unknown` už `null` v sebe zahŕňa — návratový typ je zámerne
+ * len `Promise<unknown>`, nie `Promise<unknown | null>`.) */
+export type TrackingClient = (packageNumber: string) => Promise<unknown>;
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+export function createHttpTrackingClient(options: { readonly timeoutMs?: number } = {}): TrackingClient {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  return async (packageNumber: string): Promise<unknown> => {
+    try {
+      const response = await fetch(trackingApiUrl(packageNumber), { signal: AbortSignal.timeout(timeoutMs) });
+      if (!response.ok) {
+        log.warn({ packageNumber, status: response.status }, "sledovanie zásielky (posta.sk) vrátilo ne-2xx");
+        return null;
+      }
+      return await response.json();
+    } catch (error) {
+      const rawErrorMessage = error instanceof Error ? error.message : String(error);
+      log.warn({ packageNumber, rawErrorMessage }, "sledovanie zásielky (posta.sk) zlyhalo");
+      return null;
+    }
+  };
+}

--- a/apps/api/src/modules/scheduler/jobs.ts
+++ b/apps/api/src/modules/scheduler/jobs.ts
@@ -1,8 +1,11 @@
+import type { Database } from "../../db/client.js";
 import { cleanupExpiredSessions } from "../auth/sessions.js";
 import type { RunIngest } from "../catalog/ingest.js";
 import { pruneRawSnapshots } from "../catalog/raw-store.js";
 import { ORDERS_EXPORT_URL_NOT_CONFIGURED, type RunOrdersIngest } from "../orders/ingest.js";
 import { pruneRawOrders } from "../orders/raw-prune.js";
+import { isPostaUncollectedEnabled } from "../posta-uncollected/settings.js";
+import type { PostaUncollectedRunResult } from "../posta-uncollected/run.js";
 import type { OrderNoteWritebackRunResult } from "../shoptet-writeback/run-order-note-writeback.js";
 import type { WritebackRunResult } from "../shoptet-writeback/run-writeback.js";
 import type { ScheduledJob } from "./types.js";
@@ -176,6 +179,39 @@ export function orderNoteWritebackJob(runOrderNoteWriteback: RunOrderNoteWriteba
     async run(db, now) {
       if (runOrderNoteWriteback === undefined) throw new Error(ORDER_NOTE_WRITEBACK_NOT_CONFIGURED);
       const result = await runOrderNoteWriteback(db, now);
+      return { detail: result };
+    },
+  };
+}
+
+export const POSTA_UNCOLLECTED_JOB_NAME = "posta-uncollected";
+
+export type RunPostaUncollected = (db: Database, now: Date) => Promise<PostaUncollectedRunResult>;
+
+/**
+ * "Nevyzdvihnuté zásielky" (issue 172) — denne o 09:00 Europe/Bratislava
+ * (07:00 UTC — CEST v lete/CET v zime posunie skutočný čas behu o hodinu,
+ * rovnaká DST-nevedomá disciplína ako ostatné `daily` joby v tomto súbore;
+ * presnosť na hodinu nie je pre túto úlohu kritická). Na rozdiel od
+ * `catalogImportJob`/`ordersImportJob` NIE JE `run` nikdy `undefined` — táto
+ * automatizácia číta priamo z už importovaných objednávok (žiadna
+ * samostatná URL na nakonfigurovanie), a chýbajúce SMTP/BCC rieši
+ * `runPostaUncollected` SAMA (per-zásielka, viditeľne v `job_run.detail`),
+ * nikdy vyhodením. Tento wrapper kontroluje LEN `enabled` flag PRED behom —
+ * "Spustiť teraz" (`http/posta-uncollected-routes.ts`) volá `run` PRIAMO,
+ * bez tejto kontroly (návrhový komentár na issue 172: manuálny beh je
+ * explicitná ľudská akcia, funguje bez ohľadu na Štart/Stop).
+ */
+export function postaUncollectedJob(run: RunPostaUncollected): ScheduledJob {
+  return {
+    name: POSTA_UNCOLLECTED_JOB_NAME,
+    schedule: { kind: "daily", hourUtc: 7, minuteUtc: 0 },
+    async run(db, now) {
+      const enabled = await isPostaUncollectedEnabled(db);
+      if (!enabled) {
+        return { detail: { skipped: true, reason: "automatizácia je vypnutá (Štart/Stop)" } };
+      }
+      const result = await run(db, now);
       return { detail: result };
     },
   };

--- a/apps/api/src/modules/scheduler/queries.ts
+++ b/apps/api/src/modules/scheduler/queries.ts
@@ -1,4 +1,4 @@
-import { desc } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
 import { jobRuns } from "../../db/schema.js";
 
@@ -36,4 +36,34 @@ export async function listLatestJobRuns(db: Database): Promise<readonly JobRunSu
     detail: row.detail,
     errorMessage: row.errorMessage,
   }));
+}
+
+// issue 172: "Nevyzdvihnuté zásielky" potrebuje LEN svoj vlastný job — jeho
+// posledný beh nesie celý zobrazovací stav v `detail` (rovnaký vzor ako
+// každý iný job, žiadna nová tabuľka navyše, viď návrhový komentár na
+// tickete). `listLatestJobRuns` vyššie vracia VŠETKY joby naraz — táto
+// funkcia sa priamo pýta na JEDEN konkrétny.
+export async function getLatestJobRun(db: Database, jobName: string): Promise<JobRunSummary | null> {
+  const [row] = await db
+    .select({
+      jobName: jobRuns.jobName,
+      startedAt: jobRuns.startedAt,
+      finishedAt: jobRuns.finishedAt,
+      status: jobRuns.status,
+      detail: jobRuns.detail,
+      errorMessage: jobRuns.errorMessage,
+    })
+    .from(jobRuns)
+    .where(eq(jobRuns.jobName, jobName))
+    .orderBy(desc(jobRuns.startedAt))
+    .limit(1);
+  if (row === undefined) return null;
+  return {
+    jobName: row.jobName,
+    startedAt: row.startedAt.toISOString(),
+    finishedAt: row.finishedAt === null ? null : row.finishedAt.toISOString(),
+    status: row.status,
+    detail: row.detail,
+    errorMessage: row.errorMessage,
+  };
 }

--- a/apps/api/tests/helpers/db.ts
+++ b/apps/api/tests/helpers/db.ts
@@ -1,8 +1,9 @@
 import { sql } from "drizzle-orm";
 import pg from "pg";
 import { createDb, type Database } from "../../src/db/client.js";
-import { orderOpenStatuses } from "../../src/db/schema.js";
+import { orderOpenStatuses, postaUncollectedSettings } from "../../src/db/schema.js";
 import { DEFAULT_ORDER_OPEN_STATUS } from "../../src/modules/orders/open-statuses.js";
+import { POSTA_UNCOLLECTED_SETTINGS_ID } from "../../src/modules/posta-uncollected/settings.js";
 
 /**
  * Distinct advisory-lock key for serializing `withCleanDb()` across
@@ -45,9 +46,11 @@ export async function withCleanDb(): Promise<{ db: Database; close: () => Promis
     // explicitly anyway for the same self-documenting reason "order_line" is.
     // "order_open_status" (issue 59) is the SAME situation again — no FK in
     // either direction (keyed on a free-text status name) — CASCADE never
-    // reaches it.
+    // reaches it. "posta_uncollected_settings"/"posta_uncollected_state"
+    // (issue 172) are the SAME situation too — no FK in either direction
+    // (singleton id / order-code keyed).
     await db.execute(
-      sql`TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status RESTART IDENTITY CASCADE`,
+      sql`TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state RESTART IDENTITY CASCADE`,
     );
     // issue 59: `order_open_status` is a NEW table with real production
     // content (the migration seeds it) — TRUNCATE alone would leave every
@@ -56,6 +59,11 @@ export async function withCleanDb(): Promise<{ db: Database; close: () => Promis
     // them). Re-seed the same default the migration writes on a fresh
     // install, so each test starts from the identical "just migrated" state.
     await db.insert(orderOpenStatuses).values({ statusName: DEFAULT_ORDER_OPEN_STATUS });
+    // issue 172: `posta_uncollected_settings` is the SAME situation as
+    // `order_open_status` above — the migration seeds its singleton row
+    // (`enabled=false`), so every test must start from that same
+    // just-migrated state, not an empty table.
+    await db.insert(postaUncollectedSettings).values({ id: POSTA_UNCOLLECTED_SETTINGS_ID, enabled: false });
   } catch (err) {
     try {
       await pool.end();

--- a/apps/api/tests/orders-ingest-posta-fields.integration.test.ts
+++ b/apps/api/tests/orders-ingest-posta-fields.integration.test.ts
@@ -1,0 +1,187 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { eq } from "drizzle-orm";
+import { afterEach, expect, it } from "vitest";
+import { orders } from "../src/db/schema.js";
+import { ingestOrders, type OrdersExportFetcher } from "../src/modules/orders/ingest.js";
+import { insertTestVariant } from "./helpers/orders.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 172: overuje, že "Nevyzdvihnuté zásielky" má z čoho čítať — `email`/
+// `phone`/`packageNumber`/`shippingCarrierName` sa objavia na `order` riadku
+// PO importe, extrahované NEZÁVISLE od `mapOrderRow`'s item-validácie
+// (vydelené od `orders-ingest.integration.test.ts`, aby ani jeden súbor
+// nenarástol cez `.claude/rules/testing.md`'s eslint `max-lines: 400`).
+const WINDOW_START = new Date("2020-01-01T00:00:00Z");
+const WINDOW_END = new Date("2030-01-01T00:00:00Z");
+const NOW = new Date("2026-07-30T10:00:00Z");
+
+let close: (() => Promise<void>) | undefined;
+let rawDir: string | undefined;
+
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  if (rawDir !== undefined) await rm(rawDir, { recursive: true, force: true });
+  rawDir = undefined;
+});
+
+async function boot(): Promise<{ db: Awaited<ReturnType<typeof withCleanDb>>["db"]; dir: string }> {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  rawDir = await mkdtemp(join(tmpdir(), "forestshop-orders-posta-raw-"));
+  return { db: ctx.db, dir: rawDir };
+}
+
+function fetcherOf(body: Buffer): OrdersExportFetcher {
+  return () => Promise.resolve({ body, sourceLabel: "fixtúra" });
+}
+
+// Rovnaký ASCII-only dôvod ako `orders-ingest.integration.test.ts`'s
+// `buildCsv` (`.claude/rules/orders.md`) — `ingestOrders` vždy dekóduje ako
+// windows-1250, diakritika priamo tu by na druhej strane vyšla pokazená.
+function buildCsv(header: readonly string[], rows: readonly Record<string, string>[]): Buffer {
+  const esc = (v: string): string => `"${v.replaceAll('"', '""')}"`;
+  const lines = [header.map(esc).join(";") + ";"];
+  for (const row of rows) {
+    lines.push(header.map((c) => esc(row[c] ?? "")).join(";") + ";");
+  }
+  return Buffer.from(lines.join("\r\n") + "\r\n", "utf-8");
+}
+
+const HEADER = [
+  "code",
+  "date",
+  "statusName",
+  "billFullName",
+  "email",
+  "phone",
+  "packageNumber",
+  "itemName",
+  "itemAmount",
+  "itemCode",
+] as const;
+
+it("naplní email/phone/packageNumber/shippingCarrierName z produktového aj SHIPPING pseudo-riadku", async () => {
+  const { db, dir } = await boot();
+  await insertTestVariant(db, "40237/XL");
+
+  const csv = buildCsv(HEADER, [
+    {
+      code: "20400001",
+      date: "2026-06-15 10:30:00",
+      statusName: "Vybavuje sa",
+      billFullName: "Jan Novak",
+      email: "jan@example.sk",
+      phone: "+421900123456",
+      packageNumber: "EF123456789SK",
+      itemName: "Nohavice",
+      itemAmount: "1",
+      itemCode: "40237/XL",
+    },
+    // SHIPPING pseudo-riadok — rovnaké objednávkové polia (opakované), meno
+    // dopravcu je jeho VLASTNÝ `itemName` — presne toto MUSÍ appka vytiahnuť,
+    // hoci `mapOrderRow` tento riadok ako POLOŽKU celý zahodí.
+    {
+      code: "20400001",
+      date: "2026-06-15 10:30:00",
+      statusName: "Vybavuje sa",
+      billFullName: "Jan Novak",
+      email: "jan@example.sk",
+      phone: "+421900123456",
+      packageNumber: "EF123456789SK",
+      itemName: "Kurier",
+      itemAmount: "1",
+      itemCode: "SHIPPING6",
+    },
+  ]);
+
+  const result = await ingestOrders(db, {
+    fetchExport: fetcherOf(csv),
+    now: NOW,
+    rawDir: dir,
+    windowStart: WINDOW_START,
+    windowEnd: WINDOW_END,
+  });
+  expect(result.status).toBe("accepted");
+
+  const [row] = await db.select().from(orders).where(eq(orders.externalOrderId, "20400001"));
+  expect(row).toBeDefined();
+  expect(row?.email).toBe("jan@example.sk");
+  expect(row?.phone).toBe("+421900123456");
+  expect(row?.packageNumber).toBe("EF123456789SK");
+  expect(row?.shippingCarrierName).toBe("Kurier");
+});
+
+it("chýbajúce polia sa mapujú na null (objednávka bez SHIPPING riadku, bez telefónu)", async () => {
+  const { db, dir } = await boot();
+  await insertTestVariant(db, "40237/XL");
+
+  const csv = buildCsv(HEADER, [
+    {
+      code: "20400002",
+      date: "2026-06-15 10:30:00",
+      statusName: "Vybavuje sa",
+      billFullName: "Jan Novak",
+      email: "",
+      phone: "",
+      packageNumber: "",
+      itemName: "Nohavice",
+      itemAmount: "1",
+      itemCode: "40237/XL",
+    },
+  ]);
+
+  await ingestOrders(db, {
+    fetchExport: fetcherOf(csv),
+    now: NOW,
+    rawDir: dir,
+    windowStart: WINDOW_START,
+    windowEnd: WINDOW_END,
+  });
+
+  const [row] = await db.select().from(orders).where(eq(orders.externalOrderId, "20400002"));
+  expect(row?.email).toBeNull();
+  expect(row?.phone).toBeNull();
+  expect(row?.packageNumber).toBeNull();
+  expect(row?.shippingCarrierName).toBeNull();
+});
+
+it("re-import OSVIEŽI packageNumber (zásielka dostane číslo neskôr, po prvom importe)", async () => {
+  const { db, dir } = await boot();
+  await insertTestVariant(db, "40237/XL");
+
+  const rowOf = (packageNumber: string): Record<string, string> => ({
+    code: "20400003",
+    date: "2026-06-15 10:30:00",
+    statusName: "Vybavuje sa",
+    billFullName: "Jan Novak",
+    email: "jan@example.sk",
+    phone: "",
+    packageNumber,
+    itemName: "Nohavice",
+    itemAmount: "1",
+    itemCode: "40237/XL",
+  });
+
+  await ingestOrders(db, {
+    fetchExport: fetcherOf(buildCsv(HEADER, [rowOf("")])),
+    now: NOW,
+    rawDir: dir,
+    windowStart: WINDOW_START,
+    windowEnd: WINDOW_END,
+  });
+  const [beforeRow] = await db.select().from(orders).where(eq(orders.externalOrderId, "20400003"));
+  expect(beforeRow?.packageNumber).toBeNull();
+
+  await ingestOrders(db, {
+    fetchExport: fetcherOf(buildCsv(HEADER, [rowOf("EF999999999SK")])),
+    now: NOW,
+    rawDir: dir,
+    windowStart: WINDOW_START,
+    windowEnd: WINDOW_END,
+  });
+  const [afterRow] = await db.select().from(orders).where(eq(orders.externalOrderId, "20400003"));
+  expect(afterRow?.packageNumber).toBe("EF999999999SK");
+});

--- a/apps/api/tests/orders-ingest-posta-fields.integration.test.ts
+++ b/apps/api/tests/orders-ingest-posta-fields.integration.test.ts
@@ -185,3 +185,44 @@ it("re-import OSVIEŽI packageNumber (zásielka dostane číslo neskôr, po prvo
   const [afterRow] = await db.select().from(orders).where(eq(orders.externalOrderId, "20400003"));
   expect(afterRow?.packageNumber).toBe("EF999999999SK");
 });
+
+it("re-import, ktorý príde s prázdnym packageNumber, NEVYNULUJE už zistenú hodnotu (coalesce, review PR 177)", async () => {
+  const { db, dir } = await boot();
+  await insertTestVariant(db, "40237/XL");
+
+  const rowOf = (packageNumber: string): Record<string, string> => ({
+    code: "20400004",
+    date: "2026-06-15 10:30:00",
+    statusName: "Vybavuje sa",
+    billFullName: "Jan Novak",
+    email: "jan@example.sk",
+    phone: "",
+    packageNumber,
+    itemName: "Nohavice",
+    itemAmount: "1",
+    itemCode: "40237/XL",
+  });
+
+  await ingestOrders(db, {
+    fetchExport: fetcherOf(buildCsv(HEADER, [rowOf("EF888888888SK")])),
+    now: NOW,
+    rawDir: dir,
+    windowStart: WINDOW_START,
+    windowEnd: WINDOW_END,
+  });
+  const [beforeRow] = await db.select().from(orders).where(eq(orders.externalOrderId, "20400004"));
+  expect(beforeRow?.packageNumber).toBe("EF888888888SK");
+
+  // Druhý import PRÁZDNE toto pole na VŠETKÝCH riadkoch objednávky (napr.
+  // dočasný formátovací výpadok exportu) — predtým zistená hodnota MUSÍ
+  // prežiť, priame prepísanie by ju ticho vynulovalo.
+  await ingestOrders(db, {
+    fetchExport: fetcherOf(buildCsv(HEADER, [rowOf("")])),
+    now: NOW,
+    rawDir: dir,
+    windowStart: WINDOW_START,
+    windowEnd: WINDOW_END,
+  });
+  const [afterRow] = await db.select().from(orders).where(eq(orders.externalOrderId, "20400004"));
+  expect(afterRow?.packageNumber).toBe("EF888888888SK");
+});

--- a/apps/api/tests/posta-uncollected-http.integration.test.ts
+++ b/apps/api/tests/posta-uncollected-http.integration.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, expect, it } from "vitest";
+import { orders, users } from "../src/db/schema.js";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import type { UserRole } from "../src/modules/auth/service.js";
+import type { MailMessage } from "../src/modules/mail/transport.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 172: HTTP vrstva pre "Nevyzdvihnuté zásielky". Falošný tracking klient
+// + falošný mail transport — NIKDY skutočné api.posta.sk ani skutočný SMTP
+// (ticket's bezpečnostná podmienka pre testy).
+const HESLO = "test-heslo-abc";
+
+let close: (() => Promise<void>) | undefined;
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  resetLoginRateLimit();
+});
+
+async function boot(role: UserRole, options: { readonly sent?: MailMessage[]; readonly bccEmail?: string } = {}) {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await ctx.db.insert(users).values({
+    email: "pouzivatel@forestshop.sk",
+    passwordHash: await hashPassword(HESLO),
+    displayName: "Test",
+    role,
+  });
+
+  const app = createApp(ctx.db, {
+    cookieSecure: false,
+    postaUncollected: {
+      trackingClient: () =>
+        Promise.resolve({
+          results: [{ status: "ok", events: [{ stateCode: "notified", detailCode: "ZNP1AN", localDate: "2026-07-30", postOffice: { name: "Pošta 1" } }] }],
+        }),
+      mailTransport:
+        options.sent === undefined
+          ? undefined
+          : (m: MailMessage) => {
+              options.sent?.push(m);
+              return Promise.resolve();
+            },
+      bccEmail: options.bccEmail,
+      adminBaseUrl: "https://www.forestshop.sk",
+    },
+  });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "pouzivatel@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie, db: ctx.db };
+}
+
+it("GET bez prihlásenia vráti 401", async () => {
+  const { app } = await boot("manazer");
+  const res = await app.request("/api/posta-uncollected");
+  expect(res.status).toBe(401);
+});
+
+it("GET vráti enabled=false hneď po migrácii (bezpečný default)", async () => {
+  const { app, cookie } = await boot("citanie");
+  const res = await app.request("/api/posta-uncollected", { headers: { cookie } });
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { enabled: boolean; lastRun: unknown };
+  expect(body.enabled).toBe(false);
+  expect(body.lastRun).toBeNull();
+});
+
+it("rola citanie NESMIE prepnúť Štart/Stop (403)", async () => {
+  const { app, cookie } = await boot("citanie");
+  const res = await app.request("/api/posta-uncollected/enabled", {
+    method: "PUT",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ enabled: true }),
+  });
+  expect(res.status).toBe(403);
+});
+
+it("manazer prepne Štart/Stop a GET to hneď odzrkadlí", async () => {
+  const { app, cookie } = await boot("manazer");
+  const put = await app.request("/api/posta-uncollected/enabled", {
+    method: "PUT",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ enabled: true }),
+  });
+  expect(put.status).toBe(200);
+
+  const res = await app.request("/api/posta-uncollected", { headers: { cookie } });
+  const body = (await res.json()) as { enabled: boolean };
+  expect(body.enabled).toBe(true);
+});
+
+it("'Spustiť teraz' funguje BEZ ohľadu na enabled=false, ale bez BCC neposlé nič", async () => {
+  const sent: MailMessage[] = [];
+  const { app, cookie, db } = await boot("manazer", { sent });
+  await db.insert(orders).values({
+    externalOrderId: "20600001",
+    customerName: "Test",
+    statusName: "Vybavená",
+    placedAt: new Date("2026-07-25T00:00:00Z"),
+    email: "zakaznik@example.sk",
+    packageNumber: "EF1SK",
+    shippingCarrierName: "Kuriér",
+  });
+
+  const res = await app.request("/api/posta-uncollected/run-now", {
+    method: "POST",
+    headers: { cookie },
+  });
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { ok: boolean; result: { stats: { emailsBlocked: number }; uncollected: unknown[] } };
+  expect(body.ok).toBe(true);
+  expect(body.result.stats.emailsBlocked).toBe(1);
+  expect(sent).toHaveLength(0);
+
+  // GET hneď odzrkadlí manuálny beh (žiadny ďalší tick netreba čakať).
+  const status = await app.request("/api/posta-uncollected", { headers: { cookie } });
+  const statusBody = (await status.json()) as { lastRun: { result: { uncollected: unknown[] } } | null };
+  expect(statusBody.lastRun?.result.uncollected).toHaveLength(1);
+});
+
+it("s BCC adresou 'Spustiť teraz' pošle e-mail zákazníkovi", async () => {
+  const sent: MailMessage[] = [];
+  const { app, cookie, db } = await boot("manazer", { sent, bccEmail: "majitel@forestshop.sk" });
+  await db.insert(orders).values({
+    externalOrderId: "20600002",
+    customerName: "Test",
+    statusName: "Vybavená",
+    placedAt: new Date("2026-07-25T00:00:00Z"),
+    email: "zakaznik@example.sk",
+    packageNumber: "EF2SK",
+    shippingCarrierName: "Kuriér",
+  });
+
+  await app.request("/api/posta-uncollected/run-now", { method: "POST", headers: { cookie } });
+  expect(sent).toHaveLength(1);
+  expect(sent[0]?.bcc).toBe("majitel@forestshop.sk");
+});
+
+it("náhľad e-mailu (preview) vráti presne to, čo by odišlo — bez odoslania", async () => {
+  const sent: MailMessage[] = [];
+  const { app, cookie, db } = await boot("manazer", { sent, bccEmail: "majitel@forestshop.sk" });
+  await db.insert(orders).values({
+    externalOrderId: "20600003",
+    customerName: "Zákazník Testovací",
+    statusName: "Vybavená",
+    placedAt: new Date("2026-07-25T00:00:00Z"),
+    email: "zakaznik@example.sk",
+    packageNumber: "EF3SK",
+    shippingCarrierName: "Kuriér",
+  });
+  await app.request("/api/posta-uncollected/run-now", { method: "POST", headers: { cookie } });
+  expect(sent).toHaveLength(1); // prvý e-mail sa reálne poslal
+
+  const preview = await app.request("/api/posta-uncollected/preview/EF3SK", { headers: { cookie } });
+  expect(preview.status).toBe(200);
+  const body = (await preview.json()) as { ok: boolean; count: number; alreadySent: number; subject: string };
+  expect(body.ok).toBe(true);
+  expect(body.alreadySent).toBe(1);
+  expect(body.count).toBe(2); // ĎALŠÍ e-mail (2.), nie ten istý znova
+  expect(body.subject).toContain("Pripomienka");
+  // Náhľad NIKDY neposlal ďalší e-mail.
+  expect(sent).toHaveLength(1);
+});
+
+it("náhľad neexistujúceho čísla zásielky vráti 200 {ok:false} (bežný doménový výsledok, nikdy 4xx)", async () => {
+  const { app, cookie } = await boot("manazer");
+  const res = await app.request("/api/posta-uncollected/preview/NEEXISTUJE", { headers: { cookie } });
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { ok: boolean };
+  expect(body.ok).toBe(false);
+});

--- a/apps/api/tests/posta-uncollected-run.integration.test.ts
+++ b/apps/api/tests/posta-uncollected-run.integration.test.ts
@@ -1,8 +1,9 @@
 import { eq } from "drizzle-orm";
+import pg from "pg";
 import { afterEach, expect, it } from "vitest";
 import { orders, postaUncollectedState } from "../src/db/schema.js";
 import type { MailMessage } from "../src/modules/mail/transport.js";
-import { runPostaUncollected } from "../src/modules/posta-uncollected/run.js";
+import { POSTA_UNCOLLECTED_RUN_LOCK_KEY, runPostaUncollected } from "../src/modules/posta-uncollected/run.js";
 import type { TrackingClient } from "../src/modules/posta-uncollected/tracking-client.js";
 import { withCleanDb } from "./helpers/db.js";
 
@@ -12,9 +13,12 @@ import { withCleanDb } from "./helpers/db.js";
 const TODAY = new Date("2026-08-02T10:00:00Z");
 
 let close: (() => Promise<void>) | undefined;
+let checker: pg.Client | undefined;
 afterEach(async () => {
   await close?.();
   close = undefined;
+  await checker?.end();
+  checker = undefined;
 });
 
 async function boot() {
@@ -208,4 +212,50 @@ it("objednávka doručená iným dopravcom (DPD) sa nikdy nesleduje", async () =
   });
 
   expect(result.stats.checked).toBe(0);
+});
+
+// Review na PR 177 (finding "no advisory lock") — DETERMINISTICKY (nie
+// časovaním): kým je beh vnútri `runPostaUncollected` "zaseknutý" na
+// falošnom tracking klientovi, pokus o ten istý zámok z DRUHÉHO,
+// nezávislého pripojenia MUSÍ zlyhať (`pg_try_advisory_lock` je
+// neblokujúci) — presne rovnaká technika ako `db-isolation-lock
+// .integration.test.ts`.
+it("dva súbežné behy sa serializujú (advisory zámok), nikdy neprebehnú naraz", async () => {
+  const db = await boot();
+  await insertOrder(db, { externalOrderId: "20500009" });
+
+  let releaseTrackingCall: (() => void) | undefined;
+  const blockedUntilReleased = new Promise<void>((resolve) => {
+    releaseTrackingCall = resolve;
+  });
+  const trackingClient: TrackingClient = async () => {
+    await blockedUntilReleased;
+    return { results: [{ status: "ok", events: [{ stateCode: "notified", detailCode: "ZNP1AN", localDate: "2026-07-30" }] }] };
+  };
+
+  const runPromise = runPostaUncollected({
+    db,
+    now: TODAY,
+    trackingClient,
+    mailTransport: undefined,
+    bccEmail: undefined,
+    adminBaseUrl: "https://www.forestshop.sk",
+  });
+
+  // Počká, kým beh naozaj VEZME zámok (nie len že sme volanie odpálili).
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  const databaseUrl = process.env["DATABASE_URL"];
+  if (databaseUrl === undefined || databaseUrl === "") throw new Error("DATABASE_URL chýba");
+  checker = new pg.Client({ connectionString: databaseUrl });
+  await checker.connect();
+  const midRun = await checker.query<{ pg_try_advisory_lock: boolean }>("select pg_try_advisory_lock($1)", [POSTA_UNCOLLECTED_RUN_LOCK_KEY]);
+  expect(midRun.rows[0]?.pg_try_advisory_lock).toBe(false);
+
+  releaseTrackingCall?.();
+  await runPromise;
+
+  const afterRun = await checker.query<{ pg_try_advisory_lock: boolean }>("select pg_try_advisory_lock($1)", [POSTA_UNCOLLECTED_RUN_LOCK_KEY]);
+  expect(afterRun.rows[0]?.pg_try_advisory_lock).toBe(true);
+  await checker.query("select pg_advisory_unlock($1)", [POSTA_UNCOLLECTED_RUN_LOCK_KEY]);
 });

--- a/apps/api/tests/posta-uncollected-run.integration.test.ts
+++ b/apps/api/tests/posta-uncollected-run.integration.test.ts
@@ -1,0 +1,211 @@
+import { eq } from "drizzle-orm";
+import { afterEach, expect, it } from "vitest";
+import { orders, postaUncollectedState } from "../src/db/schema.js";
+import type { MailMessage } from "../src/modules/mail/transport.js";
+import { runPostaUncollected } from "../src/modules/posta-uncollected/run.js";
+import type { TrackingClient } from "../src/modules/posta-uncollected/tracking-client.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 172: koniec-koncov beh — falošný tracking klient (NIKDY skutočné
+// api.posta.sk) + falošný mail transport (NIKDY skutočný SMTP), presne per
+// ticket's bezpečnostná podmienka pre testy.
+const TODAY = new Date("2026-08-02T10:00:00Z");
+
+let close: (() => Promise<void>) | undefined;
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+});
+
+async function boot() {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  return ctx.db;
+}
+
+async function insertOrder(
+  db: Awaited<ReturnType<typeof boot>>,
+  overrides: Partial<typeof orders.$inferInsert> & { externalOrderId: string },
+): Promise<void> {
+  await db.insert(orders).values({
+    customerName: "Ján Novák",
+    statusName: "Vybavená",
+    placedAt: new Date("2026-07-20T00:00:00Z"),
+    email: "jan@example.sk",
+    packageNumber: "EF123456789SK",
+    shippingCarrierName: "Kuriér",
+    ...overrides,
+  });
+}
+
+function notifiedTrackingClient(): TrackingClient {
+  return () =>
+    Promise.resolve({
+      results: [
+        {
+          status: "ok",
+          events: [{ stateCode: "notified", detailCode: "ZNP1AN", localDate: "2026-07-30", postOffice: { name: "Pošta 1" } }],
+        },
+      ],
+    });
+}
+
+it("BEZ BCC adresy neposiela žiaden e-mail, aj keď je zásielka nevyzdvihnutá", async () => {
+  const db = await boot();
+  await insertOrder(db, { externalOrderId: "20500001" });
+  const sent: MailMessage[] = [];
+
+  const result = await runPostaUncollected({
+    db,
+    now: TODAY,
+    trackingClient: notifiedTrackingClient(),
+    mailTransport: (m) => {
+      sent.push(m);
+      return Promise.resolve();
+    },
+    bccEmail: undefined,
+    adminBaseUrl: "https://www.forestshop.sk",
+  });
+
+  expect(sent).toHaveLength(0);
+  expect(result.bccMissing).toBe(true);
+  expect(result.stats.emailsBlocked).toBe(1);
+  expect(result.uncollected).toHaveLength(1);
+  expect(result.uncollected[0]?.count).toBe(0); // nebolo odoslané → počítadlo neposunuté
+});
+
+it("S BCC adresou pošle prvý e-mail a BCC vždy majiteľovi", async () => {
+  const db = await boot();
+  await insertOrder(db, { externalOrderId: "20500002" });
+  const sent: MailMessage[] = [];
+
+  const result = await runPostaUncollected({
+    db,
+    now: TODAY,
+    trackingClient: notifiedTrackingClient(),
+    mailTransport: (m) => {
+      sent.push(m);
+      return Promise.resolve();
+    },
+    bccEmail: "majitel@forestshop.sk",
+    adminBaseUrl: "https://www.forestshop.sk",
+  });
+
+  expect(sent).toHaveLength(1);
+  expect(sent[0]?.to).toBe("jan@example.sk");
+  expect(sent[0]?.bcc).toBe("majitel@forestshop.sk");
+  expect(sent[0]?.subject).toContain("čaká na vyzdvihnutie");
+  expect(result.stats.emailsSent).toBe(1);
+  expect(result.uncollected[0]?.count).toBe(1);
+
+  const [state] = await db.select().from(postaUncollectedState).where(eq(postaUncollectedState.orderCode, "20500002"));
+  expect(state?.notifyCount).toBe(1);
+});
+
+it("druhý beh v ten istý deň NEPOŠLE druhý e-mail (kadencia 0 → +3)", async () => {
+  const db = await boot();
+  await insertOrder(db, { externalOrderId: "20500003" });
+  const deps = {
+    trackingClient: notifiedTrackingClient(),
+    bccEmail: "majitel@forestshop.sk",
+    adminBaseUrl: "https://www.forestshop.sk",
+  };
+  const sent: MailMessage[] = [];
+  const mailTransport = (m: MailMessage): Promise<void> => {
+    sent.push(m);
+    return Promise.resolve();
+  };
+
+  await runPostaUncollected({ db, now: TODAY, mailTransport, ...deps });
+  expect(sent).toHaveLength(1);
+
+  await runPostaUncollected({ db, now: TODAY, mailTransport, ...deps });
+  expect(sent).toHaveLength(1); // stále len jeden — cadence
+});
+
+it("nevalidné číslo zásielky sa hlási v 'invalid', nikdy v 'uncollected'", async () => {
+  const db = await boot();
+  await insertOrder(db, { externalOrderId: "20500004", packageNumber: "12345678901234" });
+
+  const result = await runPostaUncollected({
+    db,
+    now: TODAY,
+    trackingClient: () => Promise.resolve({ results: [{ status: "invalid_format" }] }),
+    mailTransport: undefined,
+    bccEmail: "majitel@forestshop.sk",
+    adminBaseUrl: "https://www.forestshop.sk",
+  });
+
+  expect(result.invalid).toHaveLength(1);
+  expect(result.invalid[0]?.orderCode).toBe("20500004");
+  expect(result.uncollected).toHaveLength(0);
+});
+
+it("zlyhanie sledovania (tracking klient vráti null) sa hlási v 'errors', nikdy nespadne", async () => {
+  const db = await boot();
+  await insertOrder(db, { externalOrderId: "20500005" });
+
+  const result = await runPostaUncollected({
+    db,
+    now: TODAY,
+    trackingClient: () => Promise.resolve(null),
+    mailTransport: undefined,
+    bccEmail: "majitel@forestshop.sk",
+    adminBaseUrl: "https://www.forestshop.sk",
+  });
+
+  expect(result.errors).toHaveLength(1);
+  expect(result.errors[0]?.orderCode).toBe("20500005");
+});
+
+it("doručená zásielka (terminálny stav) sa cachuje a NEPÝTA znova na druhý beh v tom istom týždni", async () => {
+  const db = await boot();
+  await insertOrder(db, { externalOrderId: "20500006" });
+  let calls = 0;
+  const trackingClient: TrackingClient = () => {
+    calls += 1;
+    return Promise.resolve({ results: [{ status: "ok", events: [{ stateCode: "delivered" }] }] });
+  };
+  const deps = { trackingClient, mailTransport: undefined, bccEmail: "majitel@forestshop.sk", adminBaseUrl: "https://www.forestshop.sk" };
+
+  const first = await runPostaUncollected({ db, now: TODAY, ...deps });
+  expect(first.uncollected).toHaveLength(0);
+  expect(calls).toBe(1);
+
+  const second = await runPostaUncollected({ db, now: new Date("2026-08-03T10:00:00Z"), ...deps });
+  expect(second.stats.apiSkipped).toBe(1);
+  expect(calls).toBe(1); // druhý beh sa vôbec nepýtal API — cache
+});
+
+it("objednávka bez čísla zásielky sa vôbec nesleduje (nepočíta sa do 'checked')", async () => {
+  const db = await boot();
+  await insertOrder(db, { externalOrderId: "20500007", packageNumber: null });
+
+  const result = await runPostaUncollected({
+    db,
+    now: TODAY,
+    trackingClient: () => Promise.resolve(null),
+    mailTransport: undefined,
+    bccEmail: "majitel@forestshop.sk",
+    adminBaseUrl: "https://www.forestshop.sk",
+  });
+
+  expect(result.stats.checked).toBe(0);
+  expect(result.errors).toHaveLength(0);
+});
+
+it("objednávka doručená iným dopravcom (DPD) sa nikdy nesleduje", async () => {
+  const db = await boot();
+  await insertOrder(db, { externalOrderId: "20500008", shippingCarrierName: "DPD doručenie na adresu" });
+
+  const result = await runPostaUncollected({
+    db,
+    now: TODAY,
+    trackingClient: () => Promise.resolve(null),
+    mailTransport: undefined,
+    bccEmail: "majitel@forestshop.sk",
+    adminBaseUrl: "https://www.forestshop.sk",
+  });
+
+  expect(result.stats.checked).toBe(0);
+});

--- a/apps/web/src/components/PostaUncollectedRow.tsx
+++ b/apps/web/src/components/PostaUncollectedRow.tsx
@@ -1,0 +1,56 @@
+import type { JSX } from "react";
+import type { PostaUncollectedShipment } from "../postaUncollectedApi.js";
+
+// Vydelené z `PostaUncollectedSection.tsx` (issue 172) — rovnaký vzor ako
+// `OrderLineRow.tsx`'s vydelenie z `OrdersSection.tsx` (`.claude/rules/
+// frontend-design.md`): opakovaná per-riadková JSX jednotka je zvyčajne
+// najsamostatnejší kus, ktorý sa dá vytiahnuť ako prvý pri raste súboru.
+export function PostaUncollectedRow({
+  shipment,
+  onPreview,
+}: {
+  readonly shipment: PostaUncollectedShipment;
+  readonly onPreview: (packageNumber: string) => void;
+}): JSX.Element {
+  return (
+    <tr data-testid={`posta-row-${shipment.packageNumber}`}>
+      <td>
+        <a href={shipment.trackingLink} target="_blank" rel="noreferrer">
+          {shipment.packageNumber}
+        </a>
+      </td>
+      <td>{shipment.officeName !== "" ? shipment.officeName : "—"}</td>
+      <td>
+        <a href={shipment.adminLink} target="_blank" rel="noreferrer">
+          {shipment.orderCode}
+        </a>
+      </td>
+      <td>
+        {shipment.name}
+        {shipment.phone !== "" && <div className="posta-phone">{shipment.phone}</div>}
+      </td>
+      <td>{shipment.daysAtPost}</td>
+      <td>{shipment.retainedTill !== "" ? shipment.retainedTill : "čo najskôr"}</td>
+      <td>
+        {shipment.count}/4{" "}
+        {shipment.callNeeded && (
+          <span className="posta-call-needed" data-testid={`posta-call-needed-${shipment.packageNumber}`}>
+            ⚠️ TREBA ZAVOLAŤ
+          </span>
+        )}
+      </td>
+      <td>{shipment.lastSentAt !== "" ? shipment.lastSentAt : "—"}</td>
+      <td>
+        <button
+          type="button"
+          className="btn sm ghost"
+          onClick={() => {
+            onPreview(shipment.packageNumber);
+          }}
+        >
+          👁 Náhľad
+        </button>
+      </td>
+    </tr>
+  );
+}

--- a/apps/web/src/components/PostaUncollectedSection.test.tsx
+++ b/apps/web/src/components/PostaUncollectedSection.test.tsx
@@ -1,0 +1,204 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { PostaUncollectedSection } from "./PostaUncollectedSection.js";
+
+const { fetchPostaUncollectedStatus, setPostaUncollectedEnabled, runPostaUncollectedNow, fetchPostaUncollectedPreview } = vi.hoisted(() => ({
+  fetchPostaUncollectedStatus: vi.fn(),
+  setPostaUncollectedEnabled: vi.fn(),
+  runPostaUncollectedNow: vi.fn(),
+  fetchPostaUncollectedPreview: vi.fn(),
+}));
+
+// `PostaUncollectedUnauthorizedError` ostáva SKUTOČNÁ trieda (rovnaký dôvod
+// ako `SchedulerSection.test.tsx` — `instanceof` v komponente musí fungovať).
+vi.mock("../postaUncollectedApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../postaUncollectedApi.js")>();
+  return { ...actual, fetchPostaUncollectedStatus, setPostaUncollectedEnabled, runPostaUncollectedNow, fetchPostaUncollectedPreview };
+});
+
+const { PostaUncollectedUnauthorizedError } = await import("../postaUncollectedApi.js");
+
+const SHIPMENT = {
+  orderCode: "20300001",
+  packageNumber: "EF123456789SK",
+  name: "Ján Novák",
+  email: "jan@example.sk",
+  phone: "+421900000000",
+  officeName: "Pošta 1",
+  officeAddr: "Hlavná 1, Žilina",
+  retainedTill: "2026-08-10",
+  notifiedSince: "2026-08-01",
+  daysAtPost: 2,
+  count: 1,
+  lastSentAt: "2026-08-02",
+  callNeeded: false,
+  trackingLink: "https://www.posta.sk/sledovanie-zasielok#parcel=EF123456789SK",
+  adminLink: "https://www.forestshop.sk/admin/vyhladavanie/?string=20300001&src=orders",
+};
+
+const RUN_RESULT = {
+  checkedAt: "2026-08-02T09:00:00.000Z",
+  uncollected: [SHIPMENT],
+  invalid: [],
+  errors: [],
+  coverage: {
+    eligibleOrders: 10,
+    dispatchedOrders: 8,
+    dispatchedWithPackage: 8,
+    dispatchedWithoutPackage: 0,
+    missingPackage: 0,
+    daysSinceLastPackage: 1,
+    dispatchedStatusUnknown: false,
+    degraded: false,
+  },
+  bccMissing: false,
+  mailNotConfigured: false,
+  stats: { checked: 1, uncollectedCount: 1, invalidCount: 0, errorCount: 0, apiSkipped: 0, emailsSent: 1, emailsBlocked: 0 },
+};
+
+const STATUS_WITH_RESULT = {
+  enabled: true,
+  lastRun: {
+    startedAt: "2026-08-02T09:00:00.000Z",
+    finishedAt: "2026-08-02T09:00:05.000Z",
+    status: "success" as const,
+    errorMessage: null,
+    result: RUN_RESULT,
+    skippedReason: null,
+  },
+};
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+it("keď zatiaľ žiadny beh nie je zaznamenaný, zobrazí informačnú vetu s výzvou spustiť", async () => {
+  fetchPostaUncollectedStatus.mockResolvedValue({ enabled: false, lastRun: null });
+
+  render(<PostaUncollectedSection role="manazer" onSessionExpired={() => {}} />);
+
+  const prazdny = await screen.findByTestId("posta-empty");
+  expect(prazdny.textContent).toContain("Spustiť teraz");
+  expect(screen.getByTestId("posta-status-pill").textContent).toBe("Zastavené");
+});
+
+it("rola citanie vidí tabuľku, ale NEVIDÍ Štart/Stop ani Spustiť teraz", async () => {
+  fetchPostaUncollectedStatus.mockResolvedValue(STATUS_WITH_RESULT);
+
+  render(<PostaUncollectedSection role="citanie" onSessionExpired={() => {}} />);
+
+  await screen.findByTestId(`posta-row-${SHIPMENT.packageNumber}`);
+  expect(screen.queryByTestId("posta-toggle")).toBeNull();
+  expect(screen.queryByTestId("posta-run-now")).toBeNull();
+});
+
+it("manazer vidí Štart/Stop a klik prepne stav", async () => {
+  fetchPostaUncollectedStatus.mockResolvedValue({ enabled: false, lastRun: null });
+  setPostaUncollectedEnabled.mockResolvedValue(true);
+
+  render(<PostaUncollectedSection role="manazer" onSessionExpired={() => {}} />);
+  await screen.findByTestId("posta-toggle");
+
+  fetchPostaUncollectedStatus.mockResolvedValue({ enabled: true, lastRun: null });
+  fireEvent.click(screen.getByTestId("posta-toggle"));
+
+  await waitFor(() => {
+    expect(setPostaUncollectedEnabled).toHaveBeenCalledWith(true);
+  });
+  await waitFor(() => {
+    expect(screen.getByTestId("posta-status-pill").textContent).toBe("Beží");
+  });
+});
+
+it("⚠️ TREBA ZAVOLAŤ sa zobrazí len keď callNeeded=true", async () => {
+  fetchPostaUncollectedStatus.mockResolvedValue({
+    ...STATUS_WITH_RESULT,
+    lastRun: {
+      ...STATUS_WITH_RESULT.lastRun,
+      result: { ...RUN_RESULT, uncollected: [{ ...SHIPMENT, count: 4, callNeeded: true }] },
+    },
+  });
+
+  render(<PostaUncollectedSection role="manazer" onSessionExpired={() => {}} />);
+
+  const badge = await screen.findByTestId(`posta-call-needed-${SHIPMENT.packageNumber}`);
+  expect(badge.textContent).toContain("TREBA ZAVOLAŤ");
+});
+
+it("chýbajúca BCC adresa zobrazí varovný banner", async () => {
+  fetchPostaUncollectedStatus.mockResolvedValue({
+    ...STATUS_WITH_RESULT,
+    lastRun: { ...STATUS_WITH_RESULT.lastRun, result: { ...RUN_RESULT, bccMissing: true } },
+  });
+
+  render(<PostaUncollectedSection role="manazer" onSessionExpired={() => {}} />);
+
+  const banner = await screen.findByTestId("posta-bcc-missing");
+  expect(banner.textContent).toContain("skrytú kópiu");
+});
+
+it("degradovaný zdroj zásielok zobrazí varovný banner", async () => {
+  fetchPostaUncollectedStatus.mockResolvedValue({
+    ...STATUS_WITH_RESULT,
+    lastRun: {
+      ...STATUS_WITH_RESULT.lastRun,
+      result: { ...RUN_RESULT, coverage: { ...RUN_RESULT.coverage, degraded: true, dispatchedWithoutPackage: 6 } },
+    },
+  });
+
+  render(<PostaUncollectedSection role="manazer" onSessionExpired={() => {}} />);
+
+  const banner = await screen.findByTestId("posta-coverage-degraded");
+  expect(banner.textContent).toContain("degradovaný");
+});
+
+it("klik na 'Náhľad' zobrazí presne to, čo by odišlo, bez odoslania", async () => {
+  fetchPostaUncollectedStatus.mockResolvedValue(STATUS_WITH_RESULT);
+  fetchPostaUncollectedPreview.mockResolvedValue({
+    ok: true,
+    subject: "Pripomienka: zásielka stále čaká | EF123456789SK",
+    html: "<p>ahoj</p>",
+    recipient: "jan@example.sk",
+    name: "Ján Novák",
+    packageNumber: SHIPMENT.packageNumber,
+    orderCode: SHIPMENT.orderCode,
+    count: 2,
+    alreadySent: 1,
+    maxReached: false,
+  });
+
+  render(<PostaUncollectedSection role="manazer" onSessionExpired={() => {}} />);
+  const row = await screen.findByTestId(`posta-row-${SHIPMENT.packageNumber}`);
+  fireEvent.click(row.querySelector("button") as HTMLButtonElement);
+
+  const preview = await screen.findByTestId("posta-preview");
+  expect(preview.textContent).toContain("jan@example.sk");
+  expect(preview.textContent).toContain("Pripomienka");
+  expect(runPostaUncollectedNow).not.toHaveBeenCalled();
+});
+
+it("'Spustiť teraz' zavolá beh a obnoví stav", async () => {
+  fetchPostaUncollectedStatus.mockResolvedValueOnce({ enabled: true, lastRun: null }).mockResolvedValue(STATUS_WITH_RESULT);
+  runPostaUncollectedNow.mockResolvedValue(RUN_RESULT);
+
+  render(<PostaUncollectedSection role="manazer" onSessionExpired={() => {}} />);
+  await screen.findByTestId("posta-run-now");
+  fireEvent.click(screen.getByTestId("posta-run-now"));
+
+  await waitFor(() => {
+    expect(runPostaUncollectedNow).toHaveBeenCalledTimes(1);
+  });
+  await screen.findByTestId(`posta-row-${SHIPMENT.packageNumber}`);
+});
+
+it("pri 401 zavolá onSessionExpired namiesto zobrazenia všeobecnej chyby", async () => {
+  fetchPostaUncollectedStatus.mockRejectedValue(new PostaUncollectedUnauthorizedError());
+  const onSessionExpired = vi.fn();
+
+  render(<PostaUncollectedSection role="manazer" onSessionExpired={onSessionExpired} />);
+
+  await waitFor(() => {
+    expect(onSessionExpired).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/PostaUncollectedSection.tsx
+++ b/apps/web/src/components/PostaUncollectedSection.tsx
@@ -1,0 +1,252 @@
+import { useCallback, useEffect, useState, type JSX } from "react";
+import type { Me } from "../api.js";
+import {
+  fetchPostaUncollectedPreview,
+  fetchPostaUncollectedStatus,
+  PostaUncollectedUnauthorizedError,
+  runPostaUncollectedNow,
+  setPostaUncollectedEnabled,
+  type PostaUncollectedPreview,
+  type PostaUncollectedStatus,
+} from "../postaUncollectedApi.js";
+import { PostaUncollectedRow } from "./PostaUncollectedRow.js";
+
+// Rovnaké dve role, ktoré server vyžaduje pre Štart/Stop + "Spustiť teraz"
+// (`requireRole("admin", "manazer")`, `posta-uncollected-routes.ts`) —
+// čítanie (tabuľka) smie vidieť KAŽDÝ prihlásený zamestnanec (rovnaká
+// úroveň ako "Sync zo Shoptetu"), preto sa táto množina používa LEN na
+// skrytie mutujúcich tlačidiel, nikdy na skrytie celej sekcie.
+const CONTROL_ROLES: ReadonlySet<Me["role"]> = new Set(["admin", "manazer"]);
+
+export function PostaUncollectedSection({
+  role,
+  onSessionExpired,
+}: {
+  readonly role: Me["role"];
+  readonly onSessionExpired: () => void;
+}): JSX.Element {
+  const [status, setStatus] = useState<PostaUncollectedStatus | null>(null);
+  const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState("");
+  const [toggleBusy, setToggleBusy] = useState(false);
+  const [runBusy, setRunBusy] = useState(false);
+  const [runNotice, setRunNotice] = useState("");
+  const [preview, setPreview] = useState<PostaUncollectedPreview | null>(null);
+  const [previewError, setPreviewError] = useState("");
+  const canControl = CONTROL_ROLES.has(role);
+
+  const load = useCallback(() => {
+    fetchPostaUncollectedStatus()
+      .then((s) => {
+        setStatus(s);
+        setLoaded(true);
+      })
+      .catch((err: unknown) => {
+        setLoaded(true);
+        if (err instanceof PostaUncollectedUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setError("Nevyzdvihnuté zásielky sa nepodarilo načítať.");
+      });
+  }, [onSessionExpired]);
+
+  useEffect(load, [load]);
+
+  const toggle = useCallback(() => {
+    if (status === null) return;
+    setToggleBusy(true);
+    setPostaUncollectedEnabled(!status.enabled)
+      .then(load)
+      .catch((err: unknown) => {
+        if (err instanceof PostaUncollectedUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setError(err instanceof Error ? err.message : "Zmena sa nepodarila.");
+      })
+      .finally(() => {
+        setToggleBusy(false);
+      });
+  }, [status, load, onSessionExpired]);
+
+  const runNow = useCallback(() => {
+    setRunBusy(true);
+    setRunNotice("");
+    runPostaUncollectedNow()
+      .then((result) => {
+        setRunNotice(
+          `Skontrolovaných ${String(result.stats.checked)}, nevyzdvihnutých ${String(result.stats.uncollectedCount)}, e-mailov odoslaných ${String(result.stats.emailsSent)}.`,
+        );
+        load();
+      })
+      .catch((err: unknown) => {
+        if (err instanceof PostaUncollectedUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setRunNotice(err instanceof Error ? err.message : "Beh zlyhal.");
+      })
+      .finally(() => {
+        setRunBusy(false);
+      });
+  }, [load, onSessionExpired]);
+
+  const openPreview = useCallback(
+    (packageNumber: string) => {
+      setPreviewError("");
+      fetchPostaUncollectedPreview(packageNumber)
+        .then(setPreview)
+        .catch((err: unknown) => {
+          if (err instanceof PostaUncollectedUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setPreviewError(err instanceof Error ? err.message : "Náhľad sa nepodarilo načítať.");
+        });
+    },
+    [onSessionExpired],
+  );
+
+  if (!loaded) return <p>Načítavam…</p>;
+  if (error !== "") return <p role="alert">{error}</p>;
+  if (status === null) return <p role="alert">Nevyzdvihnuté zásielky sa nepodarili načítať.</p>;
+
+  const result = status.lastRun?.result ?? null;
+
+  return (
+    <section>
+      <h2>Nevyzdvihnuté zásielky</h2>
+      <div className="autohead">
+        <span className={"pill" + (status.enabled ? "" : " off")} data-testid="posta-status-pill">
+          {status.enabled ? "Beží" : "Zastavené"}
+        </span>
+        {canControl && (
+          <button type="button" className="btn sm" disabled={toggleBusy} onClick={toggle} data-testid="posta-toggle">
+            {status.enabled ? "⏹ Stop" : "▶️ Štart"}
+          </button>
+        )}
+        {canControl && (
+          <button type="button" className="btn sm ghost" disabled={runBusy} onClick={runNow} data-testid="posta-run-now">
+            {runBusy ? "Spúšťam…" : "⚡ Spustiť teraz"}
+          </button>
+        )}
+      </div>
+
+      {status.lastRun !== null && (
+        <p className="posta-last-run">
+          Posledný beh: {new Date(status.lastRun.startedAt).toLocaleString("sk-SK")} —{" "}
+          {status.lastRun.status === "failure" ? "❌ chyba" : status.lastRun.skippedReason !== null ? `⏸ ${status.lastRun.skippedReason}` : "✅ OK"}
+        </p>
+      )}
+      {runNotice !== "" && <p role="status">{runNotice}</p>}
+
+      {result?.bccMissing === true && (
+        <p role="alert" data-testid="posta-bcc-missing">
+          ⚠️ Chýba adresa pre skrytú kópiu majiteľovi (POSTA_UNCOLLECTED_BCC_EMAIL) — automatizácia zatiaľ NEPOSIELA
+          žiadne e-maily zákazníkom.
+        </p>
+      )}
+      {result?.mailNotConfigured === true && (
+        <p role="alert" data-testid="posta-mail-not-configured">
+          ⚠️ Odosielanie e-mailov nie je nakonfigurované (chýba MAIL_HOST).
+        </p>
+      )}
+      {result?.coverage.degraded === true && (
+        <p role="alert" data-testid="posta-coverage-degraded">
+          ⚠️ Zdroj zásielok vyzerá degradovaný — {String(result.coverage.dispatchedWithoutPackage)} z{" "}
+          {String(result.coverage.dispatchedOrders)} odoslaných objednávok nemá číslo zásielky. Automatizácia možno
+          „oslepla".
+        </p>
+      )}
+      {result?.coverage.dispatchedStatusUnknown === true && (
+        <p role="alert" data-testid="posta-status-unknown">
+          ⚠️ Takmer žiadna objednávka v okne nie je rozpoznaná ako „odoslaná" — over nastavenie stavov objednávok.
+        </p>
+      )}
+
+      {result === null && <p data-testid="posta-empty">Zatiaľ žiadny beh — spustite kontrolu tlačidlom „⚡ Spustiť teraz".</p>}
+
+      {result !== null && result.uncollected.length === 0 && (
+        <p data-testid="posta-none-uncollected">Žiadna zásielka momentálne nečaká na vyzdvihnutie.</p>
+      )}
+
+      {result !== null && result.uncollected.length > 0 && (
+        <table>
+          <thead>
+            <tr>
+              <th>Zásielka</th>
+              <th>Pošta</th>
+              <th>Objednávka</th>
+              <th>Zákazník</th>
+              <th>Dní čaká</th>
+              <th>Vyzdvihnúť do</th>
+              <th>E-maily</th>
+              <th>Posledný e-mail</th>
+              <th>Náhľad</th>
+            </tr>
+          </thead>
+          <tbody>
+            {result.uncollected.map((shipment) => (
+              <PostaUncollectedRow key={shipment.packageNumber} shipment={shipment} onPreview={openPreview} />
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {result !== null && result.invalid.length > 0 && (
+        <div className="card posta-box" data-testid="posta-invalid-box">
+          <h3>Nesledovateľné čísla zásielky ({result.invalid.length})</h3>
+          <ul>
+            {result.invalid.map((row) => (
+              <li key={row.packageNumber}>
+                {row.orderCode} — {row.name} — {row.packageNumber}{" "}
+                <a href={row.adminLink} target="_blank" rel="noreferrer">
+                  objednávka
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {result !== null && result.errors.length > 0 && (
+        <div className="card posta-box" data-testid="posta-errors-box">
+          <h3>Chyby pri overovaní ({result.errors.length})</h3>
+          <ul>
+            {result.errors.map((row) => (
+              <li key={row.packageNumber}>
+                {row.orderCode} — {row.packageNumber} — {row.message}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {previewError !== "" && <p role="alert">{previewError}</p>}
+      {preview !== null && (
+        <div className="mail-preview posta-preview" data-testid="posta-preview">
+          <h3>
+            Náhľad e-mailu #{preview.count} {preview.maxReached && "(posledný odoslaný — kadencia vyčerpaná)"}
+          </h3>
+          <p>
+            Komu: {preview.recipient} — Predmet: {preview.subject}
+          </p>
+          {/* `preview.html` je appkou generovaný e-mail (`buildEmail`, `modules/posta-uncollected/logic.ts`) —
+              KAŽDÁ interpolovaná hodnota (meno, číslo zásielky, pošta) je tam už HTML-escapovaná,
+              nikdy surový užívateľský vstup priamo tu. Ukazuje sa PRESNE to, čo by dostal zákazník. */}
+          <div className="posta-preview-body" dangerouslySetInnerHTML={{ __html: preview.html }} />
+          <button
+            type="button"
+            className="btn sm ghost"
+            onClick={() => {
+              setPreview(null);
+            }}
+          >
+            Zavrieť náhľad
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/nav.test.ts
+++ b/apps/web/src/nav.test.ts
@@ -23,6 +23,7 @@ it("findTab nájde viditeľnú aj skrytú záložku podľa id, neznáme id vrát
   expect(findTab("catalog")?.label).toBe("Katalóg");
   expect(findTab("pairing")?.label).toBe("Kontrola párovania");
   expect(findTab("scheduler")?.label).toBe("Plánovač");
+  expect(findTab("posta-uncollected")?.label).toBe("Nevyzdvihnuté zásielky");
   expect(findTab("neexistuje")).toBeUndefined();
 });
 

--- a/apps/web/src/nav.ts
+++ b/apps/web/src/nav.ts
@@ -3,6 +3,7 @@ import type { Me } from "./api.js";
 import { CatalogPage } from "./components/CatalogPage.js";
 import { OrdersSection } from "./components/OrdersSection.js";
 import { PairingSection } from "./components/PairingSection.js";
+import { PostaUncollectedSection } from "./components/PostaUncollectedSection.js";
 import { SchedulerSection } from "./components/SchedulerSection.js";
 import { SyncSection } from "./components/SyncSection.js";
 
@@ -59,6 +60,10 @@ export const HIDDEN_TABS: Readonly<Record<string, NavTab>> = {
   catalog: { id: "catalog", label: "Katalóg", Component: CatalogPage },
   pairing: { id: "pairing", label: "Kontrola párovania", Component: PairingSection },
   scheduler: { id: "scheduler", label: "Plánovač", Component: SchedulerSection },
+  // issue 172: rovnaký vzor ako ostatné tri vyššie — majiteľ zatiaľ chce v
+  // ľavom menu len "Sync zo Shoptetu"/"Na objednanie" (issue 57), táto nová
+  // obrazovka je preto dostupná len cez `?tab=posta-uncollected`.
+  "posta-uncollected": { id: "posta-uncollected", label: "Nevyzdvihnuté zásielky", Component: PostaUncollectedSection },
 };
 
 export const DEFAULT_TAB_ID: string = NAV[0]?.tabs[0]?.id ?? "sync";

--- a/apps/web/src/postaUncollectedApi.ts
+++ b/apps/web/src/postaUncollectedApi.ts
@@ -1,0 +1,155 @@
+import { z } from "zod";
+
+// issue 172: "Nevyzdvihnuté zásielky" — zrkadlí `PostaUncollectedRunResult`
+// (`apps/api/src/modules/posta-uncollected/run.ts`).
+
+const shipmentSchema = z.object({
+  orderCode: z.string(),
+  packageNumber: z.string(),
+  name: z.string(),
+  email: z.string(),
+  phone: z.string(),
+  officeName: z.string(),
+  officeAddr: z.string(),
+  retainedTill: z.string(),
+  notifiedSince: z.string(),
+  daysAtPost: z.number(),
+  count: z.number(),
+  lastSentAt: z.string(),
+  callNeeded: z.boolean(),
+  trackingLink: z.string(),
+  adminLink: z.string(),
+});
+export type PostaUncollectedShipment = z.infer<typeof shipmentSchema>;
+
+const invalidSchema = z.object({
+  orderCode: z.string(),
+  packageNumber: z.string(),
+  name: z.string(),
+  adminLink: z.string(),
+});
+
+const errorRowSchema = z.object({ orderCode: z.string(), packageNumber: z.string(), message: z.string() });
+
+const coverageSchema = z.object({
+  eligibleOrders: z.number(),
+  dispatchedOrders: z.number(),
+  dispatchedWithPackage: z.number(),
+  dispatchedWithoutPackage: z.number(),
+  missingPackage: z.number(),
+  daysSinceLastPackage: z.number().nullable(),
+  dispatchedStatusUnknown: z.boolean(),
+  degraded: z.boolean(),
+});
+
+const runResultSchema = z.object({
+  checkedAt: z.string(),
+  uncollected: z.array(shipmentSchema),
+  invalid: z.array(invalidSchema),
+  errors: z.array(errorRowSchema),
+  coverage: coverageSchema,
+  bccMissing: z.boolean(),
+  mailNotConfigured: z.boolean(),
+  stats: z.object({
+    checked: z.number(),
+    uncollectedCount: z.number(),
+    invalidCount: z.number(),
+    errorCount: z.number(),
+    apiSkipped: z.number(),
+    emailsSent: z.number(),
+    emailsBlocked: z.number(),
+  }),
+});
+export type PostaUncollectedRunResult = z.infer<typeof runResultSchema>;
+
+const statusSchema = z.object({
+  enabled: z.boolean(),
+  lastRun: z
+    .object({
+      startedAt: z.string(),
+      finishedAt: z.string().nullable(),
+      status: z.enum(["running", "success", "failure"]),
+      errorMessage: z.string().nullable(),
+      result: runResultSchema.nullable(),
+      skippedReason: z.union([z.string(), z.null()]),
+    })
+    .nullable(),
+});
+export type PostaUncollectedStatus = z.infer<typeof statusSchema>;
+
+const setEnabledResultSchema = z.object({ ok: z.literal(true), enabled: z.boolean() });
+
+const runNowResultSchema = z.union([
+  z.object({ ok: z.literal(true), result: runResultSchema }),
+  z.object({ error: z.string() }),
+]);
+
+const previewResultSchema = z.union([
+  z.object({
+    ok: z.literal(true),
+    subject: z.string(),
+    html: z.string(),
+    recipient: z.string(),
+    name: z.string(),
+    packageNumber: z.string(),
+    orderCode: z.string(),
+    count: z.number(),
+    alreadySent: z.number(),
+    maxReached: z.boolean(),
+  }),
+  z.object({ ok: z.literal(false), error: z.string() }),
+]);
+export type PostaUncollectedPreview = Extract<z.infer<typeof previewResultSchema>, { readonly ok: true }>;
+
+export class PostaUncollectedUnauthorizedError extends Error {
+  constructor() {
+    super("Neprihlásený");
+  }
+}
+
+const errorBodySchema = z.object({ error: z.string() });
+
+async function serverErrorMessage(response: Response, fallback: string): Promise<string> {
+  try {
+    const parsed = errorBodySchema.safeParse(await response.json());
+    if (parsed.success) return parsed.data.error;
+  } catch {
+    // telo nie je platný JSON — použi všeobecnú hlášku
+  }
+  return fallback;
+}
+
+async function readJson(response: Response, fallback: string): Promise<unknown> {
+  if (response.status === 401) throw new PostaUncollectedUnauthorizedError();
+  if (!response.ok) throw new Error(await serverErrorMessage(response, fallback));
+  return await response.json();
+}
+
+export async function fetchPostaUncollectedStatus(): Promise<PostaUncollectedStatus> {
+  const response = await fetch("/api/posta-uncollected");
+  return statusSchema.parse(await readJson(response, "Nevyzdvihnuté zásielky sa nepodarilo načítať"));
+}
+
+export async function setPostaUncollectedEnabled(enabled: boolean): Promise<boolean> {
+  const response = await fetch("/api/posta-uncollected/enabled", {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ enabled }),
+  });
+  const parsed = setEnabledResultSchema.parse(await readJson(response, "Zmena sa nepodarila"));
+  return parsed.enabled;
+}
+
+export async function runPostaUncollectedNow(): Promise<PostaUncollectedRunResult> {
+  const response = await fetch("/api/posta-uncollected/run-now", { method: "POST" });
+  const parsed = runNowResultSchema.parse(await readJson(response, "Beh sa nepodarilo spustiť"));
+  if ("error" in parsed) throw new Error(parsed.error);
+  return parsed.result;
+}
+
+export async function fetchPostaUncollectedPreview(packageNumber: string): Promise<PostaUncollectedPreview> {
+  const response = await fetch(`/api/posta-uncollected/preview/${encodeURIComponent(packageNumber)}`);
+  const parsed = previewResultSchema.parse(await readJson(response, "Náhľad sa nepodarilo načítať"));
+  if (!parsed.ok) throw new Error(parsed.error);
+  return parsed;
+}

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -1554,3 +1554,41 @@ tr:last-child td {
   color: var(--fs-ink-faint);
   margin: var(--fs-space-2) 0;
 }
+
+/* ---------------- 8. NEVYZDVIHNUTÉ ZÁSIELKY (issue 172) ---------------- */
+.posta-phone {
+  font-size: var(--fs-text-xs);
+  color: var(--fs-ink-muted);
+}
+.posta-call-needed {
+  display: inline-flex;
+  align-items: center;
+  font-size: var(--fs-text-xs);
+  font-weight: var(--fs-weight-bold);
+  padding: var(--fs-space-1) var(--fs-space-2);
+  border-radius: var(--fs-radius-sm);
+  background: var(--fs-danger-bg);
+  color: var(--fs-danger);
+  margin-left: var(--fs-space-2);
+}
+.posta-box {
+  margin-top: var(--fs-space-4);
+}
+.posta-box ul {
+  margin: 0;
+  padding-left: var(--fs-space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--fs-space-1);
+}
+.posta-last-run {
+  font-size: var(--fs-text-sm);
+  color: var(--fs-ink-muted);
+  margin-top: var(--fs-space-2);
+}
+.posta-preview-body {
+  background: var(--fs-surface);
+  padding: var(--fs-space-3);
+  border-radius: var(--fs-radius-sm);
+  overflow-x: auto;
+}

--- a/apps/web/tests/e2e/posta-uncollected.spec.ts
+++ b/apps/web/tests/e2e/posta-uncollected.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test, type ConsoleMessage } from "@playwright/test";
+
+const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
+
+// Rovnaká a JEDINÁ povolená výnimka ako v login.spec.ts/catalog.spec.ts/orders.spec.ts/pairing.spec.ts.
+const jeOcakavane = (m: ConsoleMessage): boolean => m.location().url.includes("/api/me") && m.text().includes("401");
+
+// issue 172: "Nevyzdvihnuté zásielky" je SKRYTÁ obrazovka (rovnaký vzor ako
+// katalóg/párovanie/plánovač — majiteľ chce v ľavom menu zatiaľ len "Sync zo
+// Shoptetu"/"Na objednanie", issue 57) — dostupná cez `?tab=posta-uncollected`.
+//
+// Toto NEKONTAKTUJE skutočné api.posta.sk ani skutočný SMTP: `scripts/
+// e2e-setup.ts`'s seedované objednávky NIKDY nemajú `packageNumber` (nový
+// stĺpec, nikde v tomto skripte nastavený) — `runPostaUncollected` preto na
+// tomto E2E behu vždy skončí s `checked=0` a Pošta SK API sa nezavolá ANI
+// RAZ, bez ohľadu na to, že API server beží so SKUTOČNÝM tracking klientom
+// (rovnaká úvaha, akú `orders.md` dáva `sendSupplierOrderMail`u — E2E
+// nemôže MAIL_HOST nastaviť, takže odosielanie ostáva nenakonfigurované).
+test("Štart/Stop + Spustiť teraz fungujú, prázdny výsledok sa zobrazí správne, konzola je čistá", async ({ page }) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/?tab=posta-uncollected");
+  await page.getByLabel("E-mail").fill("e2e-posta@forestshop.sk");
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await expect(page.getByRole("heading", { name: "Nevyzdvihnuté zásielky" })).toBeVisible();
+
+  // Nasadené VYPNUTÉ — bezpečnostná podmienka ticketu.
+  await expect(page.getByTestId("posta-status-pill")).toHaveText("Zastavené");
+  await expect(page.getByTestId("posta-empty")).toBeVisible();
+
+  await page.getByTestId("posta-toggle").click();
+  await expect(page.getByTestId("posta-status-pill")).toHaveText("Beží");
+
+  await page.getByTestId("posta-run-now").click();
+  await expect(page.getByText(/Skontrolovaných 0/)).toBeVisible();
+  await expect(page.getByTestId("posta-none-uncollected")).toBeVisible();
+
+  // Vypnúť znova — Štart/Stop musí fungovať OBOMA smermi.
+  await page.getByTestId("posta-toggle").click();
+  await expect(page.getByTestId("posta-status-pill")).toHaveText("Zastavené");
+
+  await page.reload();
+  await expect(page.getByRole("heading", { name: "Nevyzdvihnuté zásielky" })).toBeVisible();
+  await expect(page.getByTestId("posta-status-pill")).toHaveText("Zastavené");
+
+  expect(chyby).toEqual([]);
+});

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -90,6 +90,12 @@ services:
       MAIL_USER:
       MAIL_PASS:
       MAIL_FROM:
+      # issue 172: "Nevyzdvihnuté zásielky" — skrytá kópia (BCC) majiteľovi,
+      # rovnaká úvaha ako MAIL_HOST vyššie (`.optional()` v env.ts, bare
+      # kľúč). Chýbajúca = automatizácia NEPOŠLE ani jeden e-mail zákazníkovi
+      # (fail-closed, ticket's jediná bezpečnostná podmienka) — appka beží
+      # ďalej, len viditeľne to nahlási na obrazovke.
+      POSTA_UNCOLLECTED_BCC_EMAIL:
     volumes:
       - catalog-raw:/data/catalog-raw
       - orders-raw:/data/orders-raw

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.101",
+  "version": "0.3.0-dev.102",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -9,12 +9,13 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { createDb } from "../apps/api/src/db/client.js";
-import { jobRuns, orderLines, orderOpenStatuses, orders, pairings, users } from "../apps/api/src/db/schema.js";
+import { jobRuns, orderLines, orderOpenStatuses, orders, pairings, postaUncollectedSettings, users } from "../apps/api/src/db/schema.js";
 import { CATALOG_IMPORT_JOB_NAME } from "../apps/api/src/modules/scheduler/jobs.js";
 import { hashPassword } from "../apps/api/src/modules/auth/passwords.js";
 import { ingestCatalog } from "../apps/api/src/modules/catalog/ingest.js";
 import { DEFAULT_SNAPSHOT_LIMITS } from "../apps/api/src/modules/catalog/validation.js";
 import { DEFAULT_ORDER_OPEN_STATUS } from "../apps/api/src/modules/orders/open-statuses.js";
+import { POSTA_UNCOLLECTED_SETTINGS_ID } from "../apps/api/src/modules/posta-uncollected/settings.js";
 
 const E2E_HESLO = "e2e-test-heslo"; // musí sa zhodovať s hodnotou v login.spec.ts/catalog.spec.ts/orders.spec.ts
 
@@ -126,6 +127,13 @@ const E2E_ZAPISY_EMAIL = "e2e-zapisy@forestshop.sk"; // musí sa zhodovať s hod
 // účet namiesto ďalšieho prihlásenia pod zdieľaným `e2e@forestshop.sk`.
 const E2E_SKRYTY_EDITOR_EMAIL = "e2e-skryty-editor@forestshop.sk"; // musí sa zhodovať s hodnotou v orders-hidden-editor.spec.ts
 
+// issue 172: rovnaký mechanizmus a dôvod ako `E2E_SKRYTY_EDITOR_EMAIL`
+// vyššie — zdieľaný balík (`e2e@forestshop.sk`, reálne prihlásenia spočítané
+// naprieč všetkými spec súbormi) je UŽ na hranici `MAX_ATTEMPTS` (10, komentár
+// vyššie pri `E2E_NAV_EMAIL`), takže nový spec súbor (`posta-uncollected.spec.ts`)
+// dostáva VLASTNÝ izolovaný účet namiesto ďalšieho prihlásenia pod zdieľaným.
+const E2E_POSTA_EMAIL = "e2e-posta@forestshop.sk"; // musí sa zhodovať s hodnotou v posta-uncollected.spec.ts
+
 const { db, pool } = createDb();
 // Konštantný literál bez interpolácie — obyčajný reťazec je tu rovnako bezpečný
 // ako `sql` tagovaná šablóna (tú používa ekvivalentný apps/api/tests/helpers/db.ts),
@@ -146,14 +154,19 @@ const { db, pool } = createDb();
 // sebadokumentujúcej dôslednosti ako "order_line".
 // "order_open_status" (issue 59) je rovnaký prípad ako "supplier_contact"/
 // "supplier" vyššie v komentári tesne pod TRUNCATE — kľúčovaný voľným
-// textom stavu, žiadny FK, CASCADE ho nikdy nestrhne.
+// textom stavu, žiadny FK, CASCADE ho nikdy nestrhne. "posta_uncollected_
+// settings"/"posta_uncollected_state" (issue 172) sú rovnaký prípad —
+// singleton id / kód objednávky, žiadny FK.
 await db.execute(
-  'TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status RESTART IDENTITY CASCADE',
+  'TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state RESTART IDENTITY CASCADE',
 );
 // Rovnaký dôvod ako `tests/helpers/db.ts`: bez tohto by "Na objednanie" bolo
 // v CELOM e2e behu prázdne pre KAŽDÚ objednávku (žiadny nastavený otvorený
 // stav). Reseeduje presne to, čo produkčná migrácia zapíše na čerstvej DB.
 await db.insert(orderOpenStatuses).values({ statusName: DEFAULT_ORDER_OPEN_STATUS });
+// issue 172: rovnaký dôvod — migrácia seeduje `posta_uncollected_settings`'s
+// singleton riadok (`enabled=false`), reseedovať ho treba aj tu.
+await db.insert(postaUncollectedSettings).values({ id: POSTA_UNCOLLECTED_SETTINGS_ID, enabled: false });
 await db.insert(users).values({
   email: "e2e@forestshop.sk",
   passwordHash: await hashPassword(E2E_HESLO),
@@ -237,6 +250,12 @@ await db.insert(users).values({
 });
 await db.insert(users).values({
   email: E2E_SKRYTY_EDITOR_EMAIL,
+  passwordHash: await hashPassword(E2E_HESLO),
+  displayName: "E2E Manažér",
+  role: "manazer",
+});
+await db.insert(users).values({
+  email: E2E_POSTA_EMAIL,
   passwordHash: await hashPassword(E2E_HESLO),
   displayName: "E2E Manažér",
   role: "manazer",


### PR DESCRIPTION
## Čo je vo vnútri

issue 172: automatizácia "Nevyzdvihnuté zásielky" (Slovenská pošta) —
denná kontrola čísel zásielok objednávok, ktoré zákazník nevyzdvihol,
so 4 stupňujúcimi e-mailmi (0 → +3 → +3 → +7) a "TREBA ZAVOLAŤ" po
štvrtom. Verný port starej appky (`parovanie_produktov/src/parovanie/
posta_uncollected.py`), prispôsobený tak, aby čítal priamo z už
importovaných objednávok (nová DB tabuľka namiesto CSV) a ukladal
eskalačný stav do Postgresu namiesto JSON súboru.

## Bezpečnosť (ticket's jediná záväzná podmienka)

- Nasadené **VYPNUTÉ** (`posta_uncollected_settings.enabled = false`,
  seedované migráciou).
- Žiadny mail nikdy neodíde bez skrytej kópie majiteľovi
  (`POSTA_UNCOLLECTED_BCC_EMAIL`) — chýbajúca adresa = fail-closed,
  automatizácia nepošle nič, len to viditeľne nahlási.
- Žiadny test nekontaktuje skutočné `api.posta.sk` ani neposiela
  skutočný mail (falošný tracking klient + falošný mail transport
  všade, e2e beh má vždy `checked=0`, keďže seedované objednávky
  nemajú číslo zásielky).

## Design

Návrh + zamietnuté alternatívy sú na tickete (issue 172) — komentár
predchádzajúci prvý commit.

## Overenie

- `pnpm lint` / `pnpm typecheck` — čisté
- `pnpm --filter @forestshop/api test` — 379/379
- `pnpm --filter @forestshop/api test:integration` — 315/315 (48 súborov)
- `pnpm --filter @forestshop/web test` — 296/296
- `pnpm --filter @forestshop/web e2e` — 26/26 (celý balík, vrátane nového spec súboru)
- CI (push run) — všetkých 5 jobov zelených (version-check, check,
  integration, docker-build, e2e)

## Poznámka k automatickému zatváraniu (`.claude/rules/` tohto repa)

Ticket má acceptančnú podmienku, ktorú nejde overiť pred mergom (živé
overenie na produkcii po nasadení) — preto toto telo PR úmyselne
NEOBSAHUJE `Closes #172`. Zavriem ticket ručne po post-deploy overení.

issue 172
