### PR TITLE
Pripomienky objednávok (issue 173): AI klasifikácia poznámky + jeden pripomienkový e-mail

### DIFF
--- a/apps/api/drizzle/0022_famous_sunspot.sql
+++ b/apps/api/drizzle/0022_famous_sunspot.sql
@@ -1,0 +1,22 @@
+CREATE TABLE "order_reminder_settings" (
+	"id" text PRIMARY KEY DEFAULT 'default' NOT NULL,
+	"enabled" boolean DEFAULT false NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "order_reminder_state" (
+	"order_code" text PRIMARY KEY NOT NULL,
+	"fingerprint" text NOT NULL,
+	"resolution" text,
+	"resolved_by" text,
+	"resolved_at" timestamp with time zone,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+-- issue 173: singleton riadok MUSÍ existovať hneď po nasadení — appka
+-- kontroluje "enabled" pri KAŽDOM naplánovanom behu, žiadny riadok by
+-- znamenal, že kontrola nemá čo prečítať. `enabled = false` je jediná
+-- bezpečná predvolená hodnota (žiadny e-mail bez ručného zapnutia
+-- majiteľom) — DEFAULT stĺpca to zaisťuje aj tu. "ON CONFLICT DO NOTHING"
+-- robí migráciu bezpečne opakovateľnou (rovnaký vzor ako #172).
+INSERT INTO "order_reminder_settings" ("id", "enabled") VALUES ('default', false) ON CONFLICT ("id") DO NOTHING;

--- a/apps/api/drizzle/meta/0022_snapshot.json
+++ b/apps/api/drizzle/meta/0022_snapshot.json
@@ -1,0 +1,1742 @@
+{
+  "id": "7fef5cc8-9169-4815-9478-2e55a4d31e10",
+  "prevId": "079b201d-c649-4e45-9249-f80d5caf2743",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_code": {
+          "name": "external_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_open_status": {
+      "name": "order_open_status",
+      "schema": "",
+      "columns": {
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Vybavuje sa'"
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop_remark": {
+          "name": "shop_remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shoptet_order_id": {
+          "name": "shoptet_order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_updated_at": {
+          "name": "comment_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_synced_at": {
+          "name": "comment_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_carrier_name": {
+          "name": "shipping_carrier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_link_override": {
+      "name": "product_supplier_link_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_link_override_product_key_product_key_fk": {
+          "name": "product_supplier_link_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_link_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_override": {
+      "name": "product_supplier_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_override_product_key_product_key_fk": {
+          "name": "product_supplier_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing": {
+      "name": "pairing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_url": {
+          "name": "supplier_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "pairing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'navrhnute'"
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pairing_state_idx": {
+          "name": "pairing_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_confirmed_by_idx": {
+          "name": "pairing_confirmed_by_idx",
+          "columns": [
+            {
+              "expression": "confirmed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_variant_code_variant_code_fk": {
+          "name": "pairing_variant_code_variant_code_fk",
+          "tableFrom": "pairing",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pairing_confirmed_by_users_id_fk": {
+          "name": "pairing_confirmed_by_users_id_fk",
+          "tableFrom": "pairing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pairing_variant_code_unique": {
+          "name": "pairing_variant_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pairing_confirmation_ck": {
+          "name": "pairing_confirmation_ck",
+          "value": "(\"pairing\".\"state\" = 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)\n        OR (\"pairing\".\"state\" != 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NULL AND \"pairing\".\"confirmed_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier": {
+      "name": "supplier",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wholesale_base_url": {
+          "name": "wholesale_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_key": {
+          "name": "adapter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_settings": {
+      "name": "posta_uncollected_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_state": {
+      "name": "posta_uncollected_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notify_count": {
+          "name": "notify_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_state": {
+          "name": "terminal_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_settings": {
+      "name": "order_reminder_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_state": {
+      "name": "order_reminder_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne"
+      ]
+    },
+    "public.pairing_state": {
+      "name": "pairing_state",
+      "schema": "public",
+      "values": [
+        "navrhnute",
+        "potvrdene"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1785693949589,
       "tag": "0021_bouncy_shockwave",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1785701651575,
+      "tag": "0022_famous_sunspot",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema-order-reminder.ts
+++ b/apps/api/src/db/schema-order-reminder.ts
@@ -1,0 +1,41 @@
+import { boolean, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+// issue 173: "Pripomienky objednávok" — Štart/Stop prepínač, rovnaký tvar ako
+// #172's `posta_uncollected_settings` (JEDEN singleton riadok, pevné
+// `id = 'default'`). Migrácia seeduje tento riadok s `enabled = false` —
+// nasadenie preto FYZICKY nemôže poslať e-mail zákazníkovi, kým ho majiteľ
+// sám ručne nezapne (majiteľov komentár na tickete, jediná bezpečnostná
+// podmienka). Tento flag gate-uje LEN naplánovaný denný beh
+// (`scheduler/jobs.ts`'s `orderReminderJob`) — "Spustiť teraz" aj ručné
+// per-riadkové akcie ("▶ Poslať pripomienku"/"✓ Kontaktované") volajú business
+// logiku PRIAMO, bez ohľadu na tento flag, presne ako #172's `run_now`.
+export const orderReminderSettings = pgTable("order_reminder_settings", {
+  id: text("id").primaryKey().default("default"),
+  enabled: boolean("enabled").notNull().default(false),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+});
+
+// Eskalačný stav PER OBJEDNÁVKA (rovnaký zámer ako #172's
+// `posta_uncollected_state`, ale MAX JEDEN e-mail, nikdy kadencia) —
+// `fingerprint` = `placedAt|shopRemark` (rovnaký zámer ako stará appka's
+// `order_fingerprint`, `orders_reminder.py`) je to, čo rozhoduje, či sa
+// objednávka pri nezmenenom stave znova prehodnocuje (ticket: "objednávka,
+// ktorá už bola vybavená a odvtedy sa jej dátum ani poznámka nezmenili, sa
+// znovu nespracúva"). `resolution` a `resolvedBy` sú ZÁMERNE dva samostatné
+// stĺpce (nie jeden kombinovaný enum) — ticketova poučka zo starej appky
+// ("ľudské rozhodnutie sa pripísalo stroju") sa tu rieši štrukturálne:
+// `resolvedBy` sa nikdy neodvodzuje, vždy sa zapisuje explicitne pri zápise
+// `resolution`.
+export const orderReminderState = pgTable("order_reminder_state", {
+  orderCode: text("order_code").primaryKey(),
+  fingerprint: text("fingerprint").notNull(),
+  // null = ešte nevyriešené (stále eligible na prehodnotenie/AI/mail).
+  // 'contacted' = zákazník bol už kontaktovaný (AI alebo ručne), e-mail sa
+  // NEPOSIELA. 'emailed' = pripomienkový e-mail bol odoslaný (max raz, navždy).
+  resolution: text("resolution"),
+  // null (nevyriešené) | 'ai' | 'manual' — kto o výsledku rozhodol, nikdy
+  // odvodené z `resolution` samotného.
+  resolvedBy: text("resolved_by"),
+  resolvedAt: timestamp("resolved_at", { withTimezone: true }),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+});

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -4,3 +4,4 @@ export * from "./schema-scheduler.js";
 export * from "./schema-orders.js";
 export * from "./schema-pairing.js";
 export * from "./schema-posta-uncollected.js";
+export * from "./schema-order-reminder.js";

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -60,6 +60,17 @@ const envSchema = z.object({
   // closed, ticket's jediná bezpečnostná podmienka) — nikdy sa nedotýka
   // existujúceho odosielania objednávky dodávateľovi.
   POSTA_UNCOLLECTED_BCC_EMAIL: z.string().email().optional(),
+  // issue 173: "Pripomienky objednávok" — OpenAI klasifikátor internej
+  // poznámky predajne ("bol zákazník už kontaktovaný?"). Nepovinný: bez neho
+  // automatizácia beží ďalej, len objednávky s poznámkou zostanú "čaká" (AI
+  // nedostupné) namiesto klasifikácie — nikdy sa nehádaj/nepošle naslepo.
+  // Skutočný kľúč patrí LEN do .env na dev2 a GitHub Secrets, nikdy do repa.
+  OPENAI_API_KEY: z.string().min(1).optional(),
+  // issue 173: skrytá kópia (BCC) majiteľovi — NEZÁVISLÁ, vyhradená premenná
+  // (rovnaký dôvod ako #172's `POSTA_UNCOLLECTED_BCC_EMAIL`, nie zdieľané
+  // všeobecné `MAIL_BCC`). Chýbajúca = automatizácia NEPOŠLE ani jeden e-mail
+  // zákazníkovi (fail-closed, majiteľova jediná bezpečnostná podmienka).
+  ORDER_REMINDER_BCC_EMAIL: z.string().email().optional(),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/apps/api/src/http/app.ts
+++ b/apps/api/src/http/app.ts
@@ -13,6 +13,7 @@ import { registerCatalogRoutes, type RunIngest } from "./catalog-routes.js";
 import { checkLoginRateLimit, clientIp } from "./login-rate-limit.js";
 import { SESSION_COOKIE, requireUser, type AppBindings } from "./middleware.js";
 import { registerOrdersRoutes, type RunOrdersIngest } from "./orders-routes.js";
+import { registerOrderReminderRoutes, type OrderReminderRunDeps } from "./order-reminder-routes.js";
 import { requireSameOrigin } from "./origin-check.js";
 import { registerPairingRoutes } from "./pairing-routes.js";
 import { registerPostaUncollectedRoutes, type PostaUncollectedRunDeps } from "./posta-uncollected-routes.js";
@@ -47,6 +48,11 @@ export function createApp(
     // meniť svoje volanie `createApp`). `index.ts` ho v produkcii VŽDY
     // zostavuje s reálnym tracking klientom.
     readonly postaUncollected?: PostaUncollectedRunDeps;
+    // issue 173: "Pripomienky objednávok" — rovnaký dôvod ako
+    // `postaUncollected` vyššie: voliteľné, bezpečný default nižšie pre
+    // testy/lokálny vývoj, `index.ts` v produkcii VŽDY nahradí reálnymi
+    // dependencies.
+    readonly orderReminder?: OrderReminderRunDeps;
   },
 ): Hono<AppBindings> {
   const app = new Hono<AppBindings>();
@@ -153,6 +159,20 @@ export function createApp(
       // mail (`mailTransport` chýba). Produkcia (`index.ts`) toto VŽDY
       // nahradí reálnym tracking klientom.
       trackingClient: () => Promise.resolve(null),
+      mailTransport: undefined,
+      bccEmail: undefined,
+      adminBaseUrl: options.adminBaseUrl ?? "https://www.forestshop.sk",
+    },
+  );
+  registerOrderReminderRoutes(
+    app,
+    db,
+    options.orderReminder ?? {
+      // Bezpečný default pre testy/lokálny vývoj bez explicitne dodaných
+      // dependencies — NIKDY nekontaktuje skutočné OpenAI (`classifyClient`
+      // chýba), nikdy neposiela mail (`mailTransport` chýba). Produkcia
+      // (`index.ts`) toto VŽDY nahradí reálnymi dependencies.
+      classifyClient: undefined,
       mailTransport: undefined,
       bccEmail: undefined,
       adminBaseUrl: options.adminBaseUrl ?? "https://www.forestshop.sk",

--- a/apps/api/src/http/order-reminder-routes.ts
+++ b/apps/api/src/http/order-reminder-routes.ts
@@ -1,0 +1,217 @@
+import { zValidator } from "@hono/zod-validator";
+import type { Hono } from "hono";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+import type { Database } from "../db/client.js";
+import { jobRuns } from "../db/schema.js";
+import { log } from "../logger.js";
+import { record } from "../modules/audit/service.js";
+import { buildReminderEmail } from "../modules/order-reminder/logic.js";
+import { ORDER_REMINDER_JOB_NAME } from "../modules/scheduler/jobs.js";
+import { getLatestJobRun } from "../modules/scheduler/queries.js";
+import type { OrderReminderRow, OrderReminderRunResult, RunOrderReminderOptions } from "../modules/order-reminder/run.js";
+import { runOrderReminder, runOrderReminderOverride } from "../modules/order-reminder/run.js";
+import { isOrderReminderEnabled, setOrderReminderEnabled } from "../modules/order-reminder/settings.js";
+import { requireRole, requireUser, type AppBindings } from "./middleware.js";
+import { requireSameOrigin } from "./origin-check.js";
+
+const setEnabledBody = z.object({ enabled: z.boolean() });
+const orderCodeParam = z.object({ orderCode: z.string().min(1) });
+const overrideBody = z.object({ orderCode: z.string().min(1), action: z.enum(["contact", "send"]) });
+
+// `Omit<..., "db" | "now">` — HTTP vrstva len dodá `db`/`now`, business
+// dependencies (AI klasifikátor, mail transport, BCC adresa, admin base url)
+// zostavuje `index.ts` presne raz pri štarte procesu (rovnaký vzor ako
+// #172's `PostaUncollectedRunDeps`).
+export type OrderReminderRunDeps = Omit<RunOrderReminderOptions, "db" | "now">;
+
+function isRunResult(detail: unknown): detail is OrderReminderRunResult {
+  return typeof detail === "object" && detail !== null && "noNote" in detail;
+}
+
+/**
+ * Manuálne "Spustiť teraz" aj naplánovaný beh zapisujú job_run TÝM ISTÝM
+ * vzorom, aký #172's `runAndRecord` používa — `GET /api/order-reminder` tak
+ * vidí manuálny beh HNEĎ, nielen po ďalšom pravidelnom ticku.
+ */
+async function runAndRecord(db: Database, deps: OrderReminderRunDeps, now: Date): Promise<OrderReminderRunResult> {
+  const [inserted] = await db
+    .insert(jobRuns)
+    .values({ jobName: ORDER_REMINDER_JOB_NAME, startedAt: now, status: "running" })
+    .returning({ id: jobRuns.id });
+  const runId = inserted?.id;
+  try {
+    const result = await runOrderReminder({ db, now, ...deps });
+    if (runId !== undefined) {
+      await db.update(jobRuns).set({ status: "success", finishedAt: new Date(), detail: result }).where(eq(jobRuns.id, runId));
+    }
+    return result;
+  } catch (error) {
+    const rawErrorMessage = error instanceof Error ? error.message : String(error);
+    log.error({ rawErrorMessage }, "Pripomienky objednávok: ručný beh zlyhal");
+    if (runId !== undefined) {
+      await db.update(jobRuns).set({ status: "failure", finishedAt: new Date(), errorMessage: rawErrorMessage }).where(eq(jobRuns.id, runId));
+    }
+    throw error;
+  }
+}
+
+function findRow(result: OrderReminderRunResult | null, orderCode: string): OrderReminderRow | undefined {
+  if (result === null) return undefined;
+  return (
+    result.noNote.find((r) => r.orderCode === orderCode) ??
+    result.noEmail.find((r) => r.orderCode === orderCode) ??
+    result.emailed.find((r) => r.orderCode === orderCode) ??
+    result.contacted.find((r) => r.orderCode === orderCode) ??
+    result.pending.find((r) => r.orderCode === orderCode)
+  );
+}
+
+export function registerOrderReminderRoutes(app: Hono<AppBindings>, db: Database, deps: OrderReminderRunDeps): void {
+  // Čítanie — každý prihlásený zamestnanec (rovnaká úroveň ako #172).
+  app.get("/api/order-reminder", requireUser(db), async (c) => {
+    const [enabled, lastRun] = await Promise.all([isOrderReminderEnabled(db), getLatestJobRun(db, ORDER_REMINDER_JOB_NAME)]);
+    return c.json({
+      enabled,
+      lastRun:
+        lastRun === null
+          ? null
+          : {
+              startedAt: lastRun.startedAt,
+              finishedAt: lastRun.finishedAt,
+              status: lastRun.status,
+              errorMessage: lastRun.errorMessage,
+              result: isRunResult(lastRun.detail) ? lastRun.detail : null,
+              skippedReason:
+                typeof lastRun.detail === "object" &&
+                lastRun.detail !== null &&
+                "skipped" in lastRun.detail &&
+                (lastRun.detail as { readonly skipped?: unknown }).skipped === true
+                  ? ((lastRun.detail as { readonly reason?: unknown }).reason ?? "")
+                  : null,
+            },
+    });
+  });
+
+  // Štart/Stop — gate-uje LEN naplánovaný denný beh (`scheduler/jobs.ts`'s
+  // `orderReminderJob`), nikdy "Spustiť teraz"/ručné akcie nižšie.
+  app.put(
+    "/api/order-reminder/enabled",
+    requireSameOrigin(),
+    requireUser(db),
+    requireRole("admin", "manazer"),
+    zValidator("json", setEnabledBody),
+    async (c) => {
+      const { enabled } = c.req.valid("json");
+      const user = c.get("user");
+      const now = new Date();
+      await setOrderReminderEnabled(db, enabled, now);
+      await record(db, {
+        at: now,
+        actorUserId: user.userId,
+        action: "order_reminder.enabled.set",
+        entity: "order_reminder_settings",
+        data: { enabled },
+      });
+      log.info({ actorUserId: user.userId, enabled }, "Pripomienky objednávok: Štart/Stop");
+      return c.json({ ok: true as const, enabled });
+    },
+  );
+
+  // "Spustiť teraz" — VŽDY beží, bez ohľadu na `enabled`.
+  app.post(
+    "/api/order-reminder/run-now",
+    requireSameOrigin(),
+    requireUser(db),
+    requireRole("admin", "manazer"),
+    async (c) => {
+      const user = c.get("user");
+      const now = new Date();
+      let result: OrderReminderRunResult;
+      try {
+        result = await runAndRecord(db, deps, now);
+      } catch {
+        return c.json({ error: "Beh zlyhal — skúste to znova o chvíľu." }, 502);
+      }
+      await record(db, {
+        at: now,
+        actorUserId: user.userId,
+        action: "order_reminder.run_now",
+        entity: "job_run",
+        data: { stats: result.stats },
+      });
+      log.info({ actorUserId: user.userId, stats: result.stats }, "Pripomienky objednávok: ručné spustenie");
+      return c.json({ ok: true as const, result });
+    },
+  );
+
+  // Ručný per-riadkový override ("▶ Poslať pripomienku"/"✓ Kontaktované") —
+  // dovolené na akomkoľvek nevyriešenom/AI-nesprávnom riadku, nikdy na už
+  // odoslanom (žiadny druhý mail).
+  app.post(
+    "/api/order-reminder/override",
+    requireSameOrigin(),
+    requireUser(db),
+    requireRole("admin", "manazer"),
+    zValidator("json", overrideBody),
+    async (c) => {
+      const { orderCode, action } = c.req.valid("json");
+      const user = c.get("user");
+      const now = new Date();
+      const result = await runOrderReminderOverride({ db, now, orderCode, action, ...deps });
+      if (!result.ok) {
+        const message =
+          result.code === "not_found"
+            ? "Objednávka sa v aktuálnom zozname nenašla."
+            : result.code === "already_resolved"
+              ? result.resolution === "emailed"
+                ? "Pripomienka už bola odoslaná."
+                : "Objednávka je už označená ako kontaktovaná."
+              : result.code === "no_email"
+                ? "Objednávka nemá e-mailovú adresu."
+                : result.code === "not_configured"
+                  ? result.reason
+                  : "Odoslanie e-mailu zlyhalo — skúste to znova.";
+        return c.json({ ok: false as const, error: message });
+      }
+      await record(db, {
+        at: now,
+        actorUserId: user.userId,
+        action: "order_reminder.override",
+        entity: "order_reminder_state",
+        entityId: orderCode,
+        data: { action, resolution: result.resolution },
+      });
+      log.info({ actorUserId: user.userId, orderCode, action }, "Pripomienky objednávok: ručná akcia");
+      return c.json({ ok: true as const, resolution: result.resolution });
+    },
+  );
+
+  // Náhľad — číta VÝHRADNE z POSLEDNÉHO uloženého behu (nikdy znova
+  // neklasifikuje/neposiela), presne ako #172's preview.
+  app.get(
+    "/api/order-reminder/preview/:orderCode",
+    requireUser(db),
+    zValidator("param", orderCodeParam),
+    async (c) => {
+      const { orderCode } = c.req.valid("param");
+      const lastRun = await getLatestJobRun(db, ORDER_REMINDER_JOB_NAME);
+      const result = lastRun !== null && isRunResult(lastRun.detail) ? lastRun.detail : null;
+      const row = findRow(result, orderCode);
+      if (row === undefined) {
+        // 200 (nikdy 404) — rovnaká disciplína ako #172's preview
+        // (`.claude/rules/testing.md`'s Chromium console-error pravidlo).
+        return c.json({ ok: false as const, error: "Objednávka sa v aktuálnom zozname nenašla." });
+      }
+      const built = buildReminderEmail(row.name, orderCode);
+      return c.json({
+        ok: true as const,
+        subject: built.subject,
+        html: built.html,
+        recipient: row.email,
+        name: row.name,
+        orderCode,
+      });
+    },
+  );
+}

--- a/apps/api/src/http/order-reminder-routes.ts
+++ b/apps/api/src/http/order-reminder-routes.ts
@@ -1,6 +1,6 @@
 import { zValidator } from "@hono/zod-validator";
 import type { Hono } from "hono";
-import { eq } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 import { z } from "zod";
 import type { Database } from "../db/client.js";
 import { jobRuns } from "../db/schema.js";
@@ -65,6 +65,56 @@ function findRow(result: OrderReminderRunResult | null, orderCode: string): Orde
     result.contacted.find((r) => r.orderCode === orderCode) ??
     result.pending.find((r) => r.orderCode === orderCode)
   );
+}
+
+/**
+ * Ručná akcia (override) mení LEN `order_reminder_state` — na rozdiel od
+ * "Spustiť teraz" nezapíše nový `job_run` riadok. Bez tohto by `GET
+ * /api/order-reminder` po úspešnej ručnej akcii ukázal STARÝ, nezmenený
+ * posledný beh (riadok by zostal v pôvodnej tabuľke, kým nepríde ĎALŠÍ
+ * naplánovaný/manuálny beh) — manažér by videl akciu "zaúčinkovať" v
+ * databáze, ale nie na obrazovke. Presúva riadok do správnej skupiny
+ * PRIAMO v poslednom uloženom `job_run.detail`, rovnaký zámer ako stará
+ * appka's `_relocate` (`webreview/app.py`).
+ */
+async function relocateAfterOverride(
+  db: Database,
+  orderCode: string,
+  resolution: "contacted" | "emailed",
+): Promise<void> {
+  const [latest] = await db
+    .select({ id: jobRuns.id, detail: jobRuns.detail })
+    .from(jobRuns)
+    .where(eq(jobRuns.jobName, ORDER_REMINDER_JOB_NAME))
+    .orderBy(desc(jobRuns.startedAt))
+    .limit(1);
+  if (latest === undefined || !isRunResult(latest.detail)) return;
+  const result = latest.detail;
+  const row = findRow(result, orderCode);
+  if (row === undefined) return;
+
+  const resolvedRow = {
+    orderCode: row.orderCode,
+    adminLink: row.adminLink,
+    name: row.name,
+    phone: row.phone,
+    email: row.email,
+    itemLabel: row.itemLabel,
+    days: row.days,
+    resolvedAt: new Date().toISOString(),
+    resolvedBy: "manual" as const,
+  };
+  const stripped: OrderReminderRunResult = {
+    ...result,
+    noNote: result.noNote.filter((r) => r.orderCode !== orderCode),
+    noEmail: result.noEmail.filter((r) => r.orderCode !== orderCode),
+    pending: result.pending.filter((r) => r.orderCode !== orderCode),
+    contacted: result.contacted.filter((r) => r.orderCode !== orderCode),
+    emailed: result.emailed.filter((r) => r.orderCode !== orderCode),
+  };
+  const updated: OrderReminderRunResult =
+    resolution === "emailed" ? { ...stripped, emailed: [...stripped.emailed, resolvedRow] } : { ...stripped, contacted: [...stripped.contacted, resolvedRow] };
+  await db.update(jobRuns).set({ detail: updated }).where(eq(jobRuns.id, latest.id));
 }
 
 export function registerOrderReminderRoutes(app: Hono<AppBindings>, db: Database, deps: OrderReminderRunDeps): void {
@@ -174,6 +224,7 @@ export function registerOrderReminderRoutes(app: Hono<AppBindings>, db: Database
                   : "Odoslanie e-mailu zlyhalo — skúste to znova.";
         return c.json({ ok: false as const, error: message });
       }
+      await relocateAfterOverride(db, orderCode, result.resolution);
       await record(db, {
         at: now,
         actorUserId: user.userId,

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -15,10 +15,13 @@ import { computeImportWindow, createHttpOrderIdsFetcher, createHttpOrdersExportF
 import { DEFAULT_ORDERS_IMPORT_WINDOW_DAYS, ingestOrders, type RunOrdersIngest } from "./modules/orders/ingest.js";
 import { createHttpTrackingClient } from "./modules/posta-uncollected/tracking-client.js";
 import { runPostaUncollected } from "./modules/posta-uncollected/run.js";
+import { createOpenAiClassifyClient } from "./modules/order-reminder/classify-client.js";
+import { runOrderReminder } from "./modules/order-reminder/run.js";
 import {
   catalogImportJob,
   ordersImportJob,
   orderNoteWritebackJob,
+  orderReminderJob,
   postaUncollectedJob,
   pruneRawExportsJob,
   pruneRawOrdersJob,
@@ -154,6 +157,20 @@ const postaUncollectedDeps = {
   adminBaseUrl: env.SHOPTET_ADMIN_BASE_URL,
 };
 
+// issue 173: "Pripomienky objednávok" — rovnaká úvaha ako #172 vyššie: mail
+// transport (zdieľaný `sendSupplierMail`, rovnaká SMTP infraštruktúra) a BCC
+// adresa môžu chýbať, `runOrderReminder` to sama rieši fail-closed. AI
+// klasifikátor je NOVÝ, nezávislý nepovinný závislosť — `OPENAI_API_KEY`
+// chýbajúci = `classifyClient` je `undefined`, automatizácia to zobrazí ako
+// "čaká" (AI nedostupné), nikdy nehádaj/nepošle naslepo.
+const openAiApiKey = env.OPENAI_API_KEY;
+const orderReminderDeps = {
+  classifyClient: openAiApiKey === undefined ? undefined : createOpenAiClassifyClient({ apiKey: openAiApiKey }),
+  mailTransport: sendSupplierMail,
+  bccEmail: env.ORDER_REMINDER_BCC_EMAIL,
+  adminBaseUrl: env.SHOPTET_ADMIN_BASE_URL,
+};
+
 const app = createApp(db, {
   cookieSecure: env.SESSION_COOKIE_SECURE,
   ...(runIngest === undefined ? {} : { runIngest }),
@@ -161,6 +178,7 @@ const app = createApp(db, {
   ...(sendSupplierMail === undefined ? {} : { sendSupplierMail }),
   adminBaseUrl: env.SHOPTET_ADMIN_BASE_URL,
   postaUncollected: postaUncollectedDeps,
+  orderReminder: orderReminderDeps,
 });
 
 // F2 (#12/#3) + F3 (#22/#28): nočný import katalógu/objednávok, mazanie
@@ -179,6 +197,7 @@ const scheduler = startScheduler(db, [
   shoptetWritebackJob(runShoptetWritebackFn),
   orderNoteWritebackJob(runOrderNoteWritebackFn),
   postaUncollectedJob((db2, now) => runPostaUncollected({ db: db2, now, ...postaUncollectedDeps })),
+  orderReminderJob((db2, now) => runOrderReminder({ db: db2, now, ...orderReminderDeps })),
 ]);
 
 // `@hono/node-server`'s `serveStatic` prints its OWN `console.error` on every

--- a/apps/api/src/modules/order-reminder/classify-client.ts
+++ b/apps/api/src/modules/order-reminder/classify-client.ts
@@ -1,0 +1,49 @@
+import { log } from "../../logger.js";
+import { buildClassifierMessages, parseClassification } from "./logic.js";
+
+/** Vstrekované rozhranie (rovnaký zámer ako `MailTransport`/`TrackingClient`
+ * — testy dodávajú falošný klient, NIKDY nekontaktujú skutočné OpenAI, per
+ * ticketu). `true` = zákazník už kontaktovaný (e-mail sa neposiela), `false`
+ * = nekontaktovaný (posiela sa pripomienka). Vyhodí na zlyhanie (sieť,
+ * ne-2xx, nerozpoznaná kategória) — volajúci (`run.ts`) to zaznamená ako
+ * per-objednávkovú chybu, nikdy nespadne celý beh. */
+export type ClassifyClient = (shopRemark: string | null) => Promise<boolean>;
+
+const OPENAI_URL = "https://api.openai.com/v1/chat/completions";
+const OPENAI_TIMEOUT_MS = 60_000;
+const OPENAI_MODEL = "gpt-4o-mini";
+
+export function createOpenAiClassifyClient(options: { readonly apiKey: string; readonly timeoutMs?: number }): ClassifyClient {
+  const { apiKey } = options;
+  const timeoutMs = options.timeoutMs ?? OPENAI_TIMEOUT_MS;
+  return async (shopRemark: string | null): Promise<boolean> => {
+    const messages = buildClassifierMessages(shopRemark);
+    const response = await fetch(OPENAI_URL, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        // Authorization header (nikdy URL) — API kľúč sa tak nikdy neobjaví
+        // v žiadnej chybovej hláške/logu odvodenom z URL.
+        authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: OPENAI_MODEL,
+        messages,
+        response_format: { type: "json_object" },
+        temperature: 0,
+      }),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!response.ok) {
+      const bodyText = await response.text().catch(() => "");
+      log.warn({ status: response.status, bodyText }, "OpenAI klasifikácia (Pripomienky objednávok) vrátila ne-2xx");
+      throw new Error(`OpenAI vrátilo ${String(response.status)}`);
+    }
+    const json = (await response.json()) as { readonly choices?: readonly { readonly message?: { readonly content?: unknown } }[] };
+    const content = json.choices?.[0]?.message?.content;
+    if (typeof content !== "string") {
+      throw new Error("OpenAI odpoveď nemá očakávaný tvar (chýba choices[0].message.content)");
+    }
+    return parseClassification(content);
+  };
+}

--- a/apps/api/src/modules/order-reminder/constants.ts
+++ b/apps/api/src/modules/order-reminder/constants.ts
@@ -1,0 +1,22 @@
+// issue 173: "Pripomienky objednávok" — konštanty prevzaté zo starej appky
+// (`parovanie_produktov/src/parovanie/orders_reminder.py`), preto komentáre na
+// viacerých miestach citujú presne odtiaľ.
+
+// n8n/stará appka: date before now.minus(4, 'days').
+export const MIN_DAYS = 4;
+
+// Stará appky's typo "Foresthop" opravený (rovnaký fix ako
+// `orders_reminder.py`'s vlastný komentár k tomu).
+export const EMAIL_SUBJECT = "📦 Stav vašej objednávky z Forestshop.sk";
+
+// Klasifikátorove dve kategórie (verbatim z n8n "Kontaktovany?" node) —
+// použité AJ v prompte, AJ ako jediné povolené výstupné hodnoty.
+export const CATEGORY_CONTACTED = "kontaktovany";
+export const CATEGORY_NOT_CONTACTED = "nekontaktovany";
+
+// Ďalší voľný advisory-lock kľúč v registri `.claude/rules/scheduler.md`
+// (787_878_001/002/003/004/100 sú obsadené, `.claude/rules/posta-uncollected
+// .md` + `.claude/rules/testing.md`) — serializuje CELÝ beh (naplánovaný,
+// "Spustiť teraz" AJ každú ručnú per-riadkovú akciu), rovnaký zámer ako
+// `POSTA_UNCOLLECTED_RUN_LOCK_KEY`, viď návrhový komentár na issue 173.
+export const ORDER_REMINDER_RUN_LOCK_KEY = 787_878_005;

--- a/apps/api/src/modules/order-reminder/logic.test.ts
+++ b/apps/api/src/modules/order-reminder/logic.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildClassifierMessages,
+  buildReminderEmail,
+  daysOpen,
+  fingerprint,
+  isEligibleOrder,
+  isOldEnough,
+  parseClassification,
+} from "./logic.js";
+
+describe("isEligibleOrder", () => {
+  it("objednávka v nastavenom otvorenom stave je eligible", () => {
+    expect(isEligibleOrder({ statusName: "Vybavuje sa" }, new Set(["Vybavuje sa"]))).toBe(true);
+  });
+
+  it("objednávka mimo nastaveného zoznamu (napr. Vybavená/Stornovaná) nie je eligible", () => {
+    expect(isEligibleOrder({ statusName: "Vybavená" }, new Set(["Vybavuje sa"]))).toBe(false);
+    expect(isEligibleOrder({ statusName: "Stornovaná" }, new Set(["Vybavuje sa"]))).toBe(false);
+  });
+});
+
+describe("daysOpen / isOldEnough", () => {
+  const now = new Date("2026-08-02T00:00:00Z");
+
+  it("presne 4 dni staré je 'staršie ako 4 dni' (>=)", () => {
+    const placedAt = new Date("2026-07-29T00:00:00Z");
+    expect(daysOpen(placedAt, now)).toBe(4);
+    expect(isOldEnough(placedAt, now)).toBe(true);
+  });
+
+  it("3 dni staré ešte NIE JE eligible na spracovanie", () => {
+    const placedAt = new Date("2026-07-30T00:00:00Z");
+    expect(daysOpen(placedAt, now)).toBe(3);
+    expect(isOldEnough(placedAt, now)).toBe(false);
+  });
+
+  it("budúci dátum sa berie ako 0 dní, nikdy záporne", () => {
+    const placedAt = new Date("2026-08-10T00:00:00Z");
+    expect(daysOpen(placedAt, now)).toBe(0);
+  });
+});
+
+describe("fingerprint", () => {
+  it("rovnaký dátum + poznámka → rovnaký odtlačok", () => {
+    const a = { placedAt: new Date("2026-07-01T10:00:00Z"), shopRemark: "volať zákazníka" };
+    const b = { placedAt: new Date("2026-07-01T10:00:00Z"), shopRemark: "volať zákazníka" };
+    expect(fingerprint(a)).toBe(fingerprint(b));
+  });
+
+  it("zmenená poznámka → iný odtlačok", () => {
+    const a = { placedAt: new Date("2026-07-01T10:00:00Z"), shopRemark: "volať zákazníka" };
+    const b = { placedAt: new Date("2026-07-01T10:00:00Z"), shopRemark: "volané, počká" };
+    expect(fingerprint(a)).not.toBe(fingerprint(b));
+  });
+
+  it("null poznámka sa berie ako prázdny reťazec, nie ako 'null' text", () => {
+    const a = { placedAt: new Date("2026-07-01T10:00:00Z"), shopRemark: null };
+    expect(fingerprint(a)).toBe("2026-07-01T10:00:00.000Z|");
+  });
+});
+
+describe("buildReminderEmail", () => {
+  it("obsahuje meno aj kód objednávky, HTML-escapované", () => {
+    const built = buildReminderEmail('Ján "Test" <Novák>', "20260001");
+    expect(built.subject).toBe("📦 Stav vašej objednávky z Forestshop.sk");
+    expect(built.html).toContain("&lt;Novák&gt;");
+    expect(built.html).toContain("&quot;Test&quot;");
+    expect(built.html).toContain("20260001");
+    expect(built.text).toContain("20260001");
+  });
+});
+
+describe("buildClassifierMessages / parseClassification", () => {
+  it("prázdna poznámka sa pošle ako BEZ POZNAMKY", () => {
+    const messages = buildClassifierMessages(null);
+    expect(messages[1]?.content).toContain("BEZ POZNAMKY");
+  });
+
+  it("skutočná poznámka sa pošle doslovne", () => {
+    const messages = buildClassifierMessages("volané so zákazníkom, počká");
+    expect(messages[1]?.content).toContain("volané so zákazníkom, počká");
+  });
+
+  it("parsuje čistý JSON objekt kontaktovany → true", () => {
+    expect(parseClassification('{"kategoria": "kontaktovany"}')).toBe(true);
+  });
+
+  it("parsuje čistý JSON objekt nekontaktovany → false", () => {
+    expect(parseClassification('{"kategoria": "nekontaktovany"}')).toBe(false);
+  });
+
+  it("tolerantné voči ```json plotu", () => {
+    expect(parseClassification('```json\n{"kategoria": "kontaktovany"}\n```')).toBe(true);
+  });
+
+  it("tolerantné voči holému reťazcu kategórie", () => {
+    expect(parseClassification('"nekontaktovany"')).toBe(false);
+  });
+
+  it("nerozpoznaná odpoveď vyhodí, nikdy nehádaj", () => {
+    expect(() => parseClassification("neviem")).toThrow(/nevrátil platnú kategóriu/);
+  });
+});

--- a/apps/api/src/modules/order-reminder/logic.ts
+++ b/apps/api/src/modules/order-reminder/logic.ts
@@ -1,0 +1,164 @@
+import { CATEGORY_CONTACTED, CATEGORY_NOT_CONTACTED, EMAIL_SUBJECT, MIN_DAYS } from "./constants.js";
+
+// Čistá logika (žiadna DB, žiadna sieť) — verný port `orders_reminder.py`,
+// prispôsobený tak, aby čítal priamo z `order` riadkov (nie z CSV export),
+// viď návrhový komentár na issue 173.
+
+export interface ReminderEligibleOrder {
+  readonly externalOrderId: string;
+  readonly placedAt: Date;
+  readonly statusName: string;
+  readonly shopRemark: string | null;
+  readonly email: string | null;
+  readonly phone: string | null;
+  readonly customerName: string;
+  readonly shoptetOrderId: number | null;
+}
+
+/** Objednávka, za ktorú je táto automatizácia zodpovedná — v jednom z
+ * nastavených "otvorených" stavov (ten istý zoznam ako "Na objednanie",
+ * `listOpenStatusNames`), BEZ vekového filtra (ten sa aplikuje samostatne
+ * cez `daysOpen`/`MIN_DAYS`, rovnaký zámer ako #172's rozdelenie
+ * eligible/shipments). Slúži AJ ako "okno", proti ktorému sa
+ * `order_reminder_state` čistí — objednávka, čo opustí otvorené stavy
+ * (vybavená/stornovaná), stráca svoj záznam pri ďalšom behu. */
+export function isEligibleOrder(order: { readonly statusName: string }, openStatuses: ReadonlySet<string>): boolean {
+  return openStatuses.has(order.statusName);
+}
+
+/** Celé dni od `placedAt` po `today` — nikdy záporné (budúci dátum sa berie
+ * ako 0, nikdy nevyhodí). */
+export function daysOpen(placedAt: Date, today: Date): number {
+  return Math.max(0, Math.floor((today.getTime() - placedAt.getTime()) / 86_400_000));
+}
+
+export function isOldEnough(placedAt: Date, today: Date, minDays: number = MIN_DAYS): boolean {
+  return daysOpen(placedAt, today) >= minDays;
+}
+
+/** Stabilný odtlačok polí, ktoré rozhodujú o AI/e-mailovom výsledku (#153 v
+ * starej appke — inkrementálne spracovanie) — `placedAt` + `shopRemark`.
+ * Počet dní je ZÁMERNE vynechaný: postupuje každý deň aj pre nedotknutú
+ * objednávku, takže by defeat-ol inkrementalitu (ticket: "počet dní sa
+ * zámerne NEZAPOČÍTAVA do kontroly zmeny objednávky"). */
+export function fingerprint(order: { readonly placedAt: Date; readonly shopRemark: string | null }): string {
+  return `${order.placedAt.toISOString()}|${order.shopRemark ?? ""}`;
+}
+
+function htmlEscape(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+export interface BuiltReminderEmail {
+  readonly subject: string;
+  readonly html: string;
+  readonly text: string;
+}
+
+/** (subject, html, text) — doslovný preklad `orders_reminder.py`'s
+ * `build_reminder_email` (n8n "Edit Fields2" šablóna), voľný text (meno, kód)
+ * HTML-escapovaný. JEDEN e-mail, žiadne stupňovanie podľa poradia (na rozdiel
+ * od #172's `buildEmail(count, ...)`). */
+export function buildReminderEmail(customerName: string, orderCode: string): BuiltReminderEmail {
+  const nameH = htmlEscape(customerName);
+  const codeH = htmlEscape(orderCode);
+  const html = [
+    "<!DOCTYPE html>",
+    "<html>",
+    '  <body style="font-family: Arial, sans-serif; font-size: 16px; color: #333;">',
+    `    <p>Dobrý deň, <strong>${nameH}</strong>,</p>`,
+    "",
+    `    <p>Všimli sme si, že spracovanie vašej objednávky č. <strong>${codeH}</strong> trvá o niečo dlhšie než obvykle. Chceme vás ubezpečiť, že situáciu aktívne sledujeme a riešime.</p>`,
+    "",
+    "    <p>Mierne zdržanie môže byť spôsobené dostupnosťou tovaru, dopĺňaním zásob alebo prepravnými okolnosťami. Rozumieme, že sa na svoju výbavu tešíte, a robíme všetko pre to, aby ste ju mali čo najskôr pri sebe.</p>",
+    "",
+    '    <p>👉 V prípade potreby zmeny, alternatívy alebo potvrdenia z vašej strany vás budeme osobne kontaktovať v najbližšom čase.</p>',
+    "",
+    '    <p>Ďakujeme vám za trpezlivosť a dôveru. Ak máte akékoľvek otázky, pokojne nás kontaktujte na <a href="mailto:eshop@forestshop.sk">eshop@forestshop.sk</a> alebo na telefónnom čísle <a href="tel:+421903670766">+421 903 670 766</a>.</p>',
+    "",
+    '    <p style="margin-top: 30px;">',
+    "      S pozdravom,<br>",
+    "      <strong>Tím Forestshop.sk</strong><br>",
+    '      <a href="https://www.forestshop.sk" target="_blank">www.forestshop.sk</a>',
+    "    </p>",
+    "  </body>",
+    "</html>",
+  ].join("\n");
+
+  const text = [
+    `Dobrý deň, ${customerName},`,
+    "",
+    `Všimli sme si, že spracovanie vašej objednávky č. ${orderCode} trvá o niečo dlhšie než obvykle. Chceme vás ubezpečiť, že situáciu aktívne sledujeme a riešime.`,
+    "",
+    "Mierne zdržanie môže byť spôsobené dostupnosťou tovaru, dopĺňaním zásob alebo prepravnými okolnosťami.",
+    "",
+    "V prípade potreby zmeny, alternatívy alebo potvrdenia z vašej strany vás budeme osobne kontaktovať v najbližšom čase.",
+    "",
+    "Ďakujeme vám za trpezlivosť a dôveru. Kontakt: eshop@forestshop.sk, +421 903 670 766.",
+    "",
+    "S pozdravom, Tím Forestshop.sk",
+  ].join("\n");
+
+  return { subject: EMAIL_SUBJECT, html, text };
+}
+
+export interface ClassifierMessage {
+  readonly role: "system" | "user";
+  readonly content: string;
+}
+
+/** OpenAI chat messages pre klasifikáciu internej poznámky predajne — verný
+ * port `orders_reminder.py`'s `build_classifier_messages`. Prázdna poznámka
+ * → "BEZ POZNAMKY" (zhoda s n8n inputText fallback) — čistý stavový automat
+ * túto vetvu nikdy nevolá (bez poznámky = len červené upozornenie), toto
+ * ostáva len obranné. */
+export function buildClassifierMessages(shopRemark: string | null): readonly ClassifierMessage[] {
+  const note = (shopRemark ?? "").trim() || "BEZ POZNAMKY";
+  const system = `Si klasifikátor interných poznámok predajne k objednávke. Rozhoduješ, či zákazník UŽ BOL kontaktovaný ohľadom svojej objednávky.
+
+Kategória "${CATEGORY_CONTACTED}": zákazník UŽ BOL kontaktovaný/informovaný. Dokazuje to DOKONČENÝ telefonát v minulom čase (napr. "volané so zákazníkom/zákazníčkou", "dovolal som sa", "hovoril som so zákazníkom"), najmä ak nasleduje dohoda ("počká", "bude sa čakať", "po dohode so zákazníkom"), ALEBO už odoslaná SMS ("poslaná sms", "sms poslaná"). Sem patrí aj "volané ... počká".
+
+Kategória "${CATEGORY_NOT_CONTACTED}": zákazník ešte NEBOL úspešne kontaktovaný. Patrí sem: prázdna poznámka / "BEZ POZNAMKY"; len interné poznámky o tovare ("nemáme", "objednané", "nedostupné", "chýba kus"); BUDÚCI zámer zavolať ešte nesplnený ("volať zákazníka", "budeme volať", "treba volať", "ja vybavím"); a IBA NEÚSPEŠNÝ pokus o telefonát bez SMS ("nedovolal som sa", "nezdvíha"). Tu sa posiela pripomienkový e-mail.
+
+KĽÚČOVÝ ROZDIEL: "volané" = telefonát sa UŽ uskutočnil (kontaktovaný), ale "volať" / "budeme volať" / "treba volať" = ešte sa NEvolalo (nekontaktovaný). Neodôvodňuj, vráť IBA JSON objekt v tvare {"kategoria": "${CATEGORY_CONTACTED}"} alebo {"kategoria": "${CATEGORY_NOT_CONTACTED}"}.`;
+  const user = `Interná poznámka:\n${note}`;
+  return [
+    { role: "system", content: system },
+    { role: "user", content: user },
+  ];
+}
+
+/** Parsuje odpoveď modelu → `true` keď zákazník bol UŽ kontaktovaný (e-mail sa
+ * neposiela), `false` keď NEbol (posiela sa pripomienka). Tolerantné voči
+ * ```json plotu aj holému reťazcu kategórie. Vyhodí na nerozpoznanú
+ * odpoveď — volajúci to zaznamená ako chybu, NIKDY nehádaj. */
+export function parseClassification(content: string): boolean {
+  let s = content.trim();
+  if (s.startsWith("```")) {
+    s = s
+      .replace(/^```[a-zA-Z]*\s*/, "")
+      .replace(/\s*```$/, "")
+      .trim();
+  }
+  let kategoria = "";
+  try {
+    const parsed: unknown = JSON.parse(s);
+    if (typeof parsed === "string") {
+      kategoria = parsed.trim().toLowerCase();
+    } else if (typeof parsed === "object" && parsed !== null) {
+      const obj = parsed as { readonly kategoria?: unknown; readonly category?: unknown };
+      const raw = obj.kategoria ?? obj.category ?? "";
+      kategoria = typeof raw === "string" ? raw.trim().toLowerCase() : "";
+    }
+  } catch {
+    kategoria = s.trim().replace(/^"|"$/g, "").toLowerCase();
+  }
+  if (kategoria === CATEGORY_CONTACTED) return true;
+  if (kategoria === CATEGORY_NOT_CONTACTED) return false;
+  throw new Error(`klasifikátor nevrátil platnú kategóriu: ${content}`);
+}

--- a/apps/api/src/modules/order-reminder/orders-source.ts
+++ b/apps/api/src/modules/order-reminder/orders-source.ts
@@ -1,0 +1,63 @@
+import { asc, eq, inArray } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { orderLines, orders, variants } from "../../db/schema.js";
+import { listOpenStatusNames } from "../orders/open-statuses.js";
+import { isEligibleOrder, type ReminderEligibleOrder } from "./logic.js";
+
+/** Všetky objednávky v NASTAVENOM otvorenom stave (rovnaký zoznam ako "Na
+ * objednanie", `listOpenStatusNames`) — BEZ vekového filtra (ten je na
+ * `logic.ts`'s `isOldEnough`, aplikovaný samostatne v `run.ts`, rovnaký
+ * zámer ako #172's rozdelenie eligible/shipments). Tento zoznam je AJ
+ * "oknom", proti ktorému sa `order_reminder_state` čistí — objednávka, čo
+ * medzičasom opustí otvorené stavy, stráca svoj záznam pri ďalšom behu. */
+export async function loadEligibleOrders(db: Database): Promise<readonly ReminderEligibleOrder[]> {
+  const openStatusNames = await listOpenStatusNames(db);
+  const openStatuses = new Set(openStatusNames);
+  if (openStatuses.size === 0) return [];
+  const rows = await db
+    .select({
+      externalOrderId: orders.externalOrderId,
+      placedAt: orders.placedAt,
+      statusName: orders.statusName,
+      shopRemark: orders.shopRemark,
+      email: orders.email,
+      phone: orders.phone,
+      customerName: orders.customerName,
+      shoptetOrderId: orders.shoptetOrderId,
+    })
+    .from(orders)
+    .where(inArray(orders.statusName, [...openStatuses]));
+  return rows.filter((row) => isEligibleOrder(row, openStatuses));
+}
+
+/** "Položka" stĺpec na obrazovke (ticket) — prvý (abecedne podľa
+ * `variantCode`) názov tovaru na objednávke, s "+ N ďalších" pri viacerých
+ * riadkoch. Len zobrazovacia pomôcka (rovnaký zdroj ako "Na objednanie"'s
+ * `variantName`), NIKDY nevstupuje do eligibility/AI/e-mailovej logiky. */
+export async function loadItemLabels(db: Database, externalOrderIds: readonly string[]): Promise<ReadonlyMap<string, string>> {
+  const out = new Map<string, string>();
+  if (externalOrderIds.length === 0) return out;
+  const rows = await db
+    .select({
+      externalOrderId: orders.externalOrderId,
+      variantCode: orderLines.variantCode,
+      variantName: variants.name,
+    })
+    .from(orderLines)
+    .innerJoin(orders, eq(orders.id, orderLines.orderId))
+    .innerJoin(variants, eq(variants.code, orderLines.variantCode))
+    .where(inArray(orders.externalOrderId, [...externalOrderIds]))
+    .orderBy(asc(orders.externalOrderId), asc(orderLines.variantCode));
+  const perOrder = new Map<string, string[]>();
+  for (const row of rows) {
+    const list = perOrder.get(row.externalOrderId) ?? [];
+    list.push(row.variantName);
+    perOrder.set(row.externalOrderId, list);
+  }
+  for (const [code, names] of perOrder) {
+    const [first, ...rest] = names;
+    if (first === undefined) continue;
+    out.set(code, rest.length > 0 ? `${first} (+ ${String(rest.length)} ďalších)` : first);
+  }
+  return out;
+}

--- a/apps/api/src/modules/order-reminder/run.ts
+++ b/apps/api/src/modules/order-reminder/run.ts
@@ -1,0 +1,310 @@
+import type { Database } from "../../db/client.js";
+import { log } from "../../logger.js";
+import type { MailTransport } from "../mail/transport.js";
+import { buildShoptetAdminOrderUrl } from "../orders/queries.js";
+import type { ClassifyClient } from "./classify-client.js";
+import { ORDER_REMINDER_RUN_LOCK_KEY } from "./constants.js";
+import { buildReminderEmail, daysOpen, fingerprint, isOldEnough, type ReminderEligibleOrder } from "./logic.js";
+import { loadEligibleOrders, loadItemLabels } from "./orders-source.js";
+import {
+  loadOrderReminderState,
+  loadOrderReminderStateOne,
+  upsertOrderReminderState,
+  pruneOrderReminderState,
+  type OrderReminderResolution,
+  type OrderReminderResolvedBy,
+} from "./state.js";
+
+export interface OrderReminderRow {
+  readonly orderCode: string;
+  readonly adminLink: string;
+  readonly name: string;
+  readonly phone: string;
+  readonly email: string;
+  readonly itemLabel: string;
+  readonly days: number;
+}
+
+export interface OrderReminderResolvedRow extends OrderReminderRow {
+  readonly resolvedAt: string;
+  readonly resolvedBy: OrderReminderResolvedBy;
+}
+
+export interface OrderReminderPendingRow extends OrderReminderRow {
+  readonly reason: string;
+}
+
+export interface OrderReminderRunResult {
+  readonly checkedAt: string;
+  // 🔴 bez poznámky — e-mail sa NEPOSIELA nikdy z tejto vetvy.
+  readonly noNote: readonly OrderReminderRow[];
+  // ✉️ bez e-mailovej adresy — AI sa vôbec nepýta (šetrí peniaze).
+  readonly noEmail: readonly OrderReminderRow[];
+  // 🟠 pripomienka odoslaná (AI aj ručne).
+  readonly emailed: readonly OrderReminderResolvedRow[];
+  // ⚪/✋ zákazník už kontaktovaný (AI aj ručne).
+  readonly contacted: readonly OrderReminderResolvedRow[];
+  // ⚠️ automatika začala, ale nedokončila (chýbajúce nastavenie/zlyhanie).
+  readonly pending: readonly OrderReminderPendingRow[];
+  readonly aiNotConfigured: boolean;
+  readonly bccMissing: boolean;
+  readonly mailNotConfigured: boolean;
+  readonly stats: {
+    readonly candidates: number;
+    readonly noNoteCount: number;
+    readonly noEmailCount: number;
+    readonly emailedNow: number;
+    readonly contactedNow: number;
+    readonly pendingCount: number;
+  };
+}
+
+export interface RunOrderReminderOptions {
+  readonly db: Database;
+  readonly now: Date;
+  readonly classifyClient: ClassifyClient | undefined;
+  readonly mailTransport: MailTransport | undefined;
+  readonly bccEmail: string | undefined;
+  readonly adminBaseUrl: string;
+}
+
+function toRow(order: ReminderEligibleOrder, itemLabels: ReadonlyMap<string, string>, adminBaseUrl: string, now: Date): OrderReminderRow {
+  return {
+    orderCode: order.externalOrderId,
+    adminLink: buildShoptetAdminOrderUrl(adminBaseUrl, order.externalOrderId, order.shoptetOrderId),
+    name: order.customerName,
+    phone: order.phone ?? "",
+    email: order.email ?? "",
+    itemLabel: itemLabels.get(order.externalOrderId) ?? "",
+    days: daysOpen(order.placedAt, now),
+  };
+}
+
+export async function runOrderReminder(options: RunOrderReminderOptions): Promise<OrderReminderRunResult> {
+  const { db } = options;
+  const lockClient = await db.$client.connect();
+  try {
+    await lockClient.query("select pg_advisory_lock($1)", [ORDER_REMINDER_RUN_LOCK_KEY]);
+    return await runOrderReminderLocked(options);
+  } finally {
+    await lockClient.query("select pg_advisory_unlock($1)", [ORDER_REMINDER_RUN_LOCK_KEY]);
+    lockClient.release();
+  }
+}
+
+async function runOrderReminderLocked(options: RunOrderReminderOptions): Promise<OrderReminderRunResult> {
+  const { db, now, classifyClient, mailTransport, bccEmail, adminBaseUrl } = options;
+  const eligible = await loadEligibleOrders(db);
+  const candidates = eligible.filter((o) => isOldEnough(o.placedAt, now));
+  const codes = candidates.map((c) => c.externalOrderId);
+  const [stateMap, itemLabels] = await Promise.all([loadOrderReminderState(db, codes), loadItemLabels(db, codes)]);
+
+  const noNote: OrderReminderRow[] = [];
+  const noEmail: OrderReminderRow[] = [];
+  const emailed: OrderReminderResolvedRow[] = [];
+  const contacted: OrderReminderResolvedRow[] = [];
+  const pending: OrderReminderPendingRow[] = [];
+  const aiNotConfigured = classifyClient === undefined;
+  const bccMissing = bccEmail === undefined || bccEmail.trim() === "";
+  const mailNotConfigured = mailTransport === undefined;
+  let emailedNow = 0;
+  let contactedNow = 0;
+
+  const resolvedRow = (
+    order: ReminderEligibleOrder,
+    resolution: OrderReminderResolution,
+    resolvedBy: OrderReminderResolvedBy,
+    resolvedAt: Date,
+  ): OrderReminderResolvedRow => ({
+    ...toRow(order, itemLabels, adminBaseUrl, now),
+    resolvedAt: resolvedAt.toISOString(),
+    resolvedBy,
+  });
+
+  for (const order of candidates) {
+    const fp = fingerprint(order);
+    const existing = stateMap.get(order.externalOrderId);
+
+    // Ticket: "objednávka, ktorá už bola vybavená ... sa znovu nespracúva —
+    // appka si len obnoví počet dní." RESOLUTION JE TRVALÉ, VŽDY — nielen
+    // keď sa odtlačok zhoduje. Overené priamo v starej appke's
+    // `run_orders_reminder` (`webreview/app.py:9013`): jej vlastný
+    // `_reminder_is_terminal(prev)` skrat beží PRE has_note/e-mail/AI
+    // kontrolami pre KAŽDÚ objednávku vo `to_process` (teda aj tie, čo
+    // partition_incremental poslalo ďalej práve PRETO, že sa odtlačok
+    // zmenil) — fingerprint tam rozhoduje LEN o tom, či sa vôbec oplatí
+    // prepočítavať zobrazovacie polia (rýchla vs. pomalá cesta), NIKDY o
+    // tom, či sa smie poslať druhý e-mail alebo prehodnotiť AI verdikt.
+    // Bez tohto by zmena poznámky PO odoslaní e-mailu poslala DRUHÝ e-mail
+    // (porušenie ticketovej "presne jeden e-mail, navždy" podmienky).
+    if (existing?.resolution !== undefined && existing.resolution !== null) {
+      const row = resolvedRow(order, existing.resolution, existing.resolvedBy ?? "ai", existing.resolvedAt ?? now);
+      (existing.resolution === "emailed" ? emailed : contacted).push(row);
+      continue;
+    }
+
+    const note = (order.shopRemark ?? "").trim();
+    if (note === "") {
+      // Čistý stavový automat (ticket's oprava starej appky): bez poznámky
+      // = LEN červené upozornenie, e-mail sa NEPOSIELA nikdy z tejto vetvy.
+      noNote.push(toRow(order, itemLabels, adminBaseUrl, now));
+      continue;
+    }
+
+    const email = (order.email ?? "").trim();
+    if (email === "") {
+      // Bez adresy sa pripomienka nikdy nedá poslať — AI sa nepýta (šetrí
+      // peniaze), objednávka nikdy nedosiahne terminálny stav samovoľne.
+      noEmail.push(toRow(order, itemLabels, adminBaseUrl, now));
+      continue;
+    }
+
+    if (aiNotConfigured) {
+      pending.push({ ...toRow(order, itemLabels, adminBaseUrl, now), reason: "AI klasifikácia nedostupná — chýba OPENAI_API_KEY" });
+      continue;
+    }
+    if (bccMissing) {
+      pending.push({
+        ...toRow(order, itemLabels, adminBaseUrl, now),
+        reason: "chýba adresa pre skrytú kópiu majiteľovi (ORDER_REMINDER_BCC_EMAIL)",
+      });
+      continue;
+    }
+    if (mailNotConfigured) {
+      pending.push({ ...toRow(order, itemLabels, adminBaseUrl, now), reason: "odosielanie e-mailov nie je nakonfigurované (chýba MAIL_HOST)" });
+      continue;
+    }
+
+    let isContacted: boolean;
+    try {
+      isContacted = await classifyClient(order.shopRemark);
+    } catch (error) {
+      const rawErrorMessage = error instanceof Error ? error.message : String(error);
+      log.error({ orderCode: order.externalOrderId, rawErrorMessage }, "Pripomienky objednávok: AI klasifikácia zlyhala");
+      pending.push({ ...toRow(order, itemLabels, adminBaseUrl, now), reason: "AI klasifikácia zlyhala — skúsi sa znova nabudúce" });
+      continue;
+    }
+
+    if (isContacted) {
+      await upsertOrderReminderState(db, { orderCode: order.externalOrderId, fingerprint: fp, resolution: "contacted", resolvedBy: "ai", resolvedAt: now }, now);
+      contactedNow += 1;
+      contacted.push(resolvedRow(order, "contacted", "ai", now));
+      continue;
+    }
+
+    const built = buildReminderEmail(order.customerName, order.externalOrderId);
+    try {
+      await mailTransport({ to: email, subject: built.subject, text: built.text, html: built.html, bcc: bccEmail });
+      // Zápis IHNEĎ po odoslaní — pád appky neskôr v behu nesmie stratiť
+      // dôkaz o už odoslanom e-maile (rovnaká disciplína ako #172).
+      await upsertOrderReminderState(db, { orderCode: order.externalOrderId, fingerprint: fp, resolution: "emailed", resolvedBy: "ai", resolvedAt: now }, now);
+      emailedNow += 1;
+      emailed.push(resolvedRow(order, "emailed", "ai", now));
+    } catch (error) {
+      const rawErrorMessage = error instanceof Error ? error.message : String(error);
+      log.error({ orderCode: order.externalOrderId, rawErrorMessage }, "Pripomienky objednávok: odoslanie e-mailu zlyhalo");
+      pending.push({ ...toRow(order, itemLabels, adminBaseUrl, now), reason: "odoslanie e-mailu zlyhalo — skúsi sa znova nabudúce" });
+    }
+  }
+
+  const prunedCount = await pruneOrderReminderState(db, eligible.map((o) => o.externalOrderId));
+  if (prunedCount > 0) {
+    log.info({ prunedCount }, "Pripomienky objednávok: vyčistené záznamy objednávok mimo otvorených stavov");
+  }
+
+  return {
+    checkedAt: now.toISOString(),
+    noNote,
+    noEmail,
+    emailed,
+    contacted,
+    pending,
+    aiNotConfigured,
+    bccMissing,
+    mailNotConfigured,
+    stats: {
+      candidates: candidates.length,
+      noNoteCount: noNote.length,
+      noEmailCount: noEmail.length,
+      emailedNow,
+      contactedNow,
+      pendingCount: pending.length,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Ručný per-riadkový override ("▶ Poslať pripomienku" / "✓ Kontaktované") —
+// rovnaký advisory zámok ako celý beh vyššie (návrhový komentár na issue 173:
+// Postgres serializácia nahrádza starej appky's súborový claim+TTL
+// mechanizmus). Dovolené z akéhokoľvek NEuzavretého stavu (nič, alebo
+// 'contacted' — oprava zlej AI verdiktu), NIKDY z už 'emailed' (žiadny druhý
+// mail).
+
+export type OrderReminderOverrideAction = "contact" | "send";
+
+export type OrderReminderOverrideResult =
+  | { readonly ok: true; readonly resolution: OrderReminderResolution }
+  | { readonly ok: false; readonly code: "not_found" }
+  | { readonly ok: false; readonly code: "already_resolved"; readonly resolution: OrderReminderResolution }
+  | { readonly ok: false; readonly code: "no_email" }
+  | { readonly ok: false; readonly code: "not_configured"; readonly reason: string }
+  | { readonly ok: false; readonly code: "send_failed" };
+
+export interface RunOrderReminderOverrideOptions extends RunOrderReminderOptions {
+  readonly orderCode: string;
+  readonly action: OrderReminderOverrideAction;
+}
+
+export async function runOrderReminderOverride(options: RunOrderReminderOverrideOptions): Promise<OrderReminderOverrideResult> {
+  const { db } = options;
+  const lockClient = await db.$client.connect();
+  try {
+    await lockClient.query("select pg_advisory_lock($1)", [ORDER_REMINDER_RUN_LOCK_KEY]);
+    return await runOrderReminderOverrideLocked(options);
+  } finally {
+    await lockClient.query("select pg_advisory_unlock($1)", [ORDER_REMINDER_RUN_LOCK_KEY]);
+    lockClient.release();
+  }
+}
+
+async function runOrderReminderOverrideLocked(options: RunOrderReminderOverrideOptions): Promise<OrderReminderOverrideResult> {
+  const { db, now, orderCode, action, mailTransport, bccEmail } = options;
+  const eligible = await loadEligibleOrders(db);
+  const order = eligible.find((o) => o.externalOrderId === orderCode);
+  if (order === undefined) return { ok: false, code: "not_found" };
+
+  const existing = await loadOrderReminderStateOne(db, orderCode);
+  if (existing?.resolution === "emailed") {
+    return { ok: false, code: "already_resolved", resolution: "emailed" };
+  }
+  if (action === "contact" && existing?.resolution === "contacted") {
+    return { ok: false, code: "already_resolved", resolution: "contacted" };
+  }
+
+  const fp = fingerprint(order);
+  if (action === "contact") {
+    await upsertOrderReminderState(db, { orderCode, fingerprint: fp, resolution: "contacted", resolvedBy: "manual", resolvedAt: now }, now);
+    log.info({ orderCode }, "Pripomienky objednávok: ručné označenie kontaktované");
+    return { ok: true, resolution: "contacted" };
+  }
+
+  // action === "send" — dovolené aj cez wrongly-'contacted' AI verdikt.
+  const email = (order.email ?? "").trim();
+  if (email === "") return { ok: false, code: "no_email" };
+  const bccMissing = bccEmail === undefined || bccEmail.trim() === "";
+  if (bccMissing) return { ok: false, code: "not_configured", reason: "chýba adresa pre skrytú kópiu majiteľovi (ORDER_REMINDER_BCC_EMAIL)" };
+  if (mailTransport === undefined) return { ok: false, code: "not_configured", reason: "odosielanie e-mailov nie je nakonfigurované (chýba MAIL_HOST)" };
+
+  const built = buildReminderEmail(order.customerName, orderCode);
+  try {
+    await mailTransport({ to: email, subject: built.subject, text: built.text, html: built.html, bcc: bccEmail });
+  } catch (error) {
+    const rawErrorMessage = error instanceof Error ? error.message : String(error);
+    log.error({ orderCode, rawErrorMessage }, "Pripomienky objednávok: ručné odoslanie zlyhalo");
+    return { ok: false, code: "send_failed" };
+  }
+  await upsertOrderReminderState(db, { orderCode, fingerprint: fp, resolution: "emailed", resolvedBy: "manual", resolvedAt: now }, now);
+  log.info({ orderCode }, "Pripomienky objednávok: ručné odoslanie");
+  return { ok: true, resolution: "emailed" };
+}

--- a/apps/api/src/modules/order-reminder/settings.ts
+++ b/apps/api/src/modules/order-reminder/settings.ts
@@ -1,0 +1,28 @@
+import { eq } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { orderReminderSettings } from "../../db/schema.js";
+
+// Singleton riadok (`schema-order-reminder.ts`) — jediný, pevný `id`.
+export const ORDER_REMINDER_SETTINGS_ID = "default";
+
+/** `true` len keď riadok existuje A `enabled = true` — chýbajúci riadok
+ * (stav pred prvou migráciou/testom, ktorý zabudol reseed) sa berie ako
+ * VYPNUTÉ, nikdy ako zapnuté (rovnaká bezpečnostná disciplína ako #172 —
+ * chýbajúci dôkaz nikdy neznamená "pošli mail"). */
+export async function isOrderReminderEnabled(db: Database): Promise<boolean> {
+  const [row] = await db
+    .select({ enabled: orderReminderSettings.enabled })
+    .from(orderReminderSettings)
+    .where(eq(orderReminderSettings.id, ORDER_REMINDER_SETTINGS_ID));
+  return row?.enabled ?? false;
+}
+
+export async function setOrderReminderEnabled(db: Database, enabled: boolean, now: Date): Promise<void> {
+  await db
+    .insert(orderReminderSettings)
+    .values({ id: ORDER_REMINDER_SETTINGS_ID, enabled, updatedAt: now })
+    .onConflictDoUpdate({
+      target: orderReminderSettings.id,
+      set: { enabled, updatedAt: now },
+    });
+}

--- a/apps/api/src/modules/order-reminder/state.ts
+++ b/apps/api/src/modules/order-reminder/state.ts
@@ -1,0 +1,94 @@
+import { inArray, notInArray, sql } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { orderReminderState } from "../../db/schema.js";
+
+export type OrderReminderResolution = "contacted" | "emailed";
+export type OrderReminderResolvedBy = "ai" | "manual";
+
+export interface OrderReminderStateRow {
+  readonly orderCode: string;
+  readonly fingerprint: string;
+  readonly resolution: OrderReminderResolution | null;
+  readonly resolvedBy: OrderReminderResolvedBy | null;
+  readonly resolvedAt: Date | null;
+}
+
+function toResolution(value: string | null): OrderReminderResolution | null {
+  return value === "contacted" || value === "emailed" ? value : null;
+}
+
+function toResolvedBy(value: string | null): OrderReminderResolvedBy | null {
+  return value === "ai" || value === "manual" ? value : null;
+}
+
+/** Stav pre presne tie kódy objednávok, ktoré tento beh potrebuje — chýbajúci
+ * riadok = ešte nikdy neevidovaná objednávka (nevyriešené, žiadny odtlačok). */
+export async function loadOrderReminderState(
+  db: Database,
+  orderCodes: readonly string[],
+): Promise<ReadonlyMap<string, OrderReminderStateRow>> {
+  if (orderCodes.length === 0) return new Map();
+  const rows = await db
+    .select()
+    .from(orderReminderState)
+    .where(inArray(orderReminderState.orderCode, [...orderCodes]));
+  const out = new Map<string, OrderReminderStateRow>();
+  for (const row of rows) {
+    out.set(row.orderCode, {
+      orderCode: row.orderCode,
+      fingerprint: row.fingerprint,
+      resolution: toResolution(row.resolution),
+      resolvedBy: toResolvedBy(row.resolvedBy),
+      resolvedAt: row.resolvedAt,
+    });
+  }
+  return out;
+}
+
+export async function loadOrderReminderStateOne(db: Database, orderCode: string): Promise<OrderReminderStateRow | null> {
+  const map = await loadOrderReminderState(db, [orderCode]);
+  return map.get(orderCode) ?? null;
+}
+
+export interface OrderReminderStateUpsert {
+  readonly orderCode: string;
+  readonly fingerprint: string;
+  readonly resolution: OrderReminderResolution | null;
+  readonly resolvedBy: OrderReminderResolvedBy | null;
+  readonly resolvedAt: Date | null;
+}
+
+export async function upsertOrderReminderState(db: Database, update: OrderReminderStateUpsert, now: Date): Promise<void> {
+  await db
+    .insert(orderReminderState)
+    .values({
+      orderCode: update.orderCode,
+      fingerprint: update.fingerprint,
+      resolution: update.resolution,
+      resolvedBy: update.resolvedBy,
+      resolvedAt: update.resolvedAt,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: orderReminderState.orderCode,
+      set: {
+        fingerprint: sql`excluded.fingerprint`,
+        resolution: sql`excluded.resolution`,
+        resolvedBy: sql`excluded.resolved_by`,
+        resolvedAt: sql`excluded.resolved_at`,
+        updatedAt: sql`excluded.updated_at`,
+      },
+    });
+}
+
+/** Vymaže záznamy stavu pre objednávky, ktoré medzičasom opustili nastavené
+ * otvorené stavy (vybavené/stornované) — `keepOrderCodes` je presne množina
+ * kódov, ktoré TENTO beh považuje za stále eligible (rovnaký zámer ako
+ * #172's `prunePostaUncollectedState`). */
+export async function pruneOrderReminderState(db: Database, keepOrderCodes: readonly string[]): Promise<number> {
+  const result =
+    keepOrderCodes.length === 0
+      ? await db.delete(orderReminderState)
+      : await db.delete(orderReminderState).where(notInArray(orderReminderState.orderCode, [...keepOrderCodes]));
+  return result.rowCount ?? 0;
+}

--- a/apps/api/src/modules/scheduler/jobs.ts
+++ b/apps/api/src/modules/scheduler/jobs.ts
@@ -6,6 +6,8 @@ import { ORDERS_EXPORT_URL_NOT_CONFIGURED, type RunOrdersIngest } from "../order
 import { pruneRawOrders } from "../orders/raw-prune.js";
 import { isPostaUncollectedEnabled } from "../posta-uncollected/settings.js";
 import type { PostaUncollectedRunResult } from "../posta-uncollected/run.js";
+import { isOrderReminderEnabled } from "../order-reminder/settings.js";
+import type { OrderReminderRunResult } from "../order-reminder/run.js";
 import type { OrderNoteWritebackRunResult } from "../shoptet-writeback/run-order-note-writeback.js";
 import type { WritebackRunResult } from "../shoptet-writeback/run-writeback.js";
 import type { ScheduledJob } from "./types.js";
@@ -208,6 +210,38 @@ export function postaUncollectedJob(run: RunPostaUncollected): ScheduledJob {
     schedule: { kind: "daily", hourUtc: 7, minuteUtc: 0 },
     async run(db, now) {
       const enabled = await isPostaUncollectedEnabled(db);
+      if (!enabled) {
+        return { detail: { skipped: true, reason: "automatizácia je vypnutá (Štart/Stop)" } };
+      }
+      const result = await run(db, now);
+      return { detail: result };
+    },
+  };
+}
+
+export const ORDER_REMINDER_JOB_NAME = "order-reminder";
+
+export type RunOrderReminder = (db: Database, now: Date) => Promise<OrderReminderRunResult>;
+
+/**
+ * "Pripomienky objednávok" (issue 173) — denne o 08:00 Europe/Bratislava
+ * (06:00 UTC — CEST v lete/CET v zime posunie skutočný čas behu o hodinu,
+ * rovnaká DST-nevedomá disciplína ako `postaUncollectedJob`/ostatné `daily`
+ * joby vyššie; presnosť na hodinu nie je pre túto úlohu kritická). Rovnaký
+ * vzor ako `postaUncollectedJob`: `run` nie je nikdy `undefined` (číta priamo
+ * z už importovaných objednávok), chýbajúce OPENAI_API_KEY/MAIL_HOST/BCC rieši
+ * `runOrderReminder` SAMA (per-objednávka, viditeľne v `job_run.detail`),
+ * nikdy vyhodením. Tento wrapper kontroluje LEN `enabled` flag PRED behom —
+ * "Spustiť teraz" aj ručné per-riadkové akcie (`http/order-reminder-routes.ts`)
+ * volajú `run`/override PRIAMO, bez tejto kontroly (majiteľov komentár na
+ * tickete + návrhový komentár: manuálna akcia je explicitná ľudská akcia).
+ */
+export function orderReminderJob(run: RunOrderReminder): ScheduledJob {
+  return {
+    name: ORDER_REMINDER_JOB_NAME,
+    schedule: { kind: "daily", hourUtc: 6, minuteUtc: 0 },
+    async run(db, now) {
+      const enabled = await isOrderReminderEnabled(db);
       if (!enabled) {
         return { detail: { skipped: true, reason: "automatizácia je vypnutá (Štart/Stop)" } };
       }

--- a/apps/api/tests/helpers/db.ts
+++ b/apps/api/tests/helpers/db.ts
@@ -1,9 +1,10 @@
 import { sql } from "drizzle-orm";
 import pg from "pg";
 import { createDb, type Database } from "../../src/db/client.js";
-import { orderOpenStatuses, postaUncollectedSettings } from "../../src/db/schema.js";
+import { orderOpenStatuses, orderReminderSettings, postaUncollectedSettings } from "../../src/db/schema.js";
 import { DEFAULT_ORDER_OPEN_STATUS } from "../../src/modules/orders/open-statuses.js";
 import { POSTA_UNCOLLECTED_SETTINGS_ID } from "../../src/modules/posta-uncollected/settings.js";
+import { ORDER_REMINDER_SETTINGS_ID } from "../../src/modules/order-reminder/settings.js";
 
 /**
  * Distinct advisory-lock key for serializing `withCleanDb()` across
@@ -48,9 +49,10 @@ export async function withCleanDb(): Promise<{ db: Database; close: () => Promis
     // either direction (keyed on a free-text status name) — CASCADE never
     // reaches it. "posta_uncollected_settings"/"posta_uncollected_state"
     // (issue 172) are the SAME situation too — no FK in either direction
-    // (singleton id / order-code keyed).
+    // (singleton id / order-code keyed). "order_reminder_settings"/
+    // "order_reminder_state" (issue 173) are the SAME situation again.
     await db.execute(
-      sql`TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state RESTART IDENTITY CASCADE`,
+      sql`TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state RESTART IDENTITY CASCADE`,
     );
     // issue 59: `order_open_status` is a NEW table with real production
     // content (the migration seeds it) — TRUNCATE alone would leave every
@@ -64,6 +66,10 @@ export async function withCleanDb(): Promise<{ db: Database; close: () => Promis
     // (`enabled=false`), so every test must start from that same
     // just-migrated state, not an empty table.
     await db.insert(postaUncollectedSettings).values({ id: POSTA_UNCOLLECTED_SETTINGS_ID, enabled: false });
+    // issue 173: `order_reminder_settings` is the SAME situation as
+    // `posta_uncollected_settings` above — the migration seeds its
+    // singleton row (`enabled=false`).
+    await db.insert(orderReminderSettings).values({ id: ORDER_REMINDER_SETTINGS_ID, enabled: false });
   } catch (err) {
     try {
       await pool.end();

--- a/apps/api/tests/order-reminder-http.integration.test.ts
+++ b/apps/api/tests/order-reminder-http.integration.test.ts
@@ -207,6 +207,37 @@ it("rola citanie NESMIE poslať ručnú akciu (403)", async () => {
   expect(res.status).toBe(403);
 });
 
+it("ručná akcia 'kontaktované' PRESUNIE riadok z 'bez poznámky' do 'preskočené' v NASLEDUJÚCOM GET (bez čakania na ďalší beh)", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await db.insert(orders).values({
+    externalOrderId: "20600106",
+    customerName: "Test Presun",
+    statusName: "Vybavuje sa",
+    placedAt: OLD_ENOUGH,
+    email: null,
+    shopRemark: null,
+  });
+  await app.request("/api/order-reminder/run-now", { method: "POST", headers: { cookie } });
+  const before = await app.request("/api/order-reminder", { headers: { cookie } });
+  const beforeBody = (await before.json()) as { lastRun: { result: { noNote: { orderCode: string }[] } } | null };
+  expect(beforeBody.lastRun?.result.noNote.map((r) => r.orderCode)).toContain("20600106");
+
+  const override = await app.request("/api/order-reminder/override", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ orderCode: "20600106", action: "contact" }),
+  });
+  expect(override.status).toBe(200);
+
+  const after = await app.request("/api/order-reminder", { headers: { cookie } });
+  const afterBody = (await after.json()) as {
+    lastRun: { result: { noNote: { orderCode: string }[]; contacted: { orderCode: string; resolvedBy: string }[] } } | null;
+  };
+  expect(afterBody.lastRun?.result.noNote.map((r) => r.orderCode)).not.toContain("20600106");
+  const relocated = afterBody.lastRun?.result.contacted.find((r) => r.orderCode === "20600106");
+  expect(relocated?.resolvedBy).toBe("manual");
+});
+
 it("ručná akcia na neznámy kód objednávky vráti 200 {ok:false} (bežný doménový výsledok)", async () => {
   const { app, cookie } = await boot("manazer");
   const res = await app.request("/api/order-reminder/override", {

--- a/apps/api/tests/order-reminder-http.integration.test.ts
+++ b/apps/api/tests/order-reminder-http.integration.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, expect, it } from "vitest";
+import { orders, users } from "../src/db/schema.js";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import type { UserRole } from "../src/modules/auth/service.js";
+import type { MailMessage } from "../src/modules/mail/transport.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 173: HTTP vrstva pre "Pripomienky objednávok". Falošný AI
+// klasifikátor + falošný mail transport — NIKDY skutočné OpenAI ani
+// skutočný SMTP (majiteľova bezpečnostná podmienka pre testy).
+const HESLO = "test-heslo-abc";
+const OLD_ENOUGH = new Date("2026-07-25T00:00:00Z");
+
+let close: (() => Promise<void>) | undefined;
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  resetLoginRateLimit();
+});
+
+async function boot(
+  role: UserRole,
+  options: { readonly sent?: MailMessage[]; readonly bccEmail?: string; readonly contacted?: boolean } = {},
+) {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await ctx.db.insert(users).values({
+    email: "pouzivatel@forestshop.sk",
+    passwordHash: await hashPassword(HESLO),
+    displayName: "Test",
+    role,
+  });
+
+  const app = createApp(ctx.db, {
+    cookieSecure: false,
+    orderReminder: {
+      classifyClient: () => Promise.resolve(options.contacted ?? false),
+      mailTransport:
+        options.sent === undefined
+          ? undefined
+          : (m: MailMessage) => {
+              options.sent?.push(m);
+              return Promise.resolve();
+            },
+      bccEmail: options.bccEmail,
+      adminBaseUrl: "https://www.forestshop.sk",
+    },
+  });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "pouzivatel@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie, db: ctx.db };
+}
+
+it("GET bez prihlásenia vráti 401", async () => {
+  const { app } = await boot("manazer");
+  const res = await app.request("/api/order-reminder");
+  expect(res.status).toBe(401);
+});
+
+it("GET vráti enabled=false hneď po migrácii (bezpečný default)", async () => {
+  const { app, cookie } = await boot("citanie");
+  const res = await app.request("/api/order-reminder", { headers: { cookie } });
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { enabled: boolean; lastRun: unknown };
+  expect(body.enabled).toBe(false);
+  expect(body.lastRun).toBeNull();
+});
+
+it("rola citanie NESMIE prepnúť Štart/Stop (403)", async () => {
+  const { app, cookie } = await boot("citanie");
+  const res = await app.request("/api/order-reminder/enabled", {
+    method: "PUT",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ enabled: true }),
+  });
+  expect(res.status).toBe(403);
+});
+
+it("manazer prepne Štart/Stop a GET to hneď odzrkadlí", async () => {
+  const { app, cookie } = await boot("manazer");
+  const put = await app.request("/api/order-reminder/enabled", {
+    method: "PUT",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ enabled: true }),
+  });
+  expect(put.status).toBe(200);
+
+  const res = await app.request("/api/order-reminder", { headers: { cookie } });
+  const body = (await res.json()) as { enabled: boolean };
+  expect(body.enabled).toBe(true);
+});
+
+it("'Spustiť teraz' funguje BEZ ohľadu na enabled=false, ale bez BCC neposlé nič", async () => {
+  const sent: MailMessage[] = [];
+  const { app, cookie, db } = await boot("manazer", { sent });
+  await db.insert(orders).values({
+    externalOrderId: "20600101",
+    customerName: "Test Zákazník",
+    statusName: "Vybavuje sa",
+    placedAt: OLD_ENOUGH,
+    email: "zakaznik@example.sk",
+    shopRemark: "volať zákazníka",
+  });
+
+  const res = await app.request("/api/order-reminder/run-now", { method: "POST", headers: { cookie } });
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { ok: boolean; result: { pending: unknown[] } };
+  expect(body.ok).toBe(true);
+  expect(body.result.pending).toHaveLength(1); // chýba BCC → čaká
+  expect(sent).toHaveLength(0);
+
+  const status = await app.request("/api/order-reminder", { headers: { cookie } });
+  const statusBody = (await status.json()) as { lastRun: { result: { pending: unknown[] } } | null };
+  expect(statusBody.lastRun?.result.pending).toHaveLength(1);
+});
+
+it("s BCC adresou 'Spustiť teraz' pošle e-mail zákazníkovi", async () => {
+  const sent: MailMessage[] = [];
+  const { app, cookie, db } = await boot("manazer", { sent, bccEmail: "majitel@forestshop.sk", contacted: false });
+  await db.insert(orders).values({
+    externalOrderId: "20600102",
+    customerName: "Test",
+    statusName: "Vybavuje sa",
+    placedAt: OLD_ENOUGH,
+    email: "zakaznik@example.sk",
+    shopRemark: "volať zákazníka",
+  });
+
+  await app.request("/api/order-reminder/run-now", { method: "POST", headers: { cookie } });
+  expect(sent).toHaveLength(1);
+  expect(sent[0]?.bcc).toBe("majitel@forestshop.sk");
+});
+
+it("náhľad e-mailu (preview) vráti presne to, čo by odišlo — bez odoslania", async () => {
+  const sent: MailMessage[] = [];
+  const { app, cookie, db } = await boot("manazer", { sent, bccEmail: "majitel@forestshop.sk", contacted: false });
+  await db.insert(orders).values({
+    externalOrderId: "20600103",
+    customerName: "Zákazník Testovací",
+    statusName: "Vybavuje sa",
+    placedAt: OLD_ENOUGH,
+    email: "zakaznik@example.sk",
+    shopRemark: "volať zákazníka",
+  });
+  await app.request("/api/order-reminder/run-now", { method: "POST", headers: { cookie } });
+  expect(sent).toHaveLength(1);
+
+  const preview = await app.request("/api/order-reminder/preview/20600103", { headers: { cookie } });
+  expect(preview.status).toBe(200);
+  const body = (await preview.json()) as { ok: boolean; subject: string; recipient: string };
+  expect(body.ok).toBe(true);
+  expect(body.subject).toContain("Forestshop.sk");
+  expect(body.recipient).toBe("zakaznik@example.sk");
+  expect(sent).toHaveLength(1); // náhľad neposlal ďalší e-mail
+});
+
+it("náhľad neexistujúceho kódu objednávky vráti 200 {ok:false} (bežný doménový výsledok, nikdy 4xx)", async () => {
+  const { app, cookie } = await boot("manazer");
+  const res = await app.request("/api/order-reminder/preview/NEEXISTUJE", { headers: { cookie } });
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { ok: boolean };
+  expect(body.ok).toBe(false);
+});
+
+it("ručná akcia 'kontaktované' (override) funguje aj pri enabled=false", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await db.insert(orders).values({
+    externalOrderId: "20600104",
+    customerName: "Test",
+    statusName: "Vybavuje sa",
+    placedAt: OLD_ENOUGH,
+    email: "zakaznik@example.sk",
+    shopRemark: null,
+  });
+  const res = await app.request("/api/order-reminder/override", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ orderCode: "20600104", action: "contact" }),
+  });
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { ok: boolean; resolution: string };
+  expect(body.ok).toBe(true);
+  expect(body.resolution).toBe("contacted");
+});
+
+it("rola citanie NESMIE poslať ručnú akciu (403)", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  await db.insert(orders).values({
+    externalOrderId: "20600105",
+    customerName: "Test",
+    statusName: "Vybavuje sa",
+    placedAt: OLD_ENOUGH,
+    email: "zakaznik@example.sk",
+    shopRemark: null,
+  });
+  const res = await app.request("/api/order-reminder/override", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ orderCode: "20600105", action: "contact" }),
+  });
+  expect(res.status).toBe(403);
+});
+
+it("ručná akcia na neznámy kód objednávky vráti 200 {ok:false} (bežný doménový výsledok)", async () => {
+  const { app, cookie } = await boot("manazer");
+  const res = await app.request("/api/order-reminder/override", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ orderCode: "NEEXISTUJE", action: "contact" }),
+  });
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { ok: boolean };
+  expect(body.ok).toBe(false);
+});

--- a/apps/api/tests/order-reminder-run.integration.test.ts
+++ b/apps/api/tests/order-reminder-run.integration.test.ts
@@ -1,0 +1,357 @@
+import { eq } from "drizzle-orm";
+import pg from "pg";
+import { afterEach, expect, it } from "vitest";
+import { orderReminderState, orders } from "../src/db/schema.js";
+import type { ClassifyClient } from "../src/modules/order-reminder/classify-client.js";
+import type { MailMessage } from "../src/modules/mail/transport.js";
+import { ORDER_REMINDER_RUN_LOCK_KEY } from "../src/modules/order-reminder/constants.js";
+import { runOrderReminder, runOrderReminderOverride } from "../src/modules/order-reminder/run.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 173: koniec-koncov beh — falošný AI klasifikátor (NIKDY skutočné
+// OpenAI) + falošný mail transport (NIKDY skutočný SMTP), presne per
+// majiteľovej bezpečnostnej podmienke pre testy.
+const TODAY = new Date("2026-08-02T10:00:00Z");
+const OLD_ENOUGH = new Date("2026-07-28T10:00:00Z"); // presne 5 dní staré
+const TOO_YOUNG = new Date("2026-07-31T10:00:00Z"); // 2 dni staré
+
+let close: (() => Promise<void>) | undefined;
+let checker: pg.Client | undefined;
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  await checker?.end();
+  checker = undefined;
+});
+
+async function boot() {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  return ctx.db;
+}
+
+async function insertOrder(
+  db: Awaited<ReturnType<typeof boot>>,
+  overrides: Partial<typeof orders.$inferInsert> & { externalOrderId: string },
+): Promise<void> {
+  await db.insert(orders).values({
+    customerName: "Ján Novák",
+    statusName: "Vybavuje sa",
+    placedAt: OLD_ENOUGH,
+    email: "jan@example.sk",
+    shopRemark: null,
+    ...overrides,
+  });
+}
+
+function fakeContactedClassifier(contacted: boolean): { client: ClassifyClient; calls: number[] } {
+  const calls: number[] = [];
+  const client: ClassifyClient = () => {
+    calls.push(1);
+    return Promise.resolve(contacted);
+  };
+  return { client, calls };
+}
+
+const ADMIN_BASE_URL = "https://www.forestshop.sk";
+
+it("objednávka BEZ poznámky sa zobrazí ako 'bez poznámky' — e-mail sa NEPOSIELA nikdy", async () => {
+  const db = await boot();
+  await insertOrder(db, { externalOrderId: "20600001", shopRemark: null });
+  const sent: MailMessage[] = [];
+
+  const result = await runOrderReminder({
+    db,
+    now: TODAY,
+    classifyClient: () => Promise.resolve(false),
+    mailTransport: (m) => {
+      sent.push(m);
+      return Promise.resolve();
+    },
+    bccEmail: "majitel@forestshop.sk",
+    adminBaseUrl: ADMIN_BASE_URL,
+  });
+
+  expect(result.noNote).toHaveLength(1);
+  expect(result.noNote[0]?.orderCode).toBe("20600001");
+  expect(sent).toHaveLength(0);
+  expect(result.contacted).toHaveLength(0);
+  expect(result.emailed).toHaveLength(0);
+});
+
+it("objednávka s poznámkou ale BEZ e-mailu sa zobrazí v 'bez e-mailu' — AI sa vôbec nepýta", async () => {
+  const db = await boot();
+  await insertOrder(db, { externalOrderId: "20600002", shopRemark: "volať zákazníka", email: null });
+  const { client, calls } = fakeContactedClassifier(false);
+
+  const result = await runOrderReminder({
+    db,
+    now: TODAY,
+    classifyClient: client,
+    mailTransport: undefined,
+    bccEmail: "majitel@forestshop.sk",
+    adminBaseUrl: ADMIN_BASE_URL,
+  });
+
+  expect(result.noEmail).toHaveLength(1);
+  expect(calls).toHaveLength(0);
+});
+
+it("mladšia ako 4 dni objednávka sa vôbec nezobrazí (ani ako čakajúca)", async () => {
+  const db = await boot();
+  await insertOrder(db, { externalOrderId: "20600003", shopRemark: "niečo", placedAt: TOO_YOUNG });
+
+  const result = await runOrderReminder({
+    db,
+    now: TODAY,
+    classifyClient: () => Promise.resolve(false),
+    mailTransport: undefined,
+    bccEmail: "majitel@forestshop.sk",
+    adminBaseUrl: ADMIN_BASE_URL,
+  });
+
+  expect(result.stats.candidates).toBe(0);
+});
+
+it("chýbajúci OPENAI_API_KEY (classifyClient undefined) → 'čaká', nikdy nehádaj", async () => {
+  const db = await boot();
+  await insertOrder(db, { externalOrderId: "20600004", shopRemark: "volať zákazníka" });
+
+  const result = await runOrderReminder({
+    db,
+    now: TODAY,
+    classifyClient: undefined,
+    mailTransport: undefined,
+    bccEmail: "majitel@forestshop.sk",
+    adminBaseUrl: ADMIN_BASE_URL,
+  });
+
+  expect(result.aiNotConfigured).toBe(true);
+  expect(result.pending).toHaveLength(1);
+  expect(result.pending[0]?.reason).toContain("OPENAI_API_KEY");
+});
+
+it("chýbajúca BCC adresa → 'čaká', AI sa NEPÝTA (platená operácia sa neminie zbytočne)", async () => {
+  const db = await boot();
+  await insertOrder(db, { externalOrderId: "20600005", shopRemark: "volať zákazníka" });
+  const { client, calls } = fakeContactedClassifier(false);
+
+  const result = await runOrderReminder({
+    db,
+    now: TODAY,
+    classifyClient: client,
+    mailTransport: undefined,
+    bccEmail: undefined,
+    adminBaseUrl: ADMIN_BASE_URL,
+  });
+
+  expect(result.bccMissing).toBe(true);
+  expect(result.pending).toHaveLength(1);
+  expect(calls).toHaveLength(0);
+});
+
+it("AI usúdi 'už kontaktovaný' → žiadny e-mail, trvalý zápis 'contacted'/'ai'", async () => {
+  const db = await boot();
+  await insertOrder(db, { externalOrderId: "20600006", shopRemark: "volané so zákazníkom, počká" });
+  const sent: MailMessage[] = [];
+
+  const result = await runOrderReminder({
+    db,
+    now: TODAY,
+    classifyClient: () => Promise.resolve(true),
+    mailTransport: (m) => {
+      sent.push(m);
+      return Promise.resolve();
+    },
+    bccEmail: "majitel@forestshop.sk",
+    adminBaseUrl: ADMIN_BASE_URL,
+  });
+
+  expect(sent).toHaveLength(0);
+  expect(result.contacted).toHaveLength(1);
+  expect(result.contacted[0]?.resolvedBy).toBe("ai");
+
+  const [state] = await db.select().from(orderReminderState).where(eq(orderReminderState.orderCode, "20600006"));
+  expect(state?.resolution).toBe("contacted");
+  expect(state?.resolvedBy).toBe("ai");
+});
+
+it("AI usúdi 'nekontaktovaný' → pošle presne JEDEN e-mail s BCC majiteľovi, zapíše 'emailed'", async () => {
+  const db = await boot();
+  await insertOrder(db, { externalOrderId: "20600007", shopRemark: "volať zákazníka" });
+  const sent: MailMessage[] = [];
+
+  const deps = {
+    classifyClient: () => Promise.resolve(false),
+    mailTransport: (m: MailMessage) => {
+      sent.push(m);
+      return Promise.resolve();
+    },
+    bccEmail: "majitel@forestshop.sk",
+    adminBaseUrl: ADMIN_BASE_URL,
+  };
+
+  const result = await runOrderReminder({ db, now: TODAY, ...deps });
+  expect(sent).toHaveLength(1);
+  expect(sent[0]?.to).toBe("jan@example.sk");
+  expect(sent[0]?.bcc).toBe("majitel@forestshop.sk");
+  expect(result.emailed).toHaveLength(1);
+  expect(result.emailed[0]?.resolvedBy).toBe("ai");
+
+  // Druhý beh v ten istý deň, NEZMENENÁ objednávka → rýchla cesta, ŽIADEN
+  // druhý e-mail (ticket: presne jeden e-mail, navždy).
+  const second = await runOrderReminder({ db, now: new Date("2026-08-05T10:00:00Z"), ...deps });
+  expect(sent).toHaveLength(1); // stále len jeden
+  expect(second.emailed).toHaveLength(1);
+});
+
+it("ZMENA poznámky po odoslaní e-mailu sa AJ TAK nespracuje druhýkrát (max 1 e-mail navždy)", async () => {
+  const db = await boot();
+  await insertOrder(db, { externalOrderId: "20600008", shopRemark: "volať zákazníka" });
+  const sent: MailMessage[] = [];
+  const deps = {
+    classifyClient: () => Promise.resolve(false),
+    mailTransport: (m: MailMessage) => {
+      sent.push(m);
+      return Promise.resolve();
+    },
+    bccEmail: "majitel@forestshop.sk",
+    adminBaseUrl: ADMIN_BASE_URL,
+  };
+  await runOrderReminder({ db, now: TODAY, ...deps });
+  expect(sent).toHaveLength(1);
+
+  // Zápis do DB sa nemení, len fingerprint by sa zmenil keby sa poznámka
+  // upravila — tu simulujeme zmenenú poznámku BEZ zmeny "emailed" stavu.
+  await db.update(orders).set({ shopRemark: "úplne iná poznámka" }).where(eq(orders.externalOrderId, "20600008"));
+  await runOrderReminder({ db, now: new Date("2026-08-06T10:00:00Z"), ...deps });
+  // "emailed" je TRVALÉ rozhodnutie — zmena poznámky po odoslaní nič
+  // nespustí znova (na rozdiel od "contacted", ktoré sa PRED odoslaním
+  // môže prehodnotiť).
+  expect(sent).toHaveLength(1);
+});
+
+it("ručná akcia 'kontaktované' na 'bez poznámky' riadku — trvalé, žiadny e-mail", async () => {
+  const db = await boot();
+  await insertOrder(db, { externalOrderId: "20600009", shopRemark: null });
+
+  const result = await runOrderReminderOverride({
+    db,
+    now: TODAY,
+    orderCode: "20600009",
+    action: "contact",
+    classifyClient: undefined,
+    mailTransport: undefined,
+    bccEmail: undefined,
+    adminBaseUrl: ADMIN_BASE_URL,
+  });
+
+  expect(result).toEqual({ ok: true, resolution: "contacted" });
+  const [state] = await db.select().from(orderReminderState).where(eq(orderReminderState.orderCode, "20600009"));
+  expect(state?.resolvedBy).toBe("manual"); // NIKDY pripísané AI (ticketova poučka)
+});
+
+it("ručná akcia 'poslať pripomienku' na 'bez poznámky' riadku (override) — pošle a zapíše 'manual'", async () => {
+  const db = await boot();
+  await insertOrder(db, { externalOrderId: "20600010", shopRemark: null });
+  const sent: MailMessage[] = [];
+
+  const result = await runOrderReminderOverride({
+    db,
+    now: TODAY,
+    orderCode: "20600010",
+    action: "send",
+    classifyClient: undefined,
+    mailTransport: (m) => {
+      sent.push(m);
+      return Promise.resolve();
+    },
+    bccEmail: "majitel@forestshop.sk",
+    adminBaseUrl: ADMIN_BASE_URL,
+  });
+
+  expect(result).toEqual({ ok: true, resolution: "emailed" });
+  expect(sent).toHaveLength(1);
+  expect(sent[0]?.bcc).toBe("majitel@forestshop.sk");
+});
+
+it("ručné 'poslať' na UŽ odoslanú objednávku je odmietnuté — žiadny druhý mail", async () => {
+  const db = await boot();
+  await insertOrder(db, { externalOrderId: "20600011", shopRemark: "volať zákazníka" });
+  const sent: MailMessage[] = [];
+  const deps = {
+    classifyClient: () => Promise.resolve(false),
+    mailTransport: (m: MailMessage) => {
+      sent.push(m);
+      return Promise.resolve();
+    },
+    bccEmail: "majitel@forestshop.sk",
+    adminBaseUrl: ADMIN_BASE_URL,
+  };
+  await runOrderReminder({ db, now: TODAY, ...deps });
+  expect(sent).toHaveLength(1);
+
+  const result = await runOrderReminderOverride({ db, now: TODAY, orderCode: "20600011", action: "send", ...deps });
+  expect(result).toEqual({ ok: false, code: "already_resolved", resolution: "emailed" });
+  expect(sent).toHaveLength(1); // stále len jeden
+});
+
+it("objednávka, ktorá opustí otvorené stavy (napr. 'Vybavená'), stráca svoj záznam pri ďalšom behu", async () => {
+  const db = await boot();
+  await insertOrder(db, { externalOrderId: "20600012", shopRemark: "volať zákazníka" });
+  const deps = {
+    classifyClient: () => Promise.resolve(true),
+    mailTransport: () => Promise.resolve(),
+    bccEmail: "majitel@forestshop.sk",
+    adminBaseUrl: ADMIN_BASE_URL,
+  };
+  await runOrderReminder({ db, now: TODAY, ...deps });
+  let [state] = await db.select().from(orderReminderState).where(eq(orderReminderState.orderCode, "20600012"));
+  expect(state).toBeDefined();
+
+  await db.update(orders).set({ statusName: "Vybavená" }).where(eq(orders.externalOrderId, "20600012"));
+  await runOrderReminder({ db, now: new Date("2026-08-06T10:00:00Z"), ...deps });
+  [state] = await db.select().from(orderReminderState).where(eq(orderReminderState.orderCode, "20600012"));
+  expect(state).toBeUndefined();
+});
+
+// Rovnaká deterministická technika ako `posta-uncollected-run.integration.test.ts`
+// (`pg_try_advisory_lock` z DRUHÉHO pripojenia, nikdy časovanie).
+it("dva súbežné behy sa serializujú (advisory zámok), nikdy neprebehnú naraz", async () => {
+  const db = await boot();
+  await insertOrder(db, { externalOrderId: "20600013", shopRemark: "volať zákazníka" });
+
+  let releaseClassify: (() => void) | undefined;
+  const blockedUntilReleased = new Promise<void>((resolve) => {
+    releaseClassify = resolve;
+  });
+  const classifyClient: ClassifyClient = async () => {
+    await blockedUntilReleased;
+    return false;
+  };
+
+  const runPromise = runOrderReminder({
+    db,
+    now: TODAY,
+    classifyClient,
+    mailTransport: () => Promise.resolve(),
+    bccEmail: "majitel@forestshop.sk",
+    adminBaseUrl: ADMIN_BASE_URL,
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  const databaseUrl = process.env["DATABASE_URL"];
+  if (databaseUrl === undefined || databaseUrl === "") throw new Error("DATABASE_URL chýba");
+  checker = new pg.Client({ connectionString: databaseUrl });
+  await checker.connect();
+  const midRun = await checker.query<{ pg_try_advisory_lock: boolean }>("select pg_try_advisory_lock($1)", [ORDER_REMINDER_RUN_LOCK_KEY]);
+  expect(midRun.rows[0]?.pg_try_advisory_lock).toBe(false);
+
+  releaseClassify?.();
+  await runPromise;
+
+  const afterRun = await checker.query<{ pg_try_advisory_lock: boolean }>("select pg_try_advisory_lock($1)", [ORDER_REMINDER_RUN_LOCK_KEY]);
+  expect(afterRun.rows[0]?.pg_try_advisory_lock).toBe(true);
+  await checker.query("select pg_advisory_unlock($1)", [ORDER_REMINDER_RUN_LOCK_KEY]);
+});

--- a/apps/web/src/components/OrderReminderRow.tsx
+++ b/apps/web/src/components/OrderReminderRow.tsx
@@ -1,0 +1,141 @@
+import type { JSX } from "react";
+import type { OrderReminderPendingRow, OrderReminderResolvedRow, OrderReminderRow } from "../orderReminderApi.js";
+
+// Vydelené z `OrderReminderSection.tsx` (issue 173) — rovnaký vzor ako
+// `PostaUncollectedRow.tsx`/`OrderLineRow.tsx` (`.claude/rules/
+// frontend-design.md`): opakovaná per-riadková JSX jednotka sa vyčleňuje
+// ako prvá, keď súbor rastie.
+
+function AdminLinkCell({ row }: { readonly row: OrderReminderRow }): JSX.Element {
+  return (
+    <td>
+      <a href={row.adminLink} target="_blank" rel="noreferrer">
+        {row.orderCode}
+      </a>
+    </td>
+  );
+}
+
+/** 🔴 "bez poznámky" — dve ručné tlačidlá (ticket): "▶ Poslať pripomienku"
+ * (pošle hneď, aj keď by automatika nemala) a "✓ Kontaktované" (označí ako
+ * vybavené ručne, bez e-mailu). */
+export function OrderReminderNoteRow({
+  row,
+  busy,
+  onSend,
+  onContact,
+}: {
+  readonly row: OrderReminderRow;
+  readonly busy: boolean;
+  readonly onSend: (orderCode: string) => void;
+  readonly onContact: (orderCode: string) => void;
+}): JSX.Element {
+  return (
+    <tr data-testid={`order-reminder-red-${row.orderCode}`}>
+      <AdminLinkCell row={row} />
+      <td>{row.name}</td>
+      <td>{row.phone !== "" ? row.phone : "—"}</td>
+      <td>{row.email !== "" ? row.email : "—"}</td>
+      <td>{row.itemLabel !== "" ? row.itemLabel : "—"}</td>
+      <td>{row.days}</td>
+      <td>
+        <button
+          type="button"
+          className="btn sm"
+          disabled={busy}
+          data-testid={`order-reminder-send-${row.orderCode}`}
+          onClick={() => {
+            onSend(row.orderCode);
+          }}
+        >
+          ▶ Poslať pripomienku
+        </button>{" "}
+        <button
+          type="button"
+          className="btn sm ghost"
+          disabled={busy}
+          data-testid={`order-reminder-contact-${row.orderCode}`}
+          onClick={() => {
+            onContact(row.orderCode);
+          }}
+        >
+          ✓ Kontaktované
+        </button>
+      </td>
+    </tr>
+  );
+}
+
+/** ✉️ "bez e-mailovej adresy" — bez akcií, treba doplniť adresu v Shoptete. */
+export function OrderReminderNoEmailRow({ row }: { readonly row: OrderReminderRow }): JSX.Element {
+  return (
+    <tr data-testid={`order-reminder-noemail-${row.orderCode}`}>
+      <AdminLinkCell row={row} />
+      <td>{row.name}</td>
+      <td>{row.phone !== "" ? row.phone : "—"}</td>
+      <td>{row.itemLabel !== "" ? row.itemLabel : "—"}</td>
+      <td>{row.days}</td>
+    </tr>
+  );
+}
+
+/** 🟠 "pripomienka už odoslaná" — uzavreté, bez akcie. */
+export function OrderReminderEmailedRow({ row }: { readonly row: OrderReminderResolvedRow }): JSX.Element {
+  return (
+    <tr data-testid={`order-reminder-emailed-${row.orderCode}`}>
+      <AdminLinkCell row={row} />
+      <td>{row.name}</td>
+      <td>{row.email}</td>
+      <td>{row.itemLabel !== "" ? row.itemLabel : "—"}</td>
+      <td>{row.resolvedAt.slice(0, 10)}</td>
+    </tr>
+  );
+}
+
+interface SkippedRowProps {
+  readonly row: OrderReminderResolvedRow | OrderReminderPendingRow;
+  readonly icon: string;
+  readonly reason: string;
+  readonly busy: boolean;
+  readonly onPreview: (orderCode: string) => void;
+  readonly onSend: (orderCode: string) => void;
+}
+
+/** ⚪/✋/⚠️ "preskočené" — AI usúdila kontaktovaný / vybavil ručne človek /
+ * automatika začala ale nedokončila. Každý riadok má náhľad + možnosť
+ * poslať ho ručne (override, presne ako ticket žiada). */
+export function OrderReminderSkippedRow({ row, icon, reason, busy, onPreview, onSend }: SkippedRowProps): JSX.Element {
+  return (
+    <tr data-testid={`order-reminder-skipped-${row.orderCode}`}>
+      <AdminLinkCell row={row} />
+      <td>{row.name}</td>
+      <td>
+        {icon} {reason}
+      </td>
+      <td>{row.days}</td>
+      <td>
+        <button
+          type="button"
+          className="btn sm ghost"
+          data-testid={`order-reminder-preview-${row.orderCode}`}
+          onClick={() => {
+            onPreview(row.orderCode);
+          }}
+        >
+          👁 Náhľad
+        </button>{" "}
+        <button
+          type="button"
+          className="btn sm"
+          disabled={busy || row.email === ""}
+          data-testid={`order-reminder-skipped-send-${row.orderCode}`}
+          onClick={() => {
+            onSend(row.orderCode);
+          }}
+        >
+          ▶ Poslať ručne
+        </button>
+      </td>
+    </tr>
+  );
+}

--- a/apps/web/src/components/OrderReminderSection.test.tsx
+++ b/apps/web/src/components/OrderReminderSection.test.tsx
@@ -1,0 +1,213 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { OrderReminderSection } from "./OrderReminderSection.js";
+
+const {
+  fetchOrderReminderStatus,
+  setOrderReminderEnabled,
+  runOrderReminderNow,
+  overrideOrderReminder,
+  fetchOrderReminderPreview,
+} = vi.hoisted(() => ({
+  fetchOrderReminderStatus: vi.fn(),
+  setOrderReminderEnabled: vi.fn(),
+  runOrderReminderNow: vi.fn(),
+  overrideOrderReminder: vi.fn(),
+  fetchOrderReminderPreview: vi.fn(),
+}));
+
+// `OrderReminderUnauthorizedError` ostáva SKUTOČNÁ trieda (rovnaký dôvod ako
+// `PostaUncollectedSection.test.tsx` — `instanceof` v komponente musí fungovať).
+vi.mock("../orderReminderApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../orderReminderApi.js")>();
+  return { ...actual, fetchOrderReminderStatus, setOrderReminderEnabled, runOrderReminderNow, overrideOrderReminder, fetchOrderReminderPreview };
+});
+
+const { OrderReminderUnauthorizedError } = await import("../orderReminderApi.js");
+
+const NO_NOTE_ROW = {
+  orderCode: "20600001",
+  adminLink: "https://www.forestshop.sk/admin/vyhladavanie/?string=20600001&src=orders",
+  name: "Ján Novák",
+  phone: "+421900000000",
+  email: "jan@example.sk",
+  itemLabel: "Nohavice Hart Wild-T",
+  days: 5,
+};
+
+const RUN_RESULT = {
+  checkedAt: "2026-08-02T06:00:00.000Z",
+  noNote: [NO_NOTE_ROW],
+  noEmail: [],
+  emailed: [],
+  contacted: [],
+  pending: [],
+  aiNotConfigured: false,
+  bccMissing: false,
+  mailNotConfigured: false,
+  stats: { candidates: 1, noNoteCount: 1, noEmailCount: 0, emailedNow: 0, contactedNow: 0, pendingCount: 0 },
+};
+
+const STATUS_WITH_RESULT = {
+  enabled: true,
+  lastRun: {
+    startedAt: "2026-08-02T06:00:00.000Z",
+    finishedAt: "2026-08-02T06:00:05.000Z",
+    status: "success" as const,
+    errorMessage: null,
+    result: RUN_RESULT,
+    skippedReason: null,
+  },
+};
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+it("keď zatiaľ žiadny beh nie je zaznamenaný, zobrazí informačnú vetu s výzvou spustiť", async () => {
+  fetchOrderReminderStatus.mockResolvedValue({ enabled: false, lastRun: null });
+
+  render(<OrderReminderSection role="manazer" onSessionExpired={() => {}} />);
+
+  const prazdny = await screen.findByTestId("order-reminder-empty");
+  expect(prazdny.textContent).toContain("Spustiť teraz");
+  expect(screen.getByTestId("order-reminder-status-pill").textContent).toBe("Zastavené");
+});
+
+it("rola citanie vidí tabuľku, ale NEVIDÍ Štart/Stop ani Spustiť teraz", async () => {
+  fetchOrderReminderStatus.mockResolvedValue(STATUS_WITH_RESULT);
+
+  render(<OrderReminderSection role="citanie" onSessionExpired={() => {}} />);
+
+  await screen.findByTestId(`order-reminder-red-${NO_NOTE_ROW.orderCode}`);
+  expect(screen.queryByTestId("order-reminder-toggle")).toBeNull();
+  expect(screen.queryByTestId("order-reminder-run-now")).toBeNull();
+});
+
+it("manazer vidí Štart/Stop a klik prepne stav", async () => {
+  fetchOrderReminderStatus.mockResolvedValue({ enabled: false, lastRun: null });
+  setOrderReminderEnabled.mockResolvedValue(true);
+
+  render(<OrderReminderSection role="manazer" onSessionExpired={() => {}} />);
+  await screen.findByTestId("order-reminder-toggle");
+
+  fetchOrderReminderStatus.mockResolvedValue({ enabled: true, lastRun: null });
+  fireEvent.click(screen.getByTestId("order-reminder-toggle"));
+
+  await waitFor(() => {
+    expect(setOrderReminderEnabled).toHaveBeenCalledWith(true);
+  });
+  await waitFor(() => {
+    expect(screen.getByTestId("order-reminder-status-pill").textContent).toBe("Beží");
+  });
+});
+
+it("'✓ Kontaktované' na riadku bez poznámky zavolá override s action='contact' a obnoví zoznam", async () => {
+  fetchOrderReminderStatus.mockResolvedValue(STATUS_WITH_RESULT);
+  overrideOrderReminder.mockResolvedValue({ ok: true, resolution: "contacted" });
+
+  render(<OrderReminderSection role="manazer" onSessionExpired={() => {}} />);
+  await screen.findByTestId(`order-reminder-contact-${NO_NOTE_ROW.orderCode}`);
+  fireEvent.click(screen.getByTestId(`order-reminder-contact-${NO_NOTE_ROW.orderCode}`));
+
+  await waitFor(() => {
+    expect(overrideOrderReminder).toHaveBeenCalledWith(NO_NOTE_ROW.orderCode, "contact");
+  });
+});
+
+it("'▶ Poslať pripomienku' na riadku bez poznámky zavolá override s action='send'", async () => {
+  fetchOrderReminderStatus.mockResolvedValue(STATUS_WITH_RESULT);
+  overrideOrderReminder.mockResolvedValue({ ok: true, resolution: "emailed" });
+
+  render(<OrderReminderSection role="manazer" onSessionExpired={() => {}} />);
+  await screen.findByTestId(`order-reminder-send-${NO_NOTE_ROW.orderCode}`);
+  fireEvent.click(screen.getByTestId(`order-reminder-send-${NO_NOTE_ROW.orderCode}`));
+
+  await waitFor(() => {
+    expect(overrideOrderReminder).toHaveBeenCalledWith(NO_NOTE_ROW.orderCode, "send");
+  });
+});
+
+it("zamietnutá ručná akcia (napr. už odoslaná) zobrazí hlášku zo servera", async () => {
+  fetchOrderReminderStatus.mockResolvedValue(STATUS_WITH_RESULT);
+  overrideOrderReminder.mockResolvedValue({ ok: false, error: "Pripomienka už bola odoslaná." });
+
+  render(<OrderReminderSection role="manazer" onSessionExpired={() => {}} />);
+  fireEvent.click(await screen.findByTestId(`order-reminder-send-${NO_NOTE_ROW.orderCode}`));
+
+  const alert = await screen.findByRole("alert");
+  expect(alert.textContent).toContain("už bola odoslaná");
+});
+
+it("chýbajúce OPENAI_API_KEY zobrazí varovný banner", async () => {
+  fetchOrderReminderStatus.mockResolvedValue({
+    ...STATUS_WITH_RESULT,
+    lastRun: { ...STATUS_WITH_RESULT.lastRun, result: { ...RUN_RESULT, aiNotConfigured: true } },
+  });
+
+  render(<OrderReminderSection role="manazer" onSessionExpired={() => {}} />);
+
+  const banner = await screen.findByTestId("order-reminder-ai-not-configured");
+  expect(banner.textContent).toContain("OPENAI_API_KEY");
+});
+
+it("chýbajúca BCC adresa zobrazí varovný banner", async () => {
+  fetchOrderReminderStatus.mockResolvedValue({
+    ...STATUS_WITH_RESULT,
+    lastRun: { ...STATUS_WITH_RESULT.lastRun, result: { ...RUN_RESULT, bccMissing: true } },
+  });
+
+  render(<OrderReminderSection role="manazer" onSessionExpired={() => {}} />);
+
+  const banner = await screen.findByTestId("order-reminder-bcc-missing");
+  expect(banner.textContent).toContain("skrytú kópiu");
+});
+
+it("preskočený riadok (AI kontaktovaný) má náhľad a klik zobrazí presne to, čo by odišlo", async () => {
+  const skippedRow = { ...NO_NOTE_ROW, orderCode: "20600002", resolvedAt: "2026-08-01T09:00:00.000Z", resolvedBy: "ai" as const };
+  fetchOrderReminderStatus.mockResolvedValue({
+    ...STATUS_WITH_RESULT,
+    lastRun: { ...STATUS_WITH_RESULT.lastRun, result: { ...RUN_RESULT, noNote: [], contacted: [skippedRow] } },
+  });
+  fetchOrderReminderPreview.mockResolvedValue({
+    ok: true,
+    subject: "📦 Stav vašej objednávky z Forestshop.sk",
+    html: "<p>ahoj</p>",
+    recipient: "jan@example.sk",
+    name: "Ján Novák",
+    orderCode: "20600002",
+  });
+
+  render(<OrderReminderSection role="manazer" onSessionExpired={() => {}} />);
+  fireEvent.click(await screen.findByTestId(`order-reminder-preview-${skippedRow.orderCode}`));
+
+  const preview = await screen.findByTestId("order-reminder-preview");
+  expect(preview.textContent).toContain("jan@example.sk");
+  expect(runOrderReminderNow).not.toHaveBeenCalled();
+});
+
+it("'Spustiť teraz' zavolá beh a obnoví stav", async () => {
+  fetchOrderReminderStatus.mockResolvedValueOnce({ enabled: true, lastRun: null }).mockResolvedValue(STATUS_WITH_RESULT);
+  runOrderReminderNow.mockResolvedValue(RUN_RESULT);
+
+  render(<OrderReminderSection role="manazer" onSessionExpired={() => {}} />);
+  await screen.findByTestId("order-reminder-run-now");
+  fireEvent.click(screen.getByTestId("order-reminder-run-now"));
+
+  await waitFor(() => {
+    expect(runOrderReminderNow).toHaveBeenCalledTimes(1);
+  });
+  await screen.findByTestId(`order-reminder-red-${NO_NOTE_ROW.orderCode}`);
+});
+
+it("pri 401 zavolá onSessionExpired namiesto zobrazenia všeobecnej chyby", async () => {
+  fetchOrderReminderStatus.mockRejectedValue(new OrderReminderUnauthorizedError());
+  const onSessionExpired = vi.fn();
+
+  render(<OrderReminderSection role="manazer" onSessionExpired={onSessionExpired} />);
+
+  await waitFor(() => {
+    expect(onSessionExpired).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/OrderReminderSection.tsx
+++ b/apps/web/src/components/OrderReminderSection.tsx
@@ -1,0 +1,341 @@
+import { useCallback, useEffect, useState, type JSX } from "react";
+import type { Me } from "../api.js";
+import {
+  fetchOrderReminderPreview,
+  fetchOrderReminderStatus,
+  overrideOrderReminder,
+  OrderReminderUnauthorizedError,
+  runOrderReminderNow,
+  setOrderReminderEnabled,
+  type OrderReminderPreview,
+  type OrderReminderStatus,
+} from "../orderReminderApi.js";
+import { OrderReminderEmailedRow, OrderReminderNoEmailRow, OrderReminderNoteRow, OrderReminderSkippedRow } from "./OrderReminderRow.js";
+
+// Rovnaké dve role, ktoré server vyžaduje pre Štart/Stop + ručné akcie
+// (`requireRole("admin", "manazer")`, `order-reminder-routes.ts`) — čítanie
+// (tabuľky) smie vidieť KAŽDÝ prihlásený zamestnanec, rovnaká úroveň ako #172.
+const CONTROL_ROLES: ReadonlySet<Me["role"]> = new Set(["admin", "manazer"]);
+
+export function OrderReminderSection({
+  role,
+  onSessionExpired,
+}: {
+  readonly role: Me["role"];
+  readonly onSessionExpired: () => void;
+}): JSX.Element {
+  const [status, setStatus] = useState<OrderReminderStatus | null>(null);
+  const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState("");
+  const [toggleBusy, setToggleBusy] = useState(false);
+  const [runBusy, setRunBusy] = useState(false);
+  const [runNotice, setRunNotice] = useState("");
+  const [busyOrderCode, setBusyOrderCode] = useState("");
+  const [actionError, setActionError] = useState("");
+  const [preview, setPreview] = useState<OrderReminderPreview | null>(null);
+  const [previewError, setPreviewError] = useState("");
+  const canControl = CONTROL_ROLES.has(role);
+
+  const load = useCallback(() => {
+    fetchOrderReminderStatus()
+      .then((s) => {
+        setStatus(s);
+        setLoaded(true);
+      })
+      .catch((err: unknown) => {
+        setLoaded(true);
+        if (err instanceof OrderReminderUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setError("Pripomienky objednávok sa nepodarilo načítať.");
+      });
+  }, [onSessionExpired]);
+
+  useEffect(load, [load]);
+
+  const toggle = useCallback(() => {
+    if (status === null) return;
+    setToggleBusy(true);
+    setOrderReminderEnabled(!status.enabled)
+      .then(load)
+      .catch((err: unknown) => {
+        if (err instanceof OrderReminderUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setError(err instanceof Error ? err.message : "Zmena sa nepodarila.");
+      })
+      .finally(() => {
+        setToggleBusy(false);
+      });
+  }, [status, load, onSessionExpired]);
+
+  const runNow = useCallback(() => {
+    setRunBusy(true);
+    setRunNotice("");
+    runOrderReminderNow()
+      .then((result) => {
+        setRunNotice(
+          `Skontrolovaných ${String(result.stats.candidates)}, e-mailov odoslaných ${String(result.stats.emailedNow)}, kontaktovaných (AI) ${String(result.stats.contactedNow)}.`,
+        );
+        load();
+      })
+      .catch((err: unknown) => {
+        if (err instanceof OrderReminderUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setRunNotice(err instanceof Error ? err.message : "Beh zlyhal.");
+      })
+      .finally(() => {
+        setRunBusy(false);
+      });
+  }, [load, onSessionExpired]);
+
+  const runAction = useCallback(
+    (orderCode: string, action: "contact" | "send") => {
+      setActionError("");
+      setBusyOrderCode(orderCode);
+      overrideOrderReminder(orderCode, action)
+        .then((result) => {
+          if (!result.ok) {
+            setActionError(result.error);
+            return;
+          }
+          load();
+        })
+        .catch((err: unknown) => {
+          if (err instanceof OrderReminderUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setActionError(err instanceof Error ? err.message : "Akcia zlyhala.");
+        })
+        .finally(() => {
+          setBusyOrderCode("");
+        });
+    },
+    [load, onSessionExpired],
+  );
+
+  const openPreview = useCallback(
+    (orderCode: string) => {
+      setPreviewError("");
+      fetchOrderReminderPreview(orderCode)
+        .then(setPreview)
+        .catch((err: unknown) => {
+          if (err instanceof OrderReminderUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setPreviewError(err instanceof Error ? err.message : "Náhľad sa nepodarilo načítať.");
+        });
+    },
+    [onSessionExpired],
+  );
+
+  if (!loaded) return <p>Načítavam…</p>;
+  if (error !== "") return <p role="alert">{error}</p>;
+  if (status === null) return <p role="alert">Pripomienky objednávok sa nepodarili načítať.</p>;
+
+  const result = status.lastRun?.result ?? null;
+
+  return (
+    <section>
+      <h2>Pripomienky objednávok</h2>
+      <div className="autohead">
+        <span className={"pill" + (status.enabled ? "" : " off")} data-testid="order-reminder-status-pill">
+          {status.enabled ? "Beží" : "Zastavené"}
+        </span>
+        {canControl && (
+          <button type="button" className="btn sm" disabled={toggleBusy} onClick={toggle} data-testid="order-reminder-toggle">
+            {status.enabled ? "⏹ Stop" : "▶️ Štart"}
+          </button>
+        )}
+        {canControl && (
+          <button type="button" className="btn sm ghost" disabled={runBusy} onClick={runNow} data-testid="order-reminder-run-now">
+            {runBusy ? "Spúšťam…" : "⚡ Spustiť teraz"}
+          </button>
+        )}
+      </div>
+
+      {status.lastRun !== null && (
+        <p className="order-reminder-last-run">
+          Posledný beh: {new Date(status.lastRun.startedAt).toLocaleString("sk-SK")} —{" "}
+          {status.lastRun.status === "failure" ? "❌ chyba" : status.lastRun.skippedReason !== null ? `⏸ ${status.lastRun.skippedReason}` : "✅ OK"}
+        </p>
+      )}
+      {runNotice !== "" && <p role="status">{runNotice}</p>}
+      {actionError !== "" && <p role="alert">{actionError}</p>}
+
+      {result?.aiNotConfigured === true && (
+        <p role="alert" data-testid="order-reminder-ai-not-configured">
+          ⚠️ AI klasifikácia nie je nakonfigurovaná (chýba OPENAI_API_KEY) — objednávky s poznámkou čakajú.
+        </p>
+      )}
+      {result?.bccMissing === true && (
+        <p role="alert" data-testid="order-reminder-bcc-missing">
+          ⚠️ Chýba adresa pre skrytú kópiu majiteľovi (ORDER_REMINDER_BCC_EMAIL) — automatizácia zatiaľ NEPOSIELA žiadne e-maily zákazníkom.
+        </p>
+      )}
+      {result?.mailNotConfigured === true && (
+        <p role="alert" data-testid="order-reminder-mail-not-configured">
+          ⚠️ Odosielanie e-mailov nie je nakonfigurované (chýba MAIL_HOST).
+        </p>
+      )}
+
+      {result === null && <p data-testid="order-reminder-empty">Zatiaľ žiadny beh — spustite kontrolu tlačidlom „⚡ Spustiť teraz".</p>}
+
+      {result !== null && (
+        <>
+          <h3>🔴 Bez poznámky ({result.noNote.length})</h3>
+          {result.noNote.length === 0 ? (
+            <p data-testid="order-reminder-no-note-empty">Žiadna objednávka bez poznámky.</p>
+          ) : (
+            <table>
+              <thead>
+                <tr>
+                  <th>Objednávka</th>
+                  <th>Zákazník</th>
+                  <th>Telefón</th>
+                  <th>E-mail</th>
+                  <th>Položka</th>
+                  <th>Dní nečinnosti</th>
+                  <th>Akcia</th>
+                </tr>
+              </thead>
+              <tbody>
+                {result.noNote.map((row) => (
+                  <OrderReminderNoteRow
+                    key={row.orderCode}
+                    row={row}
+                    busy={busyOrderCode === row.orderCode}
+                    onSend={(code) => {
+                      runAction(code, "send");
+                    }}
+                    onContact={(code) => {
+                      runAction(code, "contact");
+                    }}
+                  />
+                ))}
+              </tbody>
+            </table>
+          )}
+
+          {result.noEmail.length > 0 && (
+            <div className="card order-reminder-box" data-testid="order-reminder-no-email-box">
+              <h3>✉️ Bez e-mailovej adresy ({result.noEmail.length})</h3>
+              <table>
+                <thead>
+                  <tr>
+                    <th>Objednávka</th>
+                    <th>Zákazník</th>
+                    <th>Telefón</th>
+                    <th>Položka</th>
+                    <th>Dní nečinnosti</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {result.noEmail.map((row) => (
+                    <OrderReminderNoEmailRow key={row.orderCode} row={row} />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          {result.emailed.length > 0 && (
+            <div className="card order-reminder-box" data-testid="order-reminder-emailed-box">
+              <h3>🟠 Pripomienka odoslaná ({result.emailed.length})</h3>
+              <table>
+                <thead>
+                  <tr>
+                    <th>Objednávka</th>
+                    <th>Zákazník</th>
+                    <th>E-mail</th>
+                    <th>Položka</th>
+                    <th>Odoslané</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {result.emailed.map((row) => (
+                    <OrderReminderEmailedRow key={row.orderCode} row={row} />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          {(result.contacted.length > 0 || result.pending.length > 0) && (
+            <div className="card order-reminder-box" data-testid="order-reminder-skipped-box">
+              <h3>Preskočené ({result.contacted.length + result.pending.length})</h3>
+              <table>
+                <thead>
+                  <tr>
+                    <th>Objednávka</th>
+                    <th>Zákazník</th>
+                    <th>Dôvod</th>
+                    <th>Dní nečinnosti</th>
+                    <th>Akcia</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {result.contacted.map((row) => (
+                    <OrderReminderSkippedRow
+                      key={row.orderCode}
+                      row={row}
+                      icon={row.resolvedBy === "manual" ? "✋" : "⚪"}
+                      reason={row.resolvedBy === "manual" ? "vybavil ručne človek" : "AI usúdila, že zákazník je už kontaktovaný"}
+                      busy={busyOrderCode === row.orderCode}
+                      onPreview={openPreview}
+                      onSend={(code) => {
+                        runAction(code, "send");
+                      }}
+                    />
+                  ))}
+                  {result.pending.map((row) => (
+                    <OrderReminderSkippedRow
+                      key={row.orderCode}
+                      row={row}
+                      icon="⚠️"
+                      reason={row.reason}
+                      busy={busyOrderCode === row.orderCode}
+                      onPreview={openPreview}
+                      onSend={(code) => {
+                        runAction(code, "send");
+                      }}
+                    />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </>
+      )}
+
+      {previewError !== "" && <p role="alert">{previewError}</p>}
+      {preview !== null && (
+        <div className="mail-preview order-reminder-preview" data-testid="order-reminder-preview">
+          <h3>Náhľad pripomienkového e-mailu</h3>
+          <p>
+            Komu: {preview.recipient} — Predmet: {preview.subject}
+          </p>
+          {/* `preview.html` je appkou generovaný e-mail (`buildReminderEmail`,
+              `modules/order-reminder/logic.ts`) — meno aj kód objednávky sú tam
+              už HTML-escapované, nikdy surový užívateľský vstup priamo tu. */}
+          <div className="order-reminder-preview-body" dangerouslySetInnerHTML={{ __html: preview.html }} />
+          <button
+            type="button"
+            className="btn sm ghost"
+            onClick={() => {
+              setPreview(null);
+            }}
+          >
+            Zavrieť náhľad
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/nav.test.ts
+++ b/apps/web/src/nav.test.ts
@@ -24,6 +24,7 @@ it("findTab nájde viditeľnú aj skrytú záložku podľa id, neznáme id vrát
   expect(findTab("pairing")?.label).toBe("Kontrola párovania");
   expect(findTab("scheduler")?.label).toBe("Plánovač");
   expect(findTab("posta-uncollected")?.label).toBe("Nevyzdvihnuté zásielky");
+  expect(findTab("order-reminder")?.label).toBe("Pripomienky objednávok");
   expect(findTab("neexistuje")).toBeUndefined();
 });
 

--- a/apps/web/src/nav.ts
+++ b/apps/web/src/nav.ts
@@ -1,6 +1,7 @@
 import type { ComponentType } from "react";
 import type { Me } from "./api.js";
 import { CatalogPage } from "./components/CatalogPage.js";
+import { OrderReminderSection } from "./components/OrderReminderSection.js";
 import { OrdersSection } from "./components/OrdersSection.js";
 import { PairingSection } from "./components/PairingSection.js";
 import { PostaUncollectedSection } from "./components/PostaUncollectedSection.js";
@@ -64,6 +65,10 @@ export const HIDDEN_TABS: Readonly<Record<string, NavTab>> = {
   // ľavom menu len "Sync zo Shoptetu"/"Na objednanie" (issue 57), táto nová
   // obrazovka je preto dostupná len cez `?tab=posta-uncollected`.
   "posta-uncollected": { id: "posta-uncollected", label: "Nevyzdvihnuté zásielky", Component: PostaUncollectedSection },
+  // issue 173: rovnaký vzor ako "posta-uncollected" vyššie — majiteľ zatiaľ
+  // chce v ľavom menu len dve položky (#57), táto obrazovka je preto
+  // dostupná len cez `?tab=order-reminder`.
+  "order-reminder": { id: "order-reminder", label: "Pripomienky objednávok", Component: OrderReminderSection },
 };
 
 export const DEFAULT_TAB_ID: string = NAV[0]?.tabs[0]?.id ?? "sync";

--- a/apps/web/src/orderReminderApi.ts
+++ b/apps/web/src/orderReminderApi.ts
@@ -1,0 +1,142 @@
+import { z } from "zod";
+
+// issue 173: "Pripomienky objednávok" — zrkadlí `OrderReminderRunResult`
+// (`apps/api/src/modules/order-reminder/run.ts`).
+
+const rowSchema = z.object({
+  orderCode: z.string(),
+  adminLink: z.string(),
+  name: z.string(),
+  phone: z.string(),
+  email: z.string(),
+  itemLabel: z.string(),
+  days: z.number(),
+});
+
+const resolvedRowSchema = rowSchema.extend({
+  resolvedAt: z.string(),
+  resolvedBy: z.enum(["ai", "manual"]),
+});
+
+const pendingRowSchema = rowSchema.extend({ reason: z.string() });
+
+const runResultSchema = z.object({
+  checkedAt: z.string(),
+  noNote: z.array(rowSchema),
+  noEmail: z.array(rowSchema),
+  emailed: z.array(resolvedRowSchema),
+  contacted: z.array(resolvedRowSchema),
+  pending: z.array(pendingRowSchema),
+  aiNotConfigured: z.boolean(),
+  bccMissing: z.boolean(),
+  mailNotConfigured: z.boolean(),
+  stats: z.object({
+    candidates: z.number(),
+    noNoteCount: z.number(),
+    noEmailCount: z.number(),
+    emailedNow: z.number(),
+    contactedNow: z.number(),
+    pendingCount: z.number(),
+  }),
+});
+export type OrderReminderRunResult = z.infer<typeof runResultSchema>;
+export type OrderReminderRow = z.infer<typeof rowSchema>;
+export type OrderReminderResolvedRow = z.infer<typeof resolvedRowSchema>;
+export type OrderReminderPendingRow = z.infer<typeof pendingRowSchema>;
+
+const statusSchema = z.object({
+  enabled: z.boolean(),
+  lastRun: z
+    .object({
+      startedAt: z.string(),
+      finishedAt: z.string().nullable(),
+      status: z.enum(["running", "success", "failure"]),
+      errorMessage: z.string().nullable(),
+      result: runResultSchema.nullable(),
+      skippedReason: z.union([z.string(), z.null()]),
+    })
+    .nullable(),
+});
+export type OrderReminderStatus = z.infer<typeof statusSchema>;
+
+const setEnabledResultSchema = z.object({ ok: z.literal(true), enabled: z.boolean() });
+
+const runNowResultSchema = z.union([
+  z.object({ ok: z.literal(true), result: runResultSchema }),
+  z.object({ error: z.string() }),
+]);
+
+const overrideResultSchema = z.union([
+  z.object({ ok: z.literal(true), resolution: z.enum(["contacted", "emailed"]) }),
+  z.object({ ok: z.literal(false), error: z.string() }),
+]);
+export type OrderReminderOverrideResult = z.infer<typeof overrideResultSchema>;
+
+const previewResultSchema = z.union([
+  z.object({ ok: z.literal(true), subject: z.string(), html: z.string(), recipient: z.string(), name: z.string(), orderCode: z.string() }),
+  z.object({ ok: z.literal(false), error: z.string() }),
+]);
+export type OrderReminderPreview = Extract<z.infer<typeof previewResultSchema>, { readonly ok: true }>;
+
+export class OrderReminderUnauthorizedError extends Error {
+  constructor() {
+    super("Neprihlásený");
+  }
+}
+
+const errorBodySchema = z.object({ error: z.string() });
+
+async function serverErrorMessage(response: Response, fallback: string): Promise<string> {
+  try {
+    const parsed = errorBodySchema.safeParse(await response.json());
+    if (parsed.success) return parsed.data.error;
+  } catch {
+    // telo nie je platný JSON — použi všeobecnú hlášku
+  }
+  return fallback;
+}
+
+async function readJson(response: Response, fallback: string): Promise<unknown> {
+  if (response.status === 401) throw new OrderReminderUnauthorizedError();
+  if (!response.ok) throw new Error(await serverErrorMessage(response, fallback));
+  return await response.json();
+}
+
+export async function fetchOrderReminderStatus(): Promise<OrderReminderStatus> {
+  const response = await fetch("/api/order-reminder");
+  return statusSchema.parse(await readJson(response, "Pripomienky objednávok sa nepodarilo načítať"));
+}
+
+export async function setOrderReminderEnabled(enabled: boolean): Promise<boolean> {
+  const response = await fetch("/api/order-reminder/enabled", {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ enabled }),
+  });
+  const parsed = setEnabledResultSchema.parse(await readJson(response, "Zmena sa nepodarila"));
+  return parsed.enabled;
+}
+
+export async function runOrderReminderNow(): Promise<OrderReminderRunResult> {
+  const response = await fetch("/api/order-reminder/run-now", { method: "POST" });
+  const parsed = runNowResultSchema.parse(await readJson(response, "Beh sa nepodarilo spustiť"));
+  if ("error" in parsed) throw new Error(parsed.error);
+  return parsed.result;
+}
+
+export async function overrideOrderReminder(orderCode: string, action: "contact" | "send"): Promise<OrderReminderOverrideResult> {
+  const response = await fetch("/api/order-reminder/override", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ orderCode, action }),
+  });
+  if (response.status === 401) throw new OrderReminderUnauthorizedError();
+  return overrideResultSchema.parse(await response.json());
+}
+
+export async function fetchOrderReminderPreview(orderCode: string): Promise<OrderReminderPreview> {
+  const response = await fetch(`/api/order-reminder/preview/${encodeURIComponent(orderCode)}`);
+  const parsed = previewResultSchema.parse(await readJson(response, "Náhľad sa nepodarilo načítať"));
+  if (!parsed.ok) throw new Error(parsed.error);
+  return parsed;
+}

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -1592,3 +1592,19 @@ tr:last-child td {
   border-radius: var(--fs-radius-sm);
   overflow-x: auto;
 }
+
+/* ---------------- 14. PRIPOMIENKY OBJEDNÁVOK (issue 173) ---------------- */
+.order-reminder-box {
+  margin-top: var(--fs-space-4);
+}
+.order-reminder-last-run {
+  font-size: var(--fs-text-sm);
+  color: var(--fs-ink-muted);
+  margin-top: var(--fs-space-2);
+}
+.order-reminder-preview-body {
+  background: var(--fs-surface);
+  padding: var(--fs-space-3);
+  border-radius: var(--fs-radius-sm);
+  overflow-x: auto;
+}

--- a/apps/web/tests/e2e/order-reminder.spec.ts
+++ b/apps/web/tests/e2e/order-reminder.spec.ts
@@ -1,0 +1,70 @@
+import { expect, test, type ConsoleMessage } from "@playwright/test";
+
+const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
+const E2E_PRIPOMIENKY_EMAIL = "e2e-pripomienky@forestshop.sk"; // musí sa zhodovať s hodnotou v scripts/e2e-setup.ts
+
+// Rovnaká a JEDINÁ povolená výnimka ako v login.spec.ts/catalog.spec.ts/orders.spec.ts/posta-uncollected.spec.ts.
+const jeOcakavane = (m: ConsoleMessage): boolean => m.location().url.includes("/api/me") && m.text().includes("401");
+
+// issue 173: "Pripomienky objednávok" je SKRYTÁ obrazovka (rovnaký vzor ako
+// katalóg/párovanie/plánovač/#172 — majiteľ chce v ľavom menu zatiaľ len
+// "Sync zo Shoptetu"/"Na objednanie", issue 57) — dostupná cez
+// `?tab=order-reminder`.
+//
+// Toto NEKONTAKTUJE skutočné OpenAI ani skutočný SMTP: `playwright.config
+// .ts`'s API `webServer` nenastavuje `OPENAI_API_KEY` ani `MAIL_HOST`, takže
+// `classifyClient`/`mailTransport` sú v tomto behu `undefined` — rovnaká
+// úvaha, akú `orders.md` dáva `sendSupplierOrderMail`u aj #172's tracking
+// klientu. Objednávka "9002" (`scripts/e2e-setup.ts`) je stabilný, nikdy
+// nemenený fixtúrový kandidát BEZ poznámky (a bez e-mailu) v predvolenom
+// otvorenom stave — deterministicky vždy pristane v "🔴 bez poznámky".
+test("Štart/Stop + Spustiť teraz fungujú, red-riadok má obe ručné akcie, konzola je čistá", async ({ page }) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/?tab=order-reminder");
+  await page.getByLabel("E-mail").fill(E2E_PRIPOMIENKY_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await expect(page.getByRole("heading", { name: "Pripomienky objednávok" })).toBeVisible();
+
+  // Nasadené VYPNUTÉ — majiteľova bezpečnostná podmienka.
+  await expect(page.getByTestId("order-reminder-status-pill")).toHaveText("Zastavené");
+  await expect(page.getByTestId("order-reminder-empty")).toBeVisible();
+
+  await page.getByTestId("order-reminder-toggle").click();
+  await expect(page.getByTestId("order-reminder-status-pill")).toHaveText("Beží");
+
+  await page.getByTestId("order-reminder-run-now").click();
+  await expect(page.getByText(/Skontrolovaných/)).toBeVisible();
+
+  // Fixtúrová objednávka 9002 (bez poznámky, bez e-mailu) sa objaví v
+  // červenej tabuľke, s OBOMA ručnými tlačidlami.
+  const redRiadok = page.getByTestId("order-reminder-red-9002");
+  await expect(redRiadok).toBeVisible();
+  await expect(redRiadok.getByTestId("order-reminder-send-9002")).toBeVisible();
+  await expect(redRiadok.getByTestId("order-reminder-contact-9002")).toBeVisible();
+
+  // "✓ Kontaktované" ju vybaví ručne, bez e-mailu — zmizne z červenej
+  // tabuľky, nikdy neposlala žiadny e-mail (žiadny MAIL_HOST v tomto behu,
+  // takže akýkoľvek pokus o odoslanie by aj tak zlyhal 502/`ok:false`).
+  await redRiadok.getByTestId("order-reminder-contact-9002").click();
+  await expect(page.getByTestId("order-reminder-red-9002")).toHaveCount(0);
+  await expect(page.getByTestId("order-reminder-skipped-9002")).toBeVisible();
+  await expect(page.getByTestId("order-reminder-skipped-9002")).toContainText("vybavil ručne človek");
+
+  // Vypnúť Štart/Stop znova — musí fungovať OBOMA smermi.
+  await page.getByTestId("order-reminder-toggle").click();
+  await expect(page.getByTestId("order-reminder-status-pill")).toHaveText("Zastavené");
+
+  await page.reload();
+  await expect(page.getByRole("heading", { name: "Pripomienky objednávok" })).toBeVisible();
+  await expect(page.getByTestId("order-reminder-status-pill")).toHaveText("Zastavené");
+
+  expect(chyby).toEqual([]);
+});

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -96,6 +96,16 @@ services:
       # (fail-closed, ticket's jediná bezpečnostná podmienka) — appka beží
       # ďalej, len viditeľne to nahlási na obrazovke.
       POSTA_UNCOLLECTED_BCC_EMAIL:
+      # issue 173: "Pripomienky objednávok" — OpenAI klasifikátor internej
+      # poznámky predajne. Rovnaká úvaha ako MAIL_HOST vyššie (`.optional()`
+      # v env.ts, bare kľúč). Chýbajúci = objednávky s poznámkou zostanú
+      # "čaká" (AI nedostupné), appka beží ďalej, nikdy nehádaj/nepošli naslepo.
+      OPENAI_API_KEY:
+      # issue 173: skrytá kópia (BCC) majiteľovi — NEZÁVISLÁ, vyhradená
+      # premenná (rovnaký dôvod ako POSTA_UNCOLLECTED_BCC_EMAIL vyššie).
+      # Chýbajúca = automatizácia NEPOŠLE ani jeden e-mail zákazníkovi
+      # (fail-closed, majiteľova jediná bezpečnostná podmienka).
+      ORDER_REMINDER_BCC_EMAIL:
     volumes:
       - catalog-raw:/data/catalog-raw
       - orders-raw:/data/orders-raw

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.104",
+  "version": "0.3.0-dev.105",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -135,6 +135,11 @@ const E2E_SKRYTY_EDITOR_EMAIL = "e2e-skryty-editor@forestshop.sk"; // musí sa z
 // dostáva VLASTNÝ izolovaný účet namiesto ďalšieho prihlásenia pod zdieľaným.
 const E2E_POSTA_EMAIL = "e2e-posta@forestshop.sk"; // musí sa zhodovať s hodnotou v posta-uncollected.spec.ts
 
+// issue 173: rovnaký mechanizmus a dôvod ako `E2E_POSTA_EMAIL` vyššie —
+// nový spec súbor (`order-reminder.spec.ts`) dostáva VLASTNÝ izolovaný účet
+// namiesto ďalšieho prihlásenia pod zdieľaným `e2e@forestshop.sk`.
+const E2E_PRIPOMIENKY_EMAIL = "e2e-pripomienky@forestshop.sk"; // musí sa zhodovať s hodnotou v order-reminder.spec.ts
+
 const { db, pool } = createDb();
 // Konštantný literál bez interpolácie — obyčajný reťazec je tu rovnako bezpečný
 // ako `sql` tagovaná šablóna (tú používa ekvivalentný apps/api/tests/helpers/db.ts),
@@ -261,6 +266,12 @@ await db.insert(users).values({
 });
 await db.insert(users).values({
   email: E2E_POSTA_EMAIL,
+  passwordHash: await hashPassword(E2E_HESLO),
+  displayName: "E2E Manažér",
+  role: "manazer",
+});
+await db.insert(users).values({
+  email: E2E_PRIPOMIENKY_EMAIL,
   passwordHash: await hashPassword(E2E_HESLO),
   displayName: "E2E Manažér",
   role: "manazer",

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -9,13 +9,14 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { createDb } from "../apps/api/src/db/client.js";
-import { jobRuns, orderLines, orderOpenStatuses, orders, pairings, postaUncollectedSettings, users } from "../apps/api/src/db/schema.js";
+import { jobRuns, orderLines, orderOpenStatuses, orderReminderSettings, orders, pairings, postaUncollectedSettings, users } from "../apps/api/src/db/schema.js";
 import { CATALOG_IMPORT_JOB_NAME } from "../apps/api/src/modules/scheduler/jobs.js";
 import { hashPassword } from "../apps/api/src/modules/auth/passwords.js";
 import { ingestCatalog } from "../apps/api/src/modules/catalog/ingest.js";
 import { DEFAULT_SNAPSHOT_LIMITS } from "../apps/api/src/modules/catalog/validation.js";
 import { DEFAULT_ORDER_OPEN_STATUS } from "../apps/api/src/modules/orders/open-statuses.js";
 import { POSTA_UNCOLLECTED_SETTINGS_ID } from "../apps/api/src/modules/posta-uncollected/settings.js";
+import { ORDER_REMINDER_SETTINGS_ID } from "../apps/api/src/modules/order-reminder/settings.js";
 
 const E2E_HESLO = "e2e-test-heslo"; // musí sa zhodovať s hodnotou v login.spec.ts/catalog.spec.ts/orders.spec.ts
 
@@ -156,9 +157,10 @@ const { db, pool } = createDb();
 // "supplier" vyššie v komentári tesne pod TRUNCATE — kľúčovaný voľným
 // textom stavu, žiadny FK, CASCADE ho nikdy nestrhne. "posta_uncollected_
 // settings"/"posta_uncollected_state" (issue 172) sú rovnaký prípad —
-// singleton id / kód objednávky, žiadny FK.
+// singleton id / kód objednávky, žiadny FK. "order_reminder_settings"/
+// "order_reminder_state" (issue 173) sú rovnaký prípad znova.
 await db.execute(
-  'TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state RESTART IDENTITY CASCADE',
+  'TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state RESTART IDENTITY CASCADE',
 );
 // Rovnaký dôvod ako `tests/helpers/db.ts`: bez tohto by "Na objednanie" bolo
 // v CELOM e2e behu prázdne pre KAŽDÚ objednávku (žiadny nastavený otvorený
@@ -167,6 +169,9 @@ await db.insert(orderOpenStatuses).values({ statusName: DEFAULT_ORDER_OPEN_STATU
 // issue 172: rovnaký dôvod — migrácia seeduje `posta_uncollected_settings`'s
 // singleton riadok (`enabled=false`), reseedovať ho treba aj tu.
 await db.insert(postaUncollectedSettings).values({ id: POSTA_UNCOLLECTED_SETTINGS_ID, enabled: false });
+// issue 173: rovnaký dôvod — migrácia seeduje `order_reminder_settings`'s
+// singleton riadok (`enabled=false`), reseedovať ho treba aj tu.
+await db.insert(orderReminderSettings).values({ id: ORDER_REMINDER_SETTINGS_ID, enabled: false });
 await db.insert(users).values({
   email: "e2e@forestshop.sk",
   passwordHash: await hashPassword(E2E_HESLO),


### PR DESCRIPTION
## Súhrn

Implementácia "Pripomienky objednávok" (issue 173) — automatizácia zo starej
appky, popísaná v tickete a schválená majiteľom na implementáciu (komentár
"vsetky tri veci"). Sleduje objednávky vo "vybavuje sa" stave staršie ako
4 dni: bez internej poznámky predajne ukáže len červené upozornenie v
appke; s poznámkou ju AI (OpenAI) klasifikuje ako kontaktovanú/nekontaktovanú
a v druhom prípade pošle presne JEDEN pripomienkový e-mail zákazníkovi
(vždy so skrytou kópiou majiteľovi).

Rovnaký architektonický vzor ako issue 172 (Nevyzdvihnuté zásielky):
Štart/Stop singleton nastavenie, per-objednávka stav v Postgrese,
`job_run.detail` ako zdroj pravdy pre zobrazenie, fail-closed BCC/AI/mail
kontroly, Postgres advisory zámok namiesto starej appky's súborového
claim+TTL mechanizmu (podrobný návrh v komentároch na issue 173).

## Bezpečnostná podmienka (majiteľ, non-negotiable)

Nasadené **VYPNUTÉ** (`enabled=false`, migrácia to seeduje) — žiadny
e-mail zákazníkovi, kým majiteľ sám automatizáciu nezapne. BCC majiteľovi
je fail-closed (chýbajúca `ORDER_REMINDER_BCC_EMAIL` = nulové odoslanie).
Testy nikdy nekontaktujú skutočné OpenAI ani skutočný SMTP.

## Čo je nové

- `order_reminder_settings`/`order_reminder_state` (migrácia 0022)
- `apps/api/src/modules/order-reminder/*` — logika, AI klasifikátor
  (injektovaný, `OPENAI_API_KEY`), beh, stav, zdroj objednávok
- `apps/api/src/http/order-reminder-routes.ts` — GET stav, PUT Štart/Stop,
  POST Spustiť teraz, POST ručná akcia (kontaktované/poslať), GET náhľad
- `orderReminderJob` — denne o 08:00 Europe/Bratislava
- `apps/web/src/components/OrderReminder{Section,Row}.tsx` — nová skrytá
  záložka `?tab=order-reminder` (majiteľ zatiaľ chce v menu len dve
  položky, #57), vlastný dizajn podľa `app.css` tokenov (NIE vzhľad starej
  appky, `.claude/rules/frontend-design.md`)
- Nové env premenné (nepovinné): `OPENAI_API_KEY`, `ORDER_REMINDER_BCC_EMAIL`

## Testy

- 16 unit testov (`logic.test.ts`) — čistá logika, žiadna DB/sieť
- 13 integračných testov behu (`order-reminder-run.integration.test.ts`) —
  vrátane advisory-zámkovej serializácie (deterministicky) a regresie na
  "žiadny druhý e-mail po zmene poznámky"
- 11 integračných HTTP testov + 1 web-komponentový balík (11 testov) + 1
  nový e2e test (`order-reminder.spec.ts`)
- `pnpm test` / `pnpm test:integration` / `pnpm --filter @forestshop/web e2e`
  — všetko zelené lokálne, `pnpm lint`/`pnpm typecheck` čisté

## Poznámka k mergu (dôležité — nepridané zámerne)

Toto PR **zámerne NEOBSAHUJE** riadok na automatické zatvorenie tiketu
(`.claude/rules/`'s poučka o predčasnom zatváraní) — ticket 173 má
akceptančnú podmienku overiteľnú AŽ po nasadení (naživo overiť, že
automatizácia je vypnutá a neposiela e-maily). Tiket zatvorím ručne po
post-deploy overení.
