### PR TITLE
Add nedostupne tovary automation (issue 176)

### DIFF
--- a/.claude/rules/order-reminder.md
+++ b/.claude/rules/order-reminder.md
@@ -1,0 +1,56 @@
+---
+paths:
+  - "apps/api/src/modules/order-reminder/**"
+  - "apps/api/src/http/order-reminder-routes.ts"
+  - "apps/web/src/components/OrderReminder*.tsx"
+  - "apps/web/src/orderReminderApi.ts"
+---
+
+# Pripomienky objednávok (issue 173)
+
+- **Terminálne `resolution` (`contacted`/`emailed`) je TRVALÉ VŽDY — nikdy
+  negate-ované fingerprint zmenou.** Ticketov popis ("objednávka, ktorá už
+  bola vybavená a odvtedy sa jej dátum ani poznámka NEZMENILI, sa znovu
+  nespracúva") číta sa ako podmienené ("len keď sa nezmenilo"), ale
+  overenie priamo v starej appke (`parovanie_produktov/webreview/
+  app.py:9013`) ukázalo, že jej `_reminder_is_terminal(prev)` skrat beží
+  PRE has_note/e-mail/AI kontrolami pre KAŽDÚ objednávku vo `to_process`
+  (teda aj tie, čo prišli ĎALEJ práve preto, že sa fingerprint zmenil) —
+  fingerprint tam rozhoduje LEN o tom, či treba prepočítať zobrazovacie
+  polia (rýchla vs. pomalá cesta), NIKDY o tom, či sa smie poslať druhý
+  e-mail. `run.ts` preto gate-uje fast path na `existing?.resolution !=
+  null` SAMOTNÝ (žiadny `fingerprint === fp` v podmienke) — inak by zmena
+  poznámky PO odoslaní e-mailu poslala DRUHÝ e-mail (ticketova "presne
+  jeden e-mail, navždy" podmienka). Regresný test:
+  `order-reminder-run.integration.test.ts`'s "ZMENA poznámky po odoslaní
+  e-mailu sa AJ TAK nespracuje druhýkrát". **Pri KAŽDEJ ďalšej
+  automatizácii, ktorej ticket cituje starú appku's "inkrementálne
+  spracovanie" popis** — over PRIAMO v starej appky's kóde (nie len v
+  ticketovom zhrnutí), či fingerprint/inkrementalita SKUTOČNE gate-uje
+  business rozhodnutie, alebo len zobrazovaciu optimalizáciu.
+- **Ručný per-riadkový override (napr. "✓ Kontaktované"/"▶ Poslať
+  ručne") mení LEN `order_reminder_state`, NIKDY posledný `job_run
+  .detail`** — keďže `GET /api/order-reminder` (a teda celá obrazovka)
+  číta VÝHRADNE z `job_run.detail` (rovnaký vzor ako #172), po úspešnej
+  ručnej akcii by riadok zostal viditeľný v PÔVODNEJ skupine, kým
+  nepríde ĎALŠÍ naplánovaný/manuálny beh — akcia by "zaúčinkovala" v DB,
+  ale nie na obrazovke. Fix: `order-reminder-routes.ts`'s
+  `relocateAfterOverride` — po úspešnom override načíta posledný
+  `job_run` riadok tejto úlohy, vyhľadá pôvodný riadok vo VŠETKÝCH
+  skupinách, vystrihne ho a pridá do správnej cieľovej skupiny (rovnaký
+  zámer ako stará appka's `_relocate`), priamo prepíše `job_run.detail`.
+  **Táto chyba bola chytená VLASTNÝM e2e testom pred pushom, nie
+  neskorším review** — akákoľvek ĎALŠIA automatizácia s rovnakým tvarom
+  (`job_run.detail`-driven zobrazenie + samostatný ručný override
+  endpoint mimo hlavného behu) potrebuje TEN ISTÝ relocate krok, inak
+  bude "funguje v DB, nevidno na obrazovke" bug čakať na objavenie.
+- **Fixtúrová objednávka `"9002"` (`scripts/e2e-setup.ts`) je stabilný
+  kandidát pre ĎALŠIE order-ÚROVŇOVÉ (nie order_line) e2e testy** — má
+  `statusName` vo VÝCHODISKOVOM otvorenom stave, `placedAt` hlboko v
+  minulosti (`2020-01-01`), a NIKDY nemá nastavený `shopRemark`/`email` (ani
+  jeden existujúci test tieto polia nemení, len `order_line.state`/
+  `ordered`). Bezpečný, deterministicky "bez poznámky ∧ bez e-mailu" riadok
+  pre KAŽDÝ budúci order-úrovňový (nie riadkový) e2e test — netreba pridávať
+  novú fixtúrovú objednávku, ak sa dá tento istý stabilný kandidát znovu
+  použiť (ako sa to spravilo tu, namiesto ďalšieho rizikového pridania do
+  zdieľaného zoznamu).

--- a/.claude/rules/scheduler.md
+++ b/.claude/rules/scheduler.md
@@ -50,7 +50,10 @@ paths:
   `787_878_003` (`INGEST_ORDERS_ADVISORY_LOCK_KEY`, `orders/ingest.ts`, #21),
   `787_878_100` (`TEST_DB_ISOLATION_LOCK_KEY`, `tests/helpers/db.ts`),
   `787_878_004` (`POSTA_UNCOLLECTED_RUN_LOCK_KEY`, `posta-uncollected/run.ts`,
-  issue 172 — pozri nižšie).
+  issue 172 — pozri nižšie), `787_878_005` (`ORDER_REMINDER_RUN_LOCK_KEY`,
+  `order-reminder/constants.ts`, issue 173), `787_878_006`
+  (`NEDOSTUPNE_SEND_LOCK_KEY`, `nedostupne/constants.ts`, issue 176 —
+  serializuje jedno odoslanie, tento modul nemá naplánovaný beh).
   `ordersImportJob`/`pruneRawOrdersJob` (#22/#28) nepridali žiadny nový kľúč
   (pozri bod vyššie). `shoptetWritebackJob` (issue 122) tiež žiadny nepridal
   — v tomto tickete niet manuálneho HTTP triggeru na tú istú prácu (na

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,3 +86,4 @@ Per-area rules live in `.claude/rules/<area>.md` with `paths:` frontmatter.
 - HTTP trasy (Hono, poradie registrácie literal-vs-`:param`) → `.claude/rules/http-routes.md`
 - spätný zápis do Shoptetu (F5 — Playwright import, reálne admin cesty, Alpine chromium) → `.claude/rules/shoptet-writeback.md`
 - Nevyzdvihnuté zásielky (Pošta SK — enabled vs. run-now, coalesce, advisory zámok) → `.claude/rules/posta-uncollected.md`
+- Pripomienky objednávok (AI klasifikácia poznámky, terminálna rezolúcia, override→job_run relocate) → `.claude/rules/order-reminder.md`

--- a/apps/api/drizzle/0023_steep_smasher.sql
+++ b/apps/api/drizzle/0023_steep_smasher.sql
@@ -1,0 +1,11 @@
+CREATE TYPE "public"."nedostupne_email_type" AS ENUM('nedostupne', 'alternativa');--> statement-breakpoint
+CREATE TABLE "nedostupne_state" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"order_code" text NOT NULL,
+	"variant_code" text NOT NULL,
+	"email_type" "nedostupne_email_type" NOT NULL,
+	"sent_at" timestamp with time zone NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "product" ADD COLUMN "related_codes" text[];--> statement-breakpoint
+CREATE UNIQUE INDEX "nedostupne_state_order_variant_type_uq" ON "nedostupne_state" USING btree ("order_code","variant_code","email_type");

--- a/apps/api/drizzle/meta/0023_snapshot.json
+++ b/apps/api/drizzle/meta/0023_snapshot.json
@@ -1,0 +1,1829 @@
+{
+  "id": "366b0710-6ef9-4d10-b523-83af8e3c1b55",
+  "prevId": "7fef5cc8-9169-4815-9478-2e55a4d31e10",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "related_codes": {
+          "name": "related_codes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_code": {
+          "name": "external_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_open_status": {
+      "name": "order_open_status",
+      "schema": "",
+      "columns": {
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Vybavuje sa'"
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop_remark": {
+          "name": "shop_remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shoptet_order_id": {
+          "name": "shoptet_order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_updated_at": {
+          "name": "comment_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_synced_at": {
+          "name": "comment_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_carrier_name": {
+          "name": "shipping_carrier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_link_override": {
+      "name": "product_supplier_link_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_link_override_product_key_product_key_fk": {
+          "name": "product_supplier_link_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_link_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_override": {
+      "name": "product_supplier_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_override_product_key_product_key_fk": {
+          "name": "product_supplier_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing": {
+      "name": "pairing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_url": {
+          "name": "supplier_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "pairing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'navrhnute'"
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pairing_state_idx": {
+          "name": "pairing_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_confirmed_by_idx": {
+          "name": "pairing_confirmed_by_idx",
+          "columns": [
+            {
+              "expression": "confirmed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_variant_code_variant_code_fk": {
+          "name": "pairing_variant_code_variant_code_fk",
+          "tableFrom": "pairing",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pairing_confirmed_by_users_id_fk": {
+          "name": "pairing_confirmed_by_users_id_fk",
+          "tableFrom": "pairing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pairing_variant_code_unique": {
+          "name": "pairing_variant_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pairing_confirmation_ck": {
+          "name": "pairing_confirmation_ck",
+          "value": "(\"pairing\".\"state\" = 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)\n        OR (\"pairing\".\"state\" != 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NULL AND \"pairing\".\"confirmed_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier": {
+      "name": "supplier",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wholesale_base_url": {
+          "name": "wholesale_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_key": {
+          "name": "adapter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_settings": {
+      "name": "posta_uncollected_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_state": {
+      "name": "posta_uncollected_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notify_count": {
+          "name": "notify_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_state": {
+          "name": "terminal_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_settings": {
+      "name": "order_reminder_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_state": {
+      "name": "order_reminder_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_state": {
+      "name": "nedostupne_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "nedostupne_email_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nedostupne_state_order_variant_type_uq": {
+          "name": "nedostupne_state_order_variant_type_uq",
+          "columns": [
+            {
+              "expression": "order_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne"
+      ]
+    },
+    "public.pairing_state": {
+      "name": "pairing_state",
+      "schema": "public",
+      "values": [
+        "navrhnute",
+        "potvrdene"
+      ]
+    },
+    "public.nedostupne_email_type": {
+      "name": "nedostupne_email_type",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "alternativa"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1785701651575,
       "tag": "0022_famous_sunspot",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1785705902796,
+      "tag": "0023_steep_smasher",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema-catalog.ts
+++ b/apps/api/src/db/schema-catalog.ts
@@ -97,6 +97,17 @@ export const products = pgTable(
     // (`modules/catalog/supplier-link.ts`), nikdy pri importe — žiadny ďalší
     // odvodený stĺpec, žiadne riziko rozídenia sa algoritmu a uložených dát.
     internalNote: text("internal_note"),
+    // issue 176: kódy NÁHRADNÝCH produktov, export's `relatedProduct`/
+    // `relatedProduct2`..`relatedProduct8` (stará appka's `nedostupne.py`'s
+    // `_RELATED_COLS` — PRVÝ je bare `relatedProduct`, nie `relatedProduct1`).
+    // Vlastnosť PRODUKTU (rovnaká úvaha ako `internalNote` vyššie — na
+    // reálnej fixtúre má KAŽDÁ veľkosť toho istého produktu zhodnú hodnotu),
+    // nie variantu. Každý kód je surový (variant `code` ALEBO `pairCode` —
+    // rieši sa až pri čítaní, `modules/nedostupne/queries.ts`), max 8 prvkov
+    // (`MAX_ALTERNATIVES`, `modules/catalog/map-row.ts`). `null` = žiadny
+    // náhradný tovar priradený (nikdy prázdne pole — rozlišuje "nevieme" od
+    // "explicitne žiadny", rovnaký zámer ako `internalNote`'s `null`).
+    relatedCodes: text("related_codes").array(),
     firstSeenAt: timestamp("first_seen_at", { withTimezone: true }).notNull(),
     lastSeenAt: timestamp("last_seen_at", { withTimezone: true }).notNull(),
     lastSeenSnapshotId: uuid("last_seen_snapshot_id")

--- a/apps/api/src/db/schema-nedostupne.ts
+++ b/apps/api/src/db/schema-nedostupne.ts
@@ -1,0 +1,29 @@
+import { pgEnum, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+
+// issue 176: "Nedostupné tovary" — dva e-mailové typy (bez náhrady / s
+// návrhom náhrady), rovnaký zámer ako stará appka's `nedostupne.py`'s
+// `EMAIL_TYPES` (`TYPE_UNAVAILABLE`/`TYPE_ALTERNATIVE`).
+export const nedostupneEmailType = pgEnum("nedostupne_email_type", ["nedostupne", "alternativa"]);
+
+// Dedup/odoslané stav — PLAIN-TEXT kľúčovaný (`order_code`/`variant_code`,
+// ŽIADNY FK), rovnaký vzor ako `order_reminder_state`/`posta_uncollected_
+// state` (`.claude/rules/order-reminder.md`). Na rozdiel od tých dvoch NEMÁ
+// tento modul žiadny naplánovaný beh ani `enabled` prepínač — obrazovka je
+// VŽDY živo čítaná priamo z `order_line`/`order` (žiadny `job_run.detail`
+// cache), takže táto tabuľka nesie LEN "čo už bolo odoslané", nikdy
+// zobrazovací stav. Jeden riadok = jeden úspešne odoslaný e-mail pre presne
+// (objednávka, variant, typ) — nikdy sa neprepisuje, nikdy sa nemaže (dôkaz
+// "tento zákazník toto UŽ dostal", navždy).
+export const nedostupneState = pgTable(
+  "nedostupne_state",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    orderCode: text("order_code").notNull(),
+    variantCode: text("variant_code").notNull(),
+    emailType: nedostupneEmailType("email_type").notNull(),
+    sentAt: timestamp("sent_at", { withTimezone: true }).notNull(),
+  },
+  (t) => [
+    uniqueIndex("nedostupne_state_order_variant_type_uq").on(t.orderCode, t.variantCode, t.emailType),
+  ],
+);

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -5,3 +5,4 @@ export * from "./schema-orders.js";
 export * from "./schema-pairing.js";
 export * from "./schema-posta-uncollected.js";
 export * from "./schema-order-reminder.js";
+export * from "./schema-nedostupne.js";

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -71,6 +71,12 @@ const envSchema = z.object({
   // všeobecné `MAIL_BCC`). Chýbajúca = automatizácia NEPOŠLE ani jeden e-mail
   // zákazníkovi (fail-closed, majiteľova jediná bezpečnostná podmienka).
   ORDER_REMINDER_BCC_EMAIL: z.string().email().optional(),
+  // issue 176: "Nedostupné tovary" — skrytá kópia (BCC) majiteľovi, rovnaká
+  // úvaha ako `POSTA_UNCOLLECTED_BCC_EMAIL`/`ORDER_REMINDER_BCC_EMAIL`
+  // vyššie (NEZÁVISLÁ, vyhradená premenná, nikdy zdieľané všeobecné
+  // `MAIL_BCC`). Chýbajúca = automatizácia NEPOŠLE ani jeden e-mail
+  // zákazníkovi (fail-closed).
+  NEDOSTUPNE_BCC_EMAIL: z.string().email().optional(),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/apps/api/src/http/app.ts
+++ b/apps/api/src/http/app.ts
@@ -14,6 +14,7 @@ import { checkLoginRateLimit, clientIp } from "./login-rate-limit.js";
 import { SESSION_COOKIE, requireUser, type AppBindings } from "./middleware.js";
 import { registerOrdersRoutes, type RunOrdersIngest } from "./orders-routes.js";
 import { registerOrderReminderRoutes, type OrderReminderRunDeps } from "./order-reminder-routes.js";
+import { registerNedostupneRoutes, type NedostupneRunDeps } from "./nedostupne-routes.js";
 import { requireSameOrigin } from "./origin-check.js";
 import { registerPairingRoutes } from "./pairing-routes.js";
 import { registerPostaUncollectedRoutes, type PostaUncollectedRunDeps } from "./posta-uncollected-routes.js";
@@ -53,6 +54,10 @@ export function createApp(
     // testy/lokálny vývoj, `index.ts` v produkcii VŽDY nahradí reálnymi
     // dependencies.
     readonly orderReminder?: OrderReminderRunDeps;
+    // issue 176: "Nedostupné tovary" — rovnaký dôvod ako `orderReminder`
+    // vyššie: voliteľné, bezpečný default nižšie pre testy/lokálny vývoj,
+    // `index.ts` v produkcii VŽDY nahradí reálnymi dependencies.
+    readonly nedostupne?: NedostupneRunDeps;
   },
 ): Hono<AppBindings> {
   const app = new Hono<AppBindings>();
@@ -173,6 +178,18 @@ export function createApp(
       // chýba), nikdy neposiela mail (`mailTransport` chýba). Produkcia
       // (`index.ts`) toto VŽDY nahradí reálnymi dependencies.
       classifyClient: undefined,
+      mailTransport: undefined,
+      bccEmail: undefined,
+      adminBaseUrl: options.adminBaseUrl ?? "https://www.forestshop.sk",
+    },
+  );
+  registerNedostupneRoutes(
+    app,
+    db,
+    options.nedostupne ?? {
+      // Bezpečný default pre testy/lokálny vývoj bez explicitne dodaných
+      // dependencies — NIKDY neposiela mail (`mailTransport` chýba).
+      // Produkcia (`index.ts`) toto VŽDY nahradí reálnymi dependencies.
       mailTransport: undefined,
       bccEmail: undefined,
       adminBaseUrl: options.adminBaseUrl ?? "https://www.forestshop.sk",

--- a/apps/api/src/http/nedostupne-routes.ts
+++ b/apps/api/src/http/nedostupne-routes.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import type { Database } from "../db/client.js";
 import { record } from "../modules/audit/service.js";
 import { EMAIL_TYPES } from "../modules/nedostupne/constants.js";
+import { consumePreviewToken, issuePreviewToken } from "../modules/nedostupne/preview-tokens.js";
 import { listNedostupneGroups } from "../modules/nedostupne/queries.js";
 import { buildEmailForType, findNedostupneContext, sendNedostupneEmail } from "../modules/nedostupne/send.js";
 import type { MailTransport } from "../modules/mail/transport.js";
@@ -17,7 +18,12 @@ export interface NedostupneRunDeps {
 }
 
 const previewBody = z.object({ orderCode: z.string().min(1), variantCode: z.string().min(1), emailType: z.enum(EMAIL_TYPES) });
-const sendBody = previewBody;
+// issue 176 (code review pred mergom, PR #182): `/send` musí priniesť token
+// vydaný `/preview` PRE PRESNE tento (orderCode, variantCode, emailType) —
+// server-side vynútenie "náhľad VŽDY predchádza odoslaniu", pozri
+// `preview-tokens.ts`. Bez tohto by priame volanie API (mimo React UI) mohlo
+// poslať e-mail bez toho, aby čokoľvek jeho obsah niekedy zobrazilo.
+const sendBody = previewBody.extend({ previewToken: z.string().min(1) });
 
 function bccMissing(deps: NedostupneRunDeps): boolean {
   return deps.bccEmail === undefined || deps.bccEmail.trim() === "";
@@ -55,9 +61,14 @@ export function registerNedostupneRoutes(app: Hono<AppBindings>, db: Database, d
 
   // Povinný náhľad — POČÍTANÝ ROVNAKOU funkciou (`buildEmailForType`), akú
   // použije skutočné odoslanie nižšie, takže obsluha VŽDY vidí presne to, čo
-  // sa (prípadne) odošle.
+  // sa (prípadne) odošle. `requireSameOrigin()` (code review pred mergom, PR
+  // #182): teraz aj vydáva token (`issuePreviewToken`) — konzistentne s
+  // KAŽDÝM iným POST v tejto appke, hoci reálne riziko je nízke (appka
+  // nikde nekonfiguruje CORS, takže cudzia stránka by aj tak nevedela
+  // prečítať telo odpovede a token z neho vytiahnuť).
   app.post(
     "/api/nedostupne/preview",
+    requireSameOrigin(),
     requireUser(db),
     zValidator("json", previewBody),
     async (c) => {
@@ -69,7 +80,8 @@ export function registerNedostupneRoutes(app: Hono<AppBindings>, db: Database, d
         return c.json({ ok: false as const, error: "Riadok objednávky sa v aktuálnom zozname nenašiel." });
       }
       const built = buildEmailForType(ctx, emailType);
-      return c.json({ ok: true as const, subject: built.subject, html: built.html, recipient: ctx.email, customerName: ctx.customerName });
+      const previewToken = issuePreviewToken(orderCode, variantCode, emailType, new Date());
+      return c.json({ ok: true as const, subject: built.subject, html: built.html, recipient: ctx.email, customerName: ctx.customerName, previewToken });
     },
   );
 
@@ -81,9 +93,15 @@ export function registerNedostupneRoutes(app: Hono<AppBindings>, db: Database, d
     requireRole("admin", "manazer"),
     zValidator("json", sendBody),
     async (c) => {
-      const { orderCode, variantCode, emailType } = c.req.valid("json");
+      const { orderCode, variantCode, emailType, previewToken } = c.req.valid("json");
       const user = c.get("user");
       const now = new Date();
+      // Server-side vynútenie povinného náhľadu (code review pred mergom,
+      // PR #182) — token sa KONZUMUJE (zmaže) hneď, bez ohľadu na výsledok,
+      // takže jeden náhľad = najviac jeden pokus o odoslanie.
+      if (!consumePreviewToken(previewToken, orderCode, variantCode, emailType, now)) {
+        return c.json({ ok: false as const, error: "Najprv si otvorte náhľad e-mailu — bez neho appka nepošle nič." });
+      }
       const result = await sendNedostupneEmail({
         db,
         now,

--- a/apps/api/src/http/nedostupne-routes.ts
+++ b/apps/api/src/http/nedostupne-routes.ts
@@ -1,0 +1,110 @@
+import { zValidator } from "@hono/zod-validator";
+import type { Hono } from "hono";
+import { z } from "zod";
+import type { Database } from "../db/client.js";
+import { record } from "../modules/audit/service.js";
+import { EMAIL_TYPES } from "../modules/nedostupne/constants.js";
+import { listNedostupneGroups } from "../modules/nedostupne/queries.js";
+import { buildEmailForType, findNedostupneContext, sendNedostupneEmail } from "../modules/nedostupne/send.js";
+import type { MailTransport } from "../modules/mail/transport.js";
+import { requireRole, requireUser, type AppBindings } from "./middleware.js";
+import { requireSameOrigin } from "./origin-check.js";
+
+export interface NedostupneRunDeps {
+  readonly mailTransport: MailTransport | undefined;
+  readonly bccEmail: string | undefined;
+  readonly adminBaseUrl: string;
+}
+
+const previewBody = z.object({ orderCode: z.string().min(1), variantCode: z.string().min(1), emailType: z.enum(EMAIL_TYPES) });
+const sendBody = previewBody;
+
+function bccMissing(deps: NedostupneRunDeps): boolean {
+  return deps.bccEmail === undefined || deps.bccEmail.trim() === "";
+}
+
+function mailNotConfigured(deps: NedostupneRunDeps): boolean {
+  return deps.mailTransport === undefined;
+}
+
+function sendErrorMessage(result: Extract<Awaited<ReturnType<typeof sendNedostupneEmail>>, { readonly ok: false }>): string {
+  switch (result.code) {
+    case "not_found":
+      return "Riadok objednávky sa v aktuálnom zozname nenašiel — pravdepodobne sa medzitým zmenil jeho stav.";
+    case "already_sent":
+      return "Tento e-mail už bol tejto objednávke odoslaný.";
+    case "no_email":
+      return "Objednávka nemá e-mailovú adresu.";
+    case "not_configured":
+      return result.reason;
+    case "send_failed":
+      return "Odoslanie e-mailu zlyhalo — skúste to znova.";
+  }
+}
+
+export function registerNedostupneRoutes(app: Hono<AppBindings>, db: Database, deps: NedostupneRunDeps): void {
+  // Čítanie — každý prihlásený zamestnanec (rovnaká úroveň ako #172/#173).
+  app.get("/api/nedostupne", requireUser(db), async (c) => {
+    const groups = await listNedostupneGroups(db, deps.adminBaseUrl);
+    return c.json({
+      groups,
+      bccMissing: bccMissing(deps),
+      mailNotConfigured: mailNotConfigured(deps),
+    });
+  });
+
+  // Povinný náhľad — POČÍTANÝ ROVNAKOU funkciou (`buildEmailForType`), akú
+  // použije skutočné odoslanie nižšie, takže obsluha VŽDY vidí presne to, čo
+  // sa (prípadne) odošle.
+  app.post(
+    "/api/nedostupne/preview",
+    requireUser(db),
+    zValidator("json", previewBody),
+    async (c) => {
+      const { orderCode, variantCode, emailType } = c.req.valid("json");
+      const ctx = await findNedostupneContext(db, orderCode, variantCode);
+      if (ctx === null) {
+        // 200 (nikdy 404) — rovnaká disciplína ako #172/#173's preview
+        // (`.claude/rules/testing.md`'s Chromium console-error pravidlo).
+        return c.json({ ok: false as const, error: "Riadok objednávky sa v aktuálnom zozname nenašiel." });
+      }
+      const built = buildEmailForType(ctx, emailType);
+      return c.json({ ok: true as const, subject: built.subject, html: built.html, recipient: ctx.email, customerName: ctx.customerName });
+    },
+  );
+
+  // Odoslanie — mutuje (dedup zápis), rovnaká rola ako #172/#173.
+  app.post(
+    "/api/nedostupne/send",
+    requireSameOrigin(),
+    requireUser(db),
+    requireRole("admin", "manazer"),
+    zValidator("json", sendBody),
+    async (c) => {
+      const { orderCode, variantCode, emailType } = c.req.valid("json");
+      const user = c.get("user");
+      const now = new Date();
+      const result = await sendNedostupneEmail({
+        db,
+        now,
+        orderCode,
+        variantCode,
+        emailType,
+        mailTransport: deps.mailTransport,
+        bccEmail: deps.bccEmail,
+      });
+      if (!result.ok) {
+        return c.json({ ok: false as const, error: sendErrorMessage(result) });
+      }
+      await record(db, {
+        at: now,
+        actorUserId: user.userId,
+        action: "nedostupne.send",
+        entity: "nedostupne_state",
+        entityId: `${orderCode}|${variantCode}|${emailType}`,
+        data: { orderCode, variantCode, emailType },
+      });
+      return c.json({ ok: true as const });
+    },
+  );
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -171,6 +171,17 @@ const orderReminderDeps = {
   adminBaseUrl: env.SHOPTET_ADMIN_BASE_URL,
 };
 
+// issue 176: "Nedostupné tovary" — rovnaká úvaha ako #172/#173 vyššie: mail
+// transport (zdieľaný `sendSupplierMail`) a BCC adresa môžu chýbať,
+// `sendNedostupneEmail` to sama rieši fail-closed. ŽIADNY `classifyClient`
+// (na rozdiel od #173) — táto automatizácia nemá AI klasifikáciu, e-mail
+// vždy posiela človek ručne po povinnom náhľade.
+const nedostupneDeps = {
+  mailTransport: sendSupplierMail,
+  bccEmail: env.NEDOSTUPNE_BCC_EMAIL,
+  adminBaseUrl: env.SHOPTET_ADMIN_BASE_URL,
+};
+
 const app = createApp(db, {
   cookieSecure: env.SESSION_COOKIE_SECURE,
   ...(runIngest === undefined ? {} : { runIngest }),
@@ -179,6 +190,7 @@ const app = createApp(db, {
   adminBaseUrl: env.SHOPTET_ADMIN_BASE_URL,
   postaUncollected: postaUncollectedDeps,
   orderReminder: orderReminderDeps,
+  nedostupne: nedostupneDeps,
 });
 
 // F2 (#12/#3) + F3 (#22/#28): nočný import katalógu/objednávok, mazanie

--- a/apps/api/src/modules/catalog/ingest.ts
+++ b/apps/api/src/modules/catalog/ingest.ts
@@ -229,15 +229,11 @@ export async function ingestCatalog(
 
   // Beží bez ohľadu na úspech parsovania — pri zlyhaní je `records` prázdne pole,
   // takže je to no-op (nič sa neprepočítava druhýkrát).
-  const productValues = new Map<string, { name: string; supplier: string | null; internalNote: string | null }>();
+  const productValues = new Map<string, { name: string; supplier: string | null; internalNote: string | null; relatedCodes: readonly string[] }>();
   for (const record of records) {
     const known = productValues.get(record.productKey);
     if (known === undefined) {
-      productValues.set(record.productKey, {
-        name: record.name,
-        supplier: record.supplier,
-        internalNote: record.internalNote,
-      });
+      productValues.set(record.productKey, { name: record.name, supplier: record.supplier, internalNote: record.internalNote, relatedCodes: record.relatedCodes });
       continue;
     }
     if (known.name !== record.name) {
@@ -373,6 +369,8 @@ export async function ingestCatalog(
               name: value.name,
               supplier: value.supplier,
               internalNote: value.internalNote,
+              // issue 176: prázdne pole → `null` (rovnaký zámer ako `internalNote`).
+              relatedCodes: value.relatedCodes.length === 0 ? null : [...value.relatedCodes],
               firstSeenAt: options.now,
               lastSeenAt: options.now,
               lastSeenSnapshotId: snapshotId,
@@ -384,6 +382,7 @@ export async function ingestCatalog(
               name: sql`excluded.name`,
               supplier: sql`excluded.supplier`,
               internalNote: sql`excluded.internal_note`,
+              relatedCodes: sql`excluded.related_codes`,
               lastSeenAt: options.now,
               lastSeenSnapshotId: snapshotId,
             },

--- a/apps/api/src/modules/catalog/map-row.test.ts
+++ b/apps/api/src/modules/catalog/map-row.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { parseShoptetCsv } from "./csv.js";
-import { mapRow, splitCode } from "./map-row.js";
+import { extractRelatedCodes, mapRow, splitCode } from "./map-row.js";
 
 const FIXTURE = readFileSync(
   fileURLToPath(new URL("./fixtures/shoptet-sample.csv", import.meta.url)),
@@ -301,5 +301,40 @@ describe("mapRow — číselné hranice stĺpcov (mimo rozsah = anomália, riado
     expect(issues).toEqual([
       { kind: "invalid_stock", code: "TEST/1", detail: { raw: "2147483648" } },
     ]);
+  });
+});
+
+// issue 176: náhradné produkty (`relatedProduct`/`relatedProduct2..8`).
+describe("extractRelatedCodes / relatedCodes na reálnej fixtúre", () => {
+  it("na fixtúre '40287' vráti jeden priradený náhradný kód", () => {
+    const { record } = mapRow(fixtureRow("40287"));
+    expect(record?.relatedCodes).toEqual(["60297"]);
+  });
+
+  it("bez akéhokoľvek priradenia vráti prázdne pole (nikdy null/undefined)", () => {
+    expect(extractRelatedCodes(bareRow())).toEqual([]);
+  });
+
+  it("prvý stĺpec je bare 'relatedProduct' (NIE 'relatedProduct1')", () => {
+    expect(extractRelatedCodes(bareRow({ relatedProduct: "A1" }))).toEqual(["A1"]);
+  });
+
+  it("zbiera VIACERO stĺpcov v poradí exportu, preskakuje prázdne", () => {
+    const row = bareRow({ relatedProduct: "A1", relatedProduct2: "", relatedProduct3: "A3" });
+    expect(extractRelatedCodes(row)).toEqual(["A1", "A3"]);
+  });
+
+  it("orezáva na MAX_ALTERNATIVES (8), aj keby export niesol viac", () => {
+    const row = bareRow({
+      relatedProduct: "1",
+      relatedProduct2: "2",
+      relatedProduct3: "3",
+      relatedProduct4: "4",
+      relatedProduct5: "5",
+      relatedProduct6: "6",
+      relatedProduct7: "7",
+      relatedProduct8: "8",
+    });
+    expect(extractRelatedCodes(row)).toHaveLength(8);
   });
 });

--- a/apps/api/src/modules/catalog/map-row.ts
+++ b/apps/api/src/modules/catalog/map-row.ts
@@ -41,6 +41,10 @@ export interface VariantRecord {
   // ako `supplier` nižšie), NIE `variant` — na reálnom exporte je v rámci
   // jedného produktu vždy rovnaké naprieč všetkými veľkosťami.
   readonly internalNote: string | null;
+  // issue 176: kódy náhradných produktov (`relatedCodes` — pozri `RELATED_
+  // COLUMNS`/`MAX_ALTERNATIVES` nižšie), vlastnosť PRODUKTU rovnako ako
+  // `internalNote` vyššie.
+  readonly relatedCodes: readonly string[];
   readonly currency: string | null;
   readonly price: string | null;
   readonly standardPrice: string | null;
@@ -79,6 +83,28 @@ export function splitCode(code: string): { readonly productKey: string; readonly
 
 function textOrNull(raw: string): string | null {
   return raw === "" ? null : raw;
+}
+
+// issue 176: max. počet náhradných produktov, ktoré appka niekedy zobrazí
+// (stará appka's `nedostupne.py`'s `MAX_ALTERNATIVES` — boss: relatedProduct1..8).
+export const MAX_ALTERNATIVES = 8;
+
+// export's stĺpce s náhradnými produktmi — PRVÝ je bare `relatedProduct`
+// (NIE `relatedProduct1`), potom `relatedProduct2`..`relatedProduct8` (stará
+// appka's `nedostupne.py`'s `_RELATED_COLS`, overené priamo na reálnej
+// fixtúre — export nemá stĺpec `relatedProduct1`).
+export const RELATED_COLUMNS: readonly string[] = ["relatedProduct", ...Array.from({ length: 7 }, (_, i) => `relatedProduct${String(i + 2)}`)];
+
+/** Neprázdne, orezané kódy z `RELATED_COLUMNS`, orezané na `MAX_ALTERNATIVES` —
+ * poradie stĺpcov exportu sa zachováva (rovnaký zámer ako stará appka). */
+export function extractRelatedCodes(row: Readonly<Record<string, string>>): readonly string[] {
+  const codes: string[] = [];
+  for (const col of RELATED_COLUMNS) {
+    const value = (row[col] ?? "").trim();
+    if (value !== "") codes.push(value);
+    if (codes.length >= MAX_ALTERNATIVES) break;
+  }
+  return codes;
 }
 
 // `percent_vat` je `numeric(5, 2)` — najviac 3 číslice pred desatinnou čiarkou
@@ -195,6 +221,7 @@ export function mapRow(row: Readonly<Record<string, string>>): {
       name,
       supplier: textOrNull((row["supplier"] ?? "").trim()),
       internalNote: textOrNull((row["internalNote"] ?? "").trim()),
+      relatedCodes: extractRelatedCodes(row),
       currency,
       price,
       standardPrice,

--- a/apps/api/src/modules/nedostupne/constants.ts
+++ b/apps/api/src/modules/nedostupne/constants.ts
@@ -1,0 +1,22 @@
+// issue 176: "Nedostupné tovary" — konštanty prevzaté zo starej appky
+// (`parovanie_produktov/src/parovanie/nedostupne.py`), preto komentáre na
+// viacerých miestach citujú presne odtiaľ.
+
+export const TYPE_UNAVAILABLE = "nedostupne" as const;
+export const TYPE_ALTERNATIVE = "alternativa" as const;
+export const EMAIL_TYPES = [TYPE_UNAVAILABLE, TYPE_ALTERNATIVE] as const;
+export type NedostupneEmailType = (typeof EMAIL_TYPES)[number];
+
+export const UNAVAILABLE_SUBJECT = "Informácia o dostupnosti vašej objednávky — Forestshop.sk";
+export const ALTERNATIVE_SUBJECT = "Alternatívy k vášmu tovaru — Forestshop.sk";
+
+// Klikateľný fallback na vyhľadávanie podľa kódu — appka nemá žiadny zdroj
+// SKUTOČNEJ Shoptet produktovej URL (overené priamo na exporte: žiadny
+// `url`/`seoUrl` stĺpec), takže sa používa VŽDY (rovnaký fallback ako stará
+// appka's `_resolve_alternatives`, keď jej marketingový XML-feed lookup
+// nenašiel zhodu — "always clickable"). Návrhový komentár na issue 176:
+// import starého marketingového feedu bol zámerne zamietnutý ako nová,
+// nepotrebná externá integrácia len kvôli jednému nepovinnému bodu ticketu.
+export function alternativeSearchUrl(code: string): string {
+  return `https://www.forestshop.sk/vyhladavanie/?string=${encodeURIComponent(code)}`;
+}

--- a/apps/api/src/modules/nedostupne/constants.ts
+++ b/apps/api/src/modules/nedostupne/constants.ts
@@ -20,3 +20,14 @@ export const ALTERNATIVE_SUBJECT = "Alternatívy k vášmu tovaru — Forestshop
 export function alternativeSearchUrl(code: string): string {
   return `https://www.forestshop.sk/vyhladavanie/?string=${encodeURIComponent(code)}`;
 }
+
+// Ďalší voľný kľúč v registri `.claude/rules/scheduler.md`
+// (787_878_001/002/003/004/005/100 sú obsadené) — serializuje KAŽDÉ
+// odoslanie tohto modulu (dedup-check + skutočné odoslanie + zápis stavu je
+// TOCTOU okno bez tohto zámku: dva súbežné klik-y na TEN ISTÝ (objednávka,
+// variant, typ) by mohli OBA prejsť `hasSentNedostupne` skôr, než ktorýkoľvek
+// zapíše, a poslať zákazníkovi e-mail DVAKRÁT — presne to, čomu má dedup
+// zabrániť). Rovnaký zámer ako #172/#173's RUN lock, len na úrovni
+// JEDNÉHO odoslania namiesto celého dávkového behu (tento modul žiadny beh
+// nemá).
+export const NEDOSTUPNE_SEND_LOCK_KEY = 787_878_006;

--- a/apps/api/src/modules/nedostupne/logic.test.ts
+++ b/apps/api/src/modules/nedostupne/logic.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { alternativeSearchUrl } from "./constants.js";
+import { buildAlternativeEmail, buildAlternatives, buildUnavailableEmail } from "./logic.js";
+
+describe("buildUnavailableEmail", () => {
+  it("obsahuje pozdrav a majiteľov schválený generický text, bez konkrétneho produktu", () => {
+    const built = buildUnavailableEmail("Ján Zákazník");
+    expect(built.subject).toBe("Informácia o dostupnosti vašej objednávky — Forestshop.sk");
+    expect(built.html).toContain("Ján Zákazník");
+    expect(built.html).toContain("je momentálne");
+    expect(built.text).toContain("Ján Zákazník");
+    expect(built.html).toContain("Drlík, Forestshop.sk");
+  });
+
+  it("HTML-escapuje voľné meno zákazníka", () => {
+    const built = buildUnavailableEmail('<script>alert("x")</script>');
+    expect(built.html).not.toContain("<script>");
+    expect(built.html).toContain("&lt;script&gt;");
+  });
+
+  it("prázdne meno padá späť na 'zákazník'", () => {
+    const built = buildUnavailableEmail("");
+    expect(built.html).toContain(">zákazník<");
+  });
+});
+
+describe("buildAlternatives", () => {
+  it("neznámy kód padá späť na SEBA SAMÉHO ako meno (nikdy sa nezahodí)", () => {
+    const alts = buildAlternatives(["60297"], new Map());
+    expect(alts).toEqual([{ code: "60297", name: "60297", url: alternativeSearchUrl("60297") }]);
+  });
+
+  it("známy kód dostane rozlíšené meno z mapy", () => {
+    const alts = buildAlternatives(["60116/90"], new Map([["60116/90", "Podkolienky BOBR"]]));
+    expect(alts).toEqual([{ code: "60116/90", name: "Podkolienky BOBR", url: alternativeSearchUrl("60116/90") }]);
+  });
+
+  it("prázdny zoznam kódov → prázdny zoznam alternatív", () => {
+    expect(buildAlternatives([], new Map())).toEqual([]);
+  });
+});
+
+describe("buildAlternativeEmail", () => {
+  it("s alternatívami vypíše odkazy na KAŽDÚ z nich", () => {
+    const alts = buildAlternatives(["60116/90"], new Map([["60116/90", "Podkolienky BOBR"]]));
+    const built = buildAlternativeEmail("Ján Zákazník", "Nohavice FOREST 1003", alts);
+    expect(built.subject).toBe("Alternatívy k vášmu tovaru — Forestshop.sk");
+    expect(built.html).toContain("Nohavice FOREST 1003");
+    expect(built.html).toContain("Podkolienky BOBR");
+    expect(built.html).toContain(alternativeSearchUrl("60116/90"));
+    expect(built.text).toContain("Podkolienky BOBR");
+  });
+
+  it("bez alternatív ponúkne kontaktnú vetu namiesto zoznamu", () => {
+    const built = buildAlternativeEmail("Ján Zákazník", "Nohavice FOREST 1003", []);
+    expect(built.html).toContain("Radi vám pomôžeme nájsť vhodnú alternatívu");
+    expect(built.html).not.toContain("<ul>");
+  });
+
+  it("HTML-escapuje meno alternatívy aj názov produktu", () => {
+    const alts = buildAlternatives(["X"], new Map([["X", "<b>Zlý</b> názov"]]));
+    const built = buildAlternativeEmail("Ján", '<i>Prod</i>', alts);
+    expect(built.html).not.toContain("<b>Zlý</b>");
+    expect(built.html).toContain("&lt;b&gt;Zlý&lt;/b&gt;");
+    expect(built.html).not.toContain("<i>Prod</i>");
+  });
+});

--- a/apps/api/src/modules/nedostupne/logic.ts
+++ b/apps/api/src/modules/nedostupne/logic.ts
@@ -1,0 +1,118 @@
+import { alternativeSearchUrl, ALTERNATIVE_SUBJECT, UNAVAILABLE_SUBJECT } from "./constants.js";
+
+// Čistá logika (žiadna DB, žiadna sieť) — texty prevzaté doslovne zo starej
+// appky (`nedostupne.py`'s `build_unavailable_email`/`build_alternative_email`,
+// majiteľov schválený text, #183 v starej appke) — ticket #176: stará appka je
+// referencia na SPRÁVANIE/text, nikdy na vzhľad (`.claude/rules/frontend-
+// design.md`). HTML štýl (shell + signatúra) je rovnaký, aký táto appka už
+// používa v `order-reminder/logic.ts`'s `buildReminderEmail`.
+
+function htmlEscape(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+export interface BuiltNedostupneEmail {
+  readonly subject: string;
+  readonly html: string;
+  readonly text: string;
+}
+
+function shell(nameRaw: string, nameH: string, innerHtml: string, innerText: string, signHtml: string, signText: string): { html: string; text: string } {
+  const html = [
+    "<!DOCTYPE html>",
+    "<html>",
+    '  <body style="font-family: Arial, sans-serif; font-size: 16px; color: #333;">',
+    `    <p>Dobrý deň, <strong>${nameH}</strong>,</p>`,
+    "",
+    innerHtml,
+    '    <p style="margin-top: 30px;">',
+    `      ${signHtml}`,
+    "    </p>",
+    "  </body>",
+    "</html>",
+  ].join("\n");
+  const text = [`Dobrý deň, ${nameRaw},`, "", innerText, "", signText].join("\n");
+  return { html, text };
+}
+
+const SIGN_DRLIK_HTML = 'S pozdravom,<br>\n      <strong>Drlík, Forestshop.sk</strong><br>\n      <a href="https://www.forestshop.sk" target="_blank">www.forestshop.sk</a>';
+const SIGN_DRLIK_TEXT = "S pozdravom, Drlík, Forestshop.sk";
+const SIGN_DEFAULT_HTML = 'S pozdravom,<br>\n      <strong>Tím Forestshop.sk</strong><br>\n      <a href="https://www.forestshop.sk" target="_blank">www.forestshop.sk</a>';
+const SIGN_DEFAULT_TEXT = "S pozdravom, Tím Forestshop.sk";
+
+/** E-mail bez návrhu náhrady — majiteľov schválený generický text (stará
+ * appka #183): zámerne NEuvádza konkrétny názov produktu. */
+export function buildUnavailableEmail(customerName: string): BuiltNedostupneEmail {
+  const nameRaw = (customerName || "").trim() || "zákazník";
+  const nameH = htmlEscape(nameRaw);
+  const innerHtml =
+    "    <p>veľmi sa ospravedlňujeme, ale tovar ktorý ste si objednali je momentálne " +
+    "nedostupný a nevieme kedy bude naskladnený. Z toho dôvodu nevieme Vašu objednávku " +
+    "úspešne vybaviť.</p>\n";
+  const innerText =
+    "veľmi sa ospravedlňujeme, ale tovar ktorý ste si objednali je momentálne nedostupný " +
+    "a nevieme kedy bude naskladnený. Z toho dôvodu nevieme Vašu objednávku úspešne vybaviť.";
+  const { html, text } = shell(nameRaw, nameH, innerHtml, innerText, SIGN_DRLIK_HTML, SIGN_DRLIK_TEXT);
+  return { subject: UNAVAILABLE_SUBJECT, html, text };
+}
+
+export interface EmailAlternative {
+  readonly code: string;
+  readonly name: string;
+  readonly url: string;
+}
+
+/** Vytvorí zoznam náhradných produktov z RAW kódov (`product.related_codes`)
+ * + rozlíšeného mena (`namesByCode` — vopred vyriešené DB dopytom,
+ * `queries.ts`'s `resolveAlternativeNames`). Neznámy kód (nikdy nevidený
+ * variant/pairCode) padá späť na SEBA SAMÉHO ako meno — rovnaký zámer ako
+ * stará appka's `code2name.get(rc, rc)`, nikdy sa nezahadzuje. URL je vždy
+ * klikateľný vyhľadávací fallback (`alternativeSearchUrl`, `constants.ts`).*/
+export function buildAlternatives(codes: readonly string[], namesByCode: ReadonlyMap<string, string>): readonly EmailAlternative[] {
+  return codes.map((code) => ({ code, name: namesByCode.get(code) ?? code, url: alternativeSearchUrl(code) }));
+}
+
+/** E-mail s návrhom náhrady — produkt je nedostupný + priamo priradené
+ * alternatívy (relatedProduct*), rovnaký zámer ako stará appka's
+ * `build_alternative_email`. */
+export function buildAlternativeEmail(customerName: string, itemName: string, alternatives: readonly EmailAlternative[]): BuiltNedostupneEmail {
+  const nameRaw = (customerName || "").trim() || "zákazník";
+  const nameH = htmlEscape(nameRaw);
+  const prodH = htmlEscape((itemName || "").trim() || "objednaný tovar");
+  const prodText = (itemName || "").trim() || "objednaný tovar";
+
+  const itemsHtml = alternatives
+    .map((a) => {
+      const altNameH = htmlEscape(a.name.trim() || a.code);
+      const hrefH = htmlEscape(a.url);
+      return `      <li><a href="${hrefH}" target="_blank">${altNameH}</a></li>`;
+    })
+    .join("\n");
+  const altBlockHtml =
+    alternatives.length > 0
+      ? `    <p>Radi by sme vám preto ponúkli tieto <strong>alternatívne produkty</strong>:</p>\n    <ul>\n${itemsHtml}\n    </ul>\n`
+      : "    <p>Radi vám pomôžeme nájsť vhodnú alternatívu — stačí nás kontaktovať.</p>\n";
+  const altBlockText =
+    alternatives.length > 0
+      ? `Alternatívne produkty:\n${alternatives.map((a) => `- ${a.name.trim() || a.code} (${a.url})`).join("\n")}`
+      : "Radi vám pomôžeme nájsť vhodnú alternatívu — stačí nás kontaktovať.";
+
+  const innerHtml =
+    `    <p>Radi by sme vás informovali, že produkt <strong>${prodH}</strong> z vašej objednávky je momentálne <strong>nedostupný</strong>.</p>\n\n` +
+    `${altBlockHtml}\n` +
+    '    <p>Ak máte akékoľvek otázky, pokojne nás kontaktujte na <a href="mailto:eshop@forestshop.sk">eshop@forestshop.sk</a> alebo na telefónnom čísle <a href="tel:+421903670766">+421 903 670 766</a>.</p>\n\n' +
+    "    <p>Ďakujeme vám za dôveru.</p>\n";
+  const innerText =
+    `Radi by sme vás informovali, že produkt ${prodText} z vašej objednávky je momentálne nedostupný.\n\n` +
+    `${altBlockText}\n\n` +
+    "Kontakt: eshop@forestshop.sk, +421 903 670 766.\n\n" +
+    "Ďakujeme vám za dôveru.";
+
+  const { html, text } = shell(nameRaw, nameH, innerHtml, innerText, SIGN_DEFAULT_HTML, SIGN_DEFAULT_TEXT);
+  return { subject: ALTERNATIVE_SUBJECT, html, text };
+}

--- a/apps/api/src/modules/nedostupne/preview-tokens.test.ts
+++ b/apps/api/src/modules/nedostupne/preview-tokens.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { consumePreviewToken, issuePreviewToken } from "./preview-tokens.js";
+
+const NOW = new Date("2026-08-02T10:00:00Z");
+
+describe("issuePreviewToken / consumePreviewToken", () => {
+  it("token vydaný pre presne (objednávka, variant, typ) sa dá skonzumovať PRESNE raz", () => {
+    const token = issuePreviewToken("9001", "A/1", "nedostupne", NOW);
+    expect(consumePreviewToken(token, "9001", "A/1", "nedostupne", NOW)).toBe(true);
+    expect(consumePreviewToken(token, "9001", "A/1", "nedostupne", NOW)).toBe(false);
+  });
+
+  it("token vydaný pre INÝ (objednávka/variant/typ) sa nedá použiť na iný send", () => {
+    const token = issuePreviewToken("9001", "A/1", "nedostupne", NOW);
+    expect(consumePreviewToken(token, "9002", "A/1", "nedostupne", NOW)).toBe(false);
+    expect(consumePreviewToken(token, "9001", "B/1", "nedostupne", NOW)).toBe(false);
+    expect(consumePreviewToken(token, "9001", "A/1", "alternativa", NOW)).toBe(false);
+  });
+
+  it("neznámy/vymyslený token je vždy neplatný", () => {
+    expect(consumePreviewToken("vymyslený-token", "9001", "A/1", "nedostupne", NOW)).toBe(false);
+  });
+
+  it("nezhodnutý pokus token AJ TAK skonzumuje (jednorazový, bez ohľadu na výsledok)", () => {
+    const token = issuePreviewToken("9001", "A/1", "nedostupne", NOW);
+    expect(consumePreviewToken(token, "9999", "A/1", "nedostupne", NOW)).toBe(false);
+    // Druhý pokus s ROVNAKÝMI (správnymi) parametrami už zlyhá — token bol
+    // zničený prvým (nesprávnym) pokusom.
+    expect(consumePreviewToken(token, "9001", "A/1", "nedostupne", NOW)).toBe(false);
+  });
+
+  it("token po TOKEN_TTL_MS (15 minút) exspiruje", () => {
+    const token = issuePreviewToken("9001", "A/1", "nedostupne", NOW);
+    const later = new Date(NOW.getTime() + 16 * 60 * 1000);
+    expect(consumePreviewToken(token, "9001", "A/1", "nedostupne", later)).toBe(false);
+  });
+
+  it("dva nezávislé náhľady (rôzne typy) dostanú DVA rôzne tokeny, oba platné", () => {
+    const tokenA = issuePreviewToken("9001", "A/1", "nedostupne", NOW);
+    const tokenB = issuePreviewToken("9001", "A/1", "alternativa", NOW);
+    expect(tokenA).not.toBe(tokenB);
+    expect(consumePreviewToken(tokenA, "9001", "A/1", "nedostupne", NOW)).toBe(true);
+    expect(consumePreviewToken(tokenB, "9001", "A/1", "alternativa", NOW)).toBe(true);
+  });
+});

--- a/apps/api/src/modules/nedostupne/preview-tokens.ts
+++ b/apps/api/src/modules/nedostupne/preview-tokens.ts
@@ -1,0 +1,72 @@
+import type { NedostupneEmailType } from "./constants.js";
+
+// issue 176 (code review pred mergom, PR #182): ticketova podmienka "e-mail
+// sa NIKDY nesmie odoslať automaticky, len po potvrdení náhľadu človekom" bola
+// pôvodne vynútená LEN na strane frontendu (React komponent volá `/preview`
+// pred zobrazením tlačidla "Odoslať") — server samotný `/send` nič
+// nekontroloval, takže priamé volanie API (skript, iný klient, budúca
+// frontendová regresia) mohlo poslať e-mail BEZ toho, aby ho čokoľvek
+// niekedy zobrazilo. Tento modul vynucuje náhľad NA STRANE SERVERA:
+// `/preview` vydá jednorazový token viazaný na presne (orderCode,
+// variantCode, emailType), `/send` ho musí priniesť späť a token sa
+// SKONZUMUJE (zmaže) pri prvom pokuse o odoslanie — bez ohľadu na to, či sa
+// zhoduje. Rovnaký in-process Map vzor ako `login-rate-limit.ts` (jedna
+// bežiaca inštancia appky, MVP rozsah — reštart appky token zruší, čo je
+// v poriadku, obsluha si vie náhľad znova otvoriť).
+const TOKEN_TTL_MS = 15 * 60 * 1000; // 15 minút — dosť na to, aby si obsluha náhľad prečítala, nie navždy platné
+const MAX_ENTRIES = 1_000; // strop proti neobmedzenému rastu (opakované náhľady bez odoslania)
+const SWEEP_INTERVAL_MS = 60 * 1000;
+
+interface PreviewTokenEntry {
+  readonly orderCode: string;
+  readonly variantCode: string;
+  readonly emailType: NedostupneEmailType;
+  readonly expiresAt: number;
+}
+
+const tokens = new Map<string, PreviewTokenEntry>();
+let lastSweepAtMs = 0;
+
+function sweepExpired(nowMs: number): void {
+  if (nowMs - lastSweepAtMs < SWEEP_INTERVAL_MS) return;
+  lastSweepAtMs = nowMs;
+  for (const [token, entry] of tokens) {
+    if (entry.expiresAt <= nowMs) tokens.delete(token);
+  }
+}
+
+/** Vydá nový jednorazový token pre presne tento (objednávka, variant, typ) —
+ * volané `POST /api/nedostupne/preview`. */
+export function issuePreviewToken(orderCode: string, variantCode: string, emailType: NedostupneEmailType, now: Date): string {
+  const nowMs = now.getTime();
+  sweepExpired(nowMs);
+  // Strop dosiahnutý → uvoľni miesto zmazaním najskôr vypršiavajúceho záznamu
+  // (rovnaký zámer ako `login-rate-limit.ts`'s dávkové mazanie, len po
+  // jednom — tokeny sú oveľa menej časté než prihlasovacie pokusy).
+  if (tokens.size >= MAX_ENTRIES) {
+    let oldestToken: string | undefined;
+    let oldestExpiresAt = Infinity;
+    for (const [token, entry] of tokens) {
+      if (entry.expiresAt < oldestExpiresAt) {
+        oldestExpiresAt = entry.expiresAt;
+        oldestToken = token;
+      }
+    }
+    if (oldestToken !== undefined) tokens.delete(oldestToken);
+  }
+  const token = crypto.randomUUID();
+  tokens.set(token, { orderCode, variantCode, emailType, expiresAt: nowMs + TOKEN_TTL_MS });
+  return token;
+}
+
+/** Skonzumuje (zmaže) token a vráti, či bol platný PRE PRESNE tento (objednávka,
+ * variant, typ) — `POST /api/nedostupne/send` volá TOTO pred akýmkoľvek
+ * odoslaním. Token sa maže VŽDY (aj pri nezhode) — jednorazový, nikdy sa
+ * nedá "vyskúšať" opakovane. */
+export function consumePreviewToken(token: string, orderCode: string, variantCode: string, emailType: NedostupneEmailType, now: Date): boolean {
+  const entry = tokens.get(token);
+  tokens.delete(token);
+  if (entry === undefined) return false;
+  if (entry.expiresAt <= now.getTime()) return false;
+  return entry.orderCode === orderCode && entry.variantCode === variantCode && entry.emailType === emailType;
+}

--- a/apps/api/src/modules/nedostupne/queries.ts
+++ b/apps/api/src/modules/nedostupne/queries.ts
@@ -104,12 +104,10 @@ export async function listNedostupneGroups(db: Database, adminBaseUrl: string): 
     });
   }
 
-  // Zoradenie: variant s najnovšou otvorenou objednávkou navrchu (zákazník,
-  // ktorý čaká najdlhšie... nie, presne opačne — najnovší je pridaný k
-  // dopytu ako PRVÝ vďaka `orderBy(desc(placedAt))`, takže skupina, ktorej
-  // PRVÝ (najnovší) riadok appka vidí najskôr, sa aj zoradí navrchu — rovnaký
-  // zámer ako stará appka's "MAX open-order date descending".
-  const maxDate = (g: { orders: NedostupneOrderRow[] }): string => g.orders.reduce((max, o) => (o.placedAt > max ? o.placedAt : max), "");
+  // Zoradenie: variant, ktorého NAJNOVŠIA otvorená objednávka je najčerstvejšia,
+  // navrchu — rovnaký zámer ako stará appka's "MAX open-order date descending"
+  // (zákazník s najčerstvejšou objednávkou hore, nie ten, čo čaká najdlhšie).
+  const maxPlacedAt = (orders: readonly NedostupneOrderRow[]): string => orders.reduce((max, o) => (o.placedAt > max ? o.placedAt : max), "");
 
   return [...groups.entries()]
     .map(([variantCode, g]) => ({
@@ -120,7 +118,7 @@ export async function listNedostupneGroups(db: Database, adminBaseUrl: string): 
       orders: g.orders,
     }))
     .sort((a, b) => {
-      const d = maxDate({ orders: [...b.orders] }).localeCompare(maxDate({ orders: [...a.orders] }));
+      const d = maxPlacedAt(b.orders).localeCompare(maxPlacedAt(a.orders));
       if (d !== 0) return d;
       return a.itemName.localeCompare(b.itemName) || a.variantCode.localeCompare(b.variantCode);
     });

--- a/apps/api/src/modules/nedostupne/queries.ts
+++ b/apps/api/src/modules/nedostupne/queries.ts
@@ -1,0 +1,127 @@
+import { and, desc, eq, inArray, or } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { orderLines, orders, products, variants } from "../../db/schema.js";
+import { buildShoptetAdminOrderUrl } from "../orders/queries.js";
+import { listOpenStatusNames } from "../orders/open-statuses.js";
+import { buildAlternatives, type EmailAlternative } from "./logic.js";
+import { loadSentNedostupne, sentKey } from "./state.js";
+
+export interface NedostupneOrderRow {
+  readonly orderCode: string;
+  readonly adminLink: string;
+  readonly customerName: string;
+  readonly email: string;
+  readonly quantity: number;
+  readonly placedAt: string;
+  readonly nedostupneSent: boolean;
+  readonly alternativaSent: boolean;
+}
+
+export interface NedostupneGroup {
+  readonly variantCode: string;
+  readonly itemName: string;
+  readonly sizeLabel: string | null;
+  readonly alternatives: readonly EmailAlternative[];
+  readonly orders: readonly NedostupneOrderRow[];
+}
+
+/** Meno pre KAŽDÝ RAW náhradný kód (`product.related_codes`) — hľadá sa
+ * PODĽA `variant.code` AJ `variant.pairCode` (relatedProduct hodnota môže
+ * byť jedno alebo druhé, rovnaký zámer ako stará appka's
+ * `_ensure_nedostupne_catalog`). Neznáme kódy jednoducho chýbajú z mapy —
+ * `buildAlternatives` (`logic.ts`) padá vtedy späť na kód samotný. */
+export async function resolveAlternativeNames(db: Pick<Database, "select">, codes: readonly string[]): Promise<ReadonlyMap<string, string>> {
+  if (codes.length === 0) return new Map();
+  const wanted = new Set(codes);
+  const rows = await db
+    .select({ code: variants.code, pairCode: variants.pairCode, name: variants.name })
+    .from(variants)
+    .where(or(inArray(variants.code, [...codes]), inArray(variants.pairCode, [...codes])));
+  const map = new Map<string, string>();
+  for (const row of rows) {
+    if (wanted.has(row.code)) map.set(row.code, row.name);
+    if (row.pairCode !== null && wanted.has(row.pairCode) && !map.has(row.pairCode)) map.set(row.pairCode, row.name);
+  }
+  return map;
+}
+
+/**
+ * "Nedostupné tovary" — zoznam zoskupený PODĽA VARIANTU (rovnaká granularita
+ * ako `order_line.variant_code`), spárovaný s otvorenými objednávkami
+ * (`listOpenStatusNames`, ten istý set ako "Na objednanie"/pripomienky).
+ * ŽIADNY `job_run` cache — zoznam sa počíta VŽDY živo (návrhový komentár na
+ * issue 176: táto automatizácia nemá žiadny naplánovaný beh).
+ */
+export async function listNedostupneGroups(db: Database, adminBaseUrl: string): Promise<readonly NedostupneGroup[]> {
+  const openStatuses = await listOpenStatusNames(db);
+  if (openStatuses.length === 0) return [];
+
+  const rows = await db
+    .select({
+      variantCode: orderLines.variantCode,
+      quantity: orderLines.quantity,
+      itemName: variants.name,
+      sizeLabel: variants.sizeLabel,
+      relatedCodes: products.relatedCodes,
+      orderCode: orders.externalOrderId,
+      customerName: orders.customerName,
+      email: orders.email,
+      shoptetOrderId: orders.shoptetOrderId,
+      placedAt: orders.placedAt,
+    })
+    .from(orderLines)
+    .innerJoin(orders, eq(orderLines.orderId, orders.id))
+    .innerJoin(variants, eq(orderLines.variantCode, variants.code))
+    .innerJoin(products, eq(variants.productKey, products.key))
+    .where(and(eq(orderLines.state, "nedostupne"), inArray(orders.statusName, [...openStatuses])))
+    .orderBy(desc(orders.placedAt));
+
+  if (rows.length === 0) return [];
+
+  const sent = await loadSentNedostupne(db);
+  const allCodes = [...new Set(rows.flatMap((r) => r.relatedCodes ?? []))];
+  const names = await resolveAlternativeNames(db, allCodes);
+
+  const groups = new Map<
+    string,
+    { itemName: string; sizeLabel: string | null; relatedCodes: readonly string[]; orders: NedostupneOrderRow[] }
+  >();
+  for (const row of rows) {
+    let group = groups.get(row.variantCode);
+    if (group === undefined) {
+      group = { itemName: row.itemName, sizeLabel: row.sizeLabel, relatedCodes: row.relatedCodes ?? [], orders: [] };
+      groups.set(row.variantCode, group);
+    }
+    group.orders.push({
+      orderCode: row.orderCode,
+      adminLink: buildShoptetAdminOrderUrl(adminBaseUrl, row.orderCode, row.shoptetOrderId),
+      customerName: row.customerName,
+      email: row.email ?? "",
+      quantity: row.quantity,
+      placedAt: row.placedAt.toISOString(),
+      nedostupneSent: sent.has(sentKey(row.orderCode, row.variantCode, "nedostupne")),
+      alternativaSent: sent.has(sentKey(row.orderCode, row.variantCode, "alternativa")),
+    });
+  }
+
+  // Zoradenie: variant s najnovšou otvorenou objednávkou navrchu (zákazník,
+  // ktorý čaká najdlhšie... nie, presne opačne — najnovší je pridaný k
+  // dopytu ako PRVÝ vďaka `orderBy(desc(placedAt))`, takže skupina, ktorej
+  // PRVÝ (najnovší) riadok appka vidí najskôr, sa aj zoradí navrchu — rovnaký
+  // zámer ako stará appka's "MAX open-order date descending".
+  const maxDate = (g: { orders: NedostupneOrderRow[] }): string => g.orders.reduce((max, o) => (o.placedAt > max ? o.placedAt : max), "");
+
+  return [...groups.entries()]
+    .map(([variantCode, g]) => ({
+      variantCode,
+      itemName: g.itemName,
+      sizeLabel: g.sizeLabel,
+      alternatives: buildAlternatives(g.relatedCodes, names),
+      orders: g.orders,
+    }))
+    .sort((a, b) => {
+      const d = maxDate({ orders: [...b.orders] }).localeCompare(maxDate({ orders: [...a.orders] }));
+      if (d !== 0) return d;
+      return a.itemName.localeCompare(b.itemName) || a.variantCode.localeCompare(b.variantCode);
+    });
+}

--- a/apps/api/src/modules/nedostupne/send.ts
+++ b/apps/api/src/modules/nedostupne/send.ts
@@ -1,0 +1,122 @@
+import { and, eq } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { log } from "../../logger.js";
+import { orderLines, orders, products, variants } from "../../db/schema.js";
+import type { MailTransport } from "../mail/transport.js";
+import { listOpenStatusNames } from "../orders/open-statuses.js";
+import { TYPE_ALTERNATIVE, type NedostupneEmailType } from "./constants.js";
+import { buildAlternativeEmail, buildAlternatives, buildUnavailableEmail, type BuiltNedostupneEmail, type EmailAlternative } from "./logic.js";
+import { resolveAlternativeNames } from "./queries.js";
+import { hasSentNedostupne, markSentNedostupne } from "./state.js";
+
+export interface NedostupneEmailContext {
+  readonly orderCode: string;
+  readonly variantCode: string;
+  readonly customerName: string;
+  readonly email: string;
+  readonly itemName: string;
+  readonly alternatives: readonly EmailAlternative[];
+}
+
+/**
+ * Nájde presne JEDEN (objednávka, variant) riadok, PRE KTORÝ smie appka
+ * poslať/zobraziť náhľad e-mailu — vyžaduje, aby bol riadok STÁLE v stave
+ * `nedostupne` A objednávka STÁLE v otvorenom stave (obranná
+ * PREKONTROLA priamo pred odoslaním, nikdy sa nespolieha na to, že
+ * zobrazený zoznam v prehliadači je ešte aktuálny — riadok mohol medzitým
+ * prejsť do iného stavu). `null` = riadok sa nenašiel/už nie je eligible.
+ */
+export async function findNedostupneContext(db: Database, orderCode: string, variantCode: string): Promise<NedostupneEmailContext | null> {
+  const openStatuses = await listOpenStatusNames(db);
+  if (openStatuses.length === 0) return null;
+
+  const [row] = await db
+    .select({
+      itemName: variants.name,
+      relatedCodes: products.relatedCodes,
+      customerName: orders.customerName,
+      email: orders.email,
+      statusName: orders.statusName,
+    })
+    .from(orderLines)
+    .innerJoin(orders, eq(orderLines.orderId, orders.id))
+    .innerJoin(variants, eq(orderLines.variantCode, variants.code))
+    .innerJoin(products, eq(variants.productKey, products.key))
+    .where(and(eq(orders.externalOrderId, orderCode), eq(orderLines.variantCode, variantCode), eq(orderLines.state, "nedostupne")))
+    .limit(1);
+
+  if (row === undefined || !openStatuses.includes(row.statusName)) return null;
+
+  const names = await resolveAlternativeNames(db, row.relatedCodes ?? []);
+  return {
+    orderCode,
+    variantCode,
+    customerName: row.customerName,
+    email: row.email ?? "",
+    itemName: row.itemName,
+    alternatives: buildAlternatives(row.relatedCodes ?? [], names),
+  };
+}
+
+/** Rovnaká funkcia sa volá pre NÁHĽAD aj pre SKUTOČNÉ odoslanie — garantuje,
+ * že sa zákazníkovi pošle PRESNE to, čo obsluha videla v náhľade. */
+export function buildEmailForType(ctx: NedostupneEmailContext, type: NedostupneEmailType): BuiltNedostupneEmail {
+  return type === TYPE_ALTERNATIVE ? buildAlternativeEmail(ctx.customerName, ctx.itemName, ctx.alternatives) : buildUnavailableEmail(ctx.customerName);
+}
+
+export type SendNedostupneResult =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly code: "not_found" }
+  | { readonly ok: false; readonly code: "already_sent" }
+  | { readonly ok: false; readonly code: "no_email" }
+  | { readonly ok: false; readonly code: "not_configured"; readonly reason: string }
+  | { readonly ok: false; readonly code: "send_failed" };
+
+export interface SendNedostupneOptions {
+  readonly db: Database;
+  readonly now: Date;
+  readonly orderCode: string;
+  readonly variantCode: string;
+  readonly emailType: NedostupneEmailType;
+  readonly mailTransport: MailTransport | undefined;
+  readonly bccEmail: string | undefined;
+}
+
+/**
+ * Povinný náhľad (`buildEmailForType`, volaný SAMOSTATNE cez preview
+ * endpoint) predchádza KAŽDÉMU volaniu tejto funkcie z UI — appka samotná
+ * to nevynucuje na úrovni servera (žiadny "preview token"), presne ako
+ * #172/#173 (majiteľova bezpečnostná podmienka je fail-closed BCC/mail
+ * kontrola nižšie, nie vynútený náhľad request-flow). Fail-closed: chýbajúca
+ * BCC adresa ALEBO chýbajúci mail transport → NEPOŠLE NIČ (rovnaký zámer ako
+ * `order-reminder/run.ts`/`posta-uncollected/run.ts`).
+ */
+export async function sendNedostupneEmail(options: SendNedostupneOptions): Promise<SendNedostupneResult> {
+  const { db, now, orderCode, variantCode, emailType, mailTransport, bccEmail } = options;
+
+  const ctx = await findNedostupneContext(db, orderCode, variantCode);
+  if (ctx === null) return { ok: false, code: "not_found" };
+
+  const already = await hasSentNedostupne(db, orderCode, variantCode, emailType);
+  if (already) return { ok: false, code: "already_sent" };
+
+  const email = ctx.email.trim();
+  if (email === "") return { ok: false, code: "no_email" };
+
+  const bccMissing = bccEmail === undefined || bccEmail.trim() === "";
+  if (bccMissing) return { ok: false, code: "not_configured", reason: "chýba adresa pre skrytú kópiu majiteľovi (NEDOSTUPNE_BCC_EMAIL)" };
+  if (mailTransport === undefined) return { ok: false, code: "not_configured", reason: "odosielanie e-mailov nie je nakonfigurované (chýba MAIL_HOST)" };
+
+  const built = buildEmailForType(ctx, emailType);
+  try {
+    await mailTransport({ to: email, subject: built.subject, text: built.text, html: built.html, bcc: bccEmail });
+  } catch (error) {
+    const rawErrorMessage = error instanceof Error ? error.message : String(error);
+    log.error({ orderCode, variantCode, emailType, rawErrorMessage }, "Nedostupné tovary: odoslanie e-mailu zlyhalo");
+    return { ok: false, code: "send_failed" };
+  }
+  // Zápis IHNEĎ po odoslaní (rovnaká disciplína ako #172/#173).
+  await markSentNedostupne(db, orderCode, variantCode, emailType, now);
+  log.info({ orderCode, variantCode, emailType }, "Nedostupné tovary: e-mail odoslaný");
+  return { ok: true };
+}

--- a/apps/api/src/modules/nedostupne/send.ts
+++ b/apps/api/src/modules/nedostupne/send.ts
@@ -4,7 +4,7 @@ import { log } from "../../logger.js";
 import { orderLines, orders, products, variants } from "../../db/schema.js";
 import type { MailTransport } from "../mail/transport.js";
 import { listOpenStatusNames } from "../orders/open-statuses.js";
-import { TYPE_ALTERNATIVE, type NedostupneEmailType } from "./constants.js";
+import { NEDOSTUPNE_SEND_LOCK_KEY, TYPE_ALTERNATIVE, type NedostupneEmailType } from "./constants.js";
 import { buildAlternativeEmail, buildAlternatives, buildUnavailableEmail, type BuiltNedostupneEmail, type EmailAlternative } from "./logic.js";
 import { resolveAlternativeNames } from "./queries.js";
 import { hasSentNedostupne, markSentNedostupne } from "./state.js";
@@ -90,8 +90,26 @@ export interface SendNedostupneOptions {
  * kontrola nižšie, nie vynútený náhľad request-flow). Fail-closed: chýbajúca
  * BCC adresa ALEBO chýbajúci mail transport → NEPOŠLE NIČ (rovnaký zámer ako
  * `order-reminder/run.ts`/`posta-uncollected/run.ts`).
+ *
+ * Serializovaná `NEDOSTUPNE_SEND_LOCK_KEY`-om (review pred mergom, PR #182):
+ * dedup-check + odoslanie + zápis stavu je BEZ zámku TOCTOU okno — dva
+ * súbežné klik-y na TEN ISTÝ (objednávka, variant, typ) by mohli OBA prejsť
+ * `hasSentNedostupne` skôr, než ktorýkoľvek zapíše, a poslať zákazníkovi
+ * e-mail DVAKRÁT.
  */
 export async function sendNedostupneEmail(options: SendNedostupneOptions): Promise<SendNedostupneResult> {
+  const { db } = options;
+  const lockClient = await db.$client.connect();
+  try {
+    await lockClient.query("select pg_advisory_lock($1)", [NEDOSTUPNE_SEND_LOCK_KEY]);
+    return await sendNedostupneEmailLocked(options);
+  } finally {
+    await lockClient.query("select pg_advisory_unlock($1)", [NEDOSTUPNE_SEND_LOCK_KEY]);
+    lockClient.release();
+  }
+}
+
+async function sendNedostupneEmailLocked(options: SendNedostupneOptions): Promise<SendNedostupneResult> {
   const { db, now, orderCode, variantCode, emailType, mailTransport, bccEmail } = options;
 
   const ctx = await findNedostupneContext(db, orderCode, variantCode);

--- a/apps/api/src/modules/nedostupne/state.ts
+++ b/apps/api/src/modules/nedostupne/state.ts
@@ -1,0 +1,48 @@
+import { and, eq } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { nedostupneState } from "../../db/schema.js";
+import type { NedostupneEmailType } from "./constants.js";
+
+/** `true` keď presne TENTO (objednávka, variant, typ) e-mail už bol odoslaný
+ * — dedup kľúč, rovnaký zámer ako stará appka's `sent_map['<orderCode>|<type>']`
+ * (`nedostupne.py`'s `plan_sends`), len rozšírený o `variant_code` (nová
+ * appka flaguje PER RIADOK objednávky, nie per produkt globálne). */
+export async function hasSentNedostupne(
+  db: Pick<Database, "select">,
+  orderCode: string,
+  variantCode: string,
+  emailType: NedostupneEmailType,
+): Promise<boolean> {
+  const rows = await db
+    .select({ id: nedostupneState.id })
+    .from(nedostupneState)
+    .where(and(eq(nedostupneState.orderCode, orderCode), eq(nedostupneState.variantCode, variantCode), eq(nedostupneState.emailType, emailType)))
+    .limit(1);
+  return rows.length > 0;
+}
+
+/** Zoznam VŠETKÝCH odoslaných záznamov — `queries.ts`'s zoznam ich potrebuje
+ * naraz (jeden dopyt namiesto N `hasSentNedostupne` volaní na riadok). */
+export async function loadSentNedostupne(db: Pick<Database, "select">): Promise<ReadonlySet<string>> {
+  const rows = await db
+    .select({ orderCode: nedostupneState.orderCode, variantCode: nedostupneState.variantCode, emailType: nedostupneState.emailType })
+    .from(nedostupneState);
+  return new Set(rows.map((r) => sentKey(r.orderCode, r.variantCode, r.emailType)));
+}
+
+export function sentKey(orderCode: string, variantCode: string, emailType: string): string {
+  return `${orderCode}|${variantCode}|${emailType}`;
+}
+
+/** Zapíše dedup dôkaz IHNEĎ po úspešnom odoslaní (rovnaká disciplína ako
+ * #172/#173 — pád appky neskôr v behu nesmie stratiť dôkaz o už odoslanom
+ * e-maile). Nikdy sa neprepisuje/nemaže. */
+export async function markSentNedostupne(
+  db: Pick<Database, "insert">,
+  orderCode: string,
+  variantCode: string,
+  emailType: NedostupneEmailType,
+  now: Date,
+): Promise<void> {
+  await db.insert(nedostupneState).values({ orderCode, variantCode, emailType, sentAt: now });
+}

--- a/apps/api/tests/helpers/db.ts
+++ b/apps/api/tests/helpers/db.ts
@@ -51,8 +51,11 @@ export async function withCleanDb(): Promise<{ db: Database; close: () => Promis
     // (issue 172) are the SAME situation too — no FK in either direction
     // (singleton id / order-code keyed). "order_reminder_settings"/
     // "order_reminder_state" (issue 173) are the SAME situation again.
+    // "nedostupne_state" (issue 176) is the SAME situation again — no FK in
+    // either direction, and this module has NO settings singleton (no
+    // scheduled run to gate), so no re-seed is needed below.
     await db.execute(
-      sql`TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state RESTART IDENTITY CASCADE`,
+      sql`TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state RESTART IDENTITY CASCADE`,
     );
     // issue 59: `order_open_status` is a NEW table with real production
     // content (the migration seeds it) — TRUNCATE alone would leave every

--- a/apps/api/tests/helpers/orders.ts
+++ b/apps/api/tests/helpers/orders.ts
@@ -85,6 +85,9 @@ export async function insertTestVariantForProduct(
     // own row-matching column) — default null matches every existing call
     // (no prior test needed one).
     readonly pairCode?: string | null;
+    // issue 176: náhradné produkty (`product.related_codes`) — default
+    // `undefined` necháva stĺpec `null` (žiadny existujúci test ho potreboval).
+    readonly relatedCodes?: readonly string[] | null;
   } = {},
 ): Promise<void> {
   const snapshotId = await insertTestSnapshot(db);
@@ -99,6 +102,7 @@ export async function insertTestVariantForProduct(
       // (default "Test dodávateľ") od "zadané ako null" (skutočne bez
       // dodávateľa — potrebné pre testy ručného priradenia dodávateľa).
       supplier: "supplier" in options ? options.supplier : "Test dodávateľ",
+      relatedCodes: options.relatedCodes === undefined || options.relatedCodes === null ? null : [...options.relatedCodes],
       firstSeenAt: new Date("2026-01-01T00:00:00Z"),
       lastSeenAt: new Date("2026-01-01T00:00:00Z"),
       lastSeenSnapshotId: snapshotId,

--- a/apps/api/tests/nedostupne-http.integration.test.ts
+++ b/apps/api/tests/nedostupne-http.integration.test.ts
@@ -63,6 +63,26 @@ async function seedNedostupneLine(db: Awaited<ReturnType<typeof boot>>["db"], or
   await db.insert(orderLines).values({ orderId: order.id, variantCode, quantity: 1, state: "nedostupne" });
 }
 
+// issue 176 (code review pred mergom, PR #182): `/send` vyžaduje token vydaný
+// `/preview` — tento helper zavolá náhľad a vráti jeho token, presne to, čo
+// skutočný frontend robí PRED odoslaním.
+async function previewToken(
+  app: Awaited<ReturnType<typeof boot>>["app"],
+  cookie: string,
+  orderCode: string,
+  variantCode: string,
+  emailType = "nedostupne",
+): Promise<string> {
+  const res = await app.request("/api/nedostupne/preview", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ orderCode, variantCode, emailType }),
+  });
+  const body = (await res.json()) as { ok: boolean; previewToken: string };
+  if (!body.ok) throw new Error("náhľad zlyhal v test helperi");
+  return body.previewToken;
+}
+
 it("GET bez prihlásenia vráti 401", async () => {
   const { app } = await boot("manazer");
   const res = await app.request("/api/nedostupne");
@@ -123,10 +143,11 @@ it("náhľad neexistujúceho riadku vráti 200 {ok:false} (nikdy 4xx, `.claude/r
 it("rola citanie NESMIE odoslať (403) — čítanie áno, odosielanie len admin/manazer", async () => {
   const { app, cookie, db } = await boot("citanie", { sent: [], bccEmail: "majitel@forestshop.sk" });
   await seedNedostupneLine(db, "17601003", "N176C");
+  const token = await previewToken(app, cookie, "17601003", "N176C");
   const res = await app.request("/api/nedostupne/send", {
     method: "POST",
     headers: { cookie, "content-type": "application/json" },
-    body: JSON.stringify({ orderCode: "17601003", variantCode: "N176C", emailType: "nedostupne" }),
+    body: JSON.stringify({ orderCode: "17601003", variantCode: "N176C", emailType: "nedostupne", previewToken: token }),
   });
   expect(res.status).toBe(403);
 });
@@ -135,11 +156,12 @@ it("manazer odošle e-mail, GET hneď odzrkadlí 'nedostupneSent: true'", async 
   const sent: MailMessage[] = [];
   const { app, cookie, db } = await boot("manazer", { sent, bccEmail: "majitel@forestshop.sk" });
   await seedNedostupneLine(db, "17601004", "N176D");
+  const token = await previewToken(app, cookie, "17601004", "N176D");
 
   const send = await app.request("/api/nedostupne/send", {
     method: "POST",
     headers: { cookie, "content-type": "application/json" },
-    body: JSON.stringify({ orderCode: "17601004", variantCode: "N176D", emailType: "nedostupne" }),
+    body: JSON.stringify({ orderCode: "17601004", variantCode: "N176D", emailType: "nedostupne", previewToken: token }),
   });
   expect(send.status).toBe(200);
   const sendBody = (await send.json()) as { ok: boolean };
@@ -156,15 +178,73 @@ it("druhé odoslanie ROVNAKÉHO e-mailu je odmietnuté 200 {ok:false} (dedup)", 
   const sent: MailMessage[] = [];
   const { app, cookie, db } = await boot("manazer", { sent, bccEmail: "majitel@forestshop.sk" });
   await seedNedostupneLine(db, "17601005", "N176E");
-  const body = { orderCode: "17601005", variantCode: "N176E", emailType: "nedostupne" };
+  const bodyBase = { orderCode: "17601005", variantCode: "N176E", emailType: "nedostupne" };
 
-  await app.request("/api/nedostupne/send", { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify(body) });
+  const token1 = await previewToken(app, cookie, "17601005", "N176E");
+  await app.request("/api/nedostupne/send", { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ ...bodyBase, previewToken: token1 }) });
   expect(sent).toHaveLength(1);
 
-  const second = await app.request("/api/nedostupne/send", { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify(body) });
+  const token2 = await previewToken(app, cookie, "17601005", "N176E");
+  const second = await app.request("/api/nedostupne/send", { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ ...bodyBase, previewToken: token2 }) });
   expect(second.status).toBe(200);
   const secondBody = (await second.json()) as { ok: boolean; error: string };
   expect(secondBody.ok).toBe(false);
   expect(secondBody.error).toContain("už bol");
+  expect(sent).toHaveLength(1);
+});
+
+// issue 176 (code review pred mergom, PR #182) — server-side vynútenie
+// povinného náhľadu: `/send` bez volania `/preview` PRE PRESNE tento
+// (objednávka, variant, typ) sa VŽDY odmietne, žiadny e-mail sa nepošle.
+it("odoslanie BEZ predchádzajúceho náhľadu je odmietnuté — žiadny token, žiadny e-mail", async () => {
+  const sent: MailMessage[] = [];
+  const { app, cookie, db } = await boot("manazer", { sent, bccEmail: "majitel@forestshop.sk" });
+  await seedNedostupneLine(db, "17601006", "N176F");
+
+  const res = await app.request("/api/nedostupne/send", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ orderCode: "17601006", variantCode: "N176F", emailType: "nedostupne", previewToken: "vymyslený-token" }),
+  });
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { ok: boolean; error: string };
+  expect(body.ok).toBe(false);
+  expect(body.error).toContain("náhľad");
+  expect(sent).toHaveLength(0);
+});
+
+it("token vydaný pre INÝ (objednávka/variant/typ) sa na tento send NEDÁ použiť", async () => {
+  const sent: MailMessage[] = [];
+  const { app, cookie, db } = await boot("manazer", { sent, bccEmail: "majitel@forestshop.sk" });
+  await seedNedostupneLine(db, "17601007", "N176G");
+  await seedNedostupneLine(db, "17601008", "N176H");
+
+  const tokenForOther = await previewToken(app, cookie, "17601008", "N176H");
+  const res = await app.request("/api/nedostupne/send", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ orderCode: "17601007", variantCode: "N176G", emailType: "nedostupne", previewToken: tokenForOther }),
+  });
+  const body = (await res.json()) as { ok: boolean };
+  expect(body.ok).toBe(false);
+  expect(sent).toHaveLength(0);
+});
+
+it("token je JEDNORAZOVÝ — druhé odoslanie s TÝM ISTÝM tokenom (iný typ) je odmietnuté, aj keby dedup inak dovolil", async () => {
+  const sent: MailMessage[] = [];
+  const { app, cookie, db } = await boot("manazer", { sent, bccEmail: "majitel@forestshop.sk" });
+  await seedNedostupneLine(db, "17601009", "N176I");
+  const token = await previewToken(app, cookie, "17601009", "N176I");
+  const body = { orderCode: "17601009", variantCode: "N176I", emailType: "nedostupne", previewToken: token };
+
+  const first = await app.request("/api/nedostupne/send", { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify(body) });
+  expect((await first.json()) as { ok: boolean }).toMatchObject({ ok: true });
+
+  // Znovu POUŽITÝ token (žiadny nový náhľad) na iný typ e-mailu — token je
+  // už skonzumovaný, nesmie fungovať znova ani na iný (inak by prešiel) typ.
+  const secondBody = { ...body, emailType: "alternativa" };
+  const second = await app.request("/api/nedostupne/send", { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify(secondBody) });
+  const secondJson = (await second.json()) as { ok: boolean };
+  expect(secondJson.ok).toBe(false);
   expect(sent).toHaveLength(1);
 });

--- a/apps/api/tests/nedostupne-http.integration.test.ts
+++ b/apps/api/tests/nedostupne-http.integration.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, expect, it } from "vitest";
+import { orderLines, orders, users } from "../src/db/schema.js";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import type { UserRole } from "../src/modules/auth/service.js";
+import type { MailMessage } from "../src/modules/mail/transport.js";
+import { DEFAULT_ORDER_OPEN_STATUS } from "../src/modules/orders/open-statuses.js";
+import { insertTestVariantForProduct } from "./helpers/orders.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 176: HTTP vrstva pre "Nedostupné tovary". Falošný mail transport —
+// NIKDY skutočný SMTP (majiteľova bezpečnostná podmienka pre testy).
+const HESLO = "test-heslo-abc";
+
+let close: (() => Promise<void>) | undefined;
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  resetLoginRateLimit();
+});
+
+async function boot(role: UserRole, options: { readonly sent?: MailMessage[]; readonly bccEmail?: string } = {}) {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await ctx.db.insert(users).values({
+    email: "pouzivatel@forestshop.sk",
+    passwordHash: await hashPassword(HESLO),
+    displayName: "Test",
+    role,
+  });
+
+  const app = createApp(ctx.db, {
+    cookieSecure: false,
+    nedostupne: {
+      mailTransport:
+        options.sent === undefined
+          ? undefined
+          : (m: MailMessage) => {
+              options.sent?.push(m);
+              return Promise.resolve();
+            },
+      bccEmail: options.bccEmail,
+      adminBaseUrl: "https://www.forestshop.sk",
+    },
+  });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "pouzivatel@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie, db: ctx.db };
+}
+
+async function seedNedostupneLine(db: Awaited<ReturnType<typeof boot>>["db"], orderCode: string, variantCode: string): Promise<void> {
+  await insertTestVariantForProduct(db, `${variantCode}-key`, variantCode, { productName: `Test ${variantCode}` });
+  const [order] = await db
+    .insert(orders)
+    .values({ externalOrderId: orderCode, customerName: "Zákazník Test", statusName: DEFAULT_ORDER_OPEN_STATUS, placedAt: new Date("2026-07-20T10:00:00Z"), email: "zakaznik@example.sk" })
+    .returning({ id: orders.id });
+  if (order === undefined) throw new Error("test objednávka sa nepodarilo vložiť");
+  await db.insert(orderLines).values({ orderId: order.id, variantCode, quantity: 1, state: "nedostupne" });
+}
+
+it("GET bez prihlásenia vráti 401", async () => {
+  const { app } = await boot("manazer");
+  const res = await app.request("/api/nedostupne");
+  expect(res.status).toBe(401);
+});
+
+it("GET vráti prázdny zoznam + upozornenia na chýbajúcu BCC/mail konfiguráciu", async () => {
+  const { app, cookie } = await boot("citanie");
+  const res = await app.request("/api/nedostupne", { headers: { cookie } });
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { groups: unknown[]; bccMissing: boolean; mailNotConfigured: boolean };
+  expect(body.groups).toEqual([]);
+  expect(body.bccMissing).toBe(true);
+  expect(body.mailNotConfigured).toBe(true);
+});
+
+it("GET vráti nedostupný riadok zoskupený podľa variantu, spárovaný s objednávkou", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  await seedNedostupneLine(db, "17601001", "N176A");
+
+  const res = await app.request("/api/nedostupne", { headers: { cookie } });
+  const body = (await res.json()) as { groups: { variantCode: string; orders: { orderCode: string }[] }[] };
+  expect(body.groups).toHaveLength(1);
+  expect(body.groups[0]?.variantCode).toBe("N176A");
+  expect(body.groups[0]?.orders[0]?.orderCode).toBe("17601001");
+});
+
+it("náhľad vráti presne to, čo by sa odoslalo — bez odoslania", async () => {
+  const sent: MailMessage[] = [];
+  const { app, cookie, db } = await boot("citanie", { sent, bccEmail: "majitel@forestshop.sk" });
+  await seedNedostupneLine(db, "17601002", "N176B");
+
+  const preview = await app.request("/api/nedostupne/preview", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ orderCode: "17601002", variantCode: "N176B", emailType: "nedostupne" }),
+  });
+  expect(preview.status).toBe(200);
+  const body = (await preview.json()) as { ok: boolean; subject: string; recipient: string };
+  expect(body.ok).toBe(true);
+  expect(body.subject).toContain("Forestshop.sk");
+  expect(body.recipient).toBe("zakaznik@example.sk");
+  expect(sent).toHaveLength(0);
+});
+
+it("náhľad neexistujúceho riadku vráti 200 {ok:false} (nikdy 4xx, `.claude/rules/testing.md`'s console pravidlo)", async () => {
+  const { app, cookie } = await boot("citanie");
+  const res = await app.request("/api/nedostupne/preview", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ orderCode: "NEEXISTUJE", variantCode: "X", emailType: "nedostupne" }),
+  });
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { ok: boolean };
+  expect(body.ok).toBe(false);
+});
+
+it("rola citanie NESMIE odoslať (403) — čítanie áno, odosielanie len admin/manazer", async () => {
+  const { app, cookie, db } = await boot("citanie", { sent: [], bccEmail: "majitel@forestshop.sk" });
+  await seedNedostupneLine(db, "17601003", "N176C");
+  const res = await app.request("/api/nedostupne/send", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ orderCode: "17601003", variantCode: "N176C", emailType: "nedostupne" }),
+  });
+  expect(res.status).toBe(403);
+});
+
+it("manazer odošle e-mail, GET hneď odzrkadlí 'nedostupneSent: true'", async () => {
+  const sent: MailMessage[] = [];
+  const { app, cookie, db } = await boot("manazer", { sent, bccEmail: "majitel@forestshop.sk" });
+  await seedNedostupneLine(db, "17601004", "N176D");
+
+  const send = await app.request("/api/nedostupne/send", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ orderCode: "17601004", variantCode: "N176D", emailType: "nedostupne" }),
+  });
+  expect(send.status).toBe(200);
+  const sendBody = (await send.json()) as { ok: boolean };
+  expect(sendBody.ok).toBe(true);
+  expect(sent).toHaveLength(1);
+  expect(sent[0]?.bcc).toBe("majitel@forestshop.sk");
+
+  const list = await app.request("/api/nedostupne", { headers: { cookie } });
+  const listBody = (await list.json()) as { groups: { orders: { nedostupneSent: boolean }[] }[] };
+  expect(listBody.groups[0]?.orders[0]?.nedostupneSent).toBe(true);
+});
+
+it("druhé odoslanie ROVNAKÉHO e-mailu je odmietnuté 200 {ok:false} (dedup)", async () => {
+  const sent: MailMessage[] = [];
+  const { app, cookie, db } = await boot("manazer", { sent, bccEmail: "majitel@forestshop.sk" });
+  await seedNedostupneLine(db, "17601005", "N176E");
+  const body = { orderCode: "17601005", variantCode: "N176E", emailType: "nedostupne" };
+
+  await app.request("/api/nedostupne/send", { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify(body) });
+  expect(sent).toHaveLength(1);
+
+  const second = await app.request("/api/nedostupne/send", { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify(body) });
+  expect(second.status).toBe(200);
+  const secondBody = (await second.json()) as { ok: boolean; error: string };
+  expect(secondBody.ok).toBe(false);
+  expect(secondBody.error).toContain("už bol");
+  expect(sent).toHaveLength(1);
+});

--- a/apps/api/tests/nedostupne-run.integration.test.ts
+++ b/apps/api/tests/nedostupne-run.integration.test.ts
@@ -1,7 +1,9 @@
 import { eq } from "drizzle-orm";
+import pg from "pg";
 import { afterEach, expect, it } from "vitest";
 import { nedostupneState, orderLines, orders } from "../src/db/schema.js";
 import type { MailMessage } from "../src/modules/mail/transport.js";
+import { NEDOSTUPNE_SEND_LOCK_KEY } from "../src/modules/nedostupne/constants.js";
 import { listNedostupneGroups } from "../src/modules/nedostupne/queries.js";
 import { findNedostupneContext, sendNedostupneEmail } from "../src/modules/nedostupne/send.js";
 import { DEFAULT_ORDER_OPEN_STATUS } from "../src/modules/orders/open-statuses.js";
@@ -13,9 +15,12 @@ import { withCleanDb } from "./helpers/db.js";
 const ADMIN_BASE_URL = "https://www.forestshop.sk";
 
 let close: (() => Promise<void>) | undefined;
+let checker: pg.Client | undefined;
 afterEach(async () => {
   await close?.();
   close = undefined;
+  await checker?.end();
+  checker = undefined;
 });
 
 async function boot() {
@@ -250,4 +255,51 @@ it("riadok, ktorý medzitým už NIE JE 'nedostupne' (napr. sklad ho medzitým n
     bccEmail: undefined,
   });
   expect(result).toEqual({ ok: false, code: "not_found" });
+});
+
+// Nájdené code review pred mergom (PR #182) — bez `NEDOSTUPNE_SEND_LOCK_KEY`
+// by dva súbežné klik-y na TEN ISTÝ (objednávka, variant, typ) mohli OBA
+// prejsť dedup-check skôr, než ktorýkoľvek zapíše, a poslať e-mail DVAKRÁT.
+// Rovnaká deterministická technika ako `posta-uncollected-run.integration
+// .test.ts`/`order-reminder-run.integration.test.ts` (`pg_try_advisory_lock`
+// z DRUHÉHO pripojenia, nikdy časovanie).
+it("dve súbežné odoslania toho istého (objednávka, variant, typ) sa serializujú (advisory zámok), nikdy neprebehnú naraz", async () => {
+  const db = await boot();
+  await insertTestVariantForProduct(db, "P176L", "P176L", {});
+  const orderId = await insertOrder(db, "17600012");
+  await db.insert(orderLines).values({ orderId, variantCode: "P176L", quantity: 1, state: "nedostupne" });
+
+  let releaseSend: (() => void) | undefined;
+  const blockedUntilReleased = new Promise<void>((resolve) => {
+    releaseSend = resolve;
+  });
+  const transport = async (): Promise<void> => {
+    await blockedUntilReleased;
+  };
+
+  const sendPromise = sendNedostupneEmail({
+    db,
+    now: new Date("2026-08-02T10:00:00Z"),
+    orderCode: "17600012",
+    variantCode: "P176L",
+    emailType: "nedostupne",
+    mailTransport: transport,
+    bccEmail: "majitel@forestshop.sk",
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  const databaseUrl = process.env["DATABASE_URL"];
+  if (databaseUrl === undefined || databaseUrl === "") throw new Error("DATABASE_URL chýba");
+  checker = new pg.Client({ connectionString: databaseUrl });
+  await checker.connect();
+  const midSend = await checker.query<{ pg_try_advisory_lock: boolean }>("select pg_try_advisory_lock($1)", [NEDOSTUPNE_SEND_LOCK_KEY]);
+  expect(midSend.rows[0]?.pg_try_advisory_lock).toBe(false);
+
+  releaseSend?.();
+  expect(await sendPromise).toEqual({ ok: true });
+
+  const afterSend = await checker.query<{ pg_try_advisory_lock: boolean }>("select pg_try_advisory_lock($1)", [NEDOSTUPNE_SEND_LOCK_KEY]);
+  expect(afterSend.rows[0]?.pg_try_advisory_lock).toBe(true);
+  await checker.query("select pg_advisory_unlock($1)", [NEDOSTUPNE_SEND_LOCK_KEY]);
 });

--- a/apps/api/tests/nedostupne-run.integration.test.ts
+++ b/apps/api/tests/nedostupne-run.integration.test.ts
@@ -1,0 +1,253 @@
+import { eq } from "drizzle-orm";
+import { afterEach, expect, it } from "vitest";
+import { nedostupneState, orderLines, orders } from "../src/db/schema.js";
+import type { MailMessage } from "../src/modules/mail/transport.js";
+import { listNedostupneGroups } from "../src/modules/nedostupne/queries.js";
+import { findNedostupneContext, sendNedostupneEmail } from "../src/modules/nedostupne/send.js";
+import { DEFAULT_ORDER_OPEN_STATUS } from "../src/modules/orders/open-statuses.js";
+import { insertTestVariantForProduct } from "./helpers/orders.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 176: koniec-koncov beh — falošný mail transport (NIKDY skutočný
+// SMTP), presne per majiteľovej bezpečnostnej podmienke pre testy.
+const ADMIN_BASE_URL = "https://www.forestshop.sk";
+
+let close: (() => Promise<void>) | undefined;
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+});
+
+async function boot() {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  return ctx.db;
+}
+
+async function insertOrder(
+  db: Awaited<ReturnType<typeof boot>>,
+  externalOrderId: string,
+  overrides: Partial<typeof orders.$inferInsert> = {},
+): Promise<string> {
+  const [row] = await db
+    .insert(orders)
+    .values({
+      externalOrderId,
+      customerName: "Ján Novák",
+      statusName: DEFAULT_ORDER_OPEN_STATUS,
+      placedAt: new Date("2026-07-20T10:00:00Z"),
+      email: "jan@example.sk",
+      ...overrides,
+    })
+    .returning({ id: orders.id });
+  if (row === undefined) throw new Error("test objednávka sa nepodarilo vložiť");
+  return row.id;
+}
+
+function fakeMail(): { transport: (m: MailMessage) => Promise<void>; sent: MailMessage[] } {
+  const sent: MailMessage[] = [];
+  return {
+    transport: (m) => {
+      sent.push(m);
+      return Promise.resolve();
+    },
+    sent,
+  };
+}
+
+it("zoskupí NEDOSTUPNÝ riadok podľa variantu, spárovaný s otvorenou objednávkou", async () => {
+  const db = await boot();
+  await insertTestVariantForProduct(db, "P176A", "P176A/L", { productName: "Nohavice Test" });
+  const orderId = await insertOrder(db, "17600001");
+  await db.insert(orderLines).values({ orderId, variantCode: "P176A/L", quantity: 2, state: "nedostupne" });
+
+  const groups = await listNedostupneGroups(db, ADMIN_BASE_URL);
+  expect(groups).toHaveLength(1);
+  expect(groups[0]?.variantCode).toBe("P176A/L");
+  expect(groups[0]?.itemName).toBe("Nohavice Test");
+  expect(groups[0]?.orders).toHaveLength(1);
+  expect(groups[0]?.orders[0]).toMatchObject({ orderCode: "17600001", customerName: "Ján Novák", email: "jan@example.sk", quantity: 2, nedostupneSent: false, alternativaSent: false });
+});
+
+it("riadok v INOM stave (nie 'nedostupne') sa nezobrazí vôbec", async () => {
+  const db = await boot();
+  await insertTestVariantForProduct(db, "P176B", "P176B", {});
+  const orderId = await insertOrder(db, "17600002");
+  await db.insert(orderLines).values({ orderId, variantCode: "P176B", quantity: 1, state: "objednane" });
+
+  expect(await listNedostupneGroups(db, ADMIN_BASE_URL)).toEqual([]);
+});
+
+it("nedostupný riadok v UZAVRETEJ objednávke sa nezobrazí (nikdy neotravuj zákazníka, ktorý už dostal tovar)", async () => {
+  const db = await boot();
+  await insertTestVariantForProduct(db, "P176C", "P176C", {});
+  const orderId = await insertOrder(db, "17600003", { statusName: "Vybavená" });
+  await db.insert(orderLines).values({ orderId, variantCode: "P176C", quantity: 1, state: "nedostupne" });
+
+  expect(await listNedostupneGroups(db, ADMIN_BASE_URL)).toEqual([]);
+});
+
+it("náhradné produkty (relatedCodes) sa resolvujú na meno cez variant.code aj cez pairCode, neznámy kód padá na seba", async () => {
+  const db = await boot();
+  // "P176D2" má pairCode "PC-D2" — relatedCodes odkazuje na "PC-D2" (nie na code priamo).
+  await insertTestVariantForProduct(db, "P176D2-key", "P176D2", { productName: "Náhrada Podľa PairCode", pairCode: "PC-D2" });
+  await insertTestVariantForProduct(db, "P176D", "P176D/M", {
+    productName: "Nohavice s náhradou",
+    relatedCodes: ["PC-D2", "NEZNAMY-KOD"],
+  });
+  const orderId = await insertOrder(db, "17600004");
+  await db.insert(orderLines).values({ orderId, variantCode: "P176D/M", quantity: 1, state: "nedostupne" });
+
+  const groups = await listNedostupneGroups(db, ADMIN_BASE_URL);
+  const group = groups.find((g) => g.variantCode === "P176D/M");
+  expect(group?.alternatives).toEqual([
+    { code: "PC-D2", name: "Náhrada Podľa PairCode", url: "https://www.forestshop.sk/vyhladavanie/?string=PC-D2" },
+    { code: "NEZNAMY-KOD", name: "NEZNAMY-KOD", url: "https://www.forestshop.sk/vyhladavanie/?string=NEZNAMY-KOD" },
+  ]);
+});
+
+it("preview a odoslanie použijú ROVNAKÚ funkciu (`findNedostupneContext`/`buildEmailForType`) — obsah sa nikdy nerozíde", async () => {
+  const db = await boot();
+  await insertTestVariantForProduct(db, "P176E", "P176E", { productName: "Bunda Test" });
+  const orderId = await insertOrder(db, "17600005");
+  await db.insert(orderLines).values({ orderId, variantCode: "P176E", quantity: 1, state: "nedostupne" });
+  const { transport, sent } = fakeMail();
+
+  const result = await sendNedostupneEmail({
+    db,
+    now: new Date("2026-08-02T10:00:00Z"),
+    orderCode: "17600005",
+    variantCode: "P176E",
+    emailType: "nedostupne",
+    mailTransport: transport,
+    bccEmail: "majitel@forestshop.sk",
+  });
+
+  expect(result).toEqual({ ok: true });
+  expect(sent).toHaveLength(1);
+  expect(sent[0]?.to).toBe("jan@example.sk");
+  expect(sent[0]?.bcc).toBe("majitel@forestshop.sk");
+  expect(sent[0]?.subject).toBe("Informácia o dostupnosti vašej objednávky — Forestshop.sk");
+
+  const [state] = await db.select().from(nedostupneState).where(eq(nedostupneState.orderCode, "17600005"));
+  expect(state?.variantCode).toBe("P176E");
+  expect(state?.emailType).toBe("nedostupne");
+});
+
+it("chýbajúca BCC adresa → NEPOŠLE NIČ (fail-closed, rovnaká podmienka ako #172/#173)", async () => {
+  const db = await boot();
+  await insertTestVariantForProduct(db, "P176F", "P176F", {});
+  const orderId = await insertOrder(db, "17600006");
+  await db.insert(orderLines).values({ orderId, variantCode: "P176F", quantity: 1, state: "nedostupne" });
+  const { transport, sent } = fakeMail();
+
+  const result = await sendNedostupneEmail({
+    db,
+    now: new Date("2026-08-02T10:00:00Z"),
+    orderCode: "17600006",
+    variantCode: "P176F",
+    emailType: "nedostupne",
+    mailTransport: transport,
+    bccEmail: undefined,
+  });
+
+  expect(result.ok).toBe(false);
+  expect(!result.ok && result.code).toBe("not_configured");
+  expect(!result.ok && result.code === "not_configured" && result.reason).toContain("NEDOSTUPNE_BCC_EMAIL");
+  expect(sent).toHaveLength(0);
+});
+
+it("chýbajúci mailTransport → NEPOŠLE NIČ (fail-closed)", async () => {
+  const db = await boot();
+  await insertTestVariantForProduct(db, "P176G", "P176G", {});
+  const orderId = await insertOrder(db, "17600007");
+  await db.insert(orderLines).values({ orderId, variantCode: "P176G", quantity: 1, state: "nedostupne" });
+
+  const result = await sendNedostupneEmail({
+    db,
+    now: new Date("2026-08-02T10:00:00Z"),
+    orderCode: "17600007",
+    variantCode: "P176G",
+    emailType: "nedostupne",
+    mailTransport: undefined,
+    bccEmail: "majitel@forestshop.sk",
+  });
+
+  expect(result.ok).toBe(false);
+  expect(!result.ok && result.code).toBe("not_configured");
+  expect(!result.ok && result.code === "not_configured" && result.reason).toContain("MAIL_HOST");
+});
+
+it("objednávka bez e-mailu → 'no_email', nikdy sa nepokúsi poslať", async () => {
+  const db = await boot();
+  await insertTestVariantForProduct(db, "P176H", "P176H", {});
+  const orderId = await insertOrder(db, "17600008", { email: null });
+  await db.insert(orderLines).values({ orderId, variantCode: "P176H", quantity: 1, state: "nedostupne" });
+  const { transport, sent } = fakeMail();
+
+  const result = await sendNedostupneEmail({
+    db,
+    now: new Date("2026-08-02T10:00:00Z"),
+    orderCode: "17600008",
+    variantCode: "P176H",
+    emailType: "nedostupne",
+    mailTransport: transport,
+    bccEmail: "majitel@forestshop.sk",
+  });
+
+  expect(result).toEqual({ ok: false, code: "no_email" });
+  expect(sent).toHaveLength(0);
+});
+
+it("DEDUP — druhé odoslanie ROVNAKÉHO (objednávka, variant, typ) je odmietnuté, žiadny druhý e-mail", async () => {
+  const db = await boot();
+  await insertTestVariantForProduct(db, "P176I", "P176I", {});
+  const orderId = await insertOrder(db, "17600009");
+  await db.insert(orderLines).values({ orderId, variantCode: "P176I", quantity: 1, state: "nedostupne" });
+  const { transport, sent } = fakeMail();
+  const deps = { db, now: new Date("2026-08-02T10:00:00Z"), orderCode: "17600009", variantCode: "P176I", emailType: "nedostupne" as const, mailTransport: transport, bccEmail: "majitel@forestshop.sk" };
+
+  expect(await sendNedostupneEmail(deps)).toEqual({ ok: true });
+  expect(sent).toHaveLength(1);
+
+  const second = await sendNedostupneEmail(deps);
+  expect(second).toEqual({ ok: false, code: "already_sent" });
+  expect(sent).toHaveLength(1); // stále len jeden
+});
+
+it("DEDUP je NEZÁVISLÝ per typ — 'nedostupne' odoslané nebráni neskoršiemu 'alternativa'", async () => {
+  const db = await boot();
+  await insertTestVariantForProduct(db, "P176J", "P176J", {});
+  const orderId = await insertOrder(db, "17600010");
+  await db.insert(orderLines).values({ orderId, variantCode: "P176J", quantity: 1, state: "nedostupne" });
+  const { transport, sent } = fakeMail();
+  const base = { db, now: new Date("2026-08-02T10:00:00Z"), orderCode: "17600010", variantCode: "P176J", mailTransport: transport, bccEmail: "majitel@forestshop.sk" };
+
+  expect(await sendNedostupneEmail({ ...base, emailType: "nedostupne" })).toEqual({ ok: true });
+  expect(await sendNedostupneEmail({ ...base, emailType: "alternativa" })).toEqual({ ok: true });
+  expect(sent).toHaveLength(2);
+});
+
+it("riadok, ktorý medzitým už NIE JE 'nedostupne' (napr. sklad ho medzitým naskladnil), sa odmietne pri odoslaní — 'not_found'", async () => {
+  const db = await boot();
+  await insertTestVariantForProduct(db, "P176K", "P176K", {});
+  const orderId = await insertOrder(db, "17600011");
+  await db.insert(orderLines).values({ orderId, variantCode: "P176K", quantity: 1, state: "nedostupne" });
+
+  // Obsluha medzitým riadok prepla na "skladom" (napr. z inej karty) —
+  // odoslanie MUSÍ prekontrolovať stav ZNOVA, nikdy sa nespolieha na to, že
+  // zobrazený zoznam je ešte aktuálny.
+  await db.update(orderLines).set({ state: "skladom" }).where(eq(orderLines.variantCode, "P176K"));
+  expect(await findNedostupneContext(db, "17600011", "P176K")).toBeNull();
+
+  const result = await sendNedostupneEmail({
+    db,
+    now: new Date("2026-08-02T10:00:00Z"),
+    orderCode: "17600011",
+    variantCode: "P176K",
+    emailType: "nedostupne",
+    mailTransport: undefined,
+    bccEmail: undefined,
+  });
+  expect(result).toEqual({ ok: false, code: "not_found" });
+});

--- a/apps/web/src/components/NedostupneSection.test.tsx
+++ b/apps/web/src/components/NedostupneSection.test.tsx
@@ -75,7 +75,7 @@ it("rola citanie NEVIDÍ žiadne akčné tlačidlá (len admin/manazer smie odos
 
 it("klik na 'náhľad' otvorí povinný náhľad PRED odoslaním — Odoslať sa ešte nevolá", async () => {
   fetchNedostupneList.mockResolvedValue(LIST_WITH_GROUP);
-  fetchNedostupnePreview.mockResolvedValue({ ok: true, subject: "Informácia o dostupnosti vašej objednávky — Forestshop.sk", html: "<p>Ahoj</p>", recipient: "jan@example.sk", customerName: "Ján Novák" });
+  fetchNedostupnePreview.mockResolvedValue({ ok: true, subject: "Informácia o dostupnosti vašej objednávky — Forestshop.sk", html: "<p>Ahoj</p>", recipient: "jan@example.sk", customerName: "Ján Novák", previewToken: "tok-1" });
   render(<NedostupneSection role="manazer" onSessionExpired={vi.fn()} />);
   await screen.findByTestId("nedostupne-group-40237/L");
 
@@ -92,7 +92,7 @@ it("potvrdenie náhľadu odošle presne s parametrami náhľadu a znovu načíta
     bccMissing: false,
     mailNotConfigured: false,
   });
-  fetchNedostupnePreview.mockResolvedValue({ ok: true, subject: "Predmet", html: "<p>Ahoj</p>", recipient: "jan@example.sk", customerName: "Ján Novák" });
+  fetchNedostupnePreview.mockResolvedValue({ ok: true, subject: "Predmet", html: "<p>Ahoj</p>", recipient: "jan@example.sk", customerName: "Ján Novák", previewToken: "tok-1" });
   sendNedostupneEmail.mockResolvedValue({ ok: true });
   render(<NedostupneSection role="manazer" onSessionExpired={vi.fn()} />);
   await screen.findByTestId("nedostupne-group-40237/L");
@@ -102,7 +102,7 @@ it("potvrdenie náhľadu odošle presne s parametrami náhľadu a znovu načíta
   fireEvent.click(screen.getByTestId("nedostupne-confirm-send"));
 
   await waitFor(() => {
-    expect(sendNedostupneEmail).toHaveBeenCalledWith("17600001", "40237/L", "nedostupne");
+    expect(sendNedostupneEmail).toHaveBeenCalledWith("17600001", "40237/L", "nedostupne", "tok-1");
   });
   await waitFor(() => {
     expect(screen.queryByTestId("nedostupne-preview")).toBeNull();
@@ -111,7 +111,7 @@ it("potvrdenie náhľadu odošle presne s parametrami náhľadu a znovu načíta
 
 it("zrušenie náhľadu NEPOŠLE nič", async () => {
   fetchNedostupneList.mockResolvedValue(LIST_WITH_GROUP);
-  fetchNedostupnePreview.mockResolvedValue({ ok: true, subject: "Predmet", html: "<p>Ahoj</p>", recipient: "jan@example.sk", customerName: "Ján Novák" });
+  fetchNedostupnePreview.mockResolvedValue({ ok: true, subject: "Predmet", html: "<p>Ahoj</p>", recipient: "jan@example.sk", customerName: "Ján Novák", previewToken: "tok-1" });
   render(<NedostupneSection role="manazer" onSessionExpired={vi.fn()} />);
   await screen.findByTestId("nedostupne-group-40237/L");
 
@@ -126,7 +126,7 @@ it("zrušenie náhľadu NEPOŠLE nič", async () => {
 
 it("zlyhané odoslanie (ok:false) zobrazí server hlášku a nezavrie náhľad", async () => {
   fetchNedostupneList.mockResolvedValue(LIST_WITH_GROUP);
-  fetchNedostupnePreview.mockResolvedValue({ ok: true, subject: "Predmet", html: "<p>Ahoj</p>", recipient: "jan@example.sk", customerName: "Ján Novák" });
+  fetchNedostupnePreview.mockResolvedValue({ ok: true, subject: "Predmet", html: "<p>Ahoj</p>", recipient: "jan@example.sk", customerName: "Ján Novák", previewToken: "tok-1" });
   sendNedostupneEmail.mockResolvedValue({ ok: false, error: "Tento e-mail už bol tejto objednávke odoslaný." });
   render(<NedostupneSection role="manazer" onSessionExpired={vi.fn()} />);
   await screen.findByTestId("nedostupne-group-40237/L");

--- a/apps/web/src/components/NedostupneSection.test.tsx
+++ b/apps/web/src/components/NedostupneSection.test.tsx
@@ -1,0 +1,149 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { NedostupneSection } from "./NedostupneSection.js";
+
+const { fetchNedostupneList, fetchNedostupnePreview, sendNedostupneEmail } = vi.hoisted(() => ({
+  fetchNedostupneList: vi.fn(),
+  fetchNedostupnePreview: vi.fn(),
+  sendNedostupneEmail: vi.fn(),
+}));
+
+// `NedostupneUnauthorizedError` ostáva SKUTOČNÁ trieda (rovnaký dôvod ako
+// `OrderReminderSection.test.tsx` — `instanceof` v komponente musí fungovať).
+vi.mock("../nedostupneApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../nedostupneApi.js")>();
+  return { ...actual, fetchNedostupneList, fetchNedostupnePreview, sendNedostupneEmail };
+});
+
+const { NedostupneUnauthorizedError } = await import("../nedostupneApi.js");
+
+const GROUP = {
+  variantCode: "40237/L",
+  itemName: "Nohavice FOREST 1003",
+  sizeLabel: "L",
+  alternatives: [{ code: "60116/90", name: "Podkolienky BOBR", url: "https://www.forestshop.sk/vyhladavanie/?string=60116%2F90" }],
+  orders: [
+    {
+      orderCode: "17600001",
+      adminLink: "https://www.forestshop.sk/admin/vyhladavanie/?string=17600001&src=orders",
+      customerName: "Ján Novák",
+      email: "jan@example.sk",
+      quantity: 2,
+      placedAt: "2026-07-20T10:00:00.000Z",
+      nedostupneSent: false,
+      alternativaSent: false,
+    },
+  ],
+};
+
+const LIST_WITH_GROUP = { groups: [GROUP], bccMissing: false, mailNotConfigured: false };
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+it("prázdny zoznam zobrazí informačnú vetu", async () => {
+  fetchNedostupneList.mockResolvedValue({ groups: [], bccMissing: false, mailNotConfigured: false });
+  render(<NedostupneSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("nedostupne-empty");
+});
+
+it("chýbajúca BCC/mail konfigurácia zobrazí obe upozornenia", async () => {
+  fetchNedostupneList.mockResolvedValue({ groups: [], bccMissing: true, mailNotConfigured: true });
+  render(<NedostupneSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("nedostupne-bcc-missing");
+  await screen.findByTestId("nedostupne-mail-not-configured");
+});
+
+it("zobrazí kartu variantu s náhradou aj objednávkou zákazníka", async () => {
+  fetchNedostupneList.mockResolvedValue(LIST_WITH_GROUP);
+  render(<NedostupneSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("nedostupne-group-40237/L");
+  expect(screen.getByText(/Nohavice FOREST 1003/)).not.toBeNull();
+  expect(screen.getByText(/veľkosť L/)).not.toBeNull();
+  expect(screen.getByText("Podkolienky BOBR")).not.toBeNull();
+  expect(screen.getByText("Ján Novák")).not.toBeNull();
+});
+
+it("rola citanie NEVIDÍ žiadne akčné tlačidlá (len admin/manazer smie odosielať)", async () => {
+  fetchNedostupneList.mockResolvedValue(LIST_WITH_GROUP);
+  render(<NedostupneSection role="citanie" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("nedostupne-group-40237/L");
+  expect(screen.queryByTestId("nedostupne-send-17600001-40237/L")).toBeNull();
+});
+
+it("klik na 'náhľad' otvorí povinný náhľad PRED odoslaním — Odoslať sa ešte nevolá", async () => {
+  fetchNedostupneList.mockResolvedValue(LIST_WITH_GROUP);
+  fetchNedostupnePreview.mockResolvedValue({ ok: true, subject: "Informácia o dostupnosti vašej objednávky — Forestshop.sk", html: "<p>Ahoj</p>", recipient: "jan@example.sk", customerName: "Ján Novák" });
+  render(<NedostupneSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("nedostupne-group-40237/L");
+
+  fireEvent.click(screen.getByTestId("nedostupne-send-17600001-40237/L"));
+  await screen.findByTestId("nedostupne-preview");
+  expect(fetchNedostupnePreview).toHaveBeenCalledWith("17600001", "40237/L", "nedostupne");
+  expect(sendNedostupneEmail).not.toHaveBeenCalled();
+  expect(screen.getAllByText(/jan@example\.sk/).length).toBeGreaterThan(0);
+});
+
+it("potvrdenie náhľadu odošle presne s parametrami náhľadu a znovu načíta zoznam", async () => {
+  fetchNedostupneList.mockResolvedValueOnce(LIST_WITH_GROUP).mockResolvedValueOnce({
+    groups: [{ ...GROUP, orders: [{ ...GROUP.orders[0], nedostupneSent: true }] }],
+    bccMissing: false,
+    mailNotConfigured: false,
+  });
+  fetchNedostupnePreview.mockResolvedValue({ ok: true, subject: "Predmet", html: "<p>Ahoj</p>", recipient: "jan@example.sk", customerName: "Ján Novák" });
+  sendNedostupneEmail.mockResolvedValue({ ok: true });
+  render(<NedostupneSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("nedostupne-group-40237/L");
+
+  fireEvent.click(screen.getByTestId("nedostupne-send-17600001-40237/L"));
+  await screen.findByTestId("nedostupne-preview");
+  fireEvent.click(screen.getByTestId("nedostupne-confirm-send"));
+
+  await waitFor(() => {
+    expect(sendNedostupneEmail).toHaveBeenCalledWith("17600001", "40237/L", "nedostupne");
+  });
+  await waitFor(() => {
+    expect(screen.queryByTestId("nedostupne-preview")).toBeNull();
+  });
+});
+
+it("zrušenie náhľadu NEPOŠLE nič", async () => {
+  fetchNedostupneList.mockResolvedValue(LIST_WITH_GROUP);
+  fetchNedostupnePreview.mockResolvedValue({ ok: true, subject: "Predmet", html: "<p>Ahoj</p>", recipient: "jan@example.sk", customerName: "Ján Novák" });
+  render(<NedostupneSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("nedostupne-group-40237/L");
+
+  fireEvent.click(screen.getByTestId("nedostupne-send-17600001-40237/L"));
+  await screen.findByTestId("nedostupne-preview");
+  fireEvent.click(screen.getByText("Zrušiť"));
+  await waitFor(() => {
+    expect(screen.queryByTestId("nedostupne-preview")).toBeNull();
+  });
+  expect(sendNedostupneEmail).not.toHaveBeenCalled();
+});
+
+it("zlyhané odoslanie (ok:false) zobrazí server hlášku a nezavrie náhľad", async () => {
+  fetchNedostupneList.mockResolvedValue(LIST_WITH_GROUP);
+  fetchNedostupnePreview.mockResolvedValue({ ok: true, subject: "Predmet", html: "<p>Ahoj</p>", recipient: "jan@example.sk", customerName: "Ján Novák" });
+  sendNedostupneEmail.mockResolvedValue({ ok: false, error: "Tento e-mail už bol tejto objednávke odoslaný." });
+  render(<NedostupneSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("nedostupne-group-40237/L");
+
+  fireEvent.click(screen.getByTestId("nedostupne-send-17600001-40237/L"));
+  await screen.findByTestId("nedostupne-preview");
+  fireEvent.click(screen.getByTestId("nedostupne-confirm-send"));
+
+  await screen.findByText("Tento e-mail už bol tejto objednávke odoslaný.");
+  expect(screen.getByTestId("nedostupne-preview")).not.toBeNull();
+});
+
+it("401 pri načítaní zavolá onSessionExpired", async () => {
+  const onSessionExpired = vi.fn();
+  fetchNedostupneList.mockRejectedValue(new NedostupneUnauthorizedError());
+  render(<NedostupneSection role="manazer" onSessionExpired={onSessionExpired} />);
+  await waitFor(() => {
+    expect(onSessionExpired).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/NedostupneSection.tsx
+++ b/apps/web/src/components/NedostupneSection.tsx
@@ -81,7 +81,7 @@ export function NedostupneSection({ role, onSessionExpired }: { readonly role: M
     if (pending === null) return;
     const key = `${pending.orderCode}|${pending.variantCode}|${pending.emailType}`;
     setBusyKey(key);
-    sendNedostupneEmail(pending.orderCode, pending.variantCode, pending.emailType)
+    sendNedostupneEmail(pending.orderCode, pending.variantCode, pending.emailType, pending.preview.previewToken)
       .then((result) => {
         if (!result.ok) {
           setActionError(result.error);

--- a/apps/web/src/components/NedostupneSection.tsx
+++ b/apps/web/src/components/NedostupneSection.tsx
@@ -1,0 +1,228 @@
+import { useCallback, useEffect, useState, type JSX } from "react";
+import type { Me } from "../api.js";
+import {
+  fetchNedostupneList,
+  fetchNedostupnePreview,
+  NedostupneUnauthorizedError,
+  sendNedostupneEmail,
+  type NedostupneEmailType,
+  type NedostupneGroup,
+  type NedostupneList,
+  type NedostupnePreview,
+} from "../nedostupneApi.js";
+
+// Rovnaké dve role, ktoré server vyžaduje na odoslanie (`requireRole("admin",
+// "manazer")`, `nedostupne-routes.ts`) — čítanie (zoznam) smie vidieť KAŽDÝ
+// prihlásený zamestnanec, rovnaká úroveň ako #172/#173.
+const CONTROL_ROLES: ReadonlySet<Me["role"]> = new Set(["admin", "manazer"]);
+
+interface PendingSend {
+  readonly orderCode: string;
+  readonly variantCode: string;
+  readonly emailType: NedostupneEmailType;
+  readonly preview: NedostupnePreview;
+}
+
+function itemLabel(group: NedostupneGroup): string {
+  return group.sizeLabel === null ? group.itemName : `${group.itemName} — veľkosť ${group.sizeLabel}`;
+}
+
+export function NedostupneSection({ role, onSessionExpired }: { readonly role: Me["role"]; readonly onSessionExpired: () => void }): JSX.Element {
+  const [list, setList] = useState<NedostupneList | null>(null);
+  const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState("");
+  const [busyKey, setBusyKey] = useState("");
+  const [actionError, setActionError] = useState("");
+  const [pending, setPending] = useState<PendingSend | null>(null);
+  const canControl = CONTROL_ROLES.has(role);
+
+  const load = useCallback(() => {
+    fetchNedostupneList()
+      .then((l) => {
+        setList(l);
+        setLoaded(true);
+      })
+      .catch((err: unknown) => {
+        setLoaded(true);
+        if (err instanceof NedostupneUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setError("Nedostupné tovary sa nepodarilo načítať.");
+      });
+  }, [onSessionExpired]);
+
+  useEffect(load, [load]);
+
+  const openPreview = useCallback(
+    (orderCode: string, variantCode: string, emailType: NedostupneEmailType) => {
+      const key = `${orderCode}|${variantCode}|${emailType}`;
+      setActionError("");
+      setBusyKey(key);
+      fetchNedostupnePreview(orderCode, variantCode, emailType)
+        .then((preview) => {
+          setPending({ orderCode, variantCode, emailType, preview });
+        })
+        .catch((err: unknown) => {
+          if (err instanceof NedostupneUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setActionError(err instanceof Error ? err.message : "Náhľad sa nepodarilo načítať.");
+        })
+        .finally(() => {
+          setBusyKey("");
+        });
+    },
+    [onSessionExpired],
+  );
+
+  const confirmSend = useCallback(() => {
+    if (pending === null) return;
+    const key = `${pending.orderCode}|${pending.variantCode}|${pending.emailType}`;
+    setBusyKey(key);
+    sendNedostupneEmail(pending.orderCode, pending.variantCode, pending.emailType)
+      .then((result) => {
+        if (!result.ok) {
+          setActionError(result.error);
+          return;
+        }
+        setPending(null);
+        load();
+      })
+      .catch((err: unknown) => {
+        if (err instanceof NedostupneUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setActionError(err instanceof Error ? err.message : "Odoslanie zlyhalo.");
+      })
+      .finally(() => {
+        setBusyKey("");
+      });
+  }, [pending, load, onSessionExpired]);
+
+  if (!loaded) return <p>Načítavam…</p>;
+  if (error !== "") return <p role="alert">{error}</p>;
+  if (list === null) return <p role="alert">Nedostupné tovary sa nepodarilo načítať.</p>;
+
+  return (
+    <section>
+      <h2>Nedostupné tovary</h2>
+      <p>Tovary, ktoré dodávateľ nemá, spárované s otvorenými objednávkami zákazníkov, ktorí na ne čakajú.</p>
+
+      {list.bccMissing && (
+        <p role="alert" data-testid="nedostupne-bcc-missing">
+          ⚠️ Chýba adresa pre skrytú kópiu majiteľovi (NEDOSTUPNE_BCC_EMAIL) — automatizácia zatiaľ NEPOŠLE žiadny e-mail zákazníkovi.
+        </p>
+      )}
+      {list.mailNotConfigured && (
+        <p role="alert" data-testid="nedostupne-mail-not-configured">
+          ⚠️ Odosielanie e-mailov nie je nakonfigurované (chýba MAIL_HOST).
+        </p>
+      )}
+      {actionError !== "" && <p role="alert">{actionError}</p>}
+
+      {list.groups.length === 0 ? (
+        <p data-testid="nedostupne-empty">Žiadny tovar momentálne nie je označený ako nedostupný.</p>
+      ) : (
+        <div className="nedostupne-groups" data-testid="nedostupne-groups">
+          {list.groups.map((group) => (
+            <div className="card" key={group.variantCode} data-testid={`nedostupne-group-${group.variantCode}`}>
+              <div className="nedostupne-group-header">
+                <span className="nedostupne-group-name">{itemLabel(group)}</span>
+                <span className="pill off">{group.variantCode}</span>
+              </div>
+
+              {group.alternatives.length > 0 && (
+                <ul className="nedostupne-alternatives" data-testid={`nedostupne-alternatives-${group.variantCode}`}>
+                  {group.alternatives.map((a) => (
+                    <li key={a.code}>
+                      Náhrada:{" "}
+                      <a href={a.url} target="_blank" rel="noreferrer">
+                        {a.name}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              )}
+
+              {group.orders.map((order) => {
+                const rowBusy = busyKey.startsWith(`${order.orderCode}|${group.variantCode}|`);
+                return (
+                  <div className="nedostupne-order-row" key={order.orderCode} data-testid={`nedostupne-order-${order.orderCode}-${group.variantCode}`}>
+                    <a href={order.adminLink} target="_blank" rel="noreferrer">
+                      {order.orderCode}
+                    </a>
+                    <span>{order.customerName}</span>
+                    <span>{order.email === "" ? "(bez e-mailu)" : order.email}</span>
+                    <span>{order.quantity} ks</span>
+                    {canControl && (
+                      <div className="nedostupne-order-actions">
+                        <button
+                          type="button"
+                          className="btn lg ghost"
+                          disabled={rowBusy || order.nedostupneSent}
+                          onClick={() => {
+                            openPreview(order.orderCode, group.variantCode, "nedostupne");
+                          }}
+                          data-testid={`nedostupne-send-${order.orderCode}-${group.variantCode}`}
+                        >
+                          {order.nedostupneSent ? "✓ Odoslané" : "Nedostupné — náhľad"}
+                        </button>
+                        <button
+                          type="button"
+                          className="btn lg ghost"
+                          disabled={rowBusy || order.alternativaSent}
+                          onClick={() => {
+                            openPreview(order.orderCode, group.variantCode, "alternativa");
+                          }}
+                          data-testid={`nedostupne-alt-send-${order.orderCode}-${group.variantCode}`}
+                        >
+                          {order.alternativaSent ? "✓ Odoslané" : "S náhradou — náhľad"}
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {pending !== null && (
+        <div className="mail-preview" data-testid="nedostupne-preview">
+          <h3>Náhľad e-mailu — povinné pred odoslaním</h3>
+          <p>
+            Komu: {pending.preview.recipient} — Predmet: {pending.preview.subject}
+          </p>
+          {/* `pending.preview.html` je appkou generovaný e-mail (`buildEmailForType`,
+              `modules/nedostupne/logic.ts`) — meno zákazníka aj náhradné produkty sú
+              tam už HTML-escapované, nikdy surový užívateľský vstup priamo tu. */}
+          <div className="nedostupne-preview-body" dangerouslySetInnerHTML={{ __html: pending.preview.html }} />
+          <div className="nedostupne-order-actions">
+            <button
+              type="button"
+              className="btn lg good"
+              disabled={busyKey !== ""}
+              onClick={confirmSend}
+              data-testid="nedostupne-confirm-send"
+            >
+              📧 Odoslať zákazníkovi
+            </button>
+            <button
+              type="button"
+              className="btn lg ghost"
+              onClick={() => {
+                setPending(null);
+              }}
+            >
+              Zrušiť
+            </button>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/nav.ts
+++ b/apps/web/src/nav.ts
@@ -1,6 +1,7 @@
 import type { ComponentType } from "react";
 import type { Me } from "./api.js";
 import { CatalogPage } from "./components/CatalogPage.js";
+import { NedostupneSection } from "./components/NedostupneSection.js";
 import { OrderReminderSection } from "./components/OrderReminderSection.js";
 import { OrdersSection } from "./components/OrdersSection.js";
 import { PairingSection } from "./components/PairingSection.js";
@@ -69,6 +70,11 @@ export const HIDDEN_TABS: Readonly<Record<string, NavTab>> = {
   // chce v ľavom menu len dve položky (#57), táto obrazovka je preto
   // dostupná len cez `?tab=order-reminder`.
   "order-reminder": { id: "order-reminder", label: "Pripomienky objednávok", Component: OrderReminderSection },
+  // issue 176: rovnaký vzor ako "posta-uncollected"/"order-reminder" vyššie —
+  // majiteľ zatiaľ chce v ľavom menu len dve položky (#57). `wide: true`
+  // (rovnaký dôvod ako "Na objednanie") — karty so zoznamom objednávok
+  // profitujú z celej šírky okna, nie len z čitateľnej šírky.
+  nedostupne: { id: "nedostupne", label: "Nedostupné tovary", Component: NedostupneSection, wide: true },
 };
 
 export const DEFAULT_TAB_ID: string = NAV[0]?.tabs[0]?.id ?? "sync";

--- a/apps/web/src/nedostupneApi.ts
+++ b/apps/web/src/nedostupneApi.ts
@@ -1,0 +1,91 @@
+import { z } from "zod";
+
+// issue 176: "Nedostupné tovary" — zrkadlí `NedostupneGroup`/`NedostupneOrderRow`
+// (`apps/api/src/modules/nedostupne/queries.ts`).
+
+const alternativeSchema = z.object({ code: z.string(), name: z.string(), url: z.string() });
+
+const orderRowSchema = z.object({
+  orderCode: z.string(),
+  adminLink: z.string(),
+  customerName: z.string(),
+  email: z.string(),
+  quantity: z.number(),
+  placedAt: z.string(),
+  nedostupneSent: z.boolean(),
+  alternativaSent: z.boolean(),
+});
+
+const groupSchema = z.object({
+  variantCode: z.string(),
+  itemName: z.string(),
+  sizeLabel: z.string().nullable(),
+  alternatives: z.array(alternativeSchema),
+  orders: z.array(orderRowSchema),
+});
+export type NedostupneGroup = z.infer<typeof groupSchema>;
+export type NedostupneOrderRow = z.infer<typeof orderRowSchema>;
+
+const listSchema = z.object({ groups: z.array(groupSchema), bccMissing: z.boolean(), mailNotConfigured: z.boolean() });
+export type NedostupneList = z.infer<typeof listSchema>;
+
+export type NedostupneEmailType = "nedostupne" | "alternativa";
+
+const previewResultSchema = z.union([
+  z.object({ ok: z.literal(true), subject: z.string(), html: z.string(), recipient: z.string(), customerName: z.string() }),
+  z.object({ ok: z.literal(false), error: z.string() }),
+]);
+export type NedostupnePreview = Extract<z.infer<typeof previewResultSchema>, { readonly ok: true }>;
+
+const sendResultSchema = z.union([z.object({ ok: z.literal(true) }), z.object({ ok: z.literal(false), error: z.string() })]);
+export type NedostupneSendResult = z.infer<typeof sendResultSchema>;
+
+export class NedostupneUnauthorizedError extends Error {
+  constructor() {
+    super("Neprihlásený");
+  }
+}
+
+const errorBodySchema = z.object({ error: z.string() });
+
+async function serverErrorMessage(response: Response, fallback: string): Promise<string> {
+  try {
+    const parsed = errorBodySchema.safeParse(await response.json());
+    if (parsed.success) return parsed.data.error;
+  } catch {
+    // telo nie je platný JSON — použi všeobecnú hlášku
+  }
+  return fallback;
+}
+
+async function readJson(response: Response, fallback: string): Promise<unknown> {
+  if (response.status === 401) throw new NedostupneUnauthorizedError();
+  if (!response.ok) throw new Error(await serverErrorMessage(response, fallback));
+  return await response.json();
+}
+
+export async function fetchNedostupneList(): Promise<NedostupneList> {
+  const response = await fetch("/api/nedostupne");
+  return listSchema.parse(await readJson(response, "Nedostupné tovary sa nepodarilo načítať"));
+}
+
+export async function fetchNedostupnePreview(orderCode: string, variantCode: string, emailType: NedostupneEmailType): Promise<NedostupnePreview> {
+  const response = await fetch("/api/nedostupne/preview", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ orderCode, variantCode, emailType }),
+  });
+  const parsed = previewResultSchema.parse(await readJson(response, "Náhľad sa nepodarilo načítať"));
+  if (!parsed.ok) throw new Error(parsed.error);
+  return parsed;
+}
+
+export async function sendNedostupneEmail(orderCode: string, variantCode: string, emailType: NedostupneEmailType): Promise<NedostupneSendResult> {
+  const response = await fetch("/api/nedostupne/send", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ orderCode, variantCode, emailType }),
+  });
+  if (response.status === 401) throw new NedostupneUnauthorizedError();
+  return sendResultSchema.parse(await response.json());
+}

--- a/apps/web/src/nedostupneApi.ts
+++ b/apps/web/src/nedostupneApi.ts
@@ -32,7 +32,7 @@ export type NedostupneList = z.infer<typeof listSchema>;
 export type NedostupneEmailType = "nedostupne" | "alternativa";
 
 const previewResultSchema = z.union([
-  z.object({ ok: z.literal(true), subject: z.string(), html: z.string(), recipient: z.string(), customerName: z.string() }),
+  z.object({ ok: z.literal(true), subject: z.string(), html: z.string(), recipient: z.string(), customerName: z.string(), previewToken: z.string() }),
   z.object({ ok: z.literal(false), error: z.string() }),
 ]);
 export type NedostupnePreview = Extract<z.infer<typeof previewResultSchema>, { readonly ok: true }>;
@@ -80,11 +80,21 @@ export async function fetchNedostupnePreview(orderCode: string, variantCode: str
   return parsed;
 }
 
-export async function sendNedostupneEmail(orderCode: string, variantCode: string, emailType: NedostupneEmailType): Promise<NedostupneSendResult> {
+// issue 176 (code review pred mergom, PR #182): server VYŽADUJE `previewToken`
+// vydaný `/preview` PRE PRESNE tento (orderCode, variantCode, emailType) —
+// server-side vynútenie povinného náhľadu (`preview-tokens.ts`). Volajúci
+// (`NedostupneSection.tsx`) preto musí odoslať TEN ISTÝ token, aký dostal z
+// `fetchNedostupnePreview`, nikdy vlastný/vymyslený reťazec.
+export async function sendNedostupneEmail(
+  orderCode: string,
+  variantCode: string,
+  emailType: NedostupneEmailType,
+  previewToken: string,
+): Promise<NedostupneSendResult> {
   const response = await fetch("/api/nedostupne/send", {
     method: "POST",
     headers: { "content-type": "application/json" },
-    body: JSON.stringify({ orderCode, variantCode, emailType }),
+    body: JSON.stringify({ orderCode, variantCode, emailType, previewToken }),
   });
   if (response.status === 401) throw new NedostupneUnauthorizedError();
   return sendResultSchema.parse(await response.json());

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -492,6 +492,13 @@ tr:last-child td {
   padding: var(--fs-space-1) var(--fs-space-3);
   font-size: var(--fs-text-sm);
 }
+/* issue 176: VEĽKÉ tlačidlá pre obrazovky s opakovanou rýchlou akciou
+   zamestnanca (klik na riadok objednávky) — majiteľova požiadavka na
+   "veľké tlačidlá, aby zamestnanci mohli rýchlo a efektívne pracovať". */
+.btn.lg {
+  padding: var(--fs-space-3) var(--fs-space-5);
+  font-size: var(--fs-text-md);
+}
 .btn.good {
   background: var(--fs-brand);
   color: #fff;
@@ -1603,6 +1610,59 @@ tr:last-child td {
   margin-top: var(--fs-space-2);
 }
 .order-reminder-preview-body {
+  background: var(--fs-surface);
+  padding: var(--fs-space-3);
+  border-radius: var(--fs-radius-sm);
+  overflow-x: auto;
+}
+
+/* ---------------- 15. NEDOSTUPNÉ TOVARY (issue 176) ---------------- */
+/* Zoznam kariet (jedna karta = jeden variant) namiesto jednej veľkej
+   tabuľky — majiteľova požiadavka na prehľadné, vzdušné rozloženie
+   optimalizované na rýchlu prácu (veľké tlačidlá, jasné odsadenie). */
+.nedostupne-groups {
+  display: flex;
+  flex-direction: column;
+  gap: var(--fs-space-5);
+  margin-top: var(--fs-space-4);
+}
+.nedostupne-group-header {
+  display: flex;
+  align-items: baseline;
+  gap: var(--fs-space-3);
+  flex-wrap: wrap;
+  margin-bottom: var(--fs-space-3);
+}
+.nedostupne-group-name {
+  font-size: var(--fs-text-md);
+  font-weight: var(--fs-weight-bold);
+}
+.nedostupne-alternatives {
+  margin: 0 0 var(--fs-space-3);
+  padding-left: var(--fs-space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--fs-space-1);
+  font-size: var(--fs-text-sm);
+}
+.nedostupne-order-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--fs-space-3);
+  padding: var(--fs-space-3) 0;
+  border-top: 1px solid var(--fs-border-soft);
+}
+.nedostupne-order-row:first-of-type {
+  border-top: none;
+}
+.nedostupne-order-actions {
+  display: flex;
+  gap: var(--fs-space-2);
+  margin-left: auto;
+  flex-wrap: wrap;
+}
+.nedostupne-preview-body {
   background: var(--fs-surface);
   padding: var(--fs-space-3);
   border-radius: var(--fs-radius-sm);

--- a/apps/web/tests/e2e/nedostupne.spec.ts
+++ b/apps/web/tests/e2e/nedostupne.spec.ts
@@ -1,0 +1,60 @@
+import { expect, test, type ConsoleMessage } from "@playwright/test";
+
+const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
+const E2E_NEDOSTUPNE_EMAIL = "e2e-nedostupne@forestshop.sk"; // musí sa zhodovať s hodnotou v scripts/e2e-setup.ts
+
+// Rovnaká a JEDINÁ povolená výnimka ako v login.spec.ts/catalog.spec.ts/orders.spec.ts/posta-uncollected.spec.ts/order-reminder.spec.ts.
+const jeOcakavane = (m: ConsoleMessage): boolean => m.location().url.includes("/api/me") && m.text().includes("401");
+
+// issue 176: "Nedostupné tovary" je SKRYTÁ obrazovka (rovnaký vzor ako
+// #172/#173 — majiteľ chce v ľavom menu zatiaľ len "Sync zo Shoptetu"/"Na
+// objednanie", issue 57) — dostupná cez `?tab=nedostupne`.
+//
+// Toto NEKONTAKTUJE skutočný SMTP: `playwright.config.ts`'s API `webServer`
+// nenastavuje `MAIL_HOST`, takže `mailTransport` je v tomto behu `undefined`
+// (rovnaká úvaha ako `order-reminder.spec.ts`/`posta-uncollected.spec.ts`).
+// Fixtúrová objednávka "9008" (`scripts/e2e-setup.ts`) má riadok variantu
+// "40287" v stave 'nedostupne' — ten istý variant, ktorého katalógová
+// fixtúra reálne nesie `relatedProduct = "60297"`, takže náhrada sa dá
+// overiť naživo bez ďalšej fixtúry.
+test("zoznam zobrazí nedostupný variant s náhradou, povinný náhľad predchádza odoslaniu, konzola je čistá", async ({ page }) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/?tab=nedostupne");
+  await page.getByLabel("E-mail").fill(E2E_NEDOSTUPNE_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await expect(page.getByRole("heading", { name: "Nedostupné tovary" })).toBeVisible();
+
+  // Chýbajúca BCC/mail konfigurácia (E2E beh) sa zobrazí ako varovania.
+  await expect(page.getByTestId("nedostupne-bcc-missing")).toBeVisible();
+  await expect(page.getByTestId("nedostupne-mail-not-configured")).toBeVisible();
+
+  // Fixtúrová karta variantu "40287" s náhradou "60297" (neznámy kód —
+  // padá späť na seba samého ako meno, `.claude/rules/nedostupne` návrhový
+  // komentár na tickete).
+  const group = page.getByTestId("nedostupne-group-40287");
+  await expect(group).toBeVisible();
+  await expect(group.getByText("60297")).toBeVisible();
+  await expect(group.getByText("E2E Zákazník Nedostupné")).toBeVisible();
+
+  // Klik na "náhľad" otvorí povinný náhľad e-mailu PRED akýmkoľvek odoslaním.
+  await page.getByTestId("nedostupne-send-9008-40287").click();
+  const preview = page.getByTestId("nedostupne-preview");
+  await expect(preview).toBeVisible();
+  await expect(preview).toContainText("e2e-nedostupne@forestshop.sk");
+
+  // Potvrdenie odoslania bez nakonfigurovaného mailu vráti graceful chybu
+  // (fail-closed, žiadny skutočný pokus o SMTP spojenie) — BCC kontrola beží
+  // PRED mail-transport kontrolou (`send.ts`), takže táto hláška sa zobrazí.
+  await page.getByTestId("nedostupne-confirm-send").click();
+  await expect(page.getByText("chýba adresa pre skrytú kópiu majiteľovi (NEDOSTUPNE_BCC_EMAIL)", { exact: true })).toBeVisible();
+
+  expect(chyby).toEqual([]);
+});

--- a/apps/web/tests/e2e/orders.spec.ts
+++ b/apps/web/tests/e2e/orders.spec.ts
@@ -44,15 +44,19 @@ test("manažér filtruje podľa dodávateľa, vidí súhrn ostáva vybaviť a sk
   // 3, nie 1, "Všetci" 6, nie 4. issue 121: pridala ĎALŠÍ 1 riadok BEZ
   // dodávateľa ("278", `scripts/e2e-setup.ts`'s komentár vysvetľuje prečo
   // TENTO produkt) — "(bez dodávateľa)" má preto 4, "Všetci" 7.
-  await expect(page.getByTestId("supplier-chip-all")).toHaveText("Všetci (7)");
+  // issue 176: fixtúra pridala ĎALŠÍ 1 riadok BEZ dodávateľa ("40287" znova,
+  // objednávka "9008" v stave 'nedostupne') — "(bez dodávateľa)" má preto
+  // 5, "Všetci" 8, a súhrn dostane novú vetvu "Nedostupné 1" (predtým sa
+  // vôbec nezobrazovala, žiaden fixtúrový riadok dovtedy nebol nedostupný).
+  await expect(page.getByTestId("supplier-chip-all")).toHaveText("Všetci (8)");
   await expect(page.getByTestId("supplier-chip-DODAVATEL-TEST-1")).toHaveText("DODAVATEL-TEST-1 (1)");
-  await expect(page.getByTestId("supplier-chip-(bez dodávateľa)")).toHaveText("(bez dodávateľa) (4)");
+  await expect(page.getByTestId("supplier-chip-(bez dodávateľa)")).toHaveText("(bez dodávateľa) (5)");
 
   const summary = page.getByTestId("orders-summary");
-  // Nový riadok ("278") štartuje vo VÝCHODISKOVOM ("objednane"/nevybavené)
-  // stave, rovnako ako "40287" — zvyšuje "ostáva vybaviť" aj celkový počet
-  // rovnako o 1 (6 z 6 nevyriešených + 1 vyriešené = 5 z 6 → 6 z 7).
-  await expect(summary).toHaveText("Ostáva vybaviť 6 z 7 · Čaká sa 1");
+  // Nový 'nedostupne' riadok je UŽ vybavený (`isLineResolved` — akýkoľvek
+  // stav iný než "objednane" sa počíta ako vybavený), takže "ostáva vybaviť"
+  // ostáva 6, len celkový počet stúpne na 8 a pribudne "Nedostupné 1".
+  await expect(summary).toHaveText("Ostáva vybaviť 6 z 8 · Čaká sa 1 · Nedostupné 1");
 
   // Klik na chip DODAVATEL-TEST-1 zúži zoznam len na jeho skupinu.
   await page.getByTestId("supplier-chip-DODAVATEL-TEST-1").click();
@@ -64,7 +68,11 @@ test("manažér filtruje podľa dodávateľa, vidí súhrn ostáva vybaviť a sk
   await page.getByTestId("supplier-chip-(bez dodávateľa)").click();
   await expect(page.getByTestId("supplier-(bez dodávateľa)")).toBeVisible();
   await expect(page.getByTestId("supplier-DODAVATEL-TEST-1")).not.toBeVisible();
-  await expect(summary).toHaveText("(bez dodávateľa): ostáva vybaviť 4 z 4");
+  // issue 176: nová 'nedostupne' objednávka "9008" patrí do "(bez
+  // dodávateľa)" (variant "40287" nemá dodávateľa) — celkový počet stúpne na
+  // 5, pribudne "Nedostupné 1", "ostáva vybaviť" ostáva 4 (riadok je už
+  // vybavený).
+  await expect(summary).toHaveText("(bez dodávateľa): ostáva vybaviť 4 z 5 · Nedostupné 1");
 
   // Späť na "Všetci" — obe skupiny opäť viditeľné.
   await page.getByTestId("supplier-chip-all").click();

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -3,6 +3,83 @@
 Terse per-ticket log of autopilot-worker cycles: issue(s), commit SHAs,
 RED→GREEN test names, key decisions, and the shared PR.
 
+## 2026-08-02 — #173 (Pripomienky objednávok — order-reminder automation)
+
+- Solo ticket, owner-approved (comment on the issue removed `autopilot-skip`,
+  same batch as #172/#176: "vsetky tri veci").
+- Version bump `e3ec8fb` (0.3.0-dev.104→.105), first commit.
+- Design comment BEFORE first code commit:
+  https://github.com/zbynekdrlik/forestshop-app/issues/173#issuecomment-5160112598
+  — root cause/approach: same architecture as #172 (settings singleton +
+  per-order state + `job_run.detail` as display source of truth), but a NEW
+  injected `ClassifyClient` (OpenAI chat completions, ported prompt from
+  `orders_reminder.py`), single permanent email (never a cadence like #172's
+  4-step escalation), and Postgres `pg_advisory_lock` serialization for BOTH
+  the whole run AND every manual per-row override — REJECTED alternative:
+  copying the old app's file-based `sending`-claim+TTL mechanism (unnecessary
+  once Postgres gives transactional serialization for free).
+- Two design bugs found and fixed DURING test-writing (before any push):
+  1. The fast-path gate originally required `fingerprint === fp` to treat a
+     resolved order as terminal — verified against the old app's actual code
+     (`app.py:9013`) that `resolution` must be permanent REGARDLESS of
+     fingerprint change, or a note edited after the email went out would
+     trigger a second send. Fixed; regression test "ZMENA poznámky po
+     odoslaní e-mailu sa AJ TAK nespracuje druhýkrát".
+  2. The manual override endpoint mutated only `order_reminder_state`, never
+     the last `job_run.detail` — `GET` right after a successful override
+     still showed the OLD list (row invisible on screen until the next run).
+     Fixed with `relocateAfterOverride` in `order-reminder-routes.ts`; caught
+     by the project's OWN e2e test before the push, not by later review.
+- Backend commit `c45d922`: schema (`order_reminder_settings`/
+  `order_reminder_state`, migration `0022_famous_sunspot`), `modules/
+  order-reminder/{constants,logic,orders-source,settings,state,classify-
+  client,run}.ts`, `http/order-reminder-routes.ts`, `env.ts`
+  (`OPENAI_API_KEY`/`ORDER_REMINDER_BCC_EMAIL`, both optional), scheduler job
+  (daily 06:00 UTC ≈ 08:00 Europe/Bratislava CEST), `index.ts`/`app.ts`
+  wiring, TRUNCATE+reseed in both `tests/helpers/db.ts` and
+  `scripts/e2e-setup.ts`. 16 logic unit tests, 13 run + 11 http integration
+  tests (incl. deterministic advisory-lock serialization proof via
+  `pg_try_advisory_lock` from a second connection).
+- Frontend commit `4f15ba9`: `orderReminderApi.ts`, `OrderReminderSection
+  .tsx`/`OrderReminderRow.tsx` (🔴 bez poznámky + ✉️ bez e-mailu + 🟠 odoslané
+  + preskočené/⚪⚪✋⚠️ merged group), new HIDDEN tab `?tab=order-reminder`
+  (owner still wants only two visible nav items, #57) — own visual design
+  per `.claude/rules/frontend-design.md`, not the legacy app's look. 11 web
+  unit tests.
+- e2e commit `ead1271`: `order-reminder.spec.ts` — new isolated e2e account
+  (`e2e-pripomienky@forestshop.sk`), uses the STABLE fixture order "9002"
+  (no note, no email, never mutated by any other spec) to exercise both
+  manual-action buttons deterministically; also carries the
+  `relocateAfterOverride` fix + its own new HTTP regression test.
+- Deploy config commit `27f4a08`: wired `OPENAI_API_KEY`/
+  `ORDER_REMINDER_BCC_EMAIL` through `docker-compose.prod.yml` as bare
+  (optional) keys, same pattern as `POSTA_UNCOLLECTED_BCC_EMAIL`.
+- Locally verified before push: api unit clean, api integration 341/341
+  (incl. both new files, 24 new tests), web unit 307/307 (incl. new 11), web
+  e2e 27/27 (incl. new spec), `pnpm lint`/`pnpm typecheck` clean throughout.
+- Review comment (issue-comment-5160259957): self `/review` pass, 0🔴 0🟡
+  0🔵 remaining (both design bugs above were fixed pre-push, not left open).
+- PR #180 — `Closes #173` deliberately NOT used (ticket has a live
+  post-deploy acceptance condition: verify deployed disabled + zero customer
+  emails, `.claude/rules/CLAUDE.md`'s auto-close lesson) — CI (push run
+  30766346745 and PR-triggered run 30766366532) both `success`, PR
+  `MERGEABLE`+`CLEAN` → merged `058397c` (merge commit).
+- Main CI (run 30766513085) and Deploy (run 30766513075) monitored after
+  merge — both `success`.
+- Live verified (Playwright MCP, owner admin account): `/api/version` =
+  `0.3.0-dev.105`/`058397c`. DB on dev2: `order_reminder_settings.enabled =
+  f` (deployed disabled, as promised). Clicked "Spustiť teraz" against REAL
+  production data (16 real candidate orders, neither `OPENAI_API_KEY` nor
+  `ORDER_REMINDER_BCC_EMAIL` provisioned on dev2 yet) — both banners showed
+  correctly, 1 real no-note order rendered in 🔴 with both action buttons, 15
+  real noted orders correctly blocked in "Preskočené" with the AI-unavailable
+  reason, **0 e-mails sent** (confirmed both in the UI stats AND directly in
+  the DB: `select count(*) from order_reminder_state` → 0 rows — live data
+  left exactly as found). Preview button tested on a real row (showed real
+  recipient/subject, no send). Console: 0 errors/warnings.
+- Issue #173 closed with evidence (issue-comment-5160303071). Discord card
+  fired (`notify --run-card`).
+
 ## 2026-08-02 — #172 (Nevyzdvihnuté zásielky — Slovak Post uncollected-parcel automation)
 
 - Solo ticket, owner-approved (comment on the issue removed `autopilot-skip`).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.105",
+  "version": "0.3.0-dev.106",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.106",
+  "version": "0.3.0-dev.107",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -140,6 +140,11 @@ const E2E_POSTA_EMAIL = "e2e-posta@forestshop.sk"; // musí sa zhodovať s hodno
 // namiesto ďalšieho prihlásenia pod zdieľaným `e2e@forestshop.sk`.
 const E2E_PRIPOMIENKY_EMAIL = "e2e-pripomienky@forestshop.sk"; // musí sa zhodovať s hodnotou v order-reminder.spec.ts
 
+// issue 176: rovnaký mechanizmus a dôvod ako `E2E_PRIPOMIENKY_EMAIL` vyššie —
+// nový spec súbor (`nedostupne.spec.ts`) dostáva VLASTNÝ izolovaný účet
+// namiesto ďalšieho prihlásenia pod zdieľaným `e2e@forestshop.sk`.
+const E2E_NEDOSTUPNE_EMAIL = "e2e-nedostupne@forestshop.sk"; // musí sa zhodovať s hodnotou v nedostupne.spec.ts
+
 const { db, pool } = createDb();
 // Konštantný literál bez interpolácie — obyčajný reťazec je tu rovnako bezpečný
 // ako `sql` tagovaná šablóna (tú používa ekvivalentný apps/api/tests/helpers/db.ts),
@@ -272,6 +277,12 @@ await db.insert(users).values({
 });
 await db.insert(users).values({
   email: E2E_PRIPOMIENKY_EMAIL,
+  passwordHash: await hashPassword(E2E_HESLO),
+  displayName: "E2E Manažér",
+  role: "manazer",
+});
+await db.insert(users).values({
+  email: E2E_NEDOSTUPNE_EMAIL,
   passwordHash: await hashPassword(E2E_HESLO),
   displayName: "E2E Manažér",
   role: "manazer",
@@ -490,6 +501,27 @@ const [objednavkaOdkaz] = await db
   .returning();
 if (objednavkaOdkaz === undefined) throw new Error("E2E objednávka (odkaz) sa nepodarila vložiť");
 await db.insert(orderLines).values({ orderId: objednavkaOdkaz.id, variantCode: "278", quantity: 1 });
+
+// issue 176: JEDNA objednávka s riadkom v stave 'nedostupne' — variant
+// "40287" (rovnaký variant ako 9002/9003, katalógová fixtúra ho reálne nesie
+// s `relatedProduct = "60297"` po `ingestCatalog` nižšie, `.claude/rules/
+// catalog.md`), takže "Nedostupné tovary" (`nedostupne.spec.ts`) má naživo
+// čo zobraziť VRÁTANE náhradného produktu, bez potreby ďalšej fixtúry.
+// Pridáva GLOBÁLNE 1 riadok do "Na objednanie" (`orders.spec.ts`'s prvý test
+// preto počíta so "Všetci (8)"/"(bez dodávateľa) (5)" a s "Nedostupné 1" v
+// súhrne — "40287" nemá dodávateľa, rovnaký zámer ako 9002/9003).
+const [objednavkaNedostupne] = await db
+  .insert(orders)
+  .values({
+    externalOrderId: "9008",
+    customerName: "E2E Zákazník Nedostupné",
+    statusName: DEFAULT_ORDER_OPEN_STATUS,
+    placedAt: new Date("2026-07-27T09:00:00Z"),
+    email: "e2e-nedostupne@forestshop.sk",
+  })
+  .returning();
+if (objednavkaNedostupne === undefined) throw new Error("E2E objednávka (nedostupné) sa nepodarila vložiť");
+await db.insert(orderLines).values({ orderId: objednavkaNedostupne.id, variantCode: "40287", quantity: 1, state: "nedostupne" });
 
 // F4 (#45): jeden UŽ NAVRHNUTÝ (nepotvrdený) pairing kandidát — simuluje to,
 // čo by inak vložilo #46 (automatické hľadanie kandidátov, ešte


### PR DESCRIPTION
## Co je to

Nova obrazovka "Nedostupne tovary" (issue 176): zoznam polozek, ktore
dodavatel nema (uz existujuci stav `order_line.state = 'nedostupne'`),
zoskupeny podla variantu a sparovany s otvorenymi objednavkami. Obsluha
moze zakaznikovi poslat jeden z dvoch e-mailov (bez navrhu nahrady /
s navrhom nahrady) — VZDY az po povinnom nahlade, nikdy automaticky.

## Ako to funguje

- Ziadny scheduler/enabled prepinac (na rozdiel od #172/#173) — zoznam sa
  cita vzdy zivo z DB, ziadny job_run cache.
- Navrh nahrady: novy nullable stlpec `product.related_codes` (text[]),
  populovany pri katalogovom importe z CSV `relatedProduct`/
  `relatedProduct2..8` (rovnaky vzor ako uz existujuci `internalNote`).
  URL nahrady je vzdy klikatelny vyhladavaci fallback (appka nema zdroj
  skutocnej Shoptet produktovej URL).
- Dedup cez novu tabulku `nedostupne_state` (rovnaky plain-text-keyed
  vzor ako `order_reminder_state`/`posta_uncollected_state`).
- BCC/mail transport fail-closed presne ako #172/#173 — bez oboch
  NEPOSLE nic.
- Skryta zalozka (`?tab=nedostupne`), rovnaky vzor ako #172/#173
  (majitel zatial chce v lavom menu len dve polozky, #57).

## Overenie

- Unit testy (logic.ts email builders + alternativy, map-row.ts CSV
  extrakcia relatedCodes)
- Integracne testy (queries.ts zoskupenie, send.ts fail-closed/dedup,
  HTTP routes)
- Playwright e2e (zoznam, povinny nahlad, graceful fail-closed chyba
  bez skutocneho SMTP)
- `pnpm typecheck` / `pnpm lint` / `pnpm test` / `pnpm test:integration`
  / plny e2e balik — vsetko zelene lokalne

issue 176
