### PR TITLE
Docs: playbook notes for issues 176 and 181

### DIFF
--- a/.claude/rules/nedostupne.md
+++ b/.claude/rules/nedostupne.md
@@ -1,0 +1,49 @@
+---
+paths:
+  - "apps/api/src/modules/nedostupne/**"
+  - "apps/api/src/http/nedostupne-routes.ts"
+  - "apps/web/src/components/NedostupneSection*.tsx"
+  - "apps/web/src/nedostupneApi.ts"
+---
+
+# Nedostupné tovary (issue 176)
+
+- **Server-side vynútenie povinného náhľadu — jednorazový `previewToken`,
+  nikdy len UI konvencia.** Prvá verzia (merge candidate) spoliehala len na
+  to, že React komponent volá `/preview` PRED zobrazením tlačidla "Odoslať"
+  — `/send` samotné nič nekontrolovalo, takže priame API volanie mohlo
+  poslať e-mail bez toho, aby čokoľvek jeho obsah niekedy zobrazilo (nájdené
+  code review PRED mergom PR #182, nie testom). Oprava: `preview-tokens.ts`
+  vydá krátkodobý (15 min), JEDNORAZOVÝ token viazaný na presne (orderCode,
+  variantCode, emailType) pri `/preview`; `/send` ho vyžaduje a KONZUMUJE
+  (zmaže) PRED čímkoľvek iným, bez ohľadu na výsledok zhody. Rovnaký
+  in-process `Map` vzor ako `login-rate-limit.ts` (jedna bežiaca inštancia,
+  MVP rozsah — reštart appky tokeny zruší, v poriadku). Ďalšia automatizácia
+  s ticketovou podmienkou "povinný náhľad pred odoslaním" potrebuje TEN ISTÝ
+  mechanizmus, nie len frontend disciplínu.
+- **ŽIADNY scheduler/`enabled` prepínač, na rozdiel od #172/#173** — táto
+  automatizácia nemá žiadny naplánovaný beh (ticket nič také nežiadal).
+  `GET /api/nedostupne` je VŽDY živý DB dopyt, nikdy `job_run.detail` cache.
+  Jednoduchšie, žiadna zbytočná zložitosť (MVP) — nová podobná automatizácia
+  BEZ plánovaného behu by mala rovnako vynechať settings/`job_run` vrstvu.
+- **`product.related_codes` (text[]) — návrh náhrady zo Shoptetu, populovaný
+  pri katalogovom importe z CSV `relatedProduct`/`relatedProduct2..8`**
+  (`catalog/map-row.ts`'s `extractRelatedCodes`/`MAX_ALTERNATIVES=8`) — PRVÝ
+  stĺpec je bare `relatedProduct` (NIE `relatedProduct1`), overené priamo na
+  reálnej fixtúre. Vlastnosť PRODUKTU (rovnaký first-wins vzor ako
+  `internalNote`/`supplier` v `ingest.ts`), nie variantu. Appka NEMÁ zdroj
+  skutočnej Shoptet produktovej URL (overené na exporte — žiadny `url`/
+  `seoUrl` stĺpec) — alternatívy dostávajú VŽDY klikateľný vyhľadávací
+  fallback (`alternativeSearchUrl`), nikdy sa neintegroval starý marketingový
+  XML feed (zámerne zamietnuté ako zbytočná nová externá závislosť).
+- **Dedup (`nedostupne_state`) je serializovaný `NEDOSTUPNE_SEND_LOCK_KEY`
+  (`787_878_006`) — bez zámku by dva súbežné klik-y na TEN ISTÝ (objednávka,
+  variant, typ) mohli OBA prejsť dedup-check pred zápisom a poslať e-mail
+  DVAKRÁT** (nájdené vlastným code review pred mergom). Rovnaký vzor ako
+  #172/#173's RUN lock, len okolo jedného odoslania namiesto celého behu.
+  `.claude/rules/scheduler.md`'s registry MUSÍ byť aktualizovaný pri KAŽDOM
+  novom kľúči — 005 (`order-reminder`) aj 006 (toto issue) tam predtým
+  chýbali, hoci kód sám kolízii predišiel správne.
+- **`insertTestVariantForProduct` (`tests/helpers/orders.ts`) teraz podporuje
+  `relatedCodes` — nová automatizácia/test potrebujúci alternatívy nemusí
+  vkladať produkt/variant ručne, len odovzdať `{ relatedCodes: [...] }`.**

--- a/.claude/rules/shoptet-writeback.md
+++ b/.claude/rules/shoptet-writeback.md
@@ -147,6 +147,28 @@ paths:
   `docker exec -w /app/apps/api node script.mjs`. `createDb()` (`db/
   client.ts`) bez argumentu sám číta `DATABASE_URL` z kontajnerovho
   prostredia — netreba ho manuálne skladať v skripte.
+- **Číslo zásielky (tracking) v živej Shoptet administrácii (issue 181,
+  overené naživo) NIE JE na záložke "Zásielky" objednávkového detailu** —
+  tá záložka (`#t7` tab panel) ukazuje "Žiadne položky" AJ na objednávke,
+  ktorá má číslo balíka reálne vyplnené (je to iný Shoptetov submodul,
+  zrejme vlastná preprava/štítky, nie CSV/XML exportové pole
+  `packageNumber`). Skutočné pole je skryté v dropdown menu "VIAC FUNKCIÍ"
+  (položka "Číslo zásielky") priamo na hlavnej stránke objednávky, ako
+  `<input name="packageNumber" id="package-number">` — nájdi ho cez
+  `document.querySelector('#package-number').value`, netreba ani menu
+  otvárať. Test pri KAŽDOM ďalšom "existuje X v Shoptete aj keď ho
+  appka/export nevidí?" overovaní: over aj na KONTROLNEJ objednávke, o
+  ktorej vieme, že pole má vyplnené — inak ľahko omylom skončíš pri
+  nesprávnom/prázdnom UI prvku (presne sa to tu stalo s "Zásielky"
+  záložkou) a vyvodíš falošný záver "dáta neexistujú".
+- **Druhý nezávislý Shoptet export (`SHOPTET_ORDERS_XML_URL`, XML feed
+  objednávok) má TIEŽ pole `<PACKAGE_NUMBER>` per `<ORDER>`, ale keď
+  chýba v CSV, chýba aj tam** — nie je to nezávislý zdroj na obnovu tohto
+  konkrétneho poľa (issue 181: overené na 80 objednávkach, všade prázdne
+  v oboch exportoch aj v samotnej administrácii). Užitočný ako RÝCHLA
+  prvá kontrola pred Playwright vzorkou (stiahni raz cez `curl` na dev2 do
+  `/tmp`, over cez `python3`, potom zmaž), ale nečakaj od neho zázrak pri
+  tomto poli.
 - **CSV-injection ochrana (issue 153) sedí v `csv.ts`'s `dataRowToLine`, NIE
   vo validácii vyššie prúdu.** `formula-guard.ts`'s `csvSafe` sa aplikuje na
   KAŽDÚ bunku KAŽDÉHO dátového riadku PRIAMO pri zápise CSV — chráni aj

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,3 +87,4 @@ Per-area rules live in `.claude/rules/<area>.md` with `paths:` frontmatter.
 - spätný zápis do Shoptetu (F5 — Playwright import, reálne admin cesty, Alpine chromium) → `.claude/rules/shoptet-writeback.md`
 - Nevyzdvihnuté zásielky (Pošta SK — enabled vs. run-now, coalesce, advisory zámok) → `.claude/rules/posta-uncollected.md`
 - Pripomienky objednávok (AI klasifikácia poznámky, terminálna rezolúcia, override→job_run relocate) → `.claude/rules/order-reminder.md`
+- Nedostupné tovary (návrh náhrady, jednorazový preview token, žiadny scheduler) → `.claude/rules/nedostupne.md`

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -2409,3 +2409,45 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   order/order_line 535→536 / 881→882 normálnym importom).
 - Issue #171 zavretý s dôkazom (issue-comment-5158877599). Discord karta
   odoslaná (`notify --run-card`, `sent`).
+
+## Issue 176 — Nedostupné tovary (informovanie zákazníka e-mailom, s návrhom náhrady)
+
+- Design comment (issue-comment-5160403045) + validated comment
+  (issue-comment-5160403902) pred prvým kódovým commitom (verzia bump
+  `c4494e4` bol PRVÝ, feature commit `cdb5aa5` až po nich).
+- Zoskupenie podľa variantu nad existujúcim `order_line.state = 'nedostupne'`
+  (žiadny nový flag), spárovanie s otvorenými objednávkami cez
+  `listOpenStatusNames`. ŽIADNY scheduler/`enabled` — vždy živý DB dopyt.
+- Nová migrácia `0023_steep_smasher.sql`: `product.related_codes` (text[],
+  nullable), tabuľka `nedostupne_state` (dedup, plain-text kľúčovaná ako
+  `order_reminder_state`/`posta_uncollected_state`).
+- Deep code review pred mergom (PR #182, issue-comment-5160705285) našiel 1
+  Important (server-side vynútenie povinného náhľadu chýbalo) + 2 Minor
+  (chýbajúci `requireSameOrigin()` na `/preview`; scheduler.md registry bez
+  005/006) — všetky opravené commitom `a491963` PRED mergom (jednorazový
+  `previewToken`, 15 min TTL, in-memory rovnaký vzor ako
+  `login-rate-limit.ts`). Samostatný self-review nálezmi ešte skôr pridal
+  `NEDOSTUPNE_SEND_LOCK_KEY` (787_878_006, commit `77cbc38`) — bez neho by
+  dva súbežné klik-y na ten istý (objednávka, variant, typ) mohli poslať
+  e-mail dvakrát.
+- Testy: `logic.test.ts` (9), `preview-tokens.test.ts` (6), `map-row.test.ts`
+  relatedCodes rozšírenie, `nedostupne-run.integration.test.ts` (12,
+  vrátane deterministického `pg_try_advisory_lock` súbežnostného testu),
+  `nedostupne-http.integration.test.ts` (11), `NedostupneSection.test.tsx`
+  (9), `nedostupne.spec.ts` (e2e, fixtúra "9008"/variant "40287" s reálnou
+  `relatedProduct=60297` z katalógovej fixtúry). `orders.spec.ts` prvý test
+  aktualizovaný (nová 'nedostupne' fixtúra pridáva 1 riadok do "(bez
+  dodávateľa)" a novú "Nedostupné 1" vetvu do súhrnu).
+- CI (push 30770647458 aj PR-triggered 30770649121) `success` → PR #182
+  merged `2242449` (merge commit). Main CI (30770803484) + Deploy
+  (30770803482) `success`.
+- Live overené (Playwright MCP, `vychod@varos.sk`): `/api/version` =
+  `0.3.0-dev.107`/`2242449`. `?tab=nedostupne` sa načíta, 0 console chýb.
+  BCC upozornenie zobrazené správne (NEDOSTUPNE_BCC_EMAIL nie je na dev2
+  nastavené — fail-closed funguje naživo), "mail not configured" NEzobrazené
+  (MAIL_HOST JE nastavené). Prázdny zoznam (nikto zatiaľ nemá nedostupný
+  riadok) korektný. Zámerne som NEMUTOVAL žiadny reálny zákaznícky riadok
+  naživo — funkčná správnosť zoskupenia/dedup/tokenu je preukázaná plnou
+  integračnou + e2e sadou nad rovnakou schémou.
+- Nový playbook súbor `.claude/rules/nedostupne.md` + router riadok v
+  `CLAUDE.md`. Issue #176 zavretý s dôkazom. Discord karta odoslaná.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.107",
+  "version": "0.3.0-dev.108",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Iba dokumentacia — ziadna zmena kodu appky.

- Zaznam do interneho playbooku k vysetrovaniu chybajucich cisel balikov (issue 181): kde presne v Shoptet administracii sedi pole cisla zasielky a preco je zalozka "Zasielky" zavadzajuca.
- Zaznam do autopilot-logu + playbooku k automatizacii "Nedostupne tovary" (issue 176).

Verzia bumpnuta na 0.3.0-dev.108.
