### PR TITLE
Automatizacie nav folder + hourly catalog-import

### DIFF
--- a/.claude/rules/catalog.md
+++ b/.claude/rules/catalog.md
@@ -125,8 +125,10 @@ paths:
 - **Surové bajty nie sú v Postgrese.** Ležia gzipnuté v `CATALOG_RAW_DIR` (na dev2
   docker zväzok `catalog-raw`), v databáze je len `raw_path` + `content_sha256`.
   `pg_dump` ich teda NEZAHŔŇA — a nemusí, odvodený katalóg je celý v databáze.
-  Retencia (`pnpm catalog:prune-raw`): prijaté staršie než 30 dní prídu o súbor,
-  odmietnuté si ho nechávajú navždy, posledný prijatý sa nemaže nikdy. `pruneRawSnapshots`
+  Retencia (`pnpm catalog:prune-raw`): prijaté staršie než 14 dní (skrátené z 30
+  v issue 184 súčasne s prechodom importu na hodinovú kadenciu — viac
+  snapshotov/deň, box na 98 % disku) prídu o súbor, odmietnuté si ho
+  nechávajú navždy, posledný prijatý sa nemaže nikdy. `pruneRawSnapshots`
   (`raw-store.ts`) pracuje LEN cez riadky databázy — nikdy neprechádza adresár na
   disku — takže osirotený súbor bez zodpovedajúceho riadku nikdy nezmaže ani naň
   nenarazí, a `rm(..., { force: true })` mlčky prežije aj súbor, ktorý na disku už
@@ -147,7 +149,8 @@ paths:
   apps/api/dist/cli/catalog-prune-raw.js` (bez `-f docker-compose.prod.yml` by
   compose na dev2 siahol po vývojovom `docker-compose.yml`). Overené naživo na
   dev2 2026-07-29 po nasadení v0.2.0: `Zmazaných surových súborov: 0 (staršie
-  než 30 dní).` + `{"removed":0}`. Dôvod: dev2 má `scripts/` len ako `rsync`-nutú kópiu BEZ
+  než 30 dní).` + `{"removed":0}` — historický záznam behu spred issue 184
+  (dobová hodnota `KEEP_DAYS = 30`, odvtedy 14, viď vyššie). Dôvod: dev2 má `scripts/` len ako `rsync`-nutú kópiu BEZ
   `node_modules` (final-wave-b, položka 2), takže `tsx scripts/catalog-prune-raw.ts`
   tam nemá ako bežať — bez skompilovanej verzie v obraze retencia v produkcii
   nemala žiadny spôsob spustenia a `catalog-raw` zväzok rástol donekonečna.

--- a/.claude/rules/deploy.md
+++ b/.claude/rules/deploy.md
@@ -140,8 +140,9 @@ paths:
   ```
 
   Vypíše jednu ľudskú vetu aj JSON riadok (`{"removed": N}`) — bezpečné spustiť
-  kedykoľvek (nemaže nič mladšie než 30 dní ani posledný prijatý súbor, pozri
-  `pruneRawSnapshots` v `raw-store.ts`). Import (`catalog-ingest`) toto NEPOTREBUJE —
+  kedykoľvek (nemaže nič mladšie než 14 dní — skrátené z 30 v issue 184 —
+  ani posledný prijatý súbor, pozri `pruneRawSnapshots` v `raw-store.ts`).
+  Import (`catalog-ingest`) toto NEPOTREBUJE —
   beží aj cez tlačidlo na webe (`POST /api/catalog/ingest`, priamo v bežiacom
   procese appky), takže `scripts/catalog-ingest.ts` zostáva len pohodlný LOKÁLNY/CI
   vstupný bod, nie produkčná nutnosť.

--- a/.claude/rules/scheduler.md
+++ b/.claude/rules/scheduler.md
@@ -27,15 +27,22 @@ paths:
   existujúcich `daily` úloh, aby sa neprekrývali zbytočne (nie je to tvrdá
   závislosť, len aby operátor v logoch/`job_run` vedel odlíšiť poradie). Nová
   `hourly` úloha dostáva `{ kind: "hourly", minuteUtc }` — nemá `hourUtc`,
-  beží v KAŽDEJ UTC hodine. Dnes zaregistrované: 01:00 import katalógu
-  (`daily`), 01:15 mazanie surových exportov katalógu (`daily`), 01:30
-  mazanie relácií (`daily`), :45 KAŽDÚ hodinu import objednávok
-  (`ordersImportJob`, `hourly` od #115, pôvodne `daily` #22), 02:00 mazanie
-  surových exportov objednávok (`pruneRawOrdersJob`, `daily`, #28), :50
-  KAŽDÚ hodinu spätný zápis odkazov na dodávateľa do Shoptetu
-  (`shoptetWritebackJob`, `hourly`, issue 122 — mimo kolízie s `:45`).
-  Pridanie ďalšieho `kind` (napr. "weekly") by znamenalo rozšíriť
-  `periodKey()` (`scheduler.ts`) o ďalšiu vetvu — rovnaký vzor ako `hourly`.
+  beží v KAŽDEJ UTC hodine. Dnes zaregistrované: **:20 KAŽDÚ hodinu import
+  katalógu** (`catalogImportJob`, `hourly` od issue 184, pôvodne `daily`
+  01:00 — zmerané trvanie behu 19.5-22.9 s, zanedbateľné), 01:15 mazanie
+  surových exportov katalógu (`daily`, retencia skrátená z 30 na 14 dní v
+  issue 184 — hodinový import produkuje viac snapshotov, box je na 98 %
+  disku), 01:30 mazanie relácií (`daily`), :45 KAŽDÚ hodinu import
+  objednávok (`ordersImportJob`, `hourly` od #115, pôvodne `daily` #22),
+  02:00 mazanie surových exportov objednávok (`pruneRawOrdersJob`, `daily`,
+  #28), :50 KAŽDÚ hodinu spätný zápis odkazov na dodávateľa do Shoptetu
+  (`shoptetWritebackJob`, `hourly`, issue 122 — mimo kolízie s `:45`), :55
+  KAŽDÚ hodinu spätný zápis poznámky objednávky do Shoptetu
+  (`orderNoteWritebackJob`, `hourly`, issue 123 — mimo kolízie s `:45`/`:50`).
+  `:20` (katalóg) je zámerne 20-25 min od každého suseda (`:45`/`:50`/`:55`
+  predošlej aj nasledujúcej hodiny). Pridanie ďalšieho `kind` (napr.
+  "weekly") by znamenalo rozšíriť `periodKey()` (`scheduler.ts`) o ďalšiu
+  vetvu — rovnaký vzor ako `hourly`.
 - **Job NEPOTREBUJE vlastný advisory zámok, keď buď (a) volaná business
   funkcia už berie svoj vlastný vnútri seba** (`catalogImportJob`/
   `ordersImportJob` → `ingestCatalog`/`ingestOrders`), **alebo (b) sa vôbec

--- a/.claude/rules/scheduler.md
+++ b/.claude/rules/scheduler.md
@@ -39,8 +39,8 @@ paths:
   (`shoptetWritebackJob`, `hourly`, issue 122 — mimo kolízie s `:45`), :55
   KAŽDÚ hodinu spätný zápis poznámky objednávky do Shoptetu
   (`orderNoteWritebackJob`, `hourly`, issue 123 — mimo kolízie s `:45`/`:50`).
-  `:20` (katalóg) je zámerne 20-25 min od každého suseda (`:45`/`:50`/`:55`
-  predošlej aj nasledujúcej hodiny). Pridanie ďalšieho `kind` (napr.
+  `:20` (katalóg) je zámerne aspoň 25 min od každého suseda (25 min k
+  `:45`/`:55` predošlej hodiny, 30 min k `:50`). Pridanie ďalšieho `kind` (napr.
   "weekly") by znamenalo rozšíriť `periodKey()` (`scheduler.ts`) o ďalšiu
   vetvu — rovnaký vzor ako `hourly`.
 - **Job NEPOTREBUJE vlastný advisory zámok, keď buď (a) volaná business

--- a/apps/api/src/cli/catalog-prune-raw.ts
+++ b/apps/api/src/cli/catalog-prune-raw.ts
@@ -1,14 +1,18 @@
-// Zmaže uložené surové exporty prijatých snapshotov staršie než 30 dní. Toto je
-// KANONICKÁ implementácia — `scripts/catalog-prune-raw.ts` (spúšťané cez
-// `pnpm catalog:prune-raw`, tsx, mimo produkčného kontajnera) je len jej tenký
-// alias. Tento súbor žije PRIAMO v `apps/api/src`, takže ho `pnpm --filter
-// @forestshop/api build` (tsc -b) skompiluje do `apps/api/dist/cli/
-// catalog-prune-raw.js` — Dockerfile už kopíruje celý `apps/api/dist` do
-// produkčného obrazu, takže žiadna zmena Dockerfile nie je potrebná. Retencia
-// nemá HTTP trasu (na rozdiel od importu, ktorý beží aj cez tlačidlo na webe) —
-// bez tohto by na produkčnom hostiteľovi neexistoval SPÔSOB, ako ju vôbec
-// spustiť (final-wave-b, položka 2): obraz nemal `scripts/`, hostiteľ mal
-// `scripts/` bez `node_modules`, takže surový zväzok rástol donekonečna.
+// Zmaže uložené surové exporty prijatých snapshotov staršie než KEEP_DAYS
+// (14 od issue 184 — pôvodne 30, skrátené súčasne s prechodom
+// `catalogImportJob` na hodinovú kadenciu, viď `KEEP_DAYS` nižšie a
+// `modules/scheduler/jobs.ts`'s `pruneRawExportsJob` komentár pre plné
+// zdôvodnenie). Toto je KANONICKÁ implementácia — `scripts/catalog-prune-
+// raw.ts` (spúšťané cez `pnpm catalog:prune-raw`, tsx, mimo produkčného
+// kontajnera) je len jej tenký alias. Tento súbor žije PRIAMO v
+// `apps/api/src`, takže ho `pnpm --filter @forestshop/api build` (tsc -b)
+// skompiluje do `apps/api/dist/cli/catalog-prune-raw.js` — Dockerfile už
+// kopíruje celý `apps/api/dist` do produkčného obrazu, takže žiadna zmena
+// Dockerfile nie je potrebná. Retencia nemá HTTP trasu (na rozdiel od
+// importu, ktorý beží aj cez tlačidlo na webe) — bez tohto by na produkčnom
+// hostiteľovi neexistoval SPÔSOB, ako ju vôbec spustiť (final-wave-b, položka
+// 2): obraz nemal `scripts/`, hostiteľ mal `scripts/` bez `node_modules`,
+// takže surový zväzok rástol donekonečna.
 //
 // Príkaz na produkcii (viď `.claude/rules/deploy.md`):
 //   docker compose -f docker-compose.prod.yml exec app node apps/api/dist/cli/catalog-prune-raw.js
@@ -16,7 +20,7 @@ import { createDb } from "../db/client.js";
 import { loadEnv } from "../env.js";
 import { pruneRawSnapshots } from "../modules/catalog/raw-store.js";
 
-const KEEP_DAYS = 30;
+const KEEP_DAYS = 14;
 
 const env = loadEnv();
 const { db, pool } = createDb(env.DATABASE_URL);

--- a/apps/api/src/modules/scheduler/jobs.ts
+++ b/apps/api/src/modules/scheduler/jobs.ts
@@ -30,11 +30,18 @@ export const SHOPTET_WRITEBACK_NOT_CONFIGURED =
 const EXPORT_URL_NOT_CONFIGURED = "Import katalógu nie je nakonfigurovaný (chýba SHOPTET_EXPORT_URL)";
 
 /**
- * Nočný import katalógu — volá EXISTUJÚCI `runIngest` (index.ts), nič sa
- * nereimplementuje. Bohatý výsledok (accepted/rejected/duplicate) sa aj tak
- * zapíše do `catalog_snapshot` samotným `ingestCatalog` — tento job_run
- * záznam je len scheduler-úrovňová viditeľnosť navyše ("bežal naozaj dnes v
- * noci?"), nie náhrada. Keď `runIngest` nie je nakonfigurované (chýba
+ * Import katalógu (issue 184: hodinová kadencia, predtým `daily` 01:00 UTC —
+ * majiteľov pôvodný pokyn "sync zo shoptetu ma bezat kazdu hodinu" #115 sa
+ * pri zavedení uplatnil len na `ordersImportJob`, katalóg zostal denný).
+ * Zmerané na produkcii (posledných 6 denných behov): trvanie 19.5-22.9 s —
+ * zanedbateľné aj pri 24 behoch/deň. `:20` je mimo kolízie s ostatnými
+ * hodinovými jobmi (`ordersImportJob` :45, `shoptetWritebackJob` :50,
+ * `orderNoteWritebackJob` :55) — 20-25 min odstup od každého suseda. Volá
+ * EXISTUJÚCI `runIngest` (index.ts), nič sa nereimplementuje. Bohatý
+ * výsledok (accepted/rejected/duplicate) sa aj tak zapíše do
+ * `catalog_snapshot` samotným `ingestCatalog` — tento job_run záznam je len
+ * scheduler-úrovňová viditeľnosť navyše ("bežal naozaj túto hodinu?"), nie
+ * náhrada. Keď `runIngest` nie je nakonfigurované (chýba
  * SHOPTET_EXPORT_URL), job VYHODÍ — scheduler.ts to odchytí a zapíše ako
  * "failure" s touto správou, namiesto toho, aby beh ticho preskočil bez
  * záznamu.
@@ -42,7 +49,7 @@ const EXPORT_URL_NOT_CONFIGURED = "Import katalógu nie je nakonfigurovaný (ch�
 export function catalogImportJob(runIngest: RunIngest | undefined): ScheduledJob {
   return {
     name: CATALOG_IMPORT_JOB_NAME,
-    schedule: { kind: "daily", hourUtc: 1, minuteUtc: 0 },
+    schedule: { kind: "hourly", minuteUtc: 20 },
     async run(_db, now) {
       if (runIngest === undefined) throw new Error(EXPORT_URL_NOT_CONFIGURED);
       const result = await runIngest(now);
@@ -51,8 +58,24 @@ export function catalogImportJob(runIngest: RunIngest | undefined): ScheduledJob
   };
 }
 
-/** Mazanie surových exportov starších než 30 dní — volá existujúci `pruneRawSnapshots`. */
-export function pruneRawExportsJob(keepDays = 30): ScheduledJob {
+/**
+ * Mazanie surových exportov katalógu — volá existujúci `pruneRawSnapshots`.
+ * Retencia skrátená z 30 na **14 dní** (issue 184, súčasne so zavedením
+ * hodinového `catalogImportJob` vyššie) — `storeRawSnapshot` sa volá LEN keď
+ * sa obsah exportu LÍŠI od posledného prijatého (dedup na `contentSha256`,
+ * `ingest.ts`), takže hodinová kadencia produkuje WORST CASE 24 nových
+ * gzip súborov/deň (~3.7 MB každý na produkcii) namiesto 1 — a `/` na dev2
+ * je na 98 % (len ~25 GB voľných, iné projekty na tom istom hostiteľovi).
+ * Odvodený katalóg je celý v Postgrese (`pg_dump`-nutý) — surové súbory sú
+ * len dôkazový materiál, takže skrátenie retencie nestojí nič a znižuje
+ * worst-case peak z ~2.7 GB na ~1.24 GB. `apps/api/src/cli/
+ * catalog-prune-raw.ts`'s `KEEP_DAYS` (manuálny/ops vstupný bod, mimo
+ * scheduleru) dostal ROVNAKÚ hodnotu, aby oba vstupné body do retencie
+ * zostali konzistentné. Schedule (denne 01:15) ostáva NEZMENENÁ — dátumový
+ * cutoff odstráni nahromadené staršie súbory bez ohľadu na to, koľko
+ * snapshotov medzitým pribudlo, netreba ju spúšťať častejšie.
+ */
+export function pruneRawExportsJob(keepDays = 14): ScheduledJob {
   return {
     name: PRUNE_RAW_EXPORTS_JOB_NAME,
     schedule: { kind: "daily", hourUtc: 1, minuteUtc: 15 },

--- a/apps/api/src/modules/scheduler/jobs.ts
+++ b/apps/api/src/modules/scheduler/jobs.ts
@@ -36,7 +36,8 @@ const EXPORT_URL_NOT_CONFIGURED = "Import katalógu nie je nakonfigurovaný (ch�
  * Zmerané na produkcii (posledných 6 denných behov): trvanie 19.5-22.9 s —
  * zanedbateľné aj pri 24 behoch/deň. `:20` je mimo kolízie s ostatnými
  * hodinovými jobmi (`ordersImportJob` :45, `shoptetWritebackJob` :50,
- * `orderNoteWritebackJob` :55) — 20-25 min odstup od každého suseda. Volá
+ * `orderNoteWritebackJob` :55) — aspoň 25 min odstup od každého suseda
+ * (25 min k `:45`/`:55` predošlej hodiny, 30 min k `:50`). Volá
  * EXISTUJÚCI `runIngest` (index.ts), nič sa nereimplementuje. Bohatý
  * výsledok (accepted/rejected/duplicate) sa aj tak zapíše do
  * `catalog_snapshot` samotným `ingestCatalog` — tento job_run záznam je len
@@ -60,7 +61,7 @@ export function catalogImportJob(runIngest: RunIngest | undefined): ScheduledJob
 
 /**
  * Mazanie surových exportov katalógu — volá existujúci `pruneRawSnapshots`.
- * Retencia skrátená z 30 na **14 dní** (issue 184, súčasne so zavedením
+ * Retencia skrátená z 30 na 14 dní (issue 184, súčasne so zavedením
  * hodinového `catalogImportJob` vyššie) — `storeRawSnapshot` sa volá LEN keď
  * sa obsah exportu LÍŠI od posledného prijatého (dedup na `contentSha256`,
  * `ingest.ts`), takže hodinová kadencia produkuje WORST CASE 24 nových

--- a/apps/api/tests/scheduler-jobs.integration.test.ts
+++ b/apps/api/tests/scheduler-jobs.integration.test.ts
@@ -1,10 +1,12 @@
 import { mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { eq } from "drizzle-orm";
 import { afterEach, expect, it } from "vitest";
-import { sessions, users } from "../src/db/schema.js";
+import { catalogSnapshots, sessions, users } from "../src/db/schema.js";
 import { hashPassword } from "../src/modules/auth/passwords.js";
 import type { CatalogIngestResult } from "../src/modules/catalog/ingest.js";
+import { storeRawSnapshot } from "../src/modules/catalog/raw-store.js";
 import { ORDERS_EXPORT_URL_NOT_CONFIGURED, type OrdersIngestResult } from "../src/modules/orders/ingest.js";
 import {
   CATALOG_IMPORT_JOB_NAME,
@@ -60,6 +62,13 @@ it("catalogImportJob s nakonfigurovaným runIngest naň deleguje a vráti jeho v
   expect(receivedNow).toBe(NOW);
 });
 
+// Issue 184: katalógový import bol `daily` 01:00 UTC, majiteľ chce hodinovú
+// kadenciu (rovnaká požiadavka, aká #115 už uplatnilo na `ordersImportJob`).
+it("catalogImportJob je teraz hodinový (issue 184), posunutý mimo kolízie s ostatnými hodinovými jobmi (:45/:50/:55)", () => {
+  const job = catalogImportJob(undefined);
+  expect(job.schedule).toEqual({ kind: "hourly", minuteUtc: 20 });
+});
+
 it("pruneRawExportsJob deleguje na existujúci pruneRawSnapshots — starý prijatý surový súbor sa naozaj zmaže", async () => {
   const ctx = await withCleanDb();
   close = ctx.close;
@@ -85,6 +94,37 @@ it("pruneRawExportsJob deleguje na existujúci pruneRawSnapshots — starý prij
   // ho nenastavuje) — `pruneRawSnapshots` teda nemá čo reálne zmazať, no
   // volanie musí prejsť bez chyby a vrátiť detail so správnym tvarom.
   expect(outcome).toEqual({ detail: { removed: 0 } });
+});
+
+// Issue 184: predvolená retencia (žiadny argument, presne ako `index.ts`
+// volá `pruneRawExportsJob()`) sa skrátila z 30 na 14 dní — hodinový import
+// produkuje viac snapshotov, box je diskovo napnutý. Behaviorálny dôkaz (nie
+// len čítanie zdroja): 20-dňový starý PRIJATÝ súbor by pod PÔVODNOU 30-dňovou
+// retenciou PREŽIL, pod NOVOU 14-dňovou sa naozaj zmaže.
+it("pruneRawExportsJob's predvolená retencia (bez argumentu) je 14 dní (issue 184) — 20 dní stará prijatá snapshot sa zmaže", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  dir = await mkdtemp(join(tmpdir(), "forestshop-scheduler-retencia-"));
+
+  const dvadsatDni = new Date(NOW.getTime() - 20 * 24 * 60 * 60 * 1000);
+  const path = await storeRawSnapshot(dir, {
+    at: dvadsatDni,
+    sha256: "d".repeat(64),
+    body: Buffer.from("stary-20-dni"),
+  });
+  const id = await insertTestSnapshot(ctx.db, {
+    verdict: "accepted",
+    fetchedAt: dvadsatDni,
+    contentSha256: "d".repeat(64),
+  });
+  await ctx.db.update(catalogSnapshots).set({ rawPath: path }).where(eq(catalogSnapshots.id, id));
+  // Druhý (novší) prijatý snapshot, aby ten 20-dňový nebol "posledný prijatý"
+  // (ten sa nikdy nemaže, rovnaká výnimka ako inde).
+  await insertTestSnapshot(ctx.db, { verdict: "accepted", fetchedAt: NOW, contentSha256: "e".repeat(64) });
+
+  const job = pruneRawExportsJob();
+  const outcome = await job.run(ctx.db, NOW);
+  expect(outcome).toEqual({ detail: { removed: 1 } });
 });
 
 it("sessionCleanupJob deleguje na cleanupExpiredSessions — zmaže expirovanú, platnú nechá", async () => {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -6,7 +6,9 @@ import { LoginForm } from "./components/LoginForm.js";
 import { Sidebar } from "./components/Sidebar.js";
 import { Topbar } from "./components/Topbar.js";
 import { DEFAULT_TAB_ID, NAV, findTab, isVisibleTabId } from "./nav.js";
+import { fetchOrderReminderStatus } from "./orderReminderApi.js";
 import { OrdersRemainingCountContext } from "./ordersRemainingCountContext.js";
+import { fetchPostaUncollectedStatus } from "./postaUncollectedApi.js";
 
 // Prvá záložka z URL-u (`?tab=<id>`), keď existuje a je platná — inak
 // predvolená ("Sync zo Shoptetu"). Umožňuje priamy odkaz aj na SKRYTÉ
@@ -40,6 +42,37 @@ export function App(): JSX.Element {
     () => (ordersRemainingCount !== null ? { orders: ordersRemainingCount } : {}),
     [ordersRemainingCount],
   );
+
+  // issue 185: stav zapnuté/vypnuté pre "Automatizácie" priečinok v menu.
+  // Na rozdiel od `ordersRemainingCount` vyššie (publikované OBRAZOVKOU
+  // samotnou cez context) tu App.tsx volá PRIAMO tie isté existujúce
+  // `fetch*Status` funkcie, čo už používajú `PostaUncollectedSection`/
+  // `OrderReminderSection` — jednoduchšie než pridávať ďalší zdieľaný context
+  // len pre dve políčka, ktoré sa menia zriedka (Štart/Stop klik). Refetch pri
+  // KAŽDEJ zmene aktívnej záložky zachytí prípadný toggle spravený na tej
+  // obrazovke hneď po návrate na inú záložku. `nedostupne` do tejto mapy
+  // úmyselne nepatrí — nemá `enabled` koncept vôbec (Sidebar chýbajúci kľúč =
+  // žiadny odznak).
+  const [automationStatus, setAutomationStatus] = useState<Readonly<Record<string, "on" | "off">>>({});
+  useEffect(() => {
+    if (me === null) return;
+    let cancelled = false;
+    Promise.all([fetchPostaUncollectedStatus(), fetchOrderReminderStatus()])
+      .then(([posta, reminder]) => {
+        if (cancelled) return;
+        setAutomationStatus({
+          "posta-uncollected": posta.enabled ? "on" : "off",
+          "order-reminder": reminder.enabled ? "on" : "off",
+        });
+      })
+      .catch(() => {
+        // Sieťový výpadok — odznak v menu nie je kritický, ticho ponechá
+        // predošlý (alebo žiadny) stav namiesto nespracovanej výnimky.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [me, activeTabId]);
 
   const reload = useCallback(() => {
     setMeUnreachable(false);
@@ -111,7 +144,13 @@ export function App(): JSX.Element {
   return (
     <OrdersRemainingCountContext.Provider value={ordersRemainingCountContextValue}>
       <div className="app-shell">
-        <Sidebar folders={NAV} activeTabId={activeTabId} onSelectTab={selectTab} badgeCounts={badgeCounts} />
+        <Sidebar
+          folders={NAV}
+          activeTabId={activeTabId}
+          onSelectTab={selectTab}
+          badgeCounts={badgeCounts}
+          badgeStatus={automationStatus}
+        />
         <div className="main">
           <Topbar
             title={isVisibleTabId(activeTabId) ? (tab?.label ?? null) : null}

--- a/apps/web/src/components/NedostupneSection.tsx
+++ b/apps/web/src/components/NedostupneSection.tsx
@@ -108,7 +108,6 @@ export function NedostupneSection({ role, onSessionExpired }: { readonly role: M
 
   return (
     <section>
-      <h2>Nedostupné tovary</h2>
       <p>Tovary, ktoré dodávateľ nemá, spárované s otvorenými objednávkami zákazníkov, ktorí na ne čakajú.</p>
 
       {list.bccMissing && (

--- a/apps/web/src/components/OrderReminderSection.tsx
+++ b/apps/web/src/components/OrderReminderSection.tsx
@@ -143,7 +143,6 @@ export function OrderReminderSection({
 
   return (
     <section>
-      <h2>Pripomienky objednávok</h2>
       <div className="autohead">
         <span className={"pill" + (status.enabled ? "" : " off")} data-testid="order-reminder-status-pill">
           {status.enabled ? "Beží" : "Zastavené"}

--- a/apps/web/src/components/PostaUncollectedSection.tsx
+++ b/apps/web/src/components/PostaUncollectedSection.tsx
@@ -116,7 +116,6 @@ export function PostaUncollectedSection({
 
   return (
     <section>
-      <h2>Nevyzdvihnuté zásielky</h2>
       <div className="autohead">
         <span className={"pill" + (status.enabled ? "" : " off")} data-testid="posta-status-pill">
           {status.enabled ? "Beží" : "Zastavené"}

--- a/apps/web/src/components/Sidebar.test.tsx
+++ b/apps/web/src/components/Sidebar.test.tsx
@@ -52,3 +52,31 @@ it("bez badgeCounts (prop vôbec chýba) sa nevykreslí žiadny odznak", () => {
 
   expect(screen.queryByTestId("nav-badge-orders")).toBeNull();
 });
+
+// issue 185: `badgeStatus` je rovnaký generický vzor ako `badgeCounts` — over
+// oba stavy ("on"/"off") aj že tab bez kľúča nedostane žiadny odznak.
+it("vykreslí stav 'Beží' pre 'on', 'Zastavené' pre 'off', nič pre záložku bez kľúča v badgeStatus", () => {
+  render(
+    <Sidebar
+      folders={FOLDERS}
+      activeTabId="sync"
+      onSelectTab={() => {}}
+      badgeStatus={{ orders: "on", sync: "off" }}
+    />,
+  );
+
+  const orders = screen.getByTestId("nav-status-orders");
+  expect(orders.textContent).toBe("Beží");
+  expect(orders.className).not.toContain("off");
+
+  const sync = screen.getByTestId("nav-status-sync");
+  expect(sync.textContent).toBe("Zastavené");
+  expect(sync.className).toContain("off");
+});
+
+it("bez badgeStatus (prop vôbec chýba) sa nevykreslí žiadny stavový odznak", () => {
+  render(<Sidebar folders={FOLDERS} activeTabId="sync" onSelectTab={() => {}} />);
+
+  expect(screen.queryByTestId("nav-status-orders")).toBeNull();
+  expect(screen.queryByTestId("nav-status-sync")).toBeNull();
+});

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -14,6 +14,7 @@ export function Sidebar({
   activeTabId,
   onSelectTab,
   badgeCounts,
+  badgeStatus,
 }: {
   readonly folders: readonly NavFolder[];
   readonly activeTabId: string;
@@ -23,6 +24,12 @@ export function Sidebar({
   // aby AKÁKOĽVEK budúca záložka mohla dostať odznak bez zásahu sem. Chýbajúci
   // kľúč = žiadny odznak (nie "0" — appka ešte nevie, nie "isté nula").
   readonly badgeCounts?: Readonly<Record<string, number>>;
+  // issue 185: voliteľný stav zapnuté/vypnuté per záložka, rovnaký generický
+  // vzor ako `badgeCounts` vyššie — dnes ho posiela `App.tsx` pre
+  // "posta-uncollected"/"order-reminder" (jediné dve automatizácie, ktoré
+  // majú Štart/Stop). Chýbajúci kľúč = žiadny odznak (napr. "nedostupne" —
+  // tá nemá koncept zapnuté/vypnuté vôbec, je len na požiadanie).
+  readonly badgeStatus?: Readonly<Record<string, "on" | "off">>;
 }): JSX.Element {
   const [collapsed, setCollapsed] = useState<Readonly<Record<string, boolean>>>({});
 
@@ -59,6 +66,7 @@ export function Sidebar({
                 <div className="tabs">
                   {folder.tabs.map((tab) => {
                     const badgeCount = badgeCounts?.[tab.id];
+                    const status = badgeStatus?.[tab.id];
                     return (
                       <button
                         key={tab.id}
@@ -70,6 +78,18 @@ export function Sidebar({
                         }}
                       >
                         <span className="tlabel">{tab.label}</span>
+                        {status !== undefined && (
+                          // issue 185: rovnaký vizuál aj slovník ("Beží"/
+                          // "Zastavené") ako `.pill` vnútri
+                          // PostaUncollectedSection/OrderReminderSection —
+                          // žiadny nový vzor navyše, len znovupoužitá trieda.
+                          <span
+                            className={"pill tab-status" + (status === "off" ? " off" : "")}
+                            data-testid={`nav-status-${tab.id}`}
+                          >
+                            {status === "on" ? "Beží" : "Zastavené"}
+                          </span>
+                        )}
                         {badgeCount !== undefined && (
                           // Code review (PR 154): `aria-label` NESMIE niesť
                           // doménovo špecifické slovo ("nevybavených") — táto

--- a/apps/web/src/nav.test.ts
+++ b/apps/web/src/nav.test.ts
@@ -1,16 +1,22 @@
 import { expect, it } from "vitest";
 import { DEFAULT_TAB_ID, HIDDEN_TABS, NAV, findTab, isVisibleTabId } from "./nav.js";
 
-// #57: majiteľ chce naľavo PRESNE dve viditeľné položky — tento test je
+// #57 pôvodne chcel naľavo PRESNE dve viditeľné položky — issue 185 pridalo
+// tretí priečinok "Automatizácie" s tromi hotovými obrazovkami. Tento test je
 // najbližšie k tomu, čo strojovo overiť dá (registrácia, nie DOM).
-it("NAV má presne dva priečinky, každý s presne jednou záložkou", () => {
-  expect(NAV).toHaveLength(2);
-  expect(NAV.map((f) => f.label)).toEqual(["Systém", "Eshop"]);
-  for (const folder of NAV) {
-    expect(folder.tabs).toHaveLength(1);
-  }
+it("NAV má tri priečinky (Systém/Eshop/Automatizácie), s 1/1/3 záložkami v poradí podľa dôležitosti", () => {
+  expect(NAV).toHaveLength(3);
+  expect(NAV.map((f) => f.label)).toEqual(["Systém", "Eshop", "Automatizácie"]);
+  expect(NAV[0]?.tabs).toHaveLength(1);
+  expect(NAV[1]?.tabs).toHaveLength(1);
+  expect(NAV[2]?.tabs).toHaveLength(3);
   expect(NAV[0]?.tabs[0]?.label).toBe("Sync zo Shoptetu");
   expect(NAV[1]?.tabs[0]?.label).toBe("Na objednanie");
+  expect(NAV[2]?.tabs.map((t) => t.label)).toEqual([
+    "Nevyzdvihnuté zásielky",
+    "Pripomienky objednávok",
+    "Nedostupné tovary",
+  ]);
 });
 
 it("DEFAULT_TAB_ID je prvá viditeľná záložka ('sync')", () => {
@@ -31,8 +37,15 @@ it("findTab nájde viditeľnú aj skrytú záložku podľa id, neznáme id vrát
 it("isVisibleTabId rozlíši viditeľné (NAV) od skrytých (HIDDEN_TABS)", () => {
   expect(isVisibleTabId("sync")).toBe(true);
   expect(isVisibleTabId("orders")).toBe(true);
+  // issue 185: presunuté z HIDDEN_TABS do NAV — teraz viditeľné.
+  expect(isVisibleTabId("posta-uncollected")).toBe(true);
+  expect(isVisibleTabId("order-reminder")).toBe(true);
+  expect(isVisibleTabId("nedostupne")).toBe(true);
   for (const hiddenId of Object.keys(HIDDEN_TABS)) {
     expect(isVisibleTabId(hiddenId)).toBe(false);
   }
+  expect(HIDDEN_TABS).not.toHaveProperty("posta-uncollected");
+  expect(HIDDEN_TABS).not.toHaveProperty("order-reminder");
+  expect(HIDDEN_TABS).not.toHaveProperty("nedostupne");
   expect(isVisibleTabId("neexistuje")).toBe(false);
 });

--- a/apps/web/src/nav.ts
+++ b/apps/web/src/nav.ts
@@ -35,10 +35,14 @@ export interface NavFolder {
   readonly tabs: readonly NavTab[];
 }
 
-// Ľavé menu — VIDITEĽNÉ položky. Majiteľ (issue 57, 2026-07-30): "naľavo chcem
-// zatiaľ mať iba dve veci — záložku Sync zo Shoptetu v priečinku Systém a
-// záložku Na objednanie v priečinku Eshop." Pridanie ĎALŠEJ položky do menu =
-// jeden riadok v tomto poli, žiadna úprava App.tsx/Sidebar.tsx.
+// Ľavé menu — VIDITEĽNÉ položky. Pôvodne (issue 57, 2026-07-30) majiteľ chcel
+// naľavo zatiaľ len "Sync zo Shoptetu"/"Na objednanie" — platilo, kým tri
+// automatizácie nižšie neboli hotové. Issue 185 (2026-08-03, majiteľ:
+// "nevidim tam zalozku automatizacie a tie automatizacie spravene") pridáva
+// tretí priečinok "Automatizácie" s tromi hotovými obrazovkami, ktoré dovtedy
+// sedeli len v `HIDDEN_TABS` bez odkazu v menu. Pridanie ĎALŠEJ položky do
+// menu = jeden riadok v niektorom z polí nižšie, žiadna úprava
+// App.tsx/Sidebar.tsx.
 export const NAV: readonly NavFolder[] = [
   {
     id: "system",
@@ -49,6 +53,18 @@ export const NAV: readonly NavFolder[] = [
     id: "eshop",
     label: "Eshop",
     tabs: [{ id: "orders", label: "Na objednanie", Component: OrdersSection, wide: true }],
+  },
+  {
+    id: "automations",
+    label: "Automatizácie",
+    // Poradie podľa dôležitosti (issue 185, zadanie majiteľa). `wide: true`
+    // len pri "Nedostupné tovary" (rovnaký dôvod ako "Na objednanie" nižšie —
+    // karty so zoznamom objednávok profitujú z celej šírky okna).
+    tabs: [
+      { id: "posta-uncollected", label: "Nevyzdvihnuté zásielky", Component: PostaUncollectedSection },
+      { id: "order-reminder", label: "Pripomienky objednávok", Component: OrderReminderSection },
+      { id: "nedostupne", label: "Nedostupné tovary", Component: NedostupneSection, wide: true },
+    ],
   },
 ];
 
@@ -62,19 +78,6 @@ export const HIDDEN_TABS: Readonly<Record<string, NavTab>> = {
   catalog: { id: "catalog", label: "Katalóg", Component: CatalogPage },
   pairing: { id: "pairing", label: "Kontrola párovania", Component: PairingSection },
   scheduler: { id: "scheduler", label: "Plánovač", Component: SchedulerSection },
-  // issue 172: rovnaký vzor ako ostatné tri vyššie — majiteľ zatiaľ chce v
-  // ľavom menu len "Sync zo Shoptetu"/"Na objednanie" (issue 57), táto nová
-  // obrazovka je preto dostupná len cez `?tab=posta-uncollected`.
-  "posta-uncollected": { id: "posta-uncollected", label: "Nevyzdvihnuté zásielky", Component: PostaUncollectedSection },
-  // issue 173: rovnaký vzor ako "posta-uncollected" vyššie — majiteľ zatiaľ
-  // chce v ľavom menu len dve položky (#57), táto obrazovka je preto
-  // dostupná len cez `?tab=order-reminder`.
-  "order-reminder": { id: "order-reminder", label: "Pripomienky objednávok", Component: OrderReminderSection },
-  // issue 176: rovnaký vzor ako "posta-uncollected"/"order-reminder" vyššie —
-  // majiteľ zatiaľ chce v ľavom menu len dve položky (#57). `wide: true`
-  // (rovnaký dôvod ako "Na objednanie") — karty so zoznamom objednávok
-  // profitujú z celej šírky okna, nie len z čitateľnej šírky.
-  nedostupne: { id: "nedostupne", label: "Nedostupné tovary", Component: NedostupneSection, wide: true },
 };
 
 export const DEFAULT_TAB_ID: string = NAV[0]?.tabs[0]?.id ?? "sync";
@@ -89,11 +92,15 @@ export function findTab(id: string): NavTab | undefined {
 }
 
 /**
- * `true` len pre záložky VIDITEĽNÉ v ľavom menu (Sync zo Shoptetu/Na
- * objednanie). Skryté obrazovky (katalóg/párovanie/plánovač) si držia svoj
- * PÔVODNÝ vlastný `<h2>` nadpis nezmenený (existujúce e2e naň spoliehajú) —
- * `App.tsx` preto pre ne Topbar-ov `<h1>` titulok VYNECHÁVA, aby nevznikol
- * duplicitný nadpis s rovnakým textom.
+ * `true` len pre záložky VIDITEĽNÉ v ľavom menu (`NAV` vyššie — dnes Sync zo
+ * Shoptetu/Na objednanie/tri automatizácie z issue 185). Skryté obrazovky
+ * (katalóg/párovanie/plánovač) si držia svoj PÔVODNÝ vlastný `<h2>` nadpis
+ * nezmenený (existujúce e2e naň spoliehajú) — `App.tsx` preto pre ne
+ * Topbar-ov `<h1>` titulok VYNECHÁVA, aby nevznikol duplicitný nadpis s
+ * rovnakým textom. Issue 185: keď sa obrazovka presunie z `HIDDEN_TABS` do
+ * `NAV`, jej vlastný `<h2>` sa musí odstrániť (viď
+ * PostaUncollectedSection/OrderReminderSection/NedostupneSection) — inak by
+ * teraz Topbar-ov `<h1>` VYKRESLIL a vznikol by duplicitný nadpis.
  */
 export function isVisibleTabId(id: string): boolean {
   return NAV.some((folder) => folder.tabs.some((t) => t.id === id));

--- a/apps/web/src/schedulerLabels.test.ts
+++ b/apps/web/src/schedulerLabels.test.ts
@@ -1,0 +1,22 @@
+import { expect, it } from "vitest";
+import { JOB_LABELS, jobLabel } from "./schedulerLabels.js";
+
+// Issue 185: majiteľ si všimol, že "posta-uncollected"/"order-reminder"/
+// "shoptet-writeback"/"order-note-writeback" sa v tabuľke "História behov"
+// zobrazujú holým technickým názvom namiesto slovenského popisu (chýbali v
+// `JOB_LABELS`). Regresný test na presne tento nález — over KAŽDÝ zo štyroch
+// mien, nielen že mapa "má nejaký kľúč".
+it("jobLabel pozná všetky štyri novšie joby (issue 185) — nevracia holý technický názov", () => {
+  expect(jobLabel("posta-uncollected")).toBe("Nevyzdvihnuté zásielky");
+  expect(jobLabel("order-reminder")).toBe("Pripomienky objednávok");
+  expect(jobLabel("shoptet-writeback")).toBe("Spätný zápis dodávateľa do Shoptetu");
+  expect(jobLabel("order-note-writeback")).toBe("Spätný zápis poznámky do Shoptetu");
+});
+
+it("jobLabel vráti holý technický názov pre naozaj neznámy job (fallback nezmenený)", () => {
+  expect(jobLabel("neexistujuci-job")).toBe("neexistujuci-job");
+});
+
+it("JOB_LABELS pozná presne 9 jobov (5 pôvodných + 4 z issue 185) — žiadny sa nestratil", () => {
+  expect(Object.keys(JOB_LABELS)).toHaveLength(9);
+});

--- a/apps/web/src/schedulerLabels.ts
+++ b/apps/web/src/schedulerLabels.ts
@@ -8,8 +8,9 @@ import type { JobRun } from "./schedulerApi.js";
 // slovenského popisu. Issue 185 (majiteľ si všimol holé technické názvy v
 // tabuľke "História behov"): doplnené "posta-uncollected"/"order-reminder"
 // (rovnaké slovenské názvy ako ich `NavTab.label` v `nav.ts`) a
-// "shoptet-writeback"/"order-note-writeback" (rovnaké znenie ako ich
-// "*_NOT_CONFIGURED" hlášky v `modules/scheduler/jobs.ts`).
+// "shoptet-writeback"/"order-note-writeback" (skrátené znenie ich
+// "*_NOT_CONFIGURED" hlášok v `modules/scheduler/jobs.ts` — sem sa zmestí
+// len krátky popis stĺpca "Úloha", nie celá veta).
 export const JOB_LABELS: Readonly<Record<string, string>> = {
   "catalog-import": "Import katalógu",
   "prune-raw-exports": "Mazanie starých surových exportov (katalóg)",

--- a/apps/web/src/schedulerLabels.ts
+++ b/apps/web/src/schedulerLabels.ts
@@ -5,13 +5,21 @@ import type { JobRun } from "./schedulerApi.js";
 // slovenské pomenovanie job-ov, aby sa pri pridaní ďalšieho jobu nezabudlo na
 // jedno z dvoch miest. Rozšírené o "orders-import"/"prune-raw-orders" (#22/#28)
 // — predtým chýbali, takže sa zobrazoval holý technický názov jobu namiesto
-// slovenského popisu.
+// slovenského popisu. Issue 185 (majiteľ si všimol holé technické názvy v
+// tabuľke "História behov"): doplnené "posta-uncollected"/"order-reminder"
+// (rovnaké slovenské názvy ako ich `NavTab.label` v `nav.ts`) a
+// "shoptet-writeback"/"order-note-writeback" (rovnaké znenie ako ich
+// "*_NOT_CONFIGURED" hlášky v `modules/scheduler/jobs.ts`).
 export const JOB_LABELS: Readonly<Record<string, string>> = {
   "catalog-import": "Import katalógu",
   "prune-raw-exports": "Mazanie starých surových exportov (katalóg)",
   "session-cleanup": "Mazanie expirovaných relácií",
   "orders-import": "Import objednávok",
   "prune-raw-orders": "Mazanie starých surových exportov (objednávky)",
+  "posta-uncollected": "Nevyzdvihnuté zásielky",
+  "order-reminder": "Pripomienky objednávok",
+  "shoptet-writeback": "Spätný zápis dodávateľa do Shoptetu",
+  "order-note-writeback": "Spätný zápis poznámky do Shoptetu",
 };
 
 export const STATUS_LABELS: Record<JobRun["status"], string> = {

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -337,9 +337,10 @@ tr:last-child td {
 }
 /* issue 185: stav zapnuté/vypnuté per záložka ("Automatizácie" priečinok) —
    znovupoužíva `.pill`/`.pill.off` (rovnaký vizuál ako vnútri
-   PostaUncollectedSection/OrderReminderSection), len s `flex-shrink: 0` v
-   tomto úzkom nav riadku, rovnaký dôvod ako `.tab-badge` vyššie. */
-.tabs .tab .pill {
+   PostaUncollectedSection/OrderReminderSection, samotná trieda `.pill` dáva
+   farby/padding), len `flex-shrink: 0` navyše v tomto úzkom nav riadku,
+   rovnaký dôvod ako `.tab-badge` vyššie. */
+.tab-status {
   flex-shrink: 0;
 }
 

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -335,6 +335,13 @@ tr:last-child td {
   font-weight: var(--fs-weight-semibold);
   line-height: 1.25rem;
 }
+/* issue 185: stav zapnuté/vypnuté per záložka ("Automatizácie" priečinok) —
+   znovupoužíva `.pill`/`.pill.off` (rovnaký vizuál ako vnútri
+   PostaUncollectedSection/OrderReminderSection), len s `flex-shrink: 0` v
+   tomto úzkom nav riadku, rovnaký dôvod ako `.tab-badge` vyššie. */
+.tabs .tab .pill {
+  flex-shrink: 0;
+}
 
 .sidefoot {
   border-top: 1px solid var(--fs-border);

--- a/apps/web/tests/e2e/nav.spec.ts
+++ b/apps/web/tests/e2e/nav.spec.ts
@@ -15,9 +15,13 @@ const E2E_NAV_EMAIL = "e2e-nav@forestshop.sk";
 const jeOcakavane = (m: ConsoleMessage): boolean =>
   m.location().url.includes("/api/me") && m.text().includes("401");
 
-// #57: majiteľ chce naľavo PRESNE dve položky — záložku "Sync zo Shoptetu"
-// v priečinku "Systém" a záložku "Na objednanie" v priečinku "Eshop", nič iné.
-test("ľavé menu má presne dva priečinky s jednou záložkou každý, klik prepne obrazovku, konzola je čistá", async ({ page }) => {
+// #57 pôvodne chcel naľavo PRESNE dve položky. Issue 185 (2026-08-03) pridáva
+// tretí priečinok "Automatizácie" s tromi hotovými obrazovkami, dovtedy len v
+// `HIDDEN_TABS` bez odkazu v menu — tento test teraz overuje VŠETKÝCH PÄŤ
+// záložiek v troch priečinkoch.
+test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s piatimi záložkami, klik prepne obrazovku, konzola je čistá", async ({
+  page,
+}) => {
   const chyby: string[] = [];
   page.on("console", (m) => {
     if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
@@ -31,14 +35,18 @@ test("ľavé menu má presne dva priečinky s jednou záložkou každý, klik pr
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
-  // Presne dva priečinky.
+  // Presne tri priečinky.
   await expect(page.getByRole("button", { name: "Systém" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Eshop" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Automatizácie" })).toBeVisible();
 
-  // Presne dve záložky v CELOM menu — jedna na priečinok.
-  await expect(page.locator(".side-nav .tab")).toHaveCount(2);
+  // Presne päť záložiek v CELOM menu.
+  await expect(page.locator(".side-nav .tab")).toHaveCount(5);
   await expect(page.getByRole("button", { name: "Sync zo Shoptetu" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Na objednanie" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Nevyzdvihnuté zásielky" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Pripomienky objednávok" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Nedostupné tovary" })).toBeVisible();
 
   // Predvolená obrazovka (bez kliknutia) je "Sync zo Shoptetu".
   await expect(page.getByRole("heading", { name: "Sync zo Shoptetu" })).toBeVisible();
@@ -62,6 +70,27 @@ test("ľavé menu má presne dva priečinky s jednou záložkou každý, klik pr
   const odznak = page.getByTestId("nav-badge-orders");
   await expect(odznak).toBeVisible();
   await expect(odznak).toHaveText(/^\d+$/);
+
+  // issue 185: tri nové položky v priečinku "Automatizácie" — klik na každú
+  // otvorí svoju obrazovku (samostatný `<h1>` titulok v Topbar-e, žiadny
+  // duplicitný `<h2>` — obrazovky si ho pri presune z HIDDEN_TABS odstránili).
+  await page.getByRole("button", { name: "Nevyzdvihnuté zásielky" }).click();
+  await expect(page.getByRole("heading", { name: "Nevyzdvihnuté zásielky" })).toBeVisible();
+  // `scripts/e2e-setup.ts` seeduje obe automatizácie ako vypnuté (`enabled: false`)
+  // — pill v menu musí ukázať "Zastavené", nikdy "Beží", presne ako je
+  // požadovaný stav (hard constraint tohto ticketu: automatizácie ostávajú
+  // vypnuté).
+  await expect(page.getByTestId("nav-status-posta-uncollected")).toHaveText("Zastavené");
+
+  await page.getByRole("button", { name: "Pripomienky objednávok" }).click();
+  await expect(page.getByRole("heading", { name: "Pripomienky objednávok" })).toBeVisible();
+  await expect(page.getByTestId("nav-status-order-reminder")).toHaveText("Zastavené");
+
+  await page.getByRole("button", { name: "Nedostupné tovary" }).click();
+  await expect(page.getByRole("heading", { name: "Nedostupné tovary" })).toBeVisible();
+  // "Nedostupné tovary" nemá koncept zapnuté/vypnuté vôbec (je len na
+  // požiadanie) — žiadny stavový odznak v menu, ani "Zastavené".
+  await expect(page.getByTestId("nav-status-nedostupne")).toHaveCount(0);
 
   expect(chyby).toEqual([]);
 });

--- a/apps/web/tests/e2e/nav.spec.ts
+++ b/apps/web/tests/e2e/nav.spec.ts
@@ -76,15 +76,18 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s piatimi z�
   // duplicitný `<h2>` — obrazovky si ho pri presune z HIDDEN_TABS odstránili).
   await page.getByRole("button", { name: "Nevyzdvihnuté zásielky" }).click();
   await expect(page.getByRole("heading", { name: "Nevyzdvihnuté zásielky" })).toBeVisible();
-  // `scripts/e2e-setup.ts` seeduje obe automatizácie ako vypnuté (`enabled: false`)
-  // — pill v menu musí ukázať "Zastavené", nikdy "Beží", presne ako je
-  // požadovaný stav (hard constraint tohto ticketu: automatizácie ostávajú
-  // vypnuté).
-  await expect(page.getByTestId("nav-status-posta-uncollected")).toHaveText("Zastavené");
+  // `scripts/e2e-setup.ts` seeduje obe automatizácie ako vypnuté, ale
+  // `posta-uncollected.spec.ts`/`order-reminder.spec.ts` bežia ako SAMOSTATNÉ
+  // súbory na tej istej zdieľanej DB (možno súbežne, iný Playwright worker) a
+  // dočasne si Štart/Stop prepnú na "Beží" a naspäť — rovnaký dôvod, prečo
+  // `nav-badge-orders` nižšie neoveruje presné číslo (odznak počtu), len že
+  // odznak nesie PLATNÚ hodnotu. Rovnaká disciplína tu: over, že pill nesie
+  // jeden z dvoch platných stavov, nie konkrétnu hodnotu.
+  await expect(page.getByTestId("nav-status-posta-uncollected")).toHaveText(/^(Zastavené|Beží)$/);
 
   await page.getByRole("button", { name: "Pripomienky objednávok" }).click();
   await expect(page.getByRole("heading", { name: "Pripomienky objednávok" })).toBeVisible();
-  await expect(page.getByTestId("nav-status-order-reminder")).toHaveText("Zastavené");
+  await expect(page.getByTestId("nav-status-order-reminder")).toHaveText(/^(Zastavené|Beží)$/);
 
   await page.getByRole("button", { name: "Nedostupné tovary" }).click();
   await expect(page.getByRole("heading", { name: "Nedostupné tovary" })).toBeVisible();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.108",
+  "version": "0.3.0-dev.109",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Summary

Two owner-reported issues, bundled per the bundling gate (small, same-area
frontend/scheduler changes, no schema/API/security/cross-cut scope):

- issue 185 - "Automatizacie" nav folder: the three finished automation
  screens (Nevyzdvihnute zasielky, Pripomienky objednavok, Nedostupne
  tovary) were only reachable via `?tab=<id>` (HIDDEN_TABS), now they have
  a real menu entry. Also fills in the 4 missing JOB_LABELS entries and
  adds a Bezi/Zastavene status pill in the menu for the two toggleable
  automations.
- issue 184 - catalog-import now runs hourly (:20 UTC) instead of once
  daily, matching the owner's "sync every hour" requirement that #115
  already applied to orders-import. Measured production duration
  (19.5-22.9s/run) and disk headroom (dev2 root fs at 98%) before
  deciding - shortened pruneRawExportsJob's retention from 30 to 14 days
  to bound the extra raw-snapshot growth from hourly imports.

## Test plan

- [x] `pnpm --filter @forestshop/web test` - 43 files / 321 tests green
- [x] `pnpm --filter @forestshop/api test` - 26 files / 415 tests green
- [x] `pnpm --filter @forestshop/api test:integration` - 52 files / 367
      tests green (incl. new catalogImportJob schedule test +
      pruneRawExportsJob default-retention behavioral test)
- [x] Full local Playwright e2e suite - 28/28 green, zero console errors
- [x] `pnpm typecheck` / `pnpm lint` clean
- [x] CI (run 30803655535): check/integration/e2e/docker-build/version-check
      all green
- [ ] Post-deploy live verification (version label + nav click-through) -
      done after merge, per post-deploy-verification.md

Both automations stay DISABLED (verified via the e2e seed and this PR's
own behavior) and production baseline counts
(product_supplier_override/product_supplier_link_override/nedostupne_state)
are unaffected by this change.

issue 185
issue 184
