### PR TITLE
Support old-app password hashes so staff can log in

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -431,3 +431,22 @@ paths:
   correctly OR removed entirely. `pressSequentially`/`.press()`
   (Playwright) and `fireEvent.keyDown` (vitest) are the only two APIs that
   actually exercise the `onKeyDown` handler being tested.
+- **A NEW e2e assertion that reads a value from a shared SINGLETON DB row
+  (e.g. `posta_uncollected_settings`/`order_reminder_settings`'s `enabled`
+  flag) must NOT hardcode the value if a DIFFERENT spec file toggles that
+  same row.** Issue 185 (`nav.spec.ts`): a new assertion asserted the nav
+  status pill shows exactly `"Zastavené"`, matching the seeded default —
+  but `posta-uncollected.spec.ts`/`order-reminder.spec.ts` toggle that
+  SAME global singleton row on then off again mid-test (self-cleaning at
+  the end, but genuinely `enabled: true` for a window in the middle), and
+  Playwright runs spec FILES across 2 concurrent workers (`Running N tests
+  using 2 workers` in the local run). A hardcoded exact-value assertion on
+  such a row is a latent flake — found and fixed by self-review, not by an
+  observed failure (the one local run happened to pass). Fix: assert a
+  REGEX of valid states (`toHaveText(/^(Zastavené|Beží)$/)`) instead of the
+  exact expected value — the SAME discipline `nav.spec.ts` already applies
+  to `nav-badge-orders`'s count (`toHaveText(/^\d+$/)`) for the identical
+  reason (shared, concurrently-mutable state). Test on any FUTURE
+  assertion added to one spec file that reads a value another spec file
+  mutates: does the OTHER file toggle/mutate this same row mid-test? If
+  yes, assert "a valid value", never the specific one.

--- a/apps/api/src/modules/auth/legacy-scrypt.test.ts
+++ b/apps/api/src/modules/auth/legacy-scrypt.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  createLegacyScryptHash,
+  isLegacyScryptHash,
+  parseLegacyScryptHash,
+  verifyLegacyScryptPassword,
+} from "./legacy-scrypt.js";
+
+// Vymyslený reťazec v TVARE, aký píše werkzeug — slúži len na test
+// rozoberania parametrov, nie na overenie hesla (na to sú testy nižšie, ktoré
+// si odtlačok vyrobia samy). Zámerne tu nie je nič skutočné (#189).
+const WERKZEUG_SHAPE = `scrypt:32768:8:1$Lu6GkbqAyGkKZfPB$${"ab12cd34".repeat(16)}`;
+
+describe("staré scrypt odtlačky zo starej appky", () => {
+  it("rozpozná werkzeug tvar", () => {
+    expect(isLegacyScryptHash(WERKZEUG_SHAPE)).toBe(true);
+    expect(isLegacyScryptHash("$argon2id$v=19$m=19456,t=2,p=1$c29s$aGFzaA")).toBe(false);
+  });
+
+  it("rozoberie parametre werkzeug tvaru", () => {
+    const parsed = parseLegacyScryptHash(WERKZEUG_SHAPE);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.cost).toBe(32_768);
+    expect(parsed?.blockSize).toBe(8);
+    expect(parsed?.parallelization).toBe(1);
+    expect(parsed?.salt).toBe("Lu6GkbqAyGkKZfPB");
+  });
+
+  it("overí správne heslo proti vlastnému odtlačku", async () => {
+    const hash = await createLegacyScryptHash("stareheslo123");
+    expect(isLegacyScryptHash(hash)).toBe(true);
+    await expect(verifyLegacyScryptPassword(hash, "stareheslo123")).resolves.toBe(true);
+  });
+
+  it("odmietne nesprávne heslo", async () => {
+    const hash = await createLegacyScryptHash("stareheslo123");
+    await expect(verifyLegacyScryptPassword(hash, "ineheslo")).resolves.toBe(false);
+  });
+
+  it("odmietne poškodený odtlačok namiesto pádu", async () => {
+    for (const broken of [
+      "scrypt:32768:8:1$sol",
+      "scrypt:32768:8$sol$00",
+      "scrypt:0:8:1$sol$" + "0".repeat(128),
+      "scrypt:32769:8:1$sol$" + "0".repeat(128),
+      "scrypt:32768:8:1$$" + "0".repeat(128),
+      "scrypt:32768:8:1$sol$" + "0".repeat(126),
+      "scrypt:32768:8:1$sol$" + "z".repeat(128),
+      "pbkdf2:32768:8:1$sol$" + "0".repeat(128),
+    ]) {
+      expect(parseLegacyScryptHash(broken)).toBeNull();
+      await expect(verifyLegacyScryptPassword(broken, "cokolvek")).resolves.toBe(false);
+    }
+  });
+
+  it("neprijme absurdne nákladné parametre z databázy", () => {
+    expect(parseLegacyScryptHash(`scrypt:${String(1 << 21)}:8:1$sol$${"0".repeat(128)}`)).toBeNull();
+    expect(parseLegacyScryptHash(`scrypt:32768:128:1$sol$${"0".repeat(128)}`)).toBeNull();
+    expect(parseLegacyScryptHash(`scrypt:32768:8:99$sol$${"0".repeat(128)}`)).toBeNull();
+  });
+});

--- a/apps/api/src/modules/auth/legacy-scrypt.ts
+++ b/apps/api/src/modules/auth/legacy-scrypt.ts
@@ -32,8 +32,10 @@ const KEY_LENGTH_BYTES = 64;
 // Werkzeug používa N=32768, r=8, p=1. Parametre síce čítame z odtlačku, ale
 // obmedzíme ich zhora, aby poškodený alebo podvrhnutý riadok v databáze
 // nedokázal vyžiadať scrypt s absurdnou pamäťovou náročnosťou.
-const MAX_COST = 1 << 20;
-const MAX_BLOCK_SIZE = 64;
+// Limity sú zámerne tesné: scrypt si vyžiada 128 * N * r bajtov, takže pri
+// týchto stropoch je najhorší prípad ~268 MB namiesto niekoľkých gigabajtov.
+const MAX_COST = 1 << 17;
+const MAX_BLOCK_SIZE = 16;
 const MAX_PARALLELIZATION = 16;
 
 export interface LegacyScryptHash {

--- a/apps/api/src/modules/auth/legacy-scrypt.ts
+++ b/apps/api/src/modules/auth/legacy-scrypt.ts
@@ -1,0 +1,131 @@
+import type { ScryptOptions } from "node:crypto";
+import { randomBytes, scrypt, timingSafeEqual } from "node:crypto";
+
+// `promisify(scrypt)` stratí preťaženie s parametrami, preto vlastný obal.
+function scryptAsync(
+  password: string,
+  salt: string,
+  keylen: number,
+  options: ScryptOptions,
+): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    scrypt(password, salt, keylen, options, (err, derived) => {
+      if (err) reject(err);
+      else resolve(derived);
+    });
+  });
+}
+
+// Stará appka (parovanie_produktov, Flask) ukladá heslá cez werkzeug
+// `generate_password_hash`, ktorý pri scrypte zapisuje tvar
+//
+//     scrypt:N:r:p$sol$odtlacokVHexe
+//
+// kde soľ je obyčajný text (nie hex ani base64) a odtlačok má vždy 64 bajtov.
+// Novú appku sme prepli na argon2id, takže tieto odtlačky sa nedajú overiť
+// štandardnou cestou — a prepočítať ich na argon2id nejde, odtlačok je
+// jednosmerný. Aby zamestnanci pri prechode na novú appku nemuseli meniť
+// heslá, vieme ich starý odtlačok overiť aj tu; pri prvom úspešnom prihlásení
+// sa potom prepíše na argon2id (viď `login` v service.ts).
+const KEY_LENGTH_BYTES = 64;
+
+// Werkzeug používa N=32768, r=8, p=1. Parametre síce čítame z odtlačku, ale
+// obmedzíme ich zhora, aby poškodený alebo podvrhnutý riadok v databáze
+// nedokázal vyžiadať scrypt s absurdnou pamäťovou náročnosťou.
+const MAX_COST = 1 << 20;
+const MAX_BLOCK_SIZE = 64;
+const MAX_PARALLELIZATION = 16;
+
+export interface LegacyScryptHash {
+  readonly cost: number;
+  readonly blockSize: number;
+  readonly parallelization: number;
+  readonly salt: string;
+  readonly derivedKeyHex: string;
+}
+
+export function isLegacyScryptHash(passwordHash: string): boolean {
+  return passwordHash.startsWith("scrypt:");
+}
+
+function parsePositiveInt(text: string, max: number): number | null {
+  if (!/^[0-9]+$/.test(text)) return null;
+  const value = Number(text);
+  if (!Number.isSafeInteger(value) || value < 1 || value > max) return null;
+  return value;
+}
+
+export function parseLegacyScryptHash(passwordHash: string): LegacyScryptHash | null {
+  const parts = passwordHash.split("$");
+  if (parts.length !== 3) return null;
+  const [method, salt, derivedKeyHex] = parts as [string, string, string];
+
+  const methodParts = method.split(":");
+  if (methodParts.length !== 4) return null;
+  const [name, costText, blockSizeText, parallelizationText] = methodParts as [
+    string,
+    string,
+    string,
+    string,
+  ];
+  if (name !== "scrypt") return null;
+
+  const cost = parsePositiveInt(costText, MAX_COST);
+  const blockSize = parsePositiveInt(blockSizeText, MAX_BLOCK_SIZE);
+  const parallelization = parsePositiveInt(parallelizationText, MAX_PARALLELIZATION);
+  if (cost === null || blockSize === null || parallelization === null) return null;
+  // scrypt vyžaduje, aby N bola mocnina dvojky väčšia ako 1.
+  if ((cost & (cost - 1)) !== 0 || cost < 2) return null;
+
+  if (salt === "") return null;
+  if (derivedKeyHex.length !== KEY_LENGTH_BYTES * 2 || !/^[0-9a-f]+$/i.test(derivedKeyHex)) {
+    return null;
+  }
+
+  return { cost, blockSize, parallelization, salt, derivedKeyHex };
+}
+
+async function deriveKey(
+  plain: string,
+  parsed: Pick<LegacyScryptHash, "cost" | "blockSize" | "parallelization" | "salt">,
+): Promise<Buffer> {
+  // Node vyhlási chybu, keď 128 * N * r prekročí `maxmem`. Pri werkzeug
+  // parametroch to vyjde presne na predvolených 32 MiB, čo je na hrane —
+  // preto si limit nastavíme s rezervou sami.
+  const maxmem = 256 * parsed.cost * parsed.blockSize + 32 * 1024 * 1024;
+  return scryptAsync(plain, parsed.salt, KEY_LENGTH_BYTES, {
+    N: parsed.cost,
+    r: parsed.blockSize,
+    p: parsed.parallelization,
+    maxmem,
+  });
+}
+
+export async function verifyLegacyScryptPassword(
+  passwordHash: string,
+  plain: string,
+): Promise<boolean> {
+  const parsed = parseLegacyScryptHash(passwordHash);
+  if (parsed === null) return false;
+  try {
+    const derived = await deriveKey(plain, parsed);
+    const expected = Buffer.from(parsed.derivedKeyHex, "hex");
+    if (expected.length !== derived.length) return false;
+    return timingSafeEqual(derived, expected);
+  } catch {
+    return false;
+  }
+}
+
+// Používa sa LEN v testoch a pri overovaní nasadenia — vyrobí odtlačok v
+// rovnakom tvare, aký píše werkzeug, aby sa dala otestovať celá cesta bez
+// jediného skutočného hesla zamestnanca.
+export async function createLegacyScryptHash(plain: string): Promise<string> {
+  const cost = 32_768;
+  const blockSize = 8;
+  const parallelization = 1;
+  const salt = randomBytes(12).toString("base64url").slice(0, 16);
+  const derived = await deriveKey(plain, { cost, blockSize, parallelization, salt });
+  const method = `scrypt:${String(cost)}:${String(blockSize)}:${String(parallelization)}`;
+  return `${method}$${salt}$${derived.toString("hex")}`;
+}

--- a/apps/api/src/modules/auth/passwords.ts
+++ b/apps/api/src/modules/auth/passwords.ts
@@ -1,4 +1,5 @@
 import { hash, verify } from "@node-rs/argon2";
+import { isLegacyScryptHash, verifyLegacyScryptPassword } from "./legacy-scrypt.js";
 
 const OPTIONS = { memoryCost: 19_456, timeCost: 2, parallelism: 1 } as const;
 
@@ -12,7 +13,17 @@ export function hashPassword(plain: string): Promise<string> {
   return hash(plain, OPTIONS);
 }
 
+// Účty prenesené zo starej appky (#189) majú odtlačok ešte vo werkzeug
+// scrypt tvare. Overíme ho starou cestou, aby zamestnanci nemuseli meniť
+// heslá; `login` ho po prvom úspešnom prihlásení prepíše na argon2id.
+export function needsRehash(passwordHash: string): boolean {
+  return isLegacyScryptHash(passwordHash);
+}
+
 export async function verifyPassword(passwordHash: string, plain: string): Promise<boolean> {
+  if (isLegacyScryptHash(passwordHash)) {
+    return verifyLegacyScryptPassword(passwordHash, plain);
+  }
   try {
     return await verify(passwordHash, plain, OPTIONS);
   } catch {

--- a/apps/api/src/modules/auth/passwords.ts
+++ b/apps/api/src/modules/auth/passwords.ts
@@ -16,6 +16,12 @@ export function hashPassword(plain: string): Promise<string> {
 // Účty prenesené zo starej appky (#189) majú odtlačok ešte vo werkzeug
 // scrypt tvare. Overíme ho starou cestou, aby zamestnanci nemuseli meniť
 // heslá; `login` ho po prvom úspešnom prihlásení prepíše na argon2id.
+//
+// Vedľajší účinok, ktorý si treba uvedomiť: scrypt a argon2id trvajú rôzne
+// dlho, takže dovtedy, kým sa účet neprihlási prvý raz, sa dá z času odozvy
+// odvodiť, že práve TENTO e-mail je prenesený účet. Neprezrádza to heslo ani
+// existenciu iných účtov a zmizne to samo po prvom prihlásení každého z tých
+// troch účtov, preto to neriešime zložitejšie.
 export function needsRehash(passwordHash: string): boolean {
   return isLegacyScryptHash(passwordHash);
 }

--- a/apps/api/src/modules/auth/service.ts
+++ b/apps/api/src/modules/auth/service.ts
@@ -2,7 +2,7 @@ import { and, eq, gt } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
 import { sessions, users } from "../../db/schema.js";
 import { record } from "../audit/service.js";
-import { hashPassword, verifyPassword } from "./passwords.js";
+import { hashPassword, needsRehash, verifyPassword } from "./passwords.js";
 import { SESSION_TTL_MS, hashToken, newSessionToken } from "./sessions.js";
 
 // Dummy hash used to verify a password against when the e-mail is unknown, so that
@@ -47,6 +47,26 @@ export async function login(
     });
     return null;
   }
+  // Účet prenesený zo starej appky (#189) má odtlačok ešte vo werkzeug scrypt
+  // tvare. Až TERAZ, po overení hesla, poznáme heslo v čitateľnej podobe —
+  // takže je to jediné miesto, kde ho vieme prepísať na argon2id. Deje sa to
+  // len pri ÚSPECHU: nesprávne heslo sa sem nikdy nedostane, takže uložený
+  // odtlačok nemá ako pokaziť. Po prvom prihlásení každého zamestnanca už
+  // v databáze žiaden scrypt neostane.
+  if (needsRehash(user.passwordHash)) {
+    await db
+      .update(users)
+      .set({ passwordHash: await hashPassword(input.password) })
+      .where(eq(users.id, user.id));
+    await record(db, {
+      actorUserId: user.id,
+      action: "password.rehashed",
+      entity: "user",
+      entityId: user.id,
+      at: input.now,
+    });
+  }
+
   const { token, tokenHash } = newSessionToken();
   const expiresAt = new Date(input.now.getTime() + SESSION_TTL_MS);
   await db.insert(sessions).values({ tokenHash, userId: user.id, expiresAt });

--- a/apps/api/tests/auth.integration.test.ts
+++ b/apps/api/tests/auth.integration.test.ts
@@ -1,6 +1,11 @@
+import { eq } from "drizzle-orm";
 import { afterEach, expect, it } from "vitest";
 import { login, logout, resolveSession } from "../src/modules/auth/service.js";
-import { hashPassword } from "../src/modules/auth/passwords.js";
+import { hashPassword, verifyPassword } from "../src/modules/auth/passwords.js";
+import {
+  createLegacyScryptHash,
+  isLegacyScryptHash,
+} from "../src/modules/auth/legacy-scrypt.js";
 import { SESSION_TTL_MS } from "../src/modules/auth/sessions.js";
 import { auditEvents, users } from "../src/db/schema.js";
 import { withCleanDb } from "./helpers/db.js";
@@ -90,4 +95,79 @@ it("prihlásenie aj neúspešný pokus nechajú záznam v audite", async () => {
 
   const events = await ctx.db.select().from(auditEvents);
   expect(events.map((e) => e.action).sort()).toEqual(["login.failed", "login.ok"]);
+});
+
+// --- prenesené účty zo starej appky (#189) ---------------------------------
+
+const STARE_HESLO = "stare-heslo-zo-starej-appky"; // testovacie údaje, nie tajomstvo
+
+async function seedStary(
+  db: Awaited<ReturnType<typeof withCleanDb>>["db"],
+): Promise<void> {
+  await db.insert(users).values({
+    email: "prenesena@forestshop.sk",
+    passwordHash: await createLegacyScryptHash(STARE_HESLO),
+    displayName: "Prenesená",
+    role: "manazer",
+  });
+}
+
+async function ulozenyOdtlacok(
+  db: Awaited<ReturnType<typeof withCleanDb>>["db"],
+): Promise<string> {
+  const [row] = await db
+    .select({ passwordHash: users.passwordHash })
+    .from(users)
+    .where(eq(users.email, "prenesena@forestshop.sk"))
+    .limit(1);
+  return row?.passwordHash ?? "";
+}
+
+it("prihlási prenesený účet jeho pôvodným heslom a odtlačok prepíše na argon2id", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await seedStary(ctx.db);
+  expect(isLegacyScryptHash(await ulozenyOdtlacok(ctx.db))).toBe(true);
+
+  const session = await login(ctx.db, {
+    email: "prenesena@forestshop.sk",
+    password: STARE_HESLO,
+    now: NOW,
+  });
+  expect(session).not.toBeNull();
+
+  const po = await ulozenyOdtlacok(ctx.db);
+  expect(isLegacyScryptHash(po)).toBe(false);
+  expect(po.startsWith("$argon2id$")).toBe(true);
+  await expect(verifyPassword(po, STARE_HESLO)).resolves.toBe(true);
+});
+
+it("prenesený účet sa po prepise prihlási rovnakým heslom aj druhýkrát", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await seedStary(ctx.db);
+
+  await login(ctx.db, { email: "prenesena@forestshop.sk", password: STARE_HESLO, now: NOW });
+  const druhe = await login(ctx.db, {
+    email: "prenesena@forestshop.sk",
+    password: STARE_HESLO,
+    now: NOW,
+  });
+  expect(druhe).not.toBeNull();
+  expect(await resolveSession(ctx.db, druhe?.token ?? "", NOW)).not.toBeNull();
+});
+
+it("nesprávne heslo prenesený odtlačok nezmení", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await seedStary(ctx.db);
+  const pred = await ulozenyOdtlacok(ctx.db);
+
+  const session = await login(ctx.db, {
+    email: "prenesena@forestshop.sk",
+    password: ZLE_HESLO,
+    now: NOW,
+  });
+  expect(session).toBeNull();
+  expect(await ulozenyOdtlacok(ctx.db)).toBe(pred);
 });

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -2451,3 +2451,45 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   integračnou + e2e sadou nad rovnakou schémou.
 - Nový playbook súbor `.claude/rules/nedostupne.md` + router riadok v
   `CLAUDE.md`. Issue #176 zavretý s dôkazom. Discord karta odoslaná.
+
+## Issue 185 + 184 (2026-08-03, PR #186)
+
+- Issue 185 — "Automatizácie" nav folder: moved posta-uncollected/
+  order-reminder/nedostupne from `HIDDEN_TABS` into a new visible `NAV`
+  folder (`apps/web/src/nav.ts`). Commits `aec5e3a` (main change),
+  `4419a77`/`cd73b45` (self-review fixes). Added `badgeStatus` prop to
+  `Sidebar.tsx` (Beží/Zastavené pill, same pattern as issue 147's
+  `badgeCounts`), fetched by `App.tsx` from the two existing status
+  endpoints. Filled 4 missing `JOB_LABELS` entries. Removed the now-
+  duplicate `<h2>` from the three screens (Topbar's `<h1>` now renders for
+  them). Tests: `nav.test.ts`, `Sidebar.test.tsx`, `schedulerLabels.test.ts`
+  (new), `nav.spec.ts` e2e (updated to 3 folders/5 tabs).
+- Issue 184 — hourly catalog-import: `catalogImportJob` schedule
+  `daily 01:00` → `hourly :20 UTC` (commit `6fb74cd`). Measured production
+  duration first (19.5-22.9s/run, 6 samples) before deciding — negligible
+  load. Disk check found dev2 root fs at 98% (~25GB free); shortened
+  `pruneRawExportsJob`'s default retention 30→14 days (+ CLI's `KEEP_DAYS`)
+  to bound the extra raw-snapshot growth from hourly imports. New tests:
+  `catalogImportJob` schedule-shape test + a behavioral test proving the
+  DEFAULT retention (not just an explicit override) changed to 14 days.
+- Self-review (subagent dispatch limit reached this session — reviewed
+  manually instead) found and fixed: a dead CSS class targeted via a nested
+  selector instead of directly; a genuine e2e flakiness risk (hardcoded
+  pill text raced against posta-uncollected.spec.ts/order-reminder.spec.ts
+  toggling the same shared singleton row across concurrent Playwright
+  workers — relaxed to accept either valid state, matching this file's
+  existing discipline for the badge-count assertion); two doc/comment
+  precision fixes (timing claim, stray markdown-bold in a .ts comment).
+- CI (push+PR runs, multiple cycles after review fixes) all green. PR #186
+  merged `195c831` (merge commit, dev→main). Main CI `30806516180` success.
+  Deploy `30806516186`: FIRST attempt failed on the documented transient
+  containerd `failed to extract layer ... Lchown` error (`.claude/rules/
+  deploy.md`) — confirmed no concurrent runner job, reran once, succeeded.
+- Live verified (Playwright MCP, `vychod@varos.sk`): `/api/version` =
+  `0.3.0-dev.109`/`195c831`. Automatizácie folder visible with all 3 items,
+  correct Zastavené pills, no pill on Nedostupné tovary. "História behov"
+  shows translated job names. **Hourly catalog-import fired live** at
+  10:51:55 UTC with NO manual trigger (24s duration) — visible in the Sync
+  screen and history table within the hour, as required. Zero console
+  errors. Production baseline unchanged (0|0|0).
+- Both issues closed with evidence, both Discord completion cards fired.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.109",
+  "version": "0.3.0-dev.110",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Čo to rieši

Hlavná adresa je od 3. 8. 2026 prepnutá na novú appku, ale zamestnanci v nej
nemali účty — stará appka ukladá heslá vo werkzeug scrypt tvare, ktorý nová
appka nevedela overiť vôbec.

## Ako

- Nový `legacy-scrypt.ts` rozobere werkzeug tvar `scrypt:N:r:p$sol$hex`,
  overí ho vstavaným `crypto.scrypt` v Node a porovná časovo-konštantne.
  Parametre z odtlačku sú zhora obmedzené, aby poškodený alebo podvrhnutý
  riadok v databáze nedokázal vyžiadať absurdne drahý výpočet.
- `verifyPassword` podľa tvaru odtlačku vyberie starú alebo argon2id cestu.
- `login` po ÚSPEŠNOM prihlásení (jediný okamih, keď je heslo v čitateľnej
  podobe známe) prepíše starý odtlačok na argon2id a zapíše to do auditu.
  Nesprávne heslo sa tam nikdy nedostane, takže uložený odtlačok nemá ako
  pokaziť. Po prvom prihlásení každého zamestnanca už žiaden scrypt v
  databáze neostane.

## Testy

Jednotkové: rozpoznanie tvaru, rozobranie parametrov, overenie správneho aj
nesprávneho hesla, osem poškodených tvarov (žiadny pád, vždy odmietnutie),
odmietnutie absurdných parametrov. Integračné: prihlásenie preneseného účtu
pôvodným heslom + prepis na argon2id, druhé prihlásenie po prepise,
a dôkaz, že nesprávne heslo odtlačok nezmení. Všetky fixtúry si odtlačok
vyrobia samy — žiadne skutočné heslo ani odtlačok nikde v repozitári.

## Nasadenie

Samotné 3 účty sa do produkčnej tabuľky `users` vložia priamo na serveri aj
s ich pôvodnými odtlačkami (odtlačky sa nikdy nedostanú do repozitára,
commit správy, PR ani ticketu) a odstráni sa vývojový účet
`admin@forestshop.sk`.

Súvisí s issue 189 — ticket zostáva zámerne otvorený, jeho akceptačná
podmienka (naživo overené prihlásenie) sa dá splniť až po nasadení.
