### PR TITLE
Move Nedostupne tovary under the Eshop folder

### DIFF
--- a/.claude/rules/auth.md
+++ b/.claude/rules/auth.md
@@ -1,0 +1,39 @@
+---
+paths:
+  - "apps/api/src/modules/auth/**"
+  - "apps/api/tests/auth*.ts"
+---
+
+# Prihlásenie a heslá
+
+- **V databáze môžu byť DVA tvary odtlačku hesla, nie jeden.** Účty prenesené
+  zo starej Flask appky (#189) majú werkzeug scrypt tvar
+  `scrypt:N:r:p$sol$hexOdtlacok` (soľ je obyčajný text, odtlačok vždy 64 B),
+  nové účty majú argon2id. `verifyPassword` v `passwords.ts` sa rozhoduje
+  podľa prefixu; starú cestu rieši `legacy-scrypt.ts`. Každý ďalší kód, čo sa
+  pozerá na `users.password_hash`, musí počítať s oboma tvarmi, kým sa všetky
+  tri prenesené účty aspoň raz neprihlásia — potom scrypt z produkcie zmizne
+  sám a `legacy-scrypt.ts` sa dá odstrániť.
+- **Prepis odtlačku patrí VÝHRADNE do `login`, až za overenie hesla.** Je to
+  jediný okamih, keď je heslo v čitateľnej podobe známe. Nikdy ho nerob pred
+  overením ani v inej vetve — nesprávne heslo by inak vedelo prepísať uložený
+  odtlačok. Test `nesprávne heslo prenesený odtlačok nezmení`
+  (`tests/auth.integration.test.ts`) presne toto stráži.
+- **`promisify(scrypt)` z `node:util` stratí preťaženie s parametrami** —
+  `tsc` potom hlási `Expected 3 arguments, but got 4`, keď odovzdáš
+  `{N, r, p, maxmem}`. Riešenie je vlastný `new Promise` obal okolo `scrypt`,
+  nie `as any`.
+- **Node vyhlási chybu, keď `128 * N * r` presiahne `maxmem`.** Pri werkzeug
+  parametroch (`32768:8:1`) to vyjde presne na predvolených 32 MiB, čiže na
+  hrane — `maxmem` si preto nastav explicitne s rezervou. A parametre čítané
+  z uloženého odtlačku VŽDY obmedz zhora: bez limitu si poškodený alebo
+  podvrhnutý riadok vie vyžiadať výpočet na gigabajty pamäte.
+- **Neúspešné prihlásenie musí trvať rovnako dlho pri známom aj neznámom
+  e-maile** — preto `DUMMY_PASSWORD_HASH` v `service.ts`. Neoptimalizuj to
+  preč skratkou na `user === undefined`, inak čas odozvy prezradí, ktoré
+  e-maily v systéme existujú.
+- **Reálne heslá ani odtlačky sa NIKDY nepíšu do repozitára, commit správy,
+  PR ani ticketu** (`.claude/rules/sensitive-values.md`). Testy si odtlačok
+  vyrobia cez `createLegacyScryptHash` / `hashPassword`; prenos skutočných
+  účtov na produkciu prebieha priamo na serveri cez SQL súbor, ktorý sa hneď
+  po behu maže a nikdy sa nevypisuje na obrazovku.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,7 @@ Per-area rules live in `.claude/rules/<area>.md` with `paths:` frontmatter.
 - citlivé hodnoty (heslá/tokeny/hash= sa nikdy nepíšu do repa) → `.claude/rules/sensitive-values.md`
 - frontend dizajn (vizuálne tokeny, nav registry, user-menu, e2e login rate-limit) → `.claude/rules/frontend-design.md`
 - HTTP trasy (Hono, poradie registrácie literal-vs-`:param`) → `.claude/rules/http-routes.md`
+- prihlásenie a heslá (dva tvary odtlačku, prepis pri prihlásení) → `.claude/rules/auth.md`
 - spätný zápis do Shoptetu (F5 — Playwright import, reálne admin cesty, Alpine chromium) → `.claude/rules/shoptet-writeback.md`
 - Nevyzdvihnuté zásielky (Pošta SK — enabled vs. run-now, coalesce, advisory zámok) → `.claude/rules/posta-uncollected.md`
 - Pripomienky objednávok (AI klasifikácia poznámky, terminálna rezolúcia, override→job_run relocate) → `.claude/rules/order-reminder.md`

--- a/apps/web/src/nav.test.ts
+++ b/apps/web/src/nav.test.ts
@@ -2,20 +2,21 @@ import { expect, it } from "vitest";
 import { DEFAULT_TAB_ID, HIDDEN_TABS, NAV, findTab, isVisibleTabId } from "./nav.js";
 
 // #57 pôvodne chcel naľavo PRESNE dve viditeľné položky — issue 185 pridalo
-// tretí priečinok "Automatizácie" s tromi hotovými obrazovkami. Tento test je
+// tretí priečinok "Automatizácie" s tromi hotovými obrazovkami, issue 195
+// presunulo "Nedostupné tovary" z Automatizácií pod "Eshop" (nemá naplánovanú
+// úlohu ani prepínač zapnuté/vypnuté, je to pracovná obrazovka). Tento test je
 // najbližšie k tomu, čo strojovo overiť dá (registrácia, nie DOM).
-it("NAV má tri priečinky (Systém/Eshop/Automatizácie), s 1/1/3 záložkami v poradí podľa dôležitosti", () => {
+it("NAV má tri priečinky (Systém/Eshop/Automatizácie), s 1/2/2 záložkami v poradí podľa dôležitosti", () => {
   expect(NAV).toHaveLength(3);
   expect(NAV.map((f) => f.label)).toEqual(["Systém", "Eshop", "Automatizácie"]);
   expect(NAV[0]?.tabs).toHaveLength(1);
-  expect(NAV[1]?.tabs).toHaveLength(1);
-  expect(NAV[2]?.tabs).toHaveLength(3);
+  expect(NAV[1]?.tabs).toHaveLength(2);
+  expect(NAV[2]?.tabs).toHaveLength(2);
   expect(NAV[0]?.tabs[0]?.label).toBe("Sync zo Shoptetu");
-  expect(NAV[1]?.tabs[0]?.label).toBe("Na objednanie");
+  expect(NAV[1]?.tabs.map((t) => t.label)).toEqual(["Na objednanie", "Nedostupné tovary"]);
   expect(NAV[2]?.tabs.map((t) => t.label)).toEqual([
     "Nevyzdvihnuté zásielky",
     "Pripomienky objednávok",
-    "Nedostupné tovary",
   ]);
 });
 

--- a/apps/web/src/nav.ts
+++ b/apps/web/src/nav.ts
@@ -52,18 +52,24 @@ export const NAV: readonly NavFolder[] = [
   {
     id: "eshop",
     label: "Eshop",
-    tabs: [{ id: "orders", label: "Na objednanie", Component: OrdersSection, wide: true }],
+    // issue 195: "Nedostupné tovary" patrí SEM, nie medzi Automatizácie —
+    // nemá naplánovanú úlohu ani prepínač zapnuté/vypnuté, je to obrazovka,
+    // na ktorej obsluha pracuje, presne ako "Na objednanie". `wide: true` pri
+    // oboch z rovnakého dôvodu (hustý pracovný obsah profituje z celej šírky
+    // okna, viď `NavTab.wide` vyššie).
+    tabs: [
+      { id: "orders", label: "Na objednanie", Component: OrdersSection, wide: true },
+      { id: "nedostupne", label: "Nedostupné tovary", Component: NedostupneSection, wide: true },
+    ],
   },
   {
     id: "automations",
     label: "Automatizácie",
-    // Poradie podľa dôležitosti (issue 185, zadanie majiteľa). `wide: true`
-    // len pri "Nedostupné tovary" (rovnaký dôvod ako "Na objednanie" nižšie —
-    // karty so zoznamom objednávok profitujú z celej šírky okna).
+    // Len tie dve veci, ktoré SKUTOČNE bežia na plán a dajú sa zapnúť/vypnúť
+    // (issue 195). Poradie podľa dôležitosti (issue 185, zadanie majiteľa).
     tabs: [
       { id: "posta-uncollected", label: "Nevyzdvihnuté zásielky", Component: PostaUncollectedSection },
       { id: "order-reminder", label: "Pripomienky objednávok", Component: OrderReminderSection },
-      { id: "nedostupne", label: "Nedostupné tovary", Component: NedostupneSection, wide: true },
     ],
   },
 ];

--- a/apps/web/tests/e2e/nav.spec.ts
+++ b/apps/web/tests/e2e/nav.spec.ts
@@ -71,9 +71,11 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s piatimi z�
   await expect(odznak).toBeVisible();
   await expect(odznak).toHaveText(/^\d+$/);
 
-  // issue 185: tri nové položky v priečinku "Automatizácie" — klik na každú
-  // otvorí svoju obrazovku (samostatný `<h1>` titulok v Topbar-e, žiadny
-  // duplicitný `<h2>` — obrazovky si ho pri presune z HIDDEN_TABS odstránili).
+  // issue 185: tri obrazovky, ktoré dovtedy sedeli len v `HIDDEN_TABS` — klik
+  // na každú otvorí svoju obrazovku (samostatný `<h1>` titulok v Topbar-e,
+  // žiadny duplicitný `<h2>` — obrazovky si ho pri presune odstránili). Dve z
+  // nich sú v priečinku "Automatizácie", "Nedostupné tovary" je od issue 195
+  // pod "Eshop" (nemá naplánovanú úlohu ani prepínač zapnuté/vypnuté).
   await page.getByRole("button", { name: "Nevyzdvihnuté zásielky" }).click();
   await expect(page.getByRole("heading", { name: "Nevyzdvihnuté zásielky" })).toBeVisible();
   // `scripts/e2e-setup.ts` seeduje obe automatizácie ako vypnuté, ale

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.110",
+  "version": "0.3.0-dev.111",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Presúva „Nedostupné tovary" z priečinka **Automatizácie** do priečinka
**Eshop**, vedľa „Na objednanie" — podľa pokynu majiteľa z 3. 8. 2026. Ten
pokyn prišiel, keď už bola práca na menu rozrobená, takže sa do nej
nestihol dostať.

Sedí to aj vecne: tá obrazovka nemá žiadnu naplánovanú úlohu ani prepínač
zapnuté/vypnuté — je to miesto, kde obsluha pracuje, rovnako ako „Na
objednanie". V Automatizáciách tak ostávajú len dve veci, ktoré naozaj
bežia na plán.

Menu sa vykresľuje výhradne z registra `apps/web/src/nav.ts`, takže je to
presun jedného riadku medzi priečinkami — žiadna zmena v `App.tsx` ani
`Sidebar.tsx`.

Testy: register má vlastný test na presné rozloženie priečinkov, upravený na
1/2/2. E2E test menu hľadá položky podľa názvu, nie podľa priečinka, takže
prešiel bez zmeny logiky — upravený len komentár, aby nepopisoval starý
stav.

Refs issue 195 — ticket zostáva otvorený, zavriem ho po nasadení a živej
kontrole menu.
