### PR TITLE
Show ordered size; stop /api/me logging a console error

### DIFF
--- a/apps/api/src/http/app.ts
+++ b/apps/api/src/http/app.ts
@@ -6,7 +6,7 @@ import type { Database } from "../db/client.js";
 import { log } from "../logger.js";
 import { changePassword } from "../modules/auth/change-password.js";
 import { MIN_NEW_PASSWORD_LENGTH } from "../modules/auth/passwords.js";
-import { login, logout } from "../modules/auth/service.js";
+import { login, logout, resolveSession } from "../modules/auth/service.js";
 import type { MailTransport } from "../modules/mail/transport.js";
 import { appVersion } from "../version.js";
 import { registerCatalogRoutes, type RunIngest } from "./catalog-routes.js";
@@ -108,7 +108,18 @@ export function createApp(
     return c.json({ ok: true });
   });
 
-  app.get("/api/me", requireUser(db), (c) => c.json(c.get("user")));
+  // issue 188: ZÁMERNE bez `requireUser` — neprihlásený dostane 200 s telom
+  // `null`, nie 401. Chromium totiž loguje KAŽDÚ 4xx odpoveď do konzoly ako
+  // "Failed to load resource", takže úplne v poriadku fungujúca appka
+  // vypisovala na prihlasovacej obrazovke červenú chybu. Je to ten istý vzor,
+  // aký už má `POST /api/me/password` (očakávaný doménový výsledok = 200 s
+  // telom) — 4xx si nechávame pre SKUTOČNÉ HTTP chyby. Ostatné endpointy si
+  // svoju 401 ponechávajú: tie sa volajú až z prihlásenej appky, kde 401
+  // znamená vypršanú reláciu a klient na nej stavia.
+  app.get("/api/me", async (c) => {
+    const user = await resolveSession(db, getCookie(c, SESSION_COOKIE) ?? "", new Date());
+    return c.json(user);
+  });
 
   app.post(
     "/api/me/password",

--- a/apps/api/tests/http.integration.test.ts
+++ b/apps/api/tests/http.integration.test.ts
@@ -35,9 +35,14 @@ it("GET /api/version vráti verziu aj bez prihlásenia", async () => {
   expect(((await res.json()) as { version: string }).version).toMatch(/^\d+\.\d+\.\d+/);
 });
 
-it("GET /api/me bez prihlásenia vráti 401", async () => {
+// issue 188: ZÁMERNE 200 s telom `null`, nie 401 — Chromium loguje každú 4xx
+// odpoveď do konzoly ako chybu, takže 401 tu robilo červenú chybu na
+// prihlasovacej obrazovke úplne v poriadku fungujúcej appky.
+it("GET /api/me bez prihlásenia vráti 200 a telo null", async () => {
   const app = await boot();
-  expect((await app.request("/api/me")).status).toBe(401);
+  const res = await app.request("/api/me");
+  expect(res.status).toBe(200);
+  expect(await res.json()).toBeNull();
 });
 
 it("prihlásenie nastaví cookie a /api/me potom vráti používateľa", async () => {

--- a/apps/web/src/api.test.ts
+++ b/apps/web/src/api.test.ts
@@ -13,7 +13,16 @@ it("vráti používateľa pri stave 200", async () => {
   await expect(fetchMe()).resolves.toMatchObject({ role: "admin" });
 });
 
-it("vráti null pri stave 401", async () => {
+// issue 188: neprihlásený dostane 200 s telom `null` — 401 by prehliadač
+// zalogoval do konzoly ako červenú chybu na prihlasovacej obrazovke.
+it("vráti null pri stave 200 s telom null (neprihlásený)", async () => {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("null", { status: 200 })));
+  await expect(fetchMe()).resolves.toBeNull();
+});
+
+// Starý server proti novému frontendu počas nasadenia — 401 stále znamená
+// "neprihlásený", nie pád.
+it("vráti null aj pri stave 401", async () => {
   vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 401 })));
   await expect(fetchMe()).resolves.toBeNull();
 });

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -13,8 +13,14 @@ export type Me = z.infer<typeof meSchema>;
 
 export async function fetchMe(): Promise<Me | null> {
   const res = await fetch("/api/me");
+  // issue 188: neprihlásený dostane 200 s telom `null` (nie 401), aby
+  // prehliadač nelogoval červenú chybu na prihlasovacej obrazovke. 401 sa
+  // tu stále ošetruje pre istotu — počas nasadenia môže krátko bežať starý
+  // server proti novému frontendu.
   if (res.status === 401) return null;
-  return meSchema.parse(await res.json());
+  const body: unknown = await res.json();
+  if (body === null) return null;
+  return meSchema.parse(body);
 }
 
 export async function fetchVersion(): Promise<z.infer<typeof versionSchema>> {

--- a/apps/web/src/components/OrderLineRow.tsx
+++ b/apps/web/src/components/OrderLineRow.tsx
@@ -253,7 +253,22 @@ export function OrderLineRow({
             poučenie, `.claude/rules/frontend-design.md`) — dva stackované
             block divy sa prirodzene poukladajú pod seba bez toho. */}
         <td>
-          <div className="ord-product-name">{line.variantName}</div>
+          <div className="ord-product-name">
+            {line.variantName}
+            {/* issue 187: veľkosť, ktorú zákazník naozaj objednal — obsluha
+                podľa nej objednáva u dodávateľa. Kedysi bola vo VLASTNOM
+                stĺpci VEĽKOSŤ, issue 95 ju zlúčilo do stĺpca KÓD a issue 117
+                celý ten stĺpec odstránilo (kódy sa nepoužívajú), čím veľkosť
+                nechcene zmizla. Vracia sa PRI MENE, nie ako stĺpec — tabuľka
+                je na šírku napnutá (issue 105/107/111/127). Jednovariantný
+                produkt `sizeLabel` nemá: vtedy sa nevykreslí NIČ, žiadna
+                pomlčka ani prázdne miesto (zadanie majiteľa). */}
+            {line.sizeLabel !== null && (
+              <span className="ord-size" data-testid={`size-${line.lineId}`}>
+                {line.sizeLabel}
+              </span>
+            )}
+          </div>
           <div className="ord-remark-cell" data-testid={`remark-cell-${line.lineId}`}>
             {line.remark !== null && (
               <span className="ord-remark" title={line.remark}>

--- a/apps/web/src/components/OrdersSection.test.tsx
+++ b/apps/web/src/components/OrdersSection.test.tsx
@@ -461,3 +461,22 @@ it("issue 118: aj manažér (canChangeState) nevidí tlačidlá kopírovania/odo
   // Hromadné tlačidlo (mimo issue 118's scope) ostáva viditeľné.
   expect(screen.getByRole("button", { name: "✔ Označiť skupinu ako objednané" })).toBeTruthy();
 });
+
+// issue 187: objednaná veľkosť pri mene produktu — obsluha podľa nej
+// objednáva u dodávateľa. Kedysi bola vo vlastnom stĺpci VEĽKOSŤ, ten sa
+// zlúčil do KÓD (issue 95) a KÓD sa celý odstránil (issue 117), čím veľkosť
+// nechcene zmizla z obrazovky.
+it("zobrazí objednanú veľkosť pri mene produktu, a nič pri variante bez veľkosti", async () => {
+  fetchOpenOrders.mockResolvedValue([
+    { supplier: "Dodávateľ Alfa", lines: [LINE_STARA, LINE_NOVA], email: null },
+  ]);
+
+  render(<OrdersSection role="citanie" onSessionExpired={() => {}} />);
+
+  const soVelkostou = await screen.findByTestId(`size-${LINE_STARA.lineId}`);
+  expect(soVelkostou.textContent).toBe(LINE_STARA.sizeLabel);
+
+  // Riadok bez veľkosti nesmie vykresliť ANI prázdny štítok, ANI pomlčku.
+  expect(LINE_NOVA.sizeLabel).toBeNull();
+  expect(screen.queryByTestId(`size-${LINE_NOVA.lineId}`)).toBeNull();
+});

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -1276,6 +1276,24 @@ tr:last-child td {
 .ord-product-name {
   max-width: 100%;
 }
+/* issue 187: objednaná veľkosť pri mene produktu. Musí byť vidno na prvý
+   pohľad (obsluha podľa nej objednáva u dodávateľa), preto vlastný farebný
+   štítok, nie len text — ale zámerne kompaktný, aby nepribudol ďalší riadok
+   výšky (strop výšky riadku, issue 105/107/111/127). `white-space: nowrap`
+   z rovnakého dôvodu ako `.ord-admin-link` (issue 111): krátka hodnota ako
+   "3XL"/"46" sa nikdy nesmie zalomiť uprostred. */
+.ord-size {
+  display: inline-block;
+  margin-left: var(--fs-space-2);
+  padding: 0 var(--fs-space-2);
+  border-radius: var(--fs-radius-sm);
+  background: var(--fs-brand-soft);
+  color: var(--fs-brand-strong);
+  font-weight: 700;
+  font-size: var(--fs-text-sm);
+  white-space: nowrap;
+  vertical-align: baseline;
+}
 /* issue 65: zákaznícky odkaz k objednávke — read-only, rovnaký orezávací
    vzor ako `.ord-supplier-note` (issue 70) — voľný text neobmedzenej dĺžky.
    issue 171: presunuté z bývalej zlúčenej bunky POZNÁMKY sem, pod meno

--- a/apps/web/tests/e2e/catalog.spec.ts
+++ b/apps/web/tests/e2e/catalog.spec.ts
@@ -1,13 +1,10 @@
-import { expect, test, type ConsoleMessage } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
 
-// Rovnaká a JEDINÁ povolená výnimka ako v login.spec.ts: neautentifikovaný
 // `GET /api/me` s odpoveďou 401 hneď po otvorení stránky. Rozpoznáva sa podľa
 // `location().url`, nie podľa textu — Chromium URL do textu „Failed to load
 // resource" nedáva. Rozširovanie výnimky na ďalšie cesty je zakázané.
-const jeOcakavane = (m: ConsoleMessage): boolean =>
-  m.location().url.includes("/api/me") && m.text().includes("401");
 
 // #57: "Katalóg" je od nového ľavého menu SKRYTÁ obrazovka (viditeľné sú len
 // "Sync zo Shoptetu"/"Na objednanie") — kód aj testy ostávajú, dostupná ďalej
@@ -16,7 +13,7 @@ const jeOcakavane = (m: ConsoleMessage): boolean =>
 test("manažér vidí stav katalógu, vyhľadá variant a konzola je čistá", async ({ page }) => {
   const chyby: string[] = [];
   page.on("console", (m) => {
-    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
   });
   page.on("pageerror", (e) => {
     chyby.push(e.message);

--- a/apps/web/tests/e2e/login.spec.ts
+++ b/apps/web/tests/e2e/login.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type ConsoleMessage } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
 const ZLE_HESLO = "nespravne";
@@ -14,15 +14,12 @@ const E2E_HESLO_ZMENA_EMAIL = "e2e-heslo@forestshop.sk";
 
 test("manažér sa prihlási, vidí svoje meno a verziu, konzola je čistá", async ({ page }) => {
   const chyby: string[] = [];
-  // Jediná povolená výnimka: hneď po otvorení stránky (a po odhlásení) sa appka pýta
   // `/api/me`, kým používateľ ešte nie je prihlásený, a dostane 401. To je očakávané
   // správanie, nie chyba — prehliadač ho zapíše ako „Failed to load resource" console
   // error. Text správy neobsahuje URL (Chromium ju necháva len v `location()`), takže
   // rozpoznávame podľa nej, nie podľa textu. Všetko ostatné v konzole je chyba a test padá.
-  const jeOcakavane = (m: ConsoleMessage): boolean =>
-    m.location().url.includes("/api/me") && m.text().includes("401");
   page.on("console", (m) => {
-    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
   });
   page.on("pageerror", (e) => chyby.push(e.message));
 
@@ -71,12 +68,10 @@ test("zmena hesla: zlé staré heslo/nezhoda odmietnuté, úspešná zmena zruš
   browser,
 }) => {
   const NOVE_HESLO = "e2e-nove-heslo-xyz";
-  const jeOcakavane = (m: ConsoleMessage): boolean =>
-    m.location().url.includes("/api/me") && m.text().includes("401");
   const chyby: string[] = [];
   const sledujKonzolu = (p: typeof page): void => {
     p.on("console", (m) => {
-      if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+      if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
     });
     p.on("pageerror", (e) => { chyby.push(e.message); });
   };

--- a/apps/web/tests/e2e/nav.spec.ts
+++ b/apps/web/tests/e2e/nav.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type ConsoleMessage } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
 // Vlastný, IZOLOVANÝ účet len pre tento súbor (rovnaký dôvod aj mechanizmus
@@ -11,10 +11,6 @@ const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáz
 // `scripts/e2e-setup.ts`.
 const E2E_NAV_EMAIL = "e2e-nav@forestshop.sk";
 
-// Rovnaká a JEDINÁ povolená výnimka ako v ostatných e2e súboroch.
-const jeOcakavane = (m: ConsoleMessage): boolean =>
-  m.location().url.includes("/api/me") && m.text().includes("401");
-
 // #57 pôvodne chcel naľavo PRESNE dve položky. Issue 185 (2026-08-03) pridáva
 // tretí priečinok "Automatizácie" s tromi hotovými obrazovkami, dovtedy len v
 // `HIDDEN_TABS` bez odkazu v menu — tento test teraz overuje VŠETKÝCH PÄŤ
@@ -24,7 +20,7 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s piatimi z�
 }) => {
   const chyby: string[] = [];
   page.on("console", (m) => {
-    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
   });
   page.on("pageerror", (e) => {
     chyby.push(e.message);
@@ -112,7 +108,7 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s piatimi z�
 test("Sync zo Shoptetu ukazuje stav katalógu aj objednávok a tlačidlo 'Stiahnuť teraz', konzola je čistá", async ({ page }) => {
   const chyby: string[] = [];
   page.on("console", (m) => {
-    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
   });
   page.on("pageerror", (e) => {
     chyby.push(e.message);

--- a/apps/web/tests/e2e/nedostupne.spec.ts
+++ b/apps/web/tests/e2e/nedostupne.spec.ts
@@ -1,10 +1,7 @@
-import { expect, test, type ConsoleMessage } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
 const E2E_NEDOSTUPNE_EMAIL = "e2e-nedostupne@forestshop.sk"; // musí sa zhodovať s hodnotou v scripts/e2e-setup.ts
-
-// Rovnaká a JEDINÁ povolená výnimka ako v login.spec.ts/catalog.spec.ts/orders.spec.ts/posta-uncollected.spec.ts/order-reminder.spec.ts.
-const jeOcakavane = (m: ConsoleMessage): boolean => m.location().url.includes("/api/me") && m.text().includes("401");
 
 // issue 176: "Nedostupné tovary" je SKRYTÁ obrazovka (rovnaký vzor ako
 // #172/#173 — majiteľ chce v ľavom menu zatiaľ len "Sync zo Shoptetu"/"Na
@@ -20,7 +17,7 @@ const jeOcakavane = (m: ConsoleMessage): boolean => m.location().url.includes("/
 test("zoznam zobrazí nedostupný variant s náhradou, povinný náhľad predchádza odoslaniu, konzola je čistá", async ({ page }) => {
   const chyby: string[] = [];
   page.on("console", (m) => {
-    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
   });
   page.on("pageerror", (e) => {
     chyby.push(e.message);

--- a/apps/web/tests/e2e/order-reminder.spec.ts
+++ b/apps/web/tests/e2e/order-reminder.spec.ts
@@ -1,10 +1,7 @@
-import { expect, test, type ConsoleMessage } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
 const E2E_PRIPOMIENKY_EMAIL = "e2e-pripomienky@forestshop.sk"; // musí sa zhodovať s hodnotou v scripts/e2e-setup.ts
-
-// Rovnaká a JEDINÁ povolená výnimka ako v login.spec.ts/catalog.spec.ts/orders.spec.ts/posta-uncollected.spec.ts.
-const jeOcakavane = (m: ConsoleMessage): boolean => m.location().url.includes("/api/me") && m.text().includes("401");
 
 // issue 173: "Pripomienky objednávok" je SKRYTÁ obrazovka (rovnaký vzor ako
 // katalóg/párovanie/plánovač/#172 — majiteľ chce v ľavom menu zatiaľ len
@@ -21,7 +18,7 @@ const jeOcakavane = (m: ConsoleMessage): boolean => m.location().url.includes("/
 test("Štart/Stop + Spustiť teraz fungujú, red-riadok má obe ručné akcie, konzola je čistá", async ({ page }) => {
   const chyby: string[] = [];
   page.on("console", (m) => {
-    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
   });
   page.on("pageerror", (e) => {
     chyby.push(e.message);

--- a/apps/web/tests/e2e/orders-hidden-editor.spec.ts
+++ b/apps/web/tests/e2e/orders-hidden-editor.spec.ts
@@ -1,12 +1,9 @@
-import { expect, test, type ConsoleMessage } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
 // Vlastný, IZOLOVANÝ účet (`scripts/e2e-setup.ts`'s komentár vysvetľuje dôvod
 // aj mechanizmus — balík je už na hranici `MAX_ATTEMPTS`).
 const E2E_SKRYTY_EDITOR_EMAIL = "e2e-skryty-editor@forestshop.sk";
-
-const jeOcakavane = (m: ConsoleMessage): boolean =>
-  m.location().url.includes("/api/me") && m.text().includes("401");
 
 // issue 149: riadok s otvorenou (neuloženou) úpravou odkazu na dodávateľa
 // nesmie zmiznúť pri zapnutom "skryť vybavené", aj keď je riadok už
@@ -21,7 +18,7 @@ test("riadok s otvoreným editorom odkazu na dodávateľa ostáva viditeľný pr
 }) => {
   const chyby: string[] = [];
   page.on("console", (m) => {
-    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
   });
   page.on("pageerror", (e) => {
     chyby.push(e.message);

--- a/apps/web/tests/e2e/orders-layout.spec.ts
+++ b/apps/web/tests/e2e/orders-layout.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type ConsoleMessage } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
 
@@ -10,15 +10,12 @@ const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáz
 // (`scripts/e2e-setup.ts`'s komentár k `E2E_ROZLOZENIE_EMAIL`).
 const E2E_ROZLOZENIE_EMAIL = "e2e-rozlozenie@forestshop.sk";
 
-const jeOcakavane = (m: ConsoleMessage): boolean =>
-  m.location().url.includes("/api/me") && m.text().includes("401");
-
 test("STAV je celý čitateľný a POZNÁMKY pole je dosť široké na všetkých 4 šírkach, riadky bez priradenia dodávateľa ostávajú kompaktné, konzola je čistá", async ({
   page,
 }) => {
   const chyby: string[] = [];
   page.on("console", (m) => {
-    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
   });
   page.on("pageerror", (e) => {
     chyby.push(e.message);

--- a/apps/web/tests/e2e/orders-supplier-link.spec.ts
+++ b/apps/web/tests/e2e/orders-supplier-link.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type ConsoleMessage } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 // issue 121: majiteľ, doslovne "ak na produkt nie je odkaz na dodavatela, tak
 // tam ma byt moznost ho doplnit, a vlastne pri kazdom produkte ma byt moznost
@@ -7,10 +7,6 @@ import { expect, test, type ConsoleMessage } from "@playwright/test";
 // `.claude/rules/testing.md`).
 
 const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
-
-// Rovnaká a JEDINÁ povolená výnimka ako v ostatných e2e spec súboroch.
-const jeOcakavane = (m: ConsoleMessage): boolean =>
-  m.location().url.includes("/api/me") && m.text().includes("401");
 
 // VLASTNÝ izolovaný účet — balík je už na hranici `MAX_ATTEMPTS=10`
 // (`scripts/e2e-setup.ts`'s komentár k `E2E_ODKAZ_EMAIL`).
@@ -21,7 +17,7 @@ test("riadok bez odkazu ponúka 'doplniť', po uložení ponúka 'upraviť' a no
 }) => {
   const chyby: string[] = [];
   page.on("console", (m) => {
-    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
   });
   page.on("pageerror", (e) => {
     chyby.push(e.message);
@@ -117,7 +113,7 @@ test("riadok bez odkazu ponúka 'doplniť', po uložení ponúka 'upraviť' a no
 test("neplatný odkaz na dodávateľa sa odmietne HNEĎ, bez zápisu na server (konzola čistá)", async ({ page }) => {
   const chyby: string[] = [];
   page.on("console", (m) => {
-    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
   });
   page.on("pageerror", (e) => {
     chyby.push(e.message);

--- a/apps/web/tests/e2e/orders-write-failures.spec.ts
+++ b/apps/web/tests/e2e/orders-write-failures.spec.ts
@@ -1,11 +1,7 @@
-import { expect, test, type ConsoleMessage } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
 const E2E_ZAPISY_EMAIL = "e2e-zapisy@forestshop.sk";
-
-// Rovnaká a JEDINÁ povolená výnimka ako v login.spec.ts/orders.spec.ts.
-const jeOcakavane = (m: ConsoleMessage): boolean =>
-  m.location().url.includes("/api/me") && m.text().includes("401");
 
 // issue 66: predtým appka zobrazovala len JEDNU (poslednú) chybovú hlášku pri
 // zápise do "Na objednanie" — zlyhanie STARŠIEHO riadku úplne zmizlo z
@@ -23,7 +19,7 @@ test("kumulatívne hlásenie o neuložených zmenách drží VIAC zlyhaní naraz
 }) => {
   const chyby: string[] = [];
   page.on("console", (m) => {
-    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
   });
   page.on("pageerror", (e) => {
     chyby.push(e.message);

--- a/apps/web/tests/e2e/orders.spec.ts
+++ b/apps/web/tests/e2e/orders.spec.ts
@@ -1,14 +1,10 @@
-import { expect, test, type ConsoleMessage } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
 
 // #57: nové ľavé menu má "Na objednanie" ako záložku pod priečinkom Eshop,
 // nie ako predvolenú (tá je "Sync zo Shoptetu") — `?tab=orders` ju vyberie
 // priamo, bez potreby klikať cez sidebar v každom teste.
-
-// Rovnaká a JEDINÁ povolená výnimka ako v login.spec.ts/catalog.spec.ts.
-const jeOcakavane = (m: ConsoleMessage): boolean =>
-  m.location().url.includes("/api/me") && m.text().includes("401");
 
 // issue 61: VLASTNÝ izolovaný účet (`scripts/e2e-setup.ts`'s komentár k
 // `E2E_FILTRE_EMAIL` vysvetľuje dôvod aj poradie). Tento test je ZÁMERNE
@@ -24,7 +20,7 @@ test("manažér filtruje podľa dodávateľa, vidí súhrn ostáva vybaviť a sk
 }) => {
   const chyby: string[] = [];
   page.on("console", (m) => {
-    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
   });
   page.on("pageerror", (e) => {
     chyby.push(e.message);
@@ -63,6 +59,13 @@ test("manažér filtruje podľa dodávateľa, vidí súhrn ostáva vybaviť a sk
   await expect(page.getByTestId("supplier-DODAVATEL-TEST-1")).toBeVisible();
   await expect(page.getByTestId("supplier-(bez dodávateľa)")).not.toBeVisible();
   await expect(summary).toHaveText("DODAVATEL-TEST-1: ostáva vybaviť 0 z 1 · Čaká sa 1");
+
+  // issue 187: objednaná veľkosť musí byť na riadku VIDIEŤ — obsluha podľa
+  // nej objednáva u dodávateľa. Fixtúrový variant "4859/46" má veľkosť "46"
+  // (`sizeLabel` sa odvodzuje z časti kódu za lomkou, `map-row.ts`).
+  await expect(
+    page.getByTestId("supplier-DODAVATEL-TEST-1").locator(".ord-size"),
+  ).toHaveText("46");
 
   // Klik na "(bez dodávateľa)" prepne filter na druhého dodávateľa.
   await page.getByTestId("supplier-chip-(bez dodávateľa)").click();
@@ -172,7 +175,7 @@ test("súčet kusov toho istého produktu naprieč objednávkami dodávateľa sa
 }) => {
   const chyby: string[] = [];
   page.on("console", (m) => {
-    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
   });
   page.on("pageerror", (e) => {
     chyby.push(e.message);
@@ -219,7 +222,7 @@ test("súčet kusov toho istého produktu naprieč objednávkami dodávateľa sa
 test("manažér vidí otvorené objednávky zoskupené podľa dodávateľa, konzola je čistá", async ({ page }) => {
   const chyby: string[] = [];
   page.on("console", (m) => {
-    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
   });
   page.on("pageerror", (e) => {
     chyby.push(e.message);
@@ -347,7 +350,7 @@ test("manažér prepne stav riadku klikom na tlačidlo, zmena pretrvá po obnove
 }) => {
   const chyby: string[] = [];
   page.on("console", (m) => {
-    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
   });
   page.on("pageerror", (e) => {
     chyby.push(e.message);
@@ -400,7 +403,7 @@ test("manažér nastaví e-mail dodávateľa, zmena pretrvá po obnovení strán
 }) => {
   const chyby: string[] = [];
   page.on("console", (m) => {
-    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
   });
   page.on("pageerror", (e) => {
     chyby.push(e.message);
@@ -458,7 +461,7 @@ const E2E_OTVORENE_STAVY_EMAIL = "e2e-otvorene-stavy@forestshop.sk";
 test("uzavretá objednávka sa v 'Na objednanie' neukáže, kým sa jej stav nepridá do nastavenia, konzola je čistá", async ({ page }) => {
   const chyby: string[] = [];
   page.on("console", (m) => {
-    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
   });
   page.on("pageerror", (e) => {
     chyby.push(e.message);
@@ -508,7 +511,7 @@ const E2E_OBJEDNANE_EMAIL = "e2e-objednane@forestshop.sk";
 test("manažér odškrtne riadok ako objednaný a hromadne označí/zruší celú skupinu, konzola je čistá", async ({ page }) => {
   const chyby: string[] = [];
   page.on("console", (m) => {
-    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
   });
   page.on("pageerror", (e) => {
     chyby.push(e.message);
@@ -578,7 +581,7 @@ test("manažér napíše a upraví poznámku k objednávke, zmena pretrvá po ob
 }) => {
   const chyby: string[] = [];
   page.on("console", (m) => {
-    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
   });
   page.on("pageerror", (e) => {
     chyby.push(e.message);
@@ -648,7 +651,7 @@ test("manažér ručne priradí dodávateľa riadku bez dodávateľa s našepká
 }) => {
   const chyby: string[] = [];
   page.on("console", (m) => {
-    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
   });
   page.on("pageerror", (e) => {
     chyby.push(e.message);

--- a/apps/web/tests/e2e/pairing.spec.ts
+++ b/apps/web/tests/e2e/pairing.spec.ts
@@ -1,10 +1,6 @@
-import { expect, test, type ConsoleMessage } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
-
-// Rovnaká a JEDINÁ povolená výnimka ako v login.spec.ts/catalog.spec.ts/orders.spec.ts.
-const jeOcakavane = (m: ConsoleMessage): boolean =>
-  m.location().url.includes("/api/me") && m.text().includes("401");
 
 // #57: "Kontrola párovania" je od nového ľavého menu SKRYTÁ obrazovka
 // (viditeľné sú len "Sync zo Shoptetu"/"Na objednanie") — kód aj testy
@@ -31,7 +27,7 @@ test("manažér ručne napáruje variant bez existujúceho kandidáta, zmena pre
 }) => {
   const chyby: string[] = [];
   page.on("console", (m) => {
-    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
   });
   page.on("pageerror", (e) => {
     chyby.push(e.message);
@@ -81,7 +77,7 @@ test("manažér ručne napáruje variant bez existujúceho kandidáta, zmena pre
 test("manažér potvrdí navrhnutú adresu jedným klikom, filter podľa stavu funguje, konzola je čistá", async ({ page }) => {
   const chyby: string[] = [];
   page.on("console", (m) => {
-    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
   });
   page.on("pageerror", (e) => {
     chyby.push(e.message);
@@ -143,7 +139,7 @@ test("manažér nastaví JEDNU adresu pre všetkých 9 veľkostí naraz, potom r
 }) => {
   const chyby: string[] = [];
   page.on("console", (m) => {
-    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
   });
   page.on("pageerror", (e) => {
     chyby.push(e.message);

--- a/apps/web/tests/e2e/posta-uncollected.spec.ts
+++ b/apps/web/tests/e2e/posta-uncollected.spec.ts
@@ -1,9 +1,6 @@
-import { expect, test, type ConsoleMessage } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
-
-// Rovnaká a JEDINÁ povolená výnimka ako v login.spec.ts/catalog.spec.ts/orders.spec.ts/pairing.spec.ts.
-const jeOcakavane = (m: ConsoleMessage): boolean => m.location().url.includes("/api/me") && m.text().includes("401");
 
 // issue 172: "Nevyzdvihnuté zásielky" je SKRYTÁ obrazovka (rovnaký vzor ako
 // katalóg/párovanie/plánovač — majiteľ chce v ľavom menu zatiaľ len "Sync zo
@@ -19,7 +16,7 @@ const jeOcakavane = (m: ConsoleMessage): boolean => m.location().url.includes("/
 test("Štart/Stop + Spustiť teraz fungujú, prázdny výsledok sa zobrazí správne, konzola je čistá", async ({ page }) => {
   const chyby: string[] = [];
   page.on("console", (m) => {
-    if ((m.type() === "error" || m.type() === "warning") && !jeOcakavane(m)) chyby.push(m.text());
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
   });
   page.on("pageerror", (e) => {
     chyby.push(e.message);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.111",
+  "version": "0.3.0-dev.112",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Dve malé opravy obrazovky, spojené do jedného behu testov.

## Objednaná veľkosť (issue 187)

Veľkosť nikdy nechýbala v dátach — je na variante (`size_label`) a
sťahujeme ju od začiatku. Kedysi mala vlastný stĺpec VEĽKOSŤ, ten sa zlúčil
do stĺpca KÓD (kvôli šírke), a keď sa KÓD ako nepoužívaný celý odstránil,
veľkosť ticho zmizla s ním.

Vracia sa **pri mene produktu**, nie ako stĺpec: šírka tabuľky je
prerozdelená do posledného percenta a vyšší riadok by šiel proti zmyslu tej
obrazovky. Je to farebný štítok, aby ju bolo vidno na prvý pohľad. Variant
bez veľkosti nevykreslí nič — žiadnu pomlčku, žiadne prázdne miesto.

Hromadný e-mail dodávateľovi veľkosť už obsahoval (`modules/orders/mail.ts`),
takže tam nebolo čo dopĺňať.

## Chyba v konzole na prihlasovacej obrazovke (issue 188)

`/api/me` vracalo neprihlásenému **401**. Chromium loguje každú 4xx odpoveď
ako chybu bez ohľadu na to, či ju kód ošetrí — takže úplne zdravá appka
vítala majiteľa červeným textom.

Teraz vracia **200 s telom `null`** — presne ten tvar, aký tento projekt už
používa pre očakávaný doménový výsledok na `/api/me/password`. Ostatné
endpointy si 401 ponechávajú: tie sa volajú až z prihlásenej appky, kde 401
naozaj znamená vypršanú reláciu. Klient 401 stále znesie, aby počas
nasadenia krátko nesúladný server a frontend fungovali rozumne.

Tým padá aj jediná výnimka, ktorú si e2e balík na túto 401 niesol —
všetkých 13 spec súborov teraz overuje naozaj prázdnu konzolu bez výnimky.

Refs issue 187, issue 188 — oba zavriem ručne po nasadení a živej kontrole.
