### PR TITLE
Pass the two missing BCC addresses through to the container

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -450,3 +450,13 @@ paths:
   assertion added to one spec file that reads a value another spec file
   mutates: does the OTHER file toggle/mutate this same row mid-test? If
   yes, assert "a valid value", never the specific one.
+- **Konzolová výnimka na `/api/me` 401 UŽ NEEXISTUJE a nesmie sa vrátiť
+  (issue 188).** Endpoint od `0.3.0-dev.112` vracia neprihlásenému **200 s
+  telom `null`**, nie 401 — práve preto, že Chromium loguje KAŽDÚ 4xx
+  odpoveď do konzoly ako chybu, takže úplne zdravá appka vypisovala červenú
+  chybu na prihlasovacej obrazovke. Všetkých 13 e2e spec súborov teraz
+  overuje PRÁZDNU konzolu bez jedinej výnimky (filter `jeOcakavane` je
+  odstránený). Nová konzolová chyba sa preto rieši VÝHRADNE v appke, nikdy
+  pridaním filtra do testu — a nový endpoint, ktorého bežný očakávaný
+  doménový výsledok je „nič"/neúspech, vracia 200 s telom (vzor `/api/me` a
+  `POST /api/me/password`), nie 4xx.

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -90,6 +90,17 @@ services:
       MAIL_USER:
       MAIL_PASS:
       MAIL_FROM:
+      # Skrytá kópia (BCC) na KAŽDOM maile dodávateľovi z obrazovky "Na
+      # objednanie". Majiteľ 3. 8. 2026: "vsade zatial ma byt ked nieco
+      # posiela mail dokial sa to neosvedci ze to funguje dobre" — chýbal
+      # tu, hoci `env.ts` ho číta, takže sa do kontajnera vôbec nedostal.
+      MAIL_BCC:
+      # issue 176: "Nedostupné tovary" — skrytá kópia (BCC) majiteľovi.
+      # Rovnaká úvaha aj rovnaký fail-closed kontrakt ako pri dvoch
+      # premenných nižšie; chýbal v tomto zozname, takže hodnota z
+      # `/srv/forestshop/.env` sa do kontajnera nikdy nedostala a obrazovka
+      # hlásila "Chýba adresa pre skrytú kópiu majiteľovi".
+      NEDOSTUPNE_BCC_EMAIL:
       # issue 172: "Nevyzdvihnuté zásielky" — skrytá kópia (BCC) majiteľovi,
       # rovnaká úvaha ako MAIL_HOST vyššie (`.optional()` v env.ts, bare
       # kľúč). Chýbajúca = automatizácia NEPOŠLE ani jeden e-mail zákazníkovi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.112",
+  "version": "0.3.0-dev.113",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Majiteľ chce skrytú kópiu na seba pri KAŽDOM maile, ktorý appka odošle, kým
sa to neosvedčí v praxi.

Pri nastavovaní sa ukázalo, že dve zo štyroch adries sa do kontajnera vôbec
nedostávali — `env.ts` ich číta, ale v `environment:` bloku
`docker-compose.prod.yml` neboli, takže nastavenie v `/srv/forestshop/.env`
nemalo žiadny účinok:

- `NEDOSTUPNE_BCC_EMAIL` — presne preto obrazovka „Nedostupné tovary"
  hlásila „Chýba adresa pre skrytú kópiu majiteľovi" aj po nastavení
- `MAIL_BCC` — skrytá kópia na maile dodávateľovi z „Na objednanie" ticho
  vypadla

Zvyšné dve (`POSTA_UNCOLLECTED_BCC_EMAIL`, `ORDER_REMINDER_BCC_EMAIL`) tam
boli správne.

Hodnoty samotné sú už nastavené priamo na serveri (do repa nikdy nejdú).
Automatizácie zostávajú vypnuté — toto len odstraňuje prekážku, nespúšťa
žiadne odosielanie.

Refs issue 198 — zavriem ho po nasadení a živej kontrole obrazovky.
