### PR TITLE
Let the sidebar collapse to an icon-only rail

### DIFF
--- a/.claude/rules/deploy.md
+++ b/.claude/rules/deploy.md
@@ -10,6 +10,22 @@ paths:
 
 # Deployment (dev2)
 
+- **Nová premenná v `env.ts` MUSÍ dostať svoj riadok v `environment:` bloku
+  `docker-compose.prod.yml` — inak sa do kontajnera NIKDY nedostane, aj keby
+  bola korektne nastavená v `/srv/forestshop/.env`.** Compose neprenáša `.env`
+  do kontajnera automaticky: `.env` slúži len na interpoláciu `${...}` v samotnom
+  compose súbore a na `env_file`; premenná bez riadku v `environment:` sa v
+  kontajneri jednoducho nenastaví, appka ju vidí ako chýbajúcu a `.optional()`
+  vetva sa tvári ako "operátor to ešte nenastavil". Presne toto sa stalo pri
+  issue 198: `MAIL_BCC` a `NEDOSTUPNE_BCC_EMAIL` boli v `.env` nastavené,
+  obrazovka „Nedostupné tovary" napriek tomu hlásila chýbajúcu adresu a
+  automatizácia zostávala fail-closed. **Kontrola, ktorá to odhalí za sekundu**
+  (rob ju pri KAŽDOM pridaní premennej do `env.ts`, ešte pred hľadaním chyby v
+  kóde):
+  ```bash
+  ssh newlevel@dev2 'docker exec forestshop-app-1 sh -c "env | grep -E \"<PREMENNA>\""'
+  ```
+  Prázdny výstup = chýbajúci riadok v compose, nie chyba v appke.
 - **Nepovinná premenná v `environment:` bloku patrí bez `:?`, ako holý kľúč
   (`SHOPTET_EXPORT_URL:`, žiadna hodnota) — NIE `${VAR:?chyba}`.** Bare kľúč
   preberá hodnotu z `/srv/forestshop/.env`, keď tam je, a keď nie je, premenná

--- a/apps/web/src/components/Sidebar.test.tsx
+++ b/apps/web/src/components/Sidebar.test.tsx
@@ -3,12 +3,24 @@ import { afterEach, expect, it, vi } from "vitest";
 import { Sidebar } from "./Sidebar.js";
 
 const FOLDERS = [
-  { id: "system", label: "Systém", tabs: [{ id: "sync", label: "Sync zo Shoptetu", Component: () => null }] },
-  { id: "eshop", label: "Eshop", tabs: [{ id: "orders", label: "Na objednanie", Component: () => null }] },
+  {
+    id: "system",
+    label: "Systém",
+    tabs: [{ id: "sync", label: "Sync zo Shoptetu", icon: "🔄", Component: () => null }],
+  },
+  {
+    id: "eshop",
+    label: "Eshop",
+    tabs: [{ id: "orders", label: "Na objednanie", icon: "📦", Component: () => null }],
+  },
 ];
 
 afterEach(() => {
   cleanup();
+  // issue 190: zbalenie panela sa pamätá v `localStorage` — jsdom ho medzi
+  // testami NEVYNULUJE, takže bez tohto by jeden test prepol stav všetkým
+  // nasledujúcim.
+  window.localStorage.clear();
 });
 
 it("vykreslí presne dva priečinky s jednou záložkou každý a označí aktívnu", () => {
@@ -79,4 +91,72 @@ it("bez badgeStatus (prop vôbec chýba) sa nevykreslí žiadny stavový odznak"
 
   expect(screen.queryByTestId("nav-status-orders")).toBeNull();
   expect(screen.queryByTestId("nav-status-sync")).toBeNull();
+});
+
+// issue 190: zbalenie CELÉHO panela do úzkej lišty. Zámerne sa overuje DOM
+// dôsledok (názvy zmiznú, ikony ostanú, prístupný názov prežije), nie CSS
+// šírka — tú vitest/jsdom nevykresľuje vôbec (živú šírku overuje e2e).
+it("zbalenie panela skryje názvy záložiek aj hlavičky priečinkov, ikony ostanú", () => {
+  render(<Sidebar folders={FOLDERS} activeTabId="sync" onSelectTab={() => {}} />);
+
+  const prepinac = screen.getByTestId("sidebar-rail-toggle");
+  expect(prepinac.getAttribute("aria-expanded")).toBe("true");
+  expect(screen.getByRole("button", { name: "Systém" })).toBeTruthy();
+
+  fireEvent.click(prepinac);
+
+  expect(prepinac.getAttribute("aria-expanded")).toBe("false");
+  // Hlavičky priečinkov sa v lište nevykresľujú vôbec.
+  expect(screen.queryByRole("button", { name: "Systém" })).toBeNull();
+  // Záložka ostáva klikateľná a MÁ prístupný názov (z `aria-label`), hoci jej
+  // viditeľný text je preč — inak by tlačidlo v lište bolo bezmenné.
+  const zalozka = screen.getByRole("button", { name: "Na objednanie" });
+  expect(zalozka.textContent).toBe("📦");
+  expect(zalozka.getAttribute("title")).toBe("Na objednanie");
+});
+
+it("v zbalenom paneli nesie bublina aj stav automatizácie (pilulka sa tam nevykreslí)", () => {
+  render(
+    <Sidebar folders={FOLDERS} activeTabId="sync" onSelectTab={() => {}} badgeStatus={{ orders: "off" }} />,
+  );
+
+  fireEvent.click(screen.getByTestId("sidebar-rail-toggle"));
+
+  expect(screen.queryByTestId("nav-status-orders")).toBeNull();
+  expect(screen.getByRole("button", { name: "Na objednanie — Zastavené" }).getAttribute("title")).toBe(
+    "Na objednanie — Zastavené",
+  );
+});
+
+it("záložka sa dá prepnúť aj v zbalenom paneli", () => {
+  const onSelectTab = vi.fn();
+  render(<Sidebar folders={FOLDERS} activeTabId="sync" onSelectTab={onSelectTab} />);
+
+  fireEvent.click(screen.getByTestId("sidebar-rail-toggle"));
+  fireEvent.click(screen.getByRole("button", { name: "Na objednanie" }));
+
+  expect(onSelectTab).toHaveBeenCalledWith("orders");
+});
+
+it("voľba prežije obnovenie stránky (nové vykreslenie číta zapamätaný stav)", () => {
+  const prve = render(<Sidebar folders={FOLDERS} activeTabId="sync" onSelectTab={() => {}} />);
+  fireEvent.click(screen.getByTestId("sidebar-rail-toggle"));
+  prve.unmount();
+
+  render(<Sidebar folders={FOLDERS} activeTabId="sync" onSelectTab={() => {}} />);
+
+  expect(screen.getByTestId("sidebar-rail-toggle").getAttribute("aria-expanded")).toBe("false");
+  expect(screen.queryByRole("button", { name: "Systém" })).toBeNull();
+});
+
+// Priečinok zbalený PRED zbalením panela nesmie v lište schovať svoje ikony —
+// v tom stave sa hlavičky priečinkov nevykresľujú, takže by sa k záložkám už
+// nedalo dostať.
+it("priečinok zbalený pred zbalením panela nechá svoje ikony v lište viditeľné", () => {
+  render(<Sidebar folders={FOLDERS} activeTabId="sync" onSelectTab={() => {}} />);
+
+  fireEvent.click(screen.getByRole("button", { name: "Systém" }));
+  fireEvent.click(screen.getByTestId("sidebar-rail-toggle"));
+
+  expect(screen.getByRole("button", { name: "Sync zo Shoptetu" })).toBeTruthy();
 });

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1,13 +1,28 @@
-import { useState, type JSX } from "react";
+import { useEffect, useState, type JSX } from "react";
 import type { NavFolder } from "../nav.js";
 import { Footer } from "./Footer.js";
+
+// issue 190: zapamätaný stav zbaleného panela. `localStorage` môže v niektorých
+// režimoch prehliadača hodiť výnimku (zakázané úložisko) — obe strany sú preto
+// v `try`, s "rozbalený" ako bezpečným východiskom. Kľúč je zámerne
+// prefixovaný názvom appky, na doméne bežia aj iné projekty.
+const RAIL_KEY = "forestshop:sidebar-rail";
+
+function readRail(): boolean {
+  try {
+    return window.localStorage.getItem(RAIL_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
 
 // Ľavé menu — vlastný dizajn appky (issue 57): značka hore, priečinky so
 // záložkami, päta len s verziou. Prihlásený používateľ/odhlásenie/zmena hesla
 // žijú v hlavičke (`Topbar.tsx`'s používateľské menu), nie tu — to je
 // dizajnové rozhodnutie zadania #57 ("user menu in the header"), nie
 // prevzatie zo starej appky (tá menu v hlavičke vôbec nemá). Skladanie
-// priečinkov (`collapsed`) je čisto prezentačné, preto žije tu — App.tsx si
+// priečinkov (`collapsed`) aj zbalenie CELÉHO panela do úzkej lišty
+// (`rail`, issue 190) sú čisto prezentačné, preto žijú tu — App.tsx si
 // drží len AKTÍVNU záložku.
 export function Sidebar({
   folders,
@@ -32,53 +47,105 @@ export function Sidebar({
   readonly badgeStatus?: Readonly<Record<string, "on" | "off">>;
 }): JSX.Element {
   const [collapsed, setCollapsed] = useState<Readonly<Record<string, boolean>>>({});
+  const [rail, setRail] = useState<boolean>(readRail);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(RAIL_KEY, rail ? "1" : "0");
+    } catch {
+      // Zakázané úložisko — voľba potom neprežije obnovenie stránky, ale
+      // panel musí fungovať ďalej; nikdy nezhadzuj appku kvôli preferencii.
+    }
+  }, [rail]);
+
+  const railToggleLabel = rail ? "Rozbaliť bočné menu" : "Zbaliť bočné menu";
 
   return (
-    <aside className="sidebar">
+    <aside className={"sidebar" + (rail ? " sidebar-rail" : "")}>
       <div className="brand">
         <span className="logo" aria-hidden="true">
           🌲
         </span>
-        <span className="brandtxt">
-          Forestshop
-          <small>Firemný systém</small>
-        </span>
+        {!rail && (
+          <span className="brandtxt">
+            Forestshop
+            <small>Firemný systém</small>
+          </span>
+        )}
       </div>
+      {/* issue 190: prepínač má VŽDY rovnaký prístupný názov (`aria-label`),
+          aj keď je jeho text v zbalenom stave skrytý — inak by sa tlačidlo v
+          lište stalo bezmenným. `title` dáva ten istý text ako bublinu myšou. */}
+      <button
+        type="button"
+        className="rail-toggle"
+        data-testid="sidebar-rail-toggle"
+        aria-expanded={!rail}
+        aria-label={railToggleLabel}
+        title={railToggleLabel}
+        onClick={() => {
+          setRail((r) => !r);
+        }}
+      >
+        <span className="rail-toggle-icon" aria-hidden="true">
+          {rail ? "»" : "«"}
+        </span>
+        {!rail && <span className="rail-toggle-label">Zbaliť menu</span>}
+      </button>
       <nav className="side-nav">
         {folders.map((folder) => {
-          const isCollapsed = collapsed[folder.id] === true;
+          // V zbalenej lište sa hlavičky priečinkov nevykresľujú vôbec (nemajú
+          // ikonu ani miesto na text), takže ani ich vlastné skladanie nesmie
+          // schovať záložky — preto sa trieda `collapsed` v tomto stave
+          // neaplikuje. Po rozbalení panela sa pôvodný stav priečinkov vráti.
+          const isCollapsed = !rail && collapsed[folder.id] === true;
           return (
             <div className={"nav-folder" + (isCollapsed ? " collapsed" : "")} key={folder.id}>
-              <button
-                type="button"
-                className="folder-head"
-                aria-expanded={!isCollapsed}
-                onClick={() => {
-                  setCollapsed((c) => ({ ...c, [folder.id]: !isCollapsed }));
-                }}
-              >
-                <span className="ftitle">{folder.label}</span>
-                <span className="folder-chev" aria-hidden="true">
-                  ⌄
-                </span>
-              </button>
+              {!rail && (
+                <button
+                  type="button"
+                  className="folder-head"
+                  aria-expanded={!isCollapsed}
+                  onClick={() => {
+                    setCollapsed((c) => ({ ...c, [folder.id]: !isCollapsed }));
+                  }}
+                >
+                  <span className="ftitle">{folder.label}</span>
+                  <span className="folder-chev" aria-hidden="true">
+                    ⌄
+                  </span>
+                </button>
+              )}
               <div className="folder-body">
                 <div className="tabs">
                   {folder.tabs.map((tab) => {
                     const badgeCount = badgeCounts?.[tab.id];
                     const status = badgeStatus?.[tab.id];
+                    // V zbalenej lište nesie bublina/prístupný názov aj stav
+                    // automatizácie — pilulka "Beží"/"Zastavené" sa tam pre
+                    // nedostatok miesta nevykresľuje, tá informácia by sa
+                    // inak stratila úplne.
+                    const railLabel =
+                      status === undefined
+                        ? tab.label
+                        : `${tab.label} — ${status === "on" ? "Beží" : "Zastavené"}`;
                     return (
                       <button
                         key={tab.id}
                         type="button"
                         className={"tab" + (tab.id === activeTabId ? " active" : "")}
                         aria-current={tab.id === activeTabId ? "page" : undefined}
+                        aria-label={rail ? railLabel : undefined}
+                        title={rail ? railLabel : undefined}
                         onClick={() => {
                           onSelectTab(tab.id);
                         }}
                       >
-                        <span className="tlabel">{tab.label}</span>
-                        {status !== undefined && (
+                        <span className="ticon" aria-hidden="true">
+                          {tab.icon}
+                        </span>
+                        {!rail && <span className="tlabel">{tab.label}</span>}
+                        {!rail && status !== undefined && (
                           // issue 185: rovnaký vizuál aj slovník ("Beží"/
                           // "Zastavené") ako `.pill` vnútri
                           // PostaUncollectedSection/OrderReminderSection —
@@ -116,7 +183,8 @@ export function Sidebar({
       </nav>
       <div className="sidefoot">
         <div className="ver">
-          verzia <Footer />
+          {rail ? null : "verzia "}
+          <Footer />
         </div>
       </div>
     </aside>

--- a/apps/web/src/nav.ts
+++ b/apps/web/src/nav.ts
@@ -19,6 +19,12 @@ export interface SectionProps {
 export interface NavTab {
   readonly id: string;
   readonly label: string;
+  // issue 190: ikona pre ZBALENÝ bočný panel — v tom stave je to JEDINÉ, čo z
+  // položky vidno, takže musí byť na prvý pohľad rozlíšiteľná od ostatných
+  // (názov sa ukáže až po prejdení myšou, `Sidebar.tsx`'s `title`/`aria-label`).
+  // Povinná, aby nová záložka nemohla vzniknúť bez ikony a v zbalenom paneli
+  // ostať neviditeľná.
+  readonly icon: string;
   readonly Component: ComponentType<SectionProps>;
   // issue 95: `true` pre obrazovky, ktoré potrebujú viac než pohodlnú čítaciu
   // šírku (`--fs-content-width`, 1120px) — hustá pracovná tabuľka ("Na
@@ -47,7 +53,7 @@ export const NAV: readonly NavFolder[] = [
   {
     id: "system",
     label: "Systém",
-    tabs: [{ id: "sync", label: "Sync zo Shoptetu", Component: SyncSection }],
+    tabs: [{ id: "sync", label: "Sync zo Shoptetu", icon: "🔄", Component: SyncSection }],
   },
   {
     id: "eshop",
@@ -58,8 +64,8 @@ export const NAV: readonly NavFolder[] = [
     // oboch z rovnakého dôvodu (hustý pracovný obsah profituje z celej šírky
     // okna, viď `NavTab.wide` vyššie).
     tabs: [
-      { id: "orders", label: "Na objednanie", Component: OrdersSection, wide: true },
-      { id: "nedostupne", label: "Nedostupné tovary", Component: NedostupneSection, wide: true },
+      { id: "orders", label: "Na objednanie", icon: "📦", Component: OrdersSection, wide: true },
+      { id: "nedostupne", label: "Nedostupné tovary", icon: "🚫", Component: NedostupneSection, wide: true },
     ],
   },
   {
@@ -68,8 +74,8 @@ export const NAV: readonly NavFolder[] = [
     // Len tie dve veci, ktoré SKUTOČNE bežia na plán a dajú sa zapnúť/vypnúť
     // (issue 195). Poradie podľa dôležitosti (issue 185, zadanie majiteľa).
     tabs: [
-      { id: "posta-uncollected", label: "Nevyzdvihnuté zásielky", Component: PostaUncollectedSection },
-      { id: "order-reminder", label: "Pripomienky objednávok", Component: OrderReminderSection },
+      { id: "posta-uncollected", label: "Nevyzdvihnuté zásielky", icon: "📮", Component: PostaUncollectedSection },
+      { id: "order-reminder", label: "Pripomienky objednávok", icon: "⏰", Component: OrderReminderSection },
     ],
   },
 ];
@@ -81,9 +87,11 @@ export const NAV: readonly NavFolder[] = [
 // ich ďalej overuje ich vlastné e2e pokrytie (catalog.spec.ts/pairing.spec.ts),
 // bez potreby vystaviť ich v ľavom menu.
 export const HIDDEN_TABS: Readonly<Record<string, NavTab>> = {
-  catalog: { id: "catalog", label: "Katalóg", Component: CatalogPage },
-  pairing: { id: "pairing", label: "Kontrola párovania", Component: PairingSection },
-  scheduler: { id: "scheduler", label: "Plánovač", Component: SchedulerSection },
+  // Ikony sú tu len kvôli spoločnému typu `NavTab` — skryté obrazovky sa v
+  // ľavom menu (ani v jeho zbalenom stave) nikdy nevykreslia.
+  catalog: { id: "catalog", label: "Katalóg", icon: "📚", Component: CatalogPage },
+  pairing: { id: "pairing", label: "Kontrola párovania", icon: "🔗", Component: PairingSection },
+  scheduler: { id: "scheduler", label: "Plánovač", icon: "🗓️", Component: SchedulerSection },
 };
 
 export const DEFAULT_TAB_ID: string = NAV[0]?.tabs[0]?.id ?? "sync";

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -71,6 +71,10 @@
 
   --fs-content-width: 1120px;
   --fs-sidebar-width: 250px;
+  /* issue 190: šírka ZBALENÉHO panela — 72px pohodlne unesie 44px klikací
+     cieľ záložky aj s odsadením, takže sa prepína rovnako ľahko ako v
+     rozbalenom stave (zadanie: veľké ciele na klik). */
+  --fs-sidebar-rail-width: 72px;
 }
 
 /* ---------------- 2. RESET + ZÁKLADNÉ ELEMENTY ---------------- */
@@ -206,6 +210,44 @@ tr:last-child td {
   top: 0;
   height: 100vh;
 }
+/* issue 190: zbalený panel = úzka lišta len s ikonami. Mení sa VÝHRADNE
+   šírka panela — `.main` je `flex: 1`, takže obsah vpravo sa do uvoľneného
+   miesta roztiahne sám, bez akéhokoľvek prepočtu inde. */
+.sidebar.sidebar-rail {
+  width: var(--fs-sidebar-rail-width);
+  flex: 0 0 var(--fs-sidebar-rail-width);
+}
+.sidebar-rail .brand {
+  justify-content: center;
+  padding: var(--fs-space-4) 0 var(--fs-space-2);
+}
+.rail-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--fs-space-2);
+  min-height: 40px;
+  margin: 0 var(--fs-space-3) var(--fs-space-2);
+  border: 1px solid var(--fs-border);
+  border-radius: var(--fs-radius-sm);
+  background: none;
+  cursor: pointer;
+  color: var(--fs-ink-muted);
+  font-size: var(--fs-text-sm);
+  font-weight: var(--fs-weight-medium);
+}
+.rail-toggle:hover {
+  background: var(--fs-surface-alt);
+  border-color: var(--fs-ink-faint);
+}
+.rail-toggle-icon {
+  font-size: var(--fs-text-md);
+  line-height: 1;
+}
+.sidebar-rail .rail-toggle {
+  margin: 0 var(--fs-space-2) var(--fs-space-2);
+}
+
 .brand {
   display: flex;
   align-items: center;
@@ -314,6 +356,35 @@ tr:last-child td {
 }
 .tlabel {
   flex: 1;
+}
+/* issue 190: ikona modulu — v rozbalenom paneli sedí vľavo pred názvom, v
+   zbalenom je JEDINÝM obsahom tlačidla. `flex-shrink: 0` z rovnakého dôvodu
+   ako pri odznakoch nižšie (dlhý názov ju nikdy nestlačí). */
+.ticon {
+  flex-shrink: 0;
+  font-size: var(--fs-text-md);
+  line-height: 1;
+}
+.sidebar-rail .side-nav {
+  padding: var(--fs-space-2);
+}
+/* Hlavičky priečinkov sa v lište nevykresľujú, takže hranicu medzi skupinami
+   nesie tenká čiara — inak by ikony splynuli do jedného stĺpca. */
+.sidebar-rail .nav-folder + .nav-folder {
+  border-top: 1px solid var(--fs-border);
+  padding-top: var(--fs-space-2);
+}
+.sidebar-rail .folder-body {
+  margin: 0;
+}
+.sidebar-rail .tabs .tab {
+  justify-content: center;
+  min-height: 44px;
+  padding: var(--fs-space-2) 0;
+}
+.sidebar-rail .ver {
+  text-align: center;
+  font-size: var(--fs-text-xs);
 }
 /* issue 147: odznak počtu nevybavených riadkov (dnes len "Na objednanie",
    ale generický pre AKÚKOĽVEK budúcu záložku — `Sidebar.tsx`'s `badgeCounts`

--- a/apps/web/tests/e2e/nav.spec.ts
+++ b/apps/web/tests/e2e/nav.spec.ts
@@ -15,7 +15,7 @@ const E2E_NAV_EMAIL = "e2e-nav@forestshop.sk";
 // tretí priečinok "Automatizácie" s tromi hotovými obrazovkami, dovtedy len v
 // `HIDDEN_TABS` bez odkazu v menu — tento test teraz overuje VŠETKÝCH PÄŤ
 // záložiek v troch priečinkoch.
-test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s piatimi záložkami, klik prepne obrazovku, konzola je čistá", async ({
+test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s piatimi záložkami, klik prepne obrazovku, panel sa zbalí do lišty a stav si pamätá, konzola je čistá", async ({
   page,
 }) => {
   const chyby: string[] = [];
@@ -92,6 +92,44 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s piatimi z�
   // "Nedostupné tovary" nemá koncept zapnuté/vypnuté vôbec (je len na
   // požiadanie) — žiadny stavový odznak v menu, ani "Zastavené".
   await expect(page.getByTestId("nav-status-nedostupne")).toHaveCount(0);
+
+  // issue 190: zbalenie panela do úzkej lišty. Zámerne je to SÚČASŤ tohto
+  // testu, nie samostatný test — každý ďalší test v tomto súbore by znamenal
+  // ďalšie prihlásenie na zdieľanom `MAX_ATTEMPTS=10` rozpočte
+  // (`login-rate-limit.ts`, viď komentár pri `E2E_NAV_EMAIL` vyššie);
+  // `page.reload()` nižšie relácia prežije, takže tu žiadne pribúda.
+  const panel = page.locator(".sidebar");
+  const obsah = page.locator(".main");
+  const prepinac = page.getByTestId("sidebar-rail-toggle");
+  const panelRozbaleny = (await panel.boundingBox())?.width ?? 0;
+  const obsahRozbaleny = (await obsah.boundingBox())?.width ?? 0;
+
+  await prepinac.click();
+  await expect(panel).toHaveClass(/sidebar-rail/);
+
+  // Panel je naozaj užší a obsah vpravo sa do uvoľneného miesta roztiahol.
+  const panelZbaleny = (await panel.boundingBox())?.width ?? 0;
+  const obsahZbaleny = (await obsah.boundingBox())?.width ?? 0;
+  expect(panelZbaleny).toBeLessThan(panelRozbaleny);
+  expect(obsahZbaleny).toBeGreaterThan(obsahRozbaleny);
+
+  // Hlavičky priečinkov zmiznú, ikony všetkých piatich modulov ostanú.
+  await expect(page.getByRole("button", { name: "Systém" })).toHaveCount(0);
+  await expect(page.locator(".side-nav .tab")).toHaveCount(5);
+  // Názov sa v lište ukáže bublinou pri prejdení myšou.
+  await expect(page.getByRole("button", { name: "Na objednanie" })).toHaveAttribute(
+    "title",
+    "Na objednanie",
+  );
+
+  // Voľba prežije obnovenie stránky.
+  await page.reload();
+  await expect(page.locator(".sidebar")).toHaveClass(/sidebar-rail/);
+
+  // Vrátiť do pôvodného stavu — panel sa rozbalí a názvy sa vrátia.
+  await page.getByTestId("sidebar-rail-toggle").click();
+  await expect(page.locator(".sidebar")).not.toHaveClass(/sidebar-rail/);
+  await expect(page.getByRole("button", { name: "Systém" })).toBeVisible();
 
   expect(chyby).toEqual([]);
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.113",
+  "version": "0.3.0-dev.114",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Bočný panel sa dá zbaliť do úzkej lišty, v ktorej z každého modulu ostane len jeho ikona.

- Každá položka menu má vlastnú ikonu (`nav.ts`, povinné pole — nová záložka nemôže vzniknúť bez nej a v lište ostať neviditeľná).
- Prepínač nad menu; v zbalenom stave sa hlavičky priečinkov nevykresľujú vôbec a názov záložky sa ukáže bublinou pri prejdení myšou (`title` + `aria-label`, takže tlačidlo nikdy nie je bezmenné).
- Klikací cieľ v lište má 44 px — prepína sa rovnako ľahko ako v rozbalenom paneli.
- Voľba sa pamätá v `localStorage` (obe strany v `try`, zakázané úložisko appku nezhodí).
- Obsah vpravo sa roztiahne sám — `.main` je `flex: 1`, mení sa výhradne šírka panela.
- Priečinok zbalený pred zbalením panela nesmie v lište schovať svoje ikony (inak by k nim nebolo ako sa dostať) — pokryté testom.

Testy: 5 nových vitest testov v `Sidebar.test.tsx` (skrytie názvov, stav automatizácie v bubline, prepnutie záložky v lište, zapamätanie po obnovení, zbalený priečinok) + rozšírený e2e v `nav.spec.ts`, ktorý meria skutočné šírky panela aj obsahu pred a po zbalení a overuje stav po `reload()`. E2E je zámerne súčasťou existujúceho testu, nie nový súbor — každé ďalšie prihlásenie ide na zdieľaný `MAX_ATTEMPTS=10` rozpočet.

Ticket 190 sa zavrie ručne až po nasadení a živom overení.
