### PR TITLE
Show the mail preview as a dialog instead of a block at the page bottom

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -594,3 +594,34 @@ paths:
   live-production `addStyleTag` script only when the e2e fixture's content
   shape doesn't match real production data (as issue 107 found out the
   hard way).
+- **Hiding a button's visible label (conditional render, `display:none`) also
+  DELETES its accessible name — an icon-only control needs `aria-label` +
+  `title` set explicitly, and any information carried by a sibling badge that
+  you also hide must be folded into that label.** Issue 190 (zbalený bočný
+  panel do 72px lišty): the tab buttons render `{!rail && <span
+  className="tlabel">}`, so in rail mode the only remaining child is an
+  `aria-hidden` emoji — without `aria-label` the button's accessible name
+  would be empty and every existing `getByRole("button", { name: "Na
+  objednanie" })` query (unit AND e2e) would stop matching. The status pill
+  ("Beží"/"Zastavené") is hidden in rail mode too, so the label becomes
+  `${tab.label} — ${status}` and the same string goes into `title` (the
+  hover tooltip the ticket asked for). Any FUTURE icon-only/compact variant
+  of an existing labelled control in this app needs both attributes set in
+  the SAME change, plus a unit test asserting `getByRole("button", { name })`
+  still resolves in the compact state.
+- **Two independent collapse mechanisms on the same tree must be composed
+  explicitly, or one silently swallows the other.** The sidebar already had
+  per-FOLDER collapsing (`.nav-folder.collapsed .folder-body {display:none}`);
+  issue 190 added whole-PANEL collapsing where folder headings are not
+  rendered at all. A folder collapsed before the panel collapsed would have
+  hidden its icons with no heading left to click — unreachable. Fix is one
+  line in the component, not CSS: `const isCollapsed = !rail &&
+  collapsed[folder.id] === true` (the folder state is kept, just not applied
+  while railed, so it returns on expand). Covered by its own unit test.
+- **A UI preference stored in `localStorage` needs `window.localStorage
+  .clear()` in the test file's `afterEach`** — jsdom keeps it between tests
+  in the same file, so one test toggling the preference silently changes the
+  starting state of every test after it (`Sidebar.test.tsx`, issue 190). Both
+  read and write go in `try/catch` with the safe default, since a browser
+  with storage disabled throws and must never take the app down over a
+  preference.

--- a/apps/web/src/components/MailPreviewDialog.tsx
+++ b/apps/web/src/components/MailPreviewDialog.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useRef, type JSX, type ReactNode } from "react";
+
+// issue 191: náhľad e-mailu pred odoslaním sa už nerozbaľuje na spodku
+// stránky (majiteľ: "rozbaluje sa na spodku to je zle") — otvorí sa ako
+// dialóg cez obrazovku, takže je okamžite v zornom poli a nedá sa prehliadnuť.
+// Zámerne NIE natívny `<dialog>`/`showModal()`: jsdom ho neimplementuje, takže
+// by sa dal overiť len e2e testom a existujúce vitest testy tejto obrazovky by
+// prestali vidieť obsah. Vlastný prekryv je plne testovateľný v oboch vrstvách.
+//
+// Komponenta je generická (žiadna zmienka o "nedostupných tovaroch") — ďalšie
+// automatizácie posielajú e-maily rovnakým spôsobom a majú ten istý kontrakt
+// "bez potvrdenia človekom e-mail neodíde".
+export function MailPreviewDialog({
+  testId,
+  title,
+  recipient,
+  subject,
+  html,
+  confirmLabel,
+  confirmDisabled,
+  onConfirm,
+  onClose,
+  children,
+}: {
+  readonly testId: string;
+  readonly title: string;
+  readonly recipient: string;
+  readonly subject: string;
+  readonly html: string;
+  readonly confirmLabel: string;
+  readonly confirmDisabled: boolean;
+  readonly onConfirm: () => void;
+  readonly onClose: () => void;
+  readonly children?: ReactNode;
+}): JSX.Element {
+  const panelRef = useRef<HTMLDivElement | null>(null);
+
+  // Esc zavrie dialóg. Poslucháč je na `document`, nie na paneli — inak by
+  // fungoval len kým je fokus vnútri, a ten sa dá kliknutím stratiť.
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent): void {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [onClose]);
+
+  // Fokus do dialógu pri otvorení a späť na pôvodný prvok pri zavretí — bez
+  // toho by čítačka obrazovky aj klávesnica ostali v zozname za prekryvom.
+  useEffect(() => {
+    const previous = document.activeElement;
+    panelRef.current?.focus();
+    return () => {
+      if (previous instanceof HTMLElement) previous.focus();
+    };
+  }, []);
+
+  // Pozadie sa pod otvoreným dialógom neposúva — inak by koliesko myši
+  // skrolovalo zoznam za ním namiesto obsahu náhľadu.
+  useEffect(() => {
+    const original = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = original;
+    };
+  }, []);
+
+  return (
+    <div
+      className="modal-backdrop"
+      data-testid={`${testId}-backdrop`}
+      onClick={(e) => {
+        // Len klik na samotný prekryv, nikdy klik, ktorý vybublal z obsahu
+        // dialógu — inak by sa zatváral pri každom kliknutí dnu.
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        className="modal"
+        data-testid={testId}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={`${testId}-title`}
+        tabIndex={-1}
+        ref={panelRef}
+      >
+        <h3 id={`${testId}-title`} className="modal-title">
+          {title}
+        </h3>
+        <p className="modal-meta">
+          Komu: {recipient} — Predmet: {subject}
+        </p>
+        {/* `html` je appkou GENEROVANÝ e-mail (napr. `buildEmailForType`,
+            `modules/nedostupne/logic.ts`) — meno zákazníka aj náhradné
+            produkty sú tam už HTML-escapované, nikdy surový užívateľský
+            vstup priamo tu. */}
+        <div className="modal-body" dangerouslySetInnerHTML={{ __html: html }} />
+        {children}
+        <div className="modal-actions">
+          <button
+            type="button"
+            className="btn lg good"
+            disabled={confirmDisabled}
+            onClick={onConfirm}
+            data-testid={`${testId}-confirm`}
+          >
+            {confirmLabel}
+          </button>
+          <button type="button" className="btn lg ghost" onClick={onClose} data-testid={`${testId}-cancel`}>
+            Zrušiť
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/NedostupneSection.test.tsx
+++ b/apps/web/src/components/NedostupneSection.test.tsx
@@ -99,7 +99,7 @@ it("potvrdenie náhľadu odošle presne s parametrami náhľadu a znovu načíta
 
   fireEvent.click(screen.getByTestId("nedostupne-send-17600001-40237/L"));
   await screen.findByTestId("nedostupne-preview");
-  fireEvent.click(screen.getByTestId("nedostupne-confirm-send"));
+  fireEvent.click(screen.getByTestId("nedostupne-preview-confirm"));
 
   await waitFor(() => {
     expect(sendNedostupneEmail).toHaveBeenCalledWith("17600001", "40237/L", "nedostupne", "tok-1");
@@ -133,7 +133,7 @@ it("zlyhané odoslanie (ok:false) zobrazí server hlášku a nezavrie náhľad",
 
   fireEvent.click(screen.getByTestId("nedostupne-send-17600001-40237/L"));
   await screen.findByTestId("nedostupne-preview");
-  fireEvent.click(screen.getByTestId("nedostupne-confirm-send"));
+  fireEvent.click(screen.getByTestId("nedostupne-preview-confirm"));
 
   await screen.findByText("Tento e-mail už bol tejto objednávke odoslaný.");
   expect(screen.getByTestId("nedostupne-preview")).not.toBeNull();
@@ -146,4 +146,55 @@ it("401 pri načítaní zavolá onSessionExpired", async () => {
   await waitFor(() => {
     expect(onSessionExpired).toHaveBeenCalled();
   });
+});
+
+// issue 191: náhľad je dialóg cez obrazovku — musí sa dať zavrieť klávesom Esc
+// aj klikom mimo neho, a ani jedna z týchto ciest NESMIE nič odoslať.
+async function otvorNahlad(): Promise<void> {
+  fetchNedostupneList.mockResolvedValue(LIST_WITH_GROUP);
+  fetchNedostupnePreview.mockResolvedValue({ ok: true, subject: "Predmet", html: "<p>Ahoj</p>", recipient: "jan@example.sk", customerName: "Ján Novák", previewToken: "tok-1" });
+  render(<NedostupneSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("nedostupne-group-40237/L");
+  fireEvent.click(screen.getByTestId("nedostupne-send-17600001-40237/L"));
+  await screen.findByTestId("nedostupne-preview");
+}
+
+it("Esc zavrie náhľad a nič neodošle", async () => {
+  await otvorNahlad();
+
+  fireEvent.keyDown(document, { key: "Escape" });
+
+  await waitFor(() => {
+    expect(screen.queryByTestId("nedostupne-preview")).toBeNull();
+  });
+  expect(sendNedostupneEmail).not.toHaveBeenCalled();
+});
+
+it("klik mimo dialógu ho zavrie a nič neodošle", async () => {
+  await otvorNahlad();
+
+  fireEvent.click(screen.getByTestId("nedostupne-preview-backdrop"));
+
+  await waitFor(() => {
+    expect(screen.queryByTestId("nedostupne-preview")).toBeNull();
+  });
+  expect(sendNedostupneEmail).not.toHaveBeenCalled();
+});
+
+// Klik VNÚTRI dialógu vybubláva na ten istý prekryv — bez kontroly cieľa by
+// sa náhľad zatváral pri každom kliknutí do jeho vlastného obsahu.
+it("klik vnútri dialógu ho nezavrie", async () => {
+  await otvorNahlad();
+
+  fireEvent.click(screen.getByTestId("nedostupne-preview"));
+
+  expect(screen.getByTestId("nedostupne-preview")).not.toBeNull();
+});
+
+it("dialóg je označený ako modálny a nesie svoj vlastný nadpis", async () => {
+  await otvorNahlad();
+
+  const dialog = screen.getByRole("dialog");
+  expect(dialog.getAttribute("aria-modal")).toBe("true");
+  expect(screen.getByRole("heading", { name: "Náhľad e-mailu — povinné pred odoslaním" })).not.toBeNull();
 });

--- a/apps/web/src/components/NedostupneSection.tsx
+++ b/apps/web/src/components/NedostupneSection.tsx
@@ -10,6 +10,7 @@ import {
   type NedostupneList,
   type NedostupnePreview,
 } from "../nedostupneApi.js";
+import { MailPreviewDialog } from "./MailPreviewDialog.js";
 
 // Rovnaké dve role, ktoré server vyžaduje na odoslanie (`requireRole("admin",
 // "manazer")`, `nedostupne-routes.ts`) — čítanie (zoznam) smie vidieť KAŽDÝ
@@ -190,37 +191,25 @@ export function NedostupneSection({ role, onSessionExpired }: { readonly role: M
         </div>
       )}
 
+      {/* issue 191: náhľad je dialóg cez obrazovku, nie rozbalený blok na
+          spodku stránky. Jednorazový `previewToken` z `/preview` ide ďalej
+          nezmenený do `/send` (`.claude/rules/nedostupne.md`) — dialóg mení
+          len to, KDE sa náhľad ukáže, nikdy nie to, že bez potvrdenia
+          človekom e-mail neodíde. */}
       {pending !== null && (
-        <div className="mail-preview" data-testid="nedostupne-preview">
-          <h3>Náhľad e-mailu — povinné pred odoslaním</h3>
-          <p>
-            Komu: {pending.preview.recipient} — Predmet: {pending.preview.subject}
-          </p>
-          {/* `pending.preview.html` je appkou generovaný e-mail (`buildEmailForType`,
-              `modules/nedostupne/logic.ts`) — meno zákazníka aj náhradné produkty sú
-              tam už HTML-escapované, nikdy surový užívateľský vstup priamo tu. */}
-          <div className="nedostupne-preview-body" dangerouslySetInnerHTML={{ __html: pending.preview.html }} />
-          <div className="nedostupne-order-actions">
-            <button
-              type="button"
-              className="btn lg good"
-              disabled={busyKey !== ""}
-              onClick={confirmSend}
-              data-testid="nedostupne-confirm-send"
-            >
-              📧 Odoslať zákazníkovi
-            </button>
-            <button
-              type="button"
-              className="btn lg ghost"
-              onClick={() => {
-                setPending(null);
-              }}
-            >
-              Zrušiť
-            </button>
-          </div>
-        </div>
+        <MailPreviewDialog
+          testId="nedostupne-preview"
+          title="Náhľad e-mailu — povinné pred odoslaním"
+          recipient={pending.preview.recipient}
+          subject={pending.preview.subject}
+          html={pending.preview.html}
+          confirmLabel="📧 Odoslať zákazníkovi"
+          confirmDisabled={busyKey !== ""}
+          onConfirm={confirmSend}
+          onClose={() => {
+            setPending(null);
+          }}
+        />
       )}
     </section>
   );

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -1765,3 +1765,59 @@ tr:last-child td {
   border-radius: var(--fs-radius-sm);
   overflow-x: auto;
 }
+
+/* ---------------- MODÁLNY DIALÓG (issue 191) ----------------
+   Náhľad e-mailu pred odoslaním sa už nerozbaľuje na spodku stránky —
+   otvorí sa cez obrazovku, takže je okamžite v zornom poli. `z-index`
+   musí byť nad lepivou hlavičkou (`.topbar` má 10), inak by dialóg
+   ostal pod ňou. */
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: var(--fs-space-6) var(--fs-space-4);
+  background: rgba(20, 30, 22, 0.45);
+  overflow-y: auto;
+}
+.modal {
+  width: 100%;
+  max-width: 46rem;
+  background: var(--fs-surface);
+  border: 1px solid var(--fs-border);
+  border-radius: var(--fs-radius-lg);
+  box-shadow: var(--fs-shadow-md);
+  padding: var(--fs-space-5);
+}
+/* Panel dostáva fokus pri otvorení (`tabIndex={-1}`) — bez tohto by prehliadač
+   okolo neho nakreslil obrys, hoci to nie je ovládací prvok. Fokus tlačidiel
+   vnútri ostáva nedotknutý. */
+.modal:focus {
+  outline: none;
+}
+.modal-title {
+  margin: 0 0 var(--fs-space-2);
+}
+.modal-meta {
+  margin: 0 0 var(--fs-space-3);
+  color: var(--fs-ink-muted);
+  font-size: var(--fs-text-sm);
+}
+/* Dlhý e-mail sa posúva VNÚTRI dialógu, nie celou stránkou — tlačidlá
+   "Odoslať"/"Zrušiť" pod ním tak ostávajú na dosah bez skrolovania. */
+.modal-body {
+  max-height: 50vh;
+  overflow-y: auto;
+  background: var(--fs-surface-alt);
+  border: 1px solid var(--fs-border);
+  border-radius: var(--fs-radius-md);
+  padding: var(--fs-space-3) var(--fs-space-4);
+}
+.modal-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--fs-space-3);
+  margin-top: var(--fs-space-4);
+}

--- a/apps/web/tests/e2e/nedostupne.spec.ts
+++ b/apps/web/tests/e2e/nedostupne.spec.ts
@@ -47,11 +47,32 @@ test("zoznam zobrazí nedostupný variant s náhradou, povinný náhľad predch�
   await expect(preview).toBeVisible();
   await expect(preview).toContainText("e2e-nedostupne@forestshop.sk");
 
+  // issue 191: náhľad je dialóg cez obrazovku, nie blok na spodku stránky —
+  // musí byť v zornom poli bez skrolovania (jeho vrch je nad spodkom okna) a
+  // musí sa dať zavrieť klávesom Esc bez toho, aby čokoľvek odišlo.
+  const vyska = page.viewportSize()?.height ?? 0;
+  const ramec = await preview.boundingBox();
+  expect(ramec).not.toBeNull();
+  expect(ramec?.y ?? Number.MAX_SAFE_INTEGER).toBeLessThan(vyska);
+
+  await page.keyboard.press("Escape");
+  await expect(preview).toBeHidden();
+
+  // Znovu otvoriť a pokračovať v pôvodnom overení odoslania.
+  await page.getByTestId("nedostupne-send-9008-40287").click();
+  await expect(preview).toBeVisible();
+
   // Potvrdenie odoslania bez nakonfigurovaného mailu vráti graceful chybu
   // (fail-closed, žiadny skutočný pokus o SMTP spojenie) — BCC kontrola beží
   // PRED mail-transport kontrolou (`send.ts`), takže táto hláška sa zobrazí.
-  await page.getByTestId("nedostupne-confirm-send").click();
+  await page.getByTestId("nedostupne-preview-confirm").click();
   await expect(page.getByText("chýba adresa pre skrytú kópiu majiteľovi (NEDOSTUPNE_BCC_EMAIL)", { exact: true })).toBeVisible();
+
+  // Neúspešné odoslanie náhľad ZÁMERNE nezatvára (obsluha vidí dôvod) —
+  // zavrie ho až tlačidlo "Zrušiť".
+  await expect(preview).toBeVisible();
+  await page.getByTestId("nedostupne-preview-cancel").click();
+  await expect(preview).toBeHidden();
 
   expect(chyby).toEqual([]);
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.114",
+  "version": "0.3.0-dev.115",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Náhľad e-mailu na obrazovke "Nedostupné tovary" sa už nerozbaľuje na spodku
stránky (majiteľ: "nedostupne tovary sa teraz ukazka mailu rozbaluje na spodku
to je zle") — otvorí sa ako dialóg cez obrazovku, takže je hneď v zornom poli.

Refs issue 191.

## Čo sa zmenilo

- Nová generická komponenta `MailPreviewDialog` — prekryv cez obrazovku s
  `role="dialog"` + `aria-modal`, zavretie klávesom Esc aj klikom mimo panela,
  fokus ide do dialógu a po zavretí sa vráti späť, pozadie sa pod ním neskroluje.
  Zámerne nie natívny `<dialog>`/`showModal()` — jsdom ho neimplementuje.
- `NedostupneSection` ju používa namiesto pôvodného rozbaľovacieho bloku.
- Komponenta je generická (bez zmienky o nedostupných tovaroch) aj kvôli ďalším
  trom automatizáciám, ktoré posielajú maily rovnakým spôsobom.

## Čo sa NEzmenilo

Jednorazový `previewToken` z `/preview` ide ďalej nezmenený do `/send` —
bez potvrdenia človekom e-mail neodíde. Dialóg mení len to, KDE sa náhľad ukáže.
Neúspešné odoslanie náhľad zámerne nezatvára, aby obsluha videla dôvod.

## Overenie

- `pnpm typecheck`, `pnpm lint` čisté
- web unit testy: 43 súborov / 332 testov zelené (4 nové testy pre Esc, klik
  mimo, klik dnu nezatvára, `aria-modal` s vlastným nadpisom)
- e2e `nedostupne.spec.ts`: náhľad je v zornom poli okna, Esc ho zavrie bez
  odoslania, znovuotvorenie, tlačidlo "Zrušiť" ho zavrie; konzola 0 chýb
- Živé overenie na produkcii príde až PO nasadení, preto tu zámerne nie je
  riadok na automatické zavretie ticketu.
