### PR TITLE
Return focus to the button that opened the mail preview

### DIFF
--- a/apps/web/src/components/MailPreviewDialog.tsx
+++ b/apps/web/src/components/MailPreviewDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type JSX, type ReactNode } from "react";
+import { useEffect, useRef, type JSX, type ReactNode, type RefObject } from "react";
 
 // issue 191: náhľad e-mailu pred odoslaním sa už nerozbaľuje na spodku
 // stránky (majiteľ: "rozbaluje sa na spodku to je zle") — otvorí sa ako
@@ -20,6 +20,7 @@ export function MailPreviewDialog({
   confirmDisabled,
   onConfirm,
   onClose,
+  returnFocusRef,
   children,
 }: {
   readonly testId: string;
@@ -31,6 +32,7 @@ export function MailPreviewDialog({
   readonly confirmDisabled: boolean;
   readonly onConfirm: () => void;
   readonly onClose: () => void;
+  readonly returnFocusRef?: RefObject<HTMLElement | null>;
   readonly children?: ReactNode;
 }): JSX.Element {
   const panelRef = useRef<HTMLDivElement | null>(null);
@@ -49,13 +51,20 @@ export function MailPreviewDialog({
 
   // Fokus do dialógu pri otvorení a späť na pôvodný prvok pri zavretí — bez
   // toho by čítačka obrazovky aj klávesnica ostali v zozname za prekryvom.
+  //
+  // `document.activeElement` v momente OTVORENIA na to nestačí: náhľad sa
+  // načítava zo servera a spúšťacie tlačidlo je počas načítania `disabled` —
+  // prehliadač z neho fokus zhodí na `<body>`, takže dialóg by mal čo vracať
+  // až príliš neskoro (overené naživo na produkcii, issue 191). Volajúci preto
+  // môže odovzdať `returnFocusRef` so spúšťacím prvkom zapamätaným pri kliknutí.
   useEffect(() => {
     const previous = document.activeElement;
     panelRef.current?.focus();
     return () => {
-      if (previous instanceof HTMLElement) previous.focus();
+      const target = returnFocusRef?.current ?? previous;
+      if (target instanceof HTMLElement && target.isConnected) target.focus();
     };
-  }, []);
+  }, [returnFocusRef]);
 
   // Pozadie sa pod otvoreným dialógom neposúva — inak by koliesko myši
   // skrolovalo zoznam za ním namiesto obsahu náhľadu.

--- a/apps/web/src/components/NedostupneSection.test.tsx
+++ b/apps/web/src/components/NedostupneSection.test.tsx
@@ -191,6 +191,12 @@ it("klik vnútri dialógu ho nezavrie", async () => {
   expect(screen.getByTestId("nedostupne-preview")).not.toBeNull();
 });
 
+// issue 191, návrat fokusu po zavretí sa overuje LEN e2e testom
+// (`tests/e2e/nedostupne.spec.ts`): scenár stojí na tom, že prehliadač zhodí
+// fokus zo spúšťacieho tlačidla vo chvíli, keď sa počas načítania náhľadu stane
+// `disabled` — jsdom to nerobí (ani `blur()`, ani fokus na iný prvok to tu
+// nenapodobní), takže unit test by prešiel aj s pokazeným kódom.
+
 it("dialóg je označený ako modálny a nesie svoj vlastný nadpis", async () => {
   await otvorNahlad();
 

--- a/apps/web/src/components/NedostupneSection.tsx
+++ b/apps/web/src/components/NedostupneSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, type JSX } from "react";
+import { useCallback, useEffect, useRef, useState, type JSX } from "react";
 import type { Me } from "../api.js";
 import {
   fetchNedostupneList,
@@ -35,6 +35,10 @@ export function NedostupneSection({ role, onSessionExpired }: { readonly role: M
   const [busyKey, setBusyKey] = useState("");
   const [actionError, setActionError] = useState("");
   const [pending, setPending] = useState<PendingSend | null>(null);
+  // issue 191: spúšťacie tlačidlo si pamätáme už pri kliknutí — kým sa náhľad
+  // načítava, je `disabled` a prehliadač z neho fokus zhodí, takže po zavretí
+  // dialógu by sa nemal kam vrátiť (naživo overené na produkcii).
+  const triggerRef = useRef<HTMLElement | null>(null);
   const canControl = CONTROL_ROLES.has(role);
 
   const load = useCallback(() => {
@@ -58,6 +62,7 @@ export function NedostupneSection({ role, onSessionExpired }: { readonly role: M
   const openPreview = useCallback(
     (orderCode: string, variantCode: string, emailType: NedostupneEmailType) => {
       const key = `${orderCode}|${variantCode}|${emailType}`;
+      triggerRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
       setActionError("");
       setBusyKey(key);
       fetchNedostupnePreview(orderCode, variantCode, emailType)
@@ -206,6 +211,7 @@ export function NedostupneSection({ role, onSessionExpired }: { readonly role: M
           confirmLabel="📧 Odoslať zákazníkovi"
           confirmDisabled={busyKey !== ""}
           onConfirm={confirmSend}
+          returnFocusRef={triggerRef}
           onClose={() => {
             setPending(null);
           }}

--- a/apps/web/tests/e2e/nedostupne.spec.ts
+++ b/apps/web/tests/e2e/nedostupne.spec.ts
@@ -58,6 +58,14 @@ test("zoznam zobrazí nedostupný variant s náhradou, povinný náhľad predch�
   await page.keyboard.press("Escape");
   await expect(preview).toBeHidden();
 
+  // Po zavretí sa fokus vracia na tlačidlo, ktoré náhľad otvorilo — obsluha
+  // ovládajúca appku klávesnicou ostáva na svojom mieste v zozname. Tlačidlo je
+  // počas načítania náhľadu `disabled`, takže prehliadač z neho fokus zhodí:
+  // dialóg si spúšťač musí pamätať už z kliknutia, nie až z chvíle otvorenia
+  // (nájdené pri živom overení na produkcii, issue 191). jsdom tento stav
+  // nevie napodobniť, preto sa to overuje len tu, v skutočnom prehliadači.
+  await expect(page.getByTestId("nedostupne-send-9008-40287")).toBeFocused();
+
   // Znovu otvoriť a pokračovať v pôvodnom overení odoslania.
   await page.getByTestId("nedostupne-send-9008-40287").click();
   await expect(preview).toBeVisible();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.115",
+  "version": "0.3.0-dev.116",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Nadväzuje na PR #201. Pri živom overení na produkcii sa ukázalo, že po zavretí
dialógu s náhľadom e-mailu fokus neskončil späť na tlačidle, ktoré náhľad
otvorilo — obsluha ovládajúca appku klávesnicou tak stratila svoje miesto
v zozname a skončila na začiatku stránky.

Refs issue 191.

## Príčina

Spúšťacie tlačidlo je počas načítania náhľadu `disabled`, takže prehliadač z neho
fokus zhodí na `<body>`. Dialóg si pôvodný prvok bral až z `document.activeElement`
v momente svojho otvorenia — vtedy tam už bolo `<body>`.

## Oprava

Volajúca obrazovka si spúšťač zapamätá už pri kliknutí a odovzdá ho dialógu ako
`returnFocusRef`; dialóg ho po zavretí obnoví (bez tejto voliteľnej referencie sa
správa ako doteraz).

## Overenie

- `pnpm typecheck`, `pnpm lint` čisté; web unit testy 43 súborov / 332 zelené
- e2e `nedostupne.spec.ts` overuje návrat fokusu v skutočnom prehliadači
  (`toBeFocused()` po `Escape`) — jsdom scenár nevie napodobniť, lebo nezhadzuje
  fokus zo zakázaného tlačidla, takže unit test by prešiel aj s pokazeným kódom
- Živé overenie na produkcii príde až PO nasadení, preto tu zámerne nie je riadok
  na automatické zavretie ticketu.
