### PR TITLE
Editable e-mail texts with placeholder fields

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -625,3 +625,19 @@ paths:
   read and write go in `try/catch` with the safe default, since a browser
   with storage disabled throws and must never take the app down over a
   preference.
+- **Dialóg, ktorý sa otvára AŽ po dobehnutí serverového volania, si spúšťací
+  prvok musí zapamätať už pri KLIKNUTÍ — `document.activeElement` v momente
+  jeho otvorenia je vtedy už `<body>`.** Spúšťacie tlačidlo je počas
+  načítania `disabled` (busy stav) a prehliadač z neho fokus zhodí, takže
+  `MailPreviewDialog` po zavretí vracal fokus na začiatok stránky a obsluha
+  ovládajúca appku klávesnicou stratila miesto v zozname (issue 191, nájdené
+  až pri živom overení na produkcii, nie testom). Vzor: volajúci si drží
+  `useRef` naplnený v `onClick` a odovzdá ho ako `returnFocusRef`; dialóg
+  obnoví `returnFocusRef?.current ?? previous` a overí `isConnected`.
+- **Návrat fokusu po zavretí prekryvu sa dá overiť LEN e2e testom —
+  jsdom nezhadzuje fokus z prvku, ktorý sa práve stal `disabled`.** Overené
+  troma spôsobmi (`blur()`, presun fokusu na iný prvok v tom istom riadku —
+  ten je vtedy tiež `disabled`, takže fokus neprevezme): unit test prešiel aj
+  proti pokazenému kódu, čiže by bol tautológia (`test-strictness.md`). Také
+  overenie patrí do `tests/e2e/*.spec.ts` (`await expect(locator)
+  .toBeFocused()`) a v unit súbore ostane len komentár, PREČO tam test nie je.

--- a/.claude/rules/mail-templates.md
+++ b/.claude/rules/mail-templates.md
@@ -1,0 +1,76 @@
+---
+paths:
+  - "apps/api/src/modules/mail-templates/**"
+  - "apps/api/src/http/mail-template-routes.ts"
+  - "apps/api/src/db/schema-mail-templates.ts"
+  - "apps/web/src/mailTemplatesApi.ts"
+  - "apps/web/src/components/MailTemplate*.tsx"
+  - "apps/web/tests/e2e/mail-templates.spec.ts"
+  - "apps/api/src/http/login-rate-limit.ts"
+---
+
+# Upraviteľné znenia e-mailov (issue 192)
+
+- **Pôvodné znenie žije V KÓDE (`registry.ts`), nikdy sa nekopíruje do
+  databázy.** Riadok v `mail_template` existuje LEN pre šablónu, ktorú majiteľ
+  naozaj zmenil; `resolveTemplate` vracia `riadok ?? defaultText`. Vďaka tomu
+  je "vrátiť pôvodné znenie" obyčajné `DELETE` a pôvodné texty nemôžu zastarať
+  oproti kódu. **Seedovanie pôvodných znení migráciou by presne to pokazilo** —
+  po zmene textu v kóde by v databáze naďalej platila stará kópia a nikto by
+  si toho nevšimol. Pri pridaní ĎALŠIEHO druhu e-mailu stačí položka v
+  `MAIL_TEMPLATE_KEYS` + `KINDS`, žiadna migrácia.
+- **Odosielacie cesty vždy prechádzajú cez `resolveTemplate`, nikdy nečítajú
+  `mailTemplates` priamo** — priamy `select` by stratil fallback na pôvodné
+  znenie a poslal by prázdny e-mail.
+- **Šablónu načítaj RAZ pred cyklom, nie v ňom** (`order-reminder/run.ts`'s
+  `reminderTemplate`): jeden beh pošle desiatky e-mailov a znenie sa počas
+  neho meniť nemá — plus je to jeden DB dopyt namiesto N.
+- **`**tučné**` sa spracúva ako DVOJICA ZNAČIEK v prúde útržkov, nie regulárnym
+  výrazom nad reťazcom.** Hviezdičky bežne obklopujú zástupné pole
+  (`**{{meno_zakaznika}}**`), takže otváracia a zatváracia padnú do DVOCH
+  RÔZNYCH doslovných útržkov; regex ich nespáruje a namiesto toho spáruje
+  zatváraciu s otváracou o niekoľko odstavcov nižšie — výsledkom bolo
+  `<p>Dobrý deň, **zákazník<strong>,</p>` a `</strong>Drlík...**` (chytil to
+  existujúci test `nedostupne/logic.test.ts` hneď pri prechode na šablóny).
+  Nedovretá značka sa uzatvára na konci odstavca, aby sa rozbité HTML nikdy
+  nedostalo k zákazníkovi.
+- **Zalomenia a odstavce vznikajú VÝHRADNE z doslovného textu šablóny, nikdy
+  z dosadenej hodnoty.** Preto sa neskladá jeden reťazec, ktorý by sa potom
+  delil, ale postupnosť útržkov (`frag`/`bold`/`br`/`par`/`list`) — inak by
+  viacriadková hodnota poľa (zoznam náhrad) sama zakladala odstavce.
+- **Escapovanie je na strane appky, značky smie zapísať len šablóna.** Hodnota
+  poľa sa escapuje pri dosadení a hviezdičky v nej NEformátujú — inak by meno
+  zákazníka vedelo do e-mailu prepašovať HTML. Testy na to sú v
+  `render.test.ts` ("bezpečnosť").
+- **`registry.test.ts` je poistka, že pôvodné znenie nemôže vyjsť pokazené** —
+  prechádza tou istou kontrolou (`validateTemplateText`) ako uložená šablóna.
+  Pôvodné znenia sa totiž nikdy neukladajú, takže by ich preklep inak odhalil
+  až zákazník. Nová šablóna = nový riadok v tomto teste automaticky (`it.each`
+  nad `MAIL_TEMPLATE_KEYS`).
+- **Eskalácia zásielkových e-mailov ostáva ŠTYRMI samostatnými šablónami**
+  (`posta_1..posta_4`, výber cez `postaTemplateKey(count)`). Zlúčiť ich do
+  jednej by ticho zahodilo štyri rôzne znenia, ktoré appka dnes posiela.
+- **Podmienka `{{#ak pole}}…{{inak}}…{{/ak}}` nie je zbytočná zložitosť** —
+  dnešné texty ju reálne obsahujú (zásielka s termínom vyzdvihnutia vs. bez
+  neho, náhrady vs. bez náhrad). Bez nej by prechod na šablóny ticho zmenil
+  správanie. Vnorenie je zakázané a kontroluje sa pri uložení.
+- **Objednávka dodávateľovi je JEDINÝ čisto textový e-mail** — jej pôvodné
+  telo je "predmet, JEDNO zalomenie, zoznam položiek", takže výsledok ostáva
+  bajt na bajt rovnaký ako predtým (`orders/mail.test.ts` to drží). Zoznam
+  položiek preto nemá odrážkovú predponu, kým `zoznam_nahrad` má `"- "`
+  (predpona je vlastnosťou HODNOTY, nie enginu).
+- **Očakávané doménové zlyhanie vracia 200 s `{ok:false, error}`** (neznámy
+  druh e-mailu, neplatná šablóna) — nikdy 4xx, inak Chromium zaloguje
+  konzolovú chybu a e2e balík s nulovou toleranciou spadne
+  (`.claude/rules/testing.md`).
+- **E2E balík narazil na strop 30 prihlásení na IP za 5 minút**
+  (`IP_MAX_ATTEMPTS`, `login-rate-limit.ts`) — všetkých ~30 prihlásení celého
+  behu prichádza z JEDNEJ adresy (localhost), takže limit narazil zo svojej
+  podstaty, nie kvôli útoku. Prejaví sa ako "Nesprávny e-mail alebo heslo" v
+  NÁHODNOM neskoršom spec súbore, nikdy v tom, ktorý login pridal. Riešenie:
+  strop je premennou prostredia `LOGIN_IP_MAX_ATTEMPTS` (produkčná predvolená
+  hodnota 30 sa nemení, `playwright.config.ts` ju pre testovací server dvíha).
+  Limit na (IP, e-mail) pár — ten, čo chráni konkrétny účet — sa NEMENÍ ani v
+  testoch, takže vlastný izolovaný účet pre nový spec súbor je stále povinný.
+  **Nový e2e test aj tak nepridávaj s vlastným prihlásením zbytočne** — dva
+  scenáre v jednom teste sú lacnejšie než dve prihlásenia.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,3 +89,4 @@ Per-area rules live in `.claude/rules/<area>.md` with `paths:` frontmatter.
 - Nevyzdvihnuté zásielky (Pošta SK — enabled vs. run-now, coalesce, advisory zámok) → `.claude/rules/posta-uncollected.md`
 - Pripomienky objednávok (AI klasifikácia poznámky, terminálna rezolúcia, override→job_run relocate) → `.claude/rules/order-reminder.md`
 - Nedostupné tovary (návrh náhrady, jednorazový preview token, žiadny scheduler) → `.claude/rules/nedostupne.md`
+- Texty e-mailov (F192 — upraviteľné šablóny, zástupné polia, strop prihlásení v e2e) → `.claude/rules/mail-templates.md`

--- a/apps/api/drizzle/0024_far_wonder_man.sql
+++ b/apps/api/drizzle/0024_far_wonder_man.sql
@@ -1,0 +1,22 @@
+CREATE TYPE "public"."mail_template_action" AS ENUM('save', 'reset');--> statement-breakpoint
+CREATE TABLE "mail_template_history" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"key" text NOT NULL,
+	"action" "mail_template_action" NOT NULL,
+	"subject" text NOT NULL,
+	"body" text NOT NULL,
+	"changed_at" timestamp with time zone NOT NULL,
+	"changed_by_user_id" uuid
+);
+--> statement-breakpoint
+CREATE TABLE "mail_template" (
+	"key" text PRIMARY KEY NOT NULL,
+	"subject" text NOT NULL,
+	"body" text NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL,
+	"updated_by_user_id" uuid
+);
+--> statement-breakpoint
+ALTER TABLE "mail_template_history" ADD CONSTRAINT "mail_template_history_changed_by_user_id_users_id_fk" FOREIGN KEY ("changed_by_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "mail_template" ADD CONSTRAINT "mail_template_updated_by_user_id_users_id_fk" FOREIGN KEY ("updated_by_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "mail_template_history_key_idx" ON "mail_template_history" USING btree ("key","changed_at");

--- a/apps/api/drizzle/meta/0024_snapshot.json
+++ b/apps/api/drizzle/meta/0024_snapshot.json
@@ -1,0 +1,1987 @@
+{
+  "id": "5869eb90-2b14-4f85-8757-e841a8cee8c7",
+  "prevId": "366b0710-6ef9-4d10-b523-83af8e3c1b55",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "related_codes": {
+          "name": "related_codes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_code": {
+          "name": "external_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_open_status": {
+      "name": "order_open_status",
+      "schema": "",
+      "columns": {
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Vybavuje sa'"
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop_remark": {
+          "name": "shop_remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shoptet_order_id": {
+          "name": "shoptet_order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_updated_at": {
+          "name": "comment_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_synced_at": {
+          "name": "comment_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_carrier_name": {
+          "name": "shipping_carrier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_link_override": {
+      "name": "product_supplier_link_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_link_override_product_key_product_key_fk": {
+          "name": "product_supplier_link_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_link_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_override": {
+      "name": "product_supplier_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_override_product_key_product_key_fk": {
+          "name": "product_supplier_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing": {
+      "name": "pairing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_url": {
+          "name": "supplier_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "pairing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'navrhnute'"
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pairing_state_idx": {
+          "name": "pairing_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_confirmed_by_idx": {
+          "name": "pairing_confirmed_by_idx",
+          "columns": [
+            {
+              "expression": "confirmed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_variant_code_variant_code_fk": {
+          "name": "pairing_variant_code_variant_code_fk",
+          "tableFrom": "pairing",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pairing_confirmed_by_users_id_fk": {
+          "name": "pairing_confirmed_by_users_id_fk",
+          "tableFrom": "pairing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pairing_variant_code_unique": {
+          "name": "pairing_variant_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pairing_confirmation_ck": {
+          "name": "pairing_confirmation_ck",
+          "value": "(\"pairing\".\"state\" = 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)\n        OR (\"pairing\".\"state\" != 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NULL AND \"pairing\".\"confirmed_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier": {
+      "name": "supplier",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wholesale_base_url": {
+          "name": "wholesale_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_key": {
+          "name": "adapter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_settings": {
+      "name": "posta_uncollected_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_state": {
+      "name": "posta_uncollected_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notify_count": {
+          "name": "notify_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_state": {
+          "name": "terminal_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_settings": {
+      "name": "order_reminder_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_state": {
+      "name": "order_reminder_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_state": {
+      "name": "nedostupne_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "nedostupne_email_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nedostupne_state_order_variant_type_uq": {
+          "name": "nedostupne_state_order_variant_type_uq",
+          "columns": [
+            {
+              "expression": "order_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template_history": {
+      "name": "mail_template_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "mail_template_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_template_history_key_idx": {
+          "name": "mail_template_history_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_template_history_changed_by_user_id_users_id_fk": {
+          "name": "mail_template_history_changed_by_user_id_users_id_fk",
+          "tableFrom": "mail_template_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template": {
+      "name": "mail_template",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail_template_updated_by_user_id_users_id_fk": {
+          "name": "mail_template_updated_by_user_id_users_id_fk",
+          "tableFrom": "mail_template",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne"
+      ]
+    },
+    "public.pairing_state": {
+      "name": "pairing_state",
+      "schema": "public",
+      "values": [
+        "navrhnute",
+        "potvrdene"
+      ]
+    },
+    "public.nedostupne_email_type": {
+      "name": "nedostupne_email_type",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "alternativa"
+      ]
+    },
+    "public.mail_template_action": {
+      "name": "mail_template_action",
+      "schema": "public",
+      "values": [
+        "save",
+        "reset"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1785705902796,
       "tag": "0023_steep_smasher",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1785773580281,
+      "tag": "0024_far_wonder_man",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema-mail-templates.ts
+++ b/apps/api/src/db/schema-mail-templates.ts
@@ -1,0 +1,38 @@
+import { index, pgEnum, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { users } from "./schema-users.js";
+
+// issue 192: upravené znenia e-mailov. Riadok tu existuje LEN pre šablónu,
+// ktorú majiteľ naozaj zmenil — chýbajúci riadok znamená "použi pôvodné
+// znenie z kódu" (`modules/mail-templates/registry.ts`). Preto je "vrátiť
+// pôvodné znenie" obyčajné zmazanie riadku a pôvodné texty nemôžu zastarať
+// oproti kódu (kopírovanie pôvodných znení do databázy pri nasadení by presne
+// to spôsobilo).
+export const mailTemplates = pgTable("mail_template", {
+  // Kľúč druhu e-mailu (`MAIL_TEMPLATE_KEYS`) — text, nie enum: pribudnutie
+  // ďalšieho druhu e-mailu je potom zmena v kóde, nie migrácia.
+  key: text("key").primaryKey(),
+  subject: text("subject").notNull(),
+  body: text("body").notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull(),
+  updatedByUserId: uuid("updated_by_user_id").references(() => users.id, { onDelete: "set null" }),
+});
+
+export const mailTemplateAction = pgEnum("mail_template_action", ["save", "reset"]);
+
+// História zmien (ticket: "kto a kedy text zmenil"). Append-only, nikdy sa
+// nemaže ani neprepisuje — aj vrátenie pôvodného znenia je záznam.
+export const mailTemplateHistory = pgTable(
+  "mail_template_history",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    key: text("key").notNull(),
+    action: mailTemplateAction("action").notNull(),
+    // Znenie PLATNÉ PO tejto zmene — pri vrátení pôvodného sa uloží pôvodné
+    // znenie z kódu, aby sa história dala čítať bez znalosti verzie kódu.
+    subject: text("subject").notNull(),
+    body: text("body").notNull(),
+    changedAt: timestamp("changed_at", { withTimezone: true }).notNull(),
+    changedByUserId: uuid("changed_by_user_id").references(() => users.id, { onDelete: "set null" }),
+  },
+  (t) => [index("mail_template_history_key_idx").on(t.key, t.changedAt)],
+);

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -6,3 +6,4 @@ export * from "./schema-pairing.js";
 export * from "./schema-posta-uncollected.js";
 export * from "./schema-order-reminder.js";
 export * from "./schema-nedostupne.js";
+export * from "./schema-mail-templates.js";

--- a/apps/api/src/http/app.ts
+++ b/apps/api/src/http/app.ts
@@ -14,6 +14,7 @@ import { checkLoginRateLimit, clientIp } from "./login-rate-limit.js";
 import { SESSION_COOKIE, requireUser, type AppBindings } from "./middleware.js";
 import { registerOrdersRoutes, type RunOrdersIngest } from "./orders-routes.js";
 import { registerOrderReminderRoutes, type OrderReminderRunDeps } from "./order-reminder-routes.js";
+import { registerMailTemplateRoutes } from "./mail-template-routes.js";
 import { registerNedostupneRoutes, type NedostupneRunDeps } from "./nedostupne-routes.js";
 import { requireSameOrigin } from "./origin-check.js";
 import { registerPairingRoutes } from "./pairing-routes.js";
@@ -206,6 +207,9 @@ export function createApp(
       adminBaseUrl: options.adminBaseUrl ?? "https://www.forestshop.sk",
     },
   );
+
+  // issue 192: upraviteľné znenia e-mailov (obrazovka "Texty e-mailov").
+  registerMailTemplateRoutes(app, db);
 
   // Musí byť registrovaný AŽ PO všetkých skutočných /api/* trasách vyššie — Hono
   // vyberá presnejšiu zhodu, takže tie majú prednosť a sem sa dostane len to, čo

--- a/apps/api/src/http/login-rate-limit.test.ts
+++ b/apps/api/src/http/login-rate-limit.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   checkLoginRateLimit,
   rateLimitEntryCountsForTest,
@@ -68,5 +68,31 @@ describe("checkLoginRateLimit — existujúce vlastnosti zostávajú", () => {
 
     const later = new Date(BASE.getTime() + WINDOW_MS + 1);
     expect(checkLoginRateLimit(ip, email, later)).toBe(true);
+  });
+});
+
+// issue 192: E2E balík sa prihlasuje ~30-krát z jednej adresy, takže si strop
+// na IP zdvíha premennou prostredia. Test dokazuje OBE strany dohody: bez
+// premennej platí produkčných 30, s premennou platí zadaná hodnota — a limit
+// na (IP, e-mail) pár sa pritom nemení.
+describe("strop na IP sa dá zdvihnúť premennou prostredia (len pre testovacie prostredie)", () => {
+  it("bez premennej platí produkčná hodnota 30", async () => {
+    vi.resetModules();
+    vi.stubEnv("LOGIN_IP_MAX_ATTEMPTS", undefined);
+    const modul = await import("./login-rate-limit.js");
+    const ip = "203.0.113.60";
+    for (let i = 0; i < 30; i++) expect(modul.checkLoginRateLimit(ip, `a-${String(i)}@x.sk`, BASE)).toBe(true);
+    expect(modul.checkLoginRateLimit(ip, "a-30@x.sk", BASE)).toBe(false);
+    vi.unstubAllEnvs();
+  });
+
+  it("s premennou platí zadaná, vyššia hodnota", async () => {
+    vi.resetModules();
+    vi.stubEnv("LOGIN_IP_MAX_ATTEMPTS", "40");
+    const modul = await import("./login-rate-limit.js");
+    const ip = "203.0.113.61";
+    for (let i = 0; i < 40; i++) expect(modul.checkLoginRateLimit(ip, `b-${String(i)}@x.sk`, BASE)).toBe(true);
+    expect(modul.checkLoginRateLimit(ip, "b-40@x.sk", BASE)).toBe(false);
+    vi.unstubAllEnvs();
   });
 });

--- a/apps/api/src/http/login-rate-limit.ts
+++ b/apps/api/src/http/login-rate-limit.ts
@@ -20,7 +20,21 @@ const MAX_ATTEMPTS = 10; // na (IP, e-mail) pár
 // NATom/kanceláriou, zopár preklepov v hesle) nesmie nikdy naraziť LEN na
 // tento druhý, širší limit.
 const IP_WINDOW_MS = 5 * 60 * 1000;
-const IP_MAX_ATTEMPTS = 30; // na samotnú IP, bez ohľadu na e-mail
+// Predvolená PRODUKČNÁ hodnota. Prepísať sa dá len premennou prostredia, ktorú
+// produkcia nenastavuje — slúži VÝHRADNE pre E2E balík (`playwright.config
+// .ts`), kde všetkých ~30 prihlásení celého behu prichádza z JEDNEJ adresy
+// (localhost), takže by tento limit narazil zo svojej podstaty, nie kvôli
+// útoku. Znižovať/rušiť ochranu v produkcii to nijako neumožňuje: bez
+// premennej platí 30, a limit na (IP, e-mail) pár (`MAX_ATTEMPTS`) — ten, čo
+// chráni konkrétny účet — sa nemení vôbec.
+const IP_MAX_ATTEMPTS = readPositiveIntEnv("LOGIN_IP_MAX_ATTEMPTS", 30); // na samotnú IP, bez ohľadu na e-mail
+
+function readPositiveIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
 
 const MAX_ENTRIES = 10_000; // strop na počet záznamov v KAŽDEJ z dvoch máp
 // Pri dosiahnutí stropu sa naraz uvoľní táto dávka miesta zmazaním najskôr

--- a/apps/api/src/http/mail-template-routes.ts
+++ b/apps/api/src/http/mail-template-routes.ts
@@ -1,0 +1,113 @@
+import { zValidator } from "@hono/zod-validator";
+import type { Hono } from "hono";
+import { z } from "zod";
+import type { Database } from "../db/client.js";
+import { record } from "../modules/audit/service.js";
+import {
+  allowedPlaceholderNames,
+  isMailTemplateKey,
+  MAIL_TEMPLATE_KINDS,
+  placeholdersFor,
+  type MailTemplateKey,
+} from "../modules/mail-templates/registry.js";
+import { renderTemplate, validateTemplateText } from "../modules/mail-templates/render.js";
+import { previewContext } from "../modules/mail-templates/samples.js";
+import { listTemplateHistory, listTemplates, resetTemplate, saveTemplate } from "../modules/mail-templates/store.js";
+import { requireRole, requireUser, type AppBindings } from "./middleware.js";
+import { requireSameOrigin } from "./origin-check.js";
+
+// issue 192: obrazovka "Texty e-mailov". Očakávané doménové zlyhania (neznámy
+// druh e-mailu, neplatná šablóna) vracajú 200 s `{ok:false, error}` — nikdy
+// 4xx, lebo Chromium loguje konzolovú chybu pri KAŽDEJ ne-2xx odpovedi a e2e
+// balík má nulovú toleranciu (`.claude/rules/testing.md`).
+
+const keyParam = z.object({ key: z.string().min(1) });
+const draftBody = z.object({ subject: z.string().max(500), body: z.string().max(20_000) });
+const previewBody = draftBody.extend({ key: z.string().min(1) });
+
+function kindSummary(key: MailTemplateKey): {
+  readonly key: MailTemplateKey;
+  readonly label: string;
+  readonly description: string;
+  readonly defaultSubject: string;
+  readonly defaultBody: string;
+  readonly placeholders: readonly { readonly name: string; readonly label: string }[];
+} {
+  const kind = MAIL_TEMPLATE_KINDS[key];
+  return {
+    key,
+    label: kind.label,
+    description: kind.description,
+    defaultSubject: kind.defaultText.subject,
+    defaultBody: kind.defaultText.body,
+    placeholders: placeholdersFor(key).map((p) => ({ name: p.name, label: p.label })),
+  };
+}
+
+export function registerMailTemplateRoutes(app: Hono<AppBindings>, db: Database): void {
+  // Čítanie — každý prihlásený zamestnanec (rovnaká úroveň ako ostatné
+  // obrazovky); upravovať smie až admin/manažér nižšie.
+  app.get("/api/mail-templates", requireUser(db), async (c) => {
+    const resolved = await listTemplates(db);
+    return c.json({
+      templates: resolved.map((t) => ({
+        ...kindSummary(t.key),
+        subject: t.subject,
+        body: t.body,
+        isCustomized: t.isCustomized,
+        updatedAt: t.updatedAt?.toISOString() ?? null,
+        updatedByName: t.updatedByName,
+      })),
+    });
+  });
+
+  // Náhľad rozpísaného (ešte NEULOŽENÉHO) znenia na skutočných dátach.
+  // Literálna cesta MUSÍ byť registrovaná pred `/:key` súrodencami nižšie
+  // (`.claude/rules/http-routes.md`).
+  app.post("/api/mail-templates/preview", requireSameOrigin(), requireUser(db), zValidator("json", previewBody), async (c) => {
+    const { key, subject, body } = c.req.valid("json");
+    if (!isMailTemplateKey(key)) return c.json({ ok: false as const, error: "Neznámy druh e-mailu." });
+    const errors = validateTemplateText({ subject, body }, allowedPlaceholderNames(key));
+    if (errors.length > 0) return c.json({ ok: false as const, error: errors.join(" ") });
+    const rendered = renderTemplate({ subject, body }, await previewContext(db, key));
+    return c.json({ ok: true as const, subject: rendered.subject, html: rendered.html, text: rendered.text });
+  });
+
+  app.get("/api/mail-templates/:key/history", requireUser(db), zValidator("param", keyParam), async (c) => {
+    const { key } = c.req.valid("param");
+    if (!isMailTemplateKey(key)) return c.json({ ok: false as const, error: "Neznámy druh e-mailu." });
+    const entries = await listTemplateHistory(db, key);
+    return c.json({
+      ok: true as const,
+      entries: entries.map((e) => ({
+        id: e.id,
+        action: e.action,
+        subject: e.subject,
+        changedAt: e.changedAt.toISOString(),
+        changedByName: e.changedByName,
+      })),
+    });
+  });
+
+  app.put("/api/mail-templates/:key", requireSameOrigin(), requireUser(db), requireRole("admin", "manazer"), zValidator("param", keyParam), zValidator("json", draftBody), async (c) => {
+    const { key } = c.req.valid("param");
+    if (!isMailTemplateKey(key)) return c.json({ ok: false as const, error: "Neznámy druh e-mailu." });
+    const { subject, body } = c.req.valid("json");
+    const user = c.get("user");
+    const now = new Date();
+    const result = await saveTemplate(db, { key, subject, body, userId: user.userId, now });
+    if (!result.ok) return c.json({ ok: false as const, error: result.errors.join(" ") });
+    await record(db, { at: now, actorUserId: user.userId, action: "mail_template.save", entity: "mail_template", entityId: key, data: { key } });
+    return c.json({ ok: true as const });
+  });
+
+  app.post("/api/mail-templates/:key/reset", requireSameOrigin(), requireUser(db), requireRole("admin", "manazer"), zValidator("param", keyParam), async (c) => {
+    const { key } = c.req.valid("param");
+    if (!isMailTemplateKey(key)) return c.json({ ok: false as const, error: "Neznámy druh e-mailu." });
+    const user = c.get("user");
+    const now = new Date();
+    await resetTemplate(db, { key, userId: user.userId, now });
+    await record(db, { at: now, actorUserId: user.userId, action: "mail_template.reset", entity: "mail_template", entityId: key, data: { key } });
+    return c.json({ ok: true as const });
+  });
+}

--- a/apps/api/src/http/nedostupne-routes.ts
+++ b/apps/api/src/http/nedostupne-routes.ts
@@ -79,7 +79,7 @@ export function registerNedostupneRoutes(app: Hono<AppBindings>, db: Database, d
         // (`.claude/rules/testing.md`'s Chromium console-error pravidlo).
         return c.json({ ok: false as const, error: "Riadok objednávky sa v aktuálnom zozname nenašiel." });
       }
-      const built = buildEmailForType(ctx, emailType);
+      const built = await buildEmailForType(db, ctx, emailType);
       const previewToken = issuePreviewToken(orderCode, variantCode, emailType, new Date());
       return c.json({ ok: true as const, subject: built.subject, html: built.html, recipient: ctx.email, customerName: ctx.customerName, previewToken });
     },

--- a/apps/api/src/http/order-reminder-routes.ts
+++ b/apps/api/src/http/order-reminder-routes.ts
@@ -6,6 +6,7 @@ import type { Database } from "../db/client.js";
 import { jobRuns } from "../db/schema.js";
 import { log } from "../logger.js";
 import { record } from "../modules/audit/service.js";
+import { resolveTemplate } from "../modules/mail-templates/store.js";
 import { buildReminderEmail } from "../modules/order-reminder/logic.js";
 import { ORDER_REMINDER_JOB_NAME } from "../modules/scheduler/jobs.js";
 import { getLatestJobRun } from "../modules/scheduler/queries.js";
@@ -254,7 +255,7 @@ export function registerOrderReminderRoutes(app: Hono<AppBindings>, db: Database
         // (`.claude/rules/testing.md`'s Chromium console-error pravidlo).
         return c.json({ ok: false as const, error: "Objednávka sa v aktuálnom zozname nenašla." });
       }
-      const built = buildReminderEmail(row.name, orderCode);
+      const built = buildReminderEmail(await resolveTemplate(db, "order_reminder"), row.name, orderCode);
       return c.json({
         ok: true as const,
         subject: built.subject,

--- a/apps/api/src/http/posta-uncollected-routes.ts
+++ b/apps/api/src/http/posta-uncollected-routes.ts
@@ -7,7 +7,8 @@ import { jobRuns } from "../db/schema.js";
 import { log } from "../logger.js";
 import { record } from "../modules/audit/service.js";
 import { MAX_EMAILS } from "../modules/posta-uncollected/constants.js";
-import { buildEmail } from "../modules/posta-uncollected/logic.js";
+import { resolveTemplate } from "../modules/mail-templates/store.js";
+import { buildEmail, postaTemplateKey } from "../modules/posta-uncollected/logic.js";
 import { POSTA_UNCOLLECTED_JOB_NAME } from "../modules/scheduler/jobs.js";
 import { getLatestJobRun } from "../modules/scheduler/queries.js";
 import type { PostaUncollectedRunResult, RunPostaUncollectedOptions } from "../modules/posta-uncollected/run.js";
@@ -167,7 +168,8 @@ export function registerPostaUncollectedRoutes(app: Hono<AppBindings>, db: Datab
       const already = row.count;
       const maxReached = already >= MAX_EMAILS;
       const count = Math.min(already + 1, MAX_EMAILS);
-      const built = buildEmail(count, row.name, packageNumber, row.officeName, row.officeAddr, row.retainedTill, new Date());
+      const template = await resolveTemplate(db, postaTemplateKey(count));
+      const built = buildEmail(template, row.name, packageNumber, row.officeName, row.officeAddr, row.retainedTill, new Date());
       return c.json({
         ok: true as const,
         subject: built.subject,

--- a/apps/api/src/modules/mail-templates/context.ts
+++ b/apps/api/src/modules/mail-templates/context.ts
@@ -1,0 +1,21 @@
+import type { TemplateValue } from "./render.js";
+
+// issue 192: hodnoty polí, ktoré sú dostupné v KAŽDEJ šablóne. Sú tu (a nie v
+// `registry.ts`), aby ich používali OBE strany rovnako — ukážka v ponuke polí
+// aj skutočné odoslanie. Inak by sa náhľad mohol rozísť s tým, čo naozaj
+// odíde zákazníkovi.
+export const KONTAKT_EMAIL = "eshop@forestshop.sk";
+export const KONTAKT_TELEFON = "+421 903 670 766";
+export const WEB_FORESTSHOP = "https://www.forestshop.sk";
+
+export function globalContext(): Record<string, TemplateValue> {
+  return {
+    kontakt_email: { kind: "link", url: `mailto:${KONTAKT_EMAIL}`, label: KONTAKT_EMAIL },
+    kontakt_telefon: { kind: "link", url: `tel:${KONTAKT_TELEFON.replaceAll(" ", "")}`, label: KONTAKT_TELEFON },
+    web_forestshop: { kind: "link", url: WEB_FORESTSHOP, label: "www.forestshop.sk" },
+  };
+}
+
+export function textValue(value: string): TemplateValue {
+  return { kind: "text", text: value };
+}

--- a/apps/api/src/modules/mail-templates/registry.test.ts
+++ b/apps/api/src/modules/mail-templates/registry.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { allowedPlaceholderNames, exampleContext, MAIL_TEMPLATE_KEYS, MAIL_TEMPLATE_KINDS, placeholdersFor } from "./registry.js";
+import { renderTemplate, validateTemplateText } from "./render.js";
+
+// issue 192: toto je poistka, že PÔVODNÉ znenie nemôže nikdy vyjsť pokazené.
+// Uložiť sa dá len šablóna, ktorá prejde kontrolou — ale pôvodné znenia
+// kontrolou neprechádzajú (v databáze nikdy nie sú), takže preklep v nich by
+// sa inak prejavil až u zákazníka.
+describe("pôvodné znenia e-mailov", () => {
+  it.each(MAIL_TEMPLATE_KEYS)("%s prejde tou istou kontrolou ako uložená šablóna", (key) => {
+    expect(validateTemplateText(MAIL_TEMPLATE_KINDS[key].defaultText, allowedPlaceholderNames(key))).toEqual([]);
+  });
+
+  it.each(MAIL_TEMPLATE_KEYS)("%s sa dá vyrenderovať a nie je prázdny", (key) => {
+    const out = renderTemplate(MAIL_TEMPLATE_KINDS[key].defaultText, exampleContext(key));
+    expect(out.subject.length).toBeGreaterThan(0);
+    expect(out.text.length).toBeGreaterThan(0);
+    expect(out.html).toContain("<body");
+    // Žiadne nedosadené pole neostane v odoslanom znení.
+    expect(out.html).not.toContain("{{");
+    expect(out.text).not.toContain("{{");
+  });
+
+  it.each(MAIL_TEMPLATE_KEYS)("%s má slovenský názov aj popis pre obsluhu", (key) => {
+    expect(MAIL_TEMPLATE_KINDS[key].label.length).toBeGreaterThan(0);
+    expect(MAIL_TEMPLATE_KINDS[key].description.length).toBeGreaterThan(0);
+  });
+
+  it.each(MAIL_TEMPLATE_KEYS)("%s ponúka ku každému poľu vysvetlenie a ukážkovú hodnotu", (key) => {
+    const placeholders = placeholdersFor(key);
+    expect(placeholders.length).toBeGreaterThan(0);
+    for (const p of placeholders) {
+      expect(p.label.length).toBeGreaterThan(0);
+      expect(p.name).toMatch(/^[a-z][a-z0-9_]*$/);
+    }
+  });
+
+  it("kľúč každého druhu sedí s kľúčom v registri (preklep v mape by ostal neviditeľný)", () => {
+    for (const key of MAIL_TEMPLATE_KEYS) expect(MAIL_TEMPLATE_KINDS[key].key).toBe(key);
+  });
+
+  it("zásielkové znenia sa navzájom líšia — eskalácia sa zlúčením nestratila", () => {
+    const subjects = new Set((["posta_1", "posta_2", "posta_3", "posta_4"] as const).map((k) => MAIL_TEMPLATE_KINDS[k].defaultText.subject));
+    expect(subjects.size).toBe(4);
+  });
+});

--- a/apps/api/src/modules/mail-templates/registry.ts
+++ b/apps/api/src/modules/mail-templates/registry.ts
@@ -1,0 +1,281 @@
+import { globalContext } from "./context.js";
+import type { MailTemplateText, TemplateValue } from "./render.js";
+
+// issue 192: register všetkých druhov e-mailov, ktoré appka posiela — ich
+// PÔVODNÉ znenie (doslovne prevzaté z pôvodných staviteľov v
+// `nedostupne/logic.ts`, `order-reminder/logic.ts`, `posta-uncollected/
+// logic.ts` a `orders/mail.ts`) plus zoznam polí, ktoré v danom druhu smú
+// vystupovať.
+//
+// Pôvodné znenie žije TU, v kóde — nikdy sa nekopíruje do databázy. Vďaka
+// tomu je "vrátiť pôvodné znenie" obyčajné zmazanie riadku a pôvodné texty
+// nemôžu zastarať oproti kódu.
+//
+// Eskalácia pri nevyzdvihnutých zásielkach má ŠTYRI rôzne znenia (1., 2., 3.
+// a posledná výzva) — sú to štyri samostatné šablóny, nie jedna. Zlúčiť ich
+// by znamenalo stratiť správanie, ktoré appka dnes má.
+
+export const MAIL_TEMPLATE_KEYS = [
+  "nedostupne",
+  "nedostupne_alternativa",
+  "posta_1",
+  "posta_2",
+  "posta_3",
+  "posta_4",
+  "order_reminder",
+  "supplier_order",
+] as const;
+
+export type MailTemplateKey = (typeof MAIL_TEMPLATE_KEYS)[number];
+
+export function isMailTemplateKey(value: string): value is MailTemplateKey {
+  return (MAIL_TEMPLATE_KEYS as readonly string[]).includes(value);
+}
+
+export interface PlaceholderDef {
+  readonly name: string;
+  /** Ako sa pole volá v ponuke pre obsluhu — po slovensky, bez žargónu. */
+  readonly label: string;
+  /** Ukážková hodnota — použije sa v náhľade, keď skutočné dáta chýbajú. */
+  readonly example: TemplateValue;
+}
+
+export interface MailTemplateKind {
+  readonly key: MailTemplateKey;
+  readonly label: string;
+  readonly description: string;
+  readonly ownPlaceholders: readonly PlaceholderDef[];
+  readonly defaultText: MailTemplateText;
+}
+
+// Polia dostupné v KAŽDEJ šablóne — kontaktné údaje a odkaz na e-shop.
+// Ukážkové hodnoty sú TIE ISTÉ, aké dostane skutočný e-mail (`context.ts`),
+// aby sa náhľad nemohol rozísť s odoslaným znením.
+const GLOBAL_VALUES = globalContext();
+
+export const GLOBAL_PLACEHOLDERS: readonly PlaceholderDef[] = [
+  { name: "kontakt_email", label: "Náš kontaktný e-mail (odkaz)", example: GLOBAL_VALUES["kontakt_email"] as TemplateValue },
+  { name: "kontakt_telefon", label: "Náš telefón (odkaz)", example: GLOBAL_VALUES["kontakt_telefon"] as TemplateValue },
+  { name: "web_forestshop", label: "Odkaz na www.forestshop.sk", example: GLOBAL_VALUES["web_forestshop"] as TemplateValue },
+];
+
+const MENO: PlaceholderDef = { name: "meno_zakaznika", label: "Meno zákazníka", example: { kind: "text", text: "Ján Novák" } };
+const CISLO_OBJEDNAVKY: PlaceholderDef = {
+  name: "cislo_objednavky",
+  label: "Číslo objednávky",
+  example: { kind: "text", text: "20260123" },
+};
+
+const PODPIS_TIM = ["S pozdravom,", "**Tím Forestshop.sk**", "{{web_forestshop}}"].join("\n");
+
+const POSTA_PLACEHOLDERS: readonly PlaceholderDef[] = [
+  MENO,
+  { name: "cislo_zasielky", label: "Číslo zásielky", example: { kind: "text", text: "RR123456789SK" } },
+  { name: "posta", label: "Názov pošty", example: { kind: "text", text: "Pošta Žilina 1" } },
+  { name: "adresa_posty", label: "Adresa pošty (nemusí byť známa)", example: { kind: "text", text: "Sládkovičova 1, Žilina" } },
+  {
+    name: "termin_vyzdvihnutia",
+    label: "Dátum, do kedy si ju možno vyzdvihnúť (nemusí byť známy)",
+    example: { kind: "text", text: "12. 8. 2026" },
+  },
+  {
+    name: "odkaz_sledovanie",
+    label: "Odkaz na sledovanie zásielky",
+    example: {
+      kind: "link",
+      url: "https://tandt.posta.sk/zasielky/RR123456789SK",
+      label: "https://tandt.posta.sk/zasielky/RR123456789SK",
+    },
+  },
+];
+
+/** Spoločný úvod + záver zásielkových e-mailov — líšia sa len dvomi vetami
+ * (predstavenie situácie a naliehavosť), presne ako v pôvodnom `buildEmail`. */
+function postaBody(intro: string, urgency: string): string {
+  return [
+    "Dobrý deň, **{{meno_zakaznika}}**,",
+    "",
+    intro,
+    "",
+    urgency,
+    "",
+    "👉 Stav zásielky môžete sledovať tu: {{odkaz_sledovanie}}",
+    "",
+    "Ak máte akékoľvek otázky, pokojne nás kontaktujte na {{kontakt_email}}.",
+    "",
+    PODPIS_TIM,
+  ].join("\n");
+}
+
+const POSTA_MIESTO = "na pošte **{{posta}}**{{#ak adresa_posty}} ({{adresa_posty}}){{/ak}}";
+
+const KINDS: readonly MailTemplateKind[] = [
+  {
+    key: "nedostupne",
+    label: "Nedostupný tovar — bez návrhu náhrady",
+    description: "Ospravedlnenie zákazníkovi, keď objednaný tovar nie je dostupný a nevieme, kedy bude.",
+    ownPlaceholders: [MENO],
+    defaultText: {
+      subject: "Informácia o dostupnosti vašej objednávky — Forestshop.sk",
+      body: [
+        "Dobrý deň, **{{meno_zakaznika}}**,",
+        "",
+        "veľmi sa ospravedlňujeme, ale tovar ktorý ste si objednali je momentálne nedostupný a nevieme kedy bude naskladnený. Z toho dôvodu nevieme Vašu objednávku úspešne vybaviť.",
+        "",
+        "S pozdravom,",
+        "**Drlík, Forestshop.sk**",
+        "{{web_forestshop}}",
+      ].join("\n"),
+    },
+  },
+  {
+    key: "nedostupne_alternativa",
+    label: "Nedostupný tovar — s návrhom náhrady",
+    description: "To isté, ale so zoznamom náhradných produktov, ktoré k tovaru vedieme.",
+    ownPlaceholders: [
+      MENO,
+      { name: "nazov_tovaru", label: "Názov nedostupného tovaru", example: { kind: "text", text: "Nohavice FOREST 1003" } },
+      {
+        name: "zoznam_nahrad",
+        label: "Zoznam náhradných produktov (odkazy)",
+        example: {
+          kind: "list",
+          textPrefix: "- ",
+          items: [{ label: "Podkolienky BOBR", url: "https://www.forestshop.sk/vyhladavanie/?string=60116%2F90" }],
+        },
+      },
+    ],
+    defaultText: {
+      subject: "Alternatívy k vášmu tovaru — Forestshop.sk",
+      body: [
+        "Dobrý deň, **{{meno_zakaznika}}**,",
+        "",
+        "Radi by sme vás informovali, že produkt **{{nazov_tovaru}}** z vašej objednávky je momentálne **nedostupný**.",
+        "",
+        "{{#ak zoznam_nahrad}}Radi by sme vám preto ponúkli tieto **alternatívne produkty**:{{inak}}Radi vám pomôžeme nájsť vhodnú alternatívu — stačí nás kontaktovať.{{/ak}}",
+        "{{zoznam_nahrad}}",
+        "",
+        "Ak máte akékoľvek otázky, pokojne nás kontaktujte na {{kontakt_email}} alebo na telefónnom čísle {{kontakt_telefon}}.",
+        "",
+        "Ďakujeme vám za dôveru.",
+        "",
+        PODPIS_TIM,
+      ].join("\n"),
+    },
+  },
+  {
+    key: "posta_1",
+    label: "Nevyzdvihnutá zásielka — 1. upozornenie",
+    description: "Prvý e-mail, keď zásielka dorazí na poštu a čaká na vyzdvihnutie.",
+    ownPlaceholders: POSTA_PLACEHOLDERS,
+    defaultText: {
+      subject: "Vaša zásielka čaká na vyzdvihnutie | {{cislo_zasielky}}",
+      body: postaBody(
+        `vaša zásielka č. **{{cislo_zasielky}}** je uložená ${POSTA_MIESTO} a čaká na vyzdvihnutie.`,
+        "{{#ak termin_vyzdvihnutia}}Prosím vyzdvihnite si ju do **{{termin_vyzdvihnutia}}**, aby nebola vrátená späť odosielateľovi.{{inak}}Prosím vyzdvihnite si ju čo najskôr, aby nebola vrátená späť odosielateľovi.{{/ak}}",
+      ),
+    },
+  },
+  {
+    key: "posta_2",
+    label: "Nevyzdvihnutá zásielka — 2. pripomienka",
+    description: "Druhý e-mail, keď zásielka na pošte stále čaká.",
+    ownPlaceholders: POSTA_PLACEHOLDERS,
+    defaultText: {
+      subject: "Pripomienka: zásielka stále čaká | {{cislo_zasielky}}",
+      body: postaBody(
+        `opätovne vás upozorňujeme, že vaša zásielka č. **{{cislo_zasielky}}** je stále uložená ${POSTA_MIESTO} a zatiaľ nebola vyzdvihnutá.`,
+        "{{#ak termin_vyzdvihnutia}}Termín na vyzdvihnutie sa blíži: **{{termin_vyzdvihnutia}}**. Po tomto dátume bude zásielka vrátená.{{inak}}Prosím vyzdvihnite si ju čo najskôr. Zásielka bude čoskoro vrátená odosielateľovi.{{/ak}}",
+      ),
+    },
+  },
+  {
+    key: "posta_3",
+    label: "Nevyzdvihnutá zásielka — 3. posledné upozornenie",
+    description: "Tretí e-mail — posledné upozornenie pred vrátením zásielky.",
+    ownPlaceholders: POSTA_PLACEHOLDERS,
+    defaultText: {
+      subject: "Posledné upozornenie: zásielka bude vrátená | {{cislo_zasielky}}",
+      body: postaBody(
+        `toto je naše posledné upozornenie — vaša zásielka č. **{{cislo_zasielky}}** je stále ${POSTA_MIESTO}.`,
+        "{{#ak termin_vyzdvihnutia}}Ak si ju nevyzdvihnete do **{{termin_vyzdvihnutia}}**, bude vrátená späť odosielateľovi.{{inak}}Ak si ju čoskoro nevyzdvihnete, bude vrátená späť odosielateľovi.{{/ak}}",
+      ),
+    },
+  },
+  {
+    key: "posta_4",
+    label: "Nevyzdvihnutá zásielka — posledná výzva",
+    description: "Štvrtý a každý ďalší e-mail — zásielka sa v najbližších dňoch vracia.",
+    ownPlaceholders: POSTA_PLACEHOLDERS,
+    defaultText: {
+      subject: "Posledná výzva: zásielka bude vrátená | {{cislo_zasielky}}",
+      body: postaBody(
+        `napriek opakovaným upozorneniam vaša zásielka č. **{{cislo_zasielky}}** je stále nevyzdvihnutá ${POSTA_MIESTO}.`,
+        "Zásielka bude v najbližších dňoch vrátená späť. Ak ju stále chcete, prosím kontaktujte nás čo najskôr na {{kontakt_email}} alebo telefonicky.",
+      ),
+    },
+  },
+  {
+    key: "order_reminder",
+    label: "Pripomienka objednávky",
+    description: "E-mail zákazníkovi, ktorého objednávka sa vybavuje dlhšie než obvykle.",
+    ownPlaceholders: [MENO, CISLO_OBJEDNAVKY],
+    defaultText: {
+      subject: "📦 Stav vašej objednávky z Forestshop.sk",
+      body: [
+        "Dobrý deň, **{{meno_zakaznika}}**,",
+        "",
+        "Všimli sme si, že spracovanie vašej objednávky č. **{{cislo_objednavky}}** trvá o niečo dlhšie než obvykle. Chceme vás ubezpečiť, že situáciu aktívne sledujeme a riešime.",
+        "",
+        "Mierne zdržanie môže byť spôsobené dostupnosťou tovaru, dopĺňaním zásob alebo prepravnými okolnosťami. Rozumieme, že sa na svoju výbavu tešíte, a robíme všetko pre to, aby ste ju mali čo najskôr pri sebe.",
+        "",
+        "👉 V prípade potreby zmeny, alternatívy alebo potvrdenia z vašej strany vás budeme osobne kontaktovať v najbližšom čase.",
+        "",
+        "Ďakujeme vám za trpezlivosť a dôveru. Ak máte akékoľvek otázky, pokojne nás kontaktujte na {{kontakt_email}} alebo na telefónnom čísle {{kontakt_telefon}}.",
+        "",
+        PODPIS_TIM,
+      ].join("\n"),
+    },
+  },
+  {
+    key: "supplier_order",
+    label: "Objednávka dodávateľovi",
+    description: "Hromadný zoznam položiek, ktorý sa posiela dodávateľovi. Tento e-mail je čisto textový.",
+    ownPlaceholders: [
+      { name: "dodavatel", label: "Názov dodávateľa", example: { kind: "text", text: "DODAVATEL-TEST-1" } },
+      { name: "pocet_poloziek", label: "Počet položiek", example: { kind: "text", text: "2" } },
+      { name: "slovo_poloziek", label: "Slovo „položka“ v správnom tvare", example: { kind: "text", text: "položky" } },
+      {
+        name: "zoznam_poloziek",
+        label: "Zoznam objednávaných položiek",
+        example: { kind: "list", items: [{ label: "4859/46 | kód 12345 | 46 | 2 ks" }, { label: "40287 | 1 ks" }] },
+      },
+    ],
+    defaultText: {
+      subject: "Objednávka — {{dodavatel}} ({{pocet_poloziek}} {{slovo_poloziek}})",
+      // Prvý riadok tela ZÁMERNE opakuje predmet a za ním nasleduje JEDNO
+      // zalomenie — presne tak, ako to appka posielala doteraz
+      // (`[subject, ...lines].join("\n")`).
+      body: "Objednávka — {{dodavatel}} ({{pocet_poloziek}} {{slovo_poloziek}})\n{{zoznam_poloziek}}",
+    },
+  },
+];
+
+export const MAIL_TEMPLATE_KINDS: Readonly<Record<MailTemplateKey, MailTemplateKind>> = Object.fromEntries(
+  KINDS.map((kind) => [kind.key, kind]),
+) as Readonly<Record<MailTemplateKey, MailTemplateKind>>;
+
+/** Všetky polia, ktoré daná šablóna smie použiť — vlastné plus spoločné. */
+export function placeholdersFor(key: MailTemplateKey): readonly PlaceholderDef[] {
+  return [...MAIL_TEMPLATE_KINDS[key].ownPlaceholders, ...GLOBAL_PLACEHOLDERS];
+}
+
+export function allowedPlaceholderNames(key: MailTemplateKey): ReadonlySet<string> {
+  return new Set(placeholdersFor(key).map((p) => p.name));
+}
+
+/** Kontext zložený z ukážkových hodnôt — základ pre náhľad, ktorý sa prekryje
+ * skutočnými dátami, ak sa nejaké nájdu (`samples.ts`). */
+export function exampleContext(key: MailTemplateKey): Record<string, TemplateValue> {
+  return Object.fromEntries(placeholdersFor(key).map((p) => [p.name, p.example]));
+}

--- a/apps/api/src/modules/mail-templates/render.test.ts
+++ b/apps/api/src/modules/mail-templates/render.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import { renderTemplate, validateTemplateText, type TemplateContext } from "./render.js";
+
+// issue 192. Čistá jednotka — žiadna databáza, žiadna sieť, nikdy sa nič
+// neodosiela.
+
+const CTX: TemplateContext = {
+  meno_zakaznika: { kind: "text", text: "Ján Novák" },
+  cislo_objednavky: { kind: "text", text: "20260123" },
+  termin_vyzdvihnutia: { kind: "text", text: "" },
+  odkaz_sledovanie: { kind: "link", url: "https://tandt.posta.sk/x", label: "https://tandt.posta.sk/x" },
+  zoznam_nahrad: { kind: "list", textPrefix: "- ", items: [{ label: "Podkolienky BOBR", url: "https://e.sk/bobr" }] },
+  prazdny_zoznam: { kind: "list", items: [] },
+};
+
+const ALLOWED = new Set(Object.keys(CTX));
+
+describe("renderTemplate — dosadzovanie polí", () => {
+  it("dosadí text a odkaz do HTML aj do čistého textu", () => {
+    const out = renderTemplate({ subject: "Objednávka {{cislo_objednavky}}", body: "Dobrý deň, {{meno_zakaznika}}.\n\nSledovanie: {{odkaz_sledovanie}}" }, CTX);
+    expect(out.subject).toBe("Objednávka 20260123");
+    expect(out.html).toContain("<p>Dobrý deň, Ján Novák.</p>");
+    expect(out.html).toContain('<a href="https://tandt.posta.sk/x" target="_blank">https://tandt.posta.sk/x</a>');
+    expect(out.text).toBe("Dobrý deň, Ján Novák.\n\nSledovanie: https://tandt.posta.sk/x");
+  });
+
+  it("neznáme pole sa ticho zahodí (uložiť sa taká šablóna vôbec nedá — viď kontrolu nižšie)", () => {
+    const out = renderTemplate({ subject: "x", body: "A{{neexistuje}}B" }, CTX);
+    expect(out.text).toBe("AB");
+  });
+});
+
+describe("renderTemplate — tučné písmo", () => {
+  it("spáruje hviezdičky OKOLO zástupného poľa (padli by do dvoch rôznych útržkov)", () => {
+    const out = renderTemplate({ subject: "x", body: "Dobrý deň, **{{meno_zakaznika}}**," }, CTX);
+    expect(out.html).toContain("<p>Dobrý deň, <strong>Ján Novák</strong>,</p>");
+    expect(out.text).toBe("Dobrý deň, Ján Novák,");
+  });
+
+  it("dva nezávislé tučné úseky v tom istom texte sa nepomiešajú", () => {
+    const out = renderTemplate({ subject: "x", body: "**{{meno_zakaznika}}** a **{{cislo_objednavky}}**" }, CTX);
+    expect(out.html).toContain("<p><strong>Ján Novák</strong> a <strong>20260123</strong></p>");
+  });
+
+  it("nedovretá hviezdička sa uzavrie na konci odstavca — nikdy rozbité HTML", () => {
+    const out = renderTemplate({ subject: "x", body: "**zabudnutá\n\nĎalší odstavec" }, CTX);
+    expect(out.html).toContain("<p><strong>zabudnutá</strong></p>");
+    expect(out.html).toContain("<p>Ďalší odstavec</p>");
+  });
+});
+
+describe("renderTemplate — bezpečnosť", () => {
+  it("HTML v hodnote poľa sa escapuje a NIKDY sa z neho nestane značka", () => {
+    const out = renderTemplate({ subject: "x", body: "Meno: {{meno_zakaznika}}" }, { meno_zakaznika: { kind: "text", text: '<script>alert("x")</script>' } });
+    expect(out.html).toContain("&lt;script&gt;");
+    expect(out.html).not.toContain("<script>");
+  });
+
+  it("hviezdičky V HODNOTE poľa neformátujú — značku smie zapísať len šablóna", () => {
+    const out = renderTemplate({ subject: "x", body: "Meno: {{meno_zakaznika}}" }, { meno_zakaznika: { kind: "text", text: "**tučný útok**" } });
+    expect(out.html).toContain("**tučný útok**");
+    expect(out.html).not.toContain("<strong>");
+  });
+});
+
+describe("renderTemplate — podmienky", () => {
+  const body = "{{#ak termin_vyzdvihnutia}}do {{termin_vyzdvihnutia}}{{inak}}čo najskôr{{/ak}}";
+
+  it("prázdna hodnota vezme vetvu {{inak}}", () => {
+    expect(renderTemplate({ subject: "x", body }, CTX).text).toBe("čo najskôr");
+  });
+
+  it("vyplnená hodnota vezme prvú vetvu", () => {
+    const ctx = { ...CTX, termin_vyzdvihnutia: { kind: "text" as const, text: "12. 8. 2026" } };
+    expect(renderTemplate({ subject: "x", body }, ctx).text).toBe("do 12. 8. 2026");
+  });
+
+  it("prázdny zoznam je pre podmienku nevyplnená hodnota", () => {
+    const out = renderTemplate({ subject: "x", body: "{{#ak prazdny_zoznam}}je{{inak}}nie je{{/ak}}" }, CTX);
+    expect(out.text).toBe("nie je");
+  });
+});
+
+describe("renderTemplate — zoznam", () => {
+  it("v HTML je odrážkový zoznam s odkazmi, v texte riadky s predponou", () => {
+    const out = renderTemplate({ subject: "x", body: "Náhrady:\n{{zoznam_nahrad}}" }, CTX);
+    expect(out.html).toContain('<li><a href="https://e.sk/bobr" target="_blank">Podkolienky BOBR</a></li>');
+    expect(out.text).toBe("Náhrady:\n- Podkolienky BOBR (https://e.sk/bobr)");
+  });
+
+  it("prázdny zoznam nevyrobí prázdny <ul>", () => {
+    const out = renderTemplate({ subject: "x", body: "A\n{{prazdny_zoznam}}" }, CTX);
+    expect(out.html).not.toContain("<ul>");
+  });
+});
+
+describe("renderTemplate — predmet", () => {
+  it("zalomenia v predmete sa zlúčia do jedného riadku", () => {
+    expect(renderTemplate({ subject: "  Prvý\n\ndruhý  ", body: "x" }, CTX).subject).toBe("Prvý druhý");
+  });
+});
+
+describe("validateTemplateText", () => {
+  it("platná šablóna nevráti žiadnu chybu", () => {
+    expect(validateTemplateText({ subject: "Vec {{cislo_objednavky}}", body: "Ahoj {{meno_zakaznika}}" }, ALLOWED)).toEqual([]);
+  });
+
+  it("neznáme pole sa odmietne a chyba ho pomenuje", () => {
+    const errors = validateTemplateText({ subject: "x", body: "{{neznamy_kluc}}" }, ALLOWED);
+    expect(errors.join(" ")).toContain("{{neznamy_kluc}}");
+  });
+
+  it("pole použité v podmienke sa tiež kontroluje", () => {
+    const errors = validateTemplateText({ subject: "x", body: "{{#ak vymysleny}}a{{/ak}}" }, ALLOWED);
+    expect(errors.join(" ")).toContain("{{vymysleny}}");
+  });
+
+  it("neuzavretá podmienka sa odmietne", () => {
+    expect(validateTemplateText({ subject: "x", body: "{{#ak meno_zakaznika}}a" }, ALLOWED).join(" ")).toContain("nie je uzavretá");
+  });
+
+  it("vnorená podmienka sa odmietne", () => {
+    const body = "{{#ak meno_zakaznika}}{{#ak cislo_objednavky}}a{{/ak}}{{/ak}}";
+    expect(validateTemplateText({ subject: "x", body }, ALLOWED).join(" ")).toContain("vnorená");
+  });
+
+  it("{{/ak}} bez otvorenia sa odmietne", () => {
+    expect(validateTemplateText({ subject: "x", body: "a{{/ak}}" }, ALLOWED).join(" ")).toContain("navyše");
+  });
+
+  it("prázdny predmet aj prázdne telo sa odmietnu", () => {
+    const errors = validateTemplateText({ subject: "   ", body: "\n" }, ALLOWED);
+    expect(errors).toHaveLength(2);
+  });
+});

--- a/apps/api/src/modules/mail-templates/render.ts
+++ b/apps/api/src/modules/mail-templates/render.ts
@@ -1,0 +1,304 @@
+// issue 192: majiteľ si upravuje ZNENIE e-mailov, nie ich HTML. Šablóna je
+// obyčajný text so zástupnými poľami; táto jednotka z nej vyrobí HTML aj
+// čistotextovú verziu. Escapovanie tak ostáva výhradne na appke — meno
+// zákazníka, názov tovaru ani nič iné sa nikdy nedostane do HTML surové, aj
+// keby majiteľ do šablóny napísal čokoľvek.
+//
+// Podporovaná značka (zámerne minimum, viď návrhový komentár na tickete):
+//   {{pole}}                        zástupné pole (text / odkaz / zoznam)
+//   {{#ak pole}}…{{inak}}…{{/ak}}   podmienená časť (bez vnorenia)
+//   **tučné**
+//   prázdny riadok = nový odstavec, jednoduchý riadok = zalomenie
+
+export interface TemplateListItem {
+  readonly label: string;
+  readonly url?: string;
+}
+
+export type TemplateValue =
+  | { readonly kind: "text"; readonly text: string }
+  | { readonly kind: "link"; readonly url: string; readonly label: string }
+  | { readonly kind: "list"; readonly items: readonly TemplateListItem[]; readonly textPrefix?: string };
+
+export type TemplateContext = Readonly<Record<string, TemplateValue>>;
+
+export interface MailTemplateText {
+  readonly subject: string;
+  readonly body: string;
+}
+
+export interface RenderedEmail {
+  readonly subject: string;
+  readonly html: string;
+  readonly text: string;
+}
+
+const PLACEHOLDER_NAME_RE = /^[a-z][a-z0-9_]*$/;
+const TOKEN_RE = /\{\{\s*([^{}]*?)\s*\}\}/g;
+
+type Node =
+  | { readonly t: "lit"; readonly s: string }
+  | { readonly t: "ph"; readonly name: string }
+  | { readonly t: "if"; readonly name: string; readonly then: readonly Node[]; readonly other: readonly Node[] };
+
+export class TemplateSyntaxError extends Error {}
+
+/** Rozloží šablónu na uzly. Vyhodí `TemplateSyntaxError` s vetou po slovensky —
+ * volajúci ju ukáže obsluhe (`validateTemplateText`), nikdy zákazníkovi. */
+function parse(source: string): readonly Node[] {
+  const root: Node[] = [];
+  // Naraz smie byť otvorená najviac JEDNA podmienka — vnorenie je zakázané
+  // zámerne (znenia e-mailov ho nepotrebujú a vnorené vetvy sa v textovom
+  // poli nedajú prehľadne skontrolovať).
+  let open: { readonly name: string; readonly then: Node[]; readonly other: Node[]; inElse: boolean } | null = null;
+  const push = (node: Node): void => {
+    if (open === null) root.push(node);
+    else if (open.inElse) open.other.push(node);
+    else open.then.push(node);
+  };
+
+  let last = 0;
+  TOKEN_RE.lastIndex = 0;
+  let m: RegExpExecArray | null = TOKEN_RE.exec(source);
+  while (m !== null) {
+    if (m.index > last) push({ t: "lit", s: source.slice(last, m.index) });
+    last = m.index + m[0].length;
+    const inner = (m[1] ?? "").trim();
+
+    if (inner.startsWith("#ak")) {
+      const name = inner.slice(3).trim();
+      if (!PLACEHOLDER_NAME_RE.test(name)) throw new TemplateSyntaxError(`Podmienka „{{#ak ${name}}}“ nemá platný názov poľa.`);
+      if (open !== null) throw new TemplateSyntaxError("Podmienka vnorená v inej podmienke sa nepodporuje — rozdeľte text na dve samostatné podmienky.");
+      open = { name, then: [], other: [], inElse: false };
+    } else if (inner === "inak") {
+      if (open === null) throw new TemplateSyntaxError("„{{inak}}“ je mimo podmienky — chýba k nemu „{{#ak pole}}“.");
+      if (open.inElse) throw new TemplateSyntaxError("Jedna podmienka smie mať najviac jedno „{{inak}}“.");
+      open.inElse = true;
+    } else if (inner === "/ak") {
+      if (open === null) throw new TemplateSyntaxError("„{{/ak}}“ je navyše — chýba k nemu „{{#ak pole}}“.");
+      root.push({ t: "if", name: open.name, then: open.then, other: open.other });
+      open = null;
+    } else {
+      if (!PLACEHOLDER_NAME_RE.test(inner)) {
+        throw new TemplateSyntaxError(`„{{${inner}}}“ nie je platné zástupné pole (povolené sú malé písmená, číslice a podčiarkovník).`);
+      }
+      push({ t: "ph", name: inner });
+    }
+    m = TOKEN_RE.exec(source);
+  }
+  if (open !== null) throw new TemplateSyntaxError(`Podmienka „{{#ak ${open.name}}}“ nie je uzavretá — chýba „{{/ak}}“.`);
+  if (last < source.length) push({ t: "lit", s: source.slice(last) });
+  return root;
+}
+
+function htmlEscape(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+// `**tučné**` sa spracúva ako DVOJICA ZNAČIEK v prúde útržkov, nie ako
+// náhrada regulárnym výrazom nad jedným reťazcom. Dôvod je vecný: značky
+// bežne obklopujú zástupné pole (`**{{meno_zakaznika}}**`), takže otváracia a
+// zatváracia hviezdička padnú do DVOCH RÔZNYCH doslovných útržkov a regulárny
+// výraz by ich nikdy nespároval — namiesto toho by spároval zatváraciu
+// hviezdičku s otváracou o niekoľko odstavcov nižšie a vyrobil rozbité HTML
+// (nájdené testom pri prechode na šablóny, issue 192).
+//
+// Značka sa hľadá VÝHRADNE v doslovnom texte šablóny, nikdy v dosadenej
+// hodnote poľa — meno zákazníka s hviezdičkami tak nemá ako do e-mailu
+// prepašovať formátovanie.
+
+function isFilled(value: TemplateValue | undefined): boolean {
+  if (value === undefined) return false;
+  if (value.kind === "text") return value.text.trim() !== "";
+  if (value.kind === "link") return value.url.trim() !== "";
+  return value.items.length > 0;
+}
+
+// Medzikrok medzi uzlami a hotovým výstupom: doslovné zalomenia zo šablóny sa
+// musia dať odlíšiť od obsahu dosadených polí (zoznam náhrad nesmie sám od
+// seba založiť nový odstavec), preto sa neskladá jeden reťazec, ktorý by sa
+// potom delil, ale postupnosť bezpečných útržkov a značiek zalomenia.
+type Piece =
+  | { readonly p: "frag"; readonly s: string }
+  | { readonly p: "bold" }
+  | { readonly p: "br" }
+  | { readonly p: "par" }
+  | { readonly p: "list"; readonly items: readonly TemplateListItem[]; readonly textPrefix: string };
+
+type Mode = "html" | "text";
+
+function litPieces(raw: string, mode: Mode): Piece[] {
+  const prepared = mode === "html" ? htmlEscape(raw) : raw;
+  const out: Piece[] = [];
+  const paragraphs = prepared.split(/\n[ \t]*\n+/);
+  paragraphs.forEach((paragraph, pi) => {
+    if (pi > 0) out.push({ p: "par" });
+    paragraph.split("\n").forEach((line, li) => {
+      if (li > 0) out.push({ p: "br" });
+      line.split("**").forEach((part, si) => {
+        if (si > 0) out.push({ p: "bold" });
+        if (part !== "") out.push({ p: "frag", s: part });
+      });
+    });
+  });
+  return out;
+}
+
+function valuePieces(value: TemplateValue | undefined, mode: Mode): Piece[] {
+  if (value === undefined) return [];
+  if (value.kind === "text") {
+    return value.text === "" ? [] : [{ p: "frag", s: mode === "html" ? htmlEscape(value.text) : value.text }];
+  }
+  if (value.kind === "link") {
+    if (value.url === "") return [];
+    const label = value.label === "" ? value.url : value.label;
+    if (mode === "text") return [{ p: "frag", s: label === value.url ? value.url : `${label} (${value.url})` }];
+    return [{ p: "frag", s: `<a href="${htmlEscape(value.url)}" target="_blank">${htmlEscape(label)}</a>` }];
+  }
+  return [{ p: "list", items: value.items, textPrefix: value.textPrefix ?? "" }];
+}
+
+function toPieces(nodes: readonly Node[], ctx: TemplateContext, mode: Mode): Piece[] {
+  const out: Piece[] = [];
+  for (const node of nodes) {
+    if (node.t === "lit") out.push(...litPieces(node.s, mode));
+    else if (node.t === "ph") out.push(...valuePieces(ctx[node.name], mode));
+    else out.push(...toPieces(isFilled(ctx[node.name]) ? node.then : node.other, ctx, mode));
+  }
+  return out;
+}
+
+function assembleHtml(pieces: readonly Piece[]): string {
+  const blocks: string[] = [];
+  let current: string[] = [];
+  let boldOpen = false;
+  const flush = (): void => {
+    // Nedovretá značka sa uzavrie na konci odstavca — rozbité HTML sa nikdy
+    // nesmie dostať k zákazníkovi, ani keď majiteľ hviezdičku zabudne.
+    if (boldOpen) {
+      current.push("</strong>");
+      boldOpen = false;
+    }
+    const body = current.join("").trim();
+    current = [];
+    if (body !== "") blocks.push(`    <p>${body}</p>`);
+  };
+  for (const piece of pieces) {
+    if (piece.p === "frag") current.push(piece.s);
+    else if (piece.p === "bold") {
+      current.push(boldOpen ? "</strong>" : "<strong>");
+      boldOpen = !boldOpen;
+    } else if (piece.p === "br") current.push("<br>\n      ");
+    else if (piece.p === "par") flush();
+    else {
+      flush();
+      const items = piece.items
+        .map((i) => {
+          const label = htmlEscape(i.label);
+          const shown = i.url === undefined || i.url === "" ? label : `<a href="${htmlEscape(i.url)}" target="_blank">${label}</a>`;
+          return `      <li>${shown}</li>`;
+        })
+        .join("\n");
+      if (items !== "") blocks.push(`    <ul>\n${items}\n    </ul>`);
+    }
+  }
+  flush();
+  return [
+    "<!DOCTYPE html>",
+    "<html>",
+    '  <body style="font-family: Arial, sans-serif; font-size: 16px; color: #333;">',
+    ...blocks,
+    "  </body>",
+    "</html>",
+  ].join("\n");
+}
+
+function assembleText(pieces: readonly Piece[]): string {
+  const paragraphs: string[] = [];
+  let current: string[] = [];
+  const flush = (): void => {
+    const body = current.join("").trim();
+    current = [];
+    if (body !== "") paragraphs.push(body);
+  };
+  for (const piece of pieces) {
+    if (piece.p === "frag") current.push(piece.s);
+    else if (piece.p === "bold") continue; // čistý text tučné písmo nemá
+    else if (piece.p === "br") current.push("\n");
+    else if (piece.p === "par") flush();
+    else {
+      const lines = piece.items
+        .map((i) => `${piece.textPrefix}${i.label}${i.url === undefined || i.url === "" ? "" : ` (${i.url})`}`)
+        .join("\n");
+      if (lines !== "") current.push(lines);
+    }
+  }
+  flush();
+  return paragraphs.join("\n\n");
+}
+
+function assembleSubject(pieces: readonly Piece[]): string {
+  return pieces
+    .map((piece) => {
+      if (piece.p === "frag") return piece.s;
+      if (piece.p === "bold") return "";
+      if (piece.p === "list") return piece.items.map((i) => i.label).join(", ");
+      return " ";
+    })
+    .join("")
+    .replaceAll(/\s+/g, " ")
+    .trim();
+}
+
+export function renderTemplate(template: MailTemplateText, ctx: TemplateContext): RenderedEmail {
+  const bodyNodes = parse(template.body);
+  return {
+    subject: assembleSubject(toPieces(parse(template.subject), ctx, "text")),
+    html: assembleHtml(toPieces(bodyNodes, ctx, "html")),
+    text: assembleText(toPieces(bodyNodes, ctx, "text")),
+  };
+}
+
+/** Mená zástupných polí použitých v texte — vrátane tých v podmienkach. */
+function collectNames(nodes: readonly Node[], into: Set<string>): void {
+  for (const node of nodes) {
+    if (node.t === "ph") into.add(node.name);
+    else if (node.t === "if") {
+      into.add(node.name);
+      collectNames(node.then, into);
+      collectNames(node.other, into);
+    }
+  }
+}
+
+/** Kontrola PRED uložením: prázdny predmet/telo, chybná značka, neznáme pole.
+ * Vracia vety po slovensky (prázdne pole = šablóna je v poriadku). Toto je
+ * jediná poistka proti tomu, aby sa preklep v názve poľa dostal k zákazníkovi
+ * ako surový text — samotné renderovanie neznáme pole ticho zahodí. */
+export function validateTemplateText(template: MailTemplateText, allowedNames: ReadonlySet<string>): readonly string[] {
+  const errors: string[] = [];
+  if (template.subject.trim() === "") errors.push("Predmet e-mailu nesmie byť prázdny.");
+  if (template.body.trim() === "") errors.push("Text e-mailu nesmie byť prázdny.");
+  const used = new Set<string>();
+  const sources: readonly (readonly [string, string])[] = [
+    ["Predmet", template.subject],
+    ["Text", template.body],
+  ];
+  for (const [label, source] of sources) {
+    try {
+      collectNames(parse(source), used);
+    } catch (error) {
+      errors.push(`${label}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+  const unknown = [...used].filter((name) => !allowedNames.has(name)).sort();
+  if (unknown.length > 0) {
+    errors.push(`Neznáme zástupné pole: ${unknown.map((n) => `{{${n}}}`).join(", ")}. Vyberte pole zo zoznamu vpravo.`);
+  }
+  return errors;
+}

--- a/apps/api/src/modules/mail-templates/samples.ts
+++ b/apps/api/src/modules/mail-templates/samples.ts
@@ -1,0 +1,101 @@
+import { desc, isNotNull } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { orders, products, variants } from "../../db/schema.js";
+import { log } from "../../logger.js";
+import { alternativeSearchUrl } from "../nedostupne/constants.js";
+import { itemsWord } from "../orders/pluralize.js";
+import { trackingLink } from "../posta-uncollected/constants.js";
+import { textValue } from "./context.js";
+import { exampleContext, type MailTemplateKey } from "./registry.js";
+import type { TemplateContext, TemplateValue } from "./render.js";
+
+// issue 192, ticket: "Náhľad na skutočných dátach ešte pri úprave". Náhľad sa
+// preto neskladá z vymyslených hodnôt, ale z toho, čo appka reálne má —
+// posledná objednávka, skutočný názov tovaru, skutočné číslo zásielky.
+// Keď sa vzorka nenájde (prázdna databáza, čerstvé nasadenie), použijú sa
+// ukážkové hodnoty z registra: náhľad musí fungovať VŽDY, nikdy nesmie
+// spadnúť na chýbajúcich dátach.
+
+async function latestOrder(db: Database): Promise<{ customerName: string; code: string; packageNumber: string | null } | null> {
+  const [row] = await db
+    .select({ customerName: orders.customerName, code: orders.externalOrderId, packageNumber: orders.packageNumber })
+    .from(orders)
+    .orderBy(desc(orders.placedAt))
+    .limit(1);
+  return row ?? null;
+}
+
+async function latestOrderWithPackage(db: Database): Promise<{ customerName: string; packageNumber: string } | null> {
+  const [row] = await db
+    .select({ customerName: orders.customerName, packageNumber: orders.packageNumber })
+    .from(orders)
+    .where(isNotNull(orders.packageNumber))
+    .orderBy(desc(orders.placedAt))
+    .limit(1);
+  return row?.packageNumber == null ? null : { customerName: row.customerName, packageNumber: row.packageNumber };
+}
+
+async function productSample(db: Database): Promise<{ name: string; relatedCodes: readonly string[] } | null> {
+  const [row] = await db.select({ name: variants.name, productKey: variants.productKey }).from(variants).limit(1);
+  if (row === undefined) return null;
+  const [prod] = await db.select({ relatedCodes: products.relatedCodes }).from(products).limit(1);
+  return { name: row.name, relatedCodes: prod?.relatedCodes ?? [] };
+}
+
+async function supplierSample(db: Database): Promise<string | null> {
+  const [row] = await db.select({ supplier: products.supplier }).from(products).where(isNotNull(products.supplier)).limit(1);
+  return row?.supplier ?? null;
+}
+
+/** Kontext pre náhľad — ukážkové hodnoty prekryté skutočnými dátami, ak sa
+ * nejaké nájdu. Nikdy nevyhodí: pri akejkoľvek chybe dopytu ostanú ukážkové
+ * hodnoty a náhľad ďalej funguje. */
+export async function previewContext(db: Database, key: MailTemplateKey): Promise<TemplateContext> {
+  const ctx: Record<string, TemplateValue> = exampleContext(key);
+  try {
+    if (key === "order_reminder") {
+      const order = await latestOrder(db);
+      if (order !== null) {
+        ctx["meno_zakaznika"] = textValue(order.customerName);
+        ctx["cislo_objednavky"] = textValue(order.code);
+      }
+    } else if (key === "nedostupne" || key === "nedostupne_alternativa") {
+      const order = await latestOrder(db);
+      if (order !== null) ctx["meno_zakaznika"] = textValue(order.customerName);
+      if (key === "nedostupne_alternativa") {
+        const product = await productSample(db);
+        if (product !== null) {
+          ctx["nazov_tovaru"] = textValue(product.name);
+          if (product.relatedCodes.length > 0) {
+            ctx["zoznam_nahrad"] = {
+              kind: "list",
+              textPrefix: "- ",
+              items: product.relatedCodes.map((code) => ({ label: code, url: alternativeSearchUrl(code) })),
+            };
+          }
+        }
+      }
+    } else if (key.startsWith("posta_")) {
+      const shipment = await latestOrderWithPackage(db);
+      if (shipment !== null) {
+        ctx["meno_zakaznika"] = textValue(shipment.customerName);
+        ctx["cislo_zasielky"] = textValue(shipment.packageNumber);
+        ctx["odkaz_sledovanie"] = { kind: "link", url: trackingLink(shipment.packageNumber), label: trackingLink(shipment.packageNumber) };
+      }
+    } else {
+      const supplier = await supplierSample(db);
+      if (supplier !== null) ctx["dodavatel"] = textValue(supplier);
+      const product = await productSample(db);
+      if (product !== null) {
+        ctx["pocet_poloziek"] = textValue("1");
+        ctx["slovo_poloziek"] = textValue(itemsWord(1));
+        ctx["zoznam_poloziek"] = { kind: "list", items: [{ label: `${product.name} | 1 ks` }] };
+      }
+    }
+  } catch (error) {
+    // Náhľad je pomocná funkcia — chýbajúca vzorka nikdy nesmie zhodiť
+    // obrazovku, na ktorej majiteľ upravuje text.
+    log.warn({ key, rawErrorMessage: error instanceof Error ? error.message : String(error) }, "náhľad e-mailu: vzorku skutočných dát sa nepodarilo načítať");
+  }
+  return ctx;
+}

--- a/apps/api/src/modules/mail-templates/store.ts
+++ b/apps/api/src/modules/mail-templates/store.ts
@@ -1,0 +1,134 @@
+import { and, desc, eq } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { mailTemplateHistory, mailTemplates, users } from "../../db/schema.js";
+import { allowedPlaceholderNames, MAIL_TEMPLATE_KEYS, MAIL_TEMPLATE_KINDS, type MailTemplateKey } from "./registry.js";
+import { validateTemplateText, type MailTemplateText } from "./render.js";
+
+// issue 192: čítanie a zápis upravených znení. Nikde tu nie je HTTP ani
+// e-mail — odosielacie cesty si len vypýtajú výsledné znenie
+// (`resolveTemplate`) a ďalej pracujú s čistou renderovacou funkciou.
+
+export interface ResolvedTemplate extends MailTemplateText {
+  readonly key: MailTemplateKey;
+  /** `false` = platí pôvodné znenie z kódu (v databáze nie je žiadny riadok). */
+  readonly isCustomized: boolean;
+  readonly updatedAt: Date | null;
+  readonly updatedByName: string | null;
+}
+
+/** Výsledné znenie pre daný druh e-mailu — upravené, ak existuje, inak
+ * pôvodné z kódu. Toto je JEDINÝ vstup odosielacích ciest; nikdy nečítaj
+ * `mailTemplates` priamo, inak by ti chýbal fallback na pôvodné znenie. */
+export async function resolveTemplate(db: Database, key: MailTemplateKey): Promise<MailTemplateText> {
+  const [row] = await db.select({ subject: mailTemplates.subject, body: mailTemplates.body }).from(mailTemplates).where(eq(mailTemplates.key, key)).limit(1);
+  return row ?? MAIL_TEMPLATE_KINDS[key].defaultText;
+}
+
+export async function listTemplates(db: Database): Promise<readonly ResolvedTemplate[]> {
+  const rows = await db
+    .select({
+      key: mailTemplates.key,
+      subject: mailTemplates.subject,
+      body: mailTemplates.body,
+      updatedAt: mailTemplates.updatedAt,
+      updatedByName: users.displayName,
+    })
+    .from(mailTemplates)
+    .leftJoin(users, eq(users.id, mailTemplates.updatedByUserId));
+  const byKey = new Map(rows.map((r) => [r.key, r]));
+  return MAIL_TEMPLATE_KEYS.map((key) => {
+    const row = byKey.get(key);
+    if (row === undefined) {
+      const { subject, body } = MAIL_TEMPLATE_KINDS[key].defaultText;
+      return { key, subject, body, isCustomized: false, updatedAt: null, updatedByName: null };
+    }
+    return {
+      key,
+      subject: row.subject,
+      body: row.body,
+      isCustomized: true,
+      updatedAt: row.updatedAt,
+      updatedByName: row.updatedByName,
+    };
+  });
+}
+
+export type SaveTemplateResult = { readonly ok: true } | { readonly ok: false; readonly errors: readonly string[] };
+
+/** Uloží upravené znenie. Kontrola beží PRED zápisom — neplatná šablóna sa
+ * neuloží vôbec, takže preklep v názve poľa sa nikdy nemôže dostať k
+ * zákazníkovi ako surový text. */
+export async function saveTemplate(
+  db: Database,
+  input: { readonly key: MailTemplateKey; readonly subject: string; readonly body: string; readonly userId: string; readonly now: Date },
+): Promise<SaveTemplateResult> {
+  const text: MailTemplateText = { subject: input.subject.trim(), body: input.body.trim() };
+  const errors = validateTemplateText(text, allowedPlaceholderNames(input.key));
+  if (errors.length > 0) return { ok: false, errors };
+
+  await db.transaction(async (tx) => {
+    await tx
+      .insert(mailTemplates)
+      .values({ key: input.key, subject: text.subject, body: text.body, updatedAt: input.now, updatedByUserId: input.userId })
+      .onConflictDoUpdate({
+        target: mailTemplates.key,
+        set: { subject: text.subject, body: text.body, updatedAt: input.now, updatedByUserId: input.userId },
+      });
+    await tx.insert(mailTemplateHistory).values({
+      key: input.key,
+      action: "save",
+      subject: text.subject,
+      body: text.body,
+      changedAt: input.now,
+      changedByUserId: input.userId,
+    });
+  });
+  return { ok: true };
+}
+
+/** Vráti pôvodné znenie = zmaže riadok. Do histórie sa zapíše, aké znenie
+ * odvtedy platí (to pôvodné z kódu), aby sa dala čítať bez znalosti verzie
+ * kódu. */
+export async function resetTemplate(
+  db: Database,
+  input: { readonly key: MailTemplateKey; readonly userId: string; readonly now: Date },
+): Promise<void> {
+  const original = MAIL_TEMPLATE_KINDS[input.key].defaultText;
+  await db.transaction(async (tx) => {
+    await tx.delete(mailTemplates).where(eq(mailTemplates.key, input.key));
+    await tx.insert(mailTemplateHistory).values({
+      key: input.key,
+      action: "reset",
+      subject: original.subject,
+      body: original.body,
+      changedAt: input.now,
+      changedByUserId: input.userId,
+    });
+  });
+}
+
+export interface TemplateHistoryEntry {
+  readonly id: string;
+  readonly action: "save" | "reset";
+  readonly subject: string;
+  readonly body: string;
+  readonly changedAt: Date;
+  readonly changedByName: string | null;
+}
+
+export async function listTemplateHistory(db: Database, key: MailTemplateKey, limit = 20): Promise<readonly TemplateHistoryEntry[]> {
+  return db
+    .select({
+      id: mailTemplateHistory.id,
+      action: mailTemplateHistory.action,
+      subject: mailTemplateHistory.subject,
+      body: mailTemplateHistory.body,
+      changedAt: mailTemplateHistory.changedAt,
+      changedByName: users.displayName,
+    })
+    .from(mailTemplateHistory)
+    .leftJoin(users, eq(users.id, mailTemplateHistory.changedByUserId))
+    .where(and(eq(mailTemplateHistory.key, key)))
+    .orderBy(desc(mailTemplateHistory.changedAt))
+    .limit(limit);
+}

--- a/apps/api/src/modules/nedostupne/constants.ts
+++ b/apps/api/src/modules/nedostupne/constants.ts
@@ -7,8 +7,6 @@ export const TYPE_ALTERNATIVE = "alternativa" as const;
 export const EMAIL_TYPES = [TYPE_UNAVAILABLE, TYPE_ALTERNATIVE] as const;
 export type NedostupneEmailType = (typeof EMAIL_TYPES)[number];
 
-export const UNAVAILABLE_SUBJECT = "Informácia o dostupnosti vašej objednávky — Forestshop.sk";
-export const ALTERNATIVE_SUBJECT = "Alternatívy k vášmu tovaru — Forestshop.sk";
 
 // Klikateľný fallback na vyhľadávanie podľa kódu — appka nemá žiadny zdroj
 // SKUTOČNEJ Shoptet produktovej URL (overené priamo na exporte: žiadny

--- a/apps/api/src/modules/nedostupne/logic.test.ts
+++ b/apps/api/src/modules/nedostupne/logic.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, it } from "vitest";
 import { alternativeSearchUrl } from "./constants.js";
+import { MAIL_TEMPLATE_KINDS } from "../mail-templates/registry.js";
 import { buildAlternativeEmail, buildAlternatives, buildUnavailableEmail } from "./logic.js";
+
+// issue 192: znenie žije v upraviteľnej šablóne — tieto testy overujú PÔVODNÉ
+// znenie, teda presne to, čo appka použije, kým majiteľ nič nezmení.
+const NEDOSTUPNE = MAIL_TEMPLATE_KINDS["nedostupne"].defaultText;
+const ALTERNATIVA = MAIL_TEMPLATE_KINDS["nedostupne_alternativa"].defaultText;
 
 describe("buildUnavailableEmail", () => {
   it("obsahuje pozdrav a majiteľov schválený generický text, bez konkrétneho produktu", () => {
-    const built = buildUnavailableEmail("Ján Zákazník");
+    const built = buildUnavailableEmail(NEDOSTUPNE, "Ján Zákazník");
     expect(built.subject).toBe("Informácia o dostupnosti vašej objednávky — Forestshop.sk");
     expect(built.html).toContain("Ján Zákazník");
     expect(built.html).toContain("je momentálne");
@@ -13,13 +19,13 @@ describe("buildUnavailableEmail", () => {
   });
 
   it("HTML-escapuje voľné meno zákazníka", () => {
-    const built = buildUnavailableEmail('<script>alert("x")</script>');
+    const built = buildUnavailableEmail(NEDOSTUPNE, '<script>alert("x")</script>');
     expect(built.html).not.toContain("<script>");
     expect(built.html).toContain("&lt;script&gt;");
   });
 
   it("prázdne meno padá späť na 'zákazník'", () => {
-    const built = buildUnavailableEmail("");
+    const built = buildUnavailableEmail(NEDOSTUPNE, "");
     expect(built.html).toContain(">zákazník<");
   });
 });
@@ -43,7 +49,7 @@ describe("buildAlternatives", () => {
 describe("buildAlternativeEmail", () => {
   it("s alternatívami vypíše odkazy na KAŽDÚ z nich", () => {
     const alts = buildAlternatives(["60116/90"], new Map([["60116/90", "Podkolienky BOBR"]]));
-    const built = buildAlternativeEmail("Ján Zákazník", "Nohavice FOREST 1003", alts);
+    const built = buildAlternativeEmail(ALTERNATIVA, "Ján Zákazník", "Nohavice FOREST 1003", alts);
     expect(built.subject).toBe("Alternatívy k vášmu tovaru — Forestshop.sk");
     expect(built.html).toContain("Nohavice FOREST 1003");
     expect(built.html).toContain("Podkolienky BOBR");
@@ -52,14 +58,14 @@ describe("buildAlternativeEmail", () => {
   });
 
   it("bez alternatív ponúkne kontaktnú vetu namiesto zoznamu", () => {
-    const built = buildAlternativeEmail("Ján Zákazník", "Nohavice FOREST 1003", []);
+    const built = buildAlternativeEmail(ALTERNATIVA, "Ján Zákazník", "Nohavice FOREST 1003", []);
     expect(built.html).toContain("Radi vám pomôžeme nájsť vhodnú alternatívu");
     expect(built.html).not.toContain("<ul>");
   });
 
   it("HTML-escapuje meno alternatívy aj názov produktu", () => {
     const alts = buildAlternatives(["X"], new Map([["X", "<b>Zlý</b> názov"]]));
-    const built = buildAlternativeEmail("Ján", '<i>Prod</i>', alts);
+    const built = buildAlternativeEmail(ALTERNATIVA, "Ján", '<i>Prod</i>', alts);
     expect(built.html).not.toContain("<b>Zlý</b>");
     expect(built.html).toContain("&lt;b&gt;Zlý&lt;/b&gt;");
     expect(built.html).not.toContain("<i>Prod</i>");

--- a/apps/api/src/modules/nedostupne/logic.ts
+++ b/apps/api/src/modules/nedostupne/logic.ts
@@ -1,64 +1,24 @@
-import { alternativeSearchUrl, ALTERNATIVE_SUBJECT, UNAVAILABLE_SUBJECT } from "./constants.js";
+import { globalContext, textValue } from "../mail-templates/context.js";
+import { renderTemplate, type MailTemplateText, type RenderedEmail } from "../mail-templates/render.js";
+import { alternativeSearchUrl } from "./constants.js";
 
-// Čistá logika (žiadna DB, žiadna sieť) — texty prevzaté doslovne zo starej
-// appky (`nedostupne.py`'s `build_unavailable_email`/`build_alternative_email`,
-// majiteľov schválený text, #183 v starej appke) — ticket #176: stará appka je
-// referencia na SPRÁVANIE/text, nikdy na vzhľad (`.claude/rules/frontend-
-// design.md`). HTML štýl (shell + signatúra) je rovnaký, aký táto appka už
-// používa v `order-reminder/logic.ts`'s `buildReminderEmail`.
+// Čistá logika (žiadna DB, žiadna sieť). Znenie e-mailu už NIE je natvrdo tu —
+// issue 192 ho presunulo do upraviteľných šablón (`mail-templates/registry.ts`
+// nesie pôvodné znenie, prevzaté doslovne z tohto súboru). Tu ostáva len to,
+// čo appka vie o konkrétnom prípade: aké hodnoty do šablóny dosadiť.
+// Volajúci (`send.ts`) si šablónu vypýta cez `resolveTemplate` — tieto funkcie
+// zostávajú čisté a testovateľné bez databázy.
 
-function htmlEscape(value: string): string {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&#39;");
-}
+export type BuiltNedostupneEmail = RenderedEmail;
 
-export interface BuiltNedostupneEmail {
-  readonly subject: string;
-  readonly html: string;
-  readonly text: string;
-}
-
-function shell(nameRaw: string, nameH: string, innerHtml: string, innerText: string, signHtml: string, signText: string): { html: string; text: string } {
-  const html = [
-    "<!DOCTYPE html>",
-    "<html>",
-    '  <body style="font-family: Arial, sans-serif; font-size: 16px; color: #333;">',
-    `    <p>Dobrý deň, <strong>${nameH}</strong>,</p>`,
-    "",
-    innerHtml,
-    '    <p style="margin-top: 30px;">',
-    `      ${signHtml}`,
-    "    </p>",
-    "  </body>",
-    "</html>",
-  ].join("\n");
-  const text = [`Dobrý deň, ${nameRaw},`, "", innerText, "", signText].join("\n");
-  return { html, text };
-}
-
-const SIGN_DRLIK_HTML = 'S pozdravom,<br>\n      <strong>Drlík, Forestshop.sk</strong><br>\n      <a href="https://www.forestshop.sk" target="_blank">www.forestshop.sk</a>';
-const SIGN_DRLIK_TEXT = "S pozdravom, Drlík, Forestshop.sk";
-const SIGN_DEFAULT_HTML = 'S pozdravom,<br>\n      <strong>Tím Forestshop.sk</strong><br>\n      <a href="https://www.forestshop.sk" target="_blank">www.forestshop.sk</a>';
-const SIGN_DEFAULT_TEXT = "S pozdravom, Tím Forestshop.sk";
-
-/** E-mail bez návrhu náhrady — majiteľov schválený generický text (stará
- * appka #183): zámerne NEuvádza konkrétny názov produktu. */
-export function buildUnavailableEmail(customerName: string): BuiltNedostupneEmail {
-  const nameRaw = (customerName || "").trim() || "zákazník";
-  const nameH = htmlEscape(nameRaw);
-  const innerHtml =
-    "    <p>veľmi sa ospravedlňujeme, ale tovar ktorý ste si objednali je momentálne " +
-    "nedostupný a nevieme kedy bude naskladnený. Z toho dôvodu nevieme Vašu objednávku " +
-    "úspešne vybaviť.</p>\n";
-  const innerText =
-    "veľmi sa ospravedlňujeme, ale tovar ktorý ste si objednali je momentálne nedostupný " +
-    "a nevieme kedy bude naskladnený. Z toho dôvodu nevieme Vašu objednávku úspešne vybaviť.";
-  const { html, text } = shell(nameRaw, nameH, innerHtml, innerText, SIGN_DRLIK_HTML, SIGN_DRLIK_TEXT);
-  return { subject: UNAVAILABLE_SUBJECT, html, text };
+/** E-mail bez návrhu náhrady — pôvodné znenie zámerne NEUVÁDZA konkrétny
+ * názov produktu (majiteľov schválený generický text, stará appka #183),
+ * preto tento druh e-mailu ponúka len meno zákazníka. */
+export function buildUnavailableEmail(template: MailTemplateText, customerName: string): BuiltNedostupneEmail {
+  return renderTemplate(template, {
+    ...globalContext(),
+    meno_zakaznika: textValue((customerName || "").trim() || "zákazník"),
+  });
 }
 
 export interface EmailAlternative {
@@ -79,40 +39,22 @@ export function buildAlternatives(codes: readonly string[], namesByCode: Readonl
 
 /** E-mail s návrhom náhrady — produkt je nedostupný + priamo priradené
  * alternatívy (relatedProduct*), rovnaký zámer ako stará appka's
- * `build_alternative_email`. */
-export function buildAlternativeEmail(customerName: string, itemName: string, alternatives: readonly EmailAlternative[]): BuiltNedostupneEmail {
-  const nameRaw = (customerName || "").trim() || "zákazník";
-  const nameH = htmlEscape(nameRaw);
-  const prodH = htmlEscape((itemName || "").trim() || "objednaný tovar");
-  const prodText = (itemName || "").trim() || "objednaný tovar";
-
-  const itemsHtml = alternatives
-    .map((a) => {
-      const altNameH = htmlEscape(a.name.trim() || a.code);
-      const hrefH = htmlEscape(a.url);
-      return `      <li><a href="${hrefH}" target="_blank">${altNameH}</a></li>`;
-    })
-    .join("\n");
-  const altBlockHtml =
-    alternatives.length > 0
-      ? `    <p>Radi by sme vám preto ponúkli tieto <strong>alternatívne produkty</strong>:</p>\n    <ul>\n${itemsHtml}\n    </ul>\n`
-      : "    <p>Radi vám pomôžeme nájsť vhodnú alternatívu — stačí nás kontaktovať.</p>\n";
-  const altBlockText =
-    alternatives.length > 0
-      ? `Alternatívne produkty:\n${alternatives.map((a) => `- ${a.name.trim() || a.code} (${a.url})`).join("\n")}`
-      : "Radi vám pomôžeme nájsť vhodnú alternatívu — stačí nás kontaktovať.";
-
-  const innerHtml =
-    `    <p>Radi by sme vás informovali, že produkt <strong>${prodH}</strong> z vašej objednávky je momentálne <strong>nedostupný</strong>.</p>\n\n` +
-    `${altBlockHtml}\n` +
-    '    <p>Ak máte akékoľvek otázky, pokojne nás kontaktujte na <a href="mailto:eshop@forestshop.sk">eshop@forestshop.sk</a> alebo na telefónnom čísle <a href="tel:+421903670766">+421 903 670 766</a>.</p>\n\n' +
-    "    <p>Ďakujeme vám za dôveru.</p>\n";
-  const innerText =
-    `Radi by sme vás informovali, že produkt ${prodText} z vašej objednávky je momentálne nedostupný.\n\n` +
-    `${altBlockText}\n\n` +
-    "Kontakt: eshop@forestshop.sk, +421 903 670 766.\n\n" +
-    "Ďakujeme vám za dôveru.";
-
-  const { html, text } = shell(nameRaw, nameH, innerHtml, innerText, SIGN_DEFAULT_HTML, SIGN_DEFAULT_TEXT);
-  return { subject: ALTERNATIVE_SUBJECT, html, text };
+ * `build_alternative_email`. Prázdny zoznam náhrad je v šablóne podmienka
+ * (`{{#ak zoznam_nahrad}}`), nie osobitná vetva v kóde. */
+export function buildAlternativeEmail(
+  template: MailTemplateText,
+  customerName: string,
+  itemName: string,
+  alternatives: readonly EmailAlternative[],
+): BuiltNedostupneEmail {
+  return renderTemplate(template, {
+    ...globalContext(),
+    meno_zakaznika: textValue((customerName || "").trim() || "zákazník"),
+    nazov_tovaru: textValue((itemName || "").trim() || "objednaný tovar"),
+    zoznam_nahrad: {
+      kind: "list",
+      textPrefix: "- ",
+      items: alternatives.map((a) => ({ label: a.name.trim() || a.code, url: a.url })),
+    },
+  });
 }

--- a/apps/api/src/modules/nedostupne/send.ts
+++ b/apps/api/src/modules/nedostupne/send.ts
@@ -3,6 +3,7 @@ import type { Database } from "../../db/client.js";
 import { log } from "../../logger.js";
 import { orderLines, orders, products, variants } from "../../db/schema.js";
 import type { MailTransport } from "../mail/transport.js";
+import { resolveTemplate } from "../mail-templates/store.js";
 import { listOpenStatusNames } from "../orders/open-statuses.js";
 import { NEDOSTUPNE_SEND_LOCK_KEY, TYPE_ALTERNATIVE, type NedostupneEmailType } from "./constants.js";
 import { buildAlternativeEmail, buildAlternatives, buildUnavailableEmail, type BuiltNedostupneEmail, type EmailAlternative } from "./logic.js";
@@ -59,9 +60,15 @@ export async function findNedostupneContext(db: Database, orderCode: string, var
 }
 
 /** Rovnaká funkcia sa volá pre NÁHĽAD aj pre SKUTOČNÉ odoslanie — garantuje,
- * že sa zákazníkovi pošle PRESNE to, čo obsluha videla v náhľade. */
-export function buildEmailForType(ctx: NedostupneEmailContext, type: NedostupneEmailType): BuiltNedostupneEmail {
-  return type === TYPE_ALTERNATIVE ? buildAlternativeEmail(ctx.customerName, ctx.itemName, ctx.alternatives) : buildUnavailableEmail(ctx.customerName);
+ * že sa zákazníkovi pošle PRESNE to, čo obsluha videla v náhľade. Znenie sa
+ * načíta z upraviteľnej šablóny (issue 192); keď majiteľ nič neupravil, vráti
+ * `resolveTemplate` pôvodné znenie z kódu. */
+export async function buildEmailForType(db: Database, ctx: NedostupneEmailContext, type: NedostupneEmailType): Promise<BuiltNedostupneEmail> {
+  if (type === TYPE_ALTERNATIVE) {
+    const template = await resolveTemplate(db, "nedostupne_alternativa");
+    return buildAlternativeEmail(template, ctx.customerName, ctx.itemName, ctx.alternatives);
+  }
+  return buildUnavailableEmail(await resolveTemplate(db, "nedostupne"), ctx.customerName);
 }
 
 export type SendNedostupneResult =
@@ -125,7 +132,7 @@ async function sendNedostupneEmailLocked(options: SendNedostupneOptions): Promis
   if (bccMissing) return { ok: false, code: "not_configured", reason: "chýba adresa pre skrytú kópiu majiteľovi (NEDOSTUPNE_BCC_EMAIL)" };
   if (mailTransport === undefined) return { ok: false, code: "not_configured", reason: "odosielanie e-mailov nie je nakonfigurované (chýba MAIL_HOST)" };
 
-  const built = buildEmailForType(ctx, emailType);
+  const built = await buildEmailForType(db, ctx, emailType);
   try {
     await mailTransport({ to: email, subject: built.subject, text: built.text, html: built.html, bcc: bccEmail });
   } catch (error) {

--- a/apps/api/src/modules/order-reminder/constants.ts
+++ b/apps/api/src/modules/order-reminder/constants.ts
@@ -7,7 +7,6 @@ export const MIN_DAYS = 4;
 
 // Stará appky's typo "Foresthop" opravený (rovnaký fix ako
 // `orders_reminder.py`'s vlastný komentár k tomu).
-export const EMAIL_SUBJECT = "📦 Stav vašej objednávky z Forestshop.sk";
 
 // Klasifikátorove dve kategórie (verbatim z n8n "Kontaktovany?" node) —
 // použité AJ v prompte, AJ ako jediné povolené výstupné hodnoty.

--- a/apps/api/src/modules/order-reminder/logic.test.ts
+++ b/apps/api/src/modules/order-reminder/logic.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { MAIL_TEMPLATE_KINDS } from "../mail-templates/registry.js";
 import {
   buildClassifierMessages,
   buildReminderEmail,
@@ -62,7 +63,7 @@ describe("fingerprint", () => {
 
 describe("buildReminderEmail", () => {
   it("obsahuje meno aj kód objednávky, HTML-escapované", () => {
-    const built = buildReminderEmail('Ján "Test" <Novák>', "20260001");
+    const built = buildReminderEmail(MAIL_TEMPLATE_KINDS["order_reminder"].defaultText, 'Ján "Test" <Novák>', "20260001");
     expect(built.subject).toBe("📦 Stav vašej objednávky z Forestshop.sk");
     expect(built.html).toContain("&lt;Novák&gt;");
     expect(built.html).toContain("&quot;Test&quot;");

--- a/apps/api/src/modules/order-reminder/logic.ts
+++ b/apps/api/src/modules/order-reminder/logic.ts
@@ -1,4 +1,6 @@
-import { CATEGORY_CONTACTED, CATEGORY_NOT_CONTACTED, EMAIL_SUBJECT, MIN_DAYS } from "./constants.js";
+import { globalContext, textValue } from "../mail-templates/context.js";
+import { renderTemplate, type MailTemplateText, type RenderedEmail } from "../mail-templates/render.js";
+import { CATEGORY_CONTACTED, CATEGORY_NOT_CONTACTED, MIN_DAYS } from "./constants.js";
 
 // Čistá logika (žiadna DB, žiadna sieť) — verný port `orders_reminder.py`,
 // prispôsobený tak, aby čítal priamo z `order` riadkov (nie z CSV export),
@@ -45,66 +47,18 @@ export function fingerprint(order: { readonly placedAt: Date; readonly shopRemar
   return `${order.placedAt.toISOString()}|${order.shopRemark ?? ""}`;
 }
 
-function htmlEscape(value: string): string {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&#39;");
-}
+export type BuiltReminderEmail = RenderedEmail;
 
-export interface BuiltReminderEmail {
-  readonly subject: string;
-  readonly html: string;
-  readonly text: string;
-}
-
-/** (subject, html, text) — doslovný preklad `orders_reminder.py`'s
- * `build_reminder_email` (n8n "Edit Fields2" šablóna), voľný text (meno, kód)
- * HTML-escapovaný. JEDEN e-mail, žiadne stupňovanie podľa poradia (na rozdiel
- * od #172's `buildEmail(count, ...)`). */
-export function buildReminderEmail(customerName: string, orderCode: string): BuiltReminderEmail {
-  const nameH = htmlEscape(customerName);
-  const codeH = htmlEscape(orderCode);
-  const html = [
-    "<!DOCTYPE html>",
-    "<html>",
-    '  <body style="font-family: Arial, sans-serif; font-size: 16px; color: #333;">',
-    `    <p>Dobrý deň, <strong>${nameH}</strong>,</p>`,
-    "",
-    `    <p>Všimli sme si, že spracovanie vašej objednávky č. <strong>${codeH}</strong> trvá o niečo dlhšie než obvykle. Chceme vás ubezpečiť, že situáciu aktívne sledujeme a riešime.</p>`,
-    "",
-    "    <p>Mierne zdržanie môže byť spôsobené dostupnosťou tovaru, dopĺňaním zásob alebo prepravnými okolnosťami. Rozumieme, že sa na svoju výbavu tešíte, a robíme všetko pre to, aby ste ju mali čo najskôr pri sebe.</p>",
-    "",
-    '    <p>👉 V prípade potreby zmeny, alternatívy alebo potvrdenia z vašej strany vás budeme osobne kontaktovať v najbližšom čase.</p>',
-    "",
-    '    <p>Ďakujeme vám za trpezlivosť a dôveru. Ak máte akékoľvek otázky, pokojne nás kontaktujte na <a href="mailto:eshop@forestshop.sk">eshop@forestshop.sk</a> alebo na telefónnom čísle <a href="tel:+421903670766">+421 903 670 766</a>.</p>',
-    "",
-    '    <p style="margin-top: 30px;">',
-    "      S pozdravom,<br>",
-    "      <strong>Tím Forestshop.sk</strong><br>",
-    '      <a href="https://www.forestshop.sk" target="_blank">www.forestshop.sk</a>',
-    "    </p>",
-    "  </body>",
-    "</html>",
-  ].join("\n");
-
-  const text = [
-    `Dobrý deň, ${customerName},`,
-    "",
-    `Všimli sme si, že spracovanie vašej objednávky č. ${orderCode} trvá o niečo dlhšie než obvykle. Chceme vás ubezpečiť, že situáciu aktívne sledujeme a riešime.`,
-    "",
-    "Mierne zdržanie môže byť spôsobené dostupnosťou tovaru, dopĺňaním zásob alebo prepravnými okolnosťami.",
-    "",
-    "V prípade potreby zmeny, alternatívy alebo potvrdenia z vašej strany vás budeme osobne kontaktovať v najbližšom čase.",
-    "",
-    "Ďakujeme vám za trpezlivosť a dôveru. Kontakt: eshop@forestshop.sk, +421 903 670 766.",
-    "",
-    "S pozdravom, Tím Forestshop.sk",
-  ].join("\n");
-
-  return { subject: EMAIL_SUBJECT, html, text };
+/** Dosadí hodnoty do upraviteľnej šablóny (issue 192 — pôvodné znenie, verný
+ * preklad `orders_reminder.py`'s `build_reminder_email`, žije v
+ * `mail-templates/registry.ts`). JEDEN e-mail, žiadne stupňovanie podľa
+ * poradia (na rozdiel od #172's štyroch zásielkových znení). */
+export function buildReminderEmail(template: MailTemplateText, customerName: string, orderCode: string): BuiltReminderEmail {
+  return renderTemplate(template, {
+    ...globalContext(),
+    meno_zakaznika: textValue(customerName),
+    cislo_objednavky: textValue(orderCode),
+  });
 }
 
 export interface ClassifierMessage {

--- a/apps/api/src/modules/order-reminder/run.ts
+++ b/apps/api/src/modules/order-reminder/run.ts
@@ -4,6 +4,7 @@ import type { MailTransport } from "../mail/transport.js";
 import { buildShoptetAdminOrderUrl } from "../orders/queries.js";
 import type { ClassifyClient } from "./classify-client.js";
 import { ORDER_REMINDER_RUN_LOCK_KEY } from "./constants.js";
+import { resolveTemplate } from "../mail-templates/store.js";
 import { buildReminderEmail, daysOpen, fingerprint, isOldEnough, type ReminderEligibleOrder } from "./logic.js";
 import { loadEligibleOrders, loadItemLabels } from "./orders-source.js";
 import {
@@ -121,6 +122,10 @@ async function runOrderReminderLocked(options: RunOrderReminderOptions): Promise
     resolvedBy,
   });
 
+  // Šablóna sa načíta RAZ pred cyklom (issue 192) — jeden beh smie poslať
+  // desiatky e-mailov a znenie sa počas neho meniť nemá.
+  const reminderTemplate = await resolveTemplate(db, "order_reminder");
+
   for (const order of candidates) {
     const fp = fingerprint(order);
     const existing = stateMap.get(order.externalOrderId);
@@ -192,7 +197,7 @@ async function runOrderReminderLocked(options: RunOrderReminderOptions): Promise
       continue;
     }
 
-    const built = buildReminderEmail(order.customerName, order.externalOrderId);
+    const built = buildReminderEmail(reminderTemplate, order.customerName, order.externalOrderId);
     try {
       await mailTransport({ to: email, subject: built.subject, text: built.text, html: built.html, bcc: bccEmail });
       // Zápis IHNEĎ po odoslaní — pád appky neskôr v behu nesmie stratiť
@@ -296,7 +301,7 @@ async function runOrderReminderOverrideLocked(options: RunOrderReminderOverrideO
   if (bccMissing) return { ok: false, code: "not_configured", reason: "chýba adresa pre skrytú kópiu majiteľovi (ORDER_REMINDER_BCC_EMAIL)" };
   if (mailTransport === undefined) return { ok: false, code: "not_configured", reason: "odosielanie e-mailov nie je nakonfigurované (chýba MAIL_HOST)" };
 
-  const built = buildReminderEmail(order.customerName, orderCode);
+  const built = buildReminderEmail(await resolveTemplate(db, "order_reminder"), order.customerName, orderCode);
   try {
     await mailTransport({ to: email, subject: built.subject, text: built.text, html: built.html, bcc: bccEmail });
   } catch (error) {

--- a/apps/api/src/modules/orders/mail.test.ts
+++ b/apps/api/src/modules/orders/mail.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
+import { MAIL_TEMPLATE_KINDS } from "../mail-templates/registry.js";
 import { formatSupplierOrderMailText, type SupplierOrderMailLine } from "./mail.js";
+
+// issue 192: pôvodné znenie objednávky dodávateľovi — presne to, čo appka
+// pošle, kým ho majiteľ nezmení. Tieto testy sú zároveň dôkazom, že prechod
+// na šablóny výsledný text NEZMENIL.
+const SUPPLIER = MAIL_TEMPLATE_KINDS["supplier_order"].defaultText;
 
 // Čisté funkcie (žiadna DB) — presné hranice slovenského skloňovania
 // (0, 1, 2, 4, 5) a zloženie riadku, ktoré `formatSupplierOrderMailText`
@@ -9,7 +15,7 @@ describe("formatSupplierOrderMailText", () => {
     const lines: SupplierOrderMailLine[] = [
       { variantCode: "40287", sizeLabel: null, quantity: 1, externalCode: null, supplierUrl: null },
     ];
-    const { subject, body } = formatSupplierOrderMailText("DODAVATEL-TEST-1", lines);
+    const { subject, body } = formatSupplierOrderMailText(SUPPLIER, "DODAVATEL-TEST-1", lines);
     expect(subject).toBe("Objednávka — DODAVATEL-TEST-1 (1 položka)");
     expect(body.split("\n")[0]).toBe(subject);
   });
@@ -29,7 +35,7 @@ describe("formatSupplierOrderMailText", () => {
       externalCode: null,
       supplierUrl: null,
     }));
-    const { subject } = formatSupplierOrderMailText("Dodávateľ", lines);
+    const { subject } = formatSupplierOrderMailText(SUPPLIER, "Dodávateľ", lines);
     expect(subject).toBe(`Objednávka — Dodávateľ (${String(count)} ${expectedWord})`);
   });
 
@@ -37,7 +43,7 @@ describe("formatSupplierOrderMailText", () => {
     const lines: SupplierOrderMailLine[] = [
       { variantCode: "4859/46", sizeLabel: "46", quantity: 3, externalCode: null, supplierUrl: null },
     ];
-    const { body } = formatSupplierOrderMailText("DODAVATEL-TEST-1", lines);
+    const { body } = formatSupplierOrderMailText(SUPPLIER, "DODAVATEL-TEST-1", lines);
     expect(body.split("\n")[1]).toBe("4859/46 | 46 | 3 ks");
   });
 
@@ -45,12 +51,12 @@ describe("formatSupplierOrderMailText", () => {
     const lines: SupplierOrderMailLine[] = [
       { variantCode: "40287", sizeLabel: null, quantity: 2, externalCode: null, supplierUrl: null },
     ];
-    const { body } = formatSupplierOrderMailText("Dodávateľ", lines);
+    const { body } = formatSupplierOrderMailText(SUPPLIER, "Dodávateľ", lines);
     expect(body.split("\n")[1]).toBe("40287 | 2 ks");
   });
 
   it("žiadne položky vyprodukuje predmet '0 položiek' a telo len s hlavičkou", () => {
-    const { subject, body } = formatSupplierOrderMailText("Prázdny dodávateľ", []);
+    const { subject, body } = formatSupplierOrderMailText(SUPPLIER, "Prázdny dodávateľ", []);
     expect(subject).toBe("Objednávka — Prázdny dodávateľ (0 položiek)");
     expect(body).toBe(subject);
   });
@@ -67,7 +73,7 @@ describe("formatSupplierOrderMailText", () => {
         supplierUrl: "https://www.huntingshop.eu/wild-t-green-nohavice",
       },
     ];
-    const { body } = formatSupplierOrderMailText("DODAVATEL-TEST-1", lines);
+    const { body } = formatSupplierOrderMailText(SUPPLIER, "DODAVATEL-TEST-1", lines);
     expect(body.split("\n")[1]).toBe(
       "4859/46 | kód OB832 | 46 | 3 ks | https://www.huntingshop.eu/wild-t-green-nohavice",
     );
@@ -77,7 +83,7 @@ describe("formatSupplierOrderMailText", () => {
     const lines: SupplierOrderMailLine[] = [
       { variantCode: "40287", sizeLabel: null, quantity: 1, externalCode: "X1", supplierUrl: null },
     ];
-    const { body } = formatSupplierOrderMailText("Dodávateľ", lines);
+    const { body } = formatSupplierOrderMailText(SUPPLIER, "Dodávateľ", lines);
     expect(body.split("\n")[1]).toBe("40287 | kód X1 | 1 ks");
   });
 });

--- a/apps/api/src/modules/orders/mail.ts
+++ b/apps/api/src/modules/orders/mail.ts
@@ -10,6 +10,9 @@ import {
   variants,
 } from "../../db/schema.js";
 import { log } from "../../logger.js";
+import { globalContext, textValue } from "../mail-templates/context.js";
+import { renderTemplate, type MailTemplateText } from "../mail-templates/render.js";
+import { resolveTemplate } from "../mail-templates/store.js";
 import type { MailTransport } from "../mail/transport.js";
 import { resolveEffectiveSupplierLink } from "./effective-supplier-link.js";
 import { NEZNAMY_DODAVATEL } from "./queries.js";
@@ -60,14 +63,22 @@ function formatSupplierOrderMailLine(line: SupplierOrderMailLine): string {
 }
 
 // Čistá funkcia (žiadna DB) — ľahko testovateľná na hraniciach skloňovania
-// (0, 1, 2, 4, 5) bez behu integračných testov.
+// (0, 1, 2, 4, 5) bez behu integračných testov. Znenie prichádza z
+// upraviteľnej šablóny (issue 192); tento e-mail je jediný ČISTO TEXTOVÝ,
+// takže sa z výsledku berie len textová verzia.
 export function formatSupplierOrderMailText(
+  template: MailTemplateText,
   supplier: string,
   lines: readonly SupplierOrderMailLine[],
 ): { readonly subject: string; readonly body: string } {
-  const subject = `Objednávka — ${supplier} (${String(lines.length)} ${itemsWord(lines.length)})`;
-  const body = [subject, ...lines.map(formatSupplierOrderMailLine)].join("\n");
-  return { subject, body };
+  const rendered = renderTemplate(template, {
+    ...globalContext(),
+    dodavatel: textValue(supplier),
+    pocet_poloziek: textValue(String(lines.length)),
+    slovo_poloziek: textValue(itemsWord(lines.length)),
+    zoznam_poloziek: { kind: "list", items: lines.map((line) => ({ label: formatSupplierOrderMailLine(line) })) },
+  });
+  return { subject: rendered.subject, body: rendered.text };
 }
 
 // Len riadky v stave "objednane" (ešte neposlané/nevybavené dodávateľovi) —
@@ -132,7 +143,7 @@ export async function buildSupplierOrderMailContent(db: Database, supplier: stri
     .from(supplierContacts)
     .where(eq(supplierContacts.supplier, supplier))
     .limit(1);
-  const { subject, body } = formatSupplierOrderMailText(supplier, lines);
+  const { subject, body } = formatSupplierOrderMailText(await resolveTemplate(db, "supplier_order"), supplier, lines);
   return { supplier, to: contact?.email ?? null, subject, body, itemCount: lines.length };
 }
 

--- a/apps/api/src/modules/posta-uncollected/logic.test.ts
+++ b/apps/api/src/modules/posta-uncollected/logic.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
+import { MAIL_TEMPLATE_KINDS } from "../mail-templates/registry.js";
 import {
   buildEmail,
+  postaTemplateKey,
   classifyTracking,
   isEligibleOrder,
   isNonPostaCarrier,
@@ -176,7 +178,7 @@ describe("shouldSend — kadencia 0 → +3 → +3 → +7", () => {
 
 describe("buildEmail", () => {
   it("prvý e-mail — predmet a HTML podľa starej appky doslovne", () => {
-    const built = buildEmail(1, "Ján Novák", "EF123456789SK", "Pošta 1", "Hlavná 1, Žilina", "2026-08-10", TODAY);
+    const built = buildEmail(MAIL_TEMPLATE_KINDS[postaTemplateKey(1)].defaultText, "Ján Novák", "EF123456789SK", "Pošta 1", "Hlavná 1, Žilina", "2026-08-10", TODAY);
     expect(built.subject).toBe("Vaša zásielka čaká na vyzdvihnutie | EF123456789SK");
     expect(built.html).toContain("Ján Novák");
     expect(built.html).toContain("10. 8. 2026"); // 2026-08-10 vs today 2026-08-02 → future, teda zobrazí sa
@@ -184,19 +186,19 @@ describe("buildEmail", () => {
   });
 
   it("4. e-mail žiada priamy kontakt na eshop@forestshop.sk", () => {
-    const built = buildEmail(4, "Ján Novák", "EF1SK", "Pošta 1", "", "", TODAY);
+    const built = buildEmail(MAIL_TEMPLATE_KINDS[postaTemplateKey(4)].defaultText, "Ján Novák", "EF1SK", "Pošta 1", "", "", TODAY);
     expect(built.subject).toBe("Posledná výzva: zásielka bude vrátená | EF1SK");
     expect(built.html).toContain("eshop@forestshop.sk");
   });
 
   it("dátum vyzdvihnutia, ktorý už PREŠIEL, sa nezobrazí (dateless 'čo najskôr')", () => {
-    const built = buildEmail(1, "Ján", "EF1SK", "Pošta 1", "", "2026-01-01", TODAY);
+    const built = buildEmail(MAIL_TEMPLATE_KINDS[postaTemplateKey(1)].defaultText, "Ján", "EF1SK", "Pošta 1", "", "2026-01-01", TODAY);
     expect(built.html).toContain("čo najskôr");
     expect(built.html).not.toContain("2026-01-01");
   });
 
   it("HTML escapuje meno zákazníka (žiadny injected tag)", () => {
-    const built = buildEmail(1, "<script>alert(1)</script>", "EF1SK", "Pošta 1", "", "", TODAY);
+    const built = buildEmail(MAIL_TEMPLATE_KINDS[postaTemplateKey(1)].defaultText, "<script>alert(1)</script>", "EF1SK", "Pošta 1", "", "", TODAY);
     expect(built.html).not.toContain("<script>alert(1)</script>");
     expect(built.html).toContain("&lt;script&gt;");
   });

--- a/apps/api/src/modules/posta-uncollected/logic.ts
+++ b/apps/api/src/modules/posta-uncollected/logic.ts
@@ -1,3 +1,6 @@
+import { globalContext, textValue } from "../mail-templates/context.js";
+import type { MailTemplateKey } from "../mail-templates/registry.js";
+import { renderTemplate, type MailTemplateText, type RenderedEmail } from "../mail-templates/render.js";
 import {
   CANCELLED_STATUSES,
   daysNeededForNextEmail,
@@ -228,27 +231,24 @@ export function shouldSend(count: number, lastSent: Date | null, today: Date): b
   return days >= needed;
 }
 
-function htmlEscape(value: string): string {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&#39;");
+export type BuiltEmail = RenderedEmail;
+
+/** Ktorá zo štyroch zásielkových šablón patrí k tomuto poradiu e-mailu —
+ * eskalácia sa zachováva presne ako predtým (1./2./3. a posledná výzva pre
+ * štvrtý a každý ďalší). */
+export function postaTemplateKey(count: number): MailTemplateKey {
+  if (count <= 1) return "posta_1";
+  if (count === 2) return "posta_2";
+  if (count === 3) return "posta_3";
+  return "posta_4";
 }
 
-export interface BuiltEmail {
-  readonly subject: string;
-  readonly html: string;
-  readonly text: string;
-}
-
-/** (subject, html, text) pre e-mail #count — doslovné znenie zo starej
- * appky. Dátum, ktorý už PREŠIEL (alebo sa nedá prečítať), sa berie ako
- * žiadny — mail dostane dateless "čo najskôr" formuláciu (rovnaký zámer ako
- * stará appka's `build_email`). */
+/** Dosadí hodnoty do šablóny vybranej `postaTemplateKey`. Dátum, ktorý už
+ * PREŠIEL (alebo sa nedá prečítať), sa berie ako žiadny — šablóna má na ten
+ * prípad vlastnú vetvu `{{#ak termin_vyzdvihnutia}}…{{inak}}…{{/ak}}`,
+ * rovnaký zámer ako pôvodná dvojica viet v starej appke's `build_email`. */
 export function buildEmail(
-  count: number,
+  template: MailTemplateText,
   name: string,
   trackNum: string,
   officeName: string,
@@ -260,79 +260,13 @@ export function buildEmail(
   const retainedTillDisplay =
     d !== null && d >= today ? `${String(d.getUTCDate())}. ${String(d.getUTCMonth() + 1)}. ${String(d.getUTCFullYear())}` : "";
   const link = trackingLink(trackNum);
-  const nameH = htmlEscape(name);
-  const numH = `<strong>${htmlEscape(trackNum)}</strong>`;
-  const officeH = `<strong>${htmlEscape(officeName)}</strong>${officeAddr !== "" ? ` (${htmlEscape(officeAddr)})` : ""}`;
-  const tillH = `<strong>${htmlEscape(retainedTillDisplay)}</strong>`;
-
-  let subject: string;
-  let intro: string;
-  let urgency: string;
-  if (count === 1) {
-    subject = `Vaša zásielka čaká na vyzdvihnutie | ${trackNum}`;
-    intro = `vaša zásielka č. ${numH} je uložená na pošte ${officeH} a čaká na vyzdvihnutie.`;
-    urgency =
-      retainedTillDisplay !== ""
-        ? `Prosím vyzdvihnite si ju do ${tillH}, aby nebola vrátená späť odosielateľovi.`
-        : "Prosím vyzdvihnite si ju čo najskôr, aby nebola vrátená späť odosielateľovi.";
-  } else if (count === 2) {
-    subject = `Pripomienka: zásielka stále čaká | ${trackNum}`;
-    intro = `opätovne vás upozorňujeme, že vaša zásielka č. ${numH} je stále uložená na pošte ${officeH} a zatiaľ nebola vyzdvihnutá.`;
-    urgency =
-      retainedTillDisplay !== ""
-        ? `Termín na vyzdvihnutie sa blíži: ${tillH}. Po tomto dátume bude zásielka vrátená.`
-        : "Prosím vyzdvihnite si ju čo najskôr. Zásielka bude čoskoro vrátená odosielateľovi.";
-  } else if (count === 3) {
-    subject = `Posledné upozornenie: zásielka bude vrátená | ${trackNum}`;
-    intro = `toto je naše posledné upozornenie — vaša zásielka č. ${numH} je stále na pošte ${officeH}.`;
-    urgency =
-      retainedTillDisplay !== ""
-        ? `Ak si ju nevyzdvihnete do ${tillH}, bude vrátená späť odosielateľovi.`
-        : "Ak si ju čoskoro nevyzdvihnete, bude vrátená späť odosielateľovi.";
-  } else {
-    subject = `Posledná výzva: zásielka bude vrátená | ${trackNum}`;
-    intro = `napriek opakovaným upozorneniam vaša zásielka č. ${numH} je stále nevyzdvihnutá na pošte ${officeH}.`;
-    urgency =
-      "Zásielka bude v najbližších dňoch vrátená späť. Ak ju stále chcete, prosím kontaktujte nás čo najskôr na " +
-      '<a href="mailto:eshop@forestshop.sk">eshop@forestshop.sk</a> alebo telefonicky.';
-  }
-
-  const html = [
-    "<!DOCTYPE html>",
-    "<html>",
-    '  <body style="font-family: Arial, sans-serif; font-size: 16px; color: #333;">',
-    `    <p>Dobrý deň, <strong>${nameH}</strong>,</p>`,
-    "",
-    `    <p>${intro}</p>`,
-    "",
-    `    <p>${urgency}</p>`,
-    "",
-    `    <p>👉 Stav zásielky môžete sledovať tu: <a href="${link}">${link}</a></p>`,
-    "",
-    "    <p>",
-    "      Ak máte akékoľvek otázky, pokojne nás kontaktujte na",
-    '      <a href="mailto:eshop@forestshop.sk">eshop@forestshop.sk</a>.',
-    "    </p>",
-    "",
-    '    <p style="margin-top: 30px;">',
-    "      S pozdravom,<br>",
-    "      <strong>Tím Forestshop.sk</strong><br>",
-    '      <a href="https://www.forestshop.sk" target="_blank">www.forestshop.sk</a>',
-    "    </p>",
-    "  </body>",
-    "</html>",
-  ].join("\n");
-
-  const text = [
-    `Dobrý deň, ${name},`,
-    "",
-    intro.replaceAll(/<[^>]+>/g, ""),
-    urgency.replaceAll(/<[^>]+>/g, ""),
-    "",
-    `Stav zásielky môžete sledovať tu: ${link}`,
-    "",
-    "S pozdravom, Tím Forestshop.sk",
-  ].join("\n");
-
-  return { subject, html, text };
+  return renderTemplate(template, {
+    ...globalContext(),
+    meno_zakaznika: textValue(name),
+    cislo_zasielky: textValue(trackNum),
+    posta: textValue(officeName),
+    adresa_posty: textValue(officeAddr),
+    termin_vyzdvihnutia: textValue(retainedTillDisplay),
+    odkaz_sledovanie: { kind: "link", url: link, label: link },
+  });
 }

--- a/apps/api/src/modules/posta-uncollected/run.ts
+++ b/apps/api/src/modules/posta-uncollected/run.ts
@@ -2,7 +2,8 @@ import type { Database } from "../../db/client.js";
 import { log } from "../../logger.js";
 import type { MailTransport } from "../mail/transport.js";
 import { buildShoptetAdminOrderUrl } from "../orders/queries.js";
-import { buildEmail, classifyTracking, shouldSend, sourceCoverage, terminalState, type SourceCoverage } from "./logic.js";
+import { resolveTemplate } from "../mail-templates/store.js";
+import { buildEmail, classifyTracking, postaTemplateKey, shouldSend, sourceCoverage, terminalState, type SourceCoverage } from "./logic.js";
 import { loadEligibleOrders } from "./orders-source.js";
 import { loadPostaUncollectedState, prunePostaUncollectedState, upsertPostaUncollectedState } from "./state.js";
 import { TERMINAL_CACHE_DAYS, trackingLink } from "./constants.js";
@@ -198,7 +199,15 @@ async function runPostaUncollectedLocked(options: RunPostaUncollectedOptions): P
           );
         }
       } else {
-        const built = buildEmail(nextCount, shipment.customerName, packageNumber, cls.officeName, cls.officeAddr, cls.retainedTill, now);
+        const built = buildEmail(
+          await resolveTemplate(db, postaTemplateKey(nextCount)),
+          shipment.customerName,
+          packageNumber,
+          cls.officeName,
+          cls.officeAddr,
+          cls.retainedTill,
+          now,
+        );
         try {
           // BCC je pre TENTO mail ZÁVÄZNÁ (ticket's jediná bezpečnostná
           // podmienka) — `bccMissing` vyššie to už vylúčilo, `bccEmail` je

--- a/apps/api/tests/helpers/db.ts
+++ b/apps/api/tests/helpers/db.ts
@@ -55,7 +55,7 @@ export async function withCleanDb(): Promise<{ db: Database; close: () => Promis
     // either direction, and this module has NO settings singleton (no
     // scheduled run to gate), so no re-seed is needed below.
     await db.execute(
-      sql`TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state RESTART IDENTITY CASCADE`,
+      sql`TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, mail_template, mail_template_history RESTART IDENTITY CASCADE`,
     );
     // issue 59: `order_open_status` is a NEW table with real production
     // content (the migration seeds it) — TRUNCATE alone would leave every

--- a/apps/api/tests/mail-templates.integration.test.ts
+++ b/apps/api/tests/mail-templates.integration.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, expect, it } from "vitest";
+import { mailTemplates, users } from "../src/db/schema.js";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import type { UserRole } from "../src/modules/auth/service.js";
+import { MAIL_TEMPLATE_KINDS } from "../src/modules/mail-templates/registry.js";
+import { resolveTemplate } from "../src/modules/mail-templates/store.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 192: obrazovka "Texty e-mailov" cez HTTP. Nikde tu neodchádza žiadny
+// e-mail — tieto trasy len čítajú a zapisujú znenie.
+const HESLO = "test-heslo-abc";
+
+let close: (() => Promise<void>) | undefined;
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  resetLoginRateLimit();
+});
+
+async function boot(role: UserRole) {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await ctx.db.insert(users).values({
+    email: "pouzivatel@forestshop.sk",
+    passwordHash: await hashPassword(HESLO),
+    displayName: "Test Používateľ",
+    role,
+  });
+  const app = createApp(ctx.db, { cookieSecure: false });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "pouzivatel@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie, db: ctx.db };
+}
+
+function jsonRequest(cookie: string, method: string, body?: unknown): RequestInit {
+  return {
+    method,
+    // Bez `origin`/`sec-fetch-site` — `requireSameOrigin` nemá čo porovnať a
+    // požiadavku pustí (rovnako ako ostatné integračné testy).
+    headers: { cookie, "content-type": "application/json" },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  };
+}
+
+it("zoznam vráti všetky druhy e-mailov s pôvodným znením, kým sa nič neupravilo", async () => {
+  const { app, cookie } = await boot("manazer");
+  const res = await app.request("/api/mail-templates", { headers: { cookie } });
+  expect(res.status).toBe(200);
+  const payload = (await res.json()) as { templates: { key: string; subject: string; isCustomized: boolean; placeholders: unknown[] }[] };
+  expect(payload.templates).toHaveLength(8);
+  const nedostupne = payload.templates.find((t) => t.key === "nedostupne");
+  expect(nedostupne?.isCustomized).toBe(false);
+  expect(nedostupne?.subject).toBe(MAIL_TEMPLATE_KINDS["nedostupne"].defaultText.subject);
+  expect((nedostupne?.placeholders.length ?? 0) > 0).toBe(true);
+});
+
+it("uloženie zmení znenie, ktoré odosielanie použije; vrátenie pôvodného ho vráti späť", async () => {
+  const { app, cookie, db } = await boot("manazer");
+
+  const save = await app.request("/api/mail-templates/nedostupne", jsonRequest(cookie, "PUT", { subject: "Nový predmet", body: "Ahoj {{meno_zakaznika}}" }));
+  expect(await save.json()).toEqual({ ok: true });
+  expect(await resolveTemplate(db, "nedostupne")).toEqual({ subject: "Nový predmet", body: "Ahoj {{meno_zakaznika}}" });
+
+  const reset = await app.request("/api/mail-templates/nedostupne/reset", jsonRequest(cookie, "POST"));
+  expect(await reset.json()).toEqual({ ok: true });
+  expect(await resolveTemplate(db, "nedostupne")).toEqual(MAIL_TEMPLATE_KINDS["nedostupne"].defaultText);
+  expect(await db.select().from(mailTemplates)).toHaveLength(0);
+});
+
+it("šablóna s neznámym poľom sa NEULOŽÍ — chyba pomenuje pole", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  const res = await app.request("/api/mail-templates/nedostupne", jsonRequest(cookie, "PUT", { subject: "Vec", body: "Ahoj {{cislo_zasielky}}" }));
+  // 200 s ok:false — nikdy 4xx (Chromium by inak zalogoval konzolovú chybu).
+  expect(res.status).toBe(200);
+  const payload = (await res.json()) as { ok: boolean; error: string };
+  expect(payload.ok).toBe(false);
+  expect(payload.error).toContain("{{cislo_zasielky}}");
+  expect(await db.select().from(mailTemplates)).toHaveLength(0);
+});
+
+it("história zaznamená uloženie aj vrátenie pôvodného znenia, aj s menom používateľa", async () => {
+  const { app, cookie } = await boot("admin");
+  await app.request("/api/mail-templates/order_reminder", jsonRequest(cookie, "PUT", { subject: "A", body: "B" }));
+  await app.request("/api/mail-templates/order_reminder/reset", jsonRequest(cookie, "POST"));
+
+  const res = await app.request("/api/mail-templates/order_reminder/history", { headers: { cookie } });
+  const payload = (await res.json()) as { ok: boolean; entries: { action: string; changedByName: string | null }[] };
+  expect(payload.ok).toBe(true);
+  expect(payload.entries.map((e) => e.action)).toEqual(["reset", "save"]);
+  expect(payload.entries[0]?.changedByName).toBe("Test Používateľ");
+});
+
+it("rola „citanie“ znenie upraviť nesmie", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const res = await app.request("/api/mail-templates/nedostupne", jsonRequest(cookie, "PUT", { subject: "Vec", body: "Text" }));
+  expect(res.status).toBe(403);
+  expect(await db.select().from(mailTemplates)).toHaveLength(0);
+});
+
+it("náhľad vyrenderuje rozpísané (neuložené) znenie a nič neuloží", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  const res = await app.request("/api/mail-templates/preview", jsonRequest(cookie, "POST", { key: "nedostupne", subject: "Vec", body: "Ahoj **{{meno_zakaznika}}**" }));
+  const payload = (await res.json()) as { ok: boolean; subject: string; html: string };
+  expect(payload.ok).toBe(true);
+  expect(payload.subject).toBe("Vec");
+  expect(payload.html).toContain("<strong>");
+  expect(await db.select().from(mailTemplates)).toHaveLength(0);
+});
+
+it("náhľad neplatnej šablóny vráti chybu namiesto rozbitého e-mailu", async () => {
+  const { app, cookie } = await boot("manazer");
+  const res = await app.request("/api/mail-templates/preview", jsonRequest(cookie, "POST", { key: "nedostupne", subject: "Vec", body: "{{vymyslene_pole}}" }));
+  const payload = (await res.json()) as { ok: boolean; error: string };
+  expect(payload.ok).toBe(false);
+  expect(payload.error).toContain("{{vymyslene_pole}}");
+});
+
+it("neznámy druh e-mailu vráti 200 s vysvetlením, nikdy 404", async () => {
+  const { app, cookie } = await boot("manazer");
+  const res = await app.request("/api/mail-templates/vymyslene/reset", jsonRequest(cookie, "POST"));
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ ok: false, error: "Neznámy druh e-mailu." });
+});

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -9,7 +9,13 @@ export default defineConfig({
       command: "pnpm exec tsx ../../scripts/e2e-setup.ts && pnpm --filter @forestshop/api start",
       url: "http://127.0.0.1:3000/api/version",
       reuseExistingServer: false,
-      env: { SESSION_COOKIE_SECURE: "false" },
+      // Celý E2E balík sa prihlasuje z JEDNEJ adresy (localhost) — okolo 30
+      // prihlásení za beh, čo je presne strop `IP_MAX_ATTEMPTS`
+      // (`login-rate-limit.ts`). Bez zdvihnutia by ktorýkoľvek ĎALŠÍ pridaný
+      // test zhodil NÁHODNÝ neskorší spec súbor hláškou "Nesprávny e-mail
+      // alebo heslo" (issue 192). Limit na (IP, e-mail) pár — ten, čo chráni
+      // konkrétny účet — ostáva nezmenený, aj v testoch.
+      env: { SESSION_COOKIE_SECURE: "false", LOGIN_IP_MAX_ATTEMPTS: "500" },
     },
     {
       command: "pnpm --filter @forestshop/web dev",

--- a/apps/web/src/components/MailTemplateEditor.tsx
+++ b/apps/web/src/components/MailTemplateEditor.tsx
@@ -1,0 +1,309 @@
+import { useCallback, useEffect, useRef, useState, type JSX } from "react";
+import {
+  fetchMailTemplateHistory,
+  fetchMailTemplatePreview,
+  MailTemplatesUnauthorizedError,
+  resetMailTemplate,
+  saveMailTemplate,
+  type MailTemplate,
+  type MailTemplateHistoryEntry,
+} from "../mailTemplatesApi.js";
+
+// issue 192: úprava JEDNÉHO druhu e-mailu. Rodič komponent montuje nanovo pri
+// zmene druhu (`key={template.key}`), takže rozpísané znenie sa načíta z props
+// v `useState` inicializátore a nepotrebuje žiadny synchronizačný efekt ani
+// jeho stráženie (`.claude/rules/frontend-design.md` — efekt sa oplatí len
+// pri VŽDY namontovanom vstupe).
+
+const DEBOUNCE_MS = 400;
+
+function formatDateTime(iso: string): string {
+  const d = new Date(iso);
+  return `${String(d.getDate())}. ${String(d.getMonth() + 1)}. ${String(d.getFullYear())} ${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+}
+
+export function MailTemplateEditor({
+  template,
+  canEdit,
+  onSaved,
+  onSessionExpired,
+}: {
+  readonly template: MailTemplate;
+  readonly canEdit: boolean;
+  readonly onSaved: () => void;
+  readonly onSessionExpired: () => void;
+}): JSX.Element {
+  const [subject, setSubject] = useState(template.subject);
+  const [body, setBody] = useState(template.body);
+  const [previewHtml, setPreviewHtml] = useState("");
+  const [previewSubject, setPreviewSubject] = useState("");
+  const [previewError, setPreviewError] = useState("");
+  const [saveError, setSaveError] = useState("");
+  const [saved, setSaved] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [history, setHistory] = useState<readonly MailTemplateHistoryEntry[] | null>(null);
+
+  const subjectRef = useRef<HTMLInputElement | null>(null);
+  const bodyRef = useRef<HTMLTextAreaElement | null>(null);
+  // Do ktorého poľa sa vloží pole vybrané z ponuky — predvolene do tela,
+  // pretože tam patrí drvivá väčšina polí.
+  const lastFocused = useRef<"subject" | "body">("body");
+
+  const dirty = subject !== template.subject || body !== template.body;
+
+  // Náhľad sa prepočítava na serveri z PRÁVE ROZPÍSANÉHO znenia (ticket:
+  // "náhľad na skutočných dátach ešte pri úprave"), s krátkym oneskorením,
+  // aby písanie nevolalo server pri každom písmene.
+  useEffect(() => {
+    let cancelled = false;
+    const timer = setTimeout(() => {
+      fetchMailTemplatePreview(template.key, subject, body)
+        .then((result) => {
+          if (cancelled) return;
+          if (result.ok) {
+            setPreviewHtml(result.html);
+            setPreviewSubject(result.subject);
+            setPreviewError("");
+          } else {
+            setPreviewError(result.error);
+          }
+        })
+        .catch((err: unknown) => {
+          if (cancelled) return;
+          if (err instanceof MailTemplatesUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setPreviewError(err instanceof Error ? err.message : "Náhľad sa nepodarilo pripraviť.");
+        });
+    }, DEBOUNCE_MS);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [template.key, subject, body, onSessionExpired]);
+
+  const insertPlaceholder = useCallback((name: string) => {
+    const token = `{{${name}}}`;
+    if (lastFocused.current === "subject") {
+      const el = subjectRef.current;
+      const at = el?.selectionStart ?? null;
+      setSubject((prev) => (at === null ? prev + token : prev.slice(0, at) + token + prev.slice(el?.selectionEnd ?? at)));
+      el?.focus();
+      return;
+    }
+    const el = bodyRef.current;
+    const at = el?.selectionStart ?? null;
+    setBody((prev) => (at === null ? prev + token : prev.slice(0, at) + token + prev.slice(el?.selectionEnd ?? at)));
+    el?.focus();
+  }, []);
+
+  const save = useCallback(() => {
+    setBusy(true);
+    setSaveError("");
+    setSaved(false);
+    saveMailTemplate(template.key, subject, body)
+      .then((result) => {
+        if (result.ok) {
+          setSaved(true);
+          setHistory(null);
+          onSaved();
+          return;
+        }
+        setSaveError(result.error);
+      })
+      .catch((err: unknown) => {
+        if (err instanceof MailTemplatesUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setSaveError(err instanceof Error ? err.message : "Uloženie zlyhalo.");
+      })
+      .finally(() => {
+        setBusy(false);
+      });
+  }, [template.key, subject, body, onSaved, onSessionExpired]);
+
+  const restoreOriginal = useCallback(() => {
+    setBusy(true);
+    setSaveError("");
+    setSaved(false);
+    resetMailTemplate(template.key)
+      .then((result) => {
+        if (!result.ok) {
+          setSaveError(result.error);
+          return;
+        }
+        setSubject(template.defaultSubject);
+        setBody(template.defaultBody);
+        setHistory(null);
+        onSaved();
+      })
+      .catch((err: unknown) => {
+        if (err instanceof MailTemplatesUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setSaveError(err instanceof Error ? err.message : "Vrátenie pôvodného znenia zlyhalo.");
+      })
+      .finally(() => {
+        setBusy(false);
+      });
+  }, [template.key, template.defaultSubject, template.defaultBody, onSaved, onSessionExpired]);
+
+  const loadHistory = useCallback(() => {
+    fetchMailTemplateHistory(template.key)
+      .then(setHistory)
+      .catch((err: unknown) => {
+        if (err instanceof MailTemplatesUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setSaveError(err instanceof Error ? err.message : "Históriu zmien sa nepodarilo načítať.");
+      });
+  }, [template.key, onSessionExpired]);
+
+  return (
+    <div className="mt-editor" data-testid={`mail-template-editor-${template.key}`}>
+      <div className="mt-editor-head">
+        <h3>{template.label}</h3>
+        <p className="mt-editor-desc">{template.description}</p>
+        {template.isCustomized ? (
+          <p className="pill" data-testid="mail-template-customized">
+            Upravené{template.updatedByName === null ? "" : ` — ${template.updatedByName}`}
+            {template.updatedAt === null ? "" : `, ${formatDateTime(template.updatedAt)}`}
+          </p>
+        ) : (
+          <p className="pill off" data-testid="mail-template-original">
+            Pôvodné znenie
+          </p>
+        )}
+      </div>
+
+      <div className="mt-editor-grid">
+        <div className="mt-fields">
+          <label className="mt-field">
+            <span>Predmet e-mailu</span>
+            <input
+              ref={subjectRef}
+              value={subject}
+              disabled={!canEdit || busy}
+              onFocus={() => {
+                lastFocused.current = "subject";
+              }}
+              onChange={(e) => {
+                setSubject(e.target.value);
+                setSaved(false);
+              }}
+              data-testid="mail-template-subject"
+            />
+          </label>
+
+          <label className="mt-field">
+            <span>Text e-mailu</span>
+            <textarea
+              ref={bodyRef}
+              value={body}
+              rows={18}
+              disabled={!canEdit || busy}
+              onFocus={() => {
+                lastFocused.current = "body";
+              }}
+              onChange={(e) => {
+                setBody(e.target.value);
+                setSaved(false);
+              }}
+              data-testid="mail-template-body"
+            />
+          </label>
+
+          <div className="mt-placeholders">
+            <p className="mt-placeholders-title">Polia, ktoré sa doplnia pri odoslaní — kliknutím ich vložíte do textu:</p>
+            <div className="mt-chips">
+              {template.placeholders.map((p) => (
+                <button
+                  key={p.name}
+                  type="button"
+                  className="btn chip"
+                  disabled={!canEdit || busy}
+                  title={p.label}
+                  onClick={() => {
+                    insertPlaceholder(p.name);
+                  }}
+                  data-testid={`mail-template-chip-${p.name}`}
+                >
+                  {p.label}
+                </button>
+              ))}
+            </div>
+            <p className="mt-hint">
+              Tučné písmo napíšete dvomi hviezdičkami: <code>**takto**</code>. Prázdny riadok začne nový odstavec.
+            </p>
+          </div>
+
+          {saveError !== "" && (
+            <p role="alert" data-testid="mail-template-error">
+              {saveError}
+            </p>
+          )}
+          {saved && !dirty && (
+            <p role="status" data-testid="mail-template-saved">
+              Znenie je uložené. Odteraz sa posiela takto.
+            </p>
+          )}
+
+          {canEdit && (
+            <div className="mt-actions">
+              <button type="button" className="btn lg good" disabled={busy || !dirty} onClick={save} data-testid="mail-template-save">
+                💾 Uložiť znenie
+              </button>
+              <button type="button" className="btn lg ghost" disabled={busy || !template.isCustomized} onClick={restoreOriginal} data-testid="mail-template-reset">
+                ↩ Vrátiť pôvodné znenie
+              </button>
+              <button type="button" className="btn lg ghost" onClick={loadHistory} data-testid="mail-template-history-load">
+                🕓 História zmien
+              </button>
+            </div>
+          )}
+        </div>
+
+        <div className="mt-preview">
+          <p className="mt-preview-title">Náhľad na skutočných údajoch</p>
+          {previewError === "" ? (
+            <>
+              <p className="mt-preview-subject" data-testid="mail-template-preview-subject">
+                Predmet: {previewSubject}
+              </p>
+              {/* `previewHtml` generuje SERVER z tejto šablóny — hodnoty polí
+                  sú tam už escapované (`mail-templates/render.ts`), nikdy sa
+                  sem nevkladá surový vstup používateľa priamo. */}
+              <div className="mt-preview-body" data-testid="mail-template-preview" dangerouslySetInnerHTML={{ __html: previewHtml }} />
+            </>
+          ) : (
+            <p role="alert" data-testid="mail-template-preview-error">
+              {previewError}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {history !== null && (
+        <div className="mt-history" data-testid="mail-template-history">
+          <h4>História zmien</h4>
+          {history.length === 0 ? (
+            <p>Zatiaľ žiadna zmena — platí pôvodné znenie.</p>
+          ) : (
+            <ul>
+              {history.map((entry) => (
+                <li key={entry.id}>
+                  {formatDateTime(entry.changedAt)} — {entry.action === "reset" ? "vrátené pôvodné znenie" : "uložené nové znenie"}
+                  {entry.changedByName === null ? "" : ` (${entry.changedByName})`}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/MailTemplatesSection.test.tsx
+++ b/apps/web/src/components/MailTemplatesSection.test.tsx
@@ -1,0 +1,164 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { MailTemplatesSection } from "./MailTemplatesSection.js";
+
+const { fetchMailTemplates, fetchMailTemplatePreview, saveMailTemplate, resetMailTemplate, fetchMailTemplateHistory } = vi.hoisted(() => ({
+  fetchMailTemplates: vi.fn(),
+  fetchMailTemplatePreview: vi.fn(),
+  saveMailTemplate: vi.fn(),
+  resetMailTemplate: vi.fn(),
+  fetchMailTemplateHistory: vi.fn(),
+}));
+
+// `MailTemplatesUnauthorizedError` ostáva SKUTOČNÁ trieda (rovnaký dôvod ako
+// `NedostupneSection.test.tsx` — `instanceof` v komponente musí fungovať).
+vi.mock("../mailTemplatesApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../mailTemplatesApi.js")>();
+  return { ...actual, fetchMailTemplates, fetchMailTemplatePreview, saveMailTemplate, resetMailTemplate, fetchMailTemplateHistory };
+});
+
+const { MailTemplatesUnauthorizedError } = await import("../mailTemplatesApi.js");
+
+const NEDOSTUPNE = {
+  key: "nedostupne",
+  label: "Nedostupný tovar — bez návrhu náhrady",
+  description: "Ospravedlnenie zákazníkovi.",
+  subject: "Pôvodný predmet",
+  body: "Dobrý deň, **{{meno_zakaznika}}**,",
+  defaultSubject: "Pôvodný predmet",
+  defaultBody: "Dobrý deň, **{{meno_zakaznika}}**,",
+  isCustomized: false,
+  updatedAt: null,
+  updatedByName: null,
+  placeholders: [
+    { name: "meno_zakaznika", label: "Meno zákazníka" },
+    { name: "web_forestshop", label: "Odkaz na www.forestshop.sk" },
+  ],
+};
+
+const REMINDER = { ...NEDOSTUPNE, key: "order_reminder", label: "Pripomienka objednávky", isCustomized: true, updatedByName: "Zbyněk", updatedAt: "2026-08-03T10:00:00.000Z" };
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+function renderSection(role: "admin" | "manazer" | "citanie" = "manazer") {
+  fetchMailTemplates.mockResolvedValue([NEDOSTUPNE, REMINDER]);
+  fetchMailTemplatePreview.mockResolvedValue({ ok: true, subject: "Pôvodný predmet", html: "<p>Dobrý deň</p>", text: "Dobrý deň" });
+  render(<MailTemplatesSection role={role} onSessionExpired={vi.fn()} />);
+}
+
+it("zobrazí zoznam druhov e-mailov a otvorí prvý z nich", async () => {
+  renderSection();
+  await screen.findByTestId("mail-template-list");
+  expect(screen.getByTestId("mail-template-pick-nedostupne")).not.toBeNull();
+  expect(screen.getByTestId("mail-template-pick-order_reminder")).not.toBeNull();
+  await screen.findByTestId("mail-template-editor-nedostupne");
+});
+
+it("prepnutie druhu otvorí jeho vlastné znenie", async () => {
+  renderSection();
+  await screen.findByTestId("mail-template-editor-nedostupne");
+  fireEvent.click(screen.getByTestId("mail-template-pick-order_reminder"));
+  await screen.findByTestId("mail-template-editor-order_reminder");
+  expect(screen.getByTestId("mail-template-customized").textContent).toContain("Zbyněk");
+});
+
+it("kliknutie na pole ho vloží do textu — netreba ho písať naspamäť", async () => {
+  renderSection();
+  await screen.findByTestId("mail-template-editor-nedostupne");
+  const body = screen.getByTestId<HTMLTextAreaElement>("mail-template-body");
+  fireEvent.focus(body);
+  fireEvent.click(screen.getByTestId("mail-template-chip-web_forestshop"));
+  await waitFor(() => {
+    expect(body.value).toContain("{{web_forestshop}}");
+  });
+});
+
+it("uloženie je nedostupné, kým sa nič nezmenilo, a po zmene odošle nové znenie", async () => {
+  renderSection();
+  await screen.findByTestId("mail-template-editor-nedostupne");
+  const save = screen.getByTestId<HTMLButtonElement>("mail-template-save");
+  expect(save.disabled).toBe(true);
+
+  saveMailTemplate.mockResolvedValue({ ok: true });
+  fireEvent.change(screen.getByTestId("mail-template-subject"), { target: { value: "Nový predmet" } });
+  await waitFor(() => {
+    expect(save.disabled).toBe(false);
+  });
+  fireEvent.click(save);
+  await waitFor(() => {
+    expect(saveMailTemplate).toHaveBeenCalledWith("nedostupne", "Nový predmet", NEDOSTUPNE.body);
+  });
+});
+
+it("zamietnuté uloženie zobrazí hlášku zo servera a znenie neoznačí za uložené", async () => {
+  renderSection();
+  await screen.findByTestId("mail-template-editor-nedostupne");
+  saveMailTemplate.mockResolvedValue({ ok: false, error: "Neznáme zástupné pole: {{vymyslene}}." });
+  fireEvent.change(screen.getByTestId("mail-template-subject"), { target: { value: "Iný predmet" } });
+  fireEvent.click(screen.getByTestId("mail-template-save"));
+  await screen.findByText("Neznáme zástupné pole: {{vymyslene}}.");
+  expect(screen.queryByTestId("mail-template-saved")).toBeNull();
+});
+
+it("vrátenie pôvodného znenia je dostupné len pri upravenej šablóne a vráti pôvodný text do polí", async () => {
+  renderSection();
+  await screen.findByTestId("mail-template-editor-nedostupne");
+  expect(screen.getByTestId<HTMLButtonElement>("mail-template-reset").disabled).toBe(true);
+
+  fireEvent.click(screen.getByTestId("mail-template-pick-order_reminder"));
+  await screen.findByTestId("mail-template-editor-order_reminder");
+  resetMailTemplate.mockResolvedValue({ ok: true });
+  fireEvent.click(screen.getByTestId("mail-template-reset"));
+  await waitFor(() => {
+    expect(resetMailTemplate).toHaveBeenCalledWith("order_reminder");
+  });
+  await waitFor(() => {
+    expect(screen.getByTestId<HTMLInputElement>("mail-template-subject").value).toBe(REMINDER.defaultSubject);
+  });
+});
+
+it("rola citanie NEVIDÍ tlačidlá na úpravu — upravovať smie len admin/manažér", async () => {
+  renderSection("citanie");
+  await screen.findByTestId("mail-template-editor-nedostupne");
+  expect(screen.queryByTestId("mail-template-save")).toBeNull();
+  expect(screen.queryByTestId("mail-template-reset")).toBeNull();
+});
+
+it("náhľad sa načíta z rozpísaného znenia", async () => {
+  renderSection();
+  await screen.findByTestId("mail-template-editor-nedostupne");
+  await waitFor(() => {
+    expect(fetchMailTemplatePreview).toHaveBeenCalledWith("nedostupne", NEDOSTUPNE.subject, NEDOSTUPNE.body);
+  });
+  await screen.findByTestId("mail-template-preview");
+});
+
+it("chyba v šablóne sa v náhľade zobrazí namiesto rozbitého e-mailu", async () => {
+  fetchMailTemplates.mockResolvedValue([NEDOSTUPNE]);
+  fetchMailTemplatePreview.mockResolvedValue({ ok: false, error: "Neznáme zástupné pole: {{zle}}." });
+  render(<MailTemplatesSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("mail-template-preview-error");
+});
+
+it("história zmien sa načíta na požiadanie", async () => {
+  renderSection();
+  await screen.findByTestId("mail-template-editor-nedostupne");
+  fetchMailTemplateHistory.mockResolvedValue([
+    { id: "1", action: "save", subject: "Nový predmet", changedAt: "2026-08-03T10:00:00.000Z", changedByName: "Zbyněk" },
+  ]);
+  fireEvent.click(screen.getByTestId("mail-template-history-load"));
+  await screen.findByTestId("mail-template-history");
+  expect(screen.getByText(/uložené nové znenie/)).not.toBeNull();
+});
+
+it("401 pri načítaní zavolá onSessionExpired", async () => {
+  const onSessionExpired = vi.fn();
+  fetchMailTemplates.mockRejectedValue(new MailTemplatesUnauthorizedError());
+  render(<MailTemplatesSection role="manazer" onSessionExpired={onSessionExpired} />);
+  await waitFor(() => {
+    expect(onSessionExpired).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/MailTemplatesSection.tsx
+++ b/apps/web/src/components/MailTemplatesSection.tsx
@@ -1,0 +1,86 @@
+import { useCallback, useEffect, useState, type JSX } from "react";
+import type { Me } from "../api.js";
+import { fetchMailTemplates, MailTemplatesUnauthorizedError, type MailTemplate } from "../mailTemplatesApi.js";
+import { MailTemplateEditor } from "./MailTemplateEditor.js";
+
+// issue 192, majiteľ: "pri každej veci čo posiela mail by mala byť možnosť
+// zmeniť text mailu". Vľavo zoznam druhov e-mailov, vpravo úprava vybraného.
+//
+// Rovnaké dve role, aké server vyžaduje na uloženie
+// (`requireRole("admin", "manazer")`) — čítať znenie smie každý prihlásený
+// zamestnanec, rovnaká úroveň ako ostatné obrazovky.
+const CONTROL_ROLES: ReadonlySet<Me["role"]> = new Set(["admin", "manazer"]);
+
+export function MailTemplatesSection({ role, onSessionExpired }: { readonly role: Me["role"]; readonly onSessionExpired: () => void }): JSX.Element {
+  const [templates, setTemplates] = useState<readonly MailTemplate[] | null>(null);
+  const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState("");
+  const [selectedKey, setSelectedKey] = useState("");
+
+  const load = useCallback(() => {
+    fetchMailTemplates()
+      .then((list) => {
+        setTemplates(list);
+        setLoaded(true);
+        setSelectedKey((current) => (current === "" ? (list[0]?.key ?? "") : current));
+      })
+      .catch((err: unknown) => {
+        setLoaded(true);
+        if (err instanceof MailTemplatesUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setError("Texty e-mailov sa nepodarilo načítať.");
+      });
+  }, [onSessionExpired]);
+
+  useEffect(load, [load]);
+
+  if (!loaded) return <p>Načítavam…</p>;
+  if (error !== "") return <p role="alert">{error}</p>;
+  if (templates === null) return <p role="alert">Texty e-mailov sa nepodarilo načítať.</p>;
+
+  const selected = templates.find((t) => t.key === selectedKey) ?? templates[0];
+
+  return (
+    <section>
+      <p>
+        Znenie každého e-mailu, ktorý appka posiela. Polia v zložených zátvorkách sa pri odoslaní nahradia skutočnými údajmi — meno zákazníka, číslo objednávky a
+        podobne.
+      </p>
+
+      <div className="mt-layout">
+        <nav className="mt-list" aria-label="Druhy e-mailov" data-testid="mail-template-list">
+          {templates.map((t) => (
+            <button
+              key={t.key}
+              type="button"
+              className={`mt-list-item${t.key === selected?.key ? " active" : ""}`}
+              onClick={() => {
+                setSelectedKey(t.key);
+              }}
+              data-testid={`mail-template-pick-${t.key}`}
+            >
+              <span className="mt-list-label">{t.label}</span>
+              {t.isCustomized && <span className="pill">upravené</span>}
+            </button>
+          ))}
+        </nav>
+
+        {selected === undefined ? (
+          <p>Žiadny druh e-mailu nie je nastavený.</p>
+        ) : (
+          // Prepnutie druhu namontuje editor NANOVO — rozpísané znenie sa tak
+          // vždy načíta z aktuálnych props a nepotrebuje synchronizačný efekt.
+          <MailTemplateEditor
+            key={selected.key}
+            template={selected}
+            canEdit={CONTROL_ROLES.has(role)}
+            onSaved={load}
+            onSessionExpired={onSessionExpired}
+          />
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/mailTemplatesApi.ts
+++ b/apps/web/src/mailTemplatesApi.ts
@@ -1,0 +1,103 @@
+import { z } from "zod";
+
+// issue 192: obrazovka "Texty e-mailov" — zrkadlí `http/mail-template-routes.ts`.
+
+const placeholderSchema = z.object({ name: z.string(), label: z.string() });
+export type MailPlaceholder = z.infer<typeof placeholderSchema>;
+
+const templateSchema = z.object({
+  key: z.string(),
+  label: z.string(),
+  description: z.string(),
+  subject: z.string(),
+  body: z.string(),
+  defaultSubject: z.string(),
+  defaultBody: z.string(),
+  isCustomized: z.boolean(),
+  updatedAt: z.string().nullable(),
+  updatedByName: z.string().nullable(),
+  placeholders: z.array(placeholderSchema),
+});
+export type MailTemplate = z.infer<typeof templateSchema>;
+
+const listSchema = z.object({ templates: z.array(templateSchema) });
+
+const previewSchema = z.union([
+  z.object({ ok: z.literal(true), subject: z.string(), html: z.string(), text: z.string() }),
+  z.object({ ok: z.literal(false), error: z.string() }),
+]);
+export type MailTemplatePreview = z.infer<typeof previewSchema>;
+
+const writeSchema = z.union([z.object({ ok: z.literal(true) }), z.object({ ok: z.literal(false), error: z.string() })]);
+export type MailTemplateWriteResult = z.infer<typeof writeSchema>;
+
+const historyEntrySchema = z.object({
+  id: z.string(),
+  action: z.enum(["save", "reset"]),
+  subject: z.string(),
+  changedAt: z.string(),
+  changedByName: z.string().nullable(),
+});
+export type MailTemplateHistoryEntry = z.infer<typeof historyEntrySchema>;
+
+const historySchema = z.union([
+  z.object({ ok: z.literal(true), entries: z.array(historyEntrySchema) }),
+  z.object({ ok: z.literal(false), error: z.string() }),
+]);
+
+export class MailTemplatesUnauthorizedError extends Error {
+  constructor() {
+    super("Neprihlásený");
+  }
+}
+
+const errorBodySchema = z.object({ error: z.string() });
+
+async function readJson(response: Response, fallback: string): Promise<unknown> {
+  if (response.status === 401) throw new MailTemplatesUnauthorizedError();
+  if (!response.ok) {
+    try {
+      const parsed = errorBodySchema.safeParse(await response.json());
+      if (parsed.success) throw new Error(parsed.data.error);
+    } catch (error) {
+      if (error instanceof Error && error.message !== "") throw error;
+    }
+    throw new Error(fallback);
+  }
+  return await response.json();
+}
+
+function jsonInit(method: string, body?: unknown): RequestInit {
+  return {
+    method,
+    headers: { "content-type": "application/json" },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  };
+}
+
+export async function fetchMailTemplates(): Promise<readonly MailTemplate[]> {
+  const response = await fetch("/api/mail-templates");
+  return listSchema.parse(await readJson(response, "Texty e-mailov sa nepodarilo načítať")).templates;
+}
+
+export async function fetchMailTemplatePreview(key: string, subject: string, body: string): Promise<MailTemplatePreview> {
+  const response = await fetch("/api/mail-templates/preview", jsonInit("POST", { key, subject, body }));
+  return previewSchema.parse(await readJson(response, "Náhľad sa nepodarilo pripraviť"));
+}
+
+export async function saveMailTemplate(key: string, subject: string, body: string): Promise<MailTemplateWriteResult> {
+  const response = await fetch(`/api/mail-templates/${encodeURIComponent(key)}`, jsonInit("PUT", { subject, body }));
+  return writeSchema.parse(await readJson(response, "Uloženie zlyhalo"));
+}
+
+export async function resetMailTemplate(key: string): Promise<MailTemplateWriteResult> {
+  const response = await fetch(`/api/mail-templates/${encodeURIComponent(key)}/reset`, jsonInit("POST"));
+  return writeSchema.parse(await readJson(response, "Vrátenie pôvodného znenia zlyhalo"));
+}
+
+export async function fetchMailTemplateHistory(key: string): Promise<readonly MailTemplateHistoryEntry[]> {
+  const response = await fetch(`/api/mail-templates/${encodeURIComponent(key)}/history`);
+  const parsed = historySchema.parse(await readJson(response, "Históriu zmien sa nepodarilo načítať"));
+  if (!parsed.ok) throw new Error(parsed.error);
+  return parsed.entries;
+}

--- a/apps/web/src/nav.test.ts
+++ b/apps/web/src/nav.test.ts
@@ -4,15 +4,17 @@ import { DEFAULT_TAB_ID, HIDDEN_TABS, NAV, findTab, isVisibleTabId } from "./nav
 // #57 pôvodne chcel naľavo PRESNE dve viditeľné položky — issue 185 pridalo
 // tretí priečinok "Automatizácie" s tromi hotovými obrazovkami, issue 195
 // presunulo "Nedostupné tovary" z Automatizácií pod "Eshop" (nemá naplánovanú
-// úlohu ani prepínač zapnuté/vypnuté, je to pracovná obrazovka). Tento test je
+// úlohu ani prepínač zapnuté/vypnuté, je to pracovná obrazovka), issue 192
+// pridalo "Texty e-mailov" do Systému (nastavenie spoločné pre VŠETKY
+// automatizácie). Tento test je
 // najbližšie k tomu, čo strojovo overiť dá (registrácia, nie DOM).
-it("NAV má tri priečinky (Systém/Eshop/Automatizácie), s 1/2/2 záložkami v poradí podľa dôležitosti", () => {
+it("NAV má tri priečinky (Systém/Eshop/Automatizácie), s 2/2/2 záložkami v poradí podľa dôležitosti", () => {
   expect(NAV).toHaveLength(3);
   expect(NAV.map((f) => f.label)).toEqual(["Systém", "Eshop", "Automatizácie"]);
-  expect(NAV[0]?.tabs).toHaveLength(1);
+  expect(NAV[0]?.tabs).toHaveLength(2);
   expect(NAV[1]?.tabs).toHaveLength(2);
   expect(NAV[2]?.tabs).toHaveLength(2);
-  expect(NAV[0]?.tabs[0]?.label).toBe("Sync zo Shoptetu");
+  expect(NAV[0]?.tabs.map((t) => t.label)).toEqual(["Sync zo Shoptetu", "Texty e-mailov"]);
   expect(NAV[1]?.tabs.map((t) => t.label)).toEqual(["Na objednanie", "Nedostupné tovary"]);
   expect(NAV[2]?.tabs.map((t) => t.label)).toEqual([
     "Nevyzdvihnuté zásielky",

--- a/apps/web/src/nav.ts
+++ b/apps/web/src/nav.ts
@@ -1,6 +1,7 @@
 import type { ComponentType } from "react";
 import type { Me } from "./api.js";
 import { CatalogPage } from "./components/CatalogPage.js";
+import { MailTemplatesSection } from "./components/MailTemplatesSection.js";
 import { NedostupneSection } from "./components/NedostupneSection.js";
 import { OrderReminderSection } from "./components/OrderReminderSection.js";
 import { OrdersSection } from "./components/OrdersSection.js";
@@ -53,7 +54,13 @@ export const NAV: readonly NavFolder[] = [
   {
     id: "system",
     label: "Systém",
-    tabs: [{ id: "sync", label: "Sync zo Shoptetu", icon: "🔄", Component: SyncSection }],
+    // issue 192: "Texty e-mailov" patrí sem — je to nastavenie appky, ktoré sa
+    // dotýka VŠETKÝCH automatizácií naraz, nie práca s konkrétnymi
+    // objednávkami (tá je v Eshope) ani jedna konkrétna automatizácia.
+    tabs: [
+      { id: "sync", label: "Sync zo Shoptetu", icon: "🔄", Component: SyncSection },
+      { id: "mail-templates", label: "Texty e-mailov", icon: "✉️", Component: MailTemplatesSection, wide: true },
+    ],
   },
   {
     id: "eshop",

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -1821,3 +1821,182 @@ tr:last-child td {
   gap: var(--fs-space-3);
   margin-top: var(--fs-space-4);
 }
+
+/* ── Texty e-mailov (issue 192) ─────────────────────────────────────────
+   Dva stĺpce: vľavo zoznam druhov e-mailov, vpravo úprava + živý náhľad.
+   Na úzkej obrazovke sa poskladajú pod seba (`auto-fit`/`minmax` namiesto
+   pevných šírok), aby sa obrazovka dala použiť aj pri priblížení. */
+.mt-layout {
+  display: grid;
+  grid-template-columns: minmax(14rem, 20rem) minmax(0, 1fr);
+  gap: var(--fs-space-5);
+  align-items: start;
+  margin-top: var(--fs-space-4);
+}
+
+@media (max-width: 60rem) {
+  .mt-layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+.mt-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--fs-space-2);
+}
+
+.mt-list-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--fs-space-2);
+  /* Veľký klikací cieľ — obsluha sa má vedieť rýchlo preklikávať
+     (zadanie majiteľa k celej appke). */
+  min-height: 3rem;
+  padding: var(--fs-space-3) var(--fs-space-4);
+  text-align: left;
+  background: var(--fs-surface);
+  border: 1px solid var(--fs-border);
+  border-radius: var(--fs-radius-md);
+  color: var(--fs-ink);
+  font-size: var(--fs-text-base);
+  cursor: pointer;
+}
+
+.mt-list-item:hover {
+  border-color: var(--fs-brand);
+}
+
+.mt-list-item.active {
+  background: var(--fs-brand-soft);
+  border-color: var(--fs-brand);
+  font-weight: var(--fs-weight-semibold);
+}
+
+.mt-list-label {
+  /* Dlhý slovenský názov sa zalomí v položke, nikdy neroztiahne stĺpec. */
+  min-width: 0;
+  overflow-wrap: break-word;
+}
+
+.mt-editor {
+  background: var(--fs-surface);
+  border: 1px solid var(--fs-border);
+  border-radius: var(--fs-radius-lg);
+  box-shadow: var(--fs-shadow-sm);
+  padding: var(--fs-space-5);
+}
+
+.mt-editor-head h3 {
+  margin: 0;
+}
+
+.mt-editor-desc {
+  margin: var(--fs-space-1) 0 var(--fs-space-2);
+  color: var(--fs-ink-muted);
+}
+
+.mt-editor-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: var(--fs-space-5);
+  margin-top: var(--fs-space-4);
+}
+
+@media (max-width: 75rem) {
+  .mt-editor-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+.mt-fields {
+  display: flex;
+  flex-direction: column;
+  gap: var(--fs-space-4);
+  min-width: 0;
+}
+
+.mt-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--fs-space-2);
+  font-weight: var(--fs-weight-medium);
+}
+
+.mt-field input,
+.mt-field textarea {
+  width: 100%;
+  font-size: var(--fs-text-base);
+  font-weight: 400;
+}
+
+.mt-field textarea {
+  /* Znenie e-mailu sa píše po riadkoch — monospace by bolo zbytočne
+     technické, ale zalomenie a výška musia dať vidieť celý text naraz. */
+  resize: vertical;
+  line-height: 1.5;
+}
+
+.mt-placeholders-title {
+  margin: 0 0 var(--fs-space-2);
+  color: var(--fs-ink-muted);
+  font-size: var(--fs-text-sm);
+}
+
+.mt-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--fs-space-2);
+}
+
+.mt-hint {
+  margin: var(--fs-space-2) 0 0;
+  color: var(--fs-ink-muted);
+  font-size: var(--fs-text-sm);
+}
+
+.mt-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--fs-space-3);
+}
+
+.mt-preview {
+  min-width: 0;
+  background: var(--fs-surface-alt);
+  border: 1px solid var(--fs-border-soft);
+  border-radius: var(--fs-radius-md);
+  padding: var(--fs-space-4);
+}
+
+.mt-preview-title {
+  margin: 0 0 var(--fs-space-2);
+  font-weight: var(--fs-weight-semibold);
+}
+
+.mt-preview-subject {
+  margin: 0 0 var(--fs-space-3);
+  color: var(--fs-ink-muted);
+  font-size: var(--fs-text-sm);
+}
+
+.mt-preview-body {
+  background: var(--fs-surface);
+  border: 1px solid var(--fs-border);
+  border-radius: var(--fs-radius-sm);
+  padding: var(--fs-space-4);
+  /* Vygenerovaný e-mail smie byť širší než náhľad — nikdy nesmie roztiahnuť
+     celú stránku do vodorovného posúvania. */
+  overflow-x: auto;
+}
+
+.mt-history {
+  margin-top: var(--fs-space-5);
+  border-top: 1px solid var(--fs-border-soft);
+  padding-top: var(--fs-space-4);
+}
+
+.mt-history h4 {
+  margin: 0 0 var(--fs-space-2);
+}

--- a/apps/web/tests/e2e/mail-templates.spec.ts
+++ b/apps/web/tests/e2e/mail-templates.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test } from "@playwright/test";
+
+const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
+const E2E_MAILY_EMAIL = "e2e-maily@forestshop.sk"; // musí sa zhodovať s hodnotou v scripts/e2e-setup.ts
+
+// issue 192: "Texty e-mailov" — obrazovka je v ľavom menu pod "Systém".
+// Nič sa tu neodosiela: tieto trasy len čítajú a zapisujú ZNENIE e-mailu,
+// žiadny mail transport sa nedotknú (`playwright.config.ts` navyše serveru
+// nenastavuje `MAIL_HOST`).
+test("úprava znenia e-mailu: vloženie poľa, živý náhľad, uloženie a vrátenie pôvodného; konzola je čistá", async ({ page }) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/");
+  await page.getByLabel("E-mail").fill(E2E_MAILY_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+
+  // Obrazovka je dostupná z ľavého menu (nie skrytá za `?tab=`).
+  await page.getByRole("button", { name: "Texty e-mailov" }).click();
+  await expect(page.getByTestId("mail-template-list")).toBeVisible();
+
+  // Prvý druh sa otvorí sám; prepneme na pripomienku objednávok, aby test
+  // zároveň overil prepínanie medzi druhmi.
+  await page.getByTestId("mail-template-pick-order_reminder").click();
+  await expect(page.getByTestId("mail-template-editor-order_reminder")).toBeVisible();
+  await expect(page.getByTestId("mail-template-original")).toBeVisible();
+
+  // Náhľad sa počíta na serveri z rozpísaného znenia.
+  await expect(page.getByTestId("mail-template-preview")).toContainText("Dobrý deň");
+
+  const predmet = page.getByTestId("mail-template-subject");
+  await predmet.fill("E2E predmet ");
+  // Kliknutie na pole ho vloží do NAPOSLEDY zameraného vstupu — tu do predmetu.
+  await page.getByTestId("mail-template-chip-cislo_objednavky").click();
+  await expect(predmet).toHaveValue("E2E predmet {{cislo_objednavky}}");
+
+  // Náhľad predmetu sa prepočíta a zástupné pole je v ňom už nahradené.
+  await expect(page.getByTestId("mail-template-preview-subject")).toContainText("E2E predmet");
+  await expect(page.getByTestId("mail-template-preview-subject")).not.toContainText("{{");
+
+  await page.getByTestId("mail-template-save").click();
+  await expect(page.getByTestId("mail-template-saved")).toBeVisible();
+  await expect(page.getByTestId("mail-template-customized")).toBeVisible();
+
+  // Uložené znenie prežije obnovenie stránky.
+  await page.reload();
+  await page.getByRole("button", { name: "Texty e-mailov" }).click();
+  await page.getByTestId("mail-template-pick-order_reminder").click();
+  await expect(page.getByTestId("mail-template-subject")).toHaveValue("E2E predmet {{cislo_objednavky}}");
+
+  // História zaznamenala zmenu.
+  await page.getByTestId("mail-template-history-load").click();
+  await expect(page.getByTestId("mail-template-history")).toContainText("uložené nové znenie");
+
+  // Vrátenie pôvodného znenia vráti obrazovku do východiskového stavu —
+  // fixtúra tak ostáva rovnaká pre ďalšie testy aj ďalšie behy.
+  await page.getByTestId("mail-template-reset").click();
+  await expect(page.getByTestId("mail-template-original")).toBeVisible();
+  await expect(page.getByTestId("mail-template-subject")).toHaveValue("📦 Stav vašej objednávky z Forestshop.sk");
+
+  // Druhá časť v TOM ISTOM teste (jedno prihlásenie): neplatná šablóna. E2E
+  // balík je na strope 30 prihlásení na IP za 5 minút
+  // (`IP_MAX_ATTEMPTS`, `login-rate-limit.ts`) — ďalší samostatný test s
+  // vlastným prihlásením by ho pretiekol a zhodil NÁHODNÝ neskorší spec
+  // súbor (`.claude/rules/testing.md`).
+  await page.getByTestId("mail-template-pick-nedostupne").click();
+  await expect(page.getByTestId("mail-template-editor-nedostupne")).toBeVisible();
+
+  await page.getByTestId("mail-template-body").fill("Dobrý deň, {{vymyslene_pole}}");
+  // Náhľad chybu ohlási hneď, ešte pred uložením.
+  await expect(page.getByTestId("mail-template-preview-error")).toContainText("{{vymyslene_pole}}");
+
+  await page.getByTestId("mail-template-save").click();
+  await expect(page.getByTestId("mail-template-error")).toContainText("{{vymyslene_pole}}");
+  // Neuložilo sa — šablóna ostáva pôvodná.
+  await expect(page.getByTestId("mail-template-original")).toBeVisible();
+
+  // Neplatná šablóna NESMIE vyrobiť konzolovú chybu — server ju vracia ako
+  // 200 s vysvetlením, nikdy ako 4xx (`.claude/rules/testing.md`).
+  expect(chyby).toEqual([]);
+});

--- a/apps/web/tests/e2e/nav.spec.ts
+++ b/apps/web/tests/e2e/nav.spec.ts
@@ -15,7 +15,7 @@ const E2E_NAV_EMAIL = "e2e-nav@forestshop.sk";
 // tretí priečinok "Automatizácie" s tromi hotovými obrazovkami, dovtedy len v
 // `HIDDEN_TABS` bez odkazu v menu — tento test teraz overuje VŠETKÝCH PÄŤ
 // záložiek v troch priečinkoch.
-test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s piatimi záložkami, klik prepne obrazovku, panel sa zbalí do lišty a stav si pamätá, konzola je čistá", async ({
+test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) so šiestimi záložkami, klik prepne obrazovku, panel sa zbalí do lišty a stav si pamätá, konzola je čistá", async ({
   page,
 }) => {
   const chyby: string[] = [];
@@ -36,9 +36,10 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s piatimi z�
   await expect(page.getByRole("button", { name: "Eshop" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Automatizácie" })).toBeVisible();
 
-  // Presne päť záložiek v CELOM menu.
-  await expect(page.locator(".side-nav .tab")).toHaveCount(5);
+  // Presne šesť záložiek v CELOM menu.
+  await expect(page.locator(".side-nav .tab")).toHaveCount(6);
   await expect(page.getByRole("button", { name: "Sync zo Shoptetu" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Texty e-mailov" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Na objednanie" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Nevyzdvihnuté zásielky" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Pripomienky objednávok" })).toBeVisible();
@@ -113,9 +114,9 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s piatimi z�
   expect(panelZbaleny).toBeLessThan(panelRozbaleny);
   expect(obsahZbaleny).toBeGreaterThan(obsahRozbaleny);
 
-  // Hlavičky priečinkov zmiznú, ikony všetkých piatich modulov ostanú.
+  // Hlavičky priečinkov zmiznú, ikony všetkých šiestich modulov ostanú.
   await expect(page.getByRole("button", { name: "Systém" })).toHaveCount(0);
-  await expect(page.locator(".side-nav .tab")).toHaveCount(5);
+  await expect(page.locator(".side-nav .tab")).toHaveCount(6);
   // Názov sa v lište ukáže bublinou pri prejdení myšou.
   await expect(page.getByRole("button", { name: "Na objednanie" })).toHaveAttribute(
     "title",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.116",
+  "version": "0.3.0-dev.117",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -145,6 +145,11 @@ const E2E_PRIPOMIENKY_EMAIL = "e2e-pripomienky@forestshop.sk"; // musí sa zhodo
 // namiesto ďalšieho prihlásenia pod zdieľaným `e2e@forestshop.sk`.
 const E2E_NEDOSTUPNE_EMAIL = "e2e-nedostupne@forestshop.sk"; // musí sa zhodovať s hodnotou v nedostupne.spec.ts
 
+// issue 192: rovnaký mechanizmus a dôvod ako `E2E_NEDOSTUPNE_EMAIL` vyššie —
+// nový spec súbor (`mail-templates.spec.ts`) dostáva VLASTNÝ izolovaný účet
+// namiesto ďalšieho prihlásenia pod zdieľaným `e2e@forestshop.sk`.
+const E2E_MAILY_EMAIL = "e2e-maily@forestshop.sk"; // musí sa zhodovať s hodnotou v mail-templates.spec.ts
+
 const { db, pool } = createDb();
 // Konštantný literál bez interpolácie — obyčajný reťazec je tu rovnako bezpečný
 // ako `sql` tagovaná šablóna (tú používa ekvivalentný apps/api/tests/helpers/db.ts),
@@ -283,6 +288,12 @@ await db.insert(users).values({
 });
 await db.insert(users).values({
   email: E2E_NEDOSTUPNE_EMAIL,
+  passwordHash: await hashPassword(E2E_HESLO),
+  displayName: "E2E Manažér",
+  role: "manazer",
+});
+await db.insert(users).values({
+  email: E2E_MAILY_EMAIL,
   passwordHash: await hashPassword(E2E_HESLO),
   displayName: "E2E Manažér",
   role: "manazer",

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -170,7 +170,7 @@ const { db, pool } = createDb();
 // singleton id / kód objednávky, žiadny FK. "order_reminder_settings"/
 // "order_reminder_state" (issue 173) sú rovnaký prípad znova.
 await db.execute(
-  'TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state RESTART IDENTITY CASCADE',
+  'TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, mail_template, mail_template_history RESTART IDENTITY CASCADE',
 );
 // Rovnaký dôvod ako `tests/helpers/db.ts`: bez tohto by "Na objednanie" bolo
 // v CELOM e2e behu prázdne pre KAŽDÚ objednávku (žiadny nastavený otvorený


### PR DESCRIPTION
Majiteľ (3. 8. 2026): *"pri každej veci čo posiela mail by mala byť možnosť
zmeniť text mailu, inteligentne aj s prepojeniami"*.

Znenia e-mailov boli doteraz napevno v kóde. Odteraz sa dajú upraviť na
obrazovke **Systém → Texty e-mailov**, bez zásahu do programu.

## Ako to funguje

Šablóna je obyčajný text so **zástupnými poľami** — appka z nej vyrobí HTML aj
čistotextovú verziu, takže majiteľ nikdy neupravuje HTML a escapovanie ostáva
na appke.

- `{{pole}}` — pole, ktoré sa pri odoslaní nahradí skutočným údajom
- `{{#ak pole}}…{{inak}}…{{/ak}}` — podmienená časť
- `**tučné**`, prázdny riadok = nový odstavec

Podmienka nie je navyše: dnešné texty ju reálne obsahujú (zásielka s termínom
vyzdvihnutia vs. bez neho, nedostupný tovar so zoznamom náhrad vs. bez neho).
Bez nej by sa zavedením šablón ticho zmenilo správanie.

**Osem šablón** — nedostupný tovar bez/s náhradou, štyri zásielkové
upozornenia (eskalácia sa zachováva), pripomienka objednávky, objednávka
dodávateľovi.

**Pôvodné znenia ostávajú v kóde.** Riadok v `mail_template` existuje len pre
šablónu, ktorú majiteľ naozaj zmenil — „vrátiť pôvodné znenie" je preto
obyčajné zmazanie riadku a pôvodné texty nemôžu zastarať oproti kódu.

**Ochrana proti nezmyslu:** uloženie prejde len keď každé použité pole patrí
do zoznamu polí danej šablóny, podmienky sú spárované a nevnorené, predmet ani
text nie sú prázdne. Preklep v názve poľa sa teda nikdy nemôže dostať k
zákazníkovi ako surový text.

**Náhľad** sa počíta na serveri z práve rozpísaného (ešte neuloženého) znenia,
na skutočných dátach z databázy. Nič sa pritom neodosiela.

## Čo ešte v tomto PR

- E2E balík narazil na strop **30 prihlásení na IP za 5 minút** — všetkých ~30
  prihlásení celého behu prichádza z jednej adresy (localhost), takže limit
  narazil zo svojej podstaty, nie kvôli útoku. Prejavovalo sa to ako
  „Nesprávny e-mail alebo heslo" v náhodnom neskoršom spec súbore. Strop je
  odteraz premennou prostredia; **produkčná hodnota 30 sa nemení** a limit na
  (IP, e-mail) pár — ten, čo chráni konkrétny účet — sa nemení ani v testoch.
- `nedostupne_state` doplnené do TRUNCATE zoznamu v `scripts/e2e-setup.ts`
  (chýbalo tam, na rozdiel od integračného zoznamu).
- Odstránené konštanty predmetov, ktoré prechodom na šablóny osireli.

## Testy

- `render.test.ts` (20) — polia, obe vetvy podmienky, tučné písmo cez hranicu
  poľa, escapovanie nepriateľskej hodnoty, zoznam v HTML aj texte, kontrola
  pred uložením
- `registry.test.ts` (34) — **každé pôvodné znenie prechádza tou istou
  kontrolou ako uložená šablóna** (poistka, že pôvodný text nemôže vyjsť
  pokazený, keďže sa nikdy neukladá)
- `mail-templates.integration.test.ts` (8) — uloženie/vrátenie, odmietnutie
  neznámeho poľa, história, rola `citanie` upravovať nesmie
- `MailTemplatesSection.test.tsx` (11) — zoznam, prepínanie, vloženie poľa,
  uloženie, vrátenie, náhľad
- `mail-templates.spec.ts` — celý postup v prehliadači, nulová konzola
- Existujúce testy štyroch staviteľov e-mailov prešli **bez zmeny znenia** —
  dôkaz, že prechod na šablóny výsledné texty nezmenil

Žiadny test neodošle skutočný e-mail (renderovanie je čistá funkcia,
integračné testy majú falošný transport, e2e beží bez `MAIL_HOST`).

Ticket: issue 192 (zostáva otvorený do živého overenia po nasadení).
