### PR TITLE
Na objednanie: pilulka suctu sa uz neprekryva s odkazom na dodavatela

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -641,3 +641,25 @@ paths:
   proti pokazenému kódu, čiže by bol tautológia (`test-strictness.md`). Také
   overenie patrí do `tests/e2e/*.spec.ts` (`await expect(locator)
   .toBeFocused()`) a v unit súbore ostane len komentár, PREČO tam test nie je.
+- **Pilulka/odznak s `white-space: nowrap` vykreslený INLINE v úzkej bunke
+  pretečie do susedného stĺpca — a `text-align: right` to ešte skryje pred
+  okom, lebo obsah "vyzerá zarovnaný".** Issue 204 (majiteľ: "link dodavatel
+  a spolu sa prekrivaju … 1 ksΣ spolu 1 ks 🔗"): `.qty-total-chip` mala 82px
+  obsahu v 54px bunke, takže sedela presne nad ikonkou 🔗 vedľajšieho
+  stĺpca (naživo namerané: `chip.right 845` vs `td.right 796`,
+  `td.scrollWidth 103` vs `clientWidth 54`). Toto je TRETÍ tvar tej istej
+  triedy chýb po `.ord-stale-badge` (issue 127) a `.ord-supplier-assign`
+  (issue 63) — **každý nový neinteraktívny odznak/pilulka v tejto tabuľke
+  dostáva rovnaké tri veci naraz:** vlastný riadok v stack `<div>`e (nikdy
+  `display:flex` priamo na `<td>` — issue 163), `max-width: 100%` +
+  `overflow:hidden; text-overflow:ellipsis` (garancia pre BUDÚCI dlhší
+  obsah, nielen dnešný), a čo najkratší text s celým vysvetlením v `title`.
+  Regresná kontrola patrí do `orders-layout.spec.ts` rovnakým vzorom ako
+  `staleOdznaky` (`element.right <= td.right` + `td.scrollWidth <=
+  clientWidth` na všetkých 4 šírkach).
+- **Skrátenie textu v bunke je lacnejšie než presúvanie `<colgroup>`
+  percent.** Pri issue 204 stačilo "Σ spolu N ks" → "Σ N ks" (potreba klesla
+  na 41px, zmestí sa do dnešných 54px) a **výška riadkov sa nezmenila ani o
+  pixel** (paired meranie na 40 reálnych riadkoch, priemer aj maximum 0px) —
+  darcovský stĺpec (postup issue 107/111/127) by naopak zhoršil iný stĺpec.
+  Než začneš hľadať darcu, over, či sa obsah nedá skrátiť.

--- a/apps/web/src/components/OrderLineRow.tsx
+++ b/apps/web/src/components/OrderLineRow.tsx
@@ -277,13 +277,21 @@ export function OrderLineRow({
             )}
           </div>
         </td>
+        {/* issue 204: majiteľ, "link dodavatel a spolu sa prekrivaju je to
+            nepekne 1 ksΣ spolu 1 ks 🔗" — pilulka bola INLINE za množstvom a
+            pretekala z 54px bunky nad ikonku odkazu v susednom stĺpci.
+            Stackujú sa teraz pod seba vo VNÚTORNOM `<div>`, nikdy cez `flex`
+            priamo na `<td>` (to bola príčina issue 163's nelícujúcej deliacej
+            čiary). */}
         <td className="ord-qty">
-          {line.quantity} ks
-          {qtyChip !== null && (
-            <span className="qty-total-chip" data-testid={`qty-total-${line.lineId}`} title={qtyChip.title}>
-              {qtyChip.text}
-            </span>
-          )}
+          <div className="ord-qty-stack">
+            <span>{line.quantity} ks</span>
+            {qtyChip !== null && (
+              <span className="qty-total-chip" data-testid={`qty-total-${line.lineId}`} title={qtyChip.title}>
+                {qtyChip.text}
+              </span>
+            )}
+          </div>
         </td>
         {/* issue 95: DODÁVATEĽ + PRIRADENIE DODÁVATEĽA zlúčené do jednej bunky
             (majiteľ, komentár #1) — oba vnorené bloky nižšie sú BEZ ZMENY

--- a/apps/web/src/ordersSummary.test.ts
+++ b/apps/web/src/ordersSummary.test.ts
@@ -129,7 +129,7 @@ it("formatVariantTotalChip vráti null, keď produkt má v skupine LEN jeden ria
 
 // issue 63 (nález pri kontrole issue 62): chip sa doteraz rozhodoval LEN
 // podľa `lineCount < 2`, nie podľa zvyšku — opakovaný produkt, ktorý je UŽ
-// celý vybavený, by preto navždy visel s "Σ spolu 0 ks".
+// celý vybavený, by preto navždy visel s "Σ 0 ks".
 it("formatVariantTotalChip vráti null, keď je produkt s ≥2 riadkami UŽ CELÝ vybavený (remaining === 0)", () => {
   const totals = computeVariantTotals([
     variantLine("4859/46", 3, "objednane", true), // odškrtnutý → vybavený
@@ -150,7 +150,7 @@ it("formatVariantTotalChip s ≥2 riadkami vráti text so ZOSTÁVAJÚCIM množst
   if (vt === undefined) throw new Error("4859/46 musí byť v mape");
   const chip = formatVariantTotalChip(vt);
   expect(chip).toEqual({
-    text: "Σ spolu 3 ks",
+    text: "Σ 3 ks",
     title: "Spolu vo všetkých objednávkach: 5 ks · nevybavené: 3 ks",
   });
 });

--- a/apps/web/src/ordersSummary.ts
+++ b/apps/web/src/ordersSummary.ts
@@ -116,7 +116,11 @@ export function computeVariantTotals(
 export function formatVariantTotalChip(vt: VariantTotal): { readonly text: string; readonly title: string } | null {
   if (vt.lineCount < 2 || vt.remaining === 0) return null;
   return {
-    text: `Σ spolu ${String(vt.remaining)} ks`,
+    // issue 204: text skrátený zo "Σ spolu N ks" na "Σ N ks" — dlhší tvar sa
+    // do 54px stĺpca s množstvom nezmestil ani po zalomení pod množstvo
+    // (nameraných 82px obsahu), takže pretekal do susedného stĺpca. Celé
+    // vysvetlenie nesie `title` nižšie, ktorý sa nemení.
+    text: `Σ ${String(vt.remaining)} ks`,
     title: `Spolu vo všetkých objednávkach: ${String(vt.total)} ks · nevybavené: ${String(vt.remaining)} ks`,
   };
 }

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -961,10 +961,26 @@ tr:last-child td {
 /* issue 62: súčet kusov toho istého produktu naprieč objednávkami dodávateľa
    — neklikateľná pilulka, zámerne odlišná od interaktívneho `.chip`
    (dodávateľský filter), aby sa nedali zameniť za ovládací prvok. */
+/* issue 204: množstvo a pilulka pod sebou, zarovnané doprava (bunka má
+   `text-align: right`). Flex je zámerne TU, na vnútornom `<div>`, nikdy na
+   `<td>` samotnej — `display:flex` na bunke ju odpojí od výšky riadku a jej
+   deliaca čiara prestane lícovať (issue 163). */
+.ord-qty-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: var(--fs-space-1);
+  min-width: 0;
+}
 .qty-total-chip {
   display: inline-flex;
   align-items: center;
-  margin-left: var(--fs-space-2);
+  /* issue 204: pilulka je vlastný riadok stacku, vodorovný odstup od
+     množstva už nedáva zmysel; `max-width` + orezanie garantujú, že sa už
+     NIKDY nedostane mimo svoju bunku, ani pri trojcifernom počte kusov. */
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
   padding: 0 var(--fs-space-2);
   font-size: var(--fs-text-xs);
   font-weight: var(--fs-weight-medium);

--- a/apps/web/tests/e2e/orders-layout.spec.ts
+++ b/apps/web/tests/e2e/orders-layout.spec.ts
@@ -167,6 +167,30 @@ test("STAV je celý čitateľný a POZNÁMKY pole je dosť široké na všetkýc
       expect(scrollOverflow, `bunka odznaku posúva obsah pri ${String(width)}px`).toBe(false);
     }
 
+    // issue 204: majiteľ, "link dodavatel a spolu sa prekrivaju je to nepekne
+    // 1 ksΣ spolu 1 ks 🔗" — pilulka so súčtom kusov sa vykresľovala INLINE za
+    // množstvom a s `white-space: nowrap` pretiekla o ~49px za pravý okraj
+    // svojej 54px bunky (naživo namerané na produkcii) presne nad ikonku
+    // odkazu na dodávateľa v susednom stĺpci. Rovnaká kontrola ako pri
+    // odznaku veku objednávky (issue 127) — pilulka sa musí CELÁ zmestiť do
+    // svojej bunky na KAŽDEJ zo 4 šírok.
+    const pretekajuceSucty = await page.evaluate(() => {
+      return [...document.querySelectorAll<HTMLElement>("[data-testid^='qty-total-']")].map((pilulka) => {
+        const td = pilulka.closest("td");
+        if (td === null) return { spill: null, scrollOverflow: null };
+        return {
+          spill: pilulka.getBoundingClientRect().right - td.getBoundingClientRect().right,
+          scrollOverflow: td.scrollWidth > td.clientWidth,
+        };
+      });
+    });
+    expect(pretekajuceSucty.length, `žiadna pilulka súčtu nenájdená pri ${String(width)}px`).toBeGreaterThan(0);
+    for (const { spill, scrollOverflow } of pretekajuceSucty) {
+      expect(spill, `pilulka súčtu pretŕča svoju bunku pri ${String(width)}px`).not.toBeNull();
+      expect(spill as number, `pilulka súčtu pretŕča svoju bunku pri ${String(width)}px`).toBeLessThanOrEqual(0);
+      expect(scrollOverflow, `bunka s množstvom posúva obsah pri ${String(width)}px`).toBe(false);
+    }
+
     // issue 111 bod 5: pri 1280px sa žiadna `.orders-table-wrap` skupina
     // nesmie posúvať vodorovne (predtým 💾 tlačidlo bolo za viditeľným
     // okrajom, kým manažér nescrolloval).

--- a/apps/web/tests/e2e/orders.spec.ts
+++ b/apps/web/tests/e2e/orders.spec.ts
@@ -197,9 +197,9 @@ test("súčet kusov toho istého produktu naprieč objednávkami dodávateľa sa
 
   // Pred akoukoľvek zmenou: obe objednávky nevybavené → chip na OBOCH
   // riadkoch ukazuje celé dopytované množstvo (3 + 2 = 5) ako zostávajúce.
-  await expect(chipPrva).toHaveText("Σ spolu 5 ks");
+  await expect(chipPrva).toHaveText("Σ 5 ks");
   await expect(chipPrva).toHaveAttribute("title", "Spolu vo všetkých objednávkach: 5 ks · nevybavené: 5 ks");
-  await expect(chipDruha).toHaveText("Σ spolu 5 ks");
+  await expect(chipDruha).toHaveText("Σ 5 ks");
 
   // Odškrtnutie PRVÉHO riadku (3 ks) ako objednané — `.click()`, nie
   // `.check()` (`.claude/rules/testing.md`: zápis je async, `.check()` by na
@@ -211,8 +211,8 @@ test("súčet kusov toho istého produktu naprieč objednávkami dodávateľa sa
   // Prepočet je OKAMŽITÝ (bez `page.reload()`) a týka sa OBOCH riadkov
   // naraz — presne požiadavka ticketu ("súčet sa musí prepočítať hneď po
   // zmene stavu riadku, bez obnovenia stránky").
-  await expect(chipPrva).toHaveText("Σ spolu 2 ks");
-  await expect(chipDruha).toHaveText("Σ spolu 2 ks");
+  await expect(chipPrva).toHaveText("Σ 2 ks");
+  await expect(chipDruha).toHaveText("Σ 2 ks");
   await expect(chipDruha).toHaveAttribute("title", "Spolu vo všetkých objednávkach: 5 ks · nevybavené: 2 ks");
   await expect(page.getByRole("alert")).toHaveCount(0);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.117",
+  "version": "0.3.0-dev.118",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Čo to rieši

Majiteľ (3. 8. 2026): "link dodavatel a spolu sa prekrivaju je to nepekne
1 ksΣ spolu 1 ks 🔗" — issue 204.

Pilulka so súčtom kusov (`Σ spolu N ks`) sa vykresľovala inline za množstvom
a s `white-space: nowrap` pretiekla za pravý okraj svojej bunky presne nad
ikonku odkazu na dodávateľa v susednom stĺpci. Naživo namerané na produkcii
(40 riadkov, 1600px): obsah pilulky 82px v 54px bunke, pretečenie 49px
(`chip.right 845` vs `td.right 796`), lokálne v teste až 62px pri 1280px.

## Ako

- Množstvo a pilulka sú pod sebou vo vnútornom `.ord-qty-stack` — flex je na
  tom `<div>`e, nikdy priamo na `<td>` (to bola príčina nelícujúcej deliacej
  čiary v predošlom tickete).
- Text skrátený na `Σ N ks` (celé vysvetlenie ostáva v `title`) — potreba
  klesla na 41px, zmestí sa do dnešného stĺpca bez zaťahovania darcovského
  stĺpca.
- Pilulka dostala `max-width: 100%` + orezanie, takže sa mimo bunku
  nedostane ani pri trojcifernom počte kusov.
- Výška riadkov sa nezmenila ani o pixel (párové meranie na 40 reálnych
  riadkoch: priemer aj maximum 0px).

## Testy

- `[red]` commit: nová kontrola v `orders-layout.spec.ts` (pilulka sa celá
  zmestí do svojej bunky na všetkých 4 šírkach) — padala o 62px.
- `[green]` commit: prechádza; celý e2e balík 29/29, typecheck, lint aj
  web unit (343) zelené.

Ticket sa zavrie ručne až po živom overení na produkcii (repo pravidlo).
