### PR TITLE
Kniha odoslanych e-mailov: komu, kedy a s akym vysledkom

### DIFF
--- a/.claude/rules/mail-log.md
+++ b/.claude/rules/mail-log.md
@@ -1,0 +1,54 @@
+---
+paths:
+  - "apps/api/src/modules/mail-log/**"
+  - "apps/api/src/http/mail-log-routes.ts"
+  - "apps/api/src/db/schema-mail-log.ts"
+  - "apps/api/src/modules/mail/transport.ts"
+  - "apps/web/src/mailLogApi.ts"
+  - "apps/web/src/components/MailLog*.tsx"
+  - "apps/web/tests/e2e/mail-log.spec.ts"
+---
+
+# Kniha odoslaných e-mailov (issue 193)
+
+- **KAŽDÉ odoslanie e-mailu ide cez `sendLoggedMail` (`mail-log/service.ts`) —
+  nikdy priamo cez `mailTransport(...)`.** Odoslanie a zápis do knihy sú
+  zámerne v JEDNEJ funkcii: keby si každý odosielateľ zapisoval sám, ďalšia
+  automatizácia by sa dala pridať tak, že na zápis zabudne — a presne to bol
+  stav pred issue 193 pri VŠETKÝCH ŠTYROCH odosielateľoch naraz (nedostupné
+  tovary, zásielky, pripomienky, objednávka dodávateľovi). Piaty odosielateľ
+  preto NEPRIDÁVA vlastné logovanie, len zavolá `sendLoggedMail` s vlastným
+  `MailLogContext`.
+- **`sendLoggedMail` NEVYHADZUJE výnimku — vracia `{ ok: false }`.** Volajúci
+  sa rozhoduje presne tak, ako to robil vo svojom pôvodnom `try/catch`. Pri
+  prepise `try/catch` → `if (!ok)` si over, čo robila PÔVODNÁ `catch` vetva:
+  v `posta-uncollected/run.ts` sa po zlyhaní e-mailu NEPRESKAKUJE zvyšok
+  iterácie (zásielka musí ostať v zozname nevyzdvihnutých s pôvodným
+  počítadlom) — `continue` by ju z výsledku ticho odstránil.
+- **`recordSkippedMail` má 24-hodinové dedup okno na (automatizácia,
+  objednávka, DOSLOVNÝ text dôvodu).** Preskočenie sa opakuje pri každom behu,
+  kým trvá jeho príčina (objednávka bez e-mailu ju má aj zajtra) — bez okna by
+  kniha rástla o ten istý riadok denne. **Dôsledok pre text dôvodu: nesmie
+  obsahovať meniace sa číslo** (počet dotknutých objednávok, čas) — meniaci sa
+  text okno obíde a riadok pribudne pri každom behu. Preto je v
+  `order-reminder/run.ts` súhrnný riadok o chýbajúcom nastavení bez počtu.
+- **Preskočenie sa zapisuje LEN keď appka SKUTOČNE chcela poslať** — chýbajúca
+  adresa, chýbajúce nastavenie, zablokovaná duplicita, zlyhaná AI klasifikácia.
+  Bežné „ešte nie je čas na ďalší e-mail" (kadencia zásielok, nevyriešená
+  objednávka) sa NEZAPISUJE: nie je to pokus a kniha by sa stala nečitateľnou.
+- **`DUPLICATE_REASON` (`mail-log/queries.ts`) je JEDEN zdieľaný reťazec** —
+  súhrn „zabránené duplicity" ho porovnáva doslovne. Kto zapíše zablokovanú
+  duplicitu vlastným textom, ticho vypadne zo súhrnu. To isté platí pre
+  fixtúru v `scripts/e2e-setup.ts`.
+- **Súhrn zámerne IGNORUJE filter stavu** (`summarizeMailLog` ho z filtra
+  vypúšťa) — inak by pri zapnutom „len odoslané" tvrdil „zlyhalo: 0", hoci len
+  nie je vidno. Filter automatizácie a obdobia sa naopak rešpektuje.
+  `exactOptionalPropertyTypes` nedovolí `{ ...filter, status: undefined }` —
+  filter sa musí zostaviť nanovo bez toho kľúča.
+- **`mail_log` NIE JE koreňová tabuľka** — má FK na `users`, takže
+  `TRUNCATE users CASCADE` ju v testoch vyprázdni sama (na rozdiel od
+  `order`/`supplier_contact`, `.claude/rules/testing.md`). Do TRUNCATE
+  zoznamov sa preto nepridáva.
+- **História pošty prežije zmazanie zamestnanca aj šablóny** — `actor_user_id`
+  je `on delete set null`, `template_key` je obyčajný text bez FK. Zmazanie
+  účtu nesmie zmazať dôkaz o tom, čo odišlo zákazníkovi.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,3 +90,4 @@ Per-area rules live in `.claude/rules/<area>.md` with `paths:` frontmatter.
 - Pripomienky objednávok (AI klasifikácia poznámky, terminálna rezolúcia, override→job_run relocate) → `.claude/rules/order-reminder.md`
 - Nedostupné tovary (návrh náhrady, jednorazový preview token, žiadny scheduler) → `.claude/rules/nedostupne.md`
 - Texty e-mailov (F192 — upraviteľné šablóny, zástupné polia, strop prihlásení v e2e) → `.claude/rules/mail-templates.md`
+- Kniha odoslaných e-mailov (F193 — jediná odosielacia cesta, dedup okno preskočení) → `.claude/rules/mail-log.md`

--- a/apps/api/drizzle/0025_funny_sally_floyd.sql
+++ b/apps/api/drizzle/0025_funny_sally_floyd.sql
@@ -1,0 +1,24 @@
+CREATE TYPE "public"."mail_log_source" AS ENUM('nedostupne', 'posta_uncollected', 'order_reminder', 'supplier_order');--> statement-breakpoint
+CREATE TYPE "public"."mail_log_status" AS ENUM('sent', 'failed', 'skipped');--> statement-breakpoint
+CREATE TYPE "public"."mail_log_trigger" AS ENUM('scheduled', 'manual');--> statement-breakpoint
+CREATE TABLE "mail_log" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"created_at" timestamp with time zone NOT NULL,
+	"source" "mail_log_source" NOT NULL,
+	"status" "mail_log_status" NOT NULL,
+	"trigger" "mail_log_trigger" NOT NULL,
+	"template_key" text,
+	"recipient" text DEFAULT '' NOT NULL,
+	"bcc" text,
+	"subject" text,
+	"order_code" text,
+	"variant_code" text,
+	"package_number" text,
+	"sequence" integer,
+	"reason" text,
+	"actor_user_id" uuid
+);
+--> statement-breakpoint
+ALTER TABLE "mail_log" ADD CONSTRAINT "mail_log_actor_user_id_users_id_fk" FOREIGN KEY ("actor_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "mail_log_created_idx" ON "mail_log" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX "mail_log_source_created_idx" ON "mail_log" USING btree ("source","created_at");

--- a/apps/api/drizzle/meta/0025_snapshot.json
+++ b/apps/api/drizzle/meta/0025_snapshot.json
@@ -1,0 +1,2173 @@
+{
+  "id": "f31c248f-c0d9-4e1f-b004-86891fe02261",
+  "prevId": "5869eb90-2b14-4f85-8757-e841a8cee8c7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "related_codes": {
+          "name": "related_codes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_code": {
+          "name": "external_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_open_status": {
+      "name": "order_open_status",
+      "schema": "",
+      "columns": {
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Vybavuje sa'"
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop_remark": {
+          "name": "shop_remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shoptet_order_id": {
+          "name": "shoptet_order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_updated_at": {
+          "name": "comment_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_synced_at": {
+          "name": "comment_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_carrier_name": {
+          "name": "shipping_carrier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_link_override": {
+      "name": "product_supplier_link_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_link_override_product_key_product_key_fk": {
+          "name": "product_supplier_link_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_link_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_override": {
+      "name": "product_supplier_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_override_product_key_product_key_fk": {
+          "name": "product_supplier_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing": {
+      "name": "pairing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_url": {
+          "name": "supplier_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "pairing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'navrhnute'"
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pairing_state_idx": {
+          "name": "pairing_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_confirmed_by_idx": {
+          "name": "pairing_confirmed_by_idx",
+          "columns": [
+            {
+              "expression": "confirmed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_variant_code_variant_code_fk": {
+          "name": "pairing_variant_code_variant_code_fk",
+          "tableFrom": "pairing",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pairing_confirmed_by_users_id_fk": {
+          "name": "pairing_confirmed_by_users_id_fk",
+          "tableFrom": "pairing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pairing_variant_code_unique": {
+          "name": "pairing_variant_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pairing_confirmation_ck": {
+          "name": "pairing_confirmation_ck",
+          "value": "(\"pairing\".\"state\" = 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)\n        OR (\"pairing\".\"state\" != 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NULL AND \"pairing\".\"confirmed_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier": {
+      "name": "supplier",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wholesale_base_url": {
+          "name": "wholesale_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_key": {
+          "name": "adapter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_settings": {
+      "name": "posta_uncollected_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_state": {
+      "name": "posta_uncollected_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notify_count": {
+          "name": "notify_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_state": {
+          "name": "terminal_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_settings": {
+      "name": "order_reminder_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_state": {
+      "name": "order_reminder_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_state": {
+      "name": "nedostupne_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "nedostupne_email_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nedostupne_state_order_variant_type_uq": {
+          "name": "nedostupne_state_order_variant_type_uq",
+          "columns": [
+            {
+              "expression": "order_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template_history": {
+      "name": "mail_template_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "mail_template_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_template_history_key_idx": {
+          "name": "mail_template_history_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_template_history_changed_by_user_id_users_id_fk": {
+          "name": "mail_template_history_changed_by_user_id_users_id_fk",
+          "tableFrom": "mail_template_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template": {
+      "name": "mail_template",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail_template_updated_by_user_id_users_id_fk": {
+          "name": "mail_template_updated_by_user_id_users_id_fk",
+          "tableFrom": "mail_template",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_log": {
+      "name": "mail_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "mail_log_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_log_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "mail_log_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_log_created_idx": {
+          "name": "mail_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_log_source_created_idx": {
+          "name": "mail_log_source_created_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_log_actor_user_id_users_id_fk": {
+          "name": "mail_log_actor_user_id_users_id_fk",
+          "tableFrom": "mail_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne"
+      ]
+    },
+    "public.pairing_state": {
+      "name": "pairing_state",
+      "schema": "public",
+      "values": [
+        "navrhnute",
+        "potvrdene"
+      ]
+    },
+    "public.nedostupne_email_type": {
+      "name": "nedostupne_email_type",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "alternativa"
+      ]
+    },
+    "public.mail_template_action": {
+      "name": "mail_template_action",
+      "schema": "public",
+      "values": [
+        "save",
+        "reset"
+      ]
+    },
+    "public.mail_log_source": {
+      "name": "mail_log_source",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "posta_uncollected",
+        "order_reminder",
+        "supplier_order"
+      ]
+    },
+    "public.mail_log_status": {
+      "name": "mail_log_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.mail_log_trigger": {
+      "name": "mail_log_trigger",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "manual"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1785773580281,
       "tag": "0024_far_wonder_man",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1785782579784,
+      "tag": "0025_funny_sally_floyd",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema-mail-log.ts
+++ b/apps/api/src/db/schema-mail-log.ts
@@ -1,0 +1,61 @@
+import { index, integer, pgEnum, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { users } from "./schema-users.js";
+
+// issue 193, majiteľ: "v automatizaciach dufam su vsetky potrebne statistiky
+// komu sa poslal mail a tak dalej". Doteraz si každá automatizácia pamätala
+// len TO, ČO POTREBOVALA PRE SEBA (`posta_uncollected_state`'s počítadlo,
+// `order_reminder_state`'s výsledok, `nedostupne_state`'s dedup dôkaz) —
+// adresa príjemcu, predmet ani dôvod zlyhania sa NIKDE neukladali a posledný
+// beh v `job_run.detail` prepíše ten ďalší. Táto tabuľka je JEDNA spoločná
+// kniha odoslaných e-mailov pre VŠETKÝCH odosielateľov appky, aby majiteľ
+// vedel, čo sa v jeho mene odoslalo.
+export const mailLogSource = pgEnum("mail_log_source", [
+  "nedostupne",
+  "posta_uncollected",
+  "order_reminder",
+  "supplier_order",
+]);
+
+// `skipped` = appka SKUTOČNE chcela poslať a nemohla (chýba adresa, chýba
+// nastavenie, dedup to zastavil) — nikdy bežné "ešte nie je čas" (to by
+// tabuľku zaplnilo desiatkami nezaujímavých riadkov denne, `mail-log/
+// service.ts`).
+export const mailLogStatus = pgEnum("mail_log_status", ["sent", "failed", "skipped"]);
+
+// Kto pokus vyvolal — plán, alebo konkrétny zamestnanec. Zámerne SAMOSTATNÝ
+// stĺpec od `actor_user_id` (rovnaký dôvod ako `order_reminder_state`'s
+// `resolution`/`resolved_by` dvojica): "spustil to plánovač" sa nikdy
+// neodvodzuje z toho, že chýba používateľ.
+export const mailLogTrigger = pgEnum("mail_log_trigger", ["scheduled", "manual"]);
+
+export const mailLog = pgTable(
+  "mail_log",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
+    source: mailLogSource("source").notNull(),
+    status: mailLogStatus("status").notNull(),
+    trigger: mailLogTrigger("trigger").notNull(),
+    // Kľúč šablóny z issue 192 (`MAIL_TEMPLATE_KEYS`) — nie FK, aby zmazanie/
+    // premenovanie šablóny nikdy nezmazalo históriu odoslanej pošty.
+    templateKey: text("template_key"),
+    recipient: text("recipient").notNull().default(""),
+    bcc: text("bcc"),
+    subject: text("subject"),
+    orderCode: text("order_code"),
+    variantCode: text("variant_code"),
+    packageNumber: text("package_number"),
+    // Koľký e-mail v poradí to bol (zásielky 1–4) — vďaka nemu je z prehľadu
+    // vidno eskaláciu namiesto zdanlivého opakovania (ticketova podmienka
+    // "ochrana pred dvojitým odoslaním musí byť z prehľadu viditeľná").
+    sequence: integer("sequence"),
+    // Čitateľný dôvod pri `failed`/`skipped` — to jediné, čo dnes končí len v
+    // serverovom logu, ktorý majiteľ nevidí.
+    reason: text("reason"),
+    // `set null`, nie `restrict` — zmazanie zamestnanca nesmie zmazať ani
+    // zablokovať históriu pošty (na rozdiel od `pairing.confirmed_by`, kde
+    // CHECK vyžaduje vyplnené, `.claude/rules/database.md`).
+    actorUserId: uuid("actor_user_id").references(() => users.id, { onDelete: "set null" }),
+  },
+  (t) => [index("mail_log_created_idx").on(t.createdAt), index("mail_log_source_created_idx").on(t.source, t.createdAt)],
+);

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -7,3 +7,4 @@ export * from "./schema-posta-uncollected.js";
 export * from "./schema-order-reminder.js";
 export * from "./schema-nedostupne.js";
 export * from "./schema-mail-templates.js";
+export * from "./schema-mail-log.js";

--- a/apps/api/src/http/app.ts
+++ b/apps/api/src/http/app.ts
@@ -14,6 +14,7 @@ import { checkLoginRateLimit, clientIp } from "./login-rate-limit.js";
 import { SESSION_COOKIE, requireUser, type AppBindings } from "./middleware.js";
 import { registerOrdersRoutes, type RunOrdersIngest } from "./orders-routes.js";
 import { registerOrderReminderRoutes, type OrderReminderRunDeps } from "./order-reminder-routes.js";
+import { registerMailLogRoutes } from "./mail-log-routes.js";
 import { registerMailTemplateRoutes } from "./mail-template-routes.js";
 import { registerNedostupneRoutes, type NedostupneRunDeps } from "./nedostupne-routes.js";
 import { requireSameOrigin } from "./origin-check.js";
@@ -210,6 +211,9 @@ export function createApp(
 
   // issue 192: upraviteľné znenia e-mailov (obrazovka "Texty e-mailov").
   registerMailTemplateRoutes(app, db);
+  // issue 193: kniha odoslaných e-mailov (len čítanie) — zapisujú do nej samy
+  // odosielacie cesty cez `mail-log/service.ts`.
+  registerMailLogRoutes(app, db, options.adminBaseUrl ?? "https://www.forestshop.sk");
 
   // Musí byť registrovaný AŽ PO všetkých skutočných /api/* trasách vyššie — Hono
   // vyberá presnejšiu zhodu, takže tie majú prednosť a sem sa dostane len to, čo

--- a/apps/api/src/http/mail-log-routes.ts
+++ b/apps/api/src/http/mail-log-routes.ts
@@ -1,0 +1,37 @@
+import { zValidator } from "@hono/zod-validator";
+import type { Hono } from "hono";
+import { z } from "zod";
+import type { Database } from "../db/client.js";
+import { listMailLog, summarizeMailLog, type MailLogFilter } from "../modules/mail-log/queries.js";
+import { requireUser, type AppBindings } from "./middleware.js";
+
+// Obdobie je ZOZNAM povolených hodnôt, nie ľubovoľný dátum — obrazovka
+// ponúka presne tieto štyri a nič iné (jednoduchšie než plný rozsah dátumov,
+// MVP), takže sa nedá poslať dopyt cez celú históriu omylom.
+const PERIOD_DAYS: Readonly<Record<string, number | null>> = { "7": 7, "30": 30, "90": 90, all: null };
+
+const listQuery = z.object({
+  source: z.enum(["nedostupne", "posta_uncollected", "order_reminder", "supplier_order"]).optional(),
+  status: z.enum(["sent", "failed", "skipped"]).optional(),
+  period: z.enum(["7", "30", "90", "all"]).default("30"),
+});
+
+export function registerMailLogRoutes(app: Hono<AppBindings>, db: Database, adminBaseUrl: string): void {
+  // Čítanie — každý prihlásený zamestnanec, rovnaká úroveň ako ostatné
+  // obrazovky s objednávkami (tie tiež zobrazujú e-mail zákazníka).
+  app.get("/api/mail-log", requireUser(db), zValidator("query", listQuery), async (c) => {
+    const { source, status, period } = c.req.valid("query");
+    const days = PERIOD_DAYS[period] ?? null;
+    const filter: MailLogFilter = {
+      limit: 200,
+      ...(source === undefined ? {} : { source }),
+      ...(status === undefined ? {} : { status }),
+      ...(days === null ? {} : { since: new Date(Date.now() - days * 24 * 60 * 60 * 1000) }),
+    };
+    // Súhrn ZÁMERNE ignoruje filter stavu (`summarizeMailLog` ho zahadzuje) —
+    // inak by "odoslané: 12, zlyhané: 0" pri zapnutom filtri "len odoslané"
+    // tvrdilo, že nič nezlyhalo, hoci len nie je vidno.
+    const [rows, summary] = await Promise.all([listMailLog(db, filter, adminBaseUrl), summarizeMailLog(db, filter)]);
+    return c.json({ rows, summary, period });
+  });
+}

--- a/apps/api/src/http/nedostupne-routes.ts
+++ b/apps/api/src/http/nedostupne-routes.ts
@@ -110,6 +110,8 @@ export function registerNedostupneRoutes(app: Hono<AppBindings>, db: Database, d
         emailType,
         mailTransport: deps.mailTransport,
         bccEmail: deps.bccEmail,
+        // issue 193: kniha odoslaných e-mailov ukáže, KTO odoslanie spustil.
+        actorUserId: user.userId,
       });
       if (!result.ok) {
         return c.json({ ok: false as const, error: sendErrorMessage(result) });

--- a/apps/api/src/http/order-reminder-routes.ts
+++ b/apps/api/src/http/order-reminder-routes.ts
@@ -35,14 +35,15 @@ function isRunResult(detail: unknown): detail is OrderReminderRunResult {
  * vzorom, aký #172's `runAndRecord` používa — `GET /api/order-reminder` tak
  * vidí manuálny beh HNEĎ, nielen po ďalšom pravidelnom ticku.
  */
-async function runAndRecord(db: Database, deps: OrderReminderRunDeps, now: Date): Promise<OrderReminderRunResult> {
+async function runAndRecord(db: Database, deps: OrderReminderRunDeps, now: Date, actorUserId: string): Promise<OrderReminderRunResult> {
   const [inserted] = await db
     .insert(jobRuns)
     .values({ jobName: ORDER_REMINDER_JOB_NAME, startedAt: now, status: "running" })
     .returning({ id: jobRuns.id });
   const runId = inserted?.id;
   try {
-    const result = await runOrderReminder({ db, now, ...deps });
+    // issue 193: "Spustiť teraz" je RUČNÁ akcia (kniha odoslaných e-mailov).
+    const result = await runOrderReminder({ db, now, ...deps, trigger: "manual", actorUserId });
     if (runId !== undefined) {
       await db.update(jobRuns).set({ status: "success", finishedAt: new Date(), detail: result }).where(eq(jobRuns.id, runId));
     }
@@ -180,7 +181,7 @@ export function registerOrderReminderRoutes(app: Hono<AppBindings>, db: Database
       const now = new Date();
       let result: OrderReminderRunResult;
       try {
-        result = await runAndRecord(db, deps, now);
+        result = await runAndRecord(db, deps, now, user.userId);
       } catch {
         return c.json({ error: "Beh zlyhal — skúste to znova o chvíľu." }, 502);
       }
@@ -209,7 +210,9 @@ export function registerOrderReminderRoutes(app: Hono<AppBindings>, db: Database
       const { orderCode, action } = c.req.valid("json");
       const user = c.get("user");
       const now = new Date();
-      const result = await runOrderReminderOverride({ db, now, orderCode, action, ...deps });
+      // issue 193: ručná per-riadková akcia sa v knihe odoslaných e-mailov
+      // pripíše zamestnancovi, ktorý ju stlačil.
+      const result = await runOrderReminderOverride({ db, now, orderCode, action, ...deps, trigger: "manual", actorUserId: user.userId });
       if (!result.ok) {
         const message =
           result.code === "not_found"

--- a/apps/api/src/http/posta-uncollected-routes.ts
+++ b/apps/api/src/http/posta-uncollected-routes.ts
@@ -37,14 +37,16 @@ function isRunResult(detail: unknown): detail is PostaUncollectedRunResult {
  * rovnaký tvar riadku priamo, aby `GET /api/posta-uncollected` videl
  * manuálny beh HNEĎ, nielen po ďalšom pravidelnom ticku.
  */
-async function runAndRecord(db: Database, deps: PostaUncollectedRunDeps, now: Date): Promise<PostaUncollectedRunResult> {
+async function runAndRecord(db: Database, deps: PostaUncollectedRunDeps, now: Date, actorUserId: string): Promise<PostaUncollectedRunResult> {
   const [inserted] = await db
     .insert(jobRuns)
     .values({ jobName: POSTA_UNCOLLECTED_JOB_NAME, startedAt: now, status: "running" })
     .returning({ id: jobRuns.id });
   const runId = inserted?.id;
   try {
-    const result = await runPostaUncollected({ db, now, ...deps });
+    // issue 193: "Spustiť teraz" je RUČNÁ akcia — kniha odoslaných e-mailov
+    // to musí odlíšiť od nočného behu (`trigger`), aj s menom zamestnanca.
+    const result = await runPostaUncollected({ db, now, ...deps, trigger: "manual", actorUserId });
     if (runId !== undefined) {
       await db.update(jobRuns).set({ status: "success", finishedAt: new Date(), detail: result }).where(eq(jobRuns.id, runId));
     }
@@ -125,7 +127,7 @@ export function registerPostaUncollectedRoutes(app: Hono<AppBindings>, db: Datab
       const now = new Date();
       let result: PostaUncollectedRunResult;
       try {
-        result = await runAndRecord(db, deps, now);
+        result = await runAndRecord(db, deps, now, user.userId);
       } catch {
         return c.json({ error: "Beh zlyhal — skúste to znova o chvíľu." }, 502);
       }

--- a/apps/api/src/http/supplier-routes.ts
+++ b/apps/api/src/http/supplier-routes.ts
@@ -110,7 +110,9 @@ export function registerSupplierRoutes(app: Hono<AppBindings>, db: Database, sen
       const user = c.get("user");
       const now = new Date();
 
-      const result = await sendSupplierOrderMail(db, sendMail, supplier);
+      // issue 193: posledný parameter = kto odoslanie spustil (kniha
+      // odoslaných e-mailov).
+      const result = await sendSupplierOrderMail(db, sendMail, supplier, user.userId);
       await record(db, {
         at: now,
         actorUserId: user.userId,

--- a/apps/api/src/modules/mail-log/queries.ts
+++ b/apps/api/src/modules/mail-log/queries.ts
@@ -1,0 +1,129 @@
+import { and, count, desc, eq, gte, sql } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { mailLog, users } from "../../db/schema.js";
+import { buildShoptetAdminOrderUrl } from "../orders/queries.js";
+import { orders } from "../../db/schema.js";
+import type { MailLogSource } from "./service.js";
+
+export interface MailLogFilter {
+  readonly source?: MailLogSource;
+  readonly status?: "sent" | "failed" | "skipped";
+  readonly since?: Date;
+  readonly limit: number;
+}
+
+export interface MailLogRow {
+  readonly id: string;
+  readonly createdAt: string;
+  readonly source: MailLogSource;
+  readonly status: "sent" | "failed" | "skipped";
+  readonly trigger: "scheduled" | "manual";
+  readonly templateKey: string | null;
+  readonly recipient: string;
+  readonly subject: string | null;
+  readonly orderCode: string | null;
+  readonly variantCode: string | null;
+  readonly packageNumber: string | null;
+  readonly sequence: number | null;
+  readonly reason: string | null;
+  readonly actorName: string | null;
+  readonly adminLink: string | null;
+}
+
+export interface MailLogSummary {
+  readonly sent: number;
+  readonly failed: number;
+  readonly skipped: number;
+  /** Koľkokrát dedup zabránil druhému e-mailu tomu istému zákazníkovi —
+   * ticketova podmienka "ochrana pred dvojitým odoslaním musí byť z prehľadu
+   * viditeľná" (`DUPLICATE_REASON`, `service.ts` volajúci ju vkladajú). */
+  readonly duplicatesBlocked: number;
+}
+
+/** Dôvod, ktorý sa počíta ako "zabránená duplicita" — jeden reťazec zdieľaný
+ * medzi zapisujúcimi miestami a týmto súhrnom, nikdy dva samostatné literály
+ * (rozišli by sa a súhrn by ticho ukazoval nulu). */
+export const DUPLICATE_REASON = "už bolo odoslané skôr — druhý e-mail sa neposiela";
+
+function whereFor(filter: MailLogFilter) {
+  const parts = [];
+  if (filter.source !== undefined) parts.push(eq(mailLog.source, filter.source));
+  if (filter.status !== undefined) parts.push(eq(mailLog.status, filter.status));
+  if (filter.since !== undefined) parts.push(gte(mailLog.createdAt, filter.since));
+  return parts.length === 0 ? undefined : and(...parts);
+}
+
+export async function listMailLog(db: Database, filter: MailLogFilter, adminBaseUrl: string): Promise<readonly MailLogRow[]> {
+  const rows = await db
+    .select({
+      id: mailLog.id,
+      createdAt: mailLog.createdAt,
+      source: mailLog.source,
+      status: mailLog.status,
+      trigger: mailLog.trigger,
+      templateKey: mailLog.templateKey,
+      recipient: mailLog.recipient,
+      subject: mailLog.subject,
+      orderCode: mailLog.orderCode,
+      variantCode: mailLog.variantCode,
+      packageNumber: mailLog.packageNumber,
+      sequence: mailLog.sequence,
+      reason: mailLog.reason,
+      actorName: users.displayName,
+      shoptetOrderId: orders.shoptetOrderId,
+    })
+    .from(mailLog)
+    .leftJoin(users, eq(mailLog.actorUserId, users.id))
+    // Objednávka sa dohľadáva LEN kvôli odkazu do Shoptetu — `leftJoin`, aby
+    // zmazaná/nikdy neimportovaná objednávka nikdy nezahodila riadok knihy.
+    .leftJoin(orders, eq(mailLog.orderCode, orders.externalOrderId))
+    .where(whereFor(filter))
+    .orderBy(desc(mailLog.createdAt))
+    .limit(filter.limit);
+
+  return rows.map((r) => ({
+    id: r.id,
+    createdAt: r.createdAt.toISOString(),
+    source: r.source,
+    status: r.status,
+    trigger: r.trigger,
+    templateKey: r.templateKey,
+    recipient: r.recipient,
+    subject: r.subject,
+    orderCode: r.orderCode,
+    variantCode: r.variantCode,
+    packageNumber: r.packageNumber,
+    sequence: r.sequence,
+    reason: r.reason,
+    actorName: r.actorName,
+    adminLink: r.orderCode === null ? null : buildShoptetAdminOrderUrl(adminBaseUrl, r.orderCode, r.shoptetOrderId),
+  }));
+}
+
+export async function summarizeMailLog(db: Database, filter: MailLogFilter): Promise<MailLogSummary> {
+  const summaryFilter: MailLogFilter = {
+    limit: filter.limit,
+    ...(filter.source === undefined ? {} : { source: filter.source }),
+    ...(filter.since === undefined ? {} : { since: filter.since }),
+  };
+  const rows = await db
+    .select({
+      status: mailLog.status,
+      total: count(),
+      duplicates: sql<number>`count(*) filter (where ${mailLog.reason} = ${DUPLICATE_REASON})::int`,
+    })
+    .from(mailLog)
+    // Súhrn zámerne bez filtra stavu — inak by pri zapnutom "len odoslané"
+    // tvrdil, že nič nezlyhalo. `status` sa preto z filtra vypúšťa celkom
+    // (nie nastaví na `undefined` — `exactOptionalPropertyTypes`).
+    .where(whereFor(summaryFilter))
+    .groupBy(mailLog.status);
+
+  const pick = (status: "sent" | "failed" | "skipped"): number => rows.find((r) => r.status === status)?.total ?? 0;
+  return {
+    sent: pick("sent"),
+    failed: pick("failed"),
+    skipped: pick("skipped"),
+    duplicatesBlocked: rows.reduce((sum, r) => sum + r.duplicates, 0),
+  };
+}

--- a/apps/api/src/modules/mail-log/service.ts
+++ b/apps/api/src/modules/mail-log/service.ts
@@ -1,0 +1,130 @@
+import { and, eq, gte, isNull } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { mailLog } from "../../db/schema.js";
+import { log } from "../../logger.js";
+import type { MailMessage, MailTransport } from "../mail/transport.js";
+import type { MailTemplateKey } from "../mail-templates/registry.js";
+
+export type MailLogSource = "nedostupne" | "posta_uncollected" | "order_reminder" | "supplier_order";
+export type MailLogTrigger = "scheduled" | "manual";
+
+/** Spoločný popis "o čom ten e-mail bol" — každé pole je nepovinné, lebo
+ * odosielatelia sa líšia (zásielka má číslo balíka, nedostupný tovar má
+ * variant, objednávka dodávateľovi nemá ani jedno). */
+export interface MailLogContext {
+  readonly source: MailLogSource;
+  readonly trigger: MailLogTrigger;
+  readonly templateKey?: MailTemplateKey;
+  readonly orderCode?: string;
+  readonly variantCode?: string;
+  readonly packageNumber?: string;
+  readonly sequence?: number;
+  readonly actorUserId?: string;
+}
+
+interface MailLogEntry extends MailLogContext {
+  readonly status: "sent" | "failed" | "skipped";
+  readonly recipient: string;
+  readonly bcc?: string | undefined;
+  readonly subject?: string;
+  readonly reason?: string;
+}
+
+async function insertEntry(db: Pick<Database, "insert">, now: Date, entry: MailLogEntry): Promise<void> {
+  try {
+    await db.insert(mailLog).values({
+      createdAt: now,
+      source: entry.source,
+      status: entry.status,
+      trigger: entry.trigger,
+      templateKey: entry.templateKey ?? null,
+      recipient: entry.recipient,
+      bcc: entry.bcc ?? null,
+      subject: entry.subject ?? null,
+      orderCode: entry.orderCode ?? null,
+      variantCode: entry.variantCode ?? null,
+      packageNumber: entry.packageNumber ?? null,
+      sequence: entry.sequence ?? null,
+      reason: entry.reason ?? null,
+      actorUserId: entry.actorUserId ?? null,
+    });
+  } catch (error) {
+    // Zlyhanie ZÁPISU do knihy nesmie zhodiť samotné odosielanie — e-mail už
+    // je (alebo nie je) odoslaný a to je dôležitejšie než jeho záznam.
+    // Zaloguje sa, aby taká strata nebola tichá.
+    const rawErrorMessage = error instanceof Error ? error.message : String(error);
+    log.error({ rawErrorMessage, source: entry.source, status: entry.status }, "Kniha odoslaných e-mailov: zápis zlyhal");
+  }
+}
+
+/** Appka CHCELA poslať, ale nemohla — chýbajúca adresa, chýbajúce nastavenie,
+ * dedup, zlyhaná AI klasifikácia. Bežné "ešte nie je čas na ďalší e-mail" sa
+ * NIKDY nezapisuje: to nie je pokus, a kniha by rástla o desiatky
+ * nezaujímavých riadkov denne. */
+export async function recordSkippedMail(
+  db: Pick<Database, "insert" | "select">,
+  now: Date,
+  ctx: MailLogContext,
+  recipient: string,
+  reason: string,
+): Promise<void> {
+  // Preskočenie sa OPAKUJE každý beh, kým trvá jeho príčina (objednávka bez
+  // e-mailu ostane bez e-mailu aj zajtra) — bez tohto okna by kniha rástla o
+  // ten istý riadok denne a prehľad by sa stal nečitateľným. 24 h = najviac
+  // jeden riadok za deň na (automatizácia, objednávka, dôvod).
+  const since = new Date(now.getTime() - SKIP_DEDUP_WINDOW_MS);
+  const existing = await db
+    .select({ id: mailLog.id })
+    .from(mailLog)
+    .where(
+      and(
+        eq(mailLog.source, ctx.source),
+        eq(mailLog.status, "skipped"),
+        eq(mailLog.reason, reason),
+        ctx.orderCode === undefined ? isNull(mailLog.orderCode) : eq(mailLog.orderCode, ctx.orderCode),
+        gte(mailLog.createdAt, since),
+      ),
+    )
+    .limit(1);
+  if (existing.length > 0) return;
+  await insertEntry(db, now, { ...ctx, status: "skipped", recipient, reason });
+}
+
+export const SKIP_DEDUP_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+export type SendLoggedMailResult = { readonly ok: true } | { readonly ok: false; readonly rawErrorMessage: string };
+
+/**
+ * JEDINÁ cesta, akou appka posiela e-mail zákazníkovi/dodávateľovi. Odoslanie
+ * a zápis do knihy sú tu zámerne SPOJENÉ v jednej funkcii — keby si každý
+ * odosielateľ zapisoval sám, ďalšia automatizácia by sa dala pridať tak, že
+ * na zápis zabudne, a majiteľ by o jej pošte nevedel (presne to bol stav pred
+ * issue 193 pri všetkých štyroch odosielateľoch naraz).
+ *
+ * Nevyhadzuje výnimku — volajúci sa rozhoduje podľa `ok`, presne ako to robil
+ * so svojím vlastným `try/catch` predtým.
+ */
+export async function sendLoggedMail(
+  db: Pick<Database, "insert">,
+  transport: MailTransport,
+  message: MailMessage,
+  now: Date,
+  ctx: MailLogContext,
+): Promise<SendLoggedMailResult> {
+  try {
+    await transport(message);
+  } catch (error) {
+    const rawErrorMessage = error instanceof Error ? error.message : String(error);
+    await insertEntry(db, now, {
+      ...ctx,
+      status: "failed",
+      recipient: message.to,
+      bcc: message.bcc,
+      subject: message.subject,
+      reason: rawErrorMessage,
+    });
+    return { ok: false, rawErrorMessage };
+  }
+  await insertEntry(db, now, { ...ctx, status: "sent", recipient: message.to, bcc: message.bcc, subject: message.subject });
+  return { ok: true };
+}

--- a/apps/api/src/modules/nedostupne/send.ts
+++ b/apps/api/src/modules/nedostupne/send.ts
@@ -3,6 +3,8 @@ import type { Database } from "../../db/client.js";
 import { log } from "../../logger.js";
 import { orderLines, orders, products, variants } from "../../db/schema.js";
 import type { MailTransport } from "../mail/transport.js";
+import { DUPLICATE_REASON } from "../mail-log/queries.js";
+import { recordSkippedMail, sendLoggedMail, type MailLogContext } from "../mail-log/service.js";
 import { resolveTemplate } from "../mail-templates/store.js";
 import { listOpenStatusNames } from "../orders/open-statuses.js";
 import { NEDOSTUPNE_SEND_LOCK_KEY, TYPE_ALTERNATIVE, type NedostupneEmailType } from "./constants.js";
@@ -87,6 +89,10 @@ export interface SendNedostupneOptions {
   readonly emailType: NedostupneEmailType;
   readonly mailTransport: MailTransport | undefined;
   readonly bccEmail: string | undefined;
+  // issue 193: kto tlačidlo stlačil — táto cesta je VŽDY ručná akcia
+  // zamestnanca (žiadny naplánovaný beh), takže sa zapisuje do knihy
+  // odoslaných e-mailov ako `manual` s jeho menom.
+  readonly actorUserId?: string;
 }
 
 /**
@@ -117,27 +123,58 @@ export async function sendNedostupneEmail(options: SendNedostupneOptions): Promi
 }
 
 async function sendNedostupneEmailLocked(options: SendNedostupneOptions): Promise<SendNedostupneResult> {
-  const { db, now, orderCode, variantCode, emailType, mailTransport, bccEmail } = options;
+  const { db, now, orderCode, variantCode, emailType, mailTransport, bccEmail, actorUserId } = options;
+
+  // issue 193: každý pokus (aj neúspešný) sa zapisuje do spoločnej knihy
+  // odoslaných e-mailov — `mail-log/service.ts`.
+  const logCtx: MailLogContext = {
+    source: "nedostupne",
+    trigger: "manual",
+    templateKey: emailType === TYPE_ALTERNATIVE ? "nedostupne_alternativa" : "nedostupne",
+    orderCode,
+    variantCode,
+    ...(actorUserId === undefined ? {} : { actorUserId }),
+  };
 
   const ctx = await findNedostupneContext(db, orderCode, variantCode);
   if (ctx === null) return { ok: false, code: "not_found" };
 
   const already = await hasSentNedostupne(db, orderCode, variantCode, emailType);
-  if (already) return { ok: false, code: "already_sent" };
+  if (already) {
+    // Zablokovaná duplicita je to, čo ticket 193 žiada mať VIDNO v prehľade —
+    // spoločný `DUPLICATE_REASON`, aby súhrn "zabránené duplicity" sedel.
+    await recordSkippedMail(db, now, logCtx, ctx.email.trim(), DUPLICATE_REASON);
+    return { ok: false, code: "already_sent" };
+  }
 
   const email = ctx.email.trim();
-  if (email === "") return { ok: false, code: "no_email" };
+  if (email === "") {
+    await recordSkippedMail(db, now, logCtx, "", "objednávka nemá e-mailovú adresu zákazníka");
+    return { ok: false, code: "no_email" };
+  }
 
   const bccMissing = bccEmail === undefined || bccEmail.trim() === "";
-  if (bccMissing) return { ok: false, code: "not_configured", reason: "chýba adresa pre skrytú kópiu majiteľovi (NEDOSTUPNE_BCC_EMAIL)" };
-  if (mailTransport === undefined) return { ok: false, code: "not_configured", reason: "odosielanie e-mailov nie je nakonfigurované (chýba MAIL_HOST)" };
+  if (bccMissing) {
+    const reason = "chýba adresa pre skrytú kópiu majiteľovi (NEDOSTUPNE_BCC_EMAIL)";
+    await recordSkippedMail(db, now, logCtx, email, reason);
+    return { ok: false, code: "not_configured", reason };
+  }
+  if (mailTransport === undefined) {
+    const reason = "odosielanie e-mailov nie je nakonfigurované (chýba MAIL_HOST)";
+    await recordSkippedMail(db, now, logCtx, email, reason);
+    return { ok: false, code: "not_configured", reason };
+  }
 
   const built = await buildEmailForType(db, ctx, emailType);
-  try {
-    await mailTransport({ to: email, subject: built.subject, text: built.text, html: built.html, bcc: bccEmail });
-  } catch (error) {
-    const rawErrorMessage = error instanceof Error ? error.message : String(error);
-    log.error({ orderCode, variantCode, emailType, rawErrorMessage }, "Nedostupné tovary: odoslanie e-mailu zlyhalo");
+  const sendResult = await sendLoggedMail(
+    db,
+    mailTransport,
+    { to: email, subject: built.subject, text: built.text, html: built.html, bcc: bccEmail },
+    now,
+    logCtx,
+  );
+  if (!sendResult.ok) {
+    log.error({ orderCode, variantCode, emailType, rawErrorMessage: sendResult.rawErrorMessage }, "Nedostupné tovary: odoslanie e-mailu zlyhalo");
     return { ok: false, code: "send_failed" };
   }
   // Zápis IHNEĎ po odoslaní (rovnaká disciplína ako #172/#173).

--- a/apps/api/src/modules/order-reminder/run.ts
+++ b/apps/api/src/modules/order-reminder/run.ts
@@ -1,6 +1,7 @@
 import type { Database } from "../../db/client.js";
 import { log } from "../../logger.js";
 import type { MailTransport } from "../mail/transport.js";
+import { recordSkippedMail, sendLoggedMail, type MailLogContext } from "../mail-log/service.js";
 import { buildShoptetAdminOrderUrl } from "../orders/queries.js";
 import type { ClassifyClient } from "./classify-client.js";
 import { ORDER_REMINDER_RUN_LOCK_KEY } from "./constants.js";
@@ -67,6 +68,10 @@ export interface RunOrderReminderOptions {
   readonly mailTransport: MailTransport | undefined;
   readonly bccEmail: string | undefined;
   readonly adminBaseUrl: string;
+  // issue 193: kto beh vyvolal (plánovač vs. "Spustiť teraz"/ručná akcia) —
+  // zapisuje sa do knihy odoslaných e-mailov. Predvolene `scheduled`.
+  readonly trigger?: "scheduled" | "manual";
+  readonly actorUserId?: string;
 }
 
 function toRow(order: ReminderEligibleOrder, itemLabels: ReadonlyMap<string, string>, adminBaseUrl: string, now: Date): OrderReminderRow {
@@ -125,6 +130,17 @@ async function runOrderReminderLocked(options: RunOrderReminderOptions): Promise
   // Šablóna sa načíta RAZ pred cyklom (issue 192) — jeden beh smie poslať
   // desiatky e-mailov a znenie sa počas neho meniť nemá.
   const reminderTemplate = await resolveTemplate(db, "order_reminder");
+
+  // issue 193: kontext pre spoločnú knihu odoslaných e-mailov.
+  const trigger = options.trigger ?? "scheduled";
+  const actorUserId = options.actorUserId;
+  const logCtxFor = (orderCode: string): MailLogContext => ({
+    source: "order_reminder",
+    trigger,
+    templateKey: "order_reminder",
+    orderCode,
+    ...(actorUserId === undefined ? {} : { actorUserId }),
+  });
 
   for (const order of candidates) {
     const fp = fingerprint(order);
@@ -186,6 +202,10 @@ async function runOrderReminderLocked(options: RunOrderReminderOptions): Promise
     } catch (error) {
       const rawErrorMessage = error instanceof Error ? error.message : String(error);
       log.error({ orderCode: order.externalOrderId, rawErrorMessage }, "Pripomienky objednávok: AI klasifikácia zlyhala");
+      // issue 193: zlyhaná klasifikácia je per-objednávkový, zriedkavý jav —
+      // zapisuje sa do knihy (na rozdiel od chýbajúceho nastavenia nižšie,
+      // ktoré je pre celý beh spoločné a zapíše sa raz).
+      await recordSkippedMail(db, now, logCtxFor(order.externalOrderId), email, "AI klasifikácia poznámky zlyhala — skúsi sa znova nabudúce");
       pending.push({ ...toRow(order, itemLabels, adminBaseUrl, now), reason: "AI klasifikácia zlyhala — skúsi sa znova nabudúce" });
       continue;
     }
@@ -198,18 +218,39 @@ async function runOrderReminderLocked(options: RunOrderReminderOptions): Promise
     }
 
     const built = buildReminderEmail(reminderTemplate, order.customerName, order.externalOrderId);
-    try {
-      await mailTransport({ to: email, subject: built.subject, text: built.text, html: built.html, bcc: bccEmail });
+    // issue 193: `sendLoggedMail` si sám zapíše výsledok do knihy odoslaných
+    // e-mailov a zlyhanie vráti ako `ok: false` namiesto výnimky — správanie
+    // oboch vetiev ostáva presne také, aké bolo v pôvodnom `try/catch`.
+    const sendResult = await sendLoggedMail(
+      db,
+      mailTransport,
+      { to: email, subject: built.subject, text: built.text, html: built.html, bcc: bccEmail },
+      now,
+      logCtxFor(order.externalOrderId),
+    );
+    if (sendResult.ok) {
       // Zápis IHNEĎ po odoslaní — pád appky neskôr v behu nesmie stratiť
       // dôkaz o už odoslanom e-maile (rovnaká disciplína ako #172).
       await upsertOrderReminderState(db, { orderCode: order.externalOrderId, fingerprint: fp, resolution: "emailed", resolvedBy: "ai", resolvedAt: now }, now);
       emailedNow += 1;
       emailed.push(resolvedRow(order, "emailed", "ai", now));
-    } catch (error) {
-      const rawErrorMessage = error instanceof Error ? error.message : String(error);
-      log.error({ orderCode: order.externalOrderId, rawErrorMessage }, "Pripomienky objednávok: odoslanie e-mailu zlyhalo");
+    } else {
+      log.error({ orderCode: order.externalOrderId, rawErrorMessage: sendResult.rawErrorMessage }, "Pripomienky objednávok: odoslanie e-mailu zlyhalo");
       pending.push({ ...toRow(order, itemLabels, adminBaseUrl, now), reason: "odoslanie e-mailu zlyhalo — skúsi sa znova nabudúce" });
     }
+  }
+
+  // issue 193: chýbajúce nastavenie (AI/BCC/SMTP) blokuje CELÝ beh naraz —
+  // zapíše sa preto JEDEN súhrnný riadok s počtom dotknutých objednávok, nie
+  // riadok na každú z nich (inak by jedna chýbajúca premenná prostredia
+  // zaplavila knihu desiatkami zhodných riadkov).
+  const configBlocked = pending.filter((p) => p.reason !== "odoslanie e-mailu zlyhalo — skúsi sa znova nabudúce" && p.reason !== "AI klasifikácia zlyhala — skúsi sa znova nabudúce");
+  if (configBlocked.length > 0) {
+    // Dôvod je ZÁMERNE bez počtu objednávok — dedup okno v `recordSkippedMail`
+    // porovnáva presný text, takže meniace sa číslo by ho obišlo a riadok by
+    // pribudol pri každom behu.
+    const reason = configBlocked[0]?.reason ?? "chýbajúce nastavenie";
+    await recordSkippedMail(db, now, { source: "order_reminder", trigger, templateKey: "order_reminder" }, "", reason);
   }
 
   const prunedCount = await pruneOrderReminderState(db, eligible.map((o) => o.externalOrderId));
@@ -302,11 +343,23 @@ async function runOrderReminderOverrideLocked(options: RunOrderReminderOverrideO
   if (mailTransport === undefined) return { ok: false, code: "not_configured", reason: "odosielanie e-mailov nie je nakonfigurované (chýba MAIL_HOST)" };
 
   const built = buildReminderEmail(await resolveTemplate(db, "order_reminder"), order.customerName, orderCode);
-  try {
-    await mailTransport({ to: email, subject: built.subject, text: built.text, html: built.html, bcc: bccEmail });
-  } catch (error) {
-    const rawErrorMessage = error instanceof Error ? error.message : String(error);
-    log.error({ orderCode, rawErrorMessage }, "Pripomienky objednávok: ručné odoslanie zlyhalo");
+  // issue 193: ručné odoslanie sa zapisuje s menom zamestnanca, ktorý ho
+  // stlačil (`trigger: "manual"`), nie ako naplánovaný beh.
+  const sendResult = await sendLoggedMail(
+    db,
+    mailTransport,
+    { to: email, subject: built.subject, text: built.text, html: built.html, bcc: bccEmail },
+    now,
+    {
+      source: "order_reminder",
+      trigger: "manual",
+      templateKey: "order_reminder",
+      orderCode,
+      ...(options.actorUserId === undefined ? {} : { actorUserId: options.actorUserId }),
+    },
+  );
+  if (!sendResult.ok) {
+    log.error({ orderCode, rawErrorMessage: sendResult.rawErrorMessage }, "Pripomienky objednávok: ručné odoslanie zlyhalo");
     return { ok: false, code: "send_failed" };
   }
   await upsertOrderReminderState(db, { orderCode, fingerprint: fp, resolution: "emailed", resolvedBy: "manual", resolvedAt: now }, now);

--- a/apps/api/src/modules/orders/mail.ts
+++ b/apps/api/src/modules/orders/mail.ts
@@ -10,6 +10,7 @@ import {
   variants,
 } from "../../db/schema.js";
 import { log } from "../../logger.js";
+import { sendLoggedMail } from "../mail-log/service.js";
 import { globalContext, textValue } from "../mail-templates/context.js";
 import { renderTemplate, type MailTemplateText } from "../mail-templates/render.js";
 import { resolveTemplate } from "../mail-templates/store.js";
@@ -161,16 +162,28 @@ export async function sendSupplierOrderMail(
   db: Database,
   transport: MailTransport,
   supplier: string,
+  // issue 193: ktorý zamestnanec odoslanie stlačil — táto cesta je vždy ručná.
+  actorUserId?: string,
 ): Promise<SendSupplierOrderMailResult> {
   const content = await buildSupplierOrderMailContent(db, supplier);
   if (content.to === null) return { status: "no_email" };
   if (content.itemCount === 0) return { status: "no_items" };
 
-  try {
-    await transport({ to: content.to, subject: content.subject, text: content.body });
-  } catch (error) {
-    const rawErrorMessage = error instanceof Error ? error.message : String(error);
-    log.error({ supplier, rawErrorMessage }, "odoslanie objednávky dodávateľovi zlyhalo (SMTP)");
+  const now = new Date();
+  const sendResult = await sendLoggedMail(
+    db,
+    transport,
+    { to: content.to, subject: content.subject, text: content.body },
+    now,
+    {
+      source: "supplier_order",
+      trigger: "manual",
+      templateKey: "supplier_order",
+      ...(actorUserId === undefined ? {} : { actorUserId }),
+    },
+  );
+  if (!sendResult.ok) {
+    log.error({ supplier, rawErrorMessage: sendResult.rawErrorMessage }, "odoslanie objednávky dodávateľovi zlyhalo (SMTP)");
     return { status: "send_failed" };
   }
   return { status: "sent", to: content.to, itemCount: content.itemCount };

--- a/apps/api/src/modules/posta-uncollected/run.ts
+++ b/apps/api/src/modules/posta-uncollected/run.ts
@@ -1,6 +1,7 @@
 import type { Database } from "../../db/client.js";
 import { log } from "../../logger.js";
 import type { MailTransport } from "../mail/transport.js";
+import { recordSkippedMail, sendLoggedMail, type MailLogContext } from "../mail-log/service.js";
 import { buildShoptetAdminOrderUrl } from "../orders/queries.js";
 import { resolveTemplate } from "../mail-templates/store.js";
 import { buildEmail, classifyTracking, postaTemplateKey, shouldSend, sourceCoverage, terminalState, type SourceCoverage } from "./logic.js";
@@ -66,6 +67,12 @@ export interface RunPostaUncollectedOptions {
   readonly mailTransport: MailTransport | undefined;
   readonly bccEmail: string | undefined;
   readonly adminBaseUrl: string;
+  // issue 193: kto beh vyvolal — plánovač, alebo zamestnanec cez "Spustiť
+  // teraz". Zapisuje sa do knihy odoslaných e-mailov, nikdy sa neodvodzuje z
+  // toho, či je `actorUserId` vyplnené. Predvolene `scheduled`, aby existujúci
+  // volajúci (job) nemusel nič meniť.
+  readonly trigger?: "scheduled" | "manual";
+  readonly actorUserId?: string;
 }
 
 // Ďalší voľný kľúč v registri `.claude/rules/scheduler.md` (787_878_001/002/
@@ -96,11 +103,11 @@ export const POSTA_UNCOLLECTED_RUN_LOCK_KEY = 787_878_004;
  * (iný manažér, alebo prekryv s naplánovaným behom) počká, kým prvý celý
  * doskončí, namiesto toho, aby mohol poslať duplicitný e-mail. */
 export async function runPostaUncollected(options: RunPostaUncollectedOptions): Promise<PostaUncollectedRunResult> {
-  const { db, now, trackingClient, mailTransport, bccEmail, adminBaseUrl } = options;
+  const { db } = options;
   const lockClient = await db.$client.connect();
   try {
     await lockClient.query("select pg_advisory_lock($1)", [POSTA_UNCOLLECTED_RUN_LOCK_KEY]);
-    return await runPostaUncollectedLocked({ db, now, trackingClient, mailTransport, bccEmail, adminBaseUrl });
+    return await runPostaUncollectedLocked(options);
   } finally {
     await lockClient.query("select pg_advisory_unlock($1)", [POSTA_UNCOLLECTED_RUN_LOCK_KEY]);
     lockClient.release();
@@ -108,7 +115,8 @@ export async function runPostaUncollected(options: RunPostaUncollectedOptions): 
 }
 
 async function runPostaUncollectedLocked(options: RunPostaUncollectedOptions): Promise<PostaUncollectedRunResult> {
-  const { db, now, trackingClient, mailTransport, bccEmail, adminBaseUrl } = options;
+  const { db, now, trackingClient, mailTransport, bccEmail, adminBaseUrl, actorUserId } = options;
+  const trigger = options.trigger ?? "scheduled";
   const adminOrderUrl = (order: { readonly externalOrderId: string; readonly shoptetOrderId: number | null }): string =>
     buildShoptetAdminOrderUrl(adminBaseUrl, order.externalOrderId, order.shoptetOrderId);
 
@@ -190,8 +198,27 @@ async function runPostaUncollectedLocked(options: RunPostaUncollectedOptions): P
     if (wantsSend) {
       const nextCount = priorCount + 1;
       const recipient = (shipment.email ?? "").trim();
+      // issue 193: kontext pre spoločnú knihu odoslaných e-mailov — `sequence`
+      // nesie poradie upozornenia (1–4), takže z prehľadu vidno eskaláciu,
+      // nie zdanlivé opakovanie toho istého e-mailu.
+      const logCtx: MailLogContext = {
+        source: "posta_uncollected",
+        trigger,
+        templateKey: postaTemplateKey(nextCount),
+        orderCode: shipment.externalOrderId,
+        packageNumber,
+        sequence: nextCount,
+        ...(actorUserId === undefined ? {} : { actorUserId }),
+      };
       if (bccMissing || mailNotConfigured || recipient === "") {
         emailsBlocked += 1;
+        const reason =
+          recipient === ""
+            ? "objednávka nemá e-mailovú adresu zákazníka"
+            : bccMissing
+              ? "chýba adresa pre skrytú kópiu majiteľovi (POSTA_UNCOLLECTED_BCC_EMAIL)"
+              : "odosielanie e-mailov nie je nakonfigurované (chýba MAIL_HOST)";
+        await recordSkippedMail(db, now, logCtx, recipient, reason);
         if (recipient === "" && !bccMissing && !mailNotConfigured) {
           log.error(
             { orderCode: shipment.externalOrderId, packageNumber },
@@ -208,17 +235,21 @@ async function runPostaUncollectedLocked(options: RunPostaUncollectedOptions): P
           cls.retainedTill,
           now,
         );
-        try {
-          // BCC je pre TENTO mail ZÁVÄZNÁ (ticket's jediná bezpečnostná
-          // podmienka) — `bccMissing` vyššie to už vylúčilo, `bccEmail` je
-          // tu vždy definovaný neprázdny reťazec.
-          await mailTransport({
-            to: recipient,
-            subject: built.subject,
-            text: built.text,
-            html: built.html,
-            bcc: bccEmail,
-          });
+        // BCC je pre TENTO mail ZÁVÄZNÁ (ticket's jediná bezpečnostná
+        // podmienka) — `bccMissing` vyššie to už vylúčilo, `bccEmail` je tu
+        // vždy definovaný neprázdny reťazec. issue 193: odoslanie ide cez
+        // `sendLoggedMail`, ktorý si sám zapíše výsledok (odoslané/zlyhalo)
+        // do knihy odoslaných e-mailov; zlyhanie sa NEVYHADZUJE, vracia sa
+        // ako `ok: false` — zásielka preto ostáva v zozname nevyzdvihnutých
+        // s PÔVODNÝM počítadlom, presne ako pred touto zmenou.
+        const sendResult = await sendLoggedMail(
+          db,
+          mailTransport,
+          { to: recipient, subject: built.subject, text: built.text, html: built.html, bcc: bccEmail },
+          now,
+          logCtx,
+        );
+        if (sendResult.ok) {
           effectiveCount = nextCount;
           effectiveLastSent = now;
           emailsSent += 1;
@@ -236,10 +267,9 @@ async function runPostaUncollectedLocked(options: RunPostaUncollectedOptions): P
             },
             now,
           );
-        } catch (error) {
-          const rawErrorMessage = error instanceof Error ? error.message : String(error);
+        } else {
           log.error(
-            { orderCode: shipment.externalOrderId, packageNumber, rawErrorMessage },
+            { orderCode: shipment.externalOrderId, packageNumber, rawErrorMessage: sendResult.rawErrorMessage },
             "odoslanie e-mailu (Nevyzdvihnuté zásielky) zlyhalo — skúsi sa znova nabudúce",
           );
         }

--- a/apps/api/tests/mail-log.integration.test.ts
+++ b/apps/api/tests/mail-log.integration.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, expect, it } from "vitest";
+import { mailLog, users } from "../src/db/schema.js";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import { DUPLICATE_REASON, listMailLog, summarizeMailLog } from "../src/modules/mail-log/queries.js";
+import { recordSkippedMail, sendLoggedMail, type MailLogContext } from "../src/modules/mail-log/service.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 193, majiteľ: "v automatizaciach dufam su vsetky potrebne statistiky
+// komu sa poslal mail a tak dalej". Žiadny SKUTOČNÝ e-mail tu neodchádza —
+// transport je vždy falošný (`.claude/rules/testing.md`).
+const HESLO = "test-heslo-abc";
+
+let close: (() => Promise<void>) | undefined;
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  resetLoginRateLimit();
+});
+
+async function boot() {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await ctx.db.insert(users).values({
+    email: "pouzivatel@forestshop.sk",
+    passwordHash: await hashPassword(HESLO),
+    displayName: "Test Používateľ",
+    role: "manazer",
+  });
+  const app = createApp(ctx.db, { cookieSecure: false });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "pouzivatel@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie, db: ctx.db };
+}
+
+const CTX: MailLogContext = {
+  source: "posta_uncollected",
+  trigger: "scheduled",
+  templateKey: "posta_1",
+  orderCode: "20260001",
+  packageNumber: "RR123456789SK",
+  sequence: 1,
+};
+
+it("úspešné odoslanie zapíše komu, kedy, čoho sa týkalo a s akým predmetom", async () => {
+  const { db } = await boot();
+  const odoslane: string[] = [];
+  const result = await sendLoggedMail(
+    db,
+    async (m) => {
+      odoslane.push(m.to);
+      await Promise.resolve();
+    },
+    { to: "zakaznik@example.com", subject: "Zásielka čaká na pošte", text: "…", bcc: "majitel@example.com" },
+    new Date("2026-08-03T10:00:00Z"),
+    CTX,
+  );
+
+  expect(result.ok).toBe(true);
+  expect(odoslane).toEqual(["zakaznik@example.com"]);
+  const rows = await listMailLog(db, { limit: 10 }, "https://www.forestshop.sk");
+  expect(rows).toHaveLength(1);
+  expect(rows[0]?.status).toBe("sent");
+  expect(rows[0]?.recipient).toBe("zakaznik@example.com");
+  expect(rows[0]?.orderCode).toBe("20260001");
+  expect(rows[0]?.packageNumber).toBe("RR123456789SK");
+  expect(rows[0]?.sequence).toBe(1);
+  expect(rows[0]?.subject).toBe("Zásielka čaká na pošte");
+  // Odkaz do Shoptetu sa skladá aj pre objednávku, ktorá v databáze nie je
+  // (vyhľadávacia podoba) — kniha e-mailov nesmie zmiznúť s objednávkou.
+  expect(rows[0]?.adminLink).toContain("20260001");
+});
+
+it("zlyhané odoslanie zapíše dôvod a NEvyhodí výnimku", async () => {
+  const { db } = await boot();
+  const result = await sendLoggedMail(
+    db,
+    () => Promise.reject(new Error("SMTP timeout")),
+    { to: "zakaznik@example.com", subject: "Zásielka čaká na pošte", text: "…" },
+    new Date("2026-08-03T10:00:00Z"),
+    CTX,
+  );
+
+  expect(result.ok).toBe(false);
+  const rows = await listMailLog(db, { limit: 10 }, "https://www.forestshop.sk");
+  expect(rows[0]?.status).toBe("failed");
+  expect(rows[0]?.reason).toBe("SMTP timeout");
+});
+
+it("preskočenie s tým istým dôvodom sa v rámci 24 h nezapíše druhýkrát", async () => {
+  const { db } = await boot();
+  const prvy = new Date("2026-08-03T10:00:00Z");
+  await recordSkippedMail(db, prvy, CTX, "", "objednávka nemá e-mailovú adresu zákazníka");
+  // O hodinu neskôr (ďalší beh) — rovnaký dôvod, rovnaká objednávka.
+  await recordSkippedMail(db, new Date("2026-08-03T11:00:00Z"), CTX, "", "objednávka nemá e-mailovú adresu zákazníka");
+  expect(await db.select().from(mailLog)).toHaveLength(1);
+
+  // O 25 hodín neskôr už áno — majiteľ má vidieť, že problém trvá aj dnes.
+  await recordSkippedMail(db, new Date("2026-08-04T11:00:00Z"), CTX, "", "objednávka nemá e-mailovú adresu zákazníka");
+  expect(await db.select().from(mailLog)).toHaveLength(2);
+});
+
+it("súhrn počíta odoslané/zlyhané/preskočené a zvlášť zabránené duplicity", async () => {
+  const { db } = await boot();
+  const now = new Date("2026-08-03T10:00:00Z");
+  await sendLoggedMail(db, () => Promise.resolve(), { to: "a@example.com", subject: "s", text: "t" }, now, CTX);
+  await sendLoggedMail(db, () => Promise.reject(new Error("SMTP")), { to: "b@example.com", subject: "s", text: "t" }, now, CTX);
+  await recordSkippedMail(db, now, { ...CTX, orderCode: "20260002" }, "c@example.com", DUPLICATE_REASON);
+  await recordSkippedMail(db, now, { ...CTX, orderCode: "20260003" }, "", "objednávka nemá e-mailovú adresu zákazníka");
+
+  const summary = await summarizeMailLog(db, { limit: 200 });
+  expect(summary).toEqual({ sent: 1, failed: 1, skipped: 2, duplicatesBlocked: 1 });
+});
+
+it("HTTP: prehľad vracia riadky aj súhrn, filtruje podľa automatizácie a stavu", async () => {
+  const { app, cookie, db } = await boot();
+  const now = new Date();
+  await sendLoggedMail(db, () => Promise.resolve(), { to: "a@example.com", subject: "s", text: "t" }, now, CTX);
+  await sendLoggedMail(
+    db,
+    () => Promise.resolve(),
+    { to: "d@example.com", subject: "objednávka", text: "t" },
+    now,
+    { source: "supplier_order", trigger: "manual", templateKey: "supplier_order" },
+  );
+
+  const vsetko = await app.request("/api/mail-log", { headers: { cookie } });
+  expect(vsetko.status).toBe(200);
+  const telo = (await vsetko.json()) as { rows: readonly { source: string }[]; summary: { sent: number } };
+  expect(telo.rows).toHaveLength(2);
+  expect(telo.summary.sent).toBe(2);
+
+  const lenDodavatel = await app.request("/api/mail-log?source=supplier_order", { headers: { cookie } });
+  const filtrovane = (await lenDodavatel.json()) as { rows: readonly { source: string }[]; summary: { sent: number } };
+  expect(filtrovane.rows.map((r) => r.source)).toEqual(["supplier_order"]);
+  // Súhrn ZÁMERNE ignoruje filter stavu, ale filter automatizácie rešpektuje.
+  expect(filtrovane.summary.sent).toBe(1);
+});
+
+it("HTTP: neprihlásený sa k prehľadu nedostane", async () => {
+  const { app } = await boot();
+  const res = await app.request("/api/mail-log");
+  expect(res.status).toBe(401);
+});

--- a/apps/web/src/components/MailLogSection.test.tsx
+++ b/apps/web/src/components/MailLogSection.test.tsx
@@ -1,0 +1,115 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { MailLogSection } from "./MailLogSection.js";
+
+const { fetchMailLog } = vi.hoisted(() => ({ fetchMailLog: vi.fn() }));
+
+// `MailLogUnauthorizedError` ostáva SKUTOČNÁ trieda (rovnaký dôvod ako
+// `MailTemplatesSection.test.tsx` — `instanceof` v komponente musí fungovať).
+vi.mock("../mailLogApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../mailLogApi.js")>();
+  return { ...actual, fetchMailLog };
+});
+
+const { MailLogUnauthorizedError } = await import("../mailLogApi.js");
+
+const RIADOK = {
+  id: "r1",
+  createdAt: "2026-08-03T08:30:00.000Z",
+  source: "posta_uncollected" as const,
+  status: "sent" as const,
+  trigger: "scheduled" as const,
+  templateKey: "posta_1",
+  recipient: "zakaznik@example.com",
+  subject: "Zásielka čaká na pošte",
+  orderCode: "20260001",
+  variantCode: null,
+  packageNumber: "RR123456789SK",
+  sequence: 1,
+  reason: null,
+  actorName: null,
+  adminLink: "https://www.forestshop.sk/admin/objednavky-detail/?id=1",
+};
+
+const DUPLICITA = {
+  ...RIADOK,
+  id: "r2",
+  status: "skipped" as const,
+  trigger: "manual" as const,
+  actorName: "Zbyněk",
+  source: "nedostupne" as const,
+  sequence: null,
+  reason: "už bolo odoslané skôr — druhý e-mail sa neposiela",
+};
+
+const SUHRN = { sent: 3, failed: 1, skipped: 2, duplicatesBlocked: 1 };
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+function renderSection(rows: readonly unknown[] = [RIADOK, DUPLICITA]) {
+  fetchMailLog.mockResolvedValue({ rows, summary: SUHRN, period: "30" });
+  render(<MailLogSection onSessionExpired={vi.fn()} />);
+}
+
+it("zobrazí súhrn za obdobie vrátane zabránených duplicít", async () => {
+  renderSection();
+  await screen.findByTestId("mail-log-summary");
+  expect(screen.getByTestId("mail-log-sum-sent").textContent).toContain("3");
+  expect(screen.getByTestId("mail-log-sum-failed").textContent).toContain("1");
+  expect(screen.getByTestId("mail-log-sum-skipped").textContent).toContain("2");
+  expect(screen.getByTestId("mail-log-sum-duplicates").textContent).toContain("1");
+});
+
+it("v riadku je vidno komu, čoho sa e-mail týkal aj poradie upozornenia", async () => {
+  renderSection();
+  const riadok = await screen.findByTestId("mail-log-row-r1");
+  expect(riadok.textContent).toContain("zakaznik@example.com");
+  expect(riadok.textContent).toContain("objednávka 20260001");
+  expect(riadok.textContent).toContain("zásielka RR123456789SK");
+  expect(riadok.textContent).toContain("1. upozornenie");
+  expect(riadok.textContent).toContain("Odoslané");
+});
+
+it("zablokovaná duplicita je vidno aj s menom zamestnanca, ktorý ju vyvolal", async () => {
+  renderSection();
+  const riadok = await screen.findByTestId("mail-log-row-r2");
+  expect(riadok.textContent).toContain("Preskočené");
+  expect(riadok.textContent).toContain("už bolo odoslané skôr");
+  expect(riadok.textContent).toContain("Zbyněk");
+});
+
+it("zmena filtra automatizácie znovu načíta prehľad s tým filtrom", async () => {
+  renderSection();
+  await screen.findByTestId("mail-log-table");
+  fireEvent.change(screen.getByTestId("mail-log-filter-source"), { target: { value: "order_reminder" } });
+  await waitFor(() => {
+    expect(fetchMailLog).toHaveBeenLastCalledWith({ source: "order_reminder", status: "", period: "30" });
+  });
+});
+
+it("zmena obdobia znovu načíta prehľad s tým obdobím", async () => {
+  renderSection();
+  await screen.findByTestId("mail-log-table");
+  fireEvent.change(screen.getByTestId("mail-log-filter-period"), { target: { value: "7" } });
+  await waitFor(() => {
+    expect(fetchMailLog).toHaveBeenLastCalledWith({ source: "", status: "", period: "7" });
+  });
+});
+
+it("prázdny prehľad povie, že sa nič neposielalo — nie prázdnu tabuľku", async () => {
+  renderSection([]);
+  await screen.findByTestId("mail-log-empty");
+  expect(screen.queryByTestId("mail-log-table")).toBeNull();
+});
+
+it("401 pri načítaní zavolá onSessionExpired", async () => {
+  const onSessionExpired = vi.fn();
+  fetchMailLog.mockRejectedValue(new MailLogUnauthorizedError());
+  render(<MailLogSection onSessionExpired={onSessionExpired} />);
+  await waitFor(() => {
+    expect(onSessionExpired).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/MailLogSection.tsx
+++ b/apps/web/src/components/MailLogSection.tsx
@@ -1,0 +1,199 @@
+import { useCallback, useEffect, useState, type JSX } from "react";
+import {
+  fetchMailLog,
+  MailLogUnauthorizedError,
+  MAIL_LOG_SOURCES,
+  MAIL_LOG_SOURCE_LABELS,
+  type MailLogList,
+  type MailLogPeriod,
+  type MailLogRow,
+  type MailLogSource,
+} from "../mailLogApi.js";
+
+// issue 193, majiteľ: "v automatizaciach dufam su vsetky potrebne statistiky
+// komu sa poslal mail a tak dalej". Jedna obrazovka pre VŠETKÝCH odosielateľov
+// appky — bez nej sa história odoslanej pošty nedala zistiť vôbec.
+
+const STATUS_LABELS: Readonly<Record<MailLogRow["status"], string>> = {
+  sent: "Odoslané",
+  failed: "Zlyhalo",
+  skipped: "Preskočené",
+};
+
+const PERIOD_LABELS: readonly { readonly value: MailLogPeriod; readonly label: string }[] = [
+  { value: "7", label: "posledných 7 dní" },
+  { value: "30", label: "posledných 30 dní" },
+  { value: "90", label: "posledných 90 dní" },
+  { value: "all", label: "celá história" },
+];
+
+function formatWhen(iso: string): string {
+  return new Date(iso).toLocaleString("sk-SK", { dateStyle: "short", timeStyle: "short" });
+}
+
+/** Čoho sa e-mail týkal — objednávka, tovar, zásielka. Prázdny reťazec, keď
+ * odosielateľ nič z toho nemá (objednávka dodávateľovi). */
+function subjectOfRow(row: MailLogRow): string {
+  const parts: string[] = [];
+  if (row.orderCode !== null) parts.push(`objednávka ${row.orderCode}`);
+  if (row.variantCode !== null) parts.push(`tovar ${row.variantCode}`);
+  if (row.packageNumber !== null) parts.push(`zásielka ${row.packageNumber}`);
+  return parts.join(" · ");
+}
+
+export function MailLogSection({ onSessionExpired }: { readonly onSessionExpired: () => void }): JSX.Element {
+  const [data, setData] = useState<MailLogList | null>(null);
+  const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState("");
+  const [source, setSource] = useState<MailLogSource | "">("");
+  const [status, setStatus] = useState<MailLogRow["status"] | "">("");
+  const [period, setPeriod] = useState<MailLogPeriod>("30");
+
+  const load = useCallback(() => {
+    fetchMailLog({ source, status, period })
+      .then((list) => {
+        setData(list);
+        setError("");
+        setLoaded(true);
+      })
+      .catch((err: unknown) => {
+        setLoaded(true);
+        if (err instanceof MailLogUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setError("Prehľad odoslaných e-mailov sa nepodarilo načítať.");
+      });
+  }, [onSessionExpired, source, status, period]);
+
+  useEffect(load, [load]);
+
+  if (!loaded) return <p>Načítavam…</p>;
+  if (error !== "") return <p role="alert">{error}</p>;
+  if (data === null) return <p role="alert">Prehľad odoslaných e-mailov sa nepodarilo načítať.</p>;
+
+  return (
+    <section>
+      <p>
+        Každý e-mail, ktorý appka poslala v mene obchodu — komu, kedy, čoho sa týkal a či odoslanie prešlo. Zapisujú sa aj pokusy, ktoré neprešli, aj tie, ktoré
+        appka zámerne neposlala (napríklad aby zákazník nedostal to isté dvakrát).
+      </p>
+
+      <div className="ml-summary" data-testid="mail-log-summary">
+        <span className="ml-chip ml-chip-sent" data-testid="mail-log-sum-sent">
+          Odoslané: {data.summary.sent}
+        </span>
+        <span className="ml-chip ml-chip-failed" data-testid="mail-log-sum-failed">
+          Zlyhalo: {data.summary.failed}
+        </span>
+        <span className="ml-chip ml-chip-skipped" data-testid="mail-log-sum-skipped">
+          Preskočené: {data.summary.skipped}
+        </span>
+        <span className="ml-chip" data-testid="mail-log-sum-duplicates" title="Koľkokrát appka zabránila druhému rovnakému e-mailu tomu istému zákazníkovi">
+          Zabránené duplicity: {data.summary.duplicatesBlocked}
+        </span>
+      </div>
+
+      <div className="ml-filters">
+        <label>
+          Automatizácia
+          <select
+            value={source}
+            data-testid="mail-log-filter-source"
+            onChange={(e) => {
+              setSource(e.target.value as MailLogSource | "");
+            }}
+          >
+            <option value="">všetky</option>
+            {MAIL_LOG_SOURCES.map((s) => (
+              <option key={s} value={s}>
+                {MAIL_LOG_SOURCE_LABELS[s]}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Stav
+          <select
+            value={status}
+            data-testid="mail-log-filter-status"
+            onChange={(e) => {
+              setStatus(e.target.value as MailLogRow["status"] | "");
+            }}
+          >
+            <option value="">všetky</option>
+            <option value="sent">odoslané</option>
+            <option value="failed">zlyhalo</option>
+            <option value="skipped">preskočené</option>
+          </select>
+        </label>
+        <label>
+          Obdobie
+          <select
+            value={period}
+            data-testid="mail-log-filter-period"
+            onChange={(e) => {
+              setPeriod(e.target.value as MailLogPeriod);
+            }}
+          >
+            {PERIOD_LABELS.map((p) => (
+              <option key={p.value} value={p.value}>
+                {p.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      {data.rows.length === 0 ? (
+        <p data-testid="mail-log-empty">Za zvolené obdobie appka neposlala ani sa nepokúsila poslať žiadny e-mail.</p>
+      ) : (
+        <div className="ml-table-wrap">
+          <table className="ml-table" data-testid="mail-log-table">
+            <thead>
+              <tr>
+                <th>Kedy</th>
+                <th>Automatizácia</th>
+                <th>Komu</th>
+                <th>Čoho sa týka</th>
+                <th>Stav</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.rows.map((row) => (
+                <tr key={row.id} data-testid={`mail-log-row-${row.id}`} className={`ml-row ml-row-${row.status}`}>
+                  <td className="ml-when">
+                    {formatWhen(row.createdAt)}
+                    <span className="ml-trigger">{row.trigger === "manual" ? (row.actorName ?? "ručne") : "plán"}</span>
+                  </td>
+                  <td>
+                    {MAIL_LOG_SOURCE_LABELS[row.source]}
+                    {row.sequence !== null && <span className="ml-seq">{row.sequence}. upozornenie</span>}
+                  </td>
+                  <td className="ml-recipient">{row.recipient === "" ? "—" : row.recipient}</td>
+                  <td>
+                    {row.adminLink === null ? (
+                      subjectOfRow(row) === "" ? (
+                        (row.subject ?? "—")
+                      ) : (
+                        subjectOfRow(row)
+                      )
+                    ) : (
+                      <a href={row.adminLink} target="_blank" rel="noreferrer noopener">
+                        {subjectOfRow(row)}
+                      </a>
+                    )}
+                  </td>
+                  <td>
+                    <span className={`ml-status ml-status-${row.status}`}>{STATUS_LABELS[row.status]}</span>
+                    {row.reason !== null && <span className="ml-reason">{row.reason}</span>}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/mailLogApi.ts
+++ b/apps/web/src/mailLogApi.ts
@@ -1,0 +1,70 @@
+import { z } from "zod";
+
+// issue 193: obrazovka "Odoslané e-maily" — zrkadlí `http/mail-log-routes.ts`.
+// Len čítanie, žiadny zápis (do knihy zapisujú samy odosielacie cesty).
+
+export const MAIL_LOG_SOURCES = ["nedostupne", "posta_uncollected", "order_reminder", "supplier_order"] as const;
+export type MailLogSource = (typeof MAIL_LOG_SOURCES)[number];
+
+// Popisky sú TU (nie na serveri) z rovnakého dôvodu ako pri stavoch riadkov
+// objednávky — server posiela kľúč, jeho slovenské meno patrí obrazovke.
+export const MAIL_LOG_SOURCE_LABELS: Readonly<Record<MailLogSource, string>> = {
+  nedostupne: "Nedostupné tovary",
+  posta_uncollected: "Nevyzdvihnuté zásielky",
+  order_reminder: "Pripomienky objednávok",
+  supplier_order: "Objednávka dodávateľovi",
+};
+
+const rowSchema = z.object({
+  id: z.string(),
+  createdAt: z.string(),
+  source: z.enum(MAIL_LOG_SOURCES),
+  status: z.enum(["sent", "failed", "skipped"]),
+  trigger: z.enum(["scheduled", "manual"]),
+  templateKey: z.string().nullable(),
+  recipient: z.string(),
+  subject: z.string().nullable(),
+  orderCode: z.string().nullable(),
+  variantCode: z.string().nullable(),
+  packageNumber: z.string().nullable(),
+  sequence: z.number().nullable(),
+  reason: z.string().nullable(),
+  actorName: z.string().nullable(),
+  adminLink: z.string().nullable(),
+});
+export type MailLogRow = z.infer<typeof rowSchema>;
+
+const summarySchema = z.object({
+  sent: z.number(),
+  failed: z.number(),
+  skipped: z.number(),
+  duplicatesBlocked: z.number(),
+});
+export type MailLogSummary = z.infer<typeof summarySchema>;
+
+const listSchema = z.object({ rows: z.array(rowSchema), summary: summarySchema, period: z.string() });
+export type MailLogList = z.infer<typeof listSchema>;
+
+export type MailLogPeriod = "7" | "30" | "90" | "all";
+
+export class MailLogUnauthorizedError extends Error {
+  constructor() {
+    super("Neprihlásený");
+  }
+}
+
+export interface MailLogFilter {
+  readonly source?: MailLogSource | "";
+  readonly status?: "sent" | "failed" | "skipped" | "";
+  readonly period: MailLogPeriod;
+}
+
+export async function fetchMailLog(filter: MailLogFilter): Promise<MailLogList> {
+  const params = new URLSearchParams({ period: filter.period });
+  if (filter.source !== undefined && filter.source !== "") params.set("source", filter.source);
+  if (filter.status !== undefined && filter.status !== "") params.set("status", filter.status);
+  const response = await fetch(`/api/mail-log?${params.toString()}`);
+  if (response.status === 401) throw new MailLogUnauthorizedError();
+  if (!response.ok) throw new Error("Prehľad odoslaných e-mailov sa nepodarilo načítať");
+  return listSchema.parse(await response.json());
+}

--- a/apps/web/src/nav.test.ts
+++ b/apps/web/src/nav.test.ts
@@ -8,17 +8,19 @@ import { DEFAULT_TAB_ID, HIDDEN_TABS, NAV, findTab, isVisibleTabId } from "./nav
 // pridalo "Texty e-mailov" do Systému (nastavenie spoločné pre VŠETKY
 // automatizácie). Tento test je
 // najbližšie k tomu, čo strojovo overiť dá (registrácia, nie DOM).
-it("NAV má tri priečinky (Systém/Eshop/Automatizácie), s 2/2/2 záložkami v poradí podľa dôležitosti", () => {
+it("NAV má tri priečinky (Systém/Eshop/Automatizácie), s 2/2/3 záložkami v poradí podľa dôležitosti", () => {
   expect(NAV).toHaveLength(3);
   expect(NAV.map((f) => f.label)).toEqual(["Systém", "Eshop", "Automatizácie"]);
   expect(NAV[0]?.tabs).toHaveLength(2);
   expect(NAV[1]?.tabs).toHaveLength(2);
-  expect(NAV[2]?.tabs).toHaveLength(2);
+  expect(NAV[2]?.tabs).toHaveLength(3);
   expect(NAV[0]?.tabs.map((t) => t.label)).toEqual(["Sync zo Shoptetu", "Texty e-mailov"]);
   expect(NAV[1]?.tabs.map((t) => t.label)).toEqual(["Na objednanie", "Nedostupné tovary"]);
+  // issue 193: "Odoslané e-maily" — prehľad toho, čo automatizácie poslali.
   expect(NAV[2]?.tabs.map((t) => t.label)).toEqual([
     "Nevyzdvihnuté zásielky",
     "Pripomienky objednávok",
+    "Odoslané e-maily",
   ]);
 });
 

--- a/apps/web/src/nav.ts
+++ b/apps/web/src/nav.ts
@@ -1,6 +1,7 @@
 import type { ComponentType } from "react";
 import type { Me } from "./api.js";
 import { CatalogPage } from "./components/CatalogPage.js";
+import { MailLogSection } from "./components/MailLogSection.js";
 import { MailTemplatesSection } from "./components/MailTemplatesSection.js";
 import { NedostupneSection } from "./components/NedostupneSection.js";
 import { OrderReminderSection } from "./components/OrderReminderSection.js";
@@ -80,9 +81,14 @@ export const NAV: readonly NavFolder[] = [
     label: "Automatizácie",
     // Len tie dve veci, ktoré SKUTOČNE bežia na plán a dajú sa zapnúť/vypnúť
     // (issue 195). Poradie podľa dôležitosti (issue 185, zadanie majiteľa).
+    // issue 193: "Odoslané e-maily" patrí SEM — je to prehľad toho, čo
+    // automatizácie poslali (majiteľ: "v automatizaciach dufam su vsetky
+    // potrebne statistiky komu sa poslal mail"). `wide: true` ako pri
+    // ostatných hustých pracovných tabuľkách.
     tabs: [
       { id: "posta-uncollected", label: "Nevyzdvihnuté zásielky", icon: "📮", Component: PostaUncollectedSection },
       { id: "order-reminder", label: "Pripomienky objednávok", icon: "⏰", Component: OrderReminderSection },
+      { id: "mail-log", label: "Odoslané e-maily", icon: "📨", Component: MailLogSection, wide: true },
     ],
   },
 ];

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2016,3 +2016,90 @@ tr:last-child td {
 .mt-history h4 {
   margin: 0 0 var(--fs-space-2);
 }
+
+/* issue 193: "Odoslané e-maily" — prehľad všetkého, čo appka poslala v mene
+   obchodu. Iba `--fs-*` tokeny (`.claude/rules/frontend-design.md`). */
+.ml-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--fs-space-2);
+  margin: var(--fs-space-4) 0;
+}
+.ml-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--fs-space-1) var(--fs-space-3);
+  font-size: var(--fs-text-sm);
+  font-weight: var(--fs-weight-medium);
+  color: var(--fs-ink);
+  background: var(--fs-surface-alt);
+  border: 1px solid var(--fs-border);
+  border-radius: 999px;
+}
+.ml-chip-sent {
+  color: var(--fs-brand);
+}
+.ml-chip-failed {
+  color: var(--fs-danger);
+}
+.ml-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--fs-space-4);
+  align-items: end;
+  margin-bottom: var(--fs-space-4);
+}
+.ml-filters label {
+  display: flex;
+  flex-direction: column;
+  gap: var(--fs-space-1);
+  font-size: var(--fs-text-sm);
+  color: var(--fs-ink-muted);
+}
+/* Vlastný vodorovný posuv tabuľky, nikdy posuv celej stránky — rovnaký vzor
+   ako `.orders-table-wrap`. */
+.ml-table-wrap {
+  overflow-x: auto;
+}
+.ml-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.ml-table th,
+.ml-table td {
+  padding: var(--fs-space-2) var(--fs-space-3);
+  text-align: left;
+  vertical-align: top;
+  border-bottom: 1px solid var(--fs-border);
+}
+.ml-table td {
+  overflow-wrap: break-word;
+}
+.ml-when,
+.ml-recipient {
+  white-space: nowrap;
+}
+/* Doplnkové údaje (kto spustil, poradie upozornenia, dôvod) idú POD hlavný
+   údaj na vlastný riadok — nikdy inline za ním, aby sa nezopakovalo
+   pretečenie do susedného stĺpca z issue 204. */
+.ml-trigger,
+.ml-seq,
+.ml-reason {
+  display: block;
+  margin-top: var(--fs-space-1);
+  font-size: var(--fs-text-xs);
+  color: var(--fs-ink-faint);
+}
+.ml-status {
+  font-weight: var(--fs-weight-medium);
+  white-space: nowrap;
+}
+.ml-status-sent {
+  color: var(--fs-brand);
+}
+.ml-status-failed {
+  color: var(--fs-danger);
+}
+.ml-status-skipped {
+  color: var(--fs-ink-muted);
+}

--- a/apps/web/tests/e2e/mail-log.spec.ts
+++ b/apps/web/tests/e2e/mail-log.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "@playwright/test";
+
+const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
+const E2E_KNIHA_EMAIL = "e2e-kniha@forestshop.sk"; // musí sa zhodovať s hodnotou v scripts/e2e-setup.ts
+
+// issue 193: "Odoslané e-maily" — prehľad toho, čo appka poslala. Táto
+// obrazovka LEN číta; žiadny e-mail sa tu neodosiela (`playwright.config.ts`
+// serveru ani nenastavuje `MAIL_HOST`).
+test("prehľad odoslaných e-mailov ukáže súhrn, riadky s príjemcom a filtrovanie; konzola je čistá", async ({ page }) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/");
+  await page.getByLabel("E-mail").fill(E2E_KNIHA_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+
+  // Obrazovka je dostupná z ľavého menu pod "Automatizácie".
+  await page.getByRole("button", { name: "Odoslané e-maily" }).click();
+  await expect(page.getByTestId("mail-log-table")).toBeVisible();
+
+  // Súhrn: fixtúra má jeden odoslaný a jednu zablokovanú duplicitu.
+  await expect(page.getByTestId("mail-log-sum-sent")).toContainText("1");
+  await expect(page.getByTestId("mail-log-sum-duplicates")).toContainText("1");
+
+  // Riadok nesie KOMU a ČOHO sa e-mail týkal — to je jadro zadania.
+  const tabulka = page.getByTestId("mail-log-table");
+  await expect(tabulka).toContainText("e2e-zakaznik@example.com");
+  await expect(tabulka).toContainText("objednávka 9001");
+  await expect(tabulka).toContainText("zásielka RR000000001SK");
+  await expect(tabulka).toContainText("1. upozornenie");
+  await expect(tabulka).toContainText("Odoslané");
+
+  // Zablokovaná duplicita je vidno aj s dôvodom (ticketova podmienka
+  // "ochrana pred dvojitým odoslaním musí byť z prehľadu viditeľná").
+  await expect(tabulka).toContainText("Preskočené");
+  await expect(tabulka).toContainText("už bolo odoslané skôr");
+
+  // Filter podľa automatizácie zúži zoznam na jednu automatizáciu.
+  await page.getByTestId("mail-log-filter-source").selectOption("posta_uncollected");
+  await expect(tabulka).toContainText("Nevyzdvihnuté zásielky");
+  await expect(tabulka).not.toContainText("Nedostupné tovary");
+
+  // Obdobie, v ktorom sa nič neposielalo, ukáže vetu — nie prázdnu tabuľku.
+  await page.getByTestId("mail-log-filter-source").selectOption("");
+  await page.getByTestId("mail-log-filter-status").selectOption("failed");
+  await expect(page.getByTestId("mail-log-empty")).toBeVisible();
+
+  // Súhrn ostáva úplný aj pri zapnutom filtri stavu — inak by tvrdil, že sa
+  // nič neodoslalo, hoci sa len nezobrazuje.
+  await expect(page.getByTestId("mail-log-sum-sent")).toContainText("1");
+
+  expect(chyby).toEqual([]);
+});

--- a/apps/web/tests/e2e/nav.spec.ts
+++ b/apps/web/tests/e2e/nav.spec.ts
@@ -37,7 +37,7 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) so šiestimi
   await expect(page.getByRole("button", { name: "Automatizácie" })).toBeVisible();
 
   // Presne šesť záložiek v CELOM menu.
-  await expect(page.locator(".side-nav .tab")).toHaveCount(6);
+  await expect(page.locator(".side-nav .tab")).toHaveCount(7);
   await expect(page.getByRole("button", { name: "Sync zo Shoptetu" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Texty e-mailov" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Na objednanie" })).toBeVisible();
@@ -116,7 +116,7 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) so šiestimi
 
   // Hlavičky priečinkov zmiznú, ikony všetkých šiestich modulov ostanú.
   await expect(page.getByRole("button", { name: "Systém" })).toHaveCount(0);
-  await expect(page.locator(".side-nav .tab")).toHaveCount(6);
+  await expect(page.locator(".side-nav .tab")).toHaveCount(7);
   // Názov sa v lište ukáže bublinou pri prejdení myšou.
   await expect(page.getByRole("button", { name: "Na objednanie" })).toHaveAttribute(
     "title",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.118",
+  "version": "0.3.0-dev.119",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -9,7 +9,7 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { createDb } from "../apps/api/src/db/client.js";
-import { jobRuns, orderLines, orderOpenStatuses, orderReminderSettings, orders, pairings, postaUncollectedSettings, users } from "../apps/api/src/db/schema.js";
+import { jobRuns, mailLog, orderLines, orderOpenStatuses, orderReminderSettings, orders, pairings, postaUncollectedSettings, users } from "../apps/api/src/db/schema.js";
 import { CATALOG_IMPORT_JOB_NAME } from "../apps/api/src/modules/scheduler/jobs.js";
 import { hashPassword } from "../apps/api/src/modules/auth/passwords.js";
 import { ingestCatalog } from "../apps/api/src/modules/catalog/ingest.js";
@@ -149,6 +149,10 @@ const E2E_NEDOSTUPNE_EMAIL = "e2e-nedostupne@forestshop.sk"; // musí sa zhodova
 // nový spec súbor (`mail-templates.spec.ts`) dostáva VLASTNÝ izolovaný účet
 // namiesto ďalšieho prihlásenia pod zdieľaným `e2e@forestshop.sk`.
 const E2E_MAILY_EMAIL = "e2e-maily@forestshop.sk"; // musí sa zhodovať s hodnotou v mail-templates.spec.ts
+
+// issue 193: rovnaký mechanizmus a dôvod ako `E2E_MAILY_EMAIL` vyššie — nový
+// spec súbor (`mail-log.spec.ts`) dostáva VLASTNÝ izolovaný účet.
+const E2E_KNIHA_EMAIL = "e2e-kniha@forestshop.sk"; // musí sa zhodovať s hodnotou v mail-log.spec.ts
 
 const { db, pool } = createDb();
 // Konštantný literál bez interpolácie — obyčajný reťazec je tu rovnako bezpečný
@@ -294,6 +298,12 @@ await db.insert(users).values({
 });
 await db.insert(users).values({
   email: E2E_MAILY_EMAIL,
+  passwordHash: await hashPassword(E2E_HESLO),
+  displayName: "E2E Manažér",
+  role: "manazer",
+});
+await db.insert(users).values({
+  email: E2E_KNIHA_EMAIL,
   passwordHash: await hashPassword(E2E_HESLO),
   displayName: "E2E Manažér",
   role: "manazer",
@@ -562,6 +572,39 @@ await db.insert(jobRuns).values({
   finishedAt: new Date("2020-01-01T09:00:05Z"),
   status: "success",
   detail: { variantCount: 1 },
+});
+
+// issue 193: dva riadky knihy odoslaných e-mailov, aby `mail-log.spec.ts`
+// overoval SKUTOČNÝ obsah obrazovky, nie prázdny stav. `created_at` je "teraz"
+// (nie zostarnutý ako `job_run` vyššie) — obrazovka predvolene zobrazuje
+// posledných 30 dní, takže starý dátum by riadky skryl. Žiadny e-mail sa tým
+// neodosiela: sú to LEN záznamy o tom, čo appka kedysi urobila.
+const teraz = new Date();
+await db.insert(mailLog).values({
+  createdAt: teraz,
+  source: "posta_uncollected",
+  status: "sent",
+  trigger: "scheduled",
+  templateKey: "posta_1",
+  recipient: "e2e-zakaznik@example.com",
+  bcc: "e2e-majitel@example.com",
+  subject: "Zásielka čaká na pošte",
+  orderCode: "9001",
+  packageNumber: "RR000000001SK",
+  sequence: 1,
+});
+await db.insert(mailLog).values({
+  createdAt: teraz,
+  source: "nedostupne",
+  status: "skipped",
+  trigger: "manual",
+  templateKey: "nedostupne",
+  recipient: "e2e-zakaznik@example.com",
+  orderCode: "9002",
+  variantCode: "4859/46",
+  // Musí sa presne zhodovať s `DUPLICATE_REASON` (`modules/mail-log/
+  // queries.ts`) — inak by súhrn "zabránené duplicity" ukázal nulu.
+  reason: "už bolo odoslané skôr — druhý e-mail sa neposiela",
 });
 
 await pool.end();


### PR DESCRIPTION
## Čo to rieši

Majiteľ (3. 8. 2026): "v automatizaciach dufam su vsetky potrebne statistiky
komu sa poslal mail a tak dalej" — issue 193.

Doteraz si každá automatizácia pamätala len to, čo potrebovala pre seba
(počítadlo upozornení, výsledok pripomienky, dedup dôkaz). **Adresa príjemcu,
predmet ani dôvod zlyhania sa nikde neukladali**, posledný beh v `job_run` vždy
prepíše ten ďalší, a zlyhania končili len v serverovom logu, ktorý majiteľ
nevidí. Odoslanie objednávky dodávateľovi neukladalo vôbec nič.

## Ako

- Nová tabuľka `mail_log` — jeden riadok na každý POKUS o odoslanie.
- Spoločný `sendLoggedMail` (`modules/mail-log/service.ts`) je **jediná cesta,
  ktorou appka posiela e-mail** — odoslanie a zápis sa nedajú rozpojiť, takže
  budúca automatizácia sa nemôže pridať tak, že sa do knihy nezapíše.
- Prepojené všetky štyri odosielacie miesta: nedostupné tovary, nevyzdvihnuté
  zásielky, pripomienky objednávok (beh aj ručná akcia), objednávka
  dodávateľovi.
- Zapisuje sa: kedy, ktorá automatizácia, komu (aj skrytá kópia), predmet,
  objednávka/tovar/zásielka, druh šablóny, poradie upozornenia, stav
  (odoslané/zlyhalo/preskočené) s čitateľným dôvodom, a kto to spustil (plán
  vs. konkrétny zamestnanec).
- Preskočenia majú 24-hodinové okno na (automatizácia, objednávka, dôvod), aby
  trvajúca príčina nezapisovala ten istý riadok každý beh.
- Nová obrazovka **Automatizácie → Odoslané e-maily**: súhrn (odoslané /
  zlyhalo / preskočené / **zabránené duplicity**), filtre podľa automatizácie,
  stavu a obdobia, preklik na objednávku v Shoptete.

## Testy

- 6 integračných (zápis pri úspechu aj zlyhaní, dedup okno preskočení, súhrn,
  HTTP filtre, neprihlásený)
- 7 web unit (súhrn, obsah riadku, duplicita s menom zamestnanca, filtre,
  prázdny stav, vypršaná relácia)
- 1 e2e cez skutočný prehliadač s nulovou toleranciou konzoly
- Celý balík zelený: 477 API unit, 384 integračných, 350 web unit, 30 e2e

Žiadny test sa nedotkne skutočnej pošty ani Shoptetu — transport je vždy
falošný. Ticket sa zavrie ručne až po živom overení na produkcii (repo
pravidlo).
