### PR TITLE
Deploy uprace starsie obrazy tejto appky na dev2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,6 +73,21 @@ jobs:
           rsync -a --delete "$GITHUB_WORKSPACE/scripts/" scripts/
           docker compose -f docker-compose.prod.yml pull app
           docker compose -f docker-compose.prod.yml up -d
+      - name: Upratať staršie obrazy TEJTO appky
+        # issue 206: dev2 je zdieľaný stroj a bol na 100 % disku — jeden náš
+        # obraz má ~1,4 GB, takže každé nasadenie doteraz nechalo po sebe
+        # ďalší. Maže sa VÝHRADNE `ghcr.io/<repo>` (naše vlastné obrazy) a
+        # nikdy ten práve nasadený — cudzie projekty na tom istom stroji sa
+        # tým nikdy nedotkneme. `|| true` je tu zámerne: obraz môže držať
+        # ešte dobiehajúci starý kontajner a nasadenie je v tej chvíli už
+        # hotové a overené — neuprataný obraz nesmie zhodiť úspešný deploy.
+        run: |
+          keep="ghcr.io/${GITHUB_REPOSITORY,,}:${IMAGE_TAG}"
+          docker images --format '{{.Repository}}:{{.Tag}}' \
+            | grep "^ghcr.io/${GITHUB_REPOSITORY,,}:" \
+            | grep -v "^${keep}$" \
+            | xargs -r -n1 docker rmi || true
+          df -h / | tail -1
       - name: Overiť verziu na živej stránke
         run: |
           sleep 5

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.119",
+  "version": "0.3.0-dev.120",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Čo to rieši

Časť issue 206 (plný disk na dev2), ktorá je **moja** — táto appka po sebe
nechávala na dev2 každý nasadený obraz (~1,4 GB za nasadenie).

## Ako

Nový krok v `deploy.yml` po úspešnom nasadení zmaže staršie obrazy
`ghcr.io/<repo>` okrem práve nasadeného. Cudzích projektov na zdieľanom
stroji sa nedotýka — vzor je zakotvený na náš vlastný repozitár.

`|| true` je zámerné: obraz môže ešte držať dobiehajúci starý kontajner a
nasadenie je v tej chvíli hotové a overené — neuprataný obraz nesmie zhodiť
úspešný deploy.

Zvyšok ticketu (525 GB `bakerion-ai`, 121 GB `camera_cache`, 242
nepoužívaných docker volumes iných projektov) čaká na rozhodnutie majiteľa —
nie sú to dáta tejto appky.
