### PR TITLE
Pripojit pomenovanu priehradku aj na nadradeny priecinok postgresu

### DIFF
--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -19,6 +19,19 @@ paths:
   explicitne pinujú `PGDATA: /var/lib/postgresql/data` v `environment:` sekcii
   `postgres` služby. Ak niekedy vznikne ďalší compose súbor s Postgres 18+
   named volume, potrebuje ten istý pin, inak zopakuje presne tento pád.
+- **Ten istý PGDATA pin má DRUHÝ dôsledok: obraz deklaruje `VOLUME
+  /var/lib/postgresql`, ale my pripájame pomenovanú priehradku až na jeho
+  podpriečinok `data` — takže docker si pri KAŽDOM prestavaní kontajnera
+  vyrobí navyše bezmennú (anonymnú) priehradku pre ten nadradený priečinok.**
+  Zmerané na dev2 pri issue 206: z 245 osirelých bezmenných priehradiek bola
+  presne jedna 4 KB (naša), zvyšok po ~40 MB patril inému projektu. Fix (issue
+  209): pridať DRUHÚ pomenovanú priehradku `pgparent:/var/lib/postgresql` PRED
+  riadok s `pgdata` — vnorený mount ide dovnútra, dáta zostávajú v `pgdata` a
+  NEPRESÚVAJÚ sa. Overené lokálne na odhodenom kontajneri predtým, než sa to
+  pustilo na produkciu: kontajner nabehol (`pg_isready` do 6 s), zápis spravený
+  pred prestavaním sa po prestavaní načítal späť, a počet osirelých priehradiek
+  sa nezmenil. **Každý ďalší compose súbor s Postgres 18+ potrebuje OBA riadky,
+  nielen `PGDATA` pin** — inak zopakuje presne tento únik.
 - CI `integration`/`e2e` joby bežia Postgres bez volume mountu vôbec (services
   kontajner, efemérny) — tento problém sa tam nikdy neprejaví, len pri
   lokálnom/prod behu s perzistentným volume.

--- a/.claude/rules/deploy.md
+++ b/.claude/rules/deploy.md
@@ -274,3 +274,17 @@ paths:
   výstup je priamo porovnateľné číslo. Použité pri issue 99's post-deploy
   overení, že zmena UI odkazu nezmenila žiadny riadok v `order`/`order_line`/
   `product_supplier_override`.
+
+- **Nasadenie si po sebe maže vlastné staršie obrazy (issue 206).** dev2 je
+  ZDIEĽANÝ stroj s inými projektmi a bol na 100 % disku — jedno nasadenie
+  zlyhalo na `failed commit on ref "layer-sha256:…"`, čo je docker tvár
+  chyby "disk plný", nie chyba obrazu. Jeden náš obraz má ~1,4 GB a
+  `docker compose pull` staré tagy nikdy nemaže, takže každé nasadenie
+  dovtedy nechalo po sebe ďalší. Krok `Upratať staršie obrazy TEJTO appky`
+  (`.github/workflows/deploy.yml`) preto maže VÝHRADNE
+  `ghcr.io/<repo>:<tag>` okrem práve nasadeného — nikdy `docker image
+  prune`/`system prune`, ktoré by siahli na obrazy cudzích projektov na tom
+  istom stroji. `|| true` je tam zámerne: obraz môže ešte držať dobiehajúci
+  starý kontajner a nasadenie je v tej chvíli už hotové — neuprataný obraz
+  nesmie zhodiť úspešný deploy. Krok beží PRED overením verzie, aby miesto
+  uvoľnil ešte v tom istom behu.

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -17,6 +17,15 @@ services:
       # (rovnaký dôvod ako v docker-compose.yml pre lokálny vývoj).
       PGDATA: /var/lib/postgresql/data
     volumes:
+      # Rovnaký dôvod ako v `docker-compose.yml` (issue 209): obraz deklaruje
+      # `/var/lib/postgresql` ako VOLUME, `pgdata` nižšie pokrýva len jeho
+      # podpriečinok `data`, takže bez tohto riadku docker pri každom
+      # prestavaní kontajnera zanechá ďalšiu bezmennú priehradku. Zmerané na
+      # dev2: presne jedna taká 4 KB priehradka bola naša, zvyšok patril inému
+      # projektu. Skutočné dáta zostávajú v `pgdata` — `pgparent` je prázdny
+      # obal a jeho pridanie NEPRESÚVA existujúcu databázu (overené lokálne
+      # na odhodenom kontajneri: zápis pred zmenou prežil prestavanie).
+      - pgparent:/var/lib/postgresql
       - pgdata:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U forestshop"]
@@ -132,6 +141,7 @@ services:
     logging: *default-logging
 
 volumes:
+  pgparent:
   pgdata:
   catalog-raw:
   orders-raw:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,12 @@ services:
     ports:
       - "127.0.0.1:5433:5432"
     volumes:
+      # `pgparent` drží NADRADENÝ priečinok, ktorý obraz deklaruje ako VOLUME
+      # (`/var/lib/postgresql`). Bez neho docker pri KAŽDOM prestavaní
+      # kontajnera vyrobí ďalšiu bezmennú priehradku navyše (issue 209) —
+      # `pgdata` nižšie pokrýva len podpriečinok `data`, kam ukazuje PGDATA.
+      # Skutočné dáta zostávajú v `pgdata`; `pgparent` je len prázdny obal.
+      - pgparent:/var/lib/postgresql
       - pgdata:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U forestshop"]
@@ -20,4 +26,5 @@ services:
       retries: 20
 
 volumes:
+  pgparent:
   pgdata:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.120",
+  "version": "0.3.0-dev.121",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Čo to rieši

issue 209. Obraz `postgres:18-alpine` deklaruje `VOLUME /var/lib/postgresql`,
ale oba compose súbory pripájali pomenovanú priehradku až na jeho podpriečinok
`data` (kvôli `PGDATA` pinu z `.claude/rules/database.md`). Docker preto pri
každom prestavaní kontajnera vyrobil navyše bezmennú priehradku pre nadradený
priečinok.

Nájdené pri diagnostike plného disku na dev2 (issue 206): z 245 osirelých
bezmenných priehradiek bola presne jedna 4 KB — naša; zvyšných 244 po ~40 MB
patrilo inému projektu.

## Ako

Pridaná druhá pomenovaná priehradka `pgparent:/var/lib/postgresql` PRED riadok
s `pgdata`. Vnorený mount ide dovnútra, takže skutočné dáta zostávajú v
`pgdata` a **nepresúvajú sa**.

## Overenie

Vyskúšané lokálne na odhodenom kontajneri (nie na produkčnej databáze),
predtým než sa to pustilo do compose súborov:

- kontajner s oboma priehradkami nabehol, `pg_isready` do 6 s
- zápis spravený pred prestavaním sa po prestavaní načítal späť (hodnota 42)
- počet osirelých priehradiek na stroji sa nezmenil (10 pred, 10 po)
- `docker compose config` prechádza pre dev aj prod súbor

Pri najbližšom nasadení compose kontajner `postgres` raz prestaví (krátky
reštart databázy, ako pri každej zmene jeho konfigurácie). Doterajšia bezmenná
priehradka sa tým stane osirelou — má 4 KB.

## Rozsah škody, ktorú to odstraňuje

~4 KB na jedno prestavanie kontajnera. Ide o poriadok, nie o miesto — skutočný
problém plného disku na dev2 rieši issue 206 a čaká na rozhodnutie majiteľa.
