### PR TITLE
Čitateľný súčet kusov + backend scrapera dodávateľského skladu

### DIFF
--- a/apps/api/drizzle/0026_supplier_stock.sql
+++ b/apps/api/drizzle/0026_supplier_stock.sql
@@ -1,0 +1,18 @@
+CREATE TYPE "public"."supplier_availability" AS ENUM('available', 'unavailable', 'unknown');--> statement-breakpoint
+CREATE TYPE "public"."supplier_stock_source" AS ENUM('json_ld', 'meta', 'text', 'none');--> statement-breakpoint
+CREATE TABLE "supplier_stock" (
+	"link" text PRIMARY KEY NOT NULL,
+	"host" text NOT NULL,
+	"availability" "supplier_availability" NOT NULL,
+	"availability_text" text DEFAULT '' NOT NULL,
+	"price" numeric(12, 2),
+	"source" "supplier_stock_source" NOT NULL,
+	"ok" boolean NOT NULL,
+	"error" text,
+	"http_status" integer,
+	"checked_at" timestamp with time zone NOT NULL,
+	"confirmed_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE INDEX "supplier_stock_host_idx" ON "supplier_stock" USING btree ("host");--> statement-breakpoint
+CREATE INDEX "supplier_stock_avail_idx" ON "supplier_stock" USING btree ("availability");

--- a/apps/api/drizzle/meta/0026_snapshot.json
+++ b/apps/api/drizzle/meta/0026_snapshot.json
@@ -1,0 +1,2305 @@
+{
+  "id": "46ed610a-1dcb-4bf8-8848-e945b923881f",
+  "prevId": "f31c248f-c0d9-4e1f-b004-86891fe02261",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "related_codes": {
+          "name": "related_codes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_code": {
+          "name": "external_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_open_status": {
+      "name": "order_open_status",
+      "schema": "",
+      "columns": {
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Vybavuje sa'"
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop_remark": {
+          "name": "shop_remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shoptet_order_id": {
+          "name": "shoptet_order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_updated_at": {
+          "name": "comment_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_synced_at": {
+          "name": "comment_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_carrier_name": {
+          "name": "shipping_carrier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_link_override": {
+      "name": "product_supplier_link_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_link_override_product_key_product_key_fk": {
+          "name": "product_supplier_link_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_link_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_override": {
+      "name": "product_supplier_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_override_product_key_product_key_fk": {
+          "name": "product_supplier_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing": {
+      "name": "pairing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_url": {
+          "name": "supplier_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "pairing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'navrhnute'"
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pairing_state_idx": {
+          "name": "pairing_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_confirmed_by_idx": {
+          "name": "pairing_confirmed_by_idx",
+          "columns": [
+            {
+              "expression": "confirmed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_variant_code_variant_code_fk": {
+          "name": "pairing_variant_code_variant_code_fk",
+          "tableFrom": "pairing",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pairing_confirmed_by_users_id_fk": {
+          "name": "pairing_confirmed_by_users_id_fk",
+          "tableFrom": "pairing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pairing_variant_code_unique": {
+          "name": "pairing_variant_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pairing_confirmation_ck": {
+          "name": "pairing_confirmation_ck",
+          "value": "(\"pairing\".\"state\" = 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)\n        OR (\"pairing\".\"state\" != 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NULL AND \"pairing\".\"confirmed_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier": {
+      "name": "supplier",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wholesale_base_url": {
+          "name": "wholesale_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_key": {
+          "name": "adapter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_settings": {
+      "name": "posta_uncollected_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_state": {
+      "name": "posta_uncollected_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notify_count": {
+          "name": "notify_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_state": {
+          "name": "terminal_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_settings": {
+      "name": "order_reminder_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_state": {
+      "name": "order_reminder_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_state": {
+      "name": "nedostupne_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "nedostupne_email_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nedostupne_state_order_variant_type_uq": {
+          "name": "nedostupne_state_order_variant_type_uq",
+          "columns": [
+            {
+              "expression": "order_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template_history": {
+      "name": "mail_template_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "mail_template_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_template_history_key_idx": {
+          "name": "mail_template_history_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_template_history_changed_by_user_id_users_id_fk": {
+          "name": "mail_template_history_changed_by_user_id_users_id_fk",
+          "tableFrom": "mail_template_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template": {
+      "name": "mail_template",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail_template_updated_by_user_id_users_id_fk": {
+          "name": "mail_template_updated_by_user_id_users_id_fk",
+          "tableFrom": "mail_template",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_log": {
+      "name": "mail_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "mail_log_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_log_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "mail_log_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_log_created_idx": {
+          "name": "mail_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_log_source_created_idx": {
+          "name": "mail_log_source_created_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_log_actor_user_id_users_id_fk": {
+          "name": "mail_log_actor_user_id_users_id_fk",
+          "tableFrom": "mail_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_stock": {
+      "name": "supplier_stock",
+      "schema": "",
+      "columns": {
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "supplier_availability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "supplier_stock_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "supplier_stock_host_idx": {
+          "name": "supplier_stock_host_idx",
+          "columns": [
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "supplier_stock_avail_idx": {
+          "name": "supplier_stock_avail_idx",
+          "columns": [
+            {
+              "expression": "availability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne"
+      ]
+    },
+    "public.pairing_state": {
+      "name": "pairing_state",
+      "schema": "public",
+      "values": [
+        "navrhnute",
+        "potvrdene"
+      ]
+    },
+    "public.nedostupne_email_type": {
+      "name": "nedostupne_email_type",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "alternativa"
+      ]
+    },
+    "public.mail_template_action": {
+      "name": "mail_template_action",
+      "schema": "public",
+      "values": [
+        "save",
+        "reset"
+      ]
+    },
+    "public.mail_log_source": {
+      "name": "mail_log_source",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "posta_uncollected",
+        "order_reminder",
+        "supplier_order"
+      ]
+    },
+    "public.mail_log_status": {
+      "name": "mail_log_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.mail_log_trigger": {
+      "name": "mail_log_trigger",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "manual"
+      ]
+    },
+    "public.supplier_availability": {
+      "name": "supplier_availability",
+      "schema": "public",
+      "values": [
+        "available",
+        "unavailable",
+        "unknown"
+      ]
+    },
+    "public.supplier_stock_source": {
+      "name": "supplier_stock_source",
+      "schema": "public",
+      "values": [
+        "json_ld",
+        "meta",
+        "text",
+        "none"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1785782579784,
       "tag": "0025_funny_sally_floyd",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1785789658908,
+      "tag": "0026_supplier_stock",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema-supplier-stock.ts
+++ b/apps/api/src/db/schema-supplier-stock.ts
@@ -1,0 +1,71 @@
+import {
+  boolean,
+  index,
+  integer,
+  numeric,
+  pgEnum,
+  pgTable,
+  text,
+  timestamp,
+} from "drizzle-orm/pg-core";
+
+// Dostupnosť tovaru U DODÁVATEĽA — zámerne INÝ číselník než `variantState`
+// (`schema-catalog.ts`). Ten popisuje NÁŠ eshop (predajný / vypredaný / už sa
+// nepredáva); tento odpovedá na jedinú otázku „vieme to od dodávateľa
+// objednať?". `unknown` je plnohodnotná hodnota, nie chýbajúci údaj: stránka
+// sa načítala, ale dostupnosť sa z nej NEDALA určiť. Automatizácia
+// (issue 213) prepína VÝHRADNE na `available` — `unknown` nikdy, aby sa
+// nikdy nezapisovalo na základe dohadu.
+export const supplierAvailability = pgEnum("supplier_availability", [
+  "available",
+  "unavailable",
+  "unknown",
+]);
+
+// Čím sa dostupnosť podarilo prečítať — diagnostika pre kartu „Stránky, ktoré
+// neviem prečítať" (majiteľ chce vidieť, pre ktorého dodávateľa sa oplatí
+// dorobiť čítanie). `none` = neprešla ani jedna úroveň.
+export const supplierStockSource = pgEnum("supplier_stock_source", [
+  "json_ld",
+  "meta",
+  "text",
+  "none",
+]);
+
+// Jeden riadok na UNIKÁTNU dodávateľskú linku, nie na variant ani produkt —
+// tá istá linka je na reálnom exporte zdieľaná mnohými variantmi toho istého
+// produktu (nameraná 238 unikátnych liniek na 1 210 riadkov), takže kľúčovať
+// per variant by znamenalo sťahovať tú istú stránku aj 30× za beh.
+export const supplierStock = pgTable(
+  "supplier_stock",
+  {
+    link: text("link").primaryKey(),
+    // Doména bez `www.` — nesie sa uložená (nie počítaná pri čítaní), aby sa
+    // dala indexovať a zoskupovať v prehľade nečitateľných stránok.
+    host: text("host").notNull(),
+    availability: supplierAvailability("availability").notNull(),
+    // Pôvodný text zo stránky, NEZMENENÝ — rovnaká filozofia ako
+    // `variant.availability_text` v katalógu: hodnota sa ukladá tak, ako
+    // prišla, a stav sa z nej len odvodzuje.
+    availabilityText: text("availability_text").notNull().default(""),
+    price: numeric("price", { precision: 12, scale: 2 }),
+    source: supplierStockSource("source").notNull(),
+    // `false` = kontrola sama zlyhala (sieť, časový limit, HTTP chyba).
+    // Odlišné od `availability = 'unknown'`, kde sa stránka NAČÍTALA, len sa
+    // z nej nedalo nič vyčítať — obe sú dôvod NEPREPNÚŤ, ale operátorovi
+    // hovoria niečo úplne iné.
+    ok: boolean("ok").notNull(),
+    error: text("error"),
+    httpStatus: integer("http_status"),
+    // Čas POSLEDNÉHO POKUSU (aj neúspešného) — riadi preskakovanie čerstvých
+    // liniek, aby zlyhávajúca stránka nezacyklila každý beh na tom istom
+    // časovom limite.
+    checkedAt: timestamp("checked_at", { withTimezone: true }).notNull(),
+    // Čas posledného ÚSPEŠNÉHO určenia dostupnosti. Automatizácia (issue 213)
+    // meria čerstvosť potvrdenia PODĽA TOHTO poľa, nikdy podľa `checkedAt` —
+    // inak by opakovane zlyhávajúca kontrola donekonečna predlžovala platnosť
+    // dávno neaktuálneho „skladom".
+    confirmedAt: timestamp("confirmed_at", { withTimezone: true }),
+  },
+  (t) => [index("supplier_stock_host_idx").on(t.host), index("supplier_stock_avail_idx").on(t.availability)],
+);

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -8,3 +8,4 @@ export * from "./schema-order-reminder.js";
 export * from "./schema-nedostupne.js";
 export * from "./schema-mail-templates.js";
 export * from "./schema-mail-log.js";
+export * from "./schema-supplier-stock.js";

--- a/apps/api/src/http/app.ts
+++ b/apps/api/src/http/app.ts
@@ -20,6 +20,8 @@ import { registerNedostupneRoutes, type NedostupneRunDeps } from "./nedostupne-r
 import { requireSameOrigin } from "./origin-check.js";
 import { registerPairingRoutes } from "./pairing-routes.js";
 import { registerPostaUncollectedRoutes, type PostaUncollectedRunDeps } from "./posta-uncollected-routes.js";
+import type { PageFetcher, PageFetchResult } from "../modules/supplier-stock/page-fetcher.js";
+import { registerSupplierStockRoutes } from "./supplier-stock-routes.js";
 import { registerSchedulerRoutes } from "./scheduler-routes.js";
 import { registerSupplierRoutes } from "./supplier-routes.js";
 
@@ -60,6 +62,10 @@ export function createApp(
     // vyššie: voliteľné, bezpečný default nižšie pre testy/lokálny vývoj,
     // `index.ts` v produkcii VŽDY nahradí reálnymi dependencies.
     readonly nedostupne?: NedostupneRunDeps;
+    // issue 212: "Dodávateľský sklad" — sťahovanie stránky dodávateľa.
+    // Voliteľné z rovnakého dôvodu ako `nedostupne` vyššie; testy dodajú
+    // vlastnú implementáciu a NIKDY nechodia na skutočnú stránku dodávateľa.
+    readonly fetchSupplierPage?: PageFetcher;
   },
 ): Hono<AppBindings> {
   const app = new Hono<AppBindings>();
@@ -214,6 +220,21 @@ export function createApp(
   // issue 193: kniha odoslaných e-mailov (len čítanie) — zapisujú do nej samy
   // odosielacie cesty cez `mail-log/service.ts`.
   registerMailLogRoutes(app, db, options.adminBaseUrl ?? "https://www.forestshop.sk");
+  // issue 212: "Dodávateľský sklad" — bez dodanej implementácie sa stránky
+  // NEsťahujú vôbec (bezpečný default pre testy aj lokálny vývoj: hlási
+  // zlyhanie kontroly, nikdy nepredstiera dostupnosť).
+  registerSupplierStockRoutes(
+    app,
+    db,
+    options.fetchSupplierPage ??
+      ((): Promise<PageFetchResult> =>
+        Promise.resolve({
+          ok: false,
+          html: "",
+          httpStatus: null,
+          error: "Sťahovanie stránok dodávateľa nie je nakonfigurované.",
+        })),
+  );
 
   // Musí byť registrovaný AŽ PO všetkých skutočných /api/* trasách vyššie — Hono
   // vyberá presnejšiu zhodu, takže tie majú prednosť a sem sa dostane len to, čo

--- a/apps/api/src/http/supplier-stock-routes.ts
+++ b/apps/api/src/http/supplier-stock-routes.ts
@@ -1,0 +1,122 @@
+import { eq } from "drizzle-orm";
+import type { Hono } from "hono";
+import type { Database } from "../db/client.js";
+import { jobRuns } from "../db/schema.js";
+import { log } from "../logger.js";
+import { record } from "../modules/audit/service.js";
+import { getLatestJobRun } from "../modules/scheduler/queries.js";
+import { SUPPLIER_STOCK_JOB_NAME } from "../modules/supplier-stock/constants.js";
+import type { PageFetcher } from "../modules/supplier-stock/page-fetcher.js";
+import {
+  getSupplierStockOverview,
+  listSupplierStock,
+  listUnreadableHosts,
+} from "../modules/supplier-stock/queries.js";
+import type { SupplierStockRunResult } from "../modules/supplier-stock/run.js";
+import { runSupplierStock } from "../modules/supplier-stock/run.js";
+import { requireRole, requireUser, type AppBindings } from "./middleware.js";
+import { requireSameOrigin } from "./origin-check.js";
+
+function isRunResult(detail: unknown): detail is SupplierStockRunResult {
+  return typeof detail === "object" && detail !== null && "checked" in detail;
+}
+
+/**
+ * Manuálny beh zapisuje `job_run` tým istým tvarom ako scheduler, aby
+ * obrazovka videla ručné spustenie HNEĎ (rovnaký vzor a rovnaký dôvod ako
+ * `posta-uncollected-routes.ts`'s `runAndRecord` — `executeJob` nie je
+ * exportované).
+ */
+async function runAndRecord(
+  db: Database,
+  fetchPage: PageFetcher,
+  now: Date,
+): Promise<SupplierStockRunResult> {
+  const [inserted] = await db
+    .insert(jobRuns)
+    .values({ jobName: SUPPLIER_STOCK_JOB_NAME, startedAt: now, status: "running" })
+    .returning({ id: jobRuns.id });
+  const runId = inserted?.id;
+  try {
+    const result = await runSupplierStock({ db, now, fetchPage });
+    if (runId !== undefined) {
+      await db
+        .update(jobRuns)
+        .set({ status: "success", finishedAt: new Date(), detail: result })
+        .where(eq(jobRuns.id, runId));
+    }
+    return result;
+  } catch (error) {
+    const rawErrorMessage = error instanceof Error ? error.message : String(error);
+    log.error({ rawErrorMessage }, "Dodávateľský sklad: ručný beh zlyhal");
+    if (runId !== undefined) {
+      await db
+        .update(jobRuns)
+        .set({ status: "failure", finishedAt: new Date(), errorMessage: rawErrorMessage })
+        .where(eq(jobRuns.id, runId));
+    }
+    throw error;
+  }
+}
+
+export function registerSupplierStockRoutes(
+  app: Hono<AppBindings>,
+  db: Database,
+  fetchPage: PageFetcher,
+): void {
+  // Čítanie — každý prihlásený zamestnanec. Scraper nemá Štart/Stop prepínač:
+  // nikam nezapisuje (len GET-y na stránky dodávateľov), takže nie je pred
+  // čím chrániť. Prepínač má AŽ automatizácia, ktorá na základe týchto dát
+  // zapisuje do Shoptetu (issue 213).
+  app.get("/api/supplier-stock", requireUser(db), async (c) => {
+    const [overview, rows, unreadable, lastRun] = await Promise.all([
+      getSupplierStockOverview(db),
+      listSupplierStock(db),
+      listUnreadableHosts(db),
+      getLatestJobRun(db, SUPPLIER_STOCK_JOB_NAME),
+    ]);
+    return c.json({
+      overview,
+      rows,
+      unreadable,
+      lastRun:
+        lastRun === null
+          ? null
+          : {
+              startedAt: lastRun.startedAt,
+              finishedAt: lastRun.finishedAt,
+              status: lastRun.status,
+              errorMessage: lastRun.errorMessage,
+              result: isRunResult(lastRun.detail) ? lastRun.detail : null,
+            },
+    });
+  });
+
+  app.post(
+    "/api/supplier-stock/run-now",
+    requireSameOrigin(),
+    requireUser(db),
+    requireRole("admin", "manazer"),
+    async (c) => {
+      const user = c.get("user");
+      const now = new Date();
+      let result: SupplierStockRunResult;
+      try {
+        result = await runAndRecord(db, fetchPage, now);
+      } catch {
+        // Presné znenie chyby je už v logu aj v `job_run` — používateľovi sa
+        // vracia len to, že beh zlyhal (rovnako ako ostatné "Spustiť teraz").
+        return c.json({ ok: false as const, error: "Beh zlyhal." }, 500);
+      }
+      await record(db, {
+        at: now,
+        actorUserId: user.userId,
+        action: "supplier_stock.run_now",
+        entity: "supplier_stock",
+        data: { checked: result.checked, failed: result.failed },
+      });
+      log.info({ actorUserId: user.userId, ...result }, "Dodávateľský sklad: ručný beh");
+      return c.json({ ok: true as const, result });
+    },
+  );
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -22,12 +22,15 @@ import {
   ordersImportJob,
   orderNoteWritebackJob,
   orderReminderJob,
+  supplierStockJob,
   postaUncollectedJob,
   pruneRawExportsJob,
   pruneRawOrdersJob,
   sessionCleanupJob,
   shoptetWritebackJob,
 } from "./modules/scheduler/jobs.js";
+import { fetchSupplierPage } from "./modules/supplier-stock/page-fetcher.js";
+import { runSupplierStock } from "./modules/supplier-stock/run.js";
 import { startScheduler } from "./modules/scheduler/scheduler.js";
 import { orderNoteWritebackConfigFromBaseUrl, shoptetImportConfigFromBaseUrl } from "./modules/shoptet-writeback/config.js";
 import { runOrderNoteWritebackJob } from "./modules/shoptet-writeback/run-order-note-writeback.js";
@@ -191,6 +194,7 @@ const app = createApp(db, {
   postaUncollected: postaUncollectedDeps,
   orderReminder: orderReminderDeps,
   nedostupne: nedostupneDeps,
+  fetchSupplierPage,
 });
 
 // F2 (#12/#3) + F3 (#22/#28): nočný import katalógu/objednávok, mazanie
@@ -210,6 +214,7 @@ const scheduler = startScheduler(db, [
   orderNoteWritebackJob(runOrderNoteWritebackFn),
   postaUncollectedJob((db2, now) => runPostaUncollected({ db: db2, now, ...postaUncollectedDeps })),
   orderReminderJob((db2, now) => runOrderReminder({ db: db2, now, ...orderReminderDeps })),
+  supplierStockJob((db2, now) => runSupplierStock({ db: db2, now, fetchPage: fetchSupplierPage })),
 ]);
 
 // `@hono/node-server`'s `serveStatic` prints its OWN `console.error` on every

--- a/apps/api/src/modules/scheduler/jobs.ts
+++ b/apps/api/src/modules/scheduler/jobs.ts
@@ -10,6 +10,8 @@ import { isOrderReminderEnabled } from "../order-reminder/settings.js";
 import type { OrderReminderRunResult } from "../order-reminder/run.js";
 import type { OrderNoteWritebackRunResult } from "../shoptet-writeback/run-order-note-writeback.js";
 import type { WritebackRunResult } from "../shoptet-writeback/run-writeback.js";
+import { SUPPLIER_STOCK_JOB_NAME } from "../supplier-stock/constants.js";
+import type { SupplierStockRunResult } from "../supplier-stock/run.js";
 import type { ScheduledJob } from "./types.js";
 
 export const CATALOG_IMPORT_JOB_NAME = "catalog-import";
@@ -271,6 +273,28 @@ export function orderReminderJob(run: RunOrderReminder): ScheduledJob {
       }
       const result = await run(db, now);
       return { detail: result };
+    },
+  };
+}
+
+export type RunSupplierStock = (db: Database, now: Date) => Promise<SupplierStockRunResult>;
+
+/**
+ * "Dodávateľský sklad" (issue 212) — denne o 04:20 UTC, teda dostatočne PRED
+ * automatizáciou prepínania (issue 213), aby tá pracovala s čerstvými dátami
+ * z tejto noci, a zároveň mimo `pruneRawExportsJob` (01:15) /
+ * `sessionCleanupJob` (01:30) / `pruneRawOrdersJob` (02:00).
+ *
+ * Žiadny `enabled` prepínač (na rozdiel od `postaUncollectedJob`/
+ * `orderReminderJob`): scraper nikam nezapisuje, len číta stránky
+ * dodávateľov — chrániť treba až zápis do Shoptetu, ktorý robí issue 213.
+ */
+export function supplierStockJob(run: RunSupplierStock): ScheduledJob {
+  return {
+    name: SUPPLIER_STOCK_JOB_NAME,
+    schedule: { kind: "daily", hourUtc: 4, minuteUtc: 20 },
+    async run(db, now) {
+      return { detail: await run(db, now) };
     },
   };
 }

--- a/apps/api/src/modules/supplier-stock/constants.ts
+++ b/apps/api/src/modules/supplier-stock/constants.ts
@@ -1,0 +1,46 @@
+// issue 212: "Dodávateľský sklad" — scraper dostupnosti u dodávateľa.
+// Majiteľ 3. 8. 2026 výslovne ZAMIETOL AI fallback (stará appka posielala
+// nečitateľné stránky do OpenAI): čo sa nedá prečítať strojovo, ostáva
+// `unknown` a ukáže sa v zozname nečitateľných stránok.
+
+export const SUPPLIER_STOCK_JOB_NAME = "supplier-stock";
+
+// Vlastný advisory zámok — job má manuálny trigger ("Spustiť teraz") na TÚ
+// ISTÚ prácu ako nočný beh, presne ako `postaUncollectedJob`
+// (`.claude/rules/scheduler.md`). Session-scoped `pg_advisory_lock` na
+// vyhradenom pripojení, nie xact-scoped: beh robí stovky sekvenčných HTTP
+// volaní a držať kvôli nim otvorenú transakciu by zbytočne blokovalo pool.
+export const SUPPLIER_STOCK_RUN_LOCK_KEY = 787_878_007;
+
+// Linka s ÚSPEŠNOU kontrolou mladšou než toto sa znova nesťahuje. 20 h (nie
+// 24) zámerne: pri dennom behu by presne 24 h občas o pár minút nevyšlo a
+// linka by sa preskočila na celý deň.
+export const MAX_AGE_HOURS = 20;
+
+// Slušnosť k dodávateľom — beh je sériový, toto je minimálna pauza medzi
+// dvoma požiadavkami na TÚ ISTÚ doménu. Reálne dáta: 969 z 1 210 riadkov
+// je jedna doména (`huntingshop.eu`), takže bez tejto pauzy by scraper
+// vyzeral ako útok.
+export const PER_HOST_DELAY_MS = 1_500;
+
+export const REQUEST_TIMEOUT_MS = 15_000;
+
+// Strop na veľkosť stiahnutej stránky — číta sa po častiach a nad týmto sa
+// spojenie prerušie (rovnaká úvaha ako `catalog/fetcher.ts`'s `readBounded`:
+// strop musí platiť POČAS čítania, nie až po zbufferovaní celého tela).
+export const MAX_PAGE_BYTES = 2_000_000;
+
+// Vlastný User-Agent s kontaktom — dodávateľ musí vedieť, kto mu chodí na
+// stránku a komu napísať, keby mu to prekážalo.
+export const USER_AGENT =
+  "ForestshopBot/1.0 (kontrola dostupnosti; +https://forestshop.sk)";
+
+// Domény, kde je čítanie dostupnosti z VOĽNÉHO TEXTU stránky overené na
+// uloženej vzorke. Mimo tohto zoznamu sa voľnému textu NEDÔVERUJE (stránka
+// môže mať slovo „Skladom" v pätičke, v inom produkte alebo v menu) a
+// výsledok je `unknown` — radšej nič než dohad, ktorý by zapol produkt.
+export const TRUSTED_TEXT_HOSTS: readonly string[] = Object.freeze([
+  "huntingshop.eu",
+  "wetland.sk",
+  "trigona.sk",
+]);

--- a/apps/api/src/modules/supplier-stock/page-fetcher.ts
+++ b/apps/api/src/modules/supplier-stock/page-fetcher.ts
@@ -1,0 +1,71 @@
+// Stiahnutie stránky dodávateľa. Jediné miesto v module, ktoré sa dotýka
+// siete — testy dodajú vlastnú implementáciu `PageFetcher` a NIKDY nechodia
+// na skutočnú stránku dodávateľa (rovnaký vzor ako `catalog/fetcher.ts`'s
+// `ExportFetcher` a `posta-uncollected`'s `tracking-client.ts`).
+
+import { MAX_PAGE_BYTES, REQUEST_TIMEOUT_MS, USER_AGENT } from "./constants.js";
+
+export interface PageFetchResult {
+  /** `false` = kontrola sama zlyhala (sieť, časový limit, HTTP chyba). */
+  readonly ok: boolean;
+  readonly html: string;
+  readonly httpStatus: number | null;
+  readonly error: string | null;
+}
+
+export type PageFetcher = (url: string) => Promise<PageFetchResult>;
+
+/**
+ * Číta telo odpovede PO ČASTIACH a nad stropom spojenie preruší. `await
+ * response.text()` by celé telo najprv zbufferoval bez ohľadu na strop —
+ * strop by potom kontroloval až po vyčerpaní pamäte (presne to isté
+ * zistenie ako `catalog/fetcher.ts`'s `readBounded`).
+ */
+async function readBounded(response: Response, maxBytes: number): Promise<string> {
+  const body = response.body;
+  if (body === null) return "";
+  const reader = (body as ReadableStream).getReader() as ReadableStreamDefaultReader<Uint8Array>;
+  const decoder = new TextDecoder("utf-8");
+  let total = 0;
+  let text = "";
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        text += decoder.decode(value, { stream: false });
+        break;
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+  } finally {
+    await reader.cancel().catch(() => undefined);
+  }
+  return text;
+}
+
+/** Skutočné sťahovanie cez `fetch`. Nikdy nevyhodí — chybu vráti v `error`. */
+export const fetchSupplierPage: PageFetcher = async (url: string): Promise<PageFetchResult> => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => {
+    controller.abort();
+  }, REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      redirect: "follow",
+      signal: controller.signal,
+      headers: { "user-agent": USER_AGENT, accept: "text/html,application/xhtml+xml" },
+    });
+    if (!response.ok) {
+      return { ok: false, html: "", httpStatus: response.status, error: `HTTP ${String(response.status)}` };
+    }
+    const html = await readBounded(response, MAX_PAGE_BYTES);
+    return { ok: true, html, httpStatus: response.status, error: null };
+  } catch (cause) {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    return { ok: false, html: "", httpStatus: null, error: message.slice(0, 300) };
+  } finally {
+    clearTimeout(timer);
+  }
+};

--- a/apps/api/src/modules/supplier-stock/parse.test.ts
+++ b/apps/api/src/modules/supplier-stock/parse.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest";
+import {
+  availabilityFromSchemaToken,
+  availabilityFromText,
+  fromJsonLd,
+  fromMetaTags,
+  hostOf,
+  isTrustedTextHost,
+  parsePage,
+  parsePrice,
+  visibleText,
+} from "./parse.js";
+
+describe("hostOf / isTrustedTextHost", () => {
+  it("odreze www a zmensi pismena", () => {
+    expect(hostOf("https://WWW.HuntingShop.eu/produkt/1")).toBe("huntingshop.eu");
+  });
+
+  it("neplatna URL nie je host ani doverovana domena", () => {
+    expect(hostOf("toto nie je url")).toBe("");
+    expect(isTrustedTextHost("toto nie je url")).toBe(false);
+  });
+
+  it("doverovana je aj poddomena, ale nie cudzia domena s rovnakym koncom", () => {
+    expect(isTrustedTextHost("https://shop.huntingshop.eu/a")).toBe(true);
+    expect(isTrustedTextHost("https://nothuntingshop.eu/a")).toBe(false);
+    expect(isTrustedTextHost("https://dogtrace.com/a")).toBe(false);
+  });
+});
+
+describe("availabilityFromSchemaToken", () => {
+  it("InStock a spol. su dostupne", () => {
+    expect(availabilityFromSchemaToken("https://schema.org/InStock")).toBe("available");
+    expect(availabilityFromSchemaToken("LimitedAvailability")).toBe("available");
+  });
+
+  it("OutOfStock a spol. su nedostupne", () => {
+    expect(availabilityFromSchemaToken("http://schema.org/OutOfStock")).toBe("unavailable");
+    expect(availabilityFromSchemaToken("SoldOut")).toBe("unavailable");
+  });
+
+  it("predobjednavka NIE je dostupnost — dodavatel to este nema", () => {
+    expect(availabilityFromSchemaToken("https://schema.org/PreOrder")).toBe("unavailable");
+    expect(availabilityFromSchemaToken("BackOrder")).toBe("unavailable");
+  });
+
+  it("neznamy alebo prazdny token je unknown", () => {
+    expect(availabilityFromSchemaToken("https://schema.org/Nieco")).toBe("unknown");
+    expect(availabilityFromSchemaToken("")).toBe("unknown");
+  });
+});
+
+describe("availabilityFromText", () => {
+  it("vypredane vyhrava nad skladom aj ked je skladom v texte skor", () => {
+    const result = availabilityFromText("Skladom u nas, ale tento kus je Vypredané");
+    expect(result.availability).toBe("unavailable");
+    expect(result.matched).toBe("vypredané");
+  });
+
+  it("rozpozna skladom bez diakritiky aj cesky tvar", () => {
+    expect(availabilityFromText("SKLADEM").availability).toBe("available");
+    expect(availabilityFromText("posledne kusy").availability).toBe("available");
+  });
+
+  it("text bez signalu je unknown", () => {
+    expect(availabilityFromText("Popis produktu, farba zelena").availability).toBe("unknown");
+  });
+});
+
+describe("parsePrice", () => {
+  it("zvlada obe oddelovacie znamienka — desatinne je to posledne", () => {
+    expect(parsePrice("1 299,00 €")).toBe(1299);
+    expect(parsePrice("1.299,00")).toBe(1299);
+    expect(parsePrice("1,299.00")).toBe(1299);
+  });
+
+  it("zvlada cislo, ciarku aj bodku", () => {
+    expect(parsePrice(59.9)).toBe(59.9);
+    expect(parsePrice("59,90")).toBe(59.9);
+    expect(parsePrice("59.90")).toBe(59.9);
+  });
+
+  it("nezmyselny vstup je null, nikdy 0", () => {
+    expect(parsePrice("")).toBeNull();
+    expect(parsePrice("na dotaz")).toBeNull();
+    expect(parsePrice(null)).toBeNull();
+    expect(parsePrice(Number.NaN)).toBeNull();
+  });
+});
+
+describe("visibleText", () => {
+  it("zahodi script a style, nie viditelny text", () => {
+    const html = `<div>Skladom<script>var x = "Vypredané";</script><style>.a{}</style></div>`;
+    expect(visibleText(html)).toBe("Skladom");
+  });
+});
+
+const JSON_LD_PAGE = `<html><head>
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"Product","name":"Bunda",
+ "offers":{"@type":"Offer","price":"129,90","priceCurrency":"EUR",
+ "availability":"https://schema.org/InStock"}}
+</script>
+</head><body>Vypredané</body></html>`;
+
+describe("fromJsonLd", () => {
+  it("precita dostupnost aj cenu z ponuky", () => {
+    const hit = fromJsonLd(JSON_LD_PAGE);
+    expect(hit?.availability).toBe("available");
+    expect(hit?.price).toBe(129.9);
+  });
+
+  it("najde ponuku aj vnorenu v poli @graph", () => {
+    const html = `<script type="application/ld+json">
+      {"@graph":[{"@type":"WebPage"},{"@type":"Product","offers":[
+        {"@type":"Offer","availability":"OutOfStock","price":"10"}]}]}
+    </script>`;
+    expect(fromJsonLd(html)?.availability).toBe("unavailable");
+  });
+
+  it("nevalidny JSON-LD nezhodi citanie, len sa preskoci", () => {
+    const html = `<script type="application/ld+json">{toto nie je JSON</script>`;
+    expect(fromJsonLd(html)).toBeNull();
+  });
+
+  it("ponuka bez pouzitelnej dostupnosti nie je zhoda", () => {
+    const html = `<script type="application/ld+json">
+      {"@type":"Product","offers":{"@type":"Offer","availability":"https://schema.org/Nieco"}}
+    </script>`;
+    expect(fromJsonLd(html)).toBeNull();
+  });
+});
+
+describe("fromMetaTags", () => {
+  it("precita product:availability aj cenu", () => {
+    const html = `<meta property="product:availability" content="instock">
+                  <meta property="product:price:amount" content="49.50">`;
+    const hit = fromMetaTags(html);
+    expect(hit?.availability).toBe("available");
+    expect(hit?.price).toBe(49.5);
+  });
+
+  it("zvlada opacne poradie atributov", () => {
+    const html = `<meta content="outofstock" name="og:availability">`;
+    expect(fromMetaTags(html)?.availability).toBe("unavailable");
+  });
+
+  it("nezrozumitelny token v prvej znacke neukonci citanie — skusi sa dalsia", () => {
+    const html = `<meta property="product:availability" content="skladom-hned">
+                  <meta property="og:availability" content="outofstock">`;
+    expect(fromMetaTags(html)?.availability).toBe("unavailable");
+  });
+
+  it("bez znaciek nic nevrati", () => {
+    expect(fromMetaTags("<html><body>Skladom</body></html>")).toBeNull();
+  });
+});
+
+describe("parsePage — poradie urovni", () => {
+  it("JSON-LD prebija text stranky", () => {
+    const result = parsePage(JSON_LD_PAGE, "https://huntingshop.eu/p/1");
+    expect(result.availability).toBe("available");
+    expect(result.source).toBe("json_ld");
+  });
+
+  it("meta znacky sa pouziju, ked JSON-LD chyba", () => {
+    const html = `<meta property="product:availability" content="outofstock"><body>Skladom</body>`;
+    const result = parsePage(html, "https://huntingshop.eu/p/1");
+    expect(result.availability).toBe("unavailable");
+    expect(result.source).toBe("meta");
+  });
+
+  it("volny text sa pouzije LEN na overenej domene", () => {
+    const html = "<html><body><h1>Bunda</h1><p>Skladom</p></body></html>";
+    expect(parsePage(html, "https://huntingshop.eu/p/1")).toMatchObject({
+      availability: "available",
+      source: "text",
+    });
+    expect(parsePage(html, "https://dogtrace.com/p/1")).toMatchObject({
+      availability: "unknown",
+      source: "none",
+    });
+  });
+
+  it("necitatelna stranka je unknown, nikdy dohad", () => {
+    const result = parsePage("<html><body>Popis produktu</body></html>", "https://huntingshop.eu/p/1");
+    expect(result).toEqual({ availability: "unknown", availabilityText: "", price: null, source: "none" });
+  });
+});

--- a/apps/api/src/modules/supplier-stock/parse.ts
+++ b/apps/api/src/modules/supplier-stock/parse.ts
@@ -1,0 +1,274 @@
+// Čítanie dostupnosti a ceny z HTML stránky dodávateľa — ČISTÉ funkcie, žiadna
+// sieť, žiadna databáza. Testuje sa nad uloženými vzorkami stránok.
+//
+// Tri úrovne v poradí od najspoľahlivejšej:
+//   1. JSON-LD `Product` (`schema.org`) — strojový údaj, ktorý dávajú Shoptet,
+//      WooCommerce aj PrestaShop; jediný, ktorý hovorí o TOMTO produkte, nie o
+//      náhodnom texte na stránke.
+//   2. `og:` / `product:` meta značky — ten istý údaj, keď JSON-LD chýba.
+//   3. Voľný text stránky — LEN pre domény v `TRUSTED_TEXT_HOSTS`, kde je to
+//      overené na vzorke. Inde je dohad horší než „neviem".
+//
+// Čokoľvek, čo neprejde ani jednou úrovňou, je `unknown` — a `unknown` nikdy
+// neprepne produkt (issue 213).
+
+import { TRUSTED_TEXT_HOSTS } from "./constants.js";
+
+export type SupplierAvailability = "available" | "unavailable" | "unknown";
+export type SupplierStockSource = "json_ld" | "meta" | "text" | "none";
+
+export interface ParsedPage {
+  readonly availability: SupplierAvailability;
+  readonly availabilityText: string;
+  readonly price: number | null;
+  readonly source: SupplierStockSource;
+}
+
+/** Doména bez `www.`, malými písmenami. Neplatná URL → prázdny reťazec. */
+export function hostOf(url: string): string {
+  let host = "";
+  try {
+    host = new URL(url).hostname.toLowerCase();
+  } catch {
+    return "";
+  }
+  return host.startsWith("www.") ? host.slice(4) : host;
+}
+
+/** `true`, keď je doména (alebo jej poddoména) medzi overenými pre voľný text. */
+export function isTrustedTextHost(url: string): boolean {
+  const host = hostOf(url);
+  if (host === "") return false;
+  return TRUSTED_TEXT_HOSTS.some((trusted) => host === trusted || host.endsWith(`.${trusted}`));
+}
+
+// `schema.org` tokeny. Zámerne sa NEBERIE `PreOrder`/`BackOrder` ako
+// dostupné: znamenajú "objednáme, príde neskôr", čo pri prepínaní nášho
+// produktu na "Skladom" nie je pravda — zákazník by dostal sľub, ktorý
+// dodávateľ nedrží.
+const SCHEMA_AVAILABLE = new Set(["instock", "limitedavailability", "onlineonly", "instoreonly"]);
+const SCHEMA_UNAVAILABLE = new Set([
+  "outofstock",
+  "soldout",
+  "discontinued",
+  "preorder",
+  "backorder",
+]);
+
+/** `schema.org`/`og` token dostupnosti → náš stav. Neznámy token → `unknown`. */
+export function availabilityFromSchemaToken(token: string): SupplierAvailability {
+  const last = token.split("/").pop() ?? "";
+  const normalized = last.toLowerCase().replace(/[^a-z]/g, "");
+  if (normalized === "") return "unknown";
+  if (SCHEMA_AVAILABLE.has(normalized)) return "available";
+  if (SCHEMA_UNAVAILABLE.has(normalized)) return "unavailable";
+  return "unknown";
+}
+
+// Vypredané sa kontroluje PRVÉ — stránka, ktorá povie "Vypredané", je
+// rozhodná aj keď sa inde na nej vyskytne slovo "skladom" (napr. v odporúčaných
+// produktoch). Slovenské, české aj anglické tvary, s diakritikou aj bez nej.
+const OUT_KEYWORDS: readonly string[] = Object.freeze([
+  "vypredané",
+  "vypredane",
+  "vypredaný",
+  "vypredany",
+  "vyprodáno",
+  "vyprodano",
+  "nedostupné",
+  "nedostupne",
+  "nedostupný",
+  "nedostupny",
+  "nie je skladom",
+  "není skladem",
+  "neni skladem",
+  "momentálne nedostupné",
+  "momentalne nedostupne",
+  "dočasne nedostupné",
+  "docasne nedostupne",
+  "predaj skončil",
+  "predaj skoncil",
+  "out of stock",
+  "sold out",
+]);
+
+const IN_KEYWORDS: readonly string[] = Object.freeze([
+  "skladom",
+  "na sklade",
+  "skladem",
+  "ihneď k odberu",
+  "ihned k odberu",
+  "posledné kusy",
+  "posledne kusy",
+  "posledný kus",
+  "posledny kus",
+  "in stock",
+]);
+
+/**
+ * Dostupnosť z voľného textu. Vypredané vyhráva nad skladom (rozhodný zápor).
+ * Vracia aj to, KTORÉ slovo rozhodlo — ide do `availabilityText`, aby bolo
+ * v appke vidieť, na základe čoho sa rozhodlo.
+ */
+export function availabilityFromText(text: string): {
+  readonly availability: SupplierAvailability;
+  readonly matched: string;
+} {
+  const lower = text.toLowerCase();
+  const out = OUT_KEYWORDS.find((keyword) => lower.includes(keyword));
+  if (out !== undefined) return { availability: "unavailable", matched: out };
+  const inStock = IN_KEYWORDS.find((keyword) => lower.includes(keyword));
+  if (inStock !== undefined) return { availability: "available", matched: inStock };
+  return { availability: "unknown", matched: "" };
+}
+
+/**
+ * Cena z voľného tvaru: „59,90", „59.90", „1 299,00 €", číslo. Keď sú
+ * prítomné obe oddeľovacie znamienka, desatinné je to POSLEDNÉ („1.299,00").
+ */
+export function parsePrice(raw: unknown): number | null {
+  if (typeof raw === "number") return Number.isFinite(raw) ? raw : null;
+  if (typeof raw !== "string") return null;
+  let text = raw.replace(/[^0-9,.-]/g, "");
+  if (text === "") return null;
+  const lastComma = text.lastIndexOf(",");
+  const lastDot = text.lastIndexOf(".");
+  if (lastComma >= 0 && lastDot >= 0) {
+    text = lastComma > lastDot ? text.replace(/\./g, "").replace(",", ".") : text.replace(/,/g, "");
+  } else if (lastComma >= 0) {
+    text = text.replace(",", ".");
+  }
+  const value = Number.parseFloat(text);
+  return Number.isFinite(value) ? value : null;
+}
+
+/** Odstráni `<script>`/`<style>` a značky — zvyšok je viditeľný text stránky. */
+export function visibleText(html: string): string {
+  return html
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+interface SchemaHit {
+  readonly availability: SupplierAvailability;
+  readonly token: string;
+  readonly price: number | null;
+}
+
+function collectOffers(node: unknown, into: Record<string, unknown>[]): void {
+  if (Array.isArray(node)) {
+    for (const item of node) collectOffers(item, into);
+    return;
+  }
+  if (node === null || typeof node !== "object") return;
+  const record = node as Record<string, unknown>;
+  const type = record["@type"];
+  const isOffer =
+    (typeof type === "string" && type.toLowerCase().includes("offer")) ||
+    (Array.isArray(type) && type.some((t) => typeof t === "string" && t.toLowerCase().includes("offer")));
+  if (isOffer) into.push(record);
+  for (const value of Object.values(record)) collectOffers(value, into);
+}
+
+/** Dostupnosť + cena z JSON-LD `Product`/`Offer`. Prvá ponuka s údajom vyhráva. */
+export function fromJsonLd(html: string): SchemaHit | null {
+  const blocks = [...html.matchAll(/<script\b[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi)];
+  const offers: Record<string, unknown>[] = [];
+  for (const block of blocks) {
+    const body = block[1];
+    if (body === undefined) continue;
+    try {
+      collectOffers(JSON.parse(body), offers);
+    } catch {
+      // Nevalidný JSON-LD je bežný — jednoducho sa preskočí, nikdy nezhodí beh.
+    }
+  }
+  for (const offer of offers) {
+    const raw = offer["availability"];
+    if (typeof raw !== "string") continue;
+    const availability = availabilityFromSchemaToken(raw);
+    if (availability === "unknown") continue;
+    return { availability, token: raw, price: parsePrice(offer["price"]) };
+  }
+  return null;
+}
+
+function metaContent(html: string, property: string): string | null {
+  const escaped = property.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(
+    `<meta\\b[^>]*(?:property|name)=["']${escaped}["'][^>]*content=["']([^"']*)["']`,
+    "i",
+  );
+  const direct = pattern.exec(html);
+  if (direct?.[1] !== undefined) return direct[1];
+  // Poradie atribútov nie je v HTML pevné — `content` môže stáť pred `property`.
+  const reversed = new RegExp(
+    `<meta\\b[^>]*content=["']([^"']*)["'][^>]*(?:property|name)=["']${escaped}["']`,
+    "i",
+  );
+  const flipped = reversed.exec(html);
+  return flipped?.[1] ?? null;
+}
+
+/** Dostupnosť + cena z `og:`/`product:` meta značiek. */
+export function fromMetaTags(html: string): SchemaHit | null {
+  // Každý kandidát sa skúsi zvlášť: keď prvá značka nesie token, ktorému
+  // nerozumieme, ďalšia ho ešte môže niesť zrozumiteľne — vzdať sa hneď pri
+  // prvej by zahodilo použiteľný údaj o pár znakov ďalej.
+  for (const property of ["product:availability", "og:availability", "availability"]) {
+    const token = metaContent(html, property);
+    if (token === null) continue;
+    const availability = availabilityFromSchemaToken(token);
+    if (availability === "unknown") continue;
+    const price =
+      parsePrice(metaContent(html, "product:price:amount")) ??
+      parsePrice(metaContent(html, "og:price:amount"));
+    return { availability, token, price };
+  }
+  return null;
+}
+
+/**
+ * Celé čítanie stránky — tri úrovne v poradí. `url` rozhoduje LEN o tom, či sa
+ * smie použiť tretia (voľný text): mimo overených domén sa radšej vráti
+ * `unknown` než dohad.
+ */
+export function parsePage(html: string, url: string): ParsedPage {
+  const jsonLd = fromJsonLd(html);
+  if (jsonLd !== null) {
+    return {
+      availability: jsonLd.availability,
+      availabilityText: jsonLd.token,
+      price: jsonLd.price,
+      source: "json_ld",
+    };
+  }
+
+  const meta = fromMetaTags(html);
+  if (meta !== null) {
+    return {
+      availability: meta.availability,
+      availabilityText: meta.token,
+      price: meta.price,
+      source: "meta",
+    };
+  }
+
+  if (isTrustedTextHost(url)) {
+    const text = availabilityFromText(visibleText(html));
+    if (text.availability !== "unknown") {
+      return {
+        availability: text.availability,
+        availabilityText: text.matched,
+        price: null,
+        source: "text",
+      };
+    }
+  }
+
+  return { availability: "unknown", availabilityText: "", price: null, source: "none" };
+}

--- a/apps/api/src/modules/supplier-stock/queries.ts
+++ b/apps/api/src/modules/supplier-stock/queries.ts
@@ -1,0 +1,120 @@
+// Čítanie pre obrazovku "Dodávateľský sklad" (issue 212). Vždy ŽIVÝ dopyt nad
+// `supplier_stock`, nikdy `job_run.detail` cache — tabuľka je tu práve preto,
+// aby stav dostupnosti prežil aj medzi behmi (na rozdiel od `nedostupne`,
+// ktoré žiadny stav medzi behmi nedrží).
+
+import { asc, desc, eq, or, sql } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { supplierStock } from "../../db/schema.js";
+
+export interface SupplierStockOverview {
+  readonly total: number;
+  readonly available: number;
+  readonly unavailable: number;
+  readonly unknown: number;
+  readonly failed: number;
+  readonly lastCheckedAt: Date | null;
+}
+
+export interface SupplierStockRow {
+  readonly link: string;
+  readonly host: string;
+  readonly availability: "available" | "unavailable" | "unknown";
+  readonly availabilityText: string;
+  readonly price: string | null;
+  readonly source: "json_ld" | "meta" | "text" | "none";
+  readonly ok: boolean;
+  readonly error: string | null;
+  readonly httpStatus: number | null;
+  readonly checkedAt: Date;
+  readonly confirmedAt: Date | null;
+}
+
+/** Jeden riadok na doménu, ktorú sa nedarí čítať — karta pre majiteľa. */
+export interface UnreadableHost {
+  readonly host: string;
+  readonly count: number;
+  /** Ukážkové linky (max 5), aby sa dalo hneď kliknúť a pozrieť sa. */
+  readonly samples: readonly string[];
+}
+
+export async function getSupplierStockOverview(db: Database): Promise<SupplierStockOverview> {
+  const [row] = await db
+    .select({
+      total: sql<number>`count(*)::int`,
+      available: sql<number>`count(*) filter (where ${supplierStock.ok} and ${supplierStock.availability} = 'available')::int`,
+      unavailable: sql<number>`count(*) filter (where ${supplierStock.ok} and ${supplierStock.availability} = 'unavailable')::int`,
+      unknown: sql<number>`count(*) filter (where ${supplierStock.ok} and ${supplierStock.availability} = 'unknown')::int`,
+      failed: sql<number>`count(*) filter (where not ${supplierStock.ok})::int`,
+      lastCheckedAt: sql<Date | null>`max(${supplierStock.checkedAt})`,
+    })
+    .from(supplierStock);
+  return (
+    row ?? { total: 0, available: 0, unavailable: 0, unknown: 0, failed: 0, lastCheckedAt: null }
+  );
+}
+
+export async function listSupplierStock(db: Database, limit = 500): Promise<readonly SupplierStockRow[]> {
+  return db
+    .select({
+      link: supplierStock.link,
+      host: supplierStock.host,
+      availability: supplierStock.availability,
+      availabilityText: supplierStock.availabilityText,
+      price: supplierStock.price,
+      source: supplierStock.source,
+      ok: supplierStock.ok,
+      error: supplierStock.error,
+      httpStatus: supplierStock.httpStatus,
+      checkedAt: supplierStock.checkedAt,
+      confirmedAt: supplierStock.confirmedAt,
+    })
+    .from(supplierStock)
+    .orderBy(asc(supplierStock.host), asc(supplierStock.link))
+    .limit(limit);
+}
+
+/**
+ * Domény, kde sa dostupnosť NEDÁ prečítať — buď stránka odpovedala, ale nič
+ * sa z nej nedalo vyčítať (`unknown`), alebo kontrola sama zlyhala (`ok =
+ * false`). Presne to, čo majiteľ chcel vidieť namiesto AI: zoznam, podľa
+ * ktorého sa dá rozhodnúť, pre koho sa oplatí dorobiť čítanie ručne.
+ */
+export async function listUnreadableHosts(db: Database): Promise<readonly UnreadableHost[]> {
+  const rows = await db
+    .select({ host: supplierStock.host, link: supplierStock.link })
+    .from(supplierStock)
+    .where(or(eq(supplierStock.ok, false), eq(supplierStock.availability, "unknown")))
+    .orderBy(asc(supplierStock.host), asc(supplierStock.link));
+
+  const byHost = new Map<string, string[]>();
+  for (const row of rows) {
+    const links = byHost.get(row.host) ?? [];
+    links.push(row.link);
+    byHost.set(row.host, links);
+  }
+  return [...byHost.entries()]
+    .map(([host, links]) => ({ host, count: links.length, samples: links.slice(0, 5) }))
+    .sort((a, b) => b.count - a.count || a.host.localeCompare(b.host));
+}
+
+/** Najnovšie kontroly — malý zoznam pre hlavičku obrazovky. */
+export async function listRecentChecks(db: Database, limit = 10): Promise<readonly SupplierStockRow[]> {
+  return db
+    .select({
+      link: supplierStock.link,
+      host: supplierStock.host,
+      availability: supplierStock.availability,
+      availabilityText: supplierStock.availabilityText,
+      price: supplierStock.price,
+      source: supplierStock.source,
+      ok: supplierStock.ok,
+      error: supplierStock.error,
+      httpStatus: supplierStock.httpStatus,
+      checkedAt: supplierStock.checkedAt,
+      confirmedAt: supplierStock.confirmedAt,
+    })
+    .from(supplierStock)
+    .orderBy(desc(supplierStock.checkedAt))
+    .limit(limit);
+}

--- a/apps/api/src/modules/supplier-stock/run.ts
+++ b/apps/api/src/modules/supplier-stock/run.ts
@@ -1,0 +1,200 @@
+// Beh scrapera dostupnosti u dodávateľa (issue 212).
+//
+// Sériový, zámerne: 969 z 1 210 riadkov reálneho exportu je JEDNA doména
+// (`huntingshop.eu`), takže paralelné sťahovanie by na ňu vyzeralo ako útok.
+// Medzi dvomi požiadavkami na tú istú doménu je pauza (`PER_HOST_DELAY_MS`).
+
+import { isNotNull } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { products, supplierStock } from "../../db/schema.js";
+import { extractSupplierLink } from "../catalog/supplier-link.js";
+import { MAX_AGE_HOURS, PER_HOST_DELAY_MS, SUPPLIER_STOCK_RUN_LOCK_KEY } from "./constants.js";
+import type { PageFetcher } from "./page-fetcher.js";
+import { hostOf, parsePage } from "./parse.js";
+
+export interface SupplierStockRunResult {
+  /** Koľko unikátnych liniek katalóg vôbec obsahuje. */
+  readonly total: number;
+  /** Preskočené, lebo majú čerstvú úspešnú kontrolu. */
+  readonly skipped: number;
+  readonly checked: number;
+  readonly available: number;
+  readonly unavailable: number;
+  readonly unknown: number;
+  /** Kontrola sama zlyhala (sieť, časový limit, HTTP chyba). */
+  readonly failed: number;
+  readonly hosts: readonly string[];
+}
+
+export interface RunSupplierStockOptions {
+  readonly db: Database;
+  readonly now: Date;
+  readonly fetchPage: PageFetcher;
+  /** Iba pre testy — bez neho beh reálne čaká medzi doménami. */
+  readonly sleep?: (ms: number) => Promise<void>;
+  /** Iba pre testy/ručný beh — obmedzí počet skutočne kontrolovaných liniek. */
+  readonly limit?: number;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+/** Unikátne dodávateľské linky z katalógu, v stabilnom poradí. */
+export async function collectSupplierLinks(db: Database): Promise<readonly string[]> {
+  const rows = await db
+    .select({ internalNote: products.internalNote })
+    .from(products)
+    .where(isNotNull(products.internalNote));
+  const links = new Set<string>();
+  for (const row of rows) {
+    const url = extractSupplierLink(row.internalNote).url;
+    if (url !== null && hostOf(url) !== "") links.add(url);
+  }
+  return [...links].sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * `true`, keď má linka ÚSPEŠNÚ kontrolu mladšiu než `MAX_AGE_HOURS`.
+ * Zlyhaná kontrola sa zámerne NEPOČÍTA — inak by stránka, ktorá stabilne
+ * padá na časovom limite, ostala „čerstvá" a nikdy by sa neskúsila znova.
+ */
+export function isFresh(
+  previous: { readonly ok: boolean; readonly confirmedAt: Date | null } | undefined,
+  now: Date,
+  maxAgeHours = MAX_AGE_HOURS,
+): boolean {
+  if (previous === undefined || !previous.ok || previous.confirmedAt === null) return false;
+  const ageMs = now.getTime() - previous.confirmedAt.getTime();
+  return ageMs >= 0 && ageMs <= maxAgeHours * 3_600_000;
+}
+
+export async function runSupplierStock(options: RunSupplierStockOptions): Promise<SupplierStockRunResult> {
+  const { db } = options;
+  const lockClient = await db.$client.connect();
+  try {
+    await lockClient.query("select pg_advisory_lock($1)", [SUPPLIER_STOCK_RUN_LOCK_KEY]);
+    return await runSupplierStockLocked(options);
+  } finally {
+    await lockClient.query("select pg_advisory_unlock($1)", [SUPPLIER_STOCK_RUN_LOCK_KEY]);
+    lockClient.release();
+  }
+}
+
+async function runSupplierStockLocked(options: RunSupplierStockOptions): Promise<SupplierStockRunResult> {
+  const { db, now, fetchPage } = options;
+  const sleep = options.sleep ?? defaultSleep;
+
+  const links = await collectSupplierLinks(db);
+  const existing = await db
+    .select({ link: supplierStock.link, ok: supplierStock.ok, confirmedAt: supplierStock.confirmedAt })
+    .from(supplierStock);
+  const previousByLink = new Map(existing.map((row) => [row.link, row]));
+
+  const counts = { available: 0, unavailable: 0, unknown: 0, failed: 0 };
+  const hosts = new Set<string>();
+  const lastFetchByHost = new Map<string, number>();
+  let skipped = 0;
+  let checked = 0;
+
+  for (const link of links) {
+    const host = hostOf(link);
+    hosts.add(host);
+    if (isFresh(previousByLink.get(link), now)) {
+      skipped += 1;
+      continue;
+    }
+    if (options.limit !== undefined && checked >= options.limit) {
+      skipped += 1;
+      continue;
+    }
+
+    // Slušnosť: pauza sa počíta od POSLEDNEJ požiadavky na TÚ ISTÚ doménu,
+    // nie paušálne medzi všetkými — striedanie domén tak nie je trestané.
+    const last = lastFetchByHost.get(host);
+    if (last !== undefined) {
+      const waitMs = PER_HOST_DELAY_MS - (Date.now() - last);
+      if (waitMs > 0) await sleep(waitMs);
+    }
+    const fetched = await fetchPage(link);
+    lastFetchByHost.set(host, Date.now());
+    checked += 1;
+
+    if (!fetched.ok) {
+      counts.failed += 1;
+      await upsert(db, {
+        link,
+        host,
+        availability: "unknown",
+        availabilityText: "",
+        price: null,
+        source: "none",
+        ok: false,
+        error: fetched.error,
+        httpStatus: fetched.httpStatus,
+        checkedAt: now,
+        // Zlyhaná kontrola NIKDY neposúva `confirmedAt` — staré potvrdenie
+        // musí zostarnúť a automatizácia ho prestane brať (issue 213).
+        confirmedAt: null,
+      });
+      continue;
+    }
+
+    const parsed = parsePage(fetched.html, link);
+    counts[parsed.availability] += 1;
+    await upsert(db, {
+      link,
+      host,
+      availability: parsed.availability,
+      availabilityText: parsed.availabilityText,
+      price: parsed.price === null ? null : parsed.price.toFixed(2),
+      source: parsed.source,
+      ok: true,
+      error: null,
+      httpStatus: fetched.httpStatus,
+      checkedAt: now,
+      // Iba SKUTOČNE určená dostupnosť je potvrdenie. `unknown` znamená
+      // „stránka sa načítala, ale nič sme sa nedozvedeli" — to nesmie
+      // predlžovať platnosť predošlého „skladom".
+      confirmedAt: parsed.availability === "unknown" ? null : now,
+    });
+  }
+
+  return {
+    total: links.length,
+    skipped,
+    checked,
+    available: counts.available,
+    unavailable: counts.unavailable,
+    unknown: counts.unknown,
+    failed: counts.failed,
+    hosts: [...hosts].sort((a, b) => a.localeCompare(b)),
+  };
+}
+
+type SupplierStockRow = typeof supplierStock.$inferInsert;
+
+async function upsert(db: Database, row: SupplierStockRow): Promise<void> {
+  await db
+    .insert(supplierStock)
+    .values(row)
+    .onConflictDoUpdate({
+      target: supplierStock.link,
+      set: {
+        host: row.host,
+        availability: row.availability,
+        availabilityText: row.availabilityText,
+        price: row.price,
+        source: row.source,
+        ok: row.ok,
+        error: row.error,
+        httpStatus: row.httpStatus,
+        checkedAt: row.checkedAt,
+        // `confirmedAt` sa pri zlyhaní/`unknown` NEPREPÍŠE na `null` —
+        // predošlé potvrdenie si má dožiť svoju 48-hodinovú platnosť
+        // (issue 213), nie zmiznúť pri prvom výpadku siete.
+        ...(row.confirmedAt === null ? {} : { confirmedAt: row.confirmedAt }),
+      },
+    });
+}

--- a/apps/web/src/ordersSummary.test.ts
+++ b/apps/web/src/ordersSummary.test.ts
@@ -150,9 +150,25 @@ it("formatVariantTotalChip s ≥2 riadkami vráti text so ZOSTÁVAJÚCIM množst
   if (vt === undefined) throw new Error("4859/46 musí byť v mape");
   const chip = formatVariantTotalChip(vt);
   expect(chip).toEqual({
-    text: "Σ 3 ks",
+    // issue 214: bez jednotky — tá je už na riadku nad pilulkou ("3 ks").
+    text: "Σ 3",
     title: "Spolu vo všetkých objednávkach: 5 ks · nevybavené: 3 ks",
   });
+});
+
+// issue 214: pilulka sa musí zmestiť do najužšej reálnej šírky stĺpca s
+// množstvom (nameraných 33 px voľného miesta pri 1280 px okna), inak ju
+// `text-overflow: ellipsis` oreže na "Σ…" a majiteľ z nej nič neprečíta.
+// Trojciferný súčet je najhorší reálny prípad, aký katalóg dnes vie vyrobiť.
+it("formatVariantTotalChip drží text krátky aj pri trojcifernom súčte", () => {
+  const totals = computeVariantTotals([
+    variantLine("4859/46", 500, "objednane", false),
+    variantLine("4859/46", 128, "nevybavene", false),
+  ]);
+  const vt = totals.get("4859/46");
+  if (vt === undefined) throw new Error("4859/46 musí byť v mape");
+  const chip = formatVariantTotalChip(vt);
+  expect(chip?.text.length).toBeLessThanOrEqual(6);
 });
 
 // issue 65 — vek nevybaveného riadku + hranica upozornenia (⚠️).

--- a/apps/web/src/ordersSummary.test.ts
+++ b/apps/web/src/ordersSummary.test.ts
@@ -163,7 +163,7 @@ it("formatVariantTotalChip s ≥2 riadkami vráti text so ZOSTÁVAJÚCIM množst
 it("formatVariantTotalChip drží text krátky aj pri trojcifernom súčte", () => {
   const totals = computeVariantTotals([
     variantLine("4859/46", 500, "objednane", false),
-    variantLine("4859/46", 128, "nevybavene", false),
+    variantLine("4859/46", 128, "caka_sa", false),
   ]);
   const vt = totals.get("4859/46");
   if (vt === undefined) throw new Error("4859/46 musí byť v mape");

--- a/apps/web/src/ordersSummary.ts
+++ b/apps/web/src/ordersSummary.ts
@@ -118,9 +118,14 @@ export function formatVariantTotalChip(vt: VariantTotal): { readonly text: strin
   return {
     // issue 204: text skrátený zo "Σ spolu N ks" na "Σ N ks" — dlhší tvar sa
     // do 54px stĺpca s množstvom nezmestil ani po zalomení pod množstvo
-    // (nameraných 82px obsahu), takže pretekal do susedného stĺpca. Celé
-    // vysvetlenie nesie `title` nižšie, ktorý sa nemení.
-    text: `Σ ${String(vt.remaining)} ks`,
+    // (nameraných 82px obsahu), takže pretekal do susedného stĺpca.
+    // issue 214: ani "Σ N ks" sa nezmestilo — na produkcii nameraných 49 px
+    // obsahu proti 16 px zobrazeným, takže `text-overflow: ellipsis` pilulku
+    // orezal na "Σ…" na KAŽDEJ šírke okna a majiteľ z nej nič neprečítal.
+    // Jednotka odpadá: riadok priamo NAD pilulkou už hovorí "N ks", takže
+    // "Σ 3" sa číta ako "spolu 3". Celé vysvetlenie nesie `title` nižšie,
+    // ktorý sa nemení.
+    text: `Σ ${String(vt.remaining)}`,
     title: `Spolu vo všetkých objednávkach: ${String(vt.total)} ks · nevybavené: ${String(vt.remaining)} ks`,
   };
 }

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -957,6 +957,11 @@ tr:last-child td {
   font-weight: var(--fs-weight-semibold);
   color: var(--fs-ink);
   text-align: right;
+  /* issue 214: najužší stĺpec tabuľky (4 %, pri 1280 px okna 41 px) — bežné
+     odsadenie buniek mu zobralo 26 px, teda takmer dve tretiny šírky, a na
+     obsah nezostalo. Zúžené LEN tu; ostatné bunky si držia pôvodné. */
+  padding-left: var(--fs-space-1);
+  padding-right: var(--fs-space-1);
 }
 /* issue 62: súčet kusov toho istého produktu naprieč objednávkami dodávateľa
    — neklikateľná pilulka, zámerne odlišná od interaktívneho `.chip`
@@ -973,15 +978,23 @@ tr:last-child td {
   min-width: 0;
 }
 .qty-total-chip {
-  display: inline-flex;
-  align-items: center;
+  /* issue 214: `inline-flex` robilo z textu pilulky flex položku, ktorá sa
+     zmrštila na NULOVÚ šírku obsahu (nameraných 16 px = presne samotné
+     odsadenie, pri 49 px obsahu) — `inline-block` + `width: max-content`
+     drží pilulku širokú presne na jej text. */
+  display: inline-block;
+  width: max-content;
   /* issue 204: pilulka je vlastný riadok stacku, vodorovný odstup od
      množstva už nedáva zmysel; `max-width` + orezanie garantujú, že sa už
-     NIKDY nedostane mimo svoju bunku, ani pri trojcifernom počte kusov. */
+     NIKDY nedostane mimo svoju bunku, ani pri trojcifernom počte kusov.
+     Orezanie zostáva ako POISTKA pre budúci dlhší obsah — dnes sa doň text
+     nedostane (issue 214, overené naživo na všetkých štyroch šírkach). */
   max-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
-  padding: 0 var(--fs-space-2);
+  /* issue 214: v 41 px bunke (1280 px okno) zaberalo pôvodné odsadenie 16 px
+     zo šírky, ktorú potrebuje samotný text. */
+  padding: 0 var(--fs-space-1);
   font-size: var(--fs-text-xs);
   font-weight: var(--fs-weight-medium);
   color: var(--fs-brand);

--- a/apps/web/tests/e2e/orders-layout.spec.ts
+++ b/apps/web/tests/e2e/orders-layout.spec.ts
@@ -191,6 +191,22 @@ test("STAV je celý čitateľný a POZNÁMKY pole je dosť široké na všetkýc
       expect(scrollOverflow, `bunka s množstvom posúva obsah pri ${String(width)}px`).toBe(false);
     }
 
+    // issue 214: pilulka sa síce do bunky ZMESTÍ (kontrola vyššie), ale
+    // predtým sa jej vykreslilo len 16 px zo 49 px obsahu — `text-overflow:
+    // ellipsis` ju orezal na "Σ…" a majiteľ z nej neprečítal nič ("teraz
+    // vobec nie je citatelne to spolu produkty"). Kontrola vyššie to
+    // nezachytí, lebo orezaný prvok svoju bunku nikdy nepretečie — treba
+    // merať vlastné orezanie pilulky, na KAŽDEJ zo 4 šírok.
+    const orezaneSucty = await page.evaluate(() => {
+      return [...document.querySelectorAll<HTMLElement>("[data-testid^='qty-total-']")].map((pilulka) => ({
+        text: pilulka.textContent.trim(),
+        orezane: pilulka.scrollWidth > pilulka.clientWidth + 1,
+      }));
+    });
+    for (const { text, orezane } of orezaneSucty) {
+      expect(orezane, `pilulka súčtu "${text}" je orezaná pri ${String(width)}px`).toBe(false);
+    }
+
     // issue 111 bod 5: pri 1280px sa žiadna `.orders-table-wrap` skupina
     // nesmie posúvať vodorovne (predtým 💾 tlačidlo bolo za viditeľným
     // okrajom, kým manažér nescrolloval).

--- a/apps/web/tests/e2e/orders.spec.ts
+++ b/apps/web/tests/e2e/orders.spec.ts
@@ -197,9 +197,9 @@ test("súčet kusov toho istého produktu naprieč objednávkami dodávateľa sa
 
   // Pred akoukoľvek zmenou: obe objednávky nevybavené → chip na OBOCH
   // riadkoch ukazuje celé dopytované množstvo (3 + 2 = 5) ako zostávajúce.
-  await expect(chipPrva).toHaveText("Σ 5 ks");
+  await expect(chipPrva).toHaveText("Σ 5");
   await expect(chipPrva).toHaveAttribute("title", "Spolu vo všetkých objednávkach: 5 ks · nevybavené: 5 ks");
-  await expect(chipDruha).toHaveText("Σ 5 ks");
+  await expect(chipDruha).toHaveText("Σ 5");
 
   // Odškrtnutie PRVÉHO riadku (3 ks) ako objednané — `.click()`, nie
   // `.check()` (`.claude/rules/testing.md`: zápis je async, `.check()` by na
@@ -211,8 +211,8 @@ test("súčet kusov toho istého produktu naprieč objednávkami dodávateľa sa
   // Prepočet je OKAMŽITÝ (bez `page.reload()`) a týka sa OBOCH riadkov
   // naraz — presne požiadavka ticketu ("súčet sa musí prepočítať hneď po
   // zmene stavu riadku, bez obnovenia stránky").
-  await expect(chipPrva).toHaveText("Σ 2 ks");
-  await expect(chipDruha).toHaveText("Σ 2 ks");
+  await expect(chipPrva).toHaveText("Σ 2");
+  await expect(chipDruha).toHaveText("Σ 2");
   await expect(chipDruha).toHaveAttribute("title", "Spolu vo všetkých objednávkach: 5 ks · nevybavené: 2 ks");
   await expect(page.getByRole("alert")).toHaveCount(0);
 

--- a/docs/superpowers/specs/2026-08-03-automaticke-zapinanie-produktov-design.md
+++ b/docs/superpowers/specs/2026-08-03-automaticke-zapinanie-produktov-design.md
@@ -1,0 +1,190 @@
+# Automatické zapínanie produktov — návrh
+
+**Cieľ:** Keď dodávateľ dostane tovar naspäť na sklad, náš vypredaný produkt sa
+sám prepne na „Skladom" — bez toho, aby to niekto ručne sledoval.
+
+**Architektúra:** Dve nezávislé časti, prepojené jednou tabuľkou. Scraper
+(Systém) každú noc zistí dostupnosť u dodávateľov a zapíše ju do
+`supplier_stock`. Automatizácia (Automatizácie) z nej po scrape vyberie naše
+vypredané produkty, ktoré dodávateľ potvrdene má, a prepne ich v Shoptete
+existujúcou spätno-zápisovou cestou. Scraper nikdy nič nezapisuje do Shoptetu;
+automatizácia nikdy nechodí na internet.
+
+**Technológie:** Hono + Drizzle + PostgreSQL 18, React 19 + Vite, Playwright
+(už existujúci Shoptet spätný zápis), `undici` fetch (súčasť Node 24).
+
+## Rozhodnutia majiteľa (3. 8. 2026)
+
+Tieto tri rozhodnutia padli pri návrhu a sú záväzné:
+
+1. **Prepínanie beží samo každú noc** — nie na kliknutie, nie nasucho. V appke
+   je vidieť, čo prepla.
+2. **Žiadna AI.** Stránka, ktorú sa nepodarí prečítať bežným spôsobom, sa označí
+   ako „neviem" a taký produkt sa nikdy neprepne. Nečitateľné stránky sa
+   majiteľovi **ukazujú v zozname**, aby sa dalo rozhodnúť, či sa oplatí dorobiť
+   pre ne čítanie ručne.
+3. **Strop 50 prepnutí za jeden beh.** Zvyšok počká na ďalšiu noc; appka napíše,
+   koľko čaká. Strop je konfigurovateľný a dá sa kedykoľvek zdvihnúť.
+
+## Meranie na reálnych dátach (nie odhad)
+
+Zmerané na produkčnom Shoptet exporte (14 014 riadkov, read-only):
+
+| Veličina | Hodnota |
+|---|---|
+| Riadkov s dodávateľskou linkou | 1 210 |
+| Unikátnych dodávateľských liniek | 238 |
+| Domén dodávateľov | 4 (`huntingshop.eu` 969, `wetland.sk` 233, `trigona.sk` 6, `dogtrace.com` 2) |
+| Vypredané + `visible` + má linku | 767 |
+| `detailOnly` riadkov spolu | 5 276 |
+| **`detailOnly`, ktoré naša derivácia dnes hlási ako `out_of_stock`** | **526 (z toho 38 s linkou)** |
+
+Posledný riadok je dôvod, prečo časť B začína opravou katalógu — bez nej by
+automatizácia zapla produkty, ktoré majiteľ vedome vypol.
+
+## Predpoklad — viditeľnosť produktu sa musí ukladať
+
+`productVisibility` sa dnes zo Shoptet exportu prečíta, použije v
+`deriveVariantState` a **zahodí** — v databáze nie je. `detailOnly` pritom nie
+je v `HIDDEN_VISIBILITIES`, takže vypredaný `detailOnly` produkt je dnes v
+databáze nerozoznateľný od bežného vypredaného.
+
+Oprava: nový stĺpec `product.visibility` (text, plnený pri katalógovom importe
+rovnakou first-wins cestou ako `supplier`/`internal_note`). Derivácia stavu sa
+**nemení** — `detailOnly` naďalej nie je „discontinued", lebo produkt sa dá
+kúpiť cez priamy odkaz. Mení sa len to, že automatizácia má podľa čoho vylúčiť.
+
+## Časť A — Scraper dostupnosti u dodávateľa
+
+### Dáta
+
+Nová tabuľka `supplier_stock`, jeden riadok na unikátnu linku:
+
+| Stĺpec | Význam |
+|---|---|
+| `link` (unique) | dodávateľská URL, kľúč |
+| `host` | doména (pre slušnosť a pre štatistiku) |
+| `availability` | `available` / `unavailable` / `unknown` |
+| `availability_text` | pôvodný text zo stránky, nezmenený |
+| `price` | cena u dodávateľa, ak sa dala prečítať |
+| `source` | `json_ld` / `meta` / `text` — čím sa to podarilo prečítať |
+| `ok` | či kontrola prebehla bez chyby |
+| `error`, `http_status` | dôkaz pri zlyhaní |
+| `checked_at` | čas poslednej úspešnej kontroly |
+
+### Čítanie stránky — tri úrovne, žiadne hádanie
+
+1. **JSON-LD `Product`** (`schema.org` `offers.availability`) — strojový údaj,
+   ktorý dávajú Shoptet, WooCommerce aj PrestaShop. Najspoľahlivejší.
+2. **`og:` / `product:` meta značky** — keď JSON-LD chýba.
+3. **Kľúčové slová v texte** („Skladom", „Vypredané", „Není skladem", …) — len
+   pre domény, kde je to overené na uloženej vzorke stránky.
+
+Čokoľvek, čo neprejde ani jednou úrovňou → `unknown`. `unknown` **nikdy**
+neprepne produkt.
+
+### Beh
+
+- Naplánovaný **denne v noci** (scheduler F2, `job_run` záznam ako ostatné joby)
+  + tlačidlo „Spustiť teraz".
+- Vlastný advisory zámok `787_878_007` (`SUPPLIER_STOCK_RUN_LOCK_KEY`) — job má
+  manuálny trigger na tú istú prácu, takže rovnaký vzor ako
+  `postaUncollectedJob`.
+- **Slušnosť:** sériovo, minimálna pauza medzi požiadavkami na tú istú doménu,
+  vlastný `User-Agent` s kontaktom, strop na veľkosť odpovede, časový limit na
+  požiadavku.
+- **Preskočenie čerstvých:** linka s úspešnou kontrolou mladšou než 20 h sa
+  znovu nesťahuje.
+- Zlyhanie jednej linky nesmie zhodiť celý beh — zapíše sa `ok = false` a ide sa
+  ďalej.
+
+### Obrazovka (Systém → Dodávateľský sklad)
+
+- Posledný beh: kedy, ako dlho trval, koľko liniek skontroloval.
+- Počty: skladom / vypredané / neviem / chyba.
+- Tabuľka liniek s dostupnosťou, cenou, časom kontroly a odkazom.
+- **Samostatná karta „Stránky, ktoré neviem prečítať"** — zoznam `unknown` a
+  chybových liniek zoskupený podľa domény, aby bolo vidieť, pre ktorého
+  dodávateľa sa oplatí dorobiť čítanie.
+
+## Časť B — Automatizácia Vypredané → Skladom
+
+### Výber kandidátov
+
+Prepne sa variant, ktorý spĺňa **všetko naraz**:
+
+- náš stav je `out_of_stock`,
+- `product.visibility` je presne `visible`,
+- produkt má dodávateľskú linku,
+- `supplier_stock` pre tú linku má `ok = true` **a** `availability = available`,
+- `checked_at` nie je staršie než **48 h**.
+
+**Nikdy sa neprepne:** `detailOnly`, `hidden`, `blocked`, `cashDeskOnly`,
+`blockUnregistered`, čokoľvek s „Predaj výrobku skončil", ani variant, ktorý už
+je `sellable` (z toho plynie idempotencia — po prepnutí a ďalšom katalógovom
+importe už kandidátom nie je).
+
+Každý `code` sa v jednom behu objaví najviac raz — Shoptet zruší celý import pri
+duplicitnom kóde.
+
+### Zápis do Shoptetu
+
+Ide **existujúcou** cestou (`buildWritebackCsv` + Playwright import na
+`/admin/import-produktov/`, `.claude/rules/shoptet-writeback.md`). Riadok nesie:
+
+| Stĺpec | Hodnota |
+|---|---|
+| `code`, `pairCode` | identita variantu |
+| `visibility` | `visible` |
+| `availabilityInStock` | `Skladom` |
+| `availabilityOutOfStock` | `Skladom` |
+| `stock` | kladné číslo |
+
+**Obidve `availability` polia sa musia nastaviť naraz.** Shoptet zobrazuje
+`availabilityOutOfStock` v momente, keď sklad klesne na nulu — zápis len do
+`availabilityInStock` nechá po dopredaní znovu naskočiť staré „Vypredané".
+(Overené v ostrej prevádzke starej appky 14. 7. 2026.)
+
+### Beh a poistky
+
+- Naplánovaný **po** scrape, tou istou nočnou kadenciou; vlastný advisory zámok
+  `787_878_008` (`RESTOCK_RUN_LOCK_KEY`).
+- **Strop 50 prepnutí za beh** (konfigurovateľné). Pri prekročení sa prepne
+  prvých 50, zvyšok ostáva kandidátom na ďalšiu noc a appka to napíše.
+- Prepínač `Beží / Vypnuté` ako ostatné automatizácie (`settings`), vypnutá
+  automatizácia nezapisuje nič.
+- Každé prepnutie sa zapíše do `restock_event` (kód, názov, dodávateľ, linka,
+  dostupnostný text dodávateľa, čas) — to je dôkaz „že to funguje".
+
+### Obrazovka (Automatizácie → Vypredané → Skladom)
+
+- Prepínač Beží/Vypnuté, posledný beh, počet prepnutých a počet čakajúcich na
+  strop.
+- Tabuľka prepnutých produktov: dátum, kód, názov, dodávateľ, odkaz na
+  dodávateľa, čo dodávateľ hlásil.
+
+## Bezpečnostné pravidlá
+
+- Prihlasovacie údaje do Shoptet administrácie ostávajú **výhradne** v
+  premenných prostredia na dev2 (`.claude/rules/sensitive-values.md`).
+- Žiadny test nesmie siahnuť na skutočnú stránku dodávateľa ani na skutočný
+  Shoptet — čítanie stránok ide cez rozhranie, ktoré si testy nahradia vlastným,
+  a vzorky stránok sú uložené ako fixtúry.
+- Zápis do Shoptetu ide vždy cez `buildWritebackCsv` (ochrana proti CSV
+  injection), nikdy vlastným skladaním stĺpcov.
+
+## Testovanie
+
+- Čisté funkcie (čítanie dostupnosti zo vzorky stránky, výber kandidátov) majú
+  jednotkové testy nad uloženými vzorkami — bez siete.
+- Integračné testy nad databázou: výber kandidátov vylúči `detailOnly`, zastarané
+  potvrdenie, `unknown`, už predajný variant; strop drží.
+- E2E test: obe obrazovky sa načítajú, ukážu posledný beh a tabuľku, konzola
+  prehliadača je bez chýb.
+
+## Čo NIE je v rozsahu
+
+- AI čítanie stránok (majiteľ zamietol 3. 8. 2026).
+- Automatické zapínanie z **nášho vlastného** fyzického skladu (stará appka to
+  mala ako samostatnú vec) — nikto to nežiadal.
+- Vypínanie produktov, keď dodávateľ vypredá. Tento návrh len zapína.

--- a/docs/superpowers/specs/2026-08-03-automaticke-zapinanie-produktov-design.md
+++ b/docs/superpowers/specs/2026-08-03-automaticke-zapinanie-produktov-design.md
@@ -42,17 +42,19 @@ Zmerané na produkčnom Shoptet exporte (14 014 riadkov, read-only):
 Posledný riadok je dôvod, prečo časť B začína opravou katalógu — bez nej by
 automatizácia zapla produkty, ktoré majiteľ vedome vypol.
 
-## Predpoklad — viditeľnosť produktu sa musí ukladať
+## Viditeľnosť produktu — už uložená, netreba migráciu
 
-`productVisibility` sa dnes zo Shoptet exportu prečíta, použije v
-`deriveVariantState` a **zahodí** — v databáze nie je. `detailOnly` pritom nie
-je v `HIDDEN_VISIBILITIES`, takže vypredaný `detailOnly` produkt je dnes v
-databáze nerozoznateľný od bežného vypredaného.
+`detailOnly` **nie je** v `HIDDEN_VISIBILITIES`, takže vypredaný `detailOnly`
+produkt má v databáze rovnaký `state` (`out_of_stock`) ako bežný vypredaný —
+526 riadkov (38 s linkou). Podľa `state` sa teda vylúčiť nedá.
 
-Oprava: nový stĺpec `product.visibility` (text, plnený pri katalógovom importe
-rovnakou first-wins cestou ako `supplier`/`internal_note`). Derivácia stavu sa
-**nemení** — `detailOnly` naďalej nie je „discontinued", lebo produkt sa dá
-kúpiť cez priamy odkaz. Mení sa len to, že automatizácia má podľa čoho vylúčiť.
+Vylúčiť sa dá podľa `variant.product_visibility` — ten sa **už ukladá** (stĺpec
+`product_visibility`, `notNull`, migrácia 0001) a plní sa pri každom katalógovom
+importe z exportu. Žiadny nový stĺpec ani migrácia netreba; automatizácia si len
+pridá podmienku `product_visibility = 'visible'`.
+
+Derivácia stavu sa **nemení** — `detailOnly` naďalej nie je „discontinued", lebo
+taký produkt sa dá kúpiť cez priamy odkaz.
 
 ## Časť A — Scraper dostupnosti u dodávateľa
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.121",
+  "version": "0.3.0-dev.122",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Čitateľný súčet kusov (issue 214)

Majiteľ naživo: *"teraz vobec nie je citatelne to spolu produkty ale zase za
linkom dodavatela je vela miesta"*. Zmerané naživo na produkcii — príčina bola
iná, než sa zdalo: pilulka sa do bunky **zmestila**, ale vykreslilo sa jej len
16 px zo 49 px obsahu, takže `text-overflow: ellipsis` z nej urobil „Σ…" na
**každej** šírke okna. Rozšírenie stĺpca to teda samo neriešilo.

Tri veci naraz:
- `inline-flex` robilo z textu pilulky flex položku zmrštenú na nulovú šírku
  obsahu → `inline-block` + `width: max-content`,
- odsadenie bunky zabralo 26 px zo 41 px šírky pri 1280 px okne → zúžené len pre
  tento najužší stĺpec,
- text skrátený na „Σ N" (jednotka je už na riadku nad pilulkou).

**Zamietnuté alternatívy, obe zmerané naživo:** brať percentá stĺpcu s odkazom
dodávateľa (výška riadkov 119 → 162 px pri 1280 px — vyzerá prázdny, ale rezervu
nemá) aj stĺpcu s číslom objednávky (orezalo všetkých 42 čísel objednávok).

Regresná e2e kontrola meria orezanie samotnej pilulky na všetkých štyroch
šírkach — pôvodná kontrola z issue 204 to nezachytila, lebo orezaný prvok svoju
bunku nikdy nepretečie.

## Scraper dostupnosti u dodávateľa — backend (issue 212)

Prvá polovica: tabuľka `supplier_stock`, čítanie stránky v troch úrovniach bez
AI (JSON-LD → meta značky → voľný text len pre overené domény), nočný beh o
04:20 UTC so slušnosťou k doménam, HTTP trasy. Obrazovka v Systéme príde
samostatne — dovtedy sa dáta len zbierajú.

Ani jeden z tých dvoch ticketov sa tu nezatvára automaticky: oba majú akceptačnú
podmienku overiteľnú až po nasadení.
