### PR TITLE
Automatické zapínanie produktov — obrazovka scrapera a prepínanie Vypredané → Skladom

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -663,3 +663,31 @@ paths:
   pixel** (paired meranie na 40 reálnych riadkoch, priemer aj maximum 0px) —
   darcovský stĺpec (postup issue 107/111/127) by naopak zhoršil iný stĺpec.
   Než začneš hľadať darcu, over, či sa obsah nedá skrátiť.
+- **`display: inline-flex` na malej pilulke/odznaku spraví z jej TEXTU flex
+  položku, ktorá sa zmrští na NULOVÚ šírku obsahu — zostane viditeľné len
+  odsadenie a `text-overflow: ellipsis` dorobí zvyšok.** Issue 214 (majiteľ:
+  *"teraz vobec nie je citatelne to spolu produkty"*): `.qty-total-chip` mala
+  naživo `clientWidth 16 px` pri `scrollWidth 49 px` — teda presne svoje
+  odsadenie a nič viac — a to na KAŽDEJ šírke okna, aj 1920 px. Fix:
+  `inline-block` + `width: max-content` (+ `max-width: 100%` a orezanie
+  ponechané ako poistka pre budúci dlhší obsah). Toto je ŠTVRTÝ tvar tej istej
+  triedy chýb po issue 63/127/204 — a jediný, ktorý sa NEDAL nájsť kontrolou
+  „pretŕča prvok svoju bunku?", lebo **orezaný prvok svoju bunku nikdy
+  nepretečie**. Regresná kontrola preto meria `element.scrollWidth >
+  element.clientWidth` na SAMOTNOM prvku, nie len jeho polohu voči bunke
+  (`orders-layout.spec.ts`, kontrola vedľa `staleOdznaky`).
+- **V najužšom stĺpci tabuľky je odsadenie bunky väčšie než jej obsah — rátaj s
+  ním PRED hľadaním darcu percent.** Issue 214: `.col-qty` má 4 %, čo je pri
+  1280 px okna 41 px, z toho bežné `--fs-space-3` odsadenie zožralo 26 px a na
+  obsah zostalo 15 px. Zúženie odsadenia LEN pre tento stĺpec vyriešilo problém
+  bez siahnutia na akýkoľvek iný stĺpec — lacnejšie než presúvanie percent
+  (rovnaká úvaha ako „skrátenie textu" pri issue 204).
+- **Zmerané naživo (issue 214, 42 reálnych riadkov): stĺpec s odkazom dodávateľa
+  ani stĺpec s číslom objednávky NEMAJÚ rezervu, hoci opticky vyzerajú prázdne.**
+  `col-supplier` −1,2 p. b. zdvihlo najvyšší riadok pri 1280 px zo 119 px na
+  162 px (potvrdzuje zistenie issue 127, ktoré medzitým mohlo zastarať);
+  `col-order` −1,2 p. b. orezalo `.ord-admin-link` na VŠETKÝCH 42 riadkoch pri
+  1280 px (`white-space: nowrap` + ellipsis, takže žiadna bunka nepretiekla a
+  kontrola cez `td.scrollWidth` to nezachytila — treba merať orezanie na
+  samotnom odkaze). Pri ďalšom hľadaní darcu preto meraj OREZANIE obsahu darcu,
+  nielen výšku riadkov.

--- a/apps/api/drizzle/0027_restock.sql
+++ b/apps/api/drizzle/0027_restock.sql
@@ -1,0 +1,21 @@
+CREATE TABLE "restock_event" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"at" timestamp with time zone NOT NULL,
+	"variant_code" text NOT NULL,
+	"pair_code" text,
+	"product_name" text NOT NULL,
+	"supplier" text,
+	"supplier_link" text NOT NULL,
+	"supplier_availability_text" text DEFAULT '' NOT NULL,
+	"supplier_price" numeric(12, 2),
+	"confirmed_at" timestamp with time zone NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "restock_settings" (
+	"id" text PRIMARY KEY NOT NULL,
+	"enabled" boolean DEFAULT false NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "restock_event_at_idx" ON "restock_event" USING btree ("at");--> statement-breakpoint
+CREATE INDEX "restock_event_variant_idx" ON "restock_event" USING btree ("variant_code");

--- a/apps/api/drizzle/meta/0027_snapshot.json
+++ b/apps/api/drizzle/meta/0027_snapshot.json
@@ -1,0 +1,2443 @@
+{
+  "id": "bf571c19-aa27-4bdd-9e9e-766127941048",
+  "prevId": "46ed610a-1dcb-4bf8-8848-e945b923881f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "related_codes": {
+          "name": "related_codes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_code": {
+          "name": "external_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_open_status": {
+      "name": "order_open_status",
+      "schema": "",
+      "columns": {
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Vybavuje sa'"
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop_remark": {
+          "name": "shop_remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shoptet_order_id": {
+          "name": "shoptet_order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_updated_at": {
+          "name": "comment_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_synced_at": {
+          "name": "comment_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_carrier_name": {
+          "name": "shipping_carrier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_link_override": {
+      "name": "product_supplier_link_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_link_override_product_key_product_key_fk": {
+          "name": "product_supplier_link_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_link_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_override": {
+      "name": "product_supplier_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_override_product_key_product_key_fk": {
+          "name": "product_supplier_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing": {
+      "name": "pairing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_url": {
+          "name": "supplier_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "pairing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'navrhnute'"
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pairing_state_idx": {
+          "name": "pairing_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_confirmed_by_idx": {
+          "name": "pairing_confirmed_by_idx",
+          "columns": [
+            {
+              "expression": "confirmed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_variant_code_variant_code_fk": {
+          "name": "pairing_variant_code_variant_code_fk",
+          "tableFrom": "pairing",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pairing_confirmed_by_users_id_fk": {
+          "name": "pairing_confirmed_by_users_id_fk",
+          "tableFrom": "pairing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pairing_variant_code_unique": {
+          "name": "pairing_variant_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pairing_confirmation_ck": {
+          "name": "pairing_confirmation_ck",
+          "value": "(\"pairing\".\"state\" = 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)\n        OR (\"pairing\".\"state\" != 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NULL AND \"pairing\".\"confirmed_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier": {
+      "name": "supplier",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wholesale_base_url": {
+          "name": "wholesale_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_key": {
+          "name": "adapter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_settings": {
+      "name": "posta_uncollected_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_state": {
+      "name": "posta_uncollected_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notify_count": {
+          "name": "notify_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_state": {
+          "name": "terminal_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_settings": {
+      "name": "order_reminder_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_state": {
+      "name": "order_reminder_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_state": {
+      "name": "nedostupne_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "nedostupne_email_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nedostupne_state_order_variant_type_uq": {
+          "name": "nedostupne_state_order_variant_type_uq",
+          "columns": [
+            {
+              "expression": "order_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template_history": {
+      "name": "mail_template_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "mail_template_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_template_history_key_idx": {
+          "name": "mail_template_history_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_template_history_changed_by_user_id_users_id_fk": {
+          "name": "mail_template_history_changed_by_user_id_users_id_fk",
+          "tableFrom": "mail_template_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template": {
+      "name": "mail_template",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail_template_updated_by_user_id_users_id_fk": {
+          "name": "mail_template_updated_by_user_id_users_id_fk",
+          "tableFrom": "mail_template",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_log": {
+      "name": "mail_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "mail_log_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_log_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "mail_log_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_log_created_idx": {
+          "name": "mail_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_log_source_created_idx": {
+          "name": "mail_log_source_created_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_log_actor_user_id_users_id_fk": {
+          "name": "mail_log_actor_user_id_users_id_fk",
+          "tableFrom": "mail_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_stock": {
+      "name": "supplier_stock",
+      "schema": "",
+      "columns": {
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "supplier_availability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "supplier_stock_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "supplier_stock_host_idx": {
+          "name": "supplier_stock_host_idx",
+          "columns": [
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "supplier_stock_avail_idx": {
+          "name": "supplier_stock_avail_idx",
+          "columns": [
+            {
+              "expression": "availability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_event": {
+      "name": "restock_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_link": {
+          "name": "supplier_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_availability_text": {
+          "name": "supplier_availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "supplier_price": {
+          "name": "supplier_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "restock_event_at_idx": {
+          "name": "restock_event_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "restock_event_variant_idx": {
+          "name": "restock_event_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_settings": {
+      "name": "restock_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne"
+      ]
+    },
+    "public.pairing_state": {
+      "name": "pairing_state",
+      "schema": "public",
+      "values": [
+        "navrhnute",
+        "potvrdene"
+      ]
+    },
+    "public.nedostupne_email_type": {
+      "name": "nedostupne_email_type",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "alternativa"
+      ]
+    },
+    "public.mail_template_action": {
+      "name": "mail_template_action",
+      "schema": "public",
+      "values": [
+        "save",
+        "reset"
+      ]
+    },
+    "public.mail_log_source": {
+      "name": "mail_log_source",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "posta_uncollected",
+        "order_reminder",
+        "supplier_order"
+      ]
+    },
+    "public.mail_log_status": {
+      "name": "mail_log_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.mail_log_trigger": {
+      "name": "mail_log_trigger",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "manual"
+      ]
+    },
+    "public.supplier_availability": {
+      "name": "supplier_availability",
+      "schema": "public",
+      "values": [
+        "available",
+        "unavailable",
+        "unknown"
+      ]
+    },
+    "public.supplier_stock_source": {
+      "name": "supplier_stock_source",
+      "schema": "public",
+      "values": [
+        "json_ld",
+        "meta",
+        "text",
+        "none"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1785789658908,
       "tag": "0026_supplier_stock",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1785793985367,
+      "tag": "0027_restock",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema-restock.ts
+++ b/apps/api/src/db/schema-restock.ts
@@ -1,0 +1,34 @@
+import { boolean, index, numeric, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+
+// issue 213: "Vypredané → Skladom". Jediná automatizácia v appke, ktorá
+// ZAPISUJE do e-shopu bez toho, aby na to niekto klikol — preto má vlastný
+// Štart/Stop prepínač (rovnaký singleton vzor ako `posta_uncollected_settings`).
+export const restockSettings = pgTable("restock_settings", {
+  id: text("id").primaryKey(),
+  enabled: boolean("enabled").notNull().default(false),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull(),
+});
+
+// Jeden riadok na KAŽDÉ prepnutie — to je odpoveď na majiteľovo "bude to tam
+// vydno ze to funguje a ze to prepina produkty". Riadky sa nikdy nemažú ani
+// neprepisujú: je to história, nie stav.
+export const restockEvents = pgTable(
+  "restock_event",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    at: timestamp("at", { withTimezone: true }).notNull(),
+    variantCode: text("variant_code").notNull(),
+    pairCode: text("pair_code"),
+    productName: text("product_name").notNull(),
+    supplier: text("supplier"),
+    // Odkaz, na základe ktorého sa rozhodlo — spolu s textom, ktorý dodávateľ
+    // hlásil, tvorí celý dôkaz „prečo sa toto preplo".
+    supplierLink: text("supplier_link").notNull(),
+    supplierAvailabilityText: text("supplier_availability_text").notNull().default(""),
+    supplierPrice: numeric("supplier_price", { precision: 12, scale: 2 }),
+    // Kedy dodávateľa naposledy potvrdila kontrola (`supplier_stock.confirmed_at`)
+    // — bez toho by sa spätne nedalo overiť, či potvrdenie bolo čerstvé.
+    confirmedAt: timestamp("confirmed_at", { withTimezone: true }).notNull(),
+  },
+  (t) => [index("restock_event_at_idx").on(t.at), index("restock_event_variant_idx").on(t.variantCode)],
+);

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -9,3 +9,4 @@ export * from "./schema-nedostupne.js";
 export * from "./schema-mail-templates.js";
 export * from "./schema-mail-log.js";
 export * from "./schema-supplier-stock.js";
+export * from "./schema-restock.js";

--- a/apps/api/src/http/app.ts
+++ b/apps/api/src/http/app.ts
@@ -22,6 +22,8 @@ import { registerPairingRoutes } from "./pairing-routes.js";
 import { registerPostaUncollectedRoutes, type PostaUncollectedRunDeps } from "./posta-uncollected-routes.js";
 import type { PageFetcher, PageFetchResult } from "../modules/supplier-stock/page-fetcher.js";
 import { registerSupplierStockRoutes } from "./supplier-stock-routes.js";
+import { registerRestockRoutes, type RestockRunDeps } from "./restock-routes.js";
+import { shoptetImportConfigFromBaseUrl } from "../modules/shoptet-writeback/config.js";
 import { registerSchedulerRoutes } from "./scheduler-routes.js";
 import { registerSupplierRoutes } from "./supplier-routes.js";
 
@@ -66,6 +68,10 @@ export function createApp(
     // Voliteľné z rovnakého dôvodu ako `nedostupne` vyššie; testy dodajú
     // vlastnú implementáciu a NIKDY nechodia na skutočnú stránku dodávateľa.
     readonly fetchSupplierPage?: PageFetcher;
+    // issue 213: "Vypredané → Skladom" — prihlasovacie údaje do Shoptet
+    // administrácie. Voliteľné z rovnakého dôvodu ako ostatné; testy
+    // dodajú vlastný zápis a NIKDY sa nedotknú skutočného Shoptetu.
+    readonly restock?: RestockRunDeps;
   },
 ): Hono<AppBindings> {
   const app = new Hono<AppBindings>();
@@ -234,6 +240,17 @@ export function createApp(
           httpStatus: null,
           error: "Sťahovanie stránok dodávateľa nie je nakonfigurované.",
         })),
+  );
+  // issue 213: bez dodanej konfigurácie sa do Shoptetu NEZAPISUJE — beh
+  // skončí chybou prihlásenia, nikdy tichým "prepnuté".
+  registerRestockRoutes(
+    app,
+    db,
+    options.restock ?? {
+      // Prázdne prihlasovacie údaje = beh sa zastaví na prihlásení do
+      // Shoptetu a vráti chybu. Fail-closed: nikdy tiché "prepnuté".
+      config: shoptetImportConfigFromBaseUrl(options.adminBaseUrl ?? "https://www.forestshop.sk", "", ""),
+    },
   );
 
   // Musí byť registrovaný AŽ PO všetkých skutočných /api/* trasách vyššie — Hono

--- a/apps/api/src/http/restock-routes.ts
+++ b/apps/api/src/http/restock-routes.ts
@@ -1,0 +1,142 @@
+import { zValidator } from "@hono/zod-validator";
+import { desc, eq } from "drizzle-orm";
+import type { Hono } from "hono";
+import { z } from "zod";
+import type { Database } from "../db/client.js";
+import { jobRuns, restockEvents } from "../db/schema.js";
+import { log } from "../logger.js";
+import { record } from "../modules/audit/service.js";
+import { MAX_PER_RUN, RESTOCK_JOB_NAME } from "../modules/restock/constants.js";
+import { selectRestockCandidates } from "../modules/restock/queries.js";
+import type { RestockRunResult, RunRestockOptions } from "../modules/restock/run.js";
+import { isRestockEnabled, runRestock, setRestockEnabled } from "../modules/restock/run.js";
+import { getLatestJobRun } from "../modules/scheduler/queries.js";
+import { requireRole, requireUser, type AppBindings } from "./middleware.js";
+import { requireSameOrigin } from "./origin-check.js";
+
+const setEnabledBody = z.object({ enabled: z.boolean() });
+
+// HTTP vrstva dodá `db`/`now`; zvyšok (prihlasovacie údaje do Shoptetu)
+// zostavuje `index.ts` raz pri štarte — rovnaký vzor ako ostatné automatizácie.
+export type RestockRunDeps = Omit<RunRestockOptions, "db" | "now">;
+
+function isRunResult(detail: unknown): detail is RestockRunResult {
+  return typeof detail === "object" && detail !== null && "status" in detail;
+}
+
+async function runAndRecord(db: Database, deps: RestockRunDeps, now: Date): Promise<RestockRunResult> {
+  const [inserted] = await db
+    .insert(jobRuns)
+    .values({ jobName: RESTOCK_JOB_NAME, startedAt: now, status: "running" })
+    .returning({ id: jobRuns.id });
+  const runId = inserted?.id;
+  try {
+    const result = await runRestock({ db, now, ...deps });
+    if (runId !== undefined) {
+      await db
+        .update(jobRuns)
+        .set({ status: "success", finishedAt: new Date(), detail: result })
+        .where(eq(jobRuns.id, runId));
+    }
+    return result;
+  } catch (error) {
+    const rawErrorMessage = error instanceof Error ? error.message : String(error);
+    log.error({ rawErrorMessage }, "Vypredané → Skladom: ručný beh zlyhal");
+    if (runId !== undefined) {
+      await db
+        .update(jobRuns)
+        .set({ status: "failure", finishedAt: new Date(), errorMessage: rawErrorMessage })
+        .where(eq(jobRuns.id, runId));
+    }
+    throw error;
+  }
+}
+
+export function registerRestockRoutes(app: Hono<AppBindings>, db: Database, deps: RestockRunDeps): void {
+  app.get("/api/restock", requireUser(db), async (c) => {
+    const now = new Date();
+    const [enabled, lastRun, candidates, events] = await Promise.all([
+      isRestockEnabled(db),
+      getLatestJobRun(db, RESTOCK_JOB_NAME),
+      selectRestockCandidates(db, now),
+      db.select().from(restockEvents).orderBy(desc(restockEvents.at)).limit(200),
+    ]);
+    return c.json({
+      enabled,
+      maxPerRun: MAX_PER_RUN,
+      // Koľko by sa prepol NAJBLIŽŠÍ beh — majiteľ tak vidí dopredu, čo ho
+      // čaká, nielen čo sa už stalo.
+      waiting: { now: candidates.picked.length, overLimit: candidates.overLimit },
+      events,
+      lastRun:
+        lastRun === null
+          ? null
+          : {
+              startedAt: lastRun.startedAt,
+              finishedAt: lastRun.finishedAt,
+              status: lastRun.status,
+              errorMessage: lastRun.errorMessage,
+              result: isRunResult(lastRun.detail) ? lastRun.detail : null,
+              skippedReason:
+                typeof lastRun.detail === "object" &&
+                lastRun.detail !== null &&
+                "skipped" in lastRun.detail &&
+                (lastRun.detail as { readonly skipped?: unknown }).skipped === true
+                  ? ((lastRun.detail as { readonly reason?: unknown }).reason ?? "")
+                  : null,
+            },
+    });
+  });
+
+  // Štart/Stop gate-uje LEN naplánovaný nočný beh (`scheduler/jobs.ts`'s
+  // `restockJob`), nikdy "Spustiť teraz" nižšie — explicitná ľudská akcia,
+  // rovnaká úvaha ako pri ostatných automatizáciách.
+  app.put(
+    "/api/restock/enabled",
+    requireSameOrigin(),
+    requireUser(db),
+    requireRole("admin", "manazer"),
+    zValidator("json", setEnabledBody),
+    async (c) => {
+      const { enabled } = c.req.valid("json");
+      const user = c.get("user");
+      const now = new Date();
+      await setRestockEnabled(db, enabled, now);
+      await record(db, {
+        at: now,
+        actorUserId: user.userId,
+        action: "restock.enabled.set",
+        entity: "restock_settings",
+        data: { enabled },
+      });
+      log.info({ actorUserId: user.userId, enabled }, "Vypredané → Skladom: Štart/Stop");
+      return c.json({ ok: true as const, enabled });
+    },
+  );
+
+  app.post(
+    "/api/restock/run-now",
+    requireSameOrigin(),
+    requireUser(db),
+    requireRole("admin", "manazer"),
+    async (c) => {
+      const user = c.get("user");
+      const now = new Date();
+      let result: RestockRunResult;
+      try {
+        result = await runAndRecord(db, deps, now);
+      } catch {
+        return c.json({ ok: false as const, error: "Beh zlyhal." }, 500);
+      }
+      await record(db, {
+        at: now,
+        actorUserId: user.userId,
+        action: "restock.run_now",
+        entity: "restock_event",
+        data: { status: result.status },
+      });
+      log.info({ actorUserId: user.userId, ...result }, "Vypredané → Skladom: ručný beh");
+      return c.json({ ok: true as const, result });
+    },
+  );
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -23,6 +23,7 @@ import {
   orderNoteWritebackJob,
   orderReminderJob,
   supplierStockJob,
+  restockJob,
   postaUncollectedJob,
   pruneRawExportsJob,
   pruneRawOrdersJob,
@@ -31,6 +32,7 @@ import {
 } from "./modules/scheduler/jobs.js";
 import { fetchSupplierPage } from "./modules/supplier-stock/page-fetcher.js";
 import { runSupplierStock } from "./modules/supplier-stock/run.js";
+import { runRestock } from "./modules/restock/run.js";
 import { startScheduler } from "./modules/scheduler/scheduler.js";
 import { orderNoteWritebackConfigFromBaseUrl, shoptetImportConfigFromBaseUrl } from "./modules/shoptet-writeback/config.js";
 import { runOrderNoteWritebackJob } from "./modules/shoptet-writeback/run-order-note-writeback.js";
@@ -135,6 +137,19 @@ const runShoptetWritebackFn =
           now,
         );
 
+// issue 213: prepínanie vypredaných produktov späť na "Skladom" — zdieľa TIE
+// ISTÉ prihlasovacie údaje ako #122/#123. Bez nich sa job vôbec nezostaví a
+// `restockJob` zapíše zlyhanie namiesto tichého preskočenia.
+const runRestockFn =
+  shoptetAdminUser === undefined || shoptetAdminPassword === undefined
+    ? undefined
+    : (db2: typeof db, now: Date) =>
+        runRestock({
+          db: db2,
+          now,
+          config: shoptetImportConfigFromBaseUrl(env.SHOPTET_ADMIN_BASE_URL, shoptetAdminUser, shoptetAdminPassword),
+        });
+
 // issue 123: spätný zápis appkinej poznámky k objednávke — zdieľa TIE ISTÉ
 // nepovinné premenné ako #122 vyššie (žiadne nové), len iná Playwright
 // automatizácia (per-objednávka, nie hromadný CSV import).
@@ -215,6 +230,7 @@ const scheduler = startScheduler(db, [
   postaUncollectedJob((db2, now) => runPostaUncollected({ db: db2, now, ...postaUncollectedDeps })),
   orderReminderJob((db2, now) => runOrderReminder({ db: db2, now, ...orderReminderDeps })),
   supplierStockJob((db2, now) => runSupplierStock({ db: db2, now, fetchPage: fetchSupplierPage })),
+  restockJob(runRestockFn),
 ]);
 
 // `@hono/node-server`'s `serveStatic` prints its OWN `console.error` on every

--- a/apps/api/src/modules/restock/constants.ts
+++ b/apps/api/src/modules/restock/constants.ts
@@ -1,0 +1,40 @@
+// issue 213: "Vypredané → Skladom" — automatické zapínanie produktov, ktoré
+// dodávateľ zase má skladom.
+
+export const RESTOCK_JOB_NAME = "restock";
+export const RESTOCK_SETTINGS_ID = "default";
+
+// Vlastný advisory zámok (`.claude/rules/scheduler.md`) — job má manuálny
+// trigger na tú istú prácu ako nočný beh, takže dva prekrývajúce sa behy by
+// mohli poslať ten istý produkt do Shoptetu dvakrát.
+export const RESTOCK_RUN_LOCK_KEY = 787_878_008;
+
+// Rozhodnutie majiteľa (3. 8. 2026): najviac 50 prepnutí za jeden beh, zvyšok
+// počká na ďalšiu noc. Zámerne konzervatívne — naposledy nameraných 767
+// vypredaných viditeľných variantov s dodávateľskou linkou, takže bez stropu
+// by prvá noc mohla preklopiť stovky produktov naraz.
+export const MAX_PER_RUN = 50;
+
+// Ako staré smie byť potvrdenie dodávateľa, aby sa naň dalo prepnúť. Scraper
+// (issue 212) kontroluje každý odkaz aspoň raz denne, takže čerstvé
+// potvrdenie je hlboko pod touto hranicou; čokoľvek staršie je dohad.
+export const CONFIRMATION_MAX_AGE_HOURS = 48;
+
+// Viditeľnosť, pri ktorej sa produkt SMIE zapnúť. Čokoľvek iné — `detailOnly`
+// (na reálnom exporte 5 276 riadkov, z toho 526 vyzerá ako obyčajné
+// vypredané), `hidden`, `blocked`, `cashDeskOnly`, `blockUnregistered` — je
+// VEDOMÉ rozhodnutie majiteľa produkt nepredávať a automatizácia ho nikdy
+// neprebije.
+export const SELLABLE_VISIBILITY = "visible";
+
+// Text, ktorý Shoptet zobrazuje zákazníkovi. Musí sa zapísať do OBOCH polí
+// naraz — Shoptet ukazuje `availabilityOutOfStock` v momente, keď sklad
+// klesne na nulu, takže zápis len do `availabilityInStock` by po dopredaní
+// fiktívnych kusov vrátil staré „Vypredané" (overené v ostrej prevádzke
+// starej appky 14. 7. 2026).
+export const AVAILABILITY_IN_STOCK_TEXT = "Skladom";
+
+// Fiktívny sklad, ktorý produkt vráti do predaja. Kladné číslo je nutné —
+// pri nule Shoptet zobrazí `availabilityOutOfStock` a prepnutie by nemalo
+// žiadny efekt.
+export const RESTOCK_STOCK = 10;

--- a/apps/api/src/modules/restock/queries.ts
+++ b/apps/api/src/modules/restock/queries.ts
@@ -1,0 +1,109 @@
+// Výber produktov, ktoré sa smú zapnúť späť na „Skladom" (issue 213).
+//
+// Toto je najcitlivejšie miesto celej automatizácie: zlý výber zapne na živom
+// e-shope produkt, ktorý majiteľ vedome vypol. Preto sa každá podmienka
+// kontroluje pozitívne (musí platiť), nikdy sa nič nepredpokladá.
+
+import { and, asc, eq, isNull, sql } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { products, supplierStock, variants } from "../../db/schema.js";
+import {
+  CONFIRMATION_MAX_AGE_HOURS,
+  MAX_PER_RUN,
+  SELLABLE_VISIBILITY,
+} from "./constants.js";
+
+export interface RestockCandidate {
+  readonly variantCode: string;
+  readonly pairCode: string | null;
+  readonly productName: string;
+  readonly supplier: string | null;
+  readonly supplierLink: string;
+  readonly supplierAvailabilityText: string;
+  readonly supplierPrice: string | null;
+  readonly confirmedAt: Date;
+}
+
+export interface RestockCandidates {
+  /** Prvých `limit` kandidátov — presne tie, ktoré sa v tomto behu prepnú. */
+  readonly picked: readonly RestockCandidate[];
+  /** Koľko kandidátov spĺňalo všetko, ale neprešlo cez strop. */
+  readonly overLimit: number;
+}
+
+/**
+ * Kandidát musí spĺňať VŠETKO naraz:
+ *  - náš stav je `out_of_stock` (vypredané) — už predajný variant sa
+ *    neprepína, z čoho plynie idempotencia: po prepnutí a ďalšom katalógovom
+ *    importe kandidátom nie je;
+ *  - `product_visibility` je presne `visible` — `detailOnly`/`hidden`/…
+ *    je vedomé „nepredávať" a nikdy sa neprebíja;
+ *  - variant nechýba z exportu (`missing_since IS NULL`) — zapnúť niečo, čo
+ *    Shoptet už nevidí, nedáva zmysel;
+ *  - dodávateľská linka má ÚSPEŠNÚ kontrolu (`ok`), dostupnosť `available`
+ *    a potvrdenie nie staršie než `CONFIRMATION_MAX_AGE_HOURS`.
+ *
+ * `unknown` (stránka sa načítala, ale nič sa z nej nedalo vyčítať) ani
+ * zlyhaná kontrola NIKDY neprepnú produkt — to je celý zmysel toho, že sme
+ * odmietli AI dohady.
+ *
+ * Každý `code` sa vráti najviac raz — Shoptet zruší CELÝ import pri
+ * duplicitnom kóde a katalóg obsahuje produkty zdieľajúce kódy variantov.
+ */
+export async function selectRestockCandidates(
+  db: Database,
+  now: Date,
+  limit = MAX_PER_RUN,
+): Promise<RestockCandidates> {
+  const oldestAcceptable = new Date(now.getTime() - CONFIRMATION_MAX_AGE_HOURS * 3_600_000);
+
+  // Linka sa z `internal_note` vyberá TÝM ISTÝM spôsobom ako v scraperi
+  // (`supplier-link.ts` → prvý `http(s)://…` výskyt): `substring` s rovnakým
+  // vzorom, aby sa kľúč na `supplier_stock` nemohol rozísť. Koncová
+  // interpunkcia sa oreže rovnako ako tam.
+  const link = sql<string>`trim(both from regexp_replace(substring(${products.internalNote} from 'https?://[^[:space:]]+'), '[.,;:)\\]]+$', ''))`;
+
+  const rows = await db
+    .select({
+      variantCode: variants.code,
+      pairCode: variants.pairCode,
+      productName: variants.name,
+      supplier: products.supplier,
+      supplierLink: supplierStock.link,
+      supplierAvailabilityText: supplierStock.availabilityText,
+      supplierPrice: supplierStock.price,
+      confirmedAt: supplierStock.confirmedAt,
+    })
+    .from(variants)
+    .innerJoin(products, eq(variants.productKey, products.key))
+    .innerJoin(supplierStock, eq(supplierStock.link, link))
+    .where(
+      and(
+        eq(variants.state, "out_of_stock"),
+        eq(variants.productVisibility, SELLABLE_VISIBILITY),
+        isNull(variants.missingSince),
+        eq(supplierStock.ok, true),
+        eq(supplierStock.availability, "available"),
+        sql`${supplierStock.confirmedAt} is not null`,
+        sql`${supplierStock.confirmedAt} >= ${oldestAcceptable}`,
+        sql`${supplierStock.confirmedAt} <= ${now}`,
+      ),
+    )
+    // Stabilné poradie: najstaršie potvrdenie prvé, potom podľa kódu — pri
+    // strope tak nikdy nezostane ten istý variant navždy „na chvoste".
+    .orderBy(asc(supplierStock.confirmedAt), asc(variants.code));
+
+  const seen = new Set<string>();
+  const unique: RestockCandidate[] = [];
+  for (const row of rows) {
+    if (seen.has(row.variantCode)) continue;
+    if (row.confirmedAt === null) continue;
+    seen.add(row.variantCode);
+    unique.push({ ...row, confirmedAt: row.confirmedAt });
+  }
+
+  return {
+    picked: unique.slice(0, limit),
+    overLimit: Math.max(0, unique.length - limit),
+  };
+}

--- a/apps/api/src/modules/restock/run.ts
+++ b/apps/api/src/modules/restock/run.ts
@@ -1,0 +1,134 @@
+// Beh automatizácie "Vypredané → Skladom" (issue 213).
+//
+// Toto je jediná automatizácia v appke, ktorá sama od seba ZAPISUJE do
+// e-shopu. Preto: vlastný Štart/Stop prepínač, strop na počet prepnutí,
+// advisory zámok proti dvom súbežným behom a záznam o KAŽDOM prepnutí.
+
+import { eq } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { restockEvents, restockSettings } from "../../db/schema.js";
+import type { ShoptetImportConfig } from "../shoptet-writeback/config.js";
+import { buildRestockCsv } from "../shoptet-writeback/csv.js";
+import { runShoptetImport } from "../shoptet-writeback/playwright-import.js";
+import {
+  AVAILABILITY_IN_STOCK_TEXT,
+  MAX_PER_RUN,
+  RESTOCK_RUN_LOCK_KEY,
+  RESTOCK_SETTINGS_ID,
+  RESTOCK_STOCK,
+} from "./constants.js";
+import { selectRestockCandidates, type RestockCandidate } from "./queries.js";
+
+export type RestockRunResult =
+  | { readonly status: "nothing_to_do"; readonly overLimit: 0 }
+  | {
+      readonly status: "ok";
+      readonly switched: number;
+      readonly overLimit: number;
+      readonly codes: readonly string[];
+    }
+  | {
+      readonly status: "failed";
+      readonly attempted: number;
+      readonly overLimit: number;
+      readonly errorDetail: string;
+    };
+
+export interface RunRestockOptions {
+  readonly db: Database;
+  readonly now: Date;
+  readonly config: ShoptetImportConfig;
+  /** Iba pre testy — nahradí skutočný Playwright zápis do Shoptetu. */
+  readonly importToShoptet?: typeof runShoptetImport;
+  readonly limit?: number;
+}
+
+export async function runRestock(options: RunRestockOptions): Promise<RestockRunResult> {
+  const { db } = options;
+  const lockClient = await db.$client.connect();
+  try {
+    await lockClient.query("select pg_advisory_lock($1)", [RESTOCK_RUN_LOCK_KEY]);
+    return await runRestockLocked(options);
+  } finally {
+    await lockClient.query("select pg_advisory_unlock($1)", [RESTOCK_RUN_LOCK_KEY]);
+    lockClient.release();
+  }
+}
+
+async function runRestockLocked(options: RunRestockOptions): Promise<RestockRunResult> {
+  const { db, now, config } = options;
+  const importToShoptet = options.importToShoptet ?? runShoptetImport;
+  const limit = options.limit ?? MAX_PER_RUN;
+
+  const { picked, overLimit } = await selectRestockCandidates(db, now, limit);
+  if (picked.length === 0) return { status: "nothing_to_do", overLimit: 0 };
+
+  // OBIDVE polia dostupnosti naraz — zápis len do `availabilityInStock` by po
+  // dopredaní fiktívnych kusov vrátil staré „Vypredané" (overené v ostrej
+  // prevádzke starej appky 14. 7. 2026).
+  const csv = buildRestockCsv(
+    picked.map((candidate) => ({
+      code: candidate.variantCode,
+      pairCode: candidate.pairCode ?? "",
+      availabilityInStock: AVAILABILITY_IN_STOCK_TEXT,
+      availabilityOutOfStock: AVAILABILITY_IN_STOCK_TEXT,
+      stock: String(RESTOCK_STOCK),
+    })),
+  );
+
+  const outcome = await importToShoptet({ config, csv, expectedRows: picked.length });
+  if (!outcome.ok) {
+    // Nezapisuje sa ŽIADNY záznam o prepnutí — import je všetko-alebo-nič,
+    // takže tvrdiť, že sa niečo preplo, by bola lož. Kandidáti ostávajú
+    // kandidátmi a ďalší beh to skúsi znova.
+    return {
+      status: "failed",
+      attempted: picked.length,
+      overLimit,
+      errorDetail: outcome.errorDetail ?? "Import do Shoptetu zlyhal bez bližšieho popisu.",
+    };
+  }
+
+  await recordEvents(db, now, picked);
+  return {
+    status: "ok",
+    switched: picked.length,
+    overLimit,
+    codes: picked.map((candidate) => candidate.variantCode),
+  };
+}
+
+async function recordEvents(db: Database, now: Date, picked: readonly RestockCandidate[]): Promise<void> {
+  await db.insert(restockEvents).values(
+    picked.map((candidate) => ({
+      at: now,
+      variantCode: candidate.variantCode,
+      pairCode: candidate.pairCode,
+      productName: candidate.productName,
+      supplier: candidate.supplier,
+      supplierLink: candidate.supplierLink,
+      supplierAvailabilityText: candidate.supplierAvailabilityText,
+      supplierPrice: candidate.supplierPrice,
+      confirmedAt: candidate.confirmedAt,
+    })),
+  );
+}
+
+/** `true` len keď riadok existuje A `enabled = true` — chýbajúci riadok sa
+ * berie ako VYPNUTÉ, nikdy ako zapnuté (rovnaká fail-closed disciplína ako
+ * `posta-uncollected/settings.ts`: chýbajúci dôkaz nikdy neznamená „zapisuj
+ * do e-shopu"). */
+export async function isRestockEnabled(db: Database): Promise<boolean> {
+  const [row] = await db
+    .select({ enabled: restockSettings.enabled })
+    .from(restockSettings)
+    .where(eq(restockSettings.id, RESTOCK_SETTINGS_ID));
+  return row?.enabled ?? false;
+}
+
+export async function setRestockEnabled(db: Database, enabled: boolean, now: Date): Promise<void> {
+  await db
+    .insert(restockSettings)
+    .values({ id: RESTOCK_SETTINGS_ID, enabled, updatedAt: now })
+    .onConflictDoUpdate({ target: restockSettings.id, set: { enabled, updatedAt: now } });
+}

--- a/apps/api/src/modules/scheduler/jobs.ts
+++ b/apps/api/src/modules/scheduler/jobs.ts
@@ -10,6 +10,9 @@ import { isOrderReminderEnabled } from "../order-reminder/settings.js";
 import type { OrderReminderRunResult } from "../order-reminder/run.js";
 import type { OrderNoteWritebackRunResult } from "../shoptet-writeback/run-order-note-writeback.js";
 import type { WritebackRunResult } from "../shoptet-writeback/run-writeback.js";
+import { RESTOCK_JOB_NAME } from "../restock/constants.js";
+import type { RestockRunResult } from "../restock/run.js";
+import { isRestockEnabled } from "../restock/run.js";
 import { SUPPLIER_STOCK_JOB_NAME } from "../supplier-stock/constants.js";
 import type { SupplierStockRunResult } from "../supplier-stock/run.js";
 import type { ScheduledJob } from "./types.js";
@@ -294,6 +297,34 @@ export function supplierStockJob(run: RunSupplierStock): ScheduledJob {
     name: SUPPLIER_STOCK_JOB_NAME,
     schedule: { kind: "daily", hourUtc: 4, minuteUtc: 20 },
     async run(db, now) {
+      return { detail: await run(db, now) };
+    },
+  };
+}
+
+export type RunRestock = (db: Database, now: Date) => Promise<RestockRunResult>;
+
+/**
+ * "Vypredané → Skladom" (issue 213) — denne o 04:50 UTC, teda 30 minút PO
+ * `supplierStockJob` (04:20), aby pracovalo s potvrdeniami z tejto noci.
+ *
+ * Na rozdiel od scrapera MÁ `enabled` prepínač: toto je jediná automatizácia,
+ * ktorá sama od seba zapisuje do živého e-shopu. Manuálne "Spustiť teraz"
+ * beží vždy, bez ohľadu na prepínač (explicitná ľudská akcia — rovnaká úvaha
+ * ako `postaUncollectedJob`).
+ */
+export function restockJob(run: RunRestock | undefined): ScheduledJob {
+  return {
+    name: RESTOCK_JOB_NAME,
+    schedule: { kind: "daily", hourUtc: 4, minuteUtc: 50 },
+    async run(db, now) {
+      const enabled = await isRestockEnabled(db);
+      if (!enabled) {
+        return { detail: { skipped: true, reason: "automatizácia je vypnutá (Štart/Stop)" } };
+      }
+      if (run === undefined) {
+        throw new Error("Chýbajú prihlasovacie údaje do Shoptet administrácie — prepnutie sa nedá zapísať.");
+      }
       return { detail: await run(db, now) };
     },
   };

--- a/apps/api/src/modules/shoptet-writeback/csv.ts
+++ b/apps/api/src/modules/shoptet-writeback/csv.ts
@@ -58,3 +58,42 @@ export function buildWritebackCsv(rows: readonly WritebackRow[]): Buffer {
   const bom = "﻿";
   return Buffer.from(bom + lines.join("\r\n") + "\r\n", "utf8");
 }
+
+// issue 213: prepnutie vypredaného produktu späť na „Skladom". Vlastný tvar
+// riadku (iné stĺpce než odkaz na dodávateľa vyššie), ale ZÁMERNE v tomto
+// súbore a cez to isté `dataRowToLine` — ochrana proti CSV-injection
+// (`.claude/rules/shoptet-writeback.md`) platí pre KAŽDÚ cestu zápisu do
+// Shoptetu, nikdy sa stĺpce neskladajú mimo tohto modulu.
+export interface RestockCsvRow {
+  readonly code: string;
+  readonly pairCode: string;
+  readonly availabilityInStock: string;
+  readonly availabilityOutOfStock: string;
+  readonly stock: string;
+}
+
+// `visible` je konštanta, nie vstup — automatizácia zapína LEN produkty,
+// ktoré už `visible` sú (`restock/queries.ts`), takže stĺpec len potvrdzuje
+// existujúci stav a nemôže odkryť nič, čo majiteľ skryl.
+const RESTOCK_HEADER = [
+  "code",
+  "pairCode",
+  "productVisibility",
+  "availabilityInStock",
+  "availabilityOutOfStock",
+  "stock",
+] as const;
+
+export function buildRestockCsv(rows: readonly RestockCsvRow[]): Buffer {
+  if (rows.length === 0) {
+    throw new Error("buildRestockCsv: žiadne riadky na zápis — CSV sa nesmie nahrať prázdne");
+  }
+  const lines = [
+    rowToLine(RESTOCK_HEADER),
+    ...rows.map((r) =>
+      dataRowToLine([r.code, r.pairCode, "visible", r.availabilityInStock, r.availabilityOutOfStock, r.stock]),
+    ),
+  ];
+  const bom = "﻿";
+  return Buffer.from(bom + lines.join("\r\n") + "\r\n", "utf8");
+}

--- a/apps/api/tests/helpers/db.ts
+++ b/apps/api/tests/helpers/db.ts
@@ -60,7 +60,7 @@ export async function withCleanDb(): Promise<{ db: Database; close: () => Promis
     // predošlého behu potom vyzerá ako platné potvrdenie a beh preskočí
     // VŠETKY odkazy (presne to sa tu stalo pri druhom spustení).
     await db.execute(
-      sql`TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, mail_template, mail_template_history, supplier_stock RESTART IDENTITY CASCADE`,
+      sql`TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, mail_template, mail_template_history, supplier_stock, restock_settings, restock_event RESTART IDENTITY CASCADE`,
     );
     // issue 59: `order_open_status` is a NEW table with real production
     // content (the migration seeds it) — TRUNCATE alone would leave every

--- a/apps/api/tests/helpers/db.ts
+++ b/apps/api/tests/helpers/db.ts
@@ -54,8 +54,13 @@ export async function withCleanDb(): Promise<{ db: Database; close: () => Promis
     // "nedostupne_state" (issue 176) is the SAME situation again — no FK in
     // either direction, and this module has NO settings singleton (no
     // scheduled run to gate), so no re-seed is needed below.
+    // "supplier_stock" (issue 212) is the SAME situation once more — keyed on
+    // the supplier URL, no FK in either direction. Bez neho riadky prežijú
+    // nielen medzi testami, ale aj medzi CELÝMI behmi: čerstvý zápis z
+    // predošlého behu potom vyzerá ako platné potvrdenie a beh preskočí
+    // VŠETKY odkazy (presne to sa tu stalo pri druhom spustení).
     await db.execute(
-      sql`TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, mail_template, mail_template_history RESTART IDENTITY CASCADE`,
+      sql`TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, mail_template, mail_template_history, supplier_stock RESTART IDENTITY CASCADE`,
     );
     // issue 59: `order_open_status` is a NEW table with real production
     // content (the migration seeds it) — TRUNCATE alone would leave every

--- a/apps/api/tests/restock-run.integration.test.ts
+++ b/apps/api/tests/restock-run.integration.test.ts
@@ -1,0 +1,212 @@
+import { eq } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Database } from "../src/db/client.js";
+import { products, restockEvents, supplierStock, variants } from "../src/db/schema.js";
+import type { ShoptetImportConfig } from "../src/modules/shoptet-writeback/config.js";
+import { runRestock, setRestockEnabled } from "../src/modules/restock/run.js";
+import { selectRestockCandidates } from "../src/modules/restock/queries.js";
+import { insertTestSnapshot } from "./helpers/catalog.js";
+import { withCleanDb } from "./helpers/db.js";
+
+const NOW = new Date("2026-08-04T04:50:00.000Z");
+const LINK = "https://huntingshop.eu/bunda";
+
+// Žiadny test nesmie siahnuť na skutočný Shoptet — zápis je vždy vlastná
+// implementácia, nikdy `runShoptetImport`.
+const CONFIG: ShoptetImportConfig = {
+  loginUrl: "https://example.invalid/admin/",
+  importUrl: "https://example.invalid/admin/import-produktov/",
+  logUrl: "https://example.invalid/admin/import-produktov/log/",
+  user: "test",
+  password: "test",
+};
+
+describe("prepínanie Vypredané → Skladom", () => {
+  let db: Database;
+  let close: () => Promise<void>;
+  let snapshotId: string;
+
+  beforeEach(async () => {
+    ({ db, close } = await withCleanDb());
+    snapshotId = await insertTestSnapshot(db);
+    await setRestockEnabled(db, true, NOW);
+  });
+  afterEach(async () => {
+    await close();
+  });
+
+  const seedSupplierStock = async (over: Partial<typeof supplierStock.$inferInsert> = {}): Promise<void> => {
+    await db.insert(supplierStock).values({
+      link: LINK,
+      host: "huntingshop.eu",
+      availability: "available",
+      availabilityText: "skladom",
+      price: "12.50",
+      source: "json_ld",
+      ok: true,
+      error: null,
+      httpStatus: 200,
+      checkedAt: NOW,
+      confirmedAt: new Date(NOW.getTime() - 3_600_000),
+      ...over,
+    });
+  };
+
+  const seedVariant = async (
+    code: string,
+    over: {
+      readonly state?: "sellable" | "out_of_stock" | "discontinued";
+      readonly productVisibility?: string;
+      readonly internalNote?: string | null;
+      readonly missingSince?: Date | null;
+    } = {},
+  ): Promise<void> => {
+    const productKey = `prod-${code}`;
+    await db.insert(products).values({
+      key: productKey,
+      name: `Produkt ${code}`,
+      supplier: "Dodávateľ",
+      internalNote: over.internalNote === undefined ? LINK : over.internalNote,
+      firstSeenAt: NOW,
+      lastSeenAt: NOW,
+      lastSeenSnapshotId: snapshotId,
+    });
+    await db.insert(variants).values({
+      code,
+      productKey,
+      guid: productKey,
+      name: `Produkt ${code}`,
+      stock: 0,
+      availabilityInStockText: "Skladom",
+      availabilityOutOfStockText: "Vypredané",
+      availabilityText: "Vypredané",
+      productVisibility: over.productVisibility ?? "visible",
+      state: over.state ?? "out_of_stock",
+      missingSince: over.missingSince ?? null,
+      firstSeenAt: NOW,
+      lastSeenAt: NOW,
+      lastSeenSnapshotId: snapshotId,
+    });
+  };
+
+  const okImport = vi.fn(() =>
+    Promise.resolve({ ok: true as const, processed: 1, updated: 1, failed: 0, errorDetail: null, rawResultText: "OK" }),
+  );
+
+  it("prepne vypredaný viditeľný produkt, ktorý dodávateľ potvrdene má", async () => {
+    await seedSupplierStock();
+    await seedVariant("A1");
+
+    const result = await runRestock({ db, now: NOW, config: CONFIG, importToShoptet: okImport });
+
+    expect(result).toMatchObject({ status: "ok", switched: 1, codes: ["A1"] });
+    const [event] = await db.select().from(restockEvents).where(eq(restockEvents.variantCode, "A1"));
+    expect(event?.supplierLink).toBe(LINK);
+    expect(event?.supplierAvailabilityText).toBe("skladom");
+  });
+
+  // TOTO je hlavná bezpečnostná podmienka celej úlohy: `detailOnly` je vedomé
+  // rozhodnutie majiteľa produkt nepredávať a má ROVNAKÝ stav `out_of_stock`
+  // ako bežné vypredané (na reálnom exporte 526 riadkov).
+  it("NIKDY neprepne detailOnly ani inú skrytú viditeľnosť", async () => {
+    await seedSupplierStock();
+    for (const [code, visibility] of [
+      ["B1", "detailOnly"],
+      ["B2", "hidden"],
+      ["B3", "blocked"],
+      ["B4", "cashDeskOnly"],
+      ["B5", "blockUnregistered"],
+    ] as const) {
+      await seedVariant(code, { productVisibility: visibility });
+    }
+
+    const { picked } = await selectRestockCandidates(db, NOW);
+
+    expect(picked).toHaveLength(0);
+  });
+
+  it("neprepne produkt, ktorý už je predajný (idempotencia)", async () => {
+    await seedSupplierStock();
+    await seedVariant("C1", { state: "sellable" });
+
+    expect((await selectRestockCandidates(db, NOW)).picked).toHaveLength(0);
+  });
+
+  it("neprepne produkt s ukončeným predajom", async () => {
+    await seedSupplierStock();
+    await seedVariant("D1", { state: "discontinued" });
+
+    expect((await selectRestockCandidates(db, NOW)).picked).toHaveLength(0);
+  });
+
+  it("neprepne variant, ktorý zmizol z exportu", async () => {
+    await seedSupplierStock();
+    await seedVariant("E1", { missingSince: NOW });
+
+    expect((await selectRestockCandidates(db, NOW)).picked).toHaveLength(0);
+  });
+
+  it("neprepne na základe nečitateľnej stránky ani zlyhanej kontroly", async () => {
+    await seedSupplierStock({ availability: "unknown", confirmedAt: null });
+    await seedVariant("F1");
+    expect((await selectRestockCandidates(db, NOW)).picked).toHaveLength(0);
+
+    await db.update(supplierStock).set({ ok: false, availability: "available" }).where(eq(supplierStock.link, LINK));
+    expect((await selectRestockCandidates(db, NOW)).picked).toHaveLength(0);
+  });
+
+  it("neprepne na základe zastaraného potvrdenia", async () => {
+    await seedSupplierStock({ confirmedAt: new Date(NOW.getTime() - 49 * 3_600_000) });
+    await seedVariant("G1");
+
+    expect((await selectRestockCandidates(db, NOW)).picked).toHaveLength(0);
+  });
+
+  it("neprepne produkt bez dodávateľskej linky", async () => {
+    await seedSupplierStock();
+    await seedVariant("H1", { internalNote: "Soxland (bez odkazu)" });
+
+    expect((await selectRestockCandidates(db, NOW)).picked).toHaveLength(0);
+  });
+
+  // Rozhodnutie majiteľa: najviac 50 za beh, zvyšok počká a appka to napíše.
+  it("drží strop prepnutí za jeden beh a povie, koľko ich čaká", async () => {
+    await seedSupplierStock();
+    for (let i = 0; i < 5; i += 1) await seedVariant(`I${String(i)}`);
+
+    const result = await runRestock({ db, now: NOW, config: CONFIG, importToShoptet: okImport, limit: 2 });
+
+    expect(result).toMatchObject({ status: "ok", switched: 2, overLimit: 3 });
+    expect(await db.select().from(restockEvents)).toHaveLength(2);
+  });
+
+  // Import do Shoptetu je všetko-alebo-nič — tvrdiť, že sa niečo preplo,
+  // by po zlyhaní bola lož.
+  it("po zlyhaní zápisu do Shoptetu nezapíše ŽIADNE prepnutie", async () => {
+    await seedSupplierStock();
+    await seedVariant("J1");
+    const zlyhanie = vi.fn(() =>
+      Promise.resolve({
+        ok: false as const,
+        processed: 0,
+        updated: 0,
+        failed: 1,
+        errorDetail: "prihlásenie zlyhalo",
+        rawResultText: "",
+      }),
+    );
+
+    const result = await runRestock({ db, now: NOW, config: CONFIG, importToShoptet: zlyhanie });
+
+    expect(result).toMatchObject({ status: "failed", attempted: 1 });
+    expect(await db.select().from(restockEvents)).toHaveLength(0);
+  });
+
+  it("bez kandidátov do Shoptetu vôbec nesiahne", async () => {
+    const import_ = vi.fn();
+    const result = await runRestock({ db, now: NOW, config: CONFIG, importToShoptet: import_ });
+
+    expect(result).toMatchObject({ status: "nothing_to_do" });
+    expect(import_).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/tests/supplier-stock-run.integration.test.ts
+++ b/apps/api/tests/supplier-stock-run.integration.test.ts
@@ -1,0 +1,172 @@
+import { eq } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Database } from "../src/db/client.js";
+import { supplierStock } from "../src/db/schema.js";
+import type { PageFetchResult } from "../src/modules/supplier-stock/page-fetcher.js";
+import { runSupplierStock } from "../src/modules/supplier-stock/run.js";
+import { withCleanDb } from "./helpers/db.js";
+import { insertTestVariant } from "./helpers/orders.js";
+
+// Žiadny test nesmie siahnuť na skutočnú stránku dodávateľa — sťahovanie je
+// vždy vlastná implementácia, nikdy `fetchSupplierPage`.
+const okPage = (html: string): PageFetchResult => ({ ok: true, html, httpStatus: 200, error: null });
+const failPage = (): PageFetchResult => ({ ok: false, html: "", httpStatus: null, error: "časový limit" });
+
+const IN_STOCK = `<script type="application/ld+json">
+  {"@type":"Product","offers":{"@type":"Offer","availability":"https://schema.org/InStock","price":"12,50"}}
+</script>`;
+const OUT_OF_STOCK = `<script type="application/ld+json">
+  {"@type":"Product","offers":{"@type":"Offer","availability":"https://schema.org/OutOfStock"}}
+</script>`;
+
+const NOW = new Date("2026-08-03T04:20:00.000Z");
+const noSleep = (): Promise<void> => Promise.resolve();
+
+describe("beh dodávateľského skladu", () => {
+  let db: Database;
+  let close: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ db, close } = await withCleanDb());
+  });
+  afterEach(async () => {
+    await close();
+  });
+
+  const row = async (link: string): Promise<typeof supplierStock.$inferSelect | undefined> => {
+    const [found] = await db.select().from(supplierStock).where(eq(supplierStock.link, link));
+    return found;
+  };
+
+  it("skontroluje každý odkaz z katalógu a zapíše dostupnosť aj cenu", async () => {
+    await insertTestVariant(db, "A1", "Dod 1", { internalNote: "https://huntingshop.eu/a" });
+    await insertTestVariant(db, "B1", "Dod 2", { internalNote: "Dodávateľ: X - https://wetland.sk/b" });
+
+    const result = await runSupplierStock({
+      db,
+      now: NOW,
+      sleep: noSleep,
+      fetchPage: (url) => Promise.resolve(okPage(url.includes("huntingshop") ? IN_STOCK : OUT_OF_STOCK)),
+    });
+
+    expect(result).toMatchObject({ total: 2, checked: 2, available: 1, unavailable: 1, failed: 0 });
+    const a = await row("https://huntingshop.eu/a");
+    expect(a?.availability).toBe("available");
+    expect(a?.price).toBe("12.50");
+    expect(a?.confirmedAt).not.toBeNull();
+    expect((await row("https://wetland.sk/b"))?.availability).toBe("unavailable");
+  });
+
+  it("produkt bez odkazu na dodávateľa sa vôbec nekontroluje", async () => {
+    await insertTestVariant(db, "C1", "Dod 3", { internalNote: "Soxland (bez odkazu)" });
+
+    const result = await runSupplierStock({ db, now: NOW, sleep: noSleep, fetchPage: () => Promise.resolve(okPage(IN_STOCK)) });
+
+    expect(result.total).toBe(0);
+    expect(result.checked).toBe(0);
+  });
+
+  // Nečitateľná stránka NESMIE vyzerať ako potvrdenie — inak by automatizácia
+  // (issue 213) prepla produkt na základe dohadu.
+  it("nečitateľná stránka skončí ako „neviem\" a NEPOTVRDÍ dostupnosť", async () => {
+    await insertTestVariant(db, "D1", "Dod 4", { internalNote: "https://dogtrace.com/d" });
+
+    const result = await runSupplierStock({
+      db,
+      now: NOW,
+      sleep: noSleep,
+      fetchPage: () => Promise.resolve(okPage("<html><body>Popis produktu, žiadna dostupnosť</body></html>")),
+    });
+
+    expect(result.unknown).toBe(1);
+    const d = await row("https://dogtrace.com/d");
+    expect(d?.availability).toBe("unknown");
+    expect(d?.ok).toBe(true);
+    expect(d?.confirmedAt).toBeNull();
+  });
+
+  it("zlyhaná kontrola sa zapíše ako chyba, nie ako dostupnosť", async () => {
+    await insertTestVariant(db, "E1", "Dod 5", { internalNote: "https://huntingshop.eu/e" });
+
+    const result = await runSupplierStock({ db, now: NOW, sleep: noSleep, fetchPage: () => Promise.resolve(failPage()) });
+
+    expect(result.failed).toBe(1);
+    const e = await row("https://huntingshop.eu/e");
+    expect(e?.ok).toBe(false);
+    expect(e?.error).toBe("časový limit");
+    expect(e?.availability).toBe("unknown");
+  });
+
+  it("odkaz s čerstvým potvrdením sa znovu nesťahuje", async () => {
+    await insertTestVariant(db, "F1", "Dod 6", { internalNote: "https://huntingshop.eu/f" });
+    await runSupplierStock({ db, now: NOW, sleep: noSleep, fetchPage: () => Promise.resolve(okPage(IN_STOCK)) });
+
+    let volani = 0;
+    const oHodinuNeskor = new Date(NOW.getTime() + 3_600_000);
+    const result = await runSupplierStock({
+      db,
+      now: oHodinuNeskor,
+      sleep: noSleep,
+      fetchPage: () => {
+        volani += 1;
+        return Promise.resolve(okPage(IN_STOCK));
+      },
+    });
+
+    expect(volani).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.checked).toBe(0);
+  });
+
+  // Bez tohto by stránka, ktorá stabilne padá na časovom limite, ostala
+  // navždy „čerstvá" a nikdy by sa neskúsila znova.
+  it("odkaz so zlyhanou kontrolou sa skúsi znova, aj keď je zápis čerstvý", async () => {
+    await insertTestVariant(db, "G1", "Dod 7", { internalNote: "https://huntingshop.eu/g" });
+    await runSupplierStock({ db, now: NOW, sleep: noSleep, fetchPage: () => Promise.resolve(failPage()) });
+
+    const result = await runSupplierStock({
+      db,
+      now: new Date(NOW.getTime() + 60_000),
+      sleep: noSleep,
+      fetchPage: () => Promise.resolve(okPage(IN_STOCK)),
+    });
+
+    expect(result.checked).toBe(1);
+    expect((await row("https://huntingshop.eu/g"))?.availability).toBe("available");
+  });
+
+  // Výpadok siete nesmie zahodiť potvrdenie, ktoré má ešte platnosť —
+  // automatizácia (issue 213) ho nechá dožiť svoje 48 hodín a potom prestane.
+  it("zlyhanie po úspechu nechá staré potvrdenie dožiť, len ho neposunie", async () => {
+    await insertTestVariant(db, "H1", "Dod 8", { internalNote: "https://huntingshop.eu/h" });
+    await runSupplierStock({ db, now: NOW, sleep: noSleep, fetchPage: () => Promise.resolve(okPage(IN_STOCK)) });
+    const povodne = (await row("https://huntingshop.eu/h"))?.confirmedAt;
+
+    const neskor = new Date(NOW.getTime() + 25 * 3_600_000);
+    await runSupplierStock({ db, now: neskor, sleep: noSleep, fetchPage: () => Promise.resolve(failPage()) });
+
+    const h = await row("https://huntingshop.eu/h");
+    expect(h?.ok).toBe(false);
+    expect(h?.confirmedAt?.toISOString()).toBe(povodne?.toISOString());
+    expect(h?.checkedAt.toISOString()).toBe(neskor.toISOString());
+  });
+
+  it("tá istá linka na viacerých produktoch sa sťahuje len raz", async () => {
+    await insertTestVariant(db, "I1", "Dod 9", { internalNote: "https://huntingshop.eu/spolocna" });
+    await insertTestVariant(db, "I2", "Dod 9", { internalNote: "https://huntingshop.eu/spolocna" });
+
+    let volani = 0;
+    const result = await runSupplierStock({
+      db,
+      now: NOW,
+      sleep: noSleep,
+      fetchPage: () => {
+        volani += 1;
+        return Promise.resolve(okPage(IN_STOCK));
+      },
+    });
+
+    expect(result.total).toBe(1);
+    expect(volani).toBe(1);
+  });
+});

--- a/apps/web/src/components/NedostupneSection.test.tsx
+++ b/apps/web/src/components/NedostupneSection.test.tsx
@@ -162,9 +162,13 @@ async function otvorNahlad(): Promise<void> {
 it("Esc zavrie náhľad a nič neodošle", async () => {
   await otvorNahlad();
 
-  fireEvent.keyDown(document, { key: "Escape" });
-
+  // Poslucháč klávesu Esc sa registruje v `useEffect` dialógu — ten je PASÍVNY
+  // efekt, takže po tom, čo sa dialóg objaví v DOM-e, ešte nemusí byť
+  // zaregistrovaný. Jediné stlačenie Esc hneď po zobrazení preto vie prehrať
+  // preteky (lokálne prechádzalo, v CI spadlo). Opakované stlačenie vnútri
+  // `waitFor` je deterministické: skúša, kým poslucháč nezačne fungovať.
   await waitFor(() => {
+    fireEvent.keyDown(document, { key: "Escape" });
     expect(screen.queryByTestId("nedostupne-preview")).toBeNull();
   });
   expect(sendNedostupneEmail).not.toHaveBeenCalled();

--- a/apps/web/src/components/RestockSection.test.tsx
+++ b/apps/web/src/components/RestockSection.test.tsx
@@ -1,0 +1,116 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { RestockSection } from "./RestockSection.js";
+
+const { fetchRestockStatus, runRestockNow, setRestockEnabled } = vi.hoisted(() => ({
+  fetchRestockStatus: vi.fn(),
+  runRestockNow: vi.fn(),
+  setRestockEnabled: vi.fn(),
+}));
+
+vi.mock("../restockApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../restockApi.js")>();
+  return { ...actual, fetchRestockStatus, runRestockNow, setRestockEnabled };
+});
+
+const STATUS = {
+  enabled: false,
+  maxPerRun: 50,
+  waiting: { now: 12, overLimit: 0 },
+  events: [
+    {
+      id: "e1",
+      at: "2026-08-04T04:50:00.000Z",
+      variantCode: "40237/L",
+      pairCode: "77",
+      productName: "Nohavice FOREST",
+      supplier: "Huntingshop",
+      supplierLink: "https://huntingshop.eu/nohavice",
+      supplierAvailabilityText: "skladom",
+      supplierPrice: "59.90",
+      confirmedAt: "2026-08-04T04:20:00.000Z",
+    },
+  ],
+  lastRun: {
+    startedAt: "2026-08-04T04:50:00.000Z",
+    finishedAt: "2026-08-04T04:52:00.000Z",
+    status: "success" as const,
+    errorMessage: null,
+    result: { status: "ok" as const, switched: 1, overLimit: 0, codes: ["40237/L"] },
+    skippedReason: null,
+  },
+};
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+// Majiteľ: "bude to tam vydno ze to funguje a ze to prepina produkty" — tabuľka
+// prepnutých produktov je celý zmysel tejto obrazovky.
+it("ukáže, ktoré produkty automatizácia prepla", async () => {
+  fetchRestockStatus.mockResolvedValue(STATUS);
+  render(<RestockSection role="admin" onSessionExpired={vi.fn()} />);
+
+  const riadok = await screen.findByTestId("restock-event-40237/L");
+  expect(riadok.textContent).toContain("Nohavice FOREST");
+  expect(riadok.textContent).toContain("Huntingshop");
+  expect(screen.getByRole("link", { name: "skladom" }).getAttribute("href")).toBe(
+    "https://huntingshop.eu/nohavice",
+  );
+});
+
+it("ukáže, koľko produktov čaká na najbližší beh", async () => {
+  fetchRestockStatus.mockResolvedValue(STATUS);
+  render(<RestockSection role="admin" onSessionExpired={vi.fn()} />);
+
+  expect((await screen.findByTestId("restock-waiting")).textContent).toContain("12");
+});
+
+it("pri prekročení stropu napíše, koľko ich čaká navyše", async () => {
+  fetchRestockStatus.mockResolvedValue({ ...STATUS, waiting: { now: 50, overLimit: 130 } });
+  render(<RestockSection role="admin" onSessionExpired={vi.fn()} />);
+
+  expect((await screen.findByTestId("restock-waiting")).textContent).toContain("130");
+});
+
+it("Štart/Stop prepne automatizáciu a znovu načíta stav", async () => {
+  fetchRestockStatus.mockResolvedValue(STATUS);
+  setRestockEnabled.mockResolvedValue(true);
+  render(<RestockSection role="admin" onSessionExpired={vi.fn()} />);
+
+  fireEvent.click(await screen.findByTestId("restock-toggle"));
+
+  await waitFor(() => {
+    expect(setRestockEnabled).toHaveBeenCalledWith(true);
+  });
+  await waitFor(() => {
+    expect(fetchRestockStatus).toHaveBeenCalledTimes(2);
+  });
+});
+
+// Zlyhanie zápisu do Shoptetu sa NESMIE tváriť ako úspech — obsluha musí
+// vidieť, že sa nič nepreplo.
+it("po zlyhaní zápisu povie, že sa nič neprepínalo", async () => {
+  fetchRestockStatus.mockResolvedValue(STATUS);
+  runRestockNow.mockResolvedValue({
+    status: "failed",
+    attempted: 3,
+    overLimit: 0,
+    errorDetail: "prihlásenie zlyhalo",
+  });
+  render(<RestockSection role="admin" onSessionExpired={vi.fn()} />);
+
+  fireEvent.click(await screen.findByTestId("restock-run-now"));
+
+  expect((await screen.findByRole("status")).textContent).toContain("Nič sa nepreplo");
+});
+
+it("role „čítanie\" ovládacie tlačidlá neponúkne", async () => {
+  fetchRestockStatus.mockResolvedValue(STATUS);
+  render(<RestockSection role="citanie" onSessionExpired={vi.fn()} />);
+
+  expect(await screen.findByTestId("restock-status-pill")).toBeTruthy();
+  expect(screen.queryByTestId("restock-toggle")).toBeNull();
+  expect(screen.queryByTestId("restock-run-now")).toBeNull();
+});

--- a/apps/web/src/components/RestockSection.tsx
+++ b/apps/web/src/components/RestockSection.tsx
@@ -1,0 +1,189 @@
+import { useCallback, useEffect, useState, type JSX } from "react";
+import type { Me } from "../api.js";
+import {
+  fetchRestockStatus,
+  RestockUnauthorizedError,
+  runRestockNow,
+  setRestockEnabled,
+  type RestockStatus,
+} from "../restockApi.js";
+
+// Rovnaké dve role, ktoré server vyžaduje pre Štart/Stop + "Spustiť teraz"
+// (`requireRole("admin", "manazer")`, `restock-routes.ts`).
+const CONTROL_ROLES: ReadonlySet<Me["role"]> = new Set(["admin", "manazer"]);
+
+function formatDateTime(iso: string): string {
+  const date = new Date(iso);
+  return Number.isNaN(date.getTime()) ? "—" : date.toLocaleString("sk-SK");
+}
+
+export function RestockSection({
+  role,
+  onSessionExpired,
+}: {
+  readonly role: Me["role"];
+  readonly onSessionExpired: () => void;
+}): JSX.Element {
+  const [status, setStatus] = useState<RestockStatus | null>(null);
+  const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState("");
+  const [toggleBusy, setToggleBusy] = useState(false);
+  const [runBusy, setRunBusy] = useState(false);
+  const [runNotice, setRunNotice] = useState("");
+  const canControl = CONTROL_ROLES.has(role);
+
+  const load = useCallback(() => {
+    fetchRestockStatus()
+      .then((s) => {
+        setStatus(s);
+        setLoaded(true);
+      })
+      .catch((err: unknown) => {
+        setLoaded(true);
+        if (err instanceof RestockUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setError("Prepínanie sa nepodarilo načítať.");
+      });
+  }, [onSessionExpired]);
+
+  useEffect(load, [load]);
+
+  const toggle = useCallback(() => {
+    if (status === null) return;
+    setToggleBusy(true);
+    setRestockEnabled(!status.enabled)
+      .then(load)
+      .catch((err: unknown) => {
+        if (err instanceof RestockUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setError(err instanceof Error ? err.message : "Zmena sa nepodarila.");
+      })
+      .finally(() => {
+        setToggleBusy(false);
+      });
+  }, [status, load, onSessionExpired]);
+
+  const runNow = useCallback(() => {
+    setRunBusy(true);
+    setRunNotice("");
+    runRestockNow()
+      .then((result) => {
+        if (result.status === "ok") {
+          setRunNotice(
+            result.overLimit > 0
+              ? `Prepnutých ${String(result.switched)} produktov, ďalších ${String(result.overLimit)} čaká na ďalší beh (strop).`
+              : `Prepnutých ${String(result.switched)} produktov.`,
+          );
+        } else if (result.status === "nothing_to_do") {
+          setRunNotice("Nebolo čo prepnúť — žiadny vypredaný produkt nemá čerstvé potvrdenie od dodávateľa.");
+        } else {
+          setRunNotice(`Zápis do Shoptetu zlyhal (${result.errorDetail}). Nič sa nepreplo, skúsi sa znova.`);
+        }
+        load();
+      })
+      .catch((err: unknown) => {
+        if (err instanceof RestockUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setError(err instanceof Error ? err.message : "Beh sa nepodarilo spustiť.");
+      })
+      .finally(() => {
+        setRunBusy(false);
+      });
+  }, [load, onSessionExpired]);
+
+  if (!loaded) return <p role="status">Načítavam…</p>;
+  if (status === null) return <p role="alert">{error === "" ? "Nepodarilo sa načítať." : error}</p>;
+
+  const { enabled, maxPerRun, waiting, events, lastRun } = status;
+
+  return (
+    <div data-testid="restock-section">
+      {error !== "" && <p role="alert">{error}</p>}
+
+      <p>
+        Keď dodávateľ dostane tovar naspäť na sklad, náš vypredaný produkt sa sám prepne na
+        „Skladom". Prepne sa najviac {maxPerRun} produktov za jeden beh; zvyšok počká na ďalšiu noc.
+        Produkty, ktoré si vedome vypol (viditeľné len cez priamy odkaz, skryté, s ukončeným
+        predajom), sa neprepnú nikdy.
+      </p>
+
+      <div className="autohead">
+        <span className={"pill" + (enabled ? "" : " off")} data-testid="restock-status-pill">
+          {enabled ? "Beží" : "Zastavené"}
+        </span>
+        {canControl && (
+          <button type="button" className="btn sm" disabled={toggleBusy} onClick={toggle} data-testid="restock-toggle">
+            {enabled ? "⏹ Stop" : "▶️ Štart"}
+          </button>
+        )}
+        {canControl && (
+          <button
+            type="button"
+            className="btn sm ghost"
+            disabled={runBusy}
+            onClick={runNow}
+            data-testid="restock-run-now"
+          >
+            {runBusy ? "Prepínam…" : "⚡ Spustiť teraz"}
+          </button>
+        )}
+        <span className="chip" data-testid="restock-waiting">
+          Pripravených na prepnutie: {waiting.now}
+          {waiting.overLimit > 0 && ` (+${String(waiting.overLimit)} nad strop)`}
+        </span>
+      </div>
+
+      {lastRun !== null && (
+        <p data-testid="restock-last-run">
+          Posledný beh: {formatDateTime(lastRun.startedAt)} —{" "}
+          {lastRun.status === "failure"
+            ? "❌ chyba"
+            : lastRun.skippedReason !== null
+              ? `⏸ ${lastRun.skippedReason}`
+              : "✅ OK"}
+        </p>
+      )}
+      {runNotice !== "" && <p role="status">{runNotice}</p>}
+
+      <div className="card">
+        <h3>Prepnuté produkty</h3>
+        {events.length === 0 ? (
+          <p className="empty">Zatiaľ nič — automatizácia ešte nič neprepla.</p>
+        ) : (
+          <table>
+            <thead>
+              <tr>
+                <th scope="col">Kedy</th>
+                <th scope="col">Kód</th>
+                <th scope="col">Názov</th>
+                <th scope="col">Dodávateľ</th>
+                <th scope="col">Čo dodávateľ hlásil</th>
+              </tr>
+            </thead>
+            <tbody>
+              {events.map((event) => (
+                <tr key={event.id} data-testid={`restock-event-${event.variantCode}`}>
+                  <td>{formatDateTime(event.at)}</td>
+                  <td>{event.variantCode}</td>
+                  <td>{event.productName}</td>
+                  <td>{event.supplier ?? "—"}</td>
+                  <td>
+                    <a href={event.supplierLink} target="_blank" rel="noreferrer noopener">
+                      {event.supplierAvailabilityText === "" ? "skladom" : event.supplierAvailabilityText}
+                    </a>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/SupplierStockSection.test.tsx
+++ b/apps/web/src/components/SupplierStockSection.test.tsx
@@ -1,0 +1,131 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { SupplierStockSection } from "./SupplierStockSection.js";
+
+const { fetchSupplierStockStatus, runSupplierStockNow } = vi.hoisted(() => ({
+  fetchSupplierStockStatus: vi.fn(),
+  runSupplierStockNow: vi.fn(),
+}));
+
+// `SupplierStockUnauthorizedError` ostáva SKUTOČNÁ trieda — `instanceof`
+// v komponente musí fungovať (rovnaký dôvod ako `NedostupneSection.test.tsx`).
+vi.mock("../supplierStockApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../supplierStockApi.js")>();
+  return { ...actual, fetchSupplierStockStatus, runSupplierStockNow };
+});
+
+const { SupplierStockUnauthorizedError } = await import("../supplierStockApi.js");
+
+const STATUS = {
+  overview: {
+    total: 238,
+    available: 120,
+    unavailable: 90,
+    unknown: 20,
+    failed: 8,
+    lastCheckedAt: "2026-08-03T04:20:00.000Z",
+  },
+  rows: [
+    {
+      link: "https://huntingshop.eu/bunda",
+      host: "huntingshop.eu",
+      availability: "available" as const,
+      availabilityText: "skladom",
+      price: "129.90",
+      source: "text" as const,
+      ok: true,
+      error: null,
+      httpStatus: 200,
+      checkedAt: "2026-08-03T04:20:00.000Z",
+      confirmedAt: "2026-08-03T04:20:00.000Z",
+    },
+  ],
+  unreadable: [{ host: "dogtrace.com", count: 2, samples: ["https://dogtrace.com/obojok"] }],
+  lastRun: {
+    startedAt: "2026-08-03T04:20:00.000Z",
+    finishedAt: "2026-08-03T04:41:00.000Z",
+    status: "success" as const,
+    errorMessage: null,
+    result: {
+      total: 238,
+      skipped: 10,
+      checked: 228,
+      available: 120,
+      unavailable: 90,
+      unknown: 20,
+      failed: 8,
+      hosts: ["huntingshop.eu"],
+    },
+  },
+};
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+it("zobrazí prehľad dostupnosti u dodávateľov", async () => {
+  fetchSupplierStockStatus.mockResolvedValue(STATUS);
+  render(<SupplierStockSection role="admin" onSessionExpired={vi.fn()} />);
+
+  expect((await screen.findByTestId("ss-total")).textContent).toContain("238");
+  expect(screen.getByTestId("ss-available").textContent).toContain("120");
+  expect(screen.getByTestId("ss-unknown").textContent).toContain("20");
+  expect(screen.getByTestId("ss-failed").textContent).toContain("8");
+});
+
+// Karta nečitateľných stránok je VÝSLOVNÁ požiadavka majiteľa namiesto AI
+// (3. 8. 2026) — bez nej sa nedá rozhodnúť, pre ktorého dodávateľa sa oplatí
+// dorobiť čítanie ručne.
+it("ukáže domény, ktoré sa nedarí prečítať, aj s ukážkovým odkazom", async () => {
+  fetchSupplierStockStatus.mockResolvedValue(STATUS);
+  render(<SupplierStockSection role="admin" onSessionExpired={vi.fn()} />);
+
+  const karta = await screen.findByTestId("ss-unreadable");
+  expect(karta.textContent).toContain("dogtrace.com");
+  expect(karta.textContent).toContain("2");
+  expect(screen.getByRole("link", { name: "https://dogtrace.com/obojok" })).toBeTruthy();
+});
+
+it("bez nečitateľných stránok povie, že je všetko v poriadku", async () => {
+  fetchSupplierStockStatus.mockResolvedValue({ ...STATUS, unreadable: [] });
+  render(<SupplierStockSection role="admin" onSessionExpired={vi.fn()} />);
+
+  expect((await screen.findByTestId("ss-unreadable")).textContent).toContain("Zatiaľ žiadne");
+});
+
+it("„Spustiť teraz\" spustí kontrolu a znovu načíta prehľad", async () => {
+  fetchSupplierStockStatus.mockResolvedValue(STATUS);
+  runSupplierStockNow.mockResolvedValue(STATUS.lastRun.result);
+  render(<SupplierStockSection role="admin" onSessionExpired={vi.fn()} />);
+
+  fireEvent.click(await screen.findByTestId("ss-run-now"));
+
+  await waitFor(() => {
+    expect(runSupplierStockNow).toHaveBeenCalledTimes(1);
+  });
+  await waitFor(() => {
+    expect(fetchSupplierStockStatus).toHaveBeenCalledTimes(2);
+  });
+  expect((await screen.findByRole("status")).textContent).toContain("Skontrolovaných 228");
+});
+
+// Rola „čítanie" smie prehľad VIDIEŤ, ale nesmie spúšťať kontrolu —
+// server to vynucuje `requireRole("admin", "manazer")`, UI to len zrkadlí.
+it("role „čítanie\" tlačidlo na spustenie neponúkne, prehľad áno", async () => {
+  fetchSupplierStockStatus.mockResolvedValue(STATUS);
+  render(<SupplierStockSection role="citanie" onSessionExpired={vi.fn()} />);
+
+  expect((await screen.findByTestId("ss-total")).textContent).toContain("238");
+  expect(screen.queryByTestId("ss-run-now")).toBeNull();
+});
+
+it("vypršaná relácia odhlási, nezobrazí chybu", async () => {
+  const onSessionExpired = vi.fn();
+  fetchSupplierStockStatus.mockRejectedValue(new SupplierStockUnauthorizedError());
+  render(<SupplierStockSection role="admin" onSessionExpired={onSessionExpired} />);
+
+  await waitFor(() => {
+    expect(onSessionExpired).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/SupplierStockSection.tsx
+++ b/apps/web/src/components/SupplierStockSection.tsx
@@ -1,0 +1,211 @@
+import { useCallback, useEffect, useState, type JSX } from "react";
+import type { Me } from "../api.js";
+import {
+  fetchSupplierStockStatus,
+  runSupplierStockNow,
+  SupplierStockUnauthorizedError,
+  type SupplierAvailability,
+  type SupplierStockStatus,
+} from "../supplierStockApi.js";
+
+// Rovnaké dve role, ktoré server vyžaduje pre "Spustiť teraz"
+// (`requireRole("admin", "manazer")`, `supplier-stock-routes.ts`) — prehľad
+// smie vidieť KAŽDÝ prihlásený zamestnanec, preto sa množina používa len na
+// skrytie tlačidla, nikdy celej obrazovky.
+const CONTROL_ROLES: ReadonlySet<Me["role"]> = new Set(["admin", "manazer"]);
+
+const AVAILABILITY_LABEL: Readonly<Record<SupplierAvailability, string>> = {
+  available: "Skladom",
+  unavailable: "Vypredané",
+  unknown: "Neviem",
+};
+
+function formatDateTime(iso: string | null): string {
+  if (iso === null) return "—";
+  const date = new Date(iso);
+  return Number.isNaN(date.getTime()) ? "—" : date.toLocaleString("sk-SK");
+}
+
+export function SupplierStockSection({
+  role,
+  onSessionExpired,
+}: {
+  readonly role: Me["role"];
+  readonly onSessionExpired: () => void;
+}): JSX.Element {
+  const [status, setStatus] = useState<SupplierStockStatus | null>(null);
+  const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState("");
+  const [runBusy, setRunBusy] = useState(false);
+  const [runNotice, setRunNotice] = useState("");
+  const canControl = CONTROL_ROLES.has(role);
+
+  const load = useCallback(() => {
+    fetchSupplierStockStatus()
+      .then((s) => {
+        setStatus(s);
+        setLoaded(true);
+      })
+      .catch((err: unknown) => {
+        setLoaded(true);
+        if (err instanceof SupplierStockUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setError("Dodávateľský sklad sa nepodarilo načítať.");
+      });
+  }, [onSessionExpired]);
+
+  useEffect(load, [load]);
+
+  const runNow = useCallback(() => {
+    setRunBusy(true);
+    setRunNotice("");
+    runSupplierStockNow()
+      .then((result) => {
+        setRunNotice(
+          `Skontrolovaných ${String(result.checked)} odkazov · skladom ${String(result.available)} · vypredané ${String(result.unavailable)} · neviem ${String(result.unknown)} · zlyhalo ${String(result.failed)}.`,
+        );
+        load();
+      })
+      .catch((err: unknown) => {
+        if (err instanceof SupplierStockUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setError(err instanceof Error ? err.message : "Beh sa nepodarilo spustiť.");
+      })
+      .finally(() => {
+        setRunBusy(false);
+      });
+  }, [load, onSessionExpired]);
+
+  if (!loaded) return <p role="status">Načítavam…</p>;
+  if (status === null) return <p role="alert">{error === "" ? "Nepodarilo sa načítať." : error}</p>;
+
+  const { overview, unreadable, rows, lastRun } = status;
+
+  return (
+    <div data-testid="supplier-stock-section">
+      {error !== "" && <p role="alert">{error}</p>}
+
+      <p>
+        Každú noc sa skontroluje, či dodávatelia majú tovar skladom. Údaj sa číta priamo zo stránky
+        dodávateľa — čo sa prečítať nedá, ostáva ako <strong>Neviem</strong> a nikdy nič neprepne.
+      </p>
+
+      <div className="autohead">
+        <span className="chip" data-testid="ss-total">
+          Sledovaných odkazov: {overview.total}
+        </span>
+        <span className="chip" data-testid="ss-available">
+          Skladom: {overview.available}
+        </span>
+        <span className="chip" data-testid="ss-unavailable">
+          Vypredané: {overview.unavailable}
+        </span>
+        <span className="chip" data-testid="ss-unknown">
+          Neviem: {overview.unknown}
+        </span>
+        <span className="chip" data-testid="ss-failed">
+          Zlyhalo: {overview.failed}
+        </span>
+        {canControl && (
+          <button
+            type="button"
+            className="btn sm ghost"
+            disabled={runBusy}
+            onClick={runNow}
+            data-testid="ss-run-now"
+          >
+            {runBusy ? "Kontrolujem…" : "⚡ Spustiť teraz"}
+          </button>
+        )}
+      </div>
+
+      <p data-testid="ss-last-checked">Naposledy kontrolované: {formatDateTime(overview.lastCheckedAt)}</p>
+      {lastRun !== null && (
+        <p data-testid="ss-last-run">
+          Posledný beh: {formatDateTime(lastRun.startedAt)} —{" "}
+          {lastRun.status === "failure" ? "❌ chyba" : lastRun.status === "running" ? "⏳ beží" : "✅ OK"}
+          {lastRun.errorMessage !== null && ` (${lastRun.errorMessage})`}
+        </p>
+      )}
+      {runNotice !== "" && <p role="status">{runNotice}</p>}
+
+      {/* Výslovná požiadavka majiteľa (3. 8. 2026) namiesto AI: nech je vidno,
+          ktoré stránky sa prečítať nedajú, aby sa dalo rozhodnúť, pre ktorého
+          dodávateľa sa oplatí dorobiť čítanie ručne. */}
+      <div className="card" data-testid="ss-unreadable">
+        <h3>Stránky, ktoré neviem prečítať</h3>
+        {unreadable.length === 0 ? (
+          <p className="empty">Zatiaľ žiadne — všetky sledované odkazy sa darí prečítať.</p>
+        ) : (
+          <table>
+            <thead>
+              <tr>
+                <th scope="col">Dodávateľ</th>
+                <th scope="col">Odkazov</th>
+                <th scope="col">Ukážky</th>
+              </tr>
+            </thead>
+            <tbody>
+              {unreadable.map((host) => (
+                <tr key={host.host} data-testid={`ss-unreadable-${host.host}`}>
+                  <td>{host.host}</td>
+                  <td>{host.count}</td>
+                  <td>
+                    {host.samples.map((link) => (
+                      <div key={link}>
+                        <a href={link} target="_blank" rel="noreferrer noopener">
+                          {link}
+                        </a>
+                      </div>
+                    ))}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      <div className="card">
+        <h3>Sledované odkazy</h3>
+        {rows.length === 0 ? (
+          <p className="empty">Zatiaľ nič — kontrola ešte nebežala.</p>
+        ) : (
+          <table>
+            <thead>
+              <tr>
+                <th scope="col">Dodávateľ</th>
+                <th scope="col">Odkaz</th>
+                <th scope="col">Dostupnosť</th>
+                <th scope="col">Cena</th>
+                <th scope="col">Kontrolované</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr key={row.link} data-testid={`ss-row-${row.link}`}>
+                  <td>{row.host}</td>
+                  <td>
+                    <a href={row.link} target="_blank" rel="noreferrer noopener">
+                      {row.link}
+                    </a>
+                  </td>
+                  <td>
+                    {row.ok ? AVAILABILITY_LABEL[row.availability] : "Kontrola zlyhala"}
+                    {row.availabilityText !== "" && ` (${row.availabilityText})`}
+                  </td>
+                  <td>{row.price === null ? "—" : `${row.price} €`}</td>
+                  <td>{formatDateTime(row.checkedAt)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/nav.test.ts
+++ b/apps/web/src/nav.test.ts
@@ -8,13 +8,15 @@ import { DEFAULT_TAB_ID, HIDDEN_TABS, NAV, findTab, isVisibleTabId } from "./nav
 // pridalo "Texty e-mailov" do Systému (nastavenie spoločné pre VŠETKY
 // automatizácie). Tento test je
 // najbližšie k tomu, čo strojovo overiť dá (registrácia, nie DOM).
-it("NAV má tri priečinky (Systém/Eshop/Automatizácie), s 2/2/3 záložkami v poradí podľa dôležitosti", () => {
+it("NAV má tri priečinky (Systém/Eshop/Automatizácie), s 3/2/3 záložkami v poradí podľa dôležitosti", () => {
   expect(NAV).toHaveLength(3);
   expect(NAV.map((f) => f.label)).toEqual(["Systém", "Eshop", "Automatizácie"]);
-  expect(NAV[0]?.tabs).toHaveLength(2);
+  expect(NAV[0]?.tabs).toHaveLength(3);
   expect(NAV[1]?.tabs).toHaveLength(2);
   expect(NAV[2]?.tabs).toHaveLength(3);
-  expect(NAV[0]?.tabs.map((t) => t.label)).toEqual(["Sync zo Shoptetu", "Texty e-mailov"]);
+  // issue 212: "Dodávateľský sklad" — scraper dostupnosti u dodávateľa;
+  // patrí do Systému (zadanie majiteľa), nie medzi Automatizácie.
+  expect(NAV[0]?.tabs.map((t) => t.label)).toEqual(["Sync zo Shoptetu", "Texty e-mailov", "Dodávateľský sklad"]);
   expect(NAV[1]?.tabs.map((t) => t.label)).toEqual(["Na objednanie", "Nedostupné tovary"]);
   // issue 193: "Odoslané e-maily" — prehľad toho, čo automatizácie poslali.
   expect(NAV[2]?.tabs.map((t) => t.label)).toEqual([

--- a/apps/web/src/nav.test.ts
+++ b/apps/web/src/nav.test.ts
@@ -8,18 +8,20 @@ import { DEFAULT_TAB_ID, HIDDEN_TABS, NAV, findTab, isVisibleTabId } from "./nav
 // pridalo "Texty e-mailov" do Systému (nastavenie spoločné pre VŠETKY
 // automatizácie). Tento test je
 // najbližšie k tomu, čo strojovo overiť dá (registrácia, nie DOM).
-it("NAV má tri priečinky (Systém/Eshop/Automatizácie), s 3/2/3 záložkami v poradí podľa dôležitosti", () => {
+it("NAV má tri priečinky (Systém/Eshop/Automatizácie), s 3/2/4 záložkami v poradí podľa dôležitosti", () => {
   expect(NAV).toHaveLength(3);
   expect(NAV.map((f) => f.label)).toEqual(["Systém", "Eshop", "Automatizácie"]);
   expect(NAV[0]?.tabs).toHaveLength(3);
   expect(NAV[1]?.tabs).toHaveLength(2);
-  expect(NAV[2]?.tabs).toHaveLength(3);
+  expect(NAV[2]?.tabs).toHaveLength(4);
   // issue 212: "Dodávateľský sklad" — scraper dostupnosti u dodávateľa;
   // patrí do Systému (zadanie majiteľa), nie medzi Automatizácie.
   expect(NAV[0]?.tabs.map((t) => t.label)).toEqual(["Sync zo Shoptetu", "Texty e-mailov", "Dodávateľský sklad"]);
   expect(NAV[1]?.tabs.map((t) => t.label)).toEqual(["Na objednanie", "Nedostupné tovary"]);
   // issue 193: "Odoslané e-maily" — prehľad toho, čo automatizácie poslali.
   expect(NAV[2]?.tabs.map((t) => t.label)).toEqual([
+    // issue 213: prepínanie vypredaných produktov späť na skladom.
+    "Vypredané → Skladom",
     "Nevyzdvihnuté zásielky",
     "Pripomienky objednávok",
     "Odoslané e-maily",

--- a/apps/web/src/nav.ts
+++ b/apps/web/src/nav.ts
@@ -8,6 +8,7 @@ import { OrderReminderSection } from "./components/OrderReminderSection.js";
 import { OrdersSection } from "./components/OrdersSection.js";
 import { PairingSection } from "./components/PairingSection.js";
 import { PostaUncollectedSection } from "./components/PostaUncollectedSection.js";
+import { RestockSection } from "./components/RestockSection.js";
 import { SchedulerSection } from "./components/SchedulerSection.js";
 import { SupplierStockSection } from "./components/SupplierStockSection.js";
 import { SyncSection } from "./components/SyncSection.js";
@@ -91,6 +92,10 @@ export const NAV: readonly NavFolder[] = [
     // potrebne statistiky komu sa poslal mail"). `wide: true` ako pri
     // ostatných hustých pracovných tabuľkách.
     tabs: [
+      // issue 213: automatické zapínanie vypredaných produktov, ktoré
+      // dodávateľ zase má skladom — beží na plán a má Štart/Stop, takže
+      // patrí sem, nie do Systému (tam je len scraper, ktorý nič neprepína).
+      { id: "restock", label: "Vypredané → Skladom", icon: "🔁", Component: RestockSection, wide: true },
       { id: "posta-uncollected", label: "Nevyzdvihnuté zásielky", icon: "📮", Component: PostaUncollectedSection },
       { id: "order-reminder", label: "Pripomienky objednávok", icon: "⏰", Component: OrderReminderSection },
       { id: "mail-log", label: "Odoslané e-maily", icon: "📨", Component: MailLogSection, wide: true },

--- a/apps/web/src/nav.ts
+++ b/apps/web/src/nav.ts
@@ -9,6 +9,7 @@ import { OrdersSection } from "./components/OrdersSection.js";
 import { PairingSection } from "./components/PairingSection.js";
 import { PostaUncollectedSection } from "./components/PostaUncollectedSection.js";
 import { SchedulerSection } from "./components/SchedulerSection.js";
+import { SupplierStockSection } from "./components/SupplierStockSection.js";
 import { SyncSection } from "./components/SyncSection.js";
 
 // Spoločný tvar props pre KAŽDÚ obrazovku registrovanú tu — presne to, čo dnes
@@ -61,6 +62,10 @@ export const NAV: readonly NavFolder[] = [
     tabs: [
       { id: "sync", label: "Sync zo Shoptetu", icon: "🔄", Component: SyncSection },
       { id: "mail-templates", label: "Texty e-mailov", icon: "✉️", Component: MailTemplatesSection, wide: true },
+      // issue 212: scraper dostupnosti u dodávateľa — patrí do Systému
+      // (majiteľ: "scrapera ktoreho chcem v zalozke system"), nie medzi
+      // Automatizácie: nič neprepína, len zbiera údaje pre issue 213.
+      { id: "supplier-stock", label: "Dodávateľský sklad", icon: "🏭", Component: SupplierStockSection, wide: true },
     ],
   },
   {

--- a/apps/web/src/restockApi.ts
+++ b/apps/web/src/restockApi.ts
@@ -1,0 +1,105 @@
+import { z } from "zod";
+
+// issue 213: "Vypredané → Skladom" — zrkadlí `GET /api/restock`
+// (`apps/api/src/http/restock-routes.ts`).
+
+const eventSchema = z.object({
+  id: z.string(),
+  at: z.string(),
+  variantCode: z.string(),
+  pairCode: z.string().nullable(),
+  productName: z.string(),
+  supplier: z.string().nullable(),
+  supplierLink: z.string(),
+  supplierAvailabilityText: z.string(),
+  supplierPrice: z.string().nullable(),
+  confirmedAt: z.string(),
+});
+export type RestockEvent = z.infer<typeof eventSchema>;
+
+const runResultSchema = z.union([
+  z.object({ status: z.literal("nothing_to_do"), overLimit: z.number() }),
+  z.object({
+    status: z.literal("ok"),
+    switched: z.number(),
+    overLimit: z.number(),
+    codes: z.array(z.string()),
+  }),
+  z.object({
+    status: z.literal("failed"),
+    attempted: z.number(),
+    overLimit: z.number(),
+    errorDetail: z.string(),
+  }),
+]);
+export type RestockRunResult = z.infer<typeof runResultSchema>;
+
+const statusSchema = z.object({
+  enabled: z.boolean(),
+  maxPerRun: z.number(),
+  waiting: z.object({ now: z.number(), overLimit: z.number() }),
+  events: z.array(eventSchema),
+  lastRun: z
+    .object({
+      startedAt: z.string(),
+      finishedAt: z.string().nullable(),
+      status: z.enum(["running", "success", "failure"]),
+      errorMessage: z.string().nullable(),
+      result: runResultSchema.nullable(),
+      skippedReason: z.string().nullable(),
+    })
+    .nullable(),
+});
+export type RestockStatus = z.infer<typeof statusSchema>;
+
+const setEnabledResultSchema = z.object({ ok: z.literal(true), enabled: z.boolean() });
+const runNowResultSchema = z.union([
+  z.object({ ok: z.literal(true), result: runResultSchema }),
+  z.object({ ok: z.literal(false), error: z.string() }),
+]);
+
+export class RestockUnauthorizedError extends Error {
+  constructor() {
+    super("Neprihlásený");
+  }
+}
+
+const errorBodySchema = z.object({ error: z.string() });
+
+async function serverErrorMessage(response: Response, fallback: string): Promise<string> {
+  try {
+    const parsed = errorBodySchema.safeParse(await response.json());
+    if (parsed.success) return parsed.data.error;
+  } catch {
+    // telo nie je platný JSON — použi všeobecnú hlášku
+  }
+  return fallback;
+}
+
+async function readJson(response: Response, fallback: string): Promise<unknown> {
+  if (response.status === 401) throw new RestockUnauthorizedError();
+  if (!response.ok) throw new Error(await serverErrorMessage(response, fallback));
+  return await response.json();
+}
+
+export async function fetchRestockStatus(): Promise<RestockStatus> {
+  const response = await fetch("/api/restock");
+  return statusSchema.parse(await readJson(response, "Prepínanie sa nepodarilo načítať"));
+}
+
+export async function setRestockEnabled(enabled: boolean): Promise<boolean> {
+  const response = await fetch("/api/restock/enabled", {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ enabled }),
+  });
+  const parsed = setEnabledResultSchema.parse(await readJson(response, "Zmena sa nepodarila"));
+  return parsed.enabled;
+}
+
+export async function runRestockNow(): Promise<RestockRunResult> {
+  const response = await fetch("/api/restock/run-now", { method: "POST" });
+  const parsed = runNowResultSchema.parse(await readJson(response, "Beh sa nepodarilo spustiť"));
+  if (!parsed.ok) throw new Error(parsed.error);
+  return parsed.result;
+}

--- a/apps/web/src/supplierStockApi.ts
+++ b/apps/web/src/supplierStockApi.ts
@@ -1,0 +1,105 @@
+import { z } from "zod";
+
+// issue 212: "Dodávateľský sklad" — zrkadlí `GET /api/supplier-stock`
+// (`apps/api/src/http/supplier-stock-routes.ts`).
+
+const availabilitySchema = z.enum(["available", "unavailable", "unknown"]);
+export type SupplierAvailability = z.infer<typeof availabilitySchema>;
+
+const rowSchema = z.object({
+  link: z.string(),
+  host: z.string(),
+  availability: availabilitySchema,
+  availabilityText: z.string(),
+  price: z.string().nullable(),
+  source: z.enum(["json_ld", "meta", "text", "none"]),
+  ok: z.boolean(),
+  error: z.string().nullable(),
+  httpStatus: z.number().nullable(),
+  checkedAt: z.string(),
+  confirmedAt: z.string().nullable(),
+});
+export type SupplierStockRow = z.infer<typeof rowSchema>;
+
+const unreadableSchema = z.object({
+  host: z.string(),
+  count: z.number(),
+  samples: z.array(z.string()),
+});
+export type UnreadableHost = z.infer<typeof unreadableSchema>;
+
+const runResultSchema = z.object({
+  total: z.number(),
+  skipped: z.number(),
+  checked: z.number(),
+  available: z.number(),
+  unavailable: z.number(),
+  unknown: z.number(),
+  failed: z.number(),
+  hosts: z.array(z.string()),
+});
+export type SupplierStockRunResult = z.infer<typeof runResultSchema>;
+
+const statusSchema = z.object({
+  overview: z.object({
+    total: z.number(),
+    available: z.number(),
+    unavailable: z.number(),
+    unknown: z.number(),
+    failed: z.number(),
+    lastCheckedAt: z.string().nullable(),
+  }),
+  rows: z.array(rowSchema),
+  unreadable: z.array(unreadableSchema),
+  lastRun: z
+    .object({
+      startedAt: z.string(),
+      finishedAt: z.string().nullable(),
+      status: z.enum(["running", "success", "failure"]),
+      errorMessage: z.string().nullable(),
+      result: runResultSchema.nullable(),
+    })
+    .nullable(),
+});
+export type SupplierStockStatus = z.infer<typeof statusSchema>;
+
+const runNowResultSchema = z.union([
+  z.object({ ok: z.literal(true), result: runResultSchema }),
+  z.object({ ok: z.literal(false), error: z.string() }),
+]);
+
+export class SupplierStockUnauthorizedError extends Error {
+  constructor() {
+    super("Neprihlásený");
+  }
+}
+
+const errorBodySchema = z.object({ error: z.string() });
+
+async function serverErrorMessage(response: Response, fallback: string): Promise<string> {
+  try {
+    const parsed = errorBodySchema.safeParse(await response.json());
+    if (parsed.success) return parsed.data.error;
+  } catch {
+    // telo nie je platný JSON — použi všeobecnú hlášku
+  }
+  return fallback;
+}
+
+async function readJson(response: Response, fallback: string): Promise<unknown> {
+  if (response.status === 401) throw new SupplierStockUnauthorizedError();
+  if (!response.ok) throw new Error(await serverErrorMessage(response, fallback));
+  return await response.json();
+}
+
+export async function fetchSupplierStockStatus(): Promise<SupplierStockStatus> {
+  const response = await fetch("/api/supplier-stock");
+  return statusSchema.parse(await readJson(response, "Dodávateľský sklad sa nepodarilo načítať"));
+}
+
+export async function runSupplierStockNow(): Promise<SupplierStockRunResult> {
+  const response = await fetch("/api/supplier-stock/run-now", { method: "POST" });
+  const parsed = runNowResultSchema.parse(await readJson(response, "Beh sa nepodarilo spustiť"));
+  if (!parsed.ok) throw new Error(parsed.error);
+  return parsed.result;
+}

--- a/apps/web/tests/e2e/nav.spec.ts
+++ b/apps/web/tests/e2e/nav.spec.ts
@@ -15,7 +15,7 @@ const E2E_NAV_EMAIL = "e2e-nav@forestshop.sk";
 // tretí priečinok "Automatizácie" s tromi hotovými obrazovkami, dovtedy len v
 // `HIDDEN_TABS` bez odkazu v menu — tento test teraz overuje VŠETKÝCH PÄŤ
 // záložiek v troch priečinkoch.
-test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) so šiestimi záložkami, klik prepne obrazovku, panel sa zbalí do lišty a stav si pamätá, konzola je čistá", async ({
+test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s deviatimi záložkami, klik prepne obrazovku, panel sa zbalí do lišty a stav si pamätá, konzola je čistá", async ({
   page,
 }) => {
   const chyby: string[] = [];
@@ -37,7 +37,7 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) so šiestimi
   await expect(page.getByRole("button", { name: "Automatizácie" })).toBeVisible();
 
   // Presne šesť záložiek v CELOM menu.
-  await expect(page.locator(".side-nav .tab")).toHaveCount(7);
+  await expect(page.locator(".side-nav .tab")).toHaveCount(9);
   await expect(page.getByRole("button", { name: "Sync zo Shoptetu" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Texty e-mailov" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Na objednanie" })).toBeVisible();
@@ -116,7 +116,7 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) so šiestimi
 
   // Hlavičky priečinkov zmiznú, ikony všetkých šiestich modulov ostanú.
   await expect(page.getByRole("button", { name: "Systém" })).toHaveCount(0);
-  await expect(page.locator(".side-nav .tab")).toHaveCount(7);
+  await expect(page.locator(".side-nav .tab")).toHaveCount(9);
   // Názov sa v lište ukáže bublinou pri prejdení myšou.
   await expect(page.getByRole("button", { name: "Na objednanie" })).toHaveAttribute(
     "title",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.122",
+  "version": "0.3.0-dev.123",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Druhá a posledná časť automatického zapínania produktov. Návrh:
`docs/superpowers/specs/2026-08-03-automaticke-zapinanie-produktov-design.md`.

## Obrazovka Dodávateľský sklad (issue 212)

Systém → Dodávateľský sklad: prehľad dostupnosti (sledované odkazy, skladom,
vypredané, neviem, zlyhalo), zoznam sledovaných odkazov, tlačidlo „Spustiť
teraz" a samostatná karta **„Stránky, ktoré neviem prečítať"** — výslovná
požiadavka majiteľa namiesto AI, aby bolo vidieť, pre ktorého dodávateľa sa
oplatí dorobiť čítanie ručne.

Osem integračných testov behu, vrátane tých, ktoré chránia prepínanie nižšie:
nečitateľná stránka nepotvrdí dostupnosť, zlyhaná kontrola sa skúsi znova a
výpadok siete nechá staré potvrdenie dožiť bez posunutia.

## Automatizácia Vypredané → Skladom (issue 213)

Kandidát musí spĺňať **všetko naraz**: náš stav vypredané, viditeľnosť presne
`visible`, variant nechýba z exportu, a dodávateľ ho má potvrdene skladom nie
staršie než 48 hodín. `detailOnly`, skryté, blokované a ukončené produkty sa
neprepnú **nikdy** — to je hlavná bezpečnostná podmienka a má vlastný test.

Zápis ide existujúcou Playwright cestou cez `buildRestockCsv` (spoločná ochrana
proti CSV injection). Obe polia dostupnosti sa nastavujú naraz, inak sa po
dopredaní fiktívnych kusov vráti staré „Vypredané".

Rozhodnutia majiteľa z 3. 8. 2026: prepína samo každú noc (04:50 UTC, po
scraperi o 04:20), strop **50 prepnutí za beh**, bez AI. Štart/Stop prepínač,
záznam o každom prepnutí a obrazovka v Automatizáciách s tabuľkou prepnutých
produktov.

Jedenásť integračných testov výberu kandidátov; šťastná cesta je medzi nimi,
takže zamietavé testy nie sú tautológia.

## Opravené popri tom

- Nová tabuľka chýbala v čistení testovacej databázy — riadky prežívali medzi
  celými behmi a druhý beh preskočil všetky odkazy.
- Esc test v Nedostupných stláčal klávesu raz hneď po zobrazení dialógu, ale
  poslucháč sa registruje v pasívnom efekte: lokálne prechádzal, v CI spadol.

Automatizácia je po nasadení **vypnutá** — zapína ju majiteľ tlačidlom Štart.
Ani jeden ticket sa tu nezatvára automaticky, oba majú overenie až po nasadení.
