### PR TITLE
Overovacia obrazovka: zoznam čakajúcich na prepnutie s odkazmi

### DIFF
--- a/.claude/rules/supplier-stock.md
+++ b/.claude/rules/supplier-stock.md
@@ -1,0 +1,57 @@
+---
+paths:
+  - "apps/api/src/modules/supplier-stock/**"
+  - "apps/api/src/modules/restock/**"
+  - "apps/api/src/http/supplier-stock-routes.ts"
+  - "apps/api/src/http/restock-routes.ts"
+  - "apps/web/src/supplierStockApi.ts"
+  - "apps/web/src/restockApi.ts"
+  - "apps/web/src/components/SupplierStockSection*.tsx"
+  - "apps/web/src/components/RestockSection*.tsx"
+  - "apps/api/tests/supplier-stock-*.test.ts"
+  - "apps/api/tests/restock-*.test.ts"
+---
+
+# Dodávateľský sklad a prepínanie Vypredané → Skladom (issues 212, 213)
+
+- **`detailOnly` má ROVNAKÝ `variant.state` ako bežné vypredané — vylúčiť sa
+  dá JEDINE cez `variant.product_visibility`.** `HIDDEN_VISIBILITIES`
+  (`catalog/availability.ts`) `detailOnly` zámerne NEobsahuje (taký produkt sa
+  dá kúpiť cez priamy odkaz, nie je to „ukončený predaj"). Zmerané na
+  produkcii pri nasadení #213: 25 variantov `detailOnly` spĺňalo VŠETKY
+  ostatné podmienky prepnutia a vylúčila ich jedine kontrola
+  `product_visibility = 'visible'` — bez nej by sa zapli. Každá ďalšia
+  automatizácia, ktorá niečo ZAPÍNA, potrebuje tú istú podmienku; `state`
+  sám nestačí.
+- **`supplier_stock.confirmed_at` je NIEČO INÉ než `checked_at` a
+  automatizácia sa smie pozerať LEN naň.** `checked_at` je čas posledného
+  POKUSU (aj neúspešného) a riadi preskakovanie čerstvých odkazov;
+  `confirmed_at` je čas posledného ÚSPEŠNÉHO určenia dostupnosti. Keby sa
+  čerstvosť potvrdenia merala podľa `checked_at`, opakovane zlyhávajúca
+  kontrola by donekonečna predlžovala platnosť dávno neaktuálneho „skladom".
+  Z rovnakého dôvodu zlyhaná kontrola `confirmed_at` NEPREPÍŠE na `null` —
+  staré potvrdenie má dožiť svojich 48 h, nie zmiznúť pri prvom výpadku siete.
+- **`unknown` (stránka sa načítala, ale nič sa z nej nedalo vyčítať) NIE JE
+  chýbajúci údaj, ale plnohodnotná odpoveď — a nikdy nesmie nič prepnúť.**
+  Majiteľ 3. 8. 2026 výslovne zamietol AI dohady (stará appka posielala
+  nečitateľné stránky do OpenAI): čo sa nedá prečítať strojovo, sa ukáže v
+  karte „Stránky, ktoré neviem prečítať" a čaká na ľudské rozhodnutie.
+- **Voľnému textu stránky sa dôveruje LEN na doménach v `TRUSTED_TEXT_HOSTS`.**
+  Slovo „Skladom" sa na cudzej stránke môže vyskytnúť v pätičke, v menu alebo
+  pri inom produkte. Pridanie novej domény do zoznamu vyžaduje overenie na
+  uloženej vzorke tej stránky, nikdy len domnienku.
+- **Obe polia dostupnosti sa do Shoptetu zapisujú NARAZ.** Shoptet zobrazuje
+  `availabilityOutOfStock` v momente, keď sklad klesne na nulu, takže zápis
+  len do `availabilityInStock` nechá po dopredaní fiktívnych kusov naskočiť
+  staré „Vypredané" (overené v ostrej prevádzke starej appky 14. 7. 2026).
+  Preto aj kladný `stock` — pri nule je prepnutie bez efektu.
+- **Nová cesta zápisu CSV do Shoptetu patrí do `shoptet-writeback/csv.ts`, aj
+  keď má úplne iné stĺpce** (`buildRestockCsv` vedľa `buildWritebackCsv`) —
+  ochrana proti CSV injection (`dataRowToLine`) musí platiť pre KAŽDÚ cestu,
+  nikdy sa stĺpce neskladajú mimo tohto modulu.
+- **Nová tabuľka MUSÍ pribudnúť do `TRUNCATE` zoznamu v
+  `tests/helpers/db.ts`, inak testy zlyhajú AŽ pri druhom behu.** Pri #212 to
+  bolo obzvlášť zákerné: prvý beh prešiel (prázdna tabuľka), druhý beh našiel
+  vlastné čerstvé zápisy z prvého behu, vyhodnotil ich ako platné potvrdenia
+  a preskočil VŠETKY odkazy — testy padli na „skipped 2, checked 0" bez
+  akejkoľvek zmeny kódu.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,4 +90,6 @@ Per-area rules live in `.claude/rules/<area>.md` with `paths:` frontmatter.
 - Pripomienky objednávok (AI klasifikácia poznámky, terminálna rezolúcia, override→job_run relocate) → `.claude/rules/order-reminder.md`
 - Nedostupné tovary (návrh náhrady, jednorazový preview token, žiadny scheduler) → `.claude/rules/nedostupne.md`
 - Texty e-mailov (F192 — upraviteľné šablóny, zástupné polia, strop prihlásení v e2e) → `.claude/rules/mail-templates.md`
+- dodávateľský sklad + prepínanie Vypredané → Skladom (#212/#213 — detailOnly, confirmed_at,
+  žiadne AI dohady) → `.claude/rules/supplier-stock.md`
 - Kniha odoslaných e-mailov (F193 — jediná odosielacia cesta, dedup okno preskočení) → `.claude/rules/mail-log.md`

--- a/apps/api/src/http/restock-routes.ts
+++ b/apps/api/src/http/restock-routes.ts
@@ -7,7 +7,7 @@ import { jobRuns, restockEvents } from "../db/schema.js";
 import { log } from "../logger.js";
 import { record } from "../modules/audit/service.js";
 import { MAX_PER_RUN, RESTOCK_JOB_NAME } from "../modules/restock/constants.js";
-import { selectRestockCandidates } from "../modules/restock/queries.js";
+import { listRestockWaiting, selectRestockCandidates } from "../modules/restock/queries.js";
 import type { RestockRunResult, RunRestockOptions } from "../modules/restock/run.js";
 import { isRestockEnabled, runRestock, setRestockEnabled } from "../modules/restock/run.js";
 import { getLatestJobRun } from "../modules/scheduler/queries.js";
@@ -15,6 +15,14 @@ import { requireRole, requireUser, type AppBindings } from "./middleware.js";
 import { requireSameOrigin } from "./origin-check.js";
 
 const setEnabledBody = z.object({ enabled: z.boolean() });
+
+// Strop stránky drží odpoveď v rozumnej veľkosti aj keď si niekto adresu
+// upraví ručne — kandidátov sú tisíce.
+const waitingQuery = z.object({
+  limit: z.coerce.number().int().min(1).max(200).default(50),
+  offset: z.coerce.number().int().min(0).default(0),
+  supplier: z.string().max(200).optional(),
+});
 
 // HTTP vrstva dodá `db`/`now`; zvyšok (prihlasovacie údaje do Shoptetu)
 // zostavuje `index.ts` raz pri štarte — rovnaký vzor ako ostatné automatizácie.
@@ -86,6 +94,20 @@ export function registerRestockRoutes(app: Hono<AppBindings>, db: Database, deps
                   : null,
             },
     });
+  });
+
+  // Overovací zoznam (issue 217) — majiteľ si chce vzorku ručne preklikať skôr,
+  // než automatizáciu pustí. Literál `/waiting` nemá pod `/api/restock` žiadneho
+  // `:param` súrodenca, takže poradie registrácie tu nič nerozbíja
+  // (`.claude/rules/http-routes.md`).
+  app.get("/api/restock/waiting", requireUser(db), zValidator("query", waitingQuery), async (c) => {
+    const { limit, offset, supplier } = c.req.valid("query");
+    const page = await listRestockWaiting(db, new Date(), {
+      limit,
+      offset,
+      ...(supplier === undefined || supplier === "" ? {} : { supplier }),
+    });
+    return c.json(page);
   });
 
   // Štart/Stop gate-uje LEN naplánovaný nočný beh (`scheduler/jobs.ts`'s

--- a/apps/api/src/modules/restock/queries.ts
+++ b/apps/api/src/modules/restock/queries.ts
@@ -31,6 +31,21 @@ export interface RestockCandidates {
   readonly overLimit: number;
 }
 
+export interface RestockSupplierCount {
+  readonly name: string;
+  readonly count: number;
+}
+
+export interface RestockWaitingPage {
+  /** Koľko kandidátov zostáva po filtri (nie veľkosť stránky). */
+  readonly total: number;
+  readonly rows: readonly RestockCandidate[];
+  /** Dodávatelia s počtami cez CELÝ zoznam, nikdy len cez stránku. */
+  readonly suppliers: readonly RestockSupplierCount[];
+}
+
+const NO_SUPPLIER_LABEL = "(bez dodávateľa)";
+
 /**
  * Kandidát musí spĺňať VŠETKO naraz:
  *  - náš stav je `out_of_stock` (vypredané) — už predajný variant sa
@@ -50,11 +65,7 @@ export interface RestockCandidates {
  * Každý `code` sa vráti najviac raz — Shoptet zruší CELÝ import pri
  * duplicitnom kóde a katalóg obsahuje produkty zdieľajúce kódy variantov.
  */
-export async function selectRestockCandidates(
-  db: Database,
-  now: Date,
-  limit = MAX_PER_RUN,
-): Promise<RestockCandidates> {
+async function allRestockCandidates(db: Database, now: Date): Promise<readonly RestockCandidate[]> {
   const oldestAcceptable = new Date(now.getTime() - CONFIRMATION_MAX_AGE_HOURS * 3_600_000);
 
   // Linka sa z `internal_note` vyberá TÝM ISTÝM spôsobom ako v scraperi
@@ -101,9 +112,53 @@ export async function selectRestockCandidates(
     seen.add(row.variantCode);
     unique.push({ ...row, confirmedAt: row.confirmedAt });
   }
+  return unique;
+}
 
+export async function selectRestockCandidates(
+  db: Database,
+  now: Date,
+  limit = MAX_PER_RUN,
+): Promise<RestockCandidates> {
+  const unique = await allRestockCandidates(db, now);
   return {
     picked: unique.slice(0, limit),
     overLimit: Math.max(0, unique.length - limit),
+  };
+}
+
+/**
+ * Overovací zoznam pre majiteľa (issue 217) — presne tí istí kandidáti, ktorých
+ * by prepli nasledujúce behy, len bez stropu a po stránkach.
+ *
+ * Zámerne stavia na tej istej `allRestockCandidates`, nie na vlastnej kópii
+ * podmienok: zoznam, podľa ktorého sa človek rozhoduje, sa nesmie rozísť s tým,
+ * čo automatizácia naozaj urobí.
+ */
+export async function listRestockWaiting(
+  db: Database,
+  now: Date,
+  options: { readonly limit: number; readonly offset: number; readonly supplier?: string },
+): Promise<RestockWaitingPage> {
+  const unique = await allRestockCandidates(db, now);
+
+  const counts = new Map<string, number>();
+  for (const row of unique) {
+    const name = row.supplier ?? NO_SUPPLIER_LABEL;
+    counts.set(name, (counts.get(name) ?? 0) + 1);
+  }
+  const suppliers = [...counts]
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name, "sk"));
+
+  const filtered =
+    options.supplier === undefined
+      ? unique
+      : unique.filter((row) => (row.supplier ?? NO_SUPPLIER_LABEL) === options.supplier);
+
+  return {
+    total: filtered.length,
+    rows: filtered.slice(options.offset, options.offset + options.limit),
+    suppliers,
   };
 }

--- a/apps/api/tests/restock-run.integration.test.ts
+++ b/apps/api/tests/restock-run.integration.test.ts
@@ -4,7 +4,7 @@ import type { Database } from "../src/db/client.js";
 import { products, restockEvents, supplierStock, variants } from "../src/db/schema.js";
 import type { ShoptetImportConfig } from "../src/modules/shoptet-writeback/config.js";
 import { runRestock, setRestockEnabled } from "../src/modules/restock/run.js";
-import { selectRestockCandidates } from "../src/modules/restock/queries.js";
+import { listRestockWaiting, selectRestockCandidates } from "../src/modules/restock/queries.js";
 import { insertTestSnapshot } from "./helpers/catalog.js";
 import { withCleanDb } from "./helpers/db.js";
 
@@ -200,6 +200,40 @@ describe("prepínanie Vypredané → Skladom", () => {
 
     expect(result).toMatchObject({ status: "failed", attempted: 1 });
     expect(await db.select().from(restockEvents)).toHaveLength(0);
+  });
+
+  // issue 217 — overovací zoznam pre majiteľa. Kľúčová vlastnosť: musí ukazovať
+  // PRESNE to, čo automatizácia prepne, len bez stropu a po stránkach.
+  it("overovací zoznam ukáže aj kandidátov nad stropom a spočíta dodávateľov", async () => {
+    await seedSupplierStock();
+    for (let i = 0; i < 5; i += 1) await seedVariant(`W${String(i)}`);
+
+    const prva = await listRestockWaiting(db, NOW, { limit: 2, offset: 0 });
+    expect(prva.total).toBe(5);
+    expect(prva.rows).toHaveLength(2);
+    expect(prva.suppliers).toEqual([{ name: "Dodávateľ", count: 5 }]);
+
+    const druha = await listRestockWaiting(db, NOW, { limit: 2, offset: 2 });
+    expect(druha.rows.map((r) => r.variantCode)).not.toEqual(prva.rows.map((r) => r.variantCode));
+  });
+
+  it("overovací zoznam filtruje podľa dodávateľa", async () => {
+    await seedSupplierStock();
+    await seedVariant("X1");
+    await db.update(products).set({ supplier: "Iný" }).where(eq(products.key, "prod-X1"));
+    await seedVariant("X2");
+
+    expect((await listRestockWaiting(db, NOW, { limit: 50, offset: 0, supplier: "Iný" })).total).toBe(1);
+    expect((await listRestockWaiting(db, NOW, { limit: 50, offset: 0, supplier: "Dodávateľ" })).total).toBe(1);
+  });
+
+  // Zoznam, podľa ktorého sa majiteľ rozhoduje, sa nesmie rozísť s výberom
+  // nočného behu — inak by overil jedno a prepli by sa iné produkty.
+  it("overovací zoznam vylučuje detailOnly rovnako ako samotné prepínanie", async () => {
+    await seedSupplierStock();
+    await seedVariant("Y1", { productVisibility: "detailOnly" });
+
+    expect((await listRestockWaiting(db, NOW, { limit: 50, offset: 0 })).total).toBe(0);
   });
 
   it("bez kandidátov do Shoptetu vôbec nesiahne", async () => {

--- a/apps/web/src/components/RestockSection.test.tsx
+++ b/apps/web/src/components/RestockSection.test.tsx
@@ -1,17 +1,40 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { afterEach, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { RestockSection } from "./RestockSection.js";
 
-const { fetchRestockStatus, runRestockNow, setRestockEnabled } = vi.hoisted(() => ({
-  fetchRestockStatus: vi.fn(),
-  runRestockNow: vi.fn(),
-  setRestockEnabled: vi.fn(),
-}));
+const { fetchRestockStatus, fetchRestockWaiting, runRestockNow, setRestockEnabled } = vi.hoisted(
+  () => ({
+    fetchRestockStatus: vi.fn(),
+    fetchRestockWaiting: vi.fn(),
+    runRestockNow: vi.fn(),
+    setRestockEnabled: vi.fn(),
+  }),
+);
 
 vi.mock("../restockApi.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../restockApi.js")>();
-  return { ...actual, fetchRestockStatus, runRestockNow, setRestockEnabled };
+  return { ...actual, fetchRestockStatus, fetchRestockWaiting, runRestockNow, setRestockEnabled };
 });
+
+const WAITING = {
+  total: 250,
+  rows: [
+    {
+      variantCode: "60542",
+      pairCode: null,
+      productName: "Ľadvinka SWEDTEAM GREEN",
+      supplier: "TTHUNT",
+      supplierLink: "https://tthunt.example/ladvinka",
+      supplierAvailabilityText: "skladom",
+      supplierPrice: "24.00",
+      confirmedAt: "2026-08-04T04:20:00.000Z",
+    },
+  ],
+  suppliers: [
+    { name: "BETALOV", count: 200 },
+    { name: "TTHUNT", count: 50 },
+  ],
+};
 
 const STATUS = {
   enabled: false,
@@ -40,6 +63,10 @@ const STATUS = {
     skippedReason: null,
   },
 };
+
+beforeEach(() => {
+  fetchRestockWaiting.mockResolvedValue(WAITING);
+});
 
 afterEach(() => {
   cleanup();
@@ -104,6 +131,51 @@ it("po zlyhaní zápisu povie, že sa nič neprepínalo", async () => {
   fireEvent.click(await screen.findByTestId("restock-run-now"));
 
   expect((await screen.findByRole("status")).textContent).toContain("Nič sa nepreplo");
+});
+
+// issue 217 — majiteľ: "link na nas produkt a link na produkt dodavatela …
+// potvaram si zo sto a overim". Oba odkazy vedľa seba sú celý zmysel karty.
+it("pri každom čakajúcom produkte ponúkne odkaz na náš eshop aj k dodávateľovi", async () => {
+  fetchRestockStatus.mockResolvedValue(STATUS);
+  render(<RestockSection role="admin" onSessionExpired={vi.fn()} />);
+
+  const riadok = await screen.findByTestId("restock-waiting-60542");
+  const odkazy = [...riadok.querySelectorAll("a")].map((a) => a.getAttribute("href"));
+  expect(odkazy).toEqual([
+    "https://www.forestshop.sk/vyhladavanie/?string=60542",
+    "https://tthunt.example/ladvinka",
+  ]);
+  // Nová karta — inak by preklikávanie zoznam pod rukami zavrelo.
+  expect([...riadok.querySelectorAll("a")].every((a) => a.getAttribute("target") === "_blank")).toBe(
+    true,
+  );
+});
+
+it("filter podľa dodávateľa načíta zoznam odznova od prvej stránky", async () => {
+  fetchRestockStatus.mockResolvedValue(STATUS);
+  render(<RestockSection role="admin" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("restock-waiting-60542");
+
+  fireEvent.click(await screen.findByTestId("restock-waiting-next"));
+  await waitFor(() => {
+    expect(fetchRestockWaiting).toHaveBeenLastCalledWith({ limit: 100, offset: 100, supplier: "" });
+  });
+
+  fireEvent.change(screen.getByTestId("restock-waiting-supplier"), { target: { value: "TTHUNT" } });
+  await waitFor(() => {
+    expect(fetchRestockWaiting).toHaveBeenLastCalledWith({
+      limit: 100,
+      offset: 0,
+      supplier: "TTHUNT",
+    });
+  });
+});
+
+it("ukáže, koľkátý úsek zo všetkých čakajúcich práve pozeráš", async () => {
+  fetchRestockStatus.mockResolvedValue(STATUS);
+  render(<RestockSection role="admin" onSessionExpired={vi.fn()} />);
+
+  expect((await screen.findByTestId("restock-waiting-range")).textContent).toContain("z 250");
 });
 
 it("role „čítanie\" ovládacie tlačidlá neponúkne", async () => {

--- a/apps/web/src/components/RestockSection.tsx
+++ b/apps/web/src/components/RestockSection.tsx
@@ -2,11 +2,18 @@ import { useCallback, useEffect, useState, type JSX } from "react";
 import type { Me } from "../api.js";
 import {
   fetchRestockStatus,
+  fetchRestockWaiting,
   RestockUnauthorizedError,
   runRestockNow,
   setRestockEnabled,
   type RestockStatus,
+  type RestockWaitingPage,
 } from "../restockApi.js";
+import { ourProductUrl } from "../shopLinks.js";
+
+// Majiteľ si chce vzorku preklikať po stovkách („potváram si zo sto a overím"),
+// takže stránka je 100 riadkov, nie tradičných 20.
+const PAGE_SIZE = 100;
 
 // Rovnaké dve role, ktoré server vyžaduje pre Štart/Stop + "Spustiť teraz"
 // (`requireRole("admin", "manazer")`, `restock-routes.ts`).
@@ -30,6 +37,9 @@ export function RestockSection({
   const [toggleBusy, setToggleBusy] = useState(false);
   const [runBusy, setRunBusy] = useState(false);
   const [runNotice, setRunNotice] = useState("");
+  const [waitingList, setWaitingList] = useState<RestockWaitingPage | null>(null);
+  const [supplier, setSupplier] = useState("");
+  const [offset, setOffset] = useState(0);
   const canControl = CONTROL_ROLES.has(role);
 
   const load = useCallback(() => {
@@ -49,6 +59,26 @@ export function RestockSection({
   }, [onSessionExpired]);
 
   useEffect(load, [load]);
+
+  useEffect(() => {
+    let current = true;
+    fetchRestockWaiting({ limit: PAGE_SIZE, offset, supplier })
+      .then((page) => {
+        // Odpoveď na starší filter nesmie prepísať novší zoznam.
+        if (current) setWaitingList(page);
+      })
+      .catch((err: unknown) => {
+        if (!current) return;
+        if (err instanceof RestockUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setError("Zoznam pripravených na prepnutie sa nepodarilo načítať.");
+      });
+    return () => {
+      current = false;
+    };
+  }, [offset, supplier, onSessionExpired]);
 
   const toggle = useCallback(() => {
     if (status === null) return;
@@ -177,6 +207,104 @@ export function RestockSection({
                     <a href={event.supplierLink} target="_blank" rel="noreferrer noopener">
                       {event.supplierAvailabilityText === "" ? "skladom" : event.supplierAvailabilityText}
                     </a>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      <div className="card" data-testid="restock-waiting-list">
+        <h3>Pripravené na prepnutie{waitingList === null ? "" : ` (${String(waitingList.total)})`}</h3>
+        <p>
+          Zoznam na ručné overenie: vľavo odkaz na náš produkt, vpravo na stránku dodávateľa.
+          Otvárajú sa do novej karty, takže zoznam ti pod rukami nezmizne.
+        </p>
+
+        <div className="autohead">
+          <label>
+            Dodávateľ:{" "}
+            <select
+              data-testid="restock-waiting-supplier"
+              value={supplier}
+              onChange={(e) => {
+                setSupplier(e.target.value);
+                setOffset(0);
+              }}
+            >
+              <option value="">Všetci</option>
+              {(waitingList?.suppliers ?? []).map((s) => (
+                <option key={s.name} value={s.name}>
+                  {s.name} ({s.count})
+                </option>
+              ))}
+            </select>
+          </label>
+          <button
+            type="button"
+            className="btn sm ghost"
+            disabled={offset === 0}
+            onClick={() => {
+              setOffset(Math.max(0, offset - PAGE_SIZE));
+            }}
+            data-testid="restock-waiting-prev"
+          >
+            ← Predošlých {PAGE_SIZE}
+          </button>
+          <button
+            type="button"
+            className="btn sm ghost"
+            disabled={waitingList === null || offset + PAGE_SIZE >= waitingList.total}
+            onClick={() => {
+              setOffset(offset + PAGE_SIZE);
+            }}
+            data-testid="restock-waiting-next"
+          >
+            Ďalších {PAGE_SIZE} →
+          </button>
+          {waitingList !== null && waitingList.total > 0 && (
+            <span className="chip" data-testid="restock-waiting-range">
+              {offset + 1}–{Math.min(offset + waitingList.rows.length, waitingList.total)} z {waitingList.total}
+            </span>
+          )}
+        </div>
+
+        {waitingList === null ? (
+          <p role="status">Načítavam zoznam…</p>
+        ) : waitingList.rows.length === 0 ? (
+          <p className="empty">Nič nečaká — žiadny vypredaný produkt nemá čerstvé potvrdenie od dodávateľa.</p>
+        ) : (
+          <table>
+            <thead>
+              <tr>
+                <th scope="col">Kód</th>
+                <th scope="col">Názov</th>
+                <th scope="col">Dodávateľ</th>
+                <th scope="col">Náš produkt</th>
+                <th scope="col">U dodávateľa</th>
+                <th scope="col">Čo hlási</th>
+              </tr>
+            </thead>
+            <tbody>
+              {waitingList.rows.map((row) => (
+                <tr key={row.variantCode} data-testid={`restock-waiting-${row.variantCode}`}>
+                  <td>{row.variantCode}</td>
+                  <td>{row.productName}</td>
+                  <td>{row.supplier ?? "—"}</td>
+                  <td>
+                    <a href={ourProductUrl(row.variantCode)} target="_blank" rel="noreferrer noopener">
+                      náš ↗
+                    </a>
+                  </td>
+                  <td>
+                    <a href={row.supplierLink} target="_blank" rel="noreferrer noopener">
+                      dodávateľ ↗
+                    </a>
+                  </td>
+                  <td>
+                    {row.supplierAvailabilityText === "" ? "skladom" : row.supplierAvailabilityText}
+                    {row.supplierPrice !== null && ` · ${row.supplierPrice}`}
                   </td>
                 </tr>
               ))}

--- a/apps/web/src/restockApi.ts
+++ b/apps/web/src/restockApi.ts
@@ -87,6 +87,39 @@ export async function fetchRestockStatus(): Promise<RestockStatus> {
   return statusSchema.parse(await readJson(response, "Prepínanie sa nepodarilo načítať"));
 }
 
+const waitingSchema = z.object({
+  total: z.number(),
+  rows: z.array(
+    z.object({
+      variantCode: z.string(),
+      pairCode: z.string().nullable(),
+      productName: z.string(),
+      supplier: z.string().nullable(),
+      supplierLink: z.string(),
+      supplierAvailabilityText: z.string(),
+      supplierPrice: z.string().nullable(),
+      confirmedAt: z.string(),
+    }),
+  ),
+  suppliers: z.array(z.object({ name: z.string(), count: z.number() })),
+});
+export type RestockWaitingPage = z.infer<typeof waitingSchema>;
+export type RestockWaitingRow = RestockWaitingPage["rows"][number];
+
+export async function fetchRestockWaiting(options: {
+  readonly limit: number;
+  readonly offset: number;
+  readonly supplier: string;
+}): Promise<RestockWaitingPage> {
+  const params = new URLSearchParams({
+    limit: String(options.limit),
+    offset: String(options.offset),
+  });
+  if (options.supplier !== "") params.set("supplier", options.supplier);
+  const response = await fetch(`/api/restock/waiting?${params.toString()}`);
+  return waitingSchema.parse(await readJson(response, "Zoznam sa nepodarilo načítať"));
+}
+
 export async function setRestockEnabled(enabled: boolean): Promise<boolean> {
   const response = await fetch("/api/restock/enabled", {
     method: "PUT",

--- a/apps/web/src/shopLinks.ts
+++ b/apps/web/src/shopLinks.ts
@@ -1,0 +1,14 @@
+// Odkaz na NÁŠ produkt na eshope (issue 217).
+//
+// Shoptet export nemá stĺpec s adresou produktu a `guid` je UUID, nie číselné
+// ID — z uložených dát sa teda priama adresa detailu poskladať nedá. Jediná
+// spoľahlivá cesta je vyhľadávanie podľa kódu produktu, overené naživo na
+// kódoch 60542, 1075 a 60515 (každý našiel svoj produkt).
+//
+// Cesta je slovenská: `/vyhledavani/` (česká podoba) vracia na tejto doméne
+// 404 — nezamieňať.
+const SEARCH_URL = "https://www.forestshop.sk/vyhladavanie/?string=";
+
+export function ourProductUrl(code: string): string {
+  return SEARCH_URL + encodeURIComponent(code);
+}

--- a/apps/web/tests/e2e/catalog.spec.ts
+++ b/apps/web/tests/e2e/catalog.spec.ts
@@ -24,9 +24,12 @@ test("manažér vidí stav katalógu, vyhľadá variant a konzola je čistá", a
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
+  // 36 = 35 riadkov fixtúry + 1 seedovaný kandidát na prepnutie ("PREP-1",
+  // issue 217, `scripts/e2e-setup.ts`). Je v stave `out_of_stock`, takže
+  // filtre "sellable"(6) a "missing"(1) nižšie zostávajú nezmenené.
   await expect(page.getByTestId("snapshot")).toContainText("Posledný import: prijatý");
-  await expect(page.getByTestId("counts")).toContainText("Variantov v katalógu (vrátane chýbajúcich): 35");
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 35");
+  await expect(page.getByTestId("counts")).toContainText("Variantov v katalógu (vrátane chýbajúcich): 36");
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 36");
 
   await page.getByLabel("Kód alebo názov").fill("40237/3XL");
   await page.getByRole("button", { name: "Hľadať" }).click();
@@ -46,7 +49,7 @@ test("filter podľa stavu zúži zoznam na predajné varianty", async ({ page })
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 35");
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 36");
   await page.getByLabel("Stav", { exact: true }).selectOption("sellable");
   await page.getByRole("button", { name: "Hľadať" }).click();
 
@@ -62,7 +65,7 @@ test("filter 'Chýbajúce' nájde presne označený variant a riadok ukazuje, od
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 35");
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 36");
   await page.getByLabel("Stav", { exact: true }).selectOption("missing");
   await page.getByRole("button", { name: "Hľadať" }).click();
 

--- a/apps/web/tests/e2e/restock-waiting.spec.ts
+++ b/apps/web/tests/e2e/restock-waiting.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "@playwright/test";
+
+const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
+const E2E_PREPINANIE_EMAIL = "e2e-prepinanie@forestshop.sk"; // musí sa zhodovať s hodnotou v scripts/e2e-setup.ts
+
+// issue 217 — majiteľ: "sprav mi jednoduchu webku kde si to rychlo overim,
+// link na nas produkt a link na produkt dodavatela". Test preto overuje presne
+// to, čo od obrazovky chce: nájsť čakajúci produkt a mať pri ňom OBA odkazy.
+test("zoznam pripravených na prepnutie ponúkne odkaz na náš produkt aj k dodávateľovi; konzola je čistá", async ({
+  page,
+}) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/");
+  await page.getByLabel("E-mail").fill(E2E_PREPINANIE_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+
+  // Obrazovka je dostupná z ľavého menu pod "Automatizácie".
+  await page.getByRole("button", { name: "Vypredané → Skladom" }).click();
+  await expect(page.getByTestId("restock-waiting-list")).toBeVisible();
+
+  // Seedovaný kandidát (`scripts/e2e-setup.ts`) — vypredaný, viditeľný,
+  // s čerstvým potvrdením dodávateľa.
+  const riadok = page.getByTestId("restock-waiting-PREP-1");
+  await expect(riadok).toBeVisible();
+  await expect(riadok).toContainText("E2E Bunda na prepnutie");
+
+  // Jadro zadania: odkaz na náš eshop (vyhľadanie podľa kódu) aj na dodávateľa,
+  // oba do novej karty, aby preklikávanie zoznam nezavrelo.
+  const nasOdkaz = riadok.getByRole("link", { name: "náš ↗" });
+  await expect(nasOdkaz).toHaveAttribute("href", "https://www.forestshop.sk/vyhladavanie/?string=PREP-1");
+  await expect(nasOdkaz).toHaveAttribute("target", "_blank");
+  const odkazDodavatela = riadok.getByRole("link", { name: "dodávateľ ↗" });
+  await expect(odkazDodavatela).toHaveAttribute("href", "https://huntingshop.eu/e2e-prepinanie");
+  await expect(odkazDodavatela).toHaveAttribute("target", "_blank");
+
+  // Filter podľa dodávateľa je pri tisíckach riadkov nutnosť — po jeho použití
+  // musí riadok ostať (patrí tomu dodávateľovi).
+  await page.getByTestId("restock-waiting-supplier").selectOption("DODAVATEL-PREPINANIE");
+  await expect(page.getByTestId("restock-waiting-PREP-1")).toBeVisible();
+
+  expect(chyby).toEqual([]);
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.123",
+  "version": "0.3.0-dev.124",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.124",
+  "version": "0.3.0-dev.125",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -9,7 +9,7 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { createDb } from "../apps/api/src/db/client.js";
-import { jobRuns, mailLog, orderLines, orderOpenStatuses, orderReminderSettings, orders, pairings, postaUncollectedSettings, users } from "../apps/api/src/db/schema.js";
+import { jobRuns, mailLog, orderLines, orderOpenStatuses, orderReminderSettings, orders, pairings, postaUncollectedSettings, products, supplierStock, users, variants } from "../apps/api/src/db/schema.js";
 import { CATALOG_IMPORT_JOB_NAME } from "../apps/api/src/modules/scheduler/jobs.js";
 import { hashPassword } from "../apps/api/src/modules/auth/passwords.js";
 import { ingestCatalog } from "../apps/api/src/modules/catalog/ingest.js";
@@ -154,6 +154,10 @@ const E2E_MAILY_EMAIL = "e2e-maily@forestshop.sk"; // musí sa zhodovať s hodno
 // spec súbor (`mail-log.spec.ts`) dostáva VLASTNÝ izolovaný účet.
 const E2E_KNIHA_EMAIL = "e2e-kniha@forestshop.sk"; // musí sa zhodovať s hodnotou v mail-log.spec.ts
 
+// issue 217: rovnaký mechanizmus a dôvod ako `E2E_KNIHA_EMAIL` vyššie — nový
+// spec súbor (`restock-waiting.spec.ts`) dostáva VLASTNÝ izolovaný účet.
+const E2E_PREPINANIE_EMAIL = "e2e-prepinanie@forestshop.sk"; // musí sa zhodovať s hodnotou v restock-waiting.spec.ts
+
 const { db, pool } = createDb();
 // Konštantný literál bez interpolácie — obyčajný reťazec je tu rovnako bezpečný
 // ako `sql` tagovaná šablóna (tú používa ekvivalentný apps/api/tests/helpers/db.ts),
@@ -179,7 +183,12 @@ const { db, pool } = createDb();
 // singleton id / kód objednávky, žiadny FK. "order_reminder_settings"/
 // "order_reminder_state" (issue 173) sú rovnaký prípad znova.
 await db.execute(
-  'TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, mail_template, mail_template_history RESTART IDENTITY CASCADE',
+  // "supplier_stock"/"restock_settings"/"restock_event" (issue 217) sú znova ten
+  // istý prípad — kľúčované odkazom / singleton id, žiadny FK do `variant`,
+  // takže CASCADE ich nikdy nestrhne. Bez nich by potvrdenia dodávateľa z
+  // PREDOŠLÉHO e2e behu prežili do ďalšieho (presne past popísaná v
+  // `.claude/rules/supplier-stock.md`, tam pre `tests/helpers/db.ts`).
+  'TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, mail_template, mail_template_history, supplier_stock, restock_settings, restock_event RESTART IDENTITY CASCADE',
 );
 // Rovnaký dôvod ako `tests/helpers/db.ts`: bez tohto by "Na objednanie" bolo
 // v CELOM e2e behu prázdne pre KAŽDÚ objednávku (žiadny nastavený otvorený
@@ -304,6 +313,12 @@ await db.insert(users).values({
 });
 await db.insert(users).values({
   email: E2E_KNIHA_EMAIL,
+  passwordHash: await hashPassword(E2E_HESLO),
+  displayName: "E2E Manažér",
+  role: "manazer",
+});
+await db.insert(users).values({
+  email: E2E_PREPINANIE_EMAIL,
   passwordHash: await hashPassword(E2E_HESLO),
   displayName: "E2E Manažér",
   role: "manazer",
@@ -605,6 +620,54 @@ await db.insert(mailLog).values({
   // Musí sa presne zhodovať s `DUPLICATE_REASON` (`modules/mail-log/
   // queries.ts`) — inak by súhrn "zabránené duplicity" ukázal nulu.
   reason: "už bolo odoslané skôr — druhý e-mail sa neposiela",
+});
+
+// issue 217: JEDEN kandidát na prepnutie „Vypredané → Skladom", aby overovacia
+// obrazovka mala naživo čo ukázať. Zámerne VLASTNÝ produkt + variant s kódom,
+// ktorý sa v žiadnom inom spec súbore nevyskytuje, a BEZ objednávkového riadku —
+// nepridáva teda nič do „Na objednanie" ani do parovania, kde iné testy počítajú
+// presné počty. `supplier_stock` je nová tabuľka, ktorú nesleduje žiadny iný test.
+const PREPINANIE_ODKAZ = "https://huntingshop.eu/e2e-prepinanie";
+// `vysledok.snapshotId` (import fixtúry vyššie) namiesto vlastného dopytu —
+// priamy import z "drizzle-orm" v `scripts/` hlási falošné `no-unsafe-*`
+// (`.claude/rules/testing.md`), takže sa mu tu vyhýbame úplne.
+const snapshotPrepinanie = vysledok.snapshotId;
+await db.insert(products).values({
+  key: "e2e-prepinanie",
+  name: "E2E Bunda na prepnutie",
+  supplier: "DODAVATEL-PREPINANIE",
+  internalNote: `Dodávateľ: ${PREPINANIE_ODKAZ}`,
+  firstSeenAt: teraz,
+  lastSeenAt: teraz,
+  lastSeenSnapshotId: snapshotPrepinanie,
+});
+await db.insert(variants).values({
+  code: "PREP-1",
+  productKey: "e2e-prepinanie",
+  guid: "e2e-prepinanie",
+  name: "E2E Bunda na prepnutie",
+  stock: 0,
+  availabilityInStockText: "Skladom",
+  availabilityOutOfStockText: "Vypredané",
+  availabilityText: "Vypredané",
+  productVisibility: "visible",
+  state: "out_of_stock",
+  firstSeenAt: teraz,
+  lastSeenAt: teraz,
+  lastSeenSnapshotId: snapshotPrepinanie,
+});
+await db.insert(supplierStock).values({
+  link: PREPINANIE_ODKAZ,
+  host: "huntingshop.eu",
+  availability: "available",
+  availabilityText: "skladom",
+  price: "49.90",
+  source: "json_ld",
+  ok: true,
+  httpStatus: 200,
+  checkedAt: teraz,
+  // Potvrdenie musí byť čerstvé (do 48 h), inak kandidát vypadne z výberu.
+  confirmedAt: new Date(teraz.getTime() - 3_600_000),
 });
 
 await pool.end();


### PR DESCRIPTION
Overovacia obrazovka pre automatizáciu „Vypredané → Skladom" (issue 217).

Majiteľ si chce vzorku produktov ručne preklikať skôr, než automatizáciu pustí — pri každom čakajúcom produkte je teraz odkaz na náš eshop aj na stránku dodávateľa vedľa seba, oba do novej karty.

**Čo pribudlo**

- `GET /api/restock/waiting` — stránkovaný zoznam kandidátov bez stropu 50, s filtrom podľa dodávateľa.
- Karta „Pripravené na prepnutie" v obrazovke Automatizácie → Vypredané → Skladom: kód, názov, dodávateľ, oba odkazy, čo dodávateľ hlási. Stránka 100 riadkov, filter podľa dodávateľa (naživo BETALOV 1212, WETLAND 677, TTHUNT 355).
- Zoznam stavia na tej istej funkcii výberu ako nočný beh — čo človek overí, sa nemôže rozísť s tým, čo sa prepne.

**Odkaz na náš produkt**

Shoptet export nemá stĺpec s adresou produktu a `guid` je UUID, nie číselné ID. Odkaz preto vedie cez vyhľadávanie podľa kódu (`/vyhladavanie/?string=<code>`) — overené naživo na kódoch 60542, 1075 a 60515. Česká cesta `/vyhledavani/` na tejto doméne vracia 404.

**Testy**

- 3 integračné (stránkovanie a počty dodávateľov, filter, vylúčenie `detailOnly` rovnako ako v nočnom behu).
- 3 komponentové (oba odkazy s `target="_blank"`, filter resetuje stránkovanie, rozsah „x–y z N").
- 1 e2e (`restock-waiting.spec.ts`, vlastný izolovaný účet + vlastný seedovaný kandidát).
- `scripts/e2e-setup.ts` doplnil `supplier_stock`/`restock_settings`/`restock_event` do TRUNCATE — bez toho by potvrdenia dodávateľa prežili z predošlého e2e behu.

Ticket sa zavrie ručne až po naživo overenom nasadení.
