### PR TITLE
Prázdny text dostupnosti nie je vypredané; zásoba do stavu nevstupuje

### DIFF
--- a/.claude/rules/catalog.md
+++ b/.claude/rules/catalog.md
@@ -26,6 +26,26 @@ paths:
   poradové číslo od Shoptetu a pri ~2 700 jednovariantných produktoch je prázdne.
   `code`-prefix pred prvou lomkou si ponecháva len odvodenie `sizeLabel`
   (`40237/3XL` → veľkosť `3XL`).
+- **`stock` NEVSTUPUJE do odvodenia stavu variantu a prázdny text dostupnosti
+  NIE JE vypredané (issue 219, zmerané na produkcii 4. 8. 2026).** Majiteľ v
+  Shoptete skladovú logistiku NEPOUŽÍVA a `negativeAmount = 1` je nastavené na
+  VŠETKÝCH 14 071 riadkoch exportu — zákazník teda produkt kúpi aj pri nulovej
+  či zápornej zásobe. Prázdna dostupnosť neznamená „vypredané", ale „produkt
+  nemá priradenú dostupnosť", takže Shoptet zobrazí PREDVOLENÚ — na tomto
+  e-shope zelené „Skladom" (naživo overené: `10-12106-087`, `10-11284-083`,
+  pončo Deerhunter Survivor → všetky `schema.org/InStock`; kontrolne
+  `60031/XXL` s textom „Vypredané" naozaj vracia `OutOfStock`). Pôvodné
+  pravidlo (prázdny text + `stock <= 0` → `out_of_stock`) označilo 6 793
+  variantov za vypredané a automatizácia „Vypredané → Skladom" ich ponúkla na
+  zapnutie, hoci sú bežne v predaji. **Test na KAŽDÉ ďalšie pravidlo
+  odvodzujúce niečo zo `stock`: over to na ŽIVEJ stránke produktu
+  (`schema.org/InStock`/`OutOfStock`), nie z hodnoty v exporte** — v tomto
+  obchode je zásoba dekoratívna.
+- **Rozdelenie textov dostupnosti na reálnom exporte** (viditeľné varianty,
+  4. 8. 2026 — užitočné pri každom ďalšom odhade „koľko toho je"): prázdny text
+  6 793, „Predaj výrobku skončil" 5 692, „Skladom" 512, „Vypredané" 145,
+  „Momentálne nedostupné" 18. Naozaj vypredaných viditeľných variantov je teda
+  153, nie tisíce.
 - **Dostupnosť je voľný text, nie číselník.** Reálne pozorované hodnoty: `Skladom`,
   `Skladem`, `Vypredané`, `Predaj výrobku skončil`, `Není skladem`,
   `Momentálne nedostupné`, `Dodanie 1-3 dni`, `Na dotaz`, `Predobjednávka`. Pôvodný

--- a/.claude/rules/supplier-stock.md
+++ b/.claude/rules/supplier-stock.md
@@ -49,6 +49,24 @@ paths:
   keď má úplne iné stĺpce** (`buildRestockCsv` vedľa `buildWritebackCsv`) —
   ochrana proti CSV injection (`dataRowToLine`) musí platiť pre KAŽDÚ cestu,
   nikdy sa stĺpce neskladajú mimo tohto modulu.
+- **Shoptet export NEMÁ stĺpec s adresou produktu a `guid` je UUID, nie číselné
+  ID — odkaz na náš vlastný produkt sa preto NEDÁ poskladať z uložených dát.**
+  Overené na hlavičke surového exportu (issue 217: v 260+ stĺpcoch nie je
+  `url`/`slug`/`link`, len `seoTitle` a kategórie porovnávačov). Jediná
+  spoľahlivá cesta je vyhľadávanie podľa kódu:
+  `https://www.forestshop.sk/vyhladavanie/?string=<code>` (`apps/web/src/
+  shopLinks.ts`) — **slovenská cesta; česká `/vyhledavani/` na tejto doméne
+  vracia 404.** Funguje aj pre variantový kód s lomítkom (`10125/41`
+  percent-encoded) — naživo overené, nájde ten istý produkt ako kód bez
+  veľkosti. Ak by niekedy pribudla potreba priameho odkazu na DETAIL, treba
+  najprv doplniť zdroj adresy (feed pre porovnávače alebo sitemapu), nie
+  hádať tvar URL z `guid`.
+- **Zoznam, podľa ktorého sa človek rozhoduje, MUSÍ stavať na tej istej funkcii
+  výberu ako samotný beh.** `listRestockWaiting` aj `selectRestockCandidates`
+  volajú spoločnú `allRestockCandidates` (`restock/queries.ts`) — druhá kópia
+  podmienok by sa skôr či neskôr rozišla a majiteľ by overil iné produkty, než
+  by sa naozaj prepli. Integračný test to drží (`overovací zoznam vylučuje
+  detailOnly rovnako ako samotné prepínanie`).
 - **Nová tabuľka MUSÍ pribudnúť do `TRUNCATE` zoznamu v
   `tests/helpers/db.ts`, inak testy zlyhajú AŽ pri druhom behu.** Pri #212 to
   bolo obzvlášť zákerné: prvý beh prešiel (prázdna tabuľka), druhý beh našiel

--- a/.claude/rules/supplier-stock.md
+++ b/.claude/rules/supplier-stock.md
@@ -40,11 +40,15 @@ paths:
   Slovo „Skladom" sa na cudzej stránke môže vyskytnúť v pätičke, v menu alebo
   pri inom produkte. Pridanie novej domény do zoznamu vyžaduje overenie na
   uloženej vzorke tej stránky, nikdy len domnienku.
-- **Obe polia dostupnosti sa do Shoptetu zapisujú NARAZ.** Shoptet zobrazuje
-  `availabilityOutOfStock` v momente, keď sklad klesne na nulu, takže zápis
-  len do `availabilityInStock` nechá po dopredaní fiktívnych kusov naskočiť
-  staré „Vypredané" (overené v ostrej prevádzke starej appky 14. 7. 2026).
-  Preto aj kladný `stock` — pri nule je prepnutie bez efektu.
+- **Obe polia dostupnosti sa do Shoptetu zapisujú NARAZ, ale `stock` sa
+  nezapisuje VÔBEC (issue 219).** Shoptet zobrazuje `availabilityOutOfStock`,
+  keď sklad klesne na nulu (overené v ostrej prevádzke starej appky
+  14. 7. 2026), a v tomto obchode je zásoba trvalo nulová — majiteľ skladovú
+  logistiku nepoužíva. Preto sa musia nastaviť OBA texty (inak zákazníkovi
+  svieti staré „Vypredané"), zatiaľ čo zápis fiktívnej zásoby by do obchodu
+  vpísal číslo, ktoré nikto neudržiava. Pôvodné pravidlo hovorilo opak
+  („preto aj kladný `stock`") — bolo postavené na predpoklade, že zásoba
+  niečo znamená.
 - **Nová cesta zápisu CSV do Shoptetu patrí do `shoptet-writeback/csv.ts`, aj
   keď má úplne iné stĺpce** (`buildRestockCsv` vedľa `buildWritebackCsv`) —
   ochrana proti CSV injection (`dataRowToLine`) musí platiť pre KAŽDÚ cestu,

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -109,6 +109,23 @@ paths:
   SQL kľúčové slovo, v raw SQL literáli (`sql\`TRUNCATE TABLE ...\``) MUSÍ byť
   ručne uvodzovkované (`"order"`) — drizzle-ove query buildre to robia
   automaticky, priamy SQL string nie.
+- **`scripts/e2e-setup.ts` má VLASTNÝ, SAMOSTATNÝ `TRUNCATE` zoznam — nová
+  tabuľka pridaná do `tests/helpers/db.ts` sa doň NEPREPÍŠE sama.** Issue 217
+  našlo, že `supplier_stock`/`restock_settings`/`restock_event` (pridané pri
+  #212/#213 správne do `tests/helpers/db.ts`) v e2e zozname chýbali — potvrdenia
+  dodávateľa by teda prežívali z predošlého e2e behu do ďalšieho, presne tá
+  istá tichá pasca, akú `.claude/rules/supplier-stock.md` popisuje pre
+  integračné testy. Pri KAŽDEJ novej koreňovej tabuľke uprav OBA zoznamy naraz.
+- **Pridanie čo i len JEDNÉHO variantu do e2e seedu posunie pevné počty v
+  `catalog.spec.ts`** (`"Nájdených: N"` aj `"Variantov v katalógu (vrátane
+  chýbajúcich): N"`) — nie je to nič, čo by sa dalo obísť, len sa na to musí
+  myslieť: zvýš obe čísla presne o počet pridaných variantov a do testu napíš,
+  odkiaľ sa ten navyše vzal. Filtrované počty (`sellable`, `missing`) sa menia
+  LEN ak nový variant do toho stavu patrí — issue 217 pridalo variant v stave
+  `out_of_stock`, takže `6`/`1` zostali. Overené celým e2e balíkom, nie
+  odhadom; opačné poradie (najprv predpoklad, že fixtúrny variant stačí)
+  stálo jeden zbytočný beh — vo fixtúre NIE JE žiadny `out_of_stock` +
+  `visible` variant s odkazom dodávateľa (overené dopytom do e2e databázy).
 - **Nová "koreňová" tabuľka, ktorá NESIE reálny produkčný obsah (napr.
   seedovaný migráciou, nie len prázdna štruktúra) potrebuje po TRUNCATE aj
   RESEED, nielen pridanie do zoznamu.** `order_open_status` (issue 59) je

--- a/apps/api/src/modules/catalog/availability.test.ts
+++ b/apps/api/src/modules/catalog/availability.test.ts
@@ -48,7 +48,10 @@ describe("deriveVariantState — skutočné reťazce z exportu", () => {
     ["malé není skladem", 0, "", "není skladem", "visible", "out_of_stock"],
     ["diakritika-free variant 'neni skladem'", 0, "", "neni skladem", "visible", "out_of_stock"],
     ["Momentálne nedostupné", 0, "", "Momentálne nedostupné", "visible", "out_of_stock"],
-    ["40237/L — obidva texty prázdne, záporný sklad", -15, "", "", "visible", "out_of_stock"],
+    // issue 219: prázdny text NIE JE vypredané. Majiteľ v Shoptete nepoužíva
+    // skladovú logistiku, takže `stock` nič nehovorí; prázdna dostupnosť
+    // znamená, že Shoptet zobrazí PREDVOLENÚ — na tomto e-shope "Skladom".
+    ["40237/L — obidva texty prázdne, záporný sklad", -15, "", "", "visible", "sellable"],
     ["prázdne texty, kladný sklad", 4, "", "", "visible", "sellable"],
     ["40237/3XL — Predaj výrobku skončil", -11, "Predaj výrobku skončil", "Predaj výrobku skončil", "visible", "discontinued"],
     ["text obsahuje oba markery naraz — vypredané aj skončilo", -1, "", "Vypredané, predaj výrobku skončil", "visible", "discontinued"],
@@ -64,6 +67,30 @@ describe("deriveVariantState — skutočné reťazce z exportu", () => {
     expect(
       deriveVariantState({ stock, inStockText, outOfStockText, productVisibility, variantVisibility: "1" }),
     ).toBe(expected);
+  });
+});
+
+// issue 219 — regresia z ostrej prevádzky. Automatizácia "Vypredané → Skladom"
+// ponúkla na zapnutie 2 953 produktov, ktoré sú v e-shope BEŽNE V PREDAJI.
+// Prvý, ktorý majiteľ otvoril (`10-12106-087`, Termoska STANLEY IceFlow 470 ml),
+// má v exporte `stock = 0` a OBA texty dostupnosti prázdne — appka ho označila
+// za vypredaný, ale stránka produktu vracia `schema.org/InStock` a zelený štítok
+// "Skladom". Príčina: prázdny text neznamená vypredané, ale "produkt nemá
+// priradenú dostupnosť", takže Shoptet zobrazí predvolenú. Zásoba do toho
+// nevstupuje vôbec — majiteľ skladovú logistiku v Shoptete nepoužíva a
+// `negativeAmount = 1` má na všetkých 14 071 riadkoch exportu, takže sa taký
+// produkt dá kúpiť aj pri nulovej zásobe.
+describe("deriveVariantState — prázdny text dostupnosti nie je vypredané (issue 219)", () => {
+  const emptyTexts = { inStockText: "", outOfStockText: "", productVisibility: "visible", variantVisibility: "" };
+
+  it.each([0, -1, -111, 5])("stock %i s prázdnymi textami je predajný", (stock) => {
+    expect(deriveVariantState({ stock, ...emptyTexts })).toBe("sellable");
+  });
+
+  it("explicitné 'Vypredané' zostáva vypredané aj pri nulovej zásobe", () => {
+    expect(
+      deriveVariantState({ stock: 0, inStockText: "", outOfStockText: "Vypredané", productVisibility: "visible", variantVisibility: "" }),
+    ).toBe("out_of_stock");
   });
 });
 

--- a/apps/api/src/modules/catalog/availability.ts
+++ b/apps/api/src/modules/catalog/availability.ts
@@ -56,8 +56,14 @@ export function deriveVariantState(
   // prebiť silnejší signál vyššie (text/produktová viditeľnosť hovoriaca
   // "discontinued"), preto je táto kontrola AŽ TU, pred predvoleným "sellable".
   if (input.variantVisibility === "0") return "out_of_stock";
-  // Prázdny text nesie nulovú informáciu (týka sa väčšiny riadkov exportu) — až
-  // vtedy, a len vtedy, rozhoduje sklad.
-  if (text === "") return input.stock > 0 ? "sellable" : "out_of_stock";
+  // Prázdny text NIE JE vypredané a `stock` do stavu nevstupuje vôbec (issue 219).
+  // Prázdna dostupnosť znamená, že produkt ju nemá priradenú, takže Shoptet
+  // zobrazí PREDVOLENÚ — na tomto e-shope zelené „Skladom" (overené naživo na
+  // 10-12106-087, 10-11284-083 a pončo Deerhunter Survivor: všetky vracajú
+  // `schema.org/InStock`). Majiteľ navyše skladovú logistiku v Shoptete
+  // NEPOUŽÍVA (rozhodnutie 4. 8. 2026) a `negativeAmount = 1` má na všetkých
+  // 14 071 riadkoch exportu, takže sa taký produkt kúpi aj pri nulovej zásobe.
+  // Zásoba tu preto nesmie nič rozhodovať — inak automatizácia zapína produkty,
+  // ktoré sú už dávno v predaji (6 793 takých riadkov).
   return "sellable";
 }

--- a/apps/api/src/modules/restock/constants.ts
+++ b/apps/api/src/modules/restock/constants.ts
@@ -29,12 +29,8 @@ export const SELLABLE_VISIBILITY = "visible";
 
 // Text, ktorý Shoptet zobrazuje zákazníkovi. Musí sa zapísať do OBOCH polí
 // naraz — Shoptet ukazuje `availabilityOutOfStock` v momente, keď sklad
-// klesne na nulu, takže zápis len do `availabilityInStock` by po dopredaní
-// fiktívnych kusov vrátil staré „Vypredané" (overené v ostrej prevádzke
-// starej appky 14. 7. 2026).
+// klesne na nulu (overené v ostrej prevádzke starej appky 14. 7. 2026), a
+// zásoba tu ostáva nulová, lebo ju majiteľ v Shoptete neudržiava a
+// automatizácia ju zámerne nezapisuje (issue 219). Zápis len do
+// `availabilityInStock` by teda zákazníkovi nechal svietiť staré „Vypredané".
 export const AVAILABILITY_IN_STOCK_TEXT = "Skladom";
-
-// Fiktívny sklad, ktorý produkt vráti do predaja. Kladné číslo je nutné —
-// pri nule Shoptet zobrazí `availabilityOutOfStock` a prepnutie by nemalo
-// žiadny efekt.
-export const RESTOCK_STOCK = 10;

--- a/apps/api/src/modules/restock/run.ts
+++ b/apps/api/src/modules/restock/run.ts
@@ -15,7 +15,6 @@ import {
   MAX_PER_RUN,
   RESTOCK_RUN_LOCK_KEY,
   RESTOCK_SETTINGS_ID,
-  RESTOCK_STOCK,
 } from "./constants.js";
 import { selectRestockCandidates, type RestockCandidate } from "./queries.js";
 
@@ -63,16 +62,16 @@ async function runRestockLocked(options: RunRestockOptions): Promise<RestockRunR
   const { picked, overLimit } = await selectRestockCandidates(db, now, limit);
   if (picked.length === 0) return { status: "nothing_to_do", overLimit: 0 };
 
-  // OBIDVE polia dostupnosti naraz — zápis len do `availabilityInStock` by po
-  // dopredaní fiktívnych kusov vrátil staré „Vypredané" (overené v ostrej
-  // prevádzke starej appky 14. 7. 2026).
+  // OBIDVE polia dostupnosti naraz — Shoptet vyberá jedno z nich podľa zásoby,
+  // takže zápis len do jedného by nechal zákazníkovi svietiť to druhé (overené
+  // v ostrej prevádzke starej appky 14. 7. 2026). Zásoba sa zámerne nezapisuje
+  // vôbec (issue 219) — majiteľ ju v Shoptete neudržiava.
   const csv = buildRestockCsv(
     picked.map((candidate) => ({
       code: candidate.variantCode,
       pairCode: candidate.pairCode ?? "",
       availabilityInStock: AVAILABILITY_IN_STOCK_TEXT,
       availabilityOutOfStock: AVAILABILITY_IN_STOCK_TEXT,
-      stock: String(RESTOCK_STOCK),
     })),
   );
 

--- a/apps/api/src/modules/shoptet-writeback/csv.test.ts
+++ b/apps/api/src/modules/shoptet-writeback/csv.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildWritebackCsv } from "./csv.js";
+import { buildRestockCsv, buildWritebackCsv } from "./csv.js";
 
 describe("buildWritebackCsv", () => {
   it("has the canonical Shoptet import header + BOM + CRLF + ';' delimiter", () => {
@@ -55,5 +55,24 @@ describe("buildWritebackCsv", () => {
     const csv = buildWritebackCsv([{ code: "A", pairCode: "", internalNote: "=cmd|'/c calc'!A1;X" }]);
     const rows = csv.toString("utf8").slice(1).split("\r\n").filter(Boolean);
     expect(rows[1]).toBe(`A;;"'=cmd|'/c calc'!A1;X"`);
+  });
+});
+
+// issue 219: majiteľ v Shoptete nepoužíva skladovú logistiku, takže zápis
+// fiktívnej zásoby by mu do obchodu vpísal číslo, ktoré nikto neudržiava.
+// Prepnutie na „Skladom" ho nepotrebuje — oba texty dostupnosti sa zapisujú
+// naraz, takže je jedno, ktorý z nich Shoptet podľa zásoby vyberie.
+describe("buildRestockCsv", () => {
+  it("zapisuje obidva texty dostupnosti a ŽIADNU zásobu", () => {
+    const csv = buildRestockCsv([
+      { code: "A1", pairCode: "77", availabilityInStock: "Skladom", availabilityOutOfStock: "Skladom" },
+    ]);
+    const lines = csv.toString("utf8").slice(1).split("\r\n").filter(Boolean);
+    expect(lines[0]).toBe("code;pairCode;productVisibility;availabilityInStock;availabilityOutOfStock");
+    expect(lines[1]).toBe("A1;77;visible;Skladom;Skladom");
+  });
+
+  it("odmietne prázdny zoznam — prázdny import do Shoptetu sa nikdy nenahráva", () => {
+    expect(() => buildRestockCsv([])).toThrow(/žiadne riadky/);
   });
 });

--- a/apps/api/src/modules/shoptet-writeback/csv.ts
+++ b/apps/api/src/modules/shoptet-writeback/csv.ts
@@ -69,19 +69,22 @@ export interface RestockCsvRow {
   readonly pairCode: string;
   readonly availabilityInStock: string;
   readonly availabilityOutOfStock: string;
-  readonly stock: string;
 }
 
 // `visible` je konštanta, nie vstup — automatizácia zapína LEN produkty,
 // ktoré už `visible` sú (`restock/queries.ts`), takže stĺpec len potvrdzuje
 // existujúci stav a nemôže odkryť nič, čo majiteľ skryl.
+// `stock` sa ZÁMERNE nezapisuje (issue 219). Majiteľ skladovú logistiku v
+// Shoptete nepoužíva — fiktívna zásoba by mu do obchodu vpísala číslo, ktoré
+// nikto neudržiava. Na zobrazenie „Skladom" nie je potrebná: oba texty
+// dostupnosti sa nastavujú naraz, takže je jedno, ktorý z nich Shoptet podľa
+// zásoby vyberie.
 const RESTOCK_HEADER = [
   "code",
   "pairCode",
   "productVisibility",
   "availabilityInStock",
   "availabilityOutOfStock",
-  "stock",
 ] as const;
 
 export function buildRestockCsv(rows: readonly RestockCsvRow[]): Buffer {
@@ -91,7 +94,7 @@ export function buildRestockCsv(rows: readonly RestockCsvRow[]): Buffer {
   const lines = [
     rowToLine(RESTOCK_HEADER),
     ...rows.map((r) =>
-      dataRowToLine([r.code, r.pairCode, "visible", r.availabilityInStock, r.availabilityOutOfStock, r.stock]),
+      dataRowToLine([r.code, r.pairCode, "visible", r.availabilityInStock, r.availabilityOutOfStock]),
     ),
   ];
   const bom = "﻿";

--- a/apps/api/tests/catalog-http.integration.test.ts
+++ b/apps/api/tests/catalog-http.integration.test.ts
@@ -141,8 +141,10 @@ it("vráti prehľad katalógu", async () => {
   expect(await res.json()).toMatchObject({
     variantCount: 35,
     productCount: 8,
-    sellable: 6,
-    outOfStock: 4,
+    // issue 219: 40237/L má oba texty dostupnosti prázdne — prázdny text
+    // znamená predvolenú dostupnosť Shoptetu, nie vypredané, takže je predajný.
+    sellable: 7,
+    outOfStock: 3,
     discontinued: 25,
     missing: 0,
     lastSnapshot: { verdict: "accepted", rowCount: 35 },
@@ -186,7 +188,7 @@ it("filtruje podľa stavu a stránkuje bez duplicít a preskočení", async () =
   const { app, cookie } = await boot({ role: "manazer", seed: true });
 
   const skladom = await app.request("/api/catalog/variants?state=sellable", { headers: { cookie } });
-  expect((await skladom.json()) as { total: number }).toMatchObject({ total: 6 });
+  expect((await skladom.json()) as { total: number }).toMatchObject({ total: 7 });
 
   // Referenčný, neostránkovaný zoznam (35 variantov sa zmestí do jednej strany
   // s pageSize=200) — voči nemu sa overuje, že strana 2 začína PRESNE tam, kde
@@ -252,7 +254,7 @@ it("filter 'missing' vráti len variant so zaznamenaným missingSince, nezávisl
   // stĺpca `state`, takže `state=sellable` naďalej vidí ten istý počet ako
   // predtým (variant "40287" je "sellable", stále sa počíta tam AJ v "missing").
   const skladom = await app.request("/api/catalog/variants?state=sellable", { headers: { cookie } });
-  expect((await skladom.json()) as { total: number }).toMatchObject({ total: 6 });
+  expect((await skladom.json()) as { total: number }).toMatchObject({ total: 7 });
 });
 
 it("vráti detail variantu a 404 pre neznámy kód", async () => {

--- a/apps/api/tests/catalog-ingest.integration.test.ts
+++ b/apps/api/tests/catalog-ingest.integration.test.ts
@@ -147,7 +147,10 @@ it("odvodí tri stavy dostupnosti presne podľa textov v exporte", async () => {
   const rows = await db.select({ code: variants.code, state: variants.state }).from(variants);
   const byState = { sellable: 0, out_of_stock: 0, discontinued: 0 };
   for (const row of rows) byState[row.state] += 1;
-  expect(byState).toEqual({ sellable: 6, out_of_stock: 4, discontinued: 25 });
+  // issue 219: jeden variant fixtúry (40237/L) má oba texty dostupnosti prázdne
+  // a zápornú zásobu — predtým padal medzi vypredané, dnes je predajný, lebo
+  // prázdny text znamená „Shoptet zobrazí predvolenú dostupnosť", nie vypredané.
+  expect(byState).toEqual({ sellable: 7, out_of_stock: 3, discontinued: 25 });
 
   const state = (code: string): string | undefined => rows.find((r) => r.code === code)?.state;
   expect(state("40237/M")).toBe("sellable");

--- a/apps/web/tests/e2e/catalog.spec.ts
+++ b/apps/web/tests/e2e/catalog.spec.ts
@@ -26,7 +26,7 @@ test("manažér vidí stav katalógu, vyhľadá variant a konzola je čistá", a
 
   // 36 = 35 riadkov fixtúry + 1 seedovaný kandidát na prepnutie ("PREP-1",
   // issue 217, `scripts/e2e-setup.ts`). Je v stave `out_of_stock`, takže
-  // filtre "sellable"(6) a "missing"(1) nižšie zostávajú nezmenené.
+  // filtre "sellable"(7 od issue 219) a "missing"(1) nižšie sa ním nemenia.
   await expect(page.getByTestId("snapshot")).toContainText("Posledný import: prijatý");
   await expect(page.getByTestId("counts")).toContainText("Variantov v katalógu (vrátane chýbajúcich): 36");
   await expect(page.getByTestId("total")).toHaveText("Nájdených: 36");
@@ -53,12 +53,15 @@ test("filter podľa stavu zúži zoznam na predajné varianty", async ({ page })
   await page.getByLabel("Stav", { exact: true }).selectOption("sellable");
   await page.getByRole("button", { name: "Hľadať" }).click();
 
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 6");
+  // 7 od issue 219: variant "40237/L" má oba texty dostupnosti prázdne, čo
+  // znamená predvolenú dostupnosť Shoptetu (na tomto e-shope "Skladom"), nie
+  // vypredané — preto sa počíta medzi predajné.
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 7");
   await expect(page.getByTestId("variant-40237/M")).toBeVisible();
 });
 
 // Review final-wave-a, položka 6: `scripts/e2e-setup.ts` označí variant
-// "40287" priamo v databáze ako chýbajúci (presne jeden zo 6 "sellable").
+// "40287" priamo v databáze ako chýbajúci (presne jeden zo 7 "sellable").
 test("filter 'Chýbajúce' nájde presne označený variant a riadok ukazuje, odkedy chýba", async ({ page }) => {
   await page.goto("/?tab=catalog");
   await page.getByLabel("E-mail").fill("e2e@forestshop.sk");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.126",
+  "version": "0.3.0-dev.127",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.125",
+  "version": "0.3.0-dev.126",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Issue 219 — appka označovala za vypredané aj produkty, ktoré sú v e-shope bežne
v predaji, a automatizácia „Vypredané → Skladom" ich ponúkala na zapnutie
(2 953 kandidátov namiesto ôsmich).

## Príčina

`deriveVariantState` brala `stock <= 0` s prázdnym textom dostupnosti ako
vypredané. Na tomto e-shope to neplatí:

- majiteľ v Shoptete **skladovú logistiku nepoužíva** (rozhodnutie 4. 8. 2026),
- `negativeAmount = 1` je na **všetkých 14 071 riadkoch** exportu, takže sa
  produkt kúpi aj pri nulovej zásobe,
- prázdna dostupnosť znamená „produkt ju nemá priradenú", takže Shoptet zobrazí
  predvolenú — na tomto e-shope zelené „Skladom".

Naživo overené: `10-12106-087`, `10-11284-083` aj pončo Deerhunter Survivor
vracajú `schema.org/InStock`; kontrolne `60031/XXL` s textom „Vypredané" naozaj
vracia `OutOfStock`.

## Zmeny

- `availability.ts`: `stock` do odvodenia stavu nevstupuje vôbec; prázdny text
  je `sellable`.
- Prepínanie do Shoptetu už **nezapisuje fiktívnu zásobu** — CSV nesie len
  viditeľnosť a oba texty dostupnosti. Zápis čísla, ktoré nikto neudržiava, do
  obchodu nepatrí; na zobrazenie „Skladom" nie je potrebné.
- Regresné testy (RED pred opravou), prepočítané pinnuté počty stavov fixtúry
  (predajných 6 → 7), playbook.

Ticket ostáva otvorený do post-deploy overenia zoznamu na živej appke.
