### PR TITLE
Jednotlivo vypnutý variant je ukončený predaj, nie vypredaný

### DIFF
--- a/.claude/rules/catalog.md
+++ b/.claude/rules/catalog.md
@@ -57,10 +57,15 @@ paths:
   štrukturálny/povinný stĺpec bez efektu). Skutočné hodnoty v exporte: "0"
   (Shoptet vypol PRÁVE TENTO variant, napr. jednu veľkosť z radu), "1", alebo
   prázdny reťazec (~2 700 jednovariantných produktov ho často nevypĺňa —
-  prázdny sa berie ako viditeľný, nikdy ako vypnutý). `deriveVariantState`
-  (`availability.ts`) ho zohľadňuje AŽ PO silnejších signáloch (text/
-  `productVisibility` hovoriaci "discontinued") — "0" vynúti aspoň
-  `out_of_stock`, nikdy neprebíja `discontinued`. Nepretrváva vo `variant`
+  prázdny sa berie ako viditeľný, nikdy ako vypnutý). **"0" znamená
+  `discontinued`, NIE `out_of_stock` (issue 219, druhá vlna)** — vypnutá
+  veľkosť je vedomé „nepredávať" (rovnaká trieda ako `detailOnly`), nie
+  „došiel tovar". Rozdiel je nosný: `out_of_stock` je VSTUPOM do automatizácie
+  „Vypredané → Skladom", takže pri starom zaradení sa 233 vypnutých variantov
+  (z 682 riadkov s "0" v reálnom exporte) stalo kandidátmi na zapnutie — a
+  zápis textu dostupnosti by ich aj tak nezapol, lebo vypnutie je iné pole.
+  Kontrola beží PRED textovými značkami, takže text „Vypredané" vypnutý
+  variant nestiahne späť medzi kandidátov. Nepretrváva vo `variant`
   tabuľke — ovplyvňuje len odvodenie `state` pri importe, žiadny ďalší
   konzument ho po importe nepotrebuje.
 - **Brána prijatia (`validation.ts`) je to, čo drží #277, #281 a #286 mimo.** Kontroluje

--- a/apps/api/src/modules/catalog/availability.test.ts
+++ b/apps/api/src/modules/catalog/availability.test.ts
@@ -100,7 +100,10 @@ describe("deriveVariantState — prázdny text dostupnosti nie je vypredané (is
 // alebo prázdny reťazec (jednovariantné produkty ho často vôbec nevypĺňajú) —
 // prázdny sa berie rovnako ako "1" (viditeľný), nikdy ako vypnutý.
 describe("deriveVariantState — variantVisibility vypína JEDNOTLIVÝ variant nezávisle od produktu", () => {
-  it("variantVisibility '0' zhodí inak predajný variant na vypredaný", () => {
+  // issue 219 (druhá vlna): vypnutý variant je `discontinued`, nie `out_of_stock` —
+  // je to vedomé „nepredávať" (ako `detailOnly`), takže sa NIKDY nesmie stať
+  // kandidátom automatizácie „Vypredané → Skladom".
+  it("variantVisibility '0' zhodí inak predajný variant na ukončený predaj", () => {
     expect(
       deriveVariantState({
         stock: 5,
@@ -109,7 +112,7 @@ describe("deriveVariantState — variantVisibility vypína JEDNOTLIVÝ variant n
         productVisibility: "visible",
         variantVisibility: "0",
       }),
-    ).toBe("out_of_stock");
+    ).toBe("discontinued");
   });
 
   it("variantVisibility '1' nechá stav nedotknutý (predajný zostáva predajný)", () => {
@@ -136,7 +139,7 @@ describe("deriveVariantState — variantVisibility vypína JEDNOTLIVÝ variant n
     ).toBe("sellable");
   });
 
-  it("variantVisibility '0' NEPREBÍJA silnejší signál 'discontinued' (text aj produktová viditeľnosť)", () => {
+  it("variantVisibility '0' vedľa iného 'discontinued' signálu (text aj produktová viditeľnosť) nič nemení", () => {
     expect(
       deriveVariantState({
         stock: 5,
@@ -157,7 +160,9 @@ describe("deriveVariantState — variantVisibility vypína JEDNOTLIVÝ variant n
     ).toBe("discontinued");
   });
 
-  it("variantVisibility '0' na variante, ktorý by aj tak bol vypredaný, nemení nič", () => {
+  // Text „Vypredané" NESMIE vypnutý variant stiahnuť späť medzi kandidátov na
+  // zapnutie — vypnutie je silnejší signál a zápis dostupnosti ho aj tak nezruší.
+  it("variantVisibility '0' prebíja aj text 'Vypredané'", () => {
     expect(
       deriveVariantState({
         stock: 0,
@@ -166,6 +171,6 @@ describe("deriveVariantState — variantVisibility vypína JEDNOTLIVÝ variant n
         productVisibility: "visible",
         variantVisibility: "0",
       }),
-    ).toBe("out_of_stock");
+    ).toBe("discontinued");
   });
 });

--- a/apps/api/src/modules/catalog/availability.ts
+++ b/apps/api/src/modules/catalog/availability.ts
@@ -48,14 +48,21 @@ export function deriveVariantState(
   },
 ): VariantState {
   if (HIDDEN_VISIBILITIES.includes(input.productVisibility)) return "discontinued";
+  // Jednotlivo vypnutý variant je `discontinued`, NIE `out_of_stock` (issue 219,
+  // druhá vlna). "0" znamená, že majiteľ TÚ KONKRÉTNU veľkosť v Shoptete vypol —
+  // je to vedomé „nepredávať", presne ako `detailOnly`, nie „došiel tovar".
+  // Rozdiel je nosný: `out_of_stock` je vstupom do automatizácie
+  // „Vypredané → Skladom", takže pri starom zaradení sa 233 vypnutých variantov
+  // stalo kandidátmi na zapnutie — a zápis textu dostupnosti by ich aj tak
+  // nezapol (vypnutie je iné pole), takže by to bolo prepínanie naprázdno na
+  // produktoch, ktoré majiteľ vedome vypol. Kontrola je PRED textom: vypnutý
+  // variant nesmie „prebiť" nič, ale text „Vypredané" ho nesmie stiahnuť späť
+  // medzi kandidátov.
+  if (input.variantVisibility === "0") return "discontinued";
 
   const text = effectiveAvailabilityText(input).toLowerCase();
   if (DISCONTINUED_MARKERS.some((marker) => text.includes(marker))) return "discontinued";
   if (OUT_OF_STOCK_MARKERS.some((marker) => text.includes(marker))) return "out_of_stock";
-  // Vypnutý jednotlivý variant sa NIKDY nezobrazí ako predajný — no nesmie
-  // prebiť silnejší signál vyššie (text/produktová viditeľnosť hovoriaca
-  // "discontinued"), preto je táto kontrola AŽ TU, pred predvoleným "sellable".
-  if (input.variantVisibility === "0") return "out_of_stock";
   // Prázdny text NIE JE vypredané a `stock` do stavu nevstupuje vôbec (issue 219).
   // Prázdna dostupnosť znamená, že produkt ju nemá priradenú, takže Shoptet
   // zobrazí PREDVOLENÚ — na tomto e-shope zelené „Skladom" (overené naživo na

--- a/apps/api/src/modules/catalog/map-row.test.ts
+++ b/apps/api/src/modules/catalog/map-row.test.ts
@@ -140,7 +140,10 @@ describe("mapRow nad reálnymi riadkami fixtúry", () => {
       availabilityInStockText: "Predaj výrobku skončil",
       availabilityOutOfStockText: "Vypredané",
       availabilityText: "Vypredané",
-      state: "out_of_stock",
+      // issue 219 (druhá vlna): 60055/8 má vo fixtúre `variantVisibility = "0"`,
+      // teda je v Shoptete vypnutý jednotlivo — to je „nepredávať", nie „došiel
+      // tovar", takže stav je `discontinued` bez ohľadu na text „Vypredané".
+      state: "discontinued",
     });
   });
 

--- a/apps/api/tests/catalog-http.integration.test.ts
+++ b/apps/api/tests/catalog-http.integration.test.ts
@@ -144,8 +144,8 @@ it("vráti prehľad katalógu", async () => {
     // issue 219: 40237/L má oba texty dostupnosti prázdne — prázdny text
     // znamená predvolenú dostupnosť Shoptetu, nie vypredané, takže je predajný.
     sellable: 7,
-    outOfStock: 3,
-    discontinued: 25,
+    outOfStock: 1,
+    discontinued: 27,
     missing: 0,
     lastSnapshot: { verdict: "accepted", rowCount: 35 },
   });

--- a/apps/api/tests/catalog-ingest.integration.test.ts
+++ b/apps/api/tests/catalog-ingest.integration.test.ts
@@ -147,10 +147,12 @@ it("odvodí tri stavy dostupnosti presne podľa textov v exporte", async () => {
   const rows = await db.select({ code: variants.code, state: variants.state }).from(variants);
   const byState = { sellable: 0, out_of_stock: 0, discontinued: 0 };
   for (const row of rows) byState[row.state] += 1;
-  // issue 219: jeden variant fixtúry (40237/L) má oba texty dostupnosti prázdne
-  // a zápornú zásobu — predtým padal medzi vypredané, dnes je predajný, lebo
-  // prázdny text znamená „Shoptet zobrazí predvolenú dostupnosť", nie vypredané.
-  expect(byState).toEqual({ sellable: 7, out_of_stock: 3, discontinued: 25 });
+  // issue 219 posunulo obe hranice: prázdny text dostupnosti už neznamená
+  // vypredané (Shoptet vtedy zobrazí predvolenú dostupnosť), a jednotlivo
+  // vypnutý variant (`variantVisibility = "0"`, vo fixtúre 20 riadkov) je
+  // `discontinued` — vedomé „nepredávať", nie „došiel tovar". Preto zostáva
+  // jediný skutočne vypredaný variant: "278" s textom „Není skladem".
+  expect(byState).toEqual({ sellable: 7, out_of_stock: 1, discontinued: 27 });
 
   const state = (code: string): string | undefined => rows.find((r) => r.code === code)?.state;
   expect(state("40237/M")).toBe("sellable");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.127",
+  "version": "0.3.0-dev.128",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Druhá vlna k tomu istému tiketu (issue 219), nájdená pri post-deploy overení
prvej opravy.

Zoznam spadol z 2 953 na 65 kandidátov, ale medzi nimi ostali varianty s textom
dostupnosti „Skladom" — napr. `15935/L` (Windblock bunda BERETTA Matajur). Majú
`variantVisibility = "0"`, teda majiteľ tú konkrétnu veľkosť v Shoptete vypol.

Na produkcii to bolo **233 z 386** viditeľných `out_of_stock` variantov (v surovom
exporte 682 riadkov s "0"). Zápis textu dostupnosti by ich navyše ani nezapol —
vypnutie je iné pole — takže by automatizácia prepínala naprázdno na produktoch,
ktoré majiteľ vedome vypol.

## Zmena

`variantVisibility = "0"` → `discontinued` (rovnaká trieda ako `detailOnly`),
kontrola beží PRED textovými značkami, aby text „Vypredané" vypnutý variant
nestiahol späť medzi kandidátov.

Prepočítané pinnuté počty stavov fixtúry: predajných 7, vypredaných 1 („278" —
„Není skladem"), ukončených 27.
