### PR TITLE
Priamy odkaz na detail nášho produktu z feedu google.xml

### DIFF
--- a/.claude/rules/shop-feed.md
+++ b/.claude/rules/shop-feed.md
@@ -1,0 +1,33 @@
+---
+paths:
+  - "apps/api/src/modules/shop-feed/**"
+  - "apps/web/src/shopLinks.ts"
+---
+
+# Adresy našich produktov z feedu pre porovnávače (issue 220)
+
+- **`https://www.forestshop.sk/google.xml` je JEDINÝ známy verejný zdroj, ktorý
+  má naraz náš kód variantu aj priamu adresu detailu.** Je to Shoptetom
+  generovaný Google Merchant feed: `<g:id>` je presne `variant.code` vrátane
+  veľkosti (`40237/M`) a `<link>` nesie aj `?variantId=…`, takže otvorí rovno
+  správnu veľkosť. Adresa je verejná — **nenesie prihlasovací údaj**, na rozdiel
+  od `SHOPTET_EXPORT_URL`, takže smie byť v repozitári.
+- **Ostatné feedy na tejto doméne NEEXISTUJÚ** — overené 4. 8. 2026:
+  `/heureka.xml`, `/zbozi.xml`, `/feed.xml`, `/export/products.xml`,
+  `/googlemerchant.xml`, `/export/google.xml` všetky vracajú 404. Funguje len
+  `/google.xml` a `/sitemap.xml`. Nehľadať znova naslepo.
+- **Feed nepokrýva celý katalóg — 7 666 položiek proti 8 279 viditeľným
+  variantom.** 626 viditeľných variantov v ňom nie je. Preto je napojenie do
+  `restock/queries.ts` `LEFT JOIN` a frontend má náhradu (`ourProductLink`
+  padne na vyhľadávanie podľa kódu). Zmena na `INNER JOIN` by zo zoznamu, podľa
+  ktorého majiteľ rozhoduje, ticho vyhodila stovky riadkov — presne tá trieda
+  chyby, ktorú riešilo issue 219.
+- **Rozoberač je zámerne regulárny výraz bez novej závislosti na XML parseri.**
+  Tvar feedu je plochý (`<entry>` s textovými deťmi). Hlavička feedu má
+  `<link href="…" />` s adresou vzorového webu — preto vzor hľadá `<link>` s
+  KONCOVOU značkou, inak by sa do mapy dostal `example.com`.
+- **`MIN_ENTRIES` je poistka proti tichému vyprázdneniu mapy.** Keď feed vráti
+  menej než 1 000 použiteľných položiek, beh vyhodí a do tabuľky NEZAPÍŠE —
+  inak by jeden pokazený beh zmazal adresy a odkazy by sa ticho vrátili na
+  vyhľadávanie. Riadky, ktoré feed už neobsahuje, sa zámerne NEMAŽÚ: stará
+  platná adresa je lepšia než žiadna.

--- a/.claude/rules/supplier-stock.md
+++ b/.claude/rules/supplier-stock.md
@@ -53,18 +53,15 @@ paths:
   keď má úplne iné stĺpce** (`buildRestockCsv` vedľa `buildWritebackCsv`) —
   ochrana proti CSV injection (`dataRowToLine`) musí platiť pre KAŽDÚ cestu,
   nikdy sa stĺpce neskladajú mimo tohto modulu.
-- **Shoptet export NEMÁ stĺpec s adresou produktu a `guid` je UUID, nie číselné
-  ID — odkaz na náš vlastný produkt sa preto NEDÁ poskladať z uložených dát.**
-  Overené na hlavičke surového exportu (issue 217: v 260+ stĺpcoch nie je
-  `url`/`slug`/`link`, len `seoTitle` a kategórie porovnávačov). Jediná
-  spoľahlivá cesta je vyhľadávanie podľa kódu:
-  `https://www.forestshop.sk/vyhladavanie/?string=<code>` (`apps/web/src/
-  shopLinks.ts`) — **slovenská cesta; česká `/vyhledavani/` na tejto doméne
-  vracia 404.** Funguje aj pre variantový kód s lomítkom (`10125/41`
-  percent-encoded) — naživo overené, nájde ten istý produkt ako kód bez
-  veľkosti. Ak by niekedy pribudla potreba priameho odkazu na DETAIL, treba
-  najprv doplniť zdroj adresy (feed pre porovnávače alebo sitemapu), nie
-  hádať tvar URL z `guid`.
+- **Shoptet export NEMÁ stĺpec s adresou produktu a `guid` je UUID — ale adresa
+  sa NEODVODZUJE, BERIE sa z feedu pre porovnávače.** Pôvodné znenie tohto
+  pravidla končilo tým, že jedinou cestou je vyhľadávanie podľa kódu
+  (`https://www.forestshop.sk/vyhladavanie/?string=<code>`); to platilo len
+  dovtedy, kým sa nenašiel zdroj adresy. Od issue 220 ju dodáva
+  `https://www.forestshop.sk/google.xml` (podrobne v `.claude/rules/
+  shop-feed.md`) a vyhľadávanie ostáva len ako NÁHRADA pre 626 viditeľných
+  variantov, ktoré vo feede nie sú. Slovenská cesta `/vyhladavanie/` naďalej
+  platí — česká `/vyhledavani/` na tejto doméne vracia 404.
 - **Zoznam, podľa ktorého sa človek rozhoduje, MUSÍ stavať na tej istej funkcii
   výberu ako samotný beh.** `listRestockWaiting` aj `selectRestockCandidates`
   volajú spoločnú `allRestockCandidates` (`restock/queries.ts`) — druhá kópia

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,4 +92,5 @@ Per-area rules live in `.claude/rules/<area>.md` with `paths:` frontmatter.
 - Texty e-mailov (F192 — upraviteľné šablóny, zástupné polia, strop prihlásení v e2e) → `.claude/rules/mail-templates.md`
 - dodávateľský sklad + prepínanie Vypredané → Skladom (#212/#213 — detailOnly, confirmed_at,
   žiadne AI dohady) → `.claude/rules/supplier-stock.md`
+- adresy našich produktov z feedu google.xml (#220) → `.claude/rules/shop-feed.md`
 - Kniha odoslaných e-mailov (F193 — jediná odosielacia cesta, dedup okno preskočení) → `.claude/rules/mail-log.md`

--- a/apps/api/drizzle/0028_shop_product_url.sql
+++ b/apps/api/drizzle/0028_shop_product_url.sql
@@ -1,0 +1,5 @@
+CREATE TABLE "shop_product_url" (
+	"code" text PRIMARY KEY NOT NULL,
+	"url" text NOT NULL,
+	"fetched_at" timestamp with time zone NOT NULL
+);

--- a/apps/api/drizzle/meta/0028_snapshot.json
+++ b/apps/api/drizzle/meta/0028_snapshot.json
@@ -1,0 +1,2474 @@
+{
+  "id": "008ab57e-6426-42c3-9aee-61017b8996cc",
+  "prevId": "bf571c19-aa27-4bdd-9e9e-766127941048",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "related_codes": {
+          "name": "related_codes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_code": {
+          "name": "external_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_open_status": {
+      "name": "order_open_status",
+      "schema": "",
+      "columns": {
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Vybavuje sa'"
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop_remark": {
+          "name": "shop_remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shoptet_order_id": {
+          "name": "shoptet_order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_updated_at": {
+          "name": "comment_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_synced_at": {
+          "name": "comment_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_carrier_name": {
+          "name": "shipping_carrier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_link_override": {
+      "name": "product_supplier_link_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_link_override_product_key_product_key_fk": {
+          "name": "product_supplier_link_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_link_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_override": {
+      "name": "product_supplier_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_override_product_key_product_key_fk": {
+          "name": "product_supplier_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing": {
+      "name": "pairing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_url": {
+          "name": "supplier_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "pairing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'navrhnute'"
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pairing_state_idx": {
+          "name": "pairing_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_confirmed_by_idx": {
+          "name": "pairing_confirmed_by_idx",
+          "columns": [
+            {
+              "expression": "confirmed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_variant_code_variant_code_fk": {
+          "name": "pairing_variant_code_variant_code_fk",
+          "tableFrom": "pairing",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pairing_confirmed_by_users_id_fk": {
+          "name": "pairing_confirmed_by_users_id_fk",
+          "tableFrom": "pairing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pairing_variant_code_unique": {
+          "name": "pairing_variant_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pairing_confirmation_ck": {
+          "name": "pairing_confirmation_ck",
+          "value": "(\"pairing\".\"state\" = 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)\n        OR (\"pairing\".\"state\" != 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NULL AND \"pairing\".\"confirmed_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier": {
+      "name": "supplier",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wholesale_base_url": {
+          "name": "wholesale_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_key": {
+          "name": "adapter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_settings": {
+      "name": "posta_uncollected_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_state": {
+      "name": "posta_uncollected_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notify_count": {
+          "name": "notify_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_state": {
+          "name": "terminal_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_settings": {
+      "name": "order_reminder_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_state": {
+      "name": "order_reminder_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_state": {
+      "name": "nedostupne_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "nedostupne_email_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nedostupne_state_order_variant_type_uq": {
+          "name": "nedostupne_state_order_variant_type_uq",
+          "columns": [
+            {
+              "expression": "order_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template_history": {
+      "name": "mail_template_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "mail_template_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_template_history_key_idx": {
+          "name": "mail_template_history_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_template_history_changed_by_user_id_users_id_fk": {
+          "name": "mail_template_history_changed_by_user_id_users_id_fk",
+          "tableFrom": "mail_template_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template": {
+      "name": "mail_template",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail_template_updated_by_user_id_users_id_fk": {
+          "name": "mail_template_updated_by_user_id_users_id_fk",
+          "tableFrom": "mail_template",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_log": {
+      "name": "mail_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "mail_log_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_log_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "mail_log_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_log_created_idx": {
+          "name": "mail_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_log_source_created_idx": {
+          "name": "mail_log_source_created_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_log_actor_user_id_users_id_fk": {
+          "name": "mail_log_actor_user_id_users_id_fk",
+          "tableFrom": "mail_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_stock": {
+      "name": "supplier_stock",
+      "schema": "",
+      "columns": {
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "supplier_availability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "supplier_stock_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "supplier_stock_host_idx": {
+          "name": "supplier_stock_host_idx",
+          "columns": [
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "supplier_stock_avail_idx": {
+          "name": "supplier_stock_avail_idx",
+          "columns": [
+            {
+              "expression": "availability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_event": {
+      "name": "restock_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_link": {
+          "name": "supplier_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_availability_text": {
+          "name": "supplier_availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "supplier_price": {
+          "name": "supplier_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "restock_event_at_idx": {
+          "name": "restock_event_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "restock_event_variant_idx": {
+          "name": "restock_event_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_settings": {
+      "name": "restock_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shop_product_url": {
+      "name": "shop_product_url",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne"
+      ]
+    },
+    "public.pairing_state": {
+      "name": "pairing_state",
+      "schema": "public",
+      "values": [
+        "navrhnute",
+        "potvrdene"
+      ]
+    },
+    "public.nedostupne_email_type": {
+      "name": "nedostupne_email_type",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "alternativa"
+      ]
+    },
+    "public.mail_template_action": {
+      "name": "mail_template_action",
+      "schema": "public",
+      "values": [
+        "save",
+        "reset"
+      ]
+    },
+    "public.mail_log_source": {
+      "name": "mail_log_source",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "posta_uncollected",
+        "order_reminder",
+        "supplier_order"
+      ]
+    },
+    "public.mail_log_status": {
+      "name": "mail_log_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.mail_log_trigger": {
+      "name": "mail_log_trigger",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "manual"
+      ]
+    },
+    "public.supplier_availability": {
+      "name": "supplier_availability",
+      "schema": "public",
+      "values": [
+        "available",
+        "unavailable",
+        "unknown"
+      ]
+    },
+    "public.supplier_stock_source": {
+      "name": "supplier_stock_source",
+      "schema": "public",
+      "values": [
+        "json_ld",
+        "meta",
+        "text",
+        "none"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1785793985367,
       "tag": "0027_restock",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1785835560612,
+      "tag": "0028_shop_product_url",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema-shop-feed.ts
+++ b/apps/api/src/db/schema-shop-feed.ts
@@ -1,0 +1,19 @@
+import { pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+// Mapa „kód variantu → adresa detailu na NAŠOM e-shope" (issue 220).
+//
+// Zdroj je Shoptetom generovaný feed pre porovnávače (`google.xml`). Tabuľka
+// je zámerne PLOCHÁ a bez väzby na `variant`: feed a katalóg sa napĺňajú
+// nezávisle a v rôznom čase, takže cudzí kľúč by pri každom nesúlade zhodil
+// celý import kvôli veci, ktorá je len pomôcka na zobrazenie odkazu.
+//
+// Kľúč je `code` v tom istom tvare ako `variant.code` (vrátane veľkosti za
+// lomítkom, napr. `40237/M`) — feed generuje jednu položku na variant, takže
+// adresa vie obsahovať aj `?variantId=…` a otvorí rovno správnu veľkosť.
+export const shopProductUrl = pgTable("shop_product_url", {
+  code: text("code").primaryKey(),
+  url: text("url").notNull(),
+  // Čas behu, ktorý riadok naposledy potvrdil — keď feed na strane Shoptetu
+  // zamrzne, na obrazovke je vidieť, že mapa starne.
+  fetchedAt: timestamp("fetched_at", { withTimezone: true }).notNull(),
+});

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -10,3 +10,4 @@ export * from "./schema-mail-templates.js";
 export * from "./schema-mail-log.js";
 export * from "./schema-supplier-stock.js";
 export * from "./schema-restock.js";
+export * from "./schema-shop-feed.js";

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -23,6 +23,13 @@ const envSchema = z.object({
   // tejto premennej nikdy nezíska interné id na priamy odkaz na detail.
   SHOPTET_ORDERS_XML_URL: z.string().url().optional(),
   ORDERS_RAW_DIR: z.string().min(1).default("./data/orders-raw"),
+
+  // Feed pre porovnávače, z ktorého sa berie mapa „kód → adresa detailu"
+  // (issue 220). Na rozdiel od `SHOPTET_EXPORT_URL` je VEREJNÝ a nenesie
+  // prihlasovací údaj, takže má predvolenú hodnotu v kóde
+  // (`DEFAULT_SHOP_FEED_URL`) — premenná je len poistka pre prípad zmeny
+  // adresy na strane Shoptetu.
+  SHOP_FEED_URL: z.string().url().optional(),
   // issue 65: základ Shoptet-ovho ADMIN rozhrania (nie exportu) pre priamy
   // odkaz na objednávku z obrazovky "Na objednanie" — na rozdiel od
   // `SHOPTET_EXPORT_URL`/`SHOPTET_ORDERS_URL` vyššie NENESIE prihlasovací

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -22,6 +22,7 @@ import {
   ordersImportJob,
   orderNoteWritebackJob,
   orderReminderJob,
+  shopFeedJob,
   supplierStockJob,
   restockJob,
   postaUncollectedJob,
@@ -30,6 +31,9 @@ import {
   sessionCleanupJob,
   shoptetWritebackJob,
 } from "./modules/scheduler/jobs.js";
+import { DEFAULT_SHOP_FEED_URL } from "./modules/shop-feed/constants.js";
+import { createHttpShopFeedFetcher } from "./modules/shop-feed/fetcher.js";
+import { runShopFeed } from "./modules/shop-feed/run.js";
 import { fetchSupplierPage } from "./modules/supplier-stock/page-fetcher.js";
 import { runSupplierStock } from "./modules/supplier-stock/run.js";
 import { runRestock } from "./modules/restock/run.js";
@@ -219,6 +223,11 @@ const app = createApp(db, {
 // dostávajú svoj `run*Ingest` (môže byť `undefined`, keď zodpovedajúca URL
 // nie je nastavená — job to zaznamená ako "failure" s vysvetlením, nikdy sa
 // nepreskočí ticho).
+// Adresa feedu je verejná (nenesie prihlasovací údaj), takže má rozumnú
+// predvolenú hodnotu v kóde — premenná prostredia je len poistka pre prípad,
+// že by Shoptet adresu zmenil.
+const fetchShopFeed = createHttpShopFeedFetcher(env.SHOP_FEED_URL ?? DEFAULT_SHOP_FEED_URL);
+
 const scheduler = startScheduler(db, [
   catalogImportJob(runIngest),
   pruneRawExportsJob(),
@@ -229,6 +238,7 @@ const scheduler = startScheduler(db, [
   orderNoteWritebackJob(runOrderNoteWritebackFn),
   postaUncollectedJob((db2, now) => runPostaUncollected({ db: db2, now, ...postaUncollectedDeps })),
   orderReminderJob((db2, now) => runOrderReminder({ db: db2, now, ...orderReminderDeps })),
+  shopFeedJob((db2, now) => runShopFeed({ db: db2, now, fetchFeed: fetchShopFeed })),
   supplierStockJob((db2, now) => runSupplierStock({ db: db2, now, fetchPage: fetchSupplierPage })),
   restockJob(runRestockFn),
 ]);

--- a/apps/api/src/modules/catalog/fetcher.ts
+++ b/apps/api/src/modules/catalog/fetcher.ts
@@ -61,7 +61,7 @@ export interface HttpExportFetcherOptions {
  * zruší čítanie (`reader.cancel()`) HNEĎ, ako súčet prekročí strop, a vyhodí
  * bežnú chybu — nikdy nenechá proces spadnúť na pamäť.
  */
-async function readBounded(response: Response, maxBytes: number): Promise<Buffer> {
+export async function readBounded(response: Response, maxBytes: number): Promise<Buffer> {
   // `Response.body` je (bez `dom` libu, len `@types/node`'s `undici-types`)
   // typovaný ako `ReadableStream` bez generika, teda efektívne
   // `ReadableStream<any>` — cast na `Uint8Array` je bezpečný, `fetch` telo

--- a/apps/api/src/modules/restock/queries.ts
+++ b/apps/api/src/modules/restock/queries.ts
@@ -6,7 +6,7 @@
 
 import { and, asc, eq, isNull, sql } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
-import { products, supplierStock, variants } from "../../db/schema.js";
+import { products, shopProductUrl, supplierStock, variants } from "../../db/schema.js";
 import {
   CONFIRMATION_MAX_AGE_HOURS,
   MAX_PER_RUN,
@@ -22,6 +22,13 @@ export interface RestockCandidate {
   readonly supplierAvailabilityText: string;
   readonly supplierPrice: string | null;
   readonly confirmedAt: Date;
+  /**
+   * Priama adresa detailu NÁŠHO produktu z feedu pre porovnávače (issue 220),
+   * alebo `null`, keď kód vo feede nie je. `null` NIE JE chyba — 626
+   * viditeľných variantov vo feede nie je a tie na obrazovke padnú späť na
+   * vyhľadávanie podľa kódu.
+   */
+  readonly ourUrl: string | null;
 }
 
 export interface RestockCandidates {
@@ -84,10 +91,15 @@ async function allRestockCandidates(db: Database, now: Date): Promise<readonly R
       supplierAvailabilityText: supplierStock.availabilityText,
       supplierPrice: supplierStock.price,
       confirmedAt: supplierStock.confirmedAt,
+      ourUrl: shopProductUrl.url,
     })
     .from(variants)
     .innerJoin(products, eq(variants.productKey, products.key))
     .innerJoin(supplierStock, eq(supplierStock.link, link))
+    // LEFT zámerne: variant bez záznamu vo feede NESMIE zo zoznamu vypadnúť —
+    // majiteľ overuje presne tie riadky, ktoré by sa prepli, takže skrytý
+    // riadok by znamenal prepnutie bez kontroly (trieda chyby z issue 219).
+    .leftJoin(shopProductUrl, eq(shopProductUrl.code, variants.code))
     .where(
       and(
         eq(variants.state, "out_of_stock"),

--- a/apps/api/src/modules/scheduler/jobs.ts
+++ b/apps/api/src/modules/scheduler/jobs.ts
@@ -13,6 +13,8 @@ import type { WritebackRunResult } from "../shoptet-writeback/run-writeback.js";
 import { RESTOCK_JOB_NAME } from "../restock/constants.js";
 import type { RestockRunResult } from "../restock/run.js";
 import { isRestockEnabled } from "../restock/run.js";
+import { SHOP_FEED_JOB_NAME } from "../shop-feed/constants.js";
+import type { ShopFeedRunResult } from "../shop-feed/run.js";
 import { SUPPLIER_STOCK_JOB_NAME } from "../supplier-stock/constants.js";
 import type { SupplierStockRunResult } from "../supplier-stock/run.js";
 import type { ScheduledJob } from "./types.js";
@@ -325,6 +327,30 @@ export function restockJob(run: RunRestock | undefined): ScheduledJob {
       if (run === undefined) {
         throw new Error("Chýbajú prihlasovacie údaje do Shoptet administrácie — prepnutie sa nedá zapísať.");
       }
+      return { detail: await run(db, now) };
+    },
+  };
+}
+
+export type RunShopFeed = (db: Database, now: Date) => Promise<ShopFeedRunResult>;
+
+/**
+ * Obnovenie mapy „kód variantu → adresa detailu" z feedu pre porovnávače
+ * (issue 220) — denne o 03:50 UTC, teda PRED `supplierStockJob` (04:20) aj
+ * `restockJob` (04:50), aby overovací zoznam ráno ukazoval čerstvé adresy.
+ *
+ * Vlastný advisory zámok NEMÁ: na rozdiel od `postaUncollectedJob` či
+ * `supplierStockJob` nemá manuálny spúšťač, takže jediným zdrojom behov je
+ * scheduler, ktorý ich už serializuje.
+ *
+ * Žiadny `enabled` prepínač: job nikam nezapisuje do e-shopu, len číta
+ * verejný feed a plní pomocnú tabuľku adries.
+ */
+export function shopFeedJob(run: RunShopFeed): ScheduledJob {
+  return {
+    name: SHOP_FEED_JOB_NAME,
+    schedule: { kind: "daily", hourUtc: 3, minuteUtc: 50 },
+    async run(db, now) {
       return { detail: await run(db, now) };
     },
   };

--- a/apps/api/src/modules/shop-feed/constants.ts
+++ b/apps/api/src/modules/shop-feed/constants.ts
@@ -1,0 +1,26 @@
+// issue 220: mapa „kód variantu → adresa detailu na našom e-shope".
+//
+// Majiteľ o dovtedajších odkazoch (vyhľadávanie podľa kódu): „tie linky na
+// nase produkty su uplne hrozne". Priama adresa sa z exportu poskladať nedá,
+// ale Shoptet ju publikuje vo feede pre porovnávače.
+
+export const SHOP_FEED_JOB_NAME = "shop-feed";
+
+// Verejná adresa feedu — NIE je to prihlasovací údaj (na rozdiel od
+// `SHOPTET_EXPORT_URL`, ktorá nesie `hash`), takže smie byť v repozitári.
+// Prepísateľná premennou prostredia pre prípad, že Shoptet adresu zmení,
+// bez nutnosti nasadzovať novú verziu.
+export const DEFAULT_SHOP_FEED_URL = "https://www.forestshop.sk/google.xml";
+
+export const REQUEST_TIMEOUT_MS = 60_000;
+
+// Feed má dnes ~12 MB. Strop je zámerne veľkorysý voči tomu, ale konečný —
+// rovnaká úvaha ako `catalog/fetcher.ts`: pokazený server nesmie vyčerpať
+// pamäť kontajnera.
+export const MAX_FEED_BYTES = 100 * 1024 * 1024;
+
+// Poistka proti prázdnemu/pokazenému feedu: keď sa rozobralo menej položiek
+// než toto, mapa sa NEPREPÍŠE a beh skončí chybou. Bez nej by jeden
+// pokazený beh zmazal všetky adresy a odkazy na obrazovke by sa ticho
+// vrátili na vyhľadávanie. Dnešný feed má 7666 položiek.
+export const MIN_ENTRIES = 1_000;

--- a/apps/api/src/modules/shop-feed/fetcher.ts
+++ b/apps/api/src/modules/shop-feed/fetcher.ts
@@ -1,0 +1,30 @@
+// Sťahovanie feedu pre porovnávače (issue 220).
+//
+// Adresa je verejná a nenesie prihlasovací údaj, takže sa — na rozdiel od
+// `catalog/fetcher.ts` — nič neprekrýva. Ohraničené čítanie tela sa ale
+// PREBERÁ odtiaľ (`readBounded`): strop musí platiť POČAS čítania, nie až po
+// zbufferovaní celého tela, inak by pokazený server vyčerpal pamäť kontajnera
+// skôr, než sa strop stihne skontrolovať.
+
+import { readBounded } from "../catalog/fetcher.js";
+import { MAX_FEED_BYTES, REQUEST_TIMEOUT_MS } from "./constants.js";
+import type { ShopFeedFetcher } from "./run.js";
+
+export function createHttpShopFeedFetcher(url: string): ShopFeedFetcher {
+  return async () => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => {
+      controller.abort();
+    }, REQUEST_TIMEOUT_MS);
+    try {
+      const response = await fetch(url, { signal: controller.signal });
+      if (!response.ok) {
+        throw new Error(`Feed ${url} vrátil HTTP ${String(response.status)}`);
+      }
+      const body = await readBounded(response, MAX_FEED_BYTES);
+      return body.toString("utf8");
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+}

--- a/apps/api/src/modules/shop-feed/fixtures/feed-sample.xml
+++ b/apps/api/src/modules/shop-feed/fixtures/feed-sample.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:g="http://base.google.com/ns/1.0">
+	<title>Názov zdroja dát</title>
+	<link href="http://www.example.com" rel="alternate" type="text/html" />
+	<author>
+		<name>Google</name>
+	</author><entry>
+	<g:id>40237/M</g:id>
+	<title>Nohavice FOREST 1003 Veľkosť: M</title>
+	<link>https://www.forestshop.sk/polovnicke-nohavice-forest-1003/?variantId=106</link>
+	<g:availability>in stock</g:availability>
+	<g:price>64.9 EUR</g:price>
+</entry><entry>
+	<g:id>15314</g:id>
+	<title>Poľovnícky ruksak HART SPEAN 25</title>
+	<link>https://www.forestshop.sk/polovnicky-ruksak-hart-spean-25/</link>
+	<g:availability>out of stock</g:availability>
+</entry><entry>
+	<g:id>10125/41</g:id>
+	<title>Obuv s lomítkom v kóde</title>
+	<link>https://www.forestshop.sk/obuv/?variantId=9&amp;utm=feed</link>
+	<g:availability></g:availability>
+</entry><entry>
+	<g:id></g:id>
+	<title>Položka bez kódu — musí sa preskočiť</title>
+	<link>https://www.forestshop.sk/bez-kodu/</link>
+</entry><entry>
+	<g:id>99999</g:id>
+	<title>Položka bez adresy — musí sa preskočiť</title>
+	<g:availability>in stock</g:availability>
+</entry><entry>
+	<g:id>40237/M</g:id>
+	<title>Duplicitný kód — platí prvý výskyt</title>
+	<link>https://www.forestshop.sk/duplikat/</link>
+</entry>
+</feed>

--- a/apps/api/src/modules/shop-feed/parse.test.ts
+++ b/apps/api/src/modules/shop-feed/parse.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { parseShopFeed } from "./parse.js";
+
+const sample = readFileSync(
+  fileURLToPath(new URL("./fixtures/feed-sample.xml", import.meta.url)),
+  "utf8",
+);
+
+describe("parseShopFeed", () => {
+  it("vráti dvojicu kód → adresa pre každú použiteľnú položku", () => {
+    expect(parseShopFeed(sample)).toEqual([
+      { code: "40237/M", url: "https://www.forestshop.sk/polovnicke-nohavice-forest-1003/?variantId=106" },
+      { code: "15314", url: "https://www.forestshop.sk/polovnicky-ruksak-hart-spean-25/" },
+      { code: "10125/41", url: "https://www.forestshop.sk/obuv/?variantId=9&utm=feed" },
+    ]);
+  });
+
+  it("nepoužije hlavičkový <link href=…> feedu ako adresu produktu", () => {
+    expect(parseShopFeed(sample).some((row) => row.url.includes("example.com"))).toBe(false);
+  });
+
+  it("z prázdneho vstupu vráti prázdny zoznam namiesto vyhodenia", () => {
+    expect(parseShopFeed("")).toEqual([]);
+  });
+});

--- a/apps/api/src/modules/shop-feed/parse.ts
+++ b/apps/api/src/modules/shop-feed/parse.ts
@@ -1,0 +1,59 @@
+// Rozoberač feedu pre porovnávače (issue 220).
+//
+// Zdroj je Shoptetom generovaný Google Merchant feed `https://www.forestshop.sk/
+// google.xml` — jediný verejný zdroj, ktorý má naraz NÁŠ kód variantu a PRIAMU
+// adresu detailu produktu. CSV export adresu nemá vôbec a `guid` je UUID, takže
+// adresa sa z uložených dát poskladať nedá (overené pri issue 217).
+//
+// Zámerne BEZ novej závislosti na XML parseri: tvar feedu je plochý a pevný
+// (`<entry>` s textovými deťmi `<g:id>` a `<link>`), takže regulárny výraz nad
+// jednou položkou stačí a nepridáva do obrazu ďalší balík. Keby feed niekedy
+// začal niesť vnorenú štruktúru, toto miesto je jediné, ktoré treba vymeniť.
+
+export interface ShopFeedEntry {
+  readonly code: string;
+  readonly url: string;
+}
+
+const ENTRY = /<entry>([\s\S]*?)<\/entry>/g;
+const CODE = /<g:id>([\s\S]*?)<\/g:id>/;
+// Zámerne `<link>` s koncovou značkou — hlavička feedu má `<link href="…" />`
+// (samostatne uzavretý, adresa vzorového webu), ktorý sa takto nikdy nechytí.
+const URL_TAG = /<link>([\s\S]*?)<\/link>/;
+
+const ENTITIES: Readonly<Record<string, string>> = {
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": '"',
+  "&apos;": "'",
+};
+
+function decode(value: string): string {
+  return value.replace(/&(?:amp|lt|gt|quot|apos);/g, (entity) => ENTITIES[entity] ?? entity).trim();
+}
+
+/**
+ * Vráti dvojice `kód → adresa` v poradí, v akom sú vo feede.
+ *
+ * Položka bez kódu alebo bez adresy sa PRESKOČÍ — do mapy sa nikdy nedostane
+ * poloprázdny riadok, ktorý by na obrazovke vyrobil odkaz nikam. Pri
+ * duplicitnom kóde platí PRVÝ výskyt: feed je generovaný po variantoch a
+ * neskorší duplikát je vždy menej špecifický záznam (bez `variantId`).
+ */
+export function parseShopFeed(xml: string): readonly ShopFeedEntry[] {
+  const seen = new Set<string>();
+  const rows: ShopFeedEntry[] = [];
+
+  for (const [, entry] of xml.matchAll(ENTRY)) {
+    if (entry === undefined) continue;
+    const code = decode(CODE.exec(entry)?.[1] ?? "");
+    const url = decode(URL_TAG.exec(entry)?.[1] ?? "");
+    if (code === "" || url === "") continue;
+    if (seen.has(code)) continue;
+    seen.add(code);
+    rows.push({ code, url });
+  }
+
+  return rows;
+}

--- a/apps/api/src/modules/shop-feed/run.test.ts
+++ b/apps/api/src/modules/shop-feed/run.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import type { Database } from "../../db/client.js";
+import { MIN_ENTRIES } from "./constants.js";
+import { runShopFeed } from "./run.js";
+
+// Databáza sa pri tomto scenári NESMIE dotknúť — poistka musí zabrať PRED
+// zápisom, inak by pokazený feed mapu adries vyprázdnil. Preto zámerne
+// vyhadzujúca atrapa: keby ju beh použil, test padne.
+const forbiddenDb = new Proxy(
+  {},
+  {
+    get() {
+      throw new Error("beh sa nesmel dotknúť databázy");
+    },
+  },
+) as Database;
+
+function feedWith(count: number): string {
+  const entries = Array.from(
+    { length: count },
+    (_unused, i) =>
+      `<entry><g:id>K${String(i)}</g:id><link>https://www.forestshop.sk/p${String(i)}/</link></entry>`,
+  ).join("");
+  return `<feed>${entries}</feed>`;
+}
+
+describe("runShopFeed — poistka proti pokazenému feedu", () => {
+  it("pri príliš málo položkách vyhodí a mapu neprepíše", async () => {
+    await expect(
+      runShopFeed({
+        db: forbiddenDb,
+        now: new Date("2026-08-04T03:50:00Z"),
+        fetchFeed: () => Promise.resolve(feedWith(MIN_ENTRIES - 1)),
+      }),
+    ).rejects.toThrow(/neprepisuje/);
+  });
+
+  it("prázdny feed spadne na tej istej poistke, nie na rozobraní", async () => {
+    await expect(
+      runShopFeed({
+        db: forbiddenDb,
+        now: new Date("2026-08-04T03:50:00Z"),
+        fetchFeed: () => Promise.resolve(""),
+      }),
+    ).rejects.toThrow(/len 0 použiteľných/);
+  });
+});

--- a/apps/api/src/modules/shop-feed/run.ts
+++ b/apps/api/src/modules/shop-feed/run.ts
@@ -1,0 +1,60 @@
+// Nočné obnovenie mapy „kód → adresa" z feedu pre porovnávače (issue 220).
+
+import { sql } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { shopProductUrl } from "../../db/schema.js";
+import { MIN_ENTRIES } from "./constants.js";
+import { parseShopFeed } from "./parse.js";
+
+export interface ShopFeedRunResult {
+  /** Koľko použiteľných dvojíc kód/adresa feed obsahoval. */
+  readonly entries: number;
+  /** Koľko riadkov je v mape po zápise. */
+  readonly stored: number;
+}
+
+/** Stiahne telo feedu. Vstrekované, aby testy nikdy nešli na živý e-shop. */
+export type ShopFeedFetcher = () => Promise<string>;
+
+export interface RunShopFeedOptions {
+  readonly db: Database;
+  readonly now: Date;
+  readonly fetchFeed: ShopFeedFetcher;
+}
+
+// Zápis po dávkach — jeden `insert` so 7 666 riadkami prekročí limit
+// parametrov na dopyt.
+const CHUNK = 500;
+
+export async function runShopFeed(options: RunShopFeedOptions): Promise<ShopFeedRunResult> {
+  const { db, now, fetchFeed } = options;
+  const rows = parseShopFeed(await fetchFeed());
+
+  // Poistka PRED zápisom: pokazený feed nesmie mapu vyprázdniť. Kým beh
+  // skončí chybou, na obrazovke ostanú adresy z posledného dobrého behu.
+  if (rows.length < MIN_ENTRIES) {
+    throw new Error(
+      `Feed obsahoval len ${String(rows.length)} použiteľných položiek (očakávaných aspoň ${String(MIN_ENTRIES)}) — mapa adries sa neprepisuje`,
+    );
+  }
+
+  for (let i = 0; i < rows.length; i += CHUNK) {
+    const chunk = rows.slice(i, i + CHUNK).map((row) => ({ ...row, fetchedAt: now }));
+    await db
+      .insert(shopProductUrl)
+      .values(chunk)
+      .onConflictDoUpdate({
+        target: shopProductUrl.code,
+        set: { url: sql`excluded.url`, fetchedAt: sql`excluded.fetched_at` },
+      });
+  }
+
+  // Riadky, ktoré feed už neobsahuje, sa ZÁMERNE nemažú: produkt vypadnutý z
+  // feedu (napr. dočasne skrytý) má stále platnú adresu a je lepšie ukázať ju,
+  // než spadnúť späť na vyhľadávanie.
+  const [count] = await db
+    .select({ value: sql<number>`count(*)::int` })
+    .from(shopProductUrl);
+
+  return { entries: rows.length, stored: count?.value ?? 0 };
+}

--- a/apps/api/tests/helpers/db.ts
+++ b/apps/api/tests/helpers/db.ts
@@ -60,7 +60,7 @@ export async function withCleanDb(): Promise<{ db: Database; close: () => Promis
     // predošlého behu potom vyzerá ako platné potvrdenie a beh preskočí
     // VŠETKY odkazy (presne to sa tu stalo pri druhom spustení).
     await db.execute(
-      sql`TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, mail_template, mail_template_history, supplier_stock, restock_settings, restock_event RESTART IDENTITY CASCADE`,
+      sql`TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, mail_template, mail_template_history, supplier_stock, restock_settings, restock_event, shop_product_url RESTART IDENTITY CASCADE`,
     );
     // issue 59: `order_open_status` is a NEW table with real production
     // content (the migration seeds it) — TRUNCATE alone would leave every

--- a/apps/api/tests/restock-run.integration.test.ts
+++ b/apps/api/tests/restock-run.integration.test.ts
@@ -1,7 +1,7 @@
 import { eq } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Database } from "../src/db/client.js";
-import { products, restockEvents, supplierStock, variants } from "../src/db/schema.js";
+import { products, restockEvents, shopProductUrl, supplierStock, variants } from "../src/db/schema.js";
 import type { ShoptetImportConfig } from "../src/modules/shoptet-writeback/config.js";
 import { runRestock, setRestockEnabled } from "../src/modules/restock/run.js";
 import { listRestockWaiting, selectRestockCandidates } from "../src/modules/restock/queries.js";
@@ -215,6 +215,30 @@ describe("prepínanie Vypredané → Skladom", () => {
 
     const druha = await listRestockWaiting(db, NOW, { limit: 2, offset: 2 });
     expect(druha.rows.map((r) => r.variantCode)).not.toEqual(prva.rows.map((r) => r.variantCode));
+  });
+
+  // issue 220 — majiteľ o pôvodných odkazoch: „tie linky na nase produkty su
+  // uplne hrozne". Adresa detailu prichádza z feedu pre porovnávače; kód, ktorý
+  // vo feede nie je, NESMIE zo zoznamu vypadnúť (inak by sa prepol produkt,
+  // ktorý majiteľ nikdy nevidel — trieda chyby z issue 219).
+  it("overovací zoznam nesie priamu adresu z feedu a bez nej riadok nezahodí", async () => {
+    await seedSupplierStock();
+    await seedVariant("U1");
+    await seedVariant("U2");
+    await db.insert(shopProductUrl).values({
+      code: "U1",
+      url: "https://www.forestshop.sk/bunda/?variantId=4211",
+      fetchedAt: NOW,
+    });
+
+    const zoznam = await listRestockWaiting(db, NOW, { limit: 50, offset: 0 });
+    expect(zoznam.total).toBe(2);
+    expect(
+      Object.fromEntries(zoznam.rows.map((r) => [r.variantCode, r.ourUrl])),
+    ).toEqual({
+      U1: "https://www.forestshop.sk/bunda/?variantId=4211",
+      U2: null,
+    });
   });
 
   it("overovací zoznam filtruje podľa dodávateľa", async () => {

--- a/apps/web/src/components/RestockSection.test.tsx
+++ b/apps/web/src/components/RestockSection.test.tsx
@@ -28,6 +28,21 @@ const WAITING = {
       supplierAvailabilityText: "skladom",
       supplierPrice: "24.00",
       confirmedAt: "2026-08-04T04:20:00.000Z",
+      ourUrl: "https://www.forestshop.sk/ladvinka-swedteam-green/?variantId=4211",
+    },
+    {
+      // Kód, ktorý vo feede pre porovnávače NIE JE (issue 220) — dnes je
+      // takých 626 viditeľných variantov. Riadok musí zostať v zozname a
+      // odkaz padnúť späť na vyhľadávanie, nikdy nie na prázdny odkaz.
+      variantCode: "15314",
+      pairCode: null,
+      productName: "Poľovnícky ruksak HART SPEAN 25",
+      supplier: "BETALOV",
+      supplierLink: "https://huntingshop.example/spean",
+      supplierAvailabilityText: "skladom",
+      supplierPrice: "59.00",
+      confirmedAt: "2026-08-04T04:21:00.000Z",
+      ourUrl: null,
     },
   ],
   suppliers: [
@@ -141,9 +156,17 @@ it("pri každom čakajúcom produkte ponúkne odkaz na náš eshop aj k dodávat
 
   const riadok = await screen.findByTestId("restock-waiting-60542");
   const odkazy = [...riadok.querySelectorAll("a")].map((a) => a.getAttribute("href"));
+  // Priama adresa z feedu vrátane výberu veľkosti — nie vyhľadávanie.
   expect(odkazy).toEqual([
-    "https://www.forestshop.sk/vyhladavanie/?string=60542",
+    "https://www.forestshop.sk/ladvinka-swedteam-green/?variantId=4211",
     "https://tthunt.example/ladvinka",
+  ]);
+
+  // Variant, ktorý vo feede nie je, ostáva v zozname a má náhradný odkaz.
+  const bezFeedu = await screen.findByTestId("restock-waiting-15314");
+  expect([...bezFeedu.querySelectorAll("a")].map((a) => a.getAttribute("href"))).toEqual([
+    "https://www.forestshop.sk/vyhladavanie/?string=15314",
+    "https://huntingshop.example/spean",
   ]);
   // Nová karta — inak by preklikávanie zoznam pod rukami zavrelo.
   expect([...riadok.querySelectorAll("a")].every((a) => a.getAttribute("target") === "_blank")).toBe(

--- a/apps/web/src/components/RestockSection.tsx
+++ b/apps/web/src/components/RestockSection.tsx
@@ -9,7 +9,7 @@ import {
   type RestockStatus,
   type RestockWaitingPage,
 } from "../restockApi.js";
-import { ourProductUrl } from "../shopLinks.js";
+import { ourProductLink } from "../shopLinks.js";
 
 // Majiteľ si chce vzorku preklikať po stovkách („potváram si zo sto a overím"),
 // takže stránka je 100 riadkov, nie tradičných 20.
@@ -293,7 +293,7 @@ export function RestockSection({
                   <td>{row.productName}</td>
                   <td>{row.supplier ?? "—"}</td>
                   <td>
-                    <a href={ourProductUrl(row.variantCode)} target="_blank" rel="noreferrer noopener">
+                    <a href={ourProductLink(row.variantCode, row.ourUrl)} target="_blank" rel="noreferrer noopener">
                       náš ↗
                     </a>
                   </td>

--- a/apps/web/src/restockApi.ts
+++ b/apps/web/src/restockApi.ts
@@ -99,6 +99,9 @@ const waitingSchema = z.object({
       supplierAvailabilityText: z.string(),
       supplierPrice: z.string().nullable(),
       confirmedAt: z.string(),
+      // Priama adresa detailu z feedu (issue 220). `null` = kód vo feede nie
+      // je; odkaz vtedy padne späť na vyhľadávanie podľa kódu.
+      ourUrl: z.string().nullable(),
     }),
   ),
   suppliers: z.array(z.object({ name: z.string(), count: z.number() })),

--- a/apps/web/src/shopLinks.test.ts
+++ b/apps/web/src/shopLinks.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { ourProductLink, ourProductUrl } from "./shopLinks.js";
+
+describe("ourProductLink (issue 220)", () => {
+  it("uprednostní priamu adresu z feedu aj s výberom veľkosti", () => {
+    expect(
+      ourProductLink("61276/M", "https://www.forestshop.sk/tricko-hart-aktiva-z/?variantId=35451"),
+    ).toBe("https://www.forestshop.sk/tricko-hart-aktiva-z/?variantId=35451");
+  });
+
+  it("bez adresy z feedu padne späť na vyhľadávanie podľa kódu", () => {
+    expect(ourProductLink("61276/M", null)).toBe(ourProductUrl("61276/M"));
+  });
+
+  it("prázdny reťazec sa berie rovnako ako chýbajúca adresa", () => {
+    expect(ourProductLink("15314", "")).toBe(ourProductUrl("15314"));
+  });
+});

--- a/apps/web/src/shopLinks.ts
+++ b/apps/web/src/shopLinks.ts
@@ -12,3 +12,15 @@ const SEARCH_URL = "https://www.forestshop.sk/vyhladavanie/?string=";
 export function ourProductUrl(code: string): string {
   return SEARCH_URL + encodeURIComponent(code);
 }
+
+/**
+ * Odkaz na detail nášho produktu (issue 220).
+ *
+ * Uprednostní PRIAMU adresu z feedu pre porovnávače (obsahuje aj `?variantId=`,
+ * takže otvorí rovno správnu veľkosť). Keď kód vo feede nie je — dnes 626
+ * viditeľných variantov — padne späť na vyhľadávanie podľa kódu, nikdy na
+ * odkaz, ktorý by viedol nikam.
+ */
+export function ourProductLink(code: string, feedUrl: string | null): string {
+  return feedUrl === null || feedUrl === "" ? ourProductUrl(code) : feedUrl;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.128",
+  "version": "0.3.0-dev.129",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Čo to rieši

Odkaz „náš ↗" v overovacom zozname automatizácie viedol na vyhľadávanie podľa kódu. Majiteľ: *„tie linky na nase produkty su uplne hrozne, ved ty normalne z exportu by si mal vediet link na nas produkt."*

Adresa sa naozaj z exportu poskladať nedá (CSV ju nemá, `guid` je UUID), ale Shoptet ju publikuje vo verejnom feede pre porovnávače `https://www.forestshop.sk/google.xml` — 7 666 položiek, `<g:id>` je presne náš kód variantu a `<link>` priama adresa detailu vrátane `?variantId=`, teda rovno správna veľkosť.

## Čo pribudlo

- Modul `shop-feed` — rozoberač feedu (čistá funkcia, testovaná na fixtúre), sťahovanie s ohraničeným čítaním tela, beh zápisu do mapy.
- Tabuľka `shop_product_url` (`code` PK, `url`, `fetched_at`) + migrácia 0028.
- Nočná úloha `shop-feed` denne 03:50 UTC — pred scraperom (04:20) aj prepínaním (04:50).
- `allRestockCandidates` pripája adresu cez **LEFT JOIN**; frontend má náhradu na vyhľadávanie pre 626 viditeľných variantov, ktoré vo feede nie sú.
- Poistka `MIN_ENTRIES`: keď feed vráti menej než 1 000 použiteľných položiek, mapa sa NEPREPÍŠE a beh skončí chybou.

## Testy

- `parse.test.ts` — položka s `?variantId=`, bez neho, s entitami, bez kódu, bez adresy, duplicitný kód, a že hlavičkový `<link href=…>` feedu sa nikdy nepoužije.
- `run.test.ts` — poistka zaberie PRED zápisom (databázová atrapa vyhadzuje, keď sa jej beh dotkne).
- `shopLinks.test.ts` — priama adresa vyhráva, chýbajúca padá na vyhľadávanie.
- `RestockSection.test.tsx` — riadok s adresou aj riadok bez nej (nesmie zo zoznamu vypadnúť).
- `restock-run.integration.test.ts` — LEFT JOIN vracia adresu pre známy kód a `null` pre neznámy.

Zelené lokálne aj v CI: 515 jednotkových API, 369 webových, 407 integračných.

## Playbook

Nové `.claude/rules/shop-feed.md`; v `supplier-stock.md` opravené zastarané tvrdenie, že adresa produktu neexistuje.

Ticket issue 220 sa zavrie ručne až po živom overení odkazu po nasadení (pravidlo projektu o odloženom overení).
