### PR TITLE
fix: skladová dostupnosť sa číta z výrezu pri produkte, nie z celej stránky (issue 223, issue 225)

### DIFF
--- a/.claude/rules/supplier-stock.md
+++ b/.claude/rules/supplier-stock.md
@@ -36,10 +36,29 @@ paths:
   Majiteľ 3. 8. 2026 výslovne zamietol AI dohady (stará appka posielala
   nečitateľné stránky do OpenAI): čo sa nedá prečítať strojovo, sa ukáže v
   karte „Stránky, ktoré neviem prečítať" a čaká na ľudské rozhodnutie.
-- **Voľnému textu stránky sa dôveruje LEN na doménach v `TRUSTED_TEXT_HOSTS`.**
-  Slovo „Skladom" sa na cudzej stránke môže vyskytnúť v pätičke, v menu alebo
-  pri inom produkte. Pridanie novej domény do zoznamu vyžaduje overenie na
-  uloženej vzorke tej stránky, nikdy len domnienku.
+- **Voľnému textu stránky sa dôveruje LEN na doménach v `TEXT_AVAILABILITY_RULES`
+  (`parse.ts`) — a LEN na VÝREZE, ktorý pravidlo označí za oblasť TOHTO
+  produktu, nikdy na celej stránke (issue 223).** Pôvodný plochý zoznam
+  `TRUSTED_TEXT_HOSTS` (`constants.ts`) bol ODSTRÁNENÝ — dôveroval CELEJ
+  stránke, takže marketingová veta v pätičke huntingshop.eu ("…máme skladom
+  ihneď k odberu.", na KAŽDEJ stránke obchodu) robila z každého produktu bez
+  výslovného záporu `available`. Nové pravidlo nesie aj VÝREZ (regulárny
+  výraz, ktorý vyberie oblasť dostupnosti PRI produkte — pre huntingshop.eu
+  detailný `badge-outline-…` štítok BEZ `badge-stock`, ktorý patrí karuselu
+  súvisiacich produktov) aj to, čo znamená CHÝBAJÚCI výrez (pre
+  huntingshop.eu `unavailable` — produkt bez štítku dostupný nie je).
+  Domény predtým v `TRUSTED_TEXT_HOSTS` bez vlastného overeného výrezu
+  (`wetland.sk`, `trigona.sk`) touto zmenou STRATILI textovú úroveň úplne a
+  končia na `unknown`, kým sa pre ne nenájde a neoverí vlastný výrez —
+  zámerný, dokumentovaný ústup, nie chyba.
+- **JSON-LD vie KLAMAŤ — na doménach v `VISIBLE_AVAILABILITY_RULES` (`parse.ts`)
+  sa krížovo overuje proti viditeľnej dostupnosti PRI produkte (issue 225).**
+  odimon.sk hlási v JSON-LD `InStock`, hoci viditeľný prvok
+  `.product-availability__value` pri produkte hovorí "Nedostupný". Keď sa obe
+  dajú prečítať a NESÚHLASIA, výsledok je `unknown` (stránka si protirečí,
+  rozhoduje človek) — nikdy sa nevyhlási `available` na takomto rozpore. Prvý
+  výskyt takého prvku v dokumente patrí hlavnému produktu — rovnaká trieda sa
+  môže opakovať aj pri súvisiacich produktoch nižšie na stránke.
 - **Obe polia dostupnosti sa do Shoptetu zapisujú NARAZ, ale `stock` sa
   nezapisuje VÔBEC (issue 219).** Shoptet zobrazuje `availabilityOutOfStock`,
   keď sklad klesne na nulu (overené v ostrej prevádzke starej appky

--- a/apps/api/src/modules/supplier-stock/constants.ts
+++ b/apps/api/src/modules/supplier-stock/constants.ts
@@ -35,12 +35,10 @@ export const MAX_PAGE_BYTES = 2_000_000;
 export const USER_AGENT =
   "ForestshopBot/1.0 (kontrola dostupnosti; +https://forestshop.sk)";
 
-// Domény, kde je čítanie dostupnosti z VOĽNÉHO TEXTU stránky overené na
-// uloženej vzorke. Mimo tohto zoznamu sa voľnému textu NEDÔVERUJE (stránka
-// môže mať slovo „Skladom" v pätičke, v inom produkte alebo v menu) a
-// výsledok je `unknown` — radšej nič než dohad, ktorý by zapol produkt.
-export const TRUSTED_TEXT_HOSTS: readonly string[] = Object.freeze([
-  "huntingshop.eu",
-  "wetland.sk",
-  "trigona.sk",
-]);
+// Domény s pravidlom pre voľný text sú definované priamo v `parse.ts`
+// (`TEXT_AVAILABILITY_RULES`) — každá nesie VÝREZ (ktorá oblasť stránky patrí
+// TOMUTO produktu), nie len meno domény. Mimo tohto zoznamu sa voľnému textu
+// NEDÔVERUJE vôbec a výsledok je `unknown` — radšej nič než dohad, ktorý by
+// zapol produkt (issue 223: `wetland.sk`/`trigona.sk` boli predtým v tomto
+// poli ako celostránkové domény bez overeného výrezu; kým sa pre ne nenájde
+// a neoverí vlastný výrez, ostávajú bez textovej úrovne).

--- a/apps/api/src/modules/supplier-stock/fixtures/huntingshop-skladom-tricko.html
+++ b/apps/api/src/modules/supplier-stock/fixtures/huntingshop-skladom-tricko.html
@@ -1,0 +1,41 @@
+<!--
+  Orezaná vzorka https://www.huntingshop.eu/aktiva-z-green-funkcne-tricko (issue 223,
+  overené 4. 8. 2026, živý fetch 4. 8. 2026). Produkt v detaile MÁ skutočný štítok
+  dostupnosti (`badge-outline-success` BEZ `badge-stock`) hneď pri cene — presne
+  ten prvok, ktorý sa má čítať namiesto celej stránky.
+-->
+<html lang="sk">
+<head><title>AKTIVA-Z green funkčné tričko | Huntingshop</title></head>
+<body>
+  <div class="product-price-wrapp-lg mb-4 d-block mt-4" id="snippet--product-price-details">
+    <div class="row">
+      <div class="col-sm-8 col-12 pe-0">
+        <span class="product-price-on-sale price-vat">24,90 €</span>
+      </div>
+      <div class="col-sm-4 col-12 d-flex align-items-center justify-content-sm-end">
+        <span class="badge badge-outline-success ms-sm-3 mt-2 mb-2 mt-sm-0 mb-sm-0 text-uppercase fs-6">
+          Skladom viac ako 3 kusy
+        </span>
+      </div>
+      <div class="col-sm-6 d-none d-sm-block">
+        <span class="badge badge-outline-success ms-sm-3 mb-3 mb-sm-0 text-uppercase fs-6">
+          Dostupné Do 24 hodín
+        </span>
+      </div>
+    </div>
+  </div>
+
+  <div class="related-products-carousel">
+    <div class="product-card">
+      <span class="badge badge-outline-success text-uppercase badge-stock ">
+        Na sklade
+      </span>
+    </div>
+  </div>
+
+  <footer>
+    <h2 class="title h6 mb-3">Skladová dostupnosť</h2>
+    <p class="fs-6 mb-0">Viac ako 90% ponúkaných produktov máme skladom ihneď k odberu.</p>
+  </footer>
+</body>
+</html>

--- a/apps/api/src/modules/supplier-stock/fixtures/huntingshop-vypredany-ruksak.html
+++ b/apps/api/src/modules/supplier-stock/fixtures/huntingshop-vypredany-ruksak.html
@@ -1,6 +1,10 @@
 <!--
-  Orezaná vzorka https://www.huntingshop.eu/hart-spean-25-ruksak-8060 (issue 223,
-  overené 4. 8. 2026). Produkt v detaile NEMÁ žiadny štítok dostupnosti — všetky
+  Rekonštrukcia https://www.huntingshop.eu/hart-spean-25-ruksak-8060 (issue 223)
+  z HTML doslovne citovanej v komentári ticketu (overené majiteľom 4. 8. 2026)
+  — NIE čerstvý fetch. K dátumu písania tejto fixtúry sa live URL presmerúva
+  na homepage (produkt zrejme odstránený z ponuky), takže sa nedala znova
+  živo stiahnuť; obe sesterské fixtúry (skladom-tricko, odimon) SÚ z čerstvého
+  živého fetchu. Produkt v detaile NEMÁ žiadny štítok dostupnosti — všetky
   nájdené `.badge` na stránke patria karuselu súvisiacich produktov (trieda
   `badge-stock`). Jediný výskyt slova „skladom" je marketingová veta v pätičke,
   ktorá je na KAŽDEJ stránke tohto obchodu, nie pri tomto produkte.

--- a/apps/api/src/modules/supplier-stock/fixtures/huntingshop-vypredany-ruksak.html
+++ b/apps/api/src/modules/supplier-stock/fixtures/huntingshop-vypredany-ruksak.html
@@ -1,0 +1,38 @@
+<!--
+  Orezaná vzorka https://www.huntingshop.eu/hart-spean-25-ruksak-8060 (issue 223,
+  overené 4. 8. 2026). Produkt v detaile NEMÁ žiadny štítok dostupnosti — všetky
+  nájdené `.badge` na stránke patria karuselu súvisiacich produktov (trieda
+  `badge-stock`). Jediný výskyt slova „skladom" je marketingová veta v pätičke,
+  ktorá je na KAŽDEJ stránke tohto obchodu, nie pri tomto produkte.
+-->
+<html lang="sk">
+<head><title>HART SPEAN 25 - ruksak | Huntingshop</title></head>
+<body>
+  <div class="product-price-wrapp-lg mb-4 d-block mt-4" id="snippet--product-price-details">
+    <div class="row">
+      <div class="col-sm-8 col-12 pe-0">
+        <span class="product-price-on-sale price-vat">89,90 €</span>
+      </div>
+      <!-- detail nemá ziadny badge-outline- bez badge-stock -->
+    </div>
+  </div>
+
+  <div class="related-products-carousel">
+    <div class="product-card">
+      <span class="badge badge-outline-success text-uppercase badge-stock ">
+        Na sklade
+      </span>
+    </div>
+    <div class="product-card">
+      <span class="badge badge-outline-danger text-uppercase badge-stock opacity-1">
+        Nie je skladom
+      </span>
+    </div>
+  </div>
+
+  <footer>
+    <h2 class="title h6 mb-3">Skladová dostupnosť</h2>
+    <p class="fs-6 mb-0">Viac ako 90% ponúkaných produktov máme skladom ihneď k odberu.</p>
+  </footer>
+</body>
+</html>

--- a/apps/api/src/modules/supplier-stock/fixtures/odimon-nedostupna-strelecka-palica.html
+++ b/apps/api/src/modules/supplier-stock/fixtures/odimon-nedostupna-strelecka-palica.html
@@ -1,0 +1,46 @@
+<!--
+  Orezaná vzorka https://www.odimon.sk/polovnicke-potreby/doplnky-na-lov/nastavitelna-strelecka-palica-odimon-primo-tetrao-gen.ii-4-noha
+  (issue 225, živý fetch 4. 8. 2026). JSON-LD tohto SPRÁVNEHO produktu klame
+  ("InStock"), kým viditeľná dostupnosť PRI PRODUKTE hovorí "Nedostupný" —
+  presne rozpor, ktorý má krížová kontrola zachytiť. Druhý (`--available`,
+  "Skladom 9 ks") blok nižšie na stránke patrí SÚVISIACEMU produktu v
+  odporúčaniach, nie tomuto — čítač smie brať LEN prvý výskyt v dokumente.
+-->
+<html lang="sk">
+<head>
+<title>Nastaviteľná strelecká palica ODIMON PRIMO TETRAO Gen.II - 4 nohá | ODIMON.sk</title>
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"Product",
+ "name":"Nastaviteľná strelecká palica ODIMON PRIMO TETRAO Gen.II - 4 nohá",
+ "url":"https://www.odimon.sk/polovnicke-potreby/doplnky-na-lov/nastavitelna-strelecka-palica-odimon-primo-tetrao-gen.ii-4-noha",
+ "offers":{"@type":"Offer","priceCurrency":"EUR","price":"149.90","availability":"http://schema.org/InStock"}}
+</script>
+</head>
+<body>
+  <h1>Nastaviteľná strelecká palica ODIMON PRIMO TETRAO Gen.II - 4 nohá</h1>
+
+  <div class="product-availability">
+    <span class="product-availability__value product-availability__value--unavailable">
+      <span class="product-availability__value--text">
+        Nedostupný
+      </span>
+    </span>
+  </div>
+
+  <div class="related-products">
+    <div class="product-box">
+      <h4><a href="/polovnicke-potreby/doplnky-na-lov/2-bodova-opierka-tetrao-na-strelecke-palice-odimon-primo">2-bodová opierka TETRAO</a></h4>
+      <div class="availability-box">
+        <div class="product-availability">
+          <span class="product-availability__value product-availability__value--available">
+            <span class="product-availability__value--text">
+              <strong>Skladom</strong>
+              <span class="product-availability__count">9 ks</span>
+            </span>
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/apps/api/src/modules/supplier-stock/parse.test.ts
+++ b/apps/api/src/modules/supplier-stock/parse.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
   availabilityFromSchemaToken,
@@ -10,6 +12,14 @@ import {
   parsePrice,
   visibleText,
 } from "./parse.js";
+
+function fixture(name: string): string {
+  return readFileSync(fileURLToPath(new URL(`./fixtures/${name}`, import.meta.url)), "utf8");
+}
+
+const HUNTINGSHOP_VYPREDANY = fixture("huntingshop-vypredany-ruksak.html");
+const HUNTINGSHOP_SKLADOM = fixture("huntingshop-skladom-tricko.html");
+const ODIMON_NEDOSTUPNA = fixture("odimon-nedostupna-strelecka-palica.html");
 
 describe("hostOf / isTrustedTextHost", () => {
   it("odreze www a zmensi pismena", () => {
@@ -170,20 +180,67 @@ describe("parsePage — poradie urovni", () => {
     expect(result.source).toBe("meta");
   });
 
-  it("volny text sa pouzije LEN na overenej domene", () => {
+  it("volny text sa pouzije LEN na overenej domene, a LEN na vyrezanej oblasti produktu", () => {
+    // Domena bez pravidla na vyrez (issue 223): text sa vobec necita, ostava unknown.
     const html = "<html><body><h1>Bunda</h1><p>Skladom</p></body></html>";
-    expect(parsePage(html, "https://huntingshop.eu/p/1")).toMatchObject({
-      availability: "available",
-      source: "text",
-    });
     expect(parsePage(html, "https://dogtrace.com/p/1")).toMatchObject({
       availability: "unknown",
       source: "none",
     });
   });
 
-  it("necitatelna stranka je unknown, nikdy dohad", () => {
-    const result = parsePage("<html><body>Popis produktu</body></html>", "https://huntingshop.eu/p/1");
+  it("necitatelna stranka na domene BEZ pravidla je unknown, nikdy dohad", () => {
+    const result = parsePage("<html><body>Popis produktu</body></html>", "https://dogtrace.com/p/1");
     expect(result).toEqual({ availability: "unknown", availabilityText: "", price: null, source: "none" });
+  });
+});
+
+describe("parsePage — issue 223: huntingshop.eu cita LEN stitok pri produkte", () => {
+  it("vypredany produkt (ziadny detailny stitok, len paticka a karusel) je unavailable", () => {
+    const result = parsePage(HUNTINGSHOP_VYPREDANY, "https://www.huntingshop.eu/hart-spean-25-ruksak-8060");
+    expect(result.availability).toBe("unavailable");
+  });
+
+  it("skladom produkt (skutocny detailny stitok badge-outline- bez badge-stock) je available", () => {
+    const result = parsePage(HUNTINGSHOP_SKLADOM, "https://www.huntingshop.eu/aktiva-z-green-funkcne-tricko");
+    expect(result.availability).toBe("available");
+    expect(result.source).toBe("text");
+    expect(result.availabilityText.toLowerCase()).toContain("skladom");
+  });
+
+  it("paticková veta SAMA O SEBE (bez detailneho stitku) nesmie stacit na available", () => {
+    // Rovnaka paticka ako v skladom-fixture, ale ako VLASTNA, izolovana stranka
+    // bez ziadneho badge-outline- stitku — presne situacia, ktora bola zdrojom
+    // falosneho pozitiva pred opravou (celostrankovy volny text).
+    const html = `<html><body><footer>
+      <h2 class="title h6">Skladová dostupnosť</h2>
+      <p class="fs-6 mb-0">Viac ako 90% ponúkaných produktov máme skladom ihneď k odberu.</p>
+    </footer></body></html>`;
+    const result = parsePage(html, "https://www.huntingshop.eu/nejaky-produkt");
+    expect(result.availability).not.toBe("available");
+  });
+});
+
+describe("parsePage — issue 225: odimon.sk — viditelna dostupnost prebija klamlive JSON-LD", () => {
+  it("rozpor JSON-LD (InStock) vs viditelne 'Nedostupny' pri produkte je unknown, nikdy available", () => {
+    const result = parsePage(
+      ODIMON_NEDOSTUPNA,
+      "https://www.odimon.sk/polovnicke-potreby/doplnky-na-lov/nastavitelna-strelecka-palica-odimon-primo-tetrao-gen.ii-4-noha",
+    );
+    expect(result.availability).toBe("unknown");
+    expect(result.availability).not.toBe("available");
+  });
+
+  it("zhoda JSON-LD a viditelnej dostupnosti sa pouzije (viditelna je zdroj textu)", () => {
+    const html = `<html><head><script type="application/ld+json">
+      {"@type":"Product","offers":{"@type":"Offer","availability":"OutOfStock"}}
+    </script></head><body>
+      <span class="product-availability__value product-availability__value--unavailable">
+        <span class="product-availability__value--text">Nedostupný</span>
+      </span>
+    </body></html>`;
+    const result = parsePage(html, "https://www.odimon.sk/p/nieco");
+    expect(result.availability).toBe("unavailable");
+    expect(result.source).toBe("text");
   });
 });

--- a/apps/api/src/modules/supplier-stock/parse.test.ts
+++ b/apps/api/src/modules/supplier-stock/parse.test.ts
@@ -243,4 +243,20 @@ describe("parsePage — issue 225: odimon.sk — viditelna dostupnost prebija kl
     expect(result.availability).toBe("unavailable");
     expect(result.source).toBe("text");
   });
+
+  it("text sa cita EXPLICITNE z vnoreneho --text prvku, aj ked ten ma dalsi vnoreny prvok (pocet kusov)", () => {
+    // Presne markup suvisiaceho produktu z ODIMON_NEDOSTUPNA fixtury: --text
+    // prvok ma VNORENY <span class="...__count">, takze naivne "druha
+    // zatvaracia znacka" by odrezala/posunula text. Token (available/
+    // unavailable) sa berie z vonkajsej triedy nezavisle od tohto vnorenia.
+    const html = `<span class="product-availability__value product-availability__value--available">
+      <span class="product-availability__value--text">
+        <strong>Skladom</strong>
+        <span class="product-availability__count">9 ks</span>
+      </span>
+    </span>`;
+    const result = parsePage(html, "https://www.odimon.sk/p/ine");
+    expect(result.availability).toBe("available");
+    expect(result.availabilityText).toBe("Skladom 9 ks");
+  });
 });

--- a/apps/api/src/modules/supplier-stock/parse.ts
+++ b/apps/api/src/modules/supplier-stock/parse.ts
@@ -287,15 +287,23 @@ interface VisibleAvailabilityRule {
  * PRI produkte je to, čo skutočne vidí zákazník — PRVÝ výskyt v dokumente
  * patrí hlavnému produktu (overené na vzorke: rovnaký prvok sa opakuje aj v
  * bloku súvisiacich produktov nižšie na stránke, ale až za hlavným).
+ *
+ * Token (`available`/`unavailable`, čo ROZHODUJE dostupnosť) sa berie z
+ * TRIEDY vonkajšieho `<span>` — to je vždy spoľahlivé. Zobrazovaný text sa
+ * ČÍTA EXPLICITNE z vnoreného `.product-availability__value--text`, nikdy sa
+ * neodvodzuje z toho, kde náhodou skončí druhá zatváracia značka — tá by sa
+ * mohla posunúť, keby stránka pridala ďalší vnorený prvok (napr. počet kusov).
  */
 function odimonVisibleAvailability(html: string): VisibleAvailabilityHit | null {
-  const match =
-    /<span\b[^>]*class="[^"]*product-availability__value--(available|unavailable)[^"]*"[^>]*>([\s\S]*?)<\/span>\s*<\/span>/i.exec(
-      html,
-    );
-  if (match === null) return null;
-  const token = match[1];
-  const text = (match[2] ?? "").replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
+  const outer =
+    /<span\b[^>]*class="[^"]*product-availability__value--(available|unavailable)\b[^"]*"[^>]*>/i.exec(html);
+  if (outer === null) return null;
+  const token = outer[1];
+  const rest = html.slice(outer.index + outer[0].length);
+  const textMatch = /<span\b[^>]*class="[^"]*product-availability__value--text[^"]*"[^>]*>([\s\S]*?)<\/span>/i.exec(
+    rest,
+  );
+  const text = (textMatch?.[1] ?? "").replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
   return { availability: token === "available" ? "available" : "unavailable", text };
 }
 

--- a/apps/api/src/modules/supplier-stock/parse.ts
+++ b/apps/api/src/modules/supplier-stock/parse.ts
@@ -1,18 +1,22 @@
 // Čítanie dostupnosti a ceny z HTML stránky dodávateľa — ČISTÉ funkcie, žiadna
 // sieť, žiadna databáza. Testuje sa nad uloženými vzorkami stránok.
 //
-// Tri úrovne v poradí od najspoľahlivejšej:
+// Úrovne v poradí od najspoľahlivejšej — ALE keď má doména vlastné pravidlo
+// na VIDITEĽNÚ dostupnosť pri produkte (`VISIBLE_AVAILABILITY_RULES`, issue
+// 225), táto sa krížovo overí proti JSON-LD a pri rozpore vyhrá „neviem":
 //   1. JSON-LD `Product` (`schema.org`) — strojový údaj, ktorý dávajú Shoptet,
-//      WooCommerce aj PrestaShop; jediný, ktorý hovorí o TOMTO produkte, nie o
-//      náhodnom texte na stránke.
+//      WooCommerce aj PrestaShop. Vie ale KLAMAŤ (issue 225: odimon.sk hlási
+//      InStock, hoci stránka pri produkte hovorí "Nedostupný") — preto sa
+//      na doménach s pravidlom na viditeľnú dostupnosť nikdy neberie ako
+//      posledné slovo bez overenia.
 //   2. `og:` / `product:` meta značky — ten istý údaj, keď JSON-LD chýba.
-//   3. Voľný text stránky — LEN pre domény v `TRUSTED_TEXT_HOSTS`, kde je to
-//      overené na vzorke. Inde je dohad horší než „neviem".
+//   3. Voľný text stránky — LEN pre domény v `TEXT_AVAILABILITY_RULES`, a LEN
+//      z VÝREZU, ktorý pravidlo označí za oblasť TOHTO produktu (issue 223:
+//      celostránkový voľný text chytal marketingovú vetu z pätičky). Inde je
+//      dohad horší než „neviem".
 //
 // Čokoľvek, čo neprejde ani jednou úrovňou, je `unknown` — a `unknown` nikdy
 // neprepne produkt (issue 213).
-
-import { TRUSTED_TEXT_HOSTS } from "./constants.js";
 
 export type SupplierAvailability = "available" | "unavailable" | "unknown";
 export type SupplierStockSource = "json_ld" | "meta" | "text" | "none";
@@ -35,11 +39,9 @@ export function hostOf(url: string): string {
   return host.startsWith("www.") ? host.slice(4) : host;
 }
 
-/** `true`, keď je doména (alebo jej poddoména) medzi overenými pre voľný text. */
+/** `true`, keď má doména (alebo jej poddoména) overené pravidlo na voľný text. */
 export function isTrustedTextHost(url: string): boolean {
-  const host = hostOf(url);
-  if (host === "") return false;
-  return TRUSTED_TEXT_HOSTS.some((trusted) => host === trusted || host.endsWith(`.${trusted}`));
+  return textAvailabilityRuleFor(url) !== null;
 }
 
 // `schema.org` tokeny. Zámerne sa NEBERIE `PreOrder`/`BackOrder` ako
@@ -232,13 +234,107 @@ export function fromMetaTags(html: string): SchemaHit | null {
   return null;
 }
 
+interface TextAvailabilityRule {
+  readonly host: string;
+  /** Vyberie z CELEJ stránky LEN oblasť s dostupnosťou TOHTO produktu. `null` = oblasť sa nenašla. */
+  readonly extractRegion: (html: string) => string | null;
+  /** Čo znamená CHÝBAJÚCA oblasť (žiadny štítok pri produkte). */
+  readonly whenRegionMissing: SupplierAvailability;
+}
+
 /**
- * Celé čítanie stránky — tri úrovne v poradí. `url` rozhoduje LEN o tom, či sa
- * smie použiť tretia (voľný text): mimo overených domén sa radšej vráti
+ * huntingshop.eu (issue 223): dostupnosť TOHTO produktu nesie `<span
+ * class="badge badge-outline-…">` hneď pri cene. Karuselové štítky
+ * súvisiacich produktov majú NAVYŠE triedu `badge-stock` — tie sa vylučujú,
+ * inak by sa dostupnosť iného produktu v karuseli počítala za tento. Keď sa
+ * nenájde ŽIADEN takýto štítok, produkt v skutočnosti nemá žiadnu značku
+ * dostupnosti — to znamená `unavailable` (overené na vzorke: vypredaný
+ * produkt štítok nemá vôbec), nikdy `available` z náhodného textu inde na
+ * stránke (napr. pätičková veta „…máme skladom ihneď k odberu").
+ */
+function huntingshopDetailBadges(html: string): string | null {
+  const spans = [...html.matchAll(/<span\b[^>]*class="([^"]*badge-outline-[^"]*)"[^>]*>([\s\S]*?)<\/span>/gi)];
+  const texts = spans
+    .filter(([, cls]) => cls !== undefined && !cls.includes("badge-stock"))
+    .map(([, , text]) => (text ?? "").replace(/\s+/g, " ").trim())
+    .filter((text) => text !== "");
+  return texts.length > 0 ? texts.join(" ") : null;
+}
+
+const TEXT_AVAILABILITY_RULES: readonly TextAvailabilityRule[] = Object.freeze([
+  { host: "huntingshop.eu", extractRegion: huntingshopDetailBadges, whenRegionMissing: "unavailable" },
+]);
+
+function textAvailabilityRuleFor(url: string): TextAvailabilityRule | null {
+  const host = hostOf(url);
+  if (host === "") return null;
+  return TEXT_AVAILABILITY_RULES.find((rule) => host === rule.host || host.endsWith(`.${rule.host}`)) ?? null;
+}
+
+interface VisibleAvailabilityHit {
+  readonly availability: SupplierAvailability;
+  readonly text: string;
+}
+
+interface VisibleAvailabilityRule {
+  readonly host: string;
+  readonly read: (html: string) => VisibleAvailabilityHit | null;
+}
+
+/**
+ * odimon.sk (issue 225): JSON-LD tejto domény vie klamať (hlási "InStock",
+ * hoci stránka pri produkte hovorí "Nedostupný"). `.product-availability__value`
+ * PRI produkte je to, čo skutočne vidí zákazník — PRVÝ výskyt v dokumente
+ * patrí hlavnému produktu (overené na vzorke: rovnaký prvok sa opakuje aj v
+ * bloku súvisiacich produktov nižšie na stránke, ale až za hlavným).
+ */
+function odimonVisibleAvailability(html: string): VisibleAvailabilityHit | null {
+  const match =
+    /<span\b[^>]*class="[^"]*product-availability__value--(available|unavailable)[^"]*"[^>]*>([\s\S]*?)<\/span>\s*<\/span>/i.exec(
+      html,
+    );
+  if (match === null) return null;
+  const token = match[1];
+  const text = (match[2] ?? "").replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
+  return { availability: token === "available" ? "available" : "unavailable", text };
+}
+
+const VISIBLE_AVAILABILITY_RULES: readonly VisibleAvailabilityRule[] = Object.freeze([
+  { host: "odimon.sk", read: odimonVisibleAvailability },
+]);
+
+function visibleAvailabilityFor(url: string, html: string): VisibleAvailabilityHit | null {
+  const host = hostOf(url);
+  if (host === "") return null;
+  const rule = VISIBLE_AVAILABILITY_RULES.find((r) => host === r.host || host.endsWith(`.${r.host}`));
+  return rule === undefined ? null : rule.read(html);
+}
+
+/**
+ * Celé čítanie stránky. `url` rozhoduje o dvoch veciach: (a) či sa smie
+ * použiť voľný text a z KTOREJ oblasti (issue 223), (b) či sa JSON-LD musí
+ * krížovo overiť proti viditeľnej dostupnosti PRI produkte skôr, než sa mu
+ * uverí (issue 225). Mimo overených domén/pravidiel sa radšej vráti
  * `unknown` než dohad.
  */
 export function parsePage(html: string, url: string): ParsedPage {
   const jsonLd = fromJsonLd(html);
+
+  const visible = visibleAvailabilityFor(url, html);
+  if (visible !== null) {
+    if (jsonLd !== null && jsonLd.availability !== visible.availability) {
+      // Stránka si protirečí (JSON-LD vs viditeľná dostupnosť) — človek
+      // rozhodne, nikdy sa nevyhlási `available` na takomto rozpore.
+      return { availability: "unknown", availabilityText: "", price: null, source: "none" };
+    }
+    return {
+      availability: visible.availability,
+      availabilityText: visible.text,
+      price: jsonLd?.price ?? null,
+      source: "text",
+    };
+  }
+
   if (jsonLd !== null) {
     return {
       availability: jsonLd.availability,
@@ -258,8 +354,13 @@ export function parsePage(html: string, url: string): ParsedPage {
     };
   }
 
-  if (isTrustedTextHost(url)) {
-    const text = availabilityFromText(visibleText(html));
+  const textRule = textAvailabilityRuleFor(url);
+  if (textRule !== null) {
+    const region = textRule.extractRegion(html);
+    if (region === null) {
+      return { availability: textRule.whenRegionMissing, availabilityText: "", price: null, source: "text" };
+    }
+    const text = availabilityFromText(region);
     if (text.availability !== "unknown") {
       return {
         availability: text.availability,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.129",
+  "version": "0.3.0-dev.130",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Čo sa opravuje

Dve z troch príčin falošných kandidátov automatizácie „Vypredané → Skladom"
(spoločné vyšetrovanie 4. 8. 2026, kontext v issue 223).

**issue 223 — huntingshop.eu.** `TRUSTED_TEXT_HOSTS` dôverovalo voľnému
textu CELEJ stránky. Marketingová veta v pätičke ("Viac ako 90% ponúkaných
produktov máme skladom ihneď k odberu.") je na KAŽDEJ stránke obchodu, takže
každý produkt bez výslovného záporu vyšiel ako `available`. Nahradené
pravidlom na doménu, ktoré číta LEN detailný štítok pri produkte
(`badge-outline-…` bez `badge-stock`, ktorý patrí karuselu súvisiacich
produktov). Chýbajúci štítok = `unavailable` (produkt bez štítku dostupný
nie je), nikdy dohad. Domény bez overeného výrezu (`wetland.sk`,
`trigona.sk`) stratili textovú úroveň a končia na `unknown`.

**issue 225 — odimon.sk.** JSON-LD tejto domény vie klamať — hlási
`InStock`, hoci viditeľná dostupnosť PRI produkte hovorí "Nedostupný".
Pridaná krížová kontrola: JSON-LD sa porovná s `.product-availability__value`
pri produkte; pri rozpore je výsledok `unknown` (stránka si protirečí,
rozhoduje človek — rovnaká zásada ako issue 213), nikdy `available`.

## Testy

RED→GREEN (`f1989aa` → `9ad65e0`): orezané fixtúry z reálnych stránok
(`apps/api/src/modules/supplier-stock/fixtures/`) — vypredaný huntingshop
produkt bez štítku, skladom produkt so skutočným štítkom, pätičková veta
samostatne (nesmie stačiť na `available`), a odimon.sk stránka s rozporom
JSON-LD/viditeľnej dostupnosti.

## Rozsah

huntingshop.eu malo 310 `available` cez text, odimon.sk malo 182 `available`
cez JSON-LD — obe podozrivé. Po nasadení zmeriam, koľko z toho zostane
(nočný beh preveruje odkaz najskôr 20 h po poslednej úspešnej kontrole).

Súvisiace tickety: issue 223, issue 225 (obe zavriem ručne až po naživo
overenom nasadení — pozri `.claude/rules/` poznámku o predčasnom auto-close).