### PR TITLE
fix: dostupnosť u dodávateľa sa berie za konkrétnu veľkosť, nie za celý odkaz

### DIFF
--- a/.claude/rules/supplier-stock.md
+++ b/.claude/rules/supplier-stock.md
@@ -87,6 +87,34 @@ paths:
   podmienok by sa skôr či neskôr rozišla a majiteľ by overil iné produkty, než
   by sa naozaj prepli. Integračný test to drží (`overovací zoznam vylučuje
   detailOnly rovnako ako samotné prepínanie`).
+- **`supplier_stock` je od issue 224 kľúčovaná na dvojicu `(link, size_label)`,
+  nie len na `link`** — 965 z 2179 odkazov pokrýva VIAC našich variantov
+  (rôzne veľkosti), a dodávateľ hlási dostupnosť PO veľkosti. `size_label=''`
+  = "dostupnosť CELÉHO odkazu" (jednoveľkostný produkt, alebo doména bez
+  `SIZE_AVAILABILITY_RULES` pravidla — nezmenené správanie). `run.ts`'s
+  `writeSupplierStockRows` VŽDY vymaže riadky linky mimo aktuálne zapisovanej
+  množiny — blanket (`''`) a per-veľkostné riadky sa pre TEN ISTÝ odkaz
+  NIKDY nesmú stretnúť naraz, inak by `restock/queries.ts`'s JOIN (`size_label
+  = coalesce(variant.size_label,'') OR size_label = ''`) mohol jeden variant
+  spárovať s DVOMA riadkami naraz (jeho vlastným aj cudzím blanket riadkom).
+- **NÁŠ `variant.size_label` sa NEMUSÍ zhodovať s dodávateľovým textom
+  znak-po-znaku — Shoptet ukladá skrátený tvar tej istej veľkosti.**
+  Zmerané v produkčnej DB (issue 224): náš `"L-X"` = dodávateľov `"L/XL"`
+  (shop.lasting.eu). `matchSizeLabel` (`parse.ts`) preto rozdelí OBE strany
+  na časti (oddeľovače preč) a porovná POZIČNE — zhoda platí pri PRESNEJ
+  zhode ALEBO keď je jedna časť PREFIXOM druhej na tej istej pozícii ("X" ~
+  "XL"), nikdy pri inom počte častí ani pri VIACNÁSOBNEJ (nejednoznačnej)
+  zhode. Toto NIE JE AI dohad — je to deterministický, testovaný algoritmus.
+- **JSON-LD sa na doméne s `SIZE_AVAILABILITY_RULES` pravidlom (issue 224:
+  `shop.lasting.eu`, PrestaShop) NIKDY neberie ako dostupnosť KONKRÉTNEJ
+  veľkosti — hlási len JEDNU (predvolenú/`checked`) veľkosť a vie byť s
+  vlastným per-veľkostným zoznamom v priamom rozpore** (živý dôkaz: JSON-LD
+  hlásil `InStock` pre veľkosť, ktorej vlastný `<li class="sklademNE">`
+  zoznam hovorí opak). `parseSizeAvailability` číta zoznam veľkostí PRIAMO
+  (trieda `sklademANO`/`sklademNE`, veľkosť v `title=""`) a keď taký zoznam
+  existuje, `parsePage` (JSON-LD/meta/text) sa pre tento odkaz vôbec
+  nepoužije — rovnaká disciplína ako issue 223/225's textové/viditeľné
+  pravidlá, len na ÚROVNI veľkosti namiesto úrovne stránky.
 - **Nová tabuľka MUSÍ pribudnúť do `TRUNCATE` zoznamu v
   `tests/helpers/db.ts`, inak testy zlyhajú AŽ pri druhom behu.** Pri #212 to
   bolo obzvlášť zákerné: prvý beh prešiel (prázdna tabuľka), druhý beh našiel

--- a/apps/api/drizzle/0029_supplier_stock_size_label.sql
+++ b/apps/api/drizzle/0029_supplier_stock_size_label.sql
@@ -1,0 +1,10 @@
+-- issue 224: "supplier_stock" bola kľúčovaná len na "link" (jedna dostupnosť
+-- pre celý odkaz) — pridáva sa "size_label" (default '' = celý odkaz, pre
+-- spätnú kompatibilitu existujúcich riadkov) a primárny kľúč sa mení na
+-- dvojicu (link, size_label), aby odkaz zdieľaný viacerými veľkosťami mohol
+-- niesť dostupnosť KAŽDEJ veľkosti samostatne. drizzle-kit nevie automaticky
+-- zistiť názov pôvodného PK — overené ručne v DB (`supplier_stock_pkey`).
+ALTER TYPE "public"."supplier_stock_source" ADD VALUE 'size_list' BEFORE 'none';--> statement-breakpoint
+ALTER TABLE "supplier_stock" ADD COLUMN "size_label" text DEFAULT '' NOT NULL;--> statement-breakpoint
+ALTER TABLE "supplier_stock" DROP CONSTRAINT "supplier_stock_pkey";--> statement-breakpoint
+ALTER TABLE "supplier_stock" ADD CONSTRAINT "supplier_stock_link_size_label_pk" PRIMARY KEY("link","size_label");

--- a/apps/api/drizzle/meta/0029_snapshot.json
+++ b/apps/api/drizzle/meta/0029_snapshot.json
@@ -1,0 +1,2490 @@
+{
+  "id": "c5b91146-fc24-47e0-b03c-9ad09d93d301",
+  "prevId": "008ab57e-6426-42c3-9aee-61017b8996cc",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "related_codes": {
+          "name": "related_codes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_code": {
+          "name": "external_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_open_status": {
+      "name": "order_open_status",
+      "schema": "",
+      "columns": {
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Vybavuje sa'"
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop_remark": {
+          "name": "shop_remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shoptet_order_id": {
+          "name": "shoptet_order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_updated_at": {
+          "name": "comment_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_synced_at": {
+          "name": "comment_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_carrier_name": {
+          "name": "shipping_carrier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_link_override": {
+      "name": "product_supplier_link_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_link_override_product_key_product_key_fk": {
+          "name": "product_supplier_link_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_link_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_override": {
+      "name": "product_supplier_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_override_product_key_product_key_fk": {
+          "name": "product_supplier_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing": {
+      "name": "pairing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_url": {
+          "name": "supplier_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "pairing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'navrhnute'"
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pairing_state_idx": {
+          "name": "pairing_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_confirmed_by_idx": {
+          "name": "pairing_confirmed_by_idx",
+          "columns": [
+            {
+              "expression": "confirmed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_variant_code_variant_code_fk": {
+          "name": "pairing_variant_code_variant_code_fk",
+          "tableFrom": "pairing",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pairing_confirmed_by_users_id_fk": {
+          "name": "pairing_confirmed_by_users_id_fk",
+          "tableFrom": "pairing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pairing_variant_code_unique": {
+          "name": "pairing_variant_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pairing_confirmation_ck": {
+          "name": "pairing_confirmation_ck",
+          "value": "(\"pairing\".\"state\" = 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)\n        OR (\"pairing\".\"state\" != 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NULL AND \"pairing\".\"confirmed_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier": {
+      "name": "supplier",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wholesale_base_url": {
+          "name": "wholesale_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_key": {
+          "name": "adapter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_settings": {
+      "name": "posta_uncollected_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_state": {
+      "name": "posta_uncollected_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notify_count": {
+          "name": "notify_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_state": {
+          "name": "terminal_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_settings": {
+      "name": "order_reminder_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_state": {
+      "name": "order_reminder_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_state": {
+      "name": "nedostupne_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "nedostupne_email_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nedostupne_state_order_variant_type_uq": {
+          "name": "nedostupne_state_order_variant_type_uq",
+          "columns": [
+            {
+              "expression": "order_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template_history": {
+      "name": "mail_template_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "mail_template_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_template_history_key_idx": {
+          "name": "mail_template_history_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_template_history_changed_by_user_id_users_id_fk": {
+          "name": "mail_template_history_changed_by_user_id_users_id_fk",
+          "tableFrom": "mail_template_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template": {
+      "name": "mail_template",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail_template_updated_by_user_id_users_id_fk": {
+          "name": "mail_template_updated_by_user_id_users_id_fk",
+          "tableFrom": "mail_template",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_log": {
+      "name": "mail_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "mail_log_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_log_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "mail_log_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_log_created_idx": {
+          "name": "mail_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_log_source_created_idx": {
+          "name": "mail_log_source_created_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_log_actor_user_id_users_id_fk": {
+          "name": "mail_log_actor_user_id_users_id_fk",
+          "tableFrom": "mail_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_stock": {
+      "name": "supplier_stock",
+      "schema": "",
+      "columns": {
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "supplier_availability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "supplier_stock_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "supplier_stock_host_idx": {
+          "name": "supplier_stock_host_idx",
+          "columns": [
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "supplier_stock_avail_idx": {
+          "name": "supplier_stock_avail_idx",
+          "columns": [
+            {
+              "expression": "availability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "supplier_stock_link_size_label_pk": {
+          "name": "supplier_stock_link_size_label_pk",
+          "columns": [
+            "link",
+            "size_label"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_event": {
+      "name": "restock_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_link": {
+          "name": "supplier_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_availability_text": {
+          "name": "supplier_availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "supplier_price": {
+          "name": "supplier_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "restock_event_at_idx": {
+          "name": "restock_event_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "restock_event_variant_idx": {
+          "name": "restock_event_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_settings": {
+      "name": "restock_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shop_product_url": {
+      "name": "shop_product_url",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne"
+      ]
+    },
+    "public.pairing_state": {
+      "name": "pairing_state",
+      "schema": "public",
+      "values": [
+        "navrhnute",
+        "potvrdene"
+      ]
+    },
+    "public.nedostupne_email_type": {
+      "name": "nedostupne_email_type",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "alternativa"
+      ]
+    },
+    "public.mail_template_action": {
+      "name": "mail_template_action",
+      "schema": "public",
+      "values": [
+        "save",
+        "reset"
+      ]
+    },
+    "public.mail_log_source": {
+      "name": "mail_log_source",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "posta_uncollected",
+        "order_reminder",
+        "supplier_order"
+      ]
+    },
+    "public.mail_log_status": {
+      "name": "mail_log_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.mail_log_trigger": {
+      "name": "mail_log_trigger",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "manual"
+      ]
+    },
+    "public.supplier_availability": {
+      "name": "supplier_availability",
+      "schema": "public",
+      "values": [
+        "available",
+        "unavailable",
+        "unknown"
+      ]
+    },
+    "public.supplier_stock_source": {
+      "name": "supplier_stock_source",
+      "schema": "public",
+      "values": [
+        "json_ld",
+        "meta",
+        "text",
+        "size_list",
+        "none"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1785835560612,
       "tag": "0028_shop_product_url",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1785846514944,
+      "tag": "0029_supplier_stock_size_label",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema-supplier-stock.ts
+++ b/apps/api/src/db/schema-supplier-stock.ts
@@ -5,6 +5,7 @@ import {
   numeric,
   pgEnum,
   pgTable,
+  primaryKey,
   text,
   timestamp,
 } from "drizzle-orm/pg-core";
@@ -29,17 +30,25 @@ export const supplierStockSource = pgEnum("supplier_stock_source", [
   "json_ld",
   "meta",
   "text",
+  "size_list",
   "none",
 ]);
 
-// Jeden riadok na UNIKÁTNU dodávateľskú linku, nie na variant ani produkt —
-// tá istá linka je na reálnom exporte zdieľaná mnohými variantmi toho istého
-// produktu (nameraná 238 unikátnych liniek na 1 210 riadkov), takže kľúčovať
-// per variant by znamenalo sťahovať tú istú stránku aj 30× za beh.
+// Jeden riadok na dvojicu (UNIKÁTNA dodávateľská linka, NAŠA veľkosť) —
+// issue 224. Pôvodne bol riadok len na linku (jedna dostupnosť pre celý
+// odkaz), čo bolo nesprávne pre 965 z 2 179 liniek, ktoré pokrývajú VIAC
+// našich variantov (rôzne veľkosti) naraz: dostupnosť náhodne prečítanej
+// veľkosti sa aplikovala na všetky ostatné. `size_label = ''` znamená
+// "dostupnosť CELÉHO odkazu" — jednoveľkostný produkt, ALEBO doména bez
+// vlastného pravidla na čítanie zoznamu veľkostí (`SIZE_AVAILABILITY_RULES`,
+// `parse.ts`) — a je to jediný riadok, aký sa pre taký odkaz zapíše. Odkaz S
+// pravidlom dostáva PRESNE jeden riadok na KAŽDÚ našu veľkosť, ktorá sa naň
+// viaže (`run.ts`), nikdy oba tvary naraz pre ten istý odkaz.
 export const supplierStock = pgTable(
   "supplier_stock",
   {
-    link: text("link").primaryKey(),
+    link: text("link").notNull(),
+    sizeLabel: text("size_label").notNull().default(""),
     // Doména bez `www.` — nesie sa uložená (nie počítaná pri čítaní), aby sa
     // dala indexovať a zoskupovať v prehľade nečitateľných stránok.
     host: text("host").notNull(),
@@ -67,5 +76,9 @@ export const supplierStock = pgTable(
     // dávno neaktuálneho „skladom".
     confirmedAt: timestamp("confirmed_at", { withTimezone: true }),
   },
-  (t) => [index("supplier_stock_host_idx").on(t.host), index("supplier_stock_avail_idx").on(t.availability)],
+  (t) => [
+    primaryKey({ columns: [t.link, t.sizeLabel] }),
+    index("supplier_stock_host_idx").on(t.host),
+    index("supplier_stock_avail_idx").on(t.availability),
+  ],
 );

--- a/apps/api/src/modules/restock/queries.ts
+++ b/apps/api/src/modules/restock/queries.ts
@@ -4,7 +4,7 @@
 // e-shope produkt, ktorý majiteľ vedome vypol. Preto sa každá podmienka
 // kontroluje pozitívne (musí platiť), nikdy sa nič nepredpokladá.
 
-import { and, asc, eq, isNull, sql } from "drizzle-orm";
+import { and, asc, eq, isNull, or, sql } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
 import { products, shopProductUrl, supplierStock, variants } from "../../db/schema.js";
 import {
@@ -95,7 +95,23 @@ async function allRestockCandidates(db: Database, now: Date): Promise<readonly R
     })
     .from(variants)
     .innerJoin(products, eq(variants.productKey, products.key))
-    .innerJoin(supplierStock, eq(supplierStock.link, link))
+    // issue 224: odkaz s pravidlom na veľkosti nesie VIAC riadkov naraz —
+    // jeden na KAŽDÚ našu veľkosť. Variant sa spáruje buď na SVOJU vlastnú
+    // veľkosť (`size_label = coalesce(variant.size_label,'')`), alebo na
+    // blanket riadok (`size_label = ''`) pre linky bez rozlíšenia veľkosti.
+    // Tieto dve vetvy sa pre TEN ISTÝ odkaz nikdy nestretnú naraz — `run.ts`
+    // pre každý odkaz zapíše VÝHRADNE jednu z týchto dvoch stratégií a
+    // zvyšné riadky vymaže.
+    .innerJoin(
+      supplierStock,
+      and(
+        eq(supplierStock.link, link),
+        or(
+          eq(supplierStock.sizeLabel, sql<string>`coalesce(${variants.sizeLabel}, '')`),
+          eq(supplierStock.sizeLabel, ""),
+        ),
+      ),
+    )
     // LEFT zámerne: variant bez záznamu vo feede NESMIE zo zoznamu vypadnúť —
     // majiteľ overuje presne tie riadky, ktoré by sa prepli, takže skrytý
     // riadok by znamenal prepnutie bez kontroly (trieda chyby z issue 219).

--- a/apps/api/src/modules/supplier-stock/fixtures/lasting-bony-cepica-l-xl.html
+++ b/apps/api/src/modules/supplier-stock/fixtures/lasting-bony-cepica-l-xl.html
@@ -1,0 +1,51 @@
+<!--
+  Orezaná vzorka https://shop.lasting.eu/cs/cepice/19937-59938-lasting-merino-
+  cepice-bony-cerna-8595067820460.html (issue 224, živý fetch 4. 8. 2026).
+
+  Dva varianty veľkosti: S/M (sklademANO) a L/XL (sklademNE, "checked" =
+  predvolená veľkosť pri načítaní stránky). Náš vlastný Shoptet size_label
+  pre veľkosť L/XL je "L-X" (skrátený tvar, overené v produkčnej DB) — čítač
+  ho musí spárovať s "L/XL" tolerantne na skrátenie POSLEDNEJ časti.
+
+  JSON-LD tejto stránky hlási "https://schema.org/InStock" — hoci vlastný
+  `offers.url` v tom istom bloku ukazuje presne na fragment
+  "1130-velikost-l_xl" (tú istú veľkosť, ktorá je podľa zoznamu veľkostí
+  NEDOSTUPNÁ). Presne to je dôvod, prečo sa JSON-LD pri viacveľkostnom
+  produkte na tejto doméne nesmie brať ako dostupnosť KONKRÉTNEJ veľkosti.
+-->
+<html lang="cs">
+<head>
+<title>BONY merino čepice černá | Lasting</title>
+<script type="application/ld+json">
+{"@context":"https://schema.org/","@type":"Product","name":"BONY merino čepice",
+ "sku":"BONY-9090L/XL",
+ "offers":{"@type":"Offer","priceCurrency":"CZK","price":"399",
+   "url":"https://shop.lasting.eu/cs/cepice/19937-59938-lasting-merino-cepice-bony-cerna-8595067820460.html#/1054-barva-cerna/1130-velikost-l_xl",
+   "availability":"https://schema.org/InStock"}}
+</script>
+</head>
+<body>
+  <h1>BONY merino čepice černá</h1>
+  <ul class="product-variants-item clearfix" id="group_8">
+    <li  class="sklademANO input-container float-xs-left ">
+      <label>
+        <input class="input-radio" type="radio" data-product-attribute="8" name="group[8]"     value="1140"       title="S/M">
+        <span class="radio-label">
+                                S/M
+        </span>
+      </label>
+    </li>
+    <li idproductstributesOK="55307,55312" class="sklademNE input-container float-xs-left ">
+      <label>
+        <input class="input-radio" type="radio" data-product-attribute="8" name="group[8]"     value="1130"       title="L/XL" checked="checked">
+        <span class="radio-label">
+          <span class='skrtnuti1'></span>
+          <span class='skrtnuti2'></span>
+                            L/XL
+        </span>
+      </label>
+    </li>
+  </ul>
+  <div id='sklademNEExist'>asdfasdf</div>
+</body>
+</html>

--- a/apps/api/src/modules/supplier-stock/fixtures/lasting-bony-cepica-l-xl.html
+++ b/apps/api/src/modules/supplier-stock/fixtures/lasting-bony-cepica-l-xl.html
@@ -12,6 +12,16 @@
   "1130-velikost-l_xl" (tú istú veľkosť, ktorá je podľa zoznamu veľkostí
   NEDOSTUPNÁ). Presne to je dôvod, prečo sa JSON-LD pri viacveľkostnom
   produkte na tejto doméne nesmie brať ako dostupnosť KONKRÉTNEJ veľkosti.
+
+  Reálna stránka nesie VIAC skupín so ZDIEĽANOU triedou
+  "clearfix product-variants-item" (Odstín, VELIKOST, Barva — overené živo,
+  code review issue 224) — rozlišuje ich AŽ popisok
+  `<span class="control-label">`. "Odstín"/"Barva" skupiny nižšie NENESÚ
+  sklademANO/NE triedu vôbec (skutočný tvar z produkcie), takže by staré
+  (neorezané) čítanie našlo LEN veľkosť aj tak — preto je za produktom
+  pridaná ešte samostatná "súvisiace produkty" karta s VLASTNÝM plným
+  veľkostným výberom iného produktu: dôkaz, že sa výrez naozaj ukončí PRED
+  ňou (na začiatku "Barva" skupiny), nie až na konci dokumentu.
 -->
 <html lang="cs">
 <head>
@@ -26,26 +36,80 @@
 </head>
 <body>
   <h1>BONY merino čepice černá</h1>
-  <ul class="product-variants-item clearfix" id="group_8">
-    <li  class="sklademANO input-container float-xs-left ">
-      <label>
-        <input class="input-radio" type="radio" data-product-attribute="8" name="group[8]"     value="1140"       title="S/M">
-        <span class="radio-label">
-                                S/M
-        </span>
-      </label>
-    </li>
-    <li idproductstributesOK="55307,55312" class="sklademNE input-container float-xs-left ">
-      <label>
-        <input class="input-radio" type="radio" data-product-attribute="8" name="group[8]"     value="1130"       title="L/XL" checked="checked">
-        <span class="radio-label">
-          <span class='skrtnuti1'></span>
-          <span class='skrtnuti2'></span>
-                            L/XL
-        </span>
-      </label>
-    </li>
-  </ul>
+
+  <div class="product-variants">
+    <div class="clearfix product-variants-item">
+      <span class="control-label">Odstín:
+        Černá 9090
+      </span>
+      <ul id="group_9">
+        <li class="input-container">
+          <span class="color texture" style="background-image:url(/x.jpg)"></span>
+        </li>
+      </ul>
+    </div>
+
+    <div class="clearfix product-variants-item">
+      <span class="control-label">VELIKOST:
+        L/XL
+      </span>
+      <ul id="group_8">
+        <li  class="sklademANO input-container float-xs-left ">
+          <label>
+            <input class="input-radio" type="radio" data-product-attribute="8" name="group[8]"     value="1140"       title="S/M">
+            <span class="radio-label">
+                                    S/M
+            </span>
+          </label>
+        </li>
+        <li idproductstributesOK="55307,55312" class="sklademNE input-container float-xs-left ">
+          <label>
+            <input class="input-radio" type="radio" data-product-attribute="8" name="group[8]"     value="1130"       title="L/XL" checked="checked">
+            <span class="radio-label">
+              <span class='skrtnuti1'></span>
+              <span class='skrtnuti2'></span>
+                                L/XL
+            </span>
+          </label>
+        </li>
+      </ul>
+    </div>
+
+    <div class="clearfix product-variants-item">
+      <span class="control-label">Barva:
+        Černá
+      </span>
+      <ul id="group_1">
+        <li class="input-container">
+          <span class="color" style="background-image:url(/y.jpg)"></span>
+        </li>
+      </ul>
+    </div>
+  </div>
+
   <div id='sklademNEExist'>asdfasdf</div>
+
+  <!-- "Súvisiace produkty" karuselová sekcia — INÝ produkt s VLASTNÝM plným
+       veľkostným výberom, mimo hlavného "product-variants" bloku vyššie.
+       Neorezaný čítač (celý dokument, bez výrezu) by túto veľkosť omylom
+       pripočítal k produktu na tejto stránke. -->
+  <div class="products-selection">
+    <div class="product-miniature js-product-miniature">
+      <a href="/cs/cepice/19938-iny-produkt.html">Iná čiapka</a>
+      <div class="clearfix product-variants-item">
+        <span class="control-label">VELIKOST:
+          XXL
+        </span>
+        <ul id="group_8">
+          <li class="sklademANO input-container float-xs-left ">
+            <label>
+              <input class="input-radio" type="radio" data-product-attribute="8" name="group[8]"     value="9999"       title="XXL">
+              <span class="radio-label">XXL</span>
+            </label>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
 </body>
 </html>

--- a/apps/api/src/modules/supplier-stock/fixtures/lasting-hila-tricko-bez-xs.html
+++ b/apps/api/src/modules/supplier-stock/fixtures/lasting-hila-tricko-bez-xs.html
@@ -8,6 +8,14 @@
   medzi nimi VÔBEC NIE JE — dodávateľ ju nemá. Čítač preto pre "XS" nesmie
   nájsť žiadnu zhodu a výsledok musí ostať "unknown" (nikdy dohad na
   najbližšiu veľkosť).
+
+  Skupina veľkostí je (rovnako ako v `lasting-bony-cepica-l-xl.html`) obalená
+  vlastným `<div class="clearfix product-variants-item">` s popiskom
+  `<span class="control-label">VELIKOST…` — tá istá trieda nesie na reálnej
+  stránke aj "Barva" skupinu, preto sa výrez musí nájsť podľa popisku, nikdy
+  len podľa triedy. Karta "súvisiace produkty" za hlavným blokom má VLASTNÝ
+  plný veľkostný výber iného produktu — dôkaz, že výrez sa naň nikdy
+  nerozšíri.
 -->
 <html lang="cs">
 <head>
@@ -15,36 +23,75 @@
 </head>
 <body>
   <h1>HILA dámske merino tričko s potlačou</h1>
-  <ul class="product-variants-item clearfix" id="group_8">
-    <li  class="sklademANO input-container float-xs-left ">
-      <label>
-        <input class="input-radio" type="radio" data-product-attribute="8" name="group[8]"     value="930"       title="S">
-        <span class="radio-label">S</span>
-      </label>
-    </li>
-    <li idproductstributesOK="" class="sklademNE input-container float-xs-left ">
-      <label>
-        <input class="input-radio" type="radio" data-product-attribute="8" name="group[8]"     value="936"       title="M">
-        <span class="radio-label">
-          <span class='skrtnuti1'></span>
-          <span class='skrtnuti2'></span>
-                            M
-        </span>
-      </label>
-    </li>
-    <li  class="sklademANO input-container float-xs-left ">
-      <label>
-        <input class="input-radio" type="radio" data-product-attribute="8" name="group[8]"     value="942"       title="L" checked="checked">
-        <span class="radio-label">L</span>
-      </label>
-    </li>
-    <li  class="sklademANO input-container float-xs-left ">
-      <label>
-        <input class="input-radio" type="radio" data-product-attribute="8" name="group[8]"     value="948"       title="XL">
-        <span class="radio-label">XL</span>
-      </label>
-    </li>
-  </ul>
+
+  <div class="product-variants">
+    <div class="clearfix product-variants-item">
+      <span class="control-label">VELIKOST:
+        L
+      </span>
+      <ul id="group_8">
+        <li  class="sklademANO input-container float-xs-left ">
+          <label>
+            <input class="input-radio" type="radio" data-product-attribute="8" name="group[8]"     value="930"       title="S">
+            <span class="radio-label">S</span>
+          </label>
+        </li>
+        <li idproductstributesOK="" class="sklademNE input-container float-xs-left ">
+          <label>
+            <input class="input-radio" type="radio" data-product-attribute="8" name="group[8]"     value="936"       title="M">
+            <span class="radio-label">
+              <span class='skrtnuti1'></span>
+              <span class='skrtnuti2'></span>
+                                M
+            </span>
+          </label>
+        </li>
+        <li  class="sklademANO input-container float-xs-left ">
+          <label>
+            <input class="input-radio" type="radio" data-product-attribute="8" name="group[8]"     value="942"       title="L" checked="checked">
+            <span class="radio-label">L</span>
+          </label>
+        </li>
+        <li  class="sklademANO input-container float-xs-left ">
+          <label>
+            <input class="input-radio" type="radio" data-product-attribute="8" name="group[8]"     value="948"       title="XL">
+            <span class="radio-label">XL</span>
+          </label>
+        </li>
+      </ul>
+    </div>
+
+    <div class="clearfix product-variants-item">
+      <span class="control-label">Barva:
+        Zelená
+      </span>
+      <ul id="group_1">
+        <li class="input-container">
+          <span class="color" style="background-image:url(/z.jpg)"></span>
+        </li>
+      </ul>
+    </div>
+  </div>
+
   <div id='sklademNEExist'>asdfasdf</div>
+
+  <div class="products-selection">
+    <div class="product-miniature js-product-miniature">
+      <a href="/cs/trika/16927-iny-produkt.html">Iné tričko</a>
+      <div class="clearfix product-variants-item">
+        <span class="control-label">VELIKOST:
+          XS
+        </span>
+        <ul id="group_8">
+          <li class="sklademANO input-container float-xs-left ">
+            <label>
+              <input class="input-radio" type="radio" data-product-attribute="8" name="group[8]"     value="9998"       title="XS">
+              <span class="radio-label">XS</span>
+            </label>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
 </body>
 </html>

--- a/apps/api/src/modules/supplier-stock/fixtures/lasting-hila-tricko-bez-xs.html
+++ b/apps/api/src/modules/supplier-stock/fixtures/lasting-hila-tricko-bez-xs.html
@@ -1,0 +1,50 @@
+<!--
+  Orezaná vzorka https://shop.lasting.eu/cs/trika-kratky-rukav-mqc/16926-56344-
+  hila-damske-merino-triko-s-tiskem-8995067844631.html (issue 224, živý fetch
+  4. 8. 2026).
+
+  Zoznam veľkostí dodávateľa: S (sklademANO), M (sklademNE), L (sklademANO),
+  XL (sklademANO). Veľkosť XS, ktorú má NÁŠ katalóg (variant "16710/XS"),
+  medzi nimi VÔBEC NIE JE — dodávateľ ju nemá. Čítač preto pre "XS" nesmie
+  nájsť žiadnu zhodu a výsledok musí ostať "unknown" (nikdy dohad na
+  najbližšiu veľkosť).
+-->
+<html lang="cs">
+<head>
+<title>HILA dámske merino tričko s potlačou | Lasting</title>
+</head>
+<body>
+  <h1>HILA dámske merino tričko s potlačou</h1>
+  <ul class="product-variants-item clearfix" id="group_8">
+    <li  class="sklademANO input-container float-xs-left ">
+      <label>
+        <input class="input-radio" type="radio" data-product-attribute="8" name="group[8]"     value="930"       title="S">
+        <span class="radio-label">S</span>
+      </label>
+    </li>
+    <li idproductstributesOK="" class="sklademNE input-container float-xs-left ">
+      <label>
+        <input class="input-radio" type="radio" data-product-attribute="8" name="group[8]"     value="936"       title="M">
+        <span class="radio-label">
+          <span class='skrtnuti1'></span>
+          <span class='skrtnuti2'></span>
+                            M
+        </span>
+      </label>
+    </li>
+    <li  class="sklademANO input-container float-xs-left ">
+      <label>
+        <input class="input-radio" type="radio" data-product-attribute="8" name="group[8]"     value="942"       title="L" checked="checked">
+        <span class="radio-label">L</span>
+      </label>
+    </li>
+    <li  class="sklademANO input-container float-xs-left ">
+      <label>
+        <input class="input-radio" type="radio" data-product-attribute="8" name="group[8]"     value="948"       title="XL">
+        <span class="radio-label">XL</span>
+      </label>
+    </li>
+  </ul>
+  <div id='sklademNEExist'>asdfasdf</div>
+</body>
+</html>

--- a/apps/api/src/modules/supplier-stock/parse.test.ts
+++ b/apps/api/src/modules/supplier-stock/parse.test.ts
@@ -8,8 +8,10 @@ import {
   fromMetaTags,
   hostOf,
   isTrustedTextHost,
+  matchSizeLabel,
   parsePage,
   parsePrice,
+  parseSizeAvailability,
   visibleText,
 } from "./parse.js";
 
@@ -20,6 +22,8 @@ function fixture(name: string): string {
 const HUNTINGSHOP_VYPREDANY = fixture("huntingshop-vypredany-ruksak.html");
 const HUNTINGSHOP_SKLADOM = fixture("huntingshop-skladom-tricko.html");
 const ODIMON_NEDOSTUPNA = fixture("odimon-nedostupna-strelecka-palica.html");
+const LASTING_BONY = fixture("lasting-bony-cepica-l-xl.html");
+const LASTING_HILA = fixture("lasting-hila-tricko-bez-xs.html");
 
 describe("hostOf / isTrustedTextHost", () => {
   it("odreze www a zmensi pismena", () => {
@@ -258,5 +262,49 @@ describe("parsePage — issue 225: odimon.sk — viditelna dostupnost prebija kl
     const result = parsePage(html, "https://www.odimon.sk/p/ine");
     expect(result.availability).toBe("available");
     expect(result.availabilityText).toBe("Skladom 9 ks");
+  });
+});
+
+describe("parseSizeAvailability — issue 224: shop.lasting.eu zoznam veľkostí", () => {
+  it("precita KAZDU velkost so svojou vlastnou dostupnostou, nikdy stranku ako celok", () => {
+    const sizes = parseSizeAvailability(
+      LASTING_BONY,
+      "https://shop.lasting.eu/cs/cepice/19937-59938-lasting-merino-cepice-bony-cerna-8595067820460.html",
+    );
+    expect(sizes).toEqual([
+      { sizeLabel: "S/M", availability: "available" },
+      { sizeLabel: "L/XL", availability: "unavailable" },
+    ]);
+  });
+
+  it("stranka bez zoznamu velkosti (ina domena) vracia null, nikdy prazdne pole", () => {
+    expect(parseSizeAvailability(LASTING_BONY, "https://www.huntingshop.eu/p/1")).toBeNull();
+  });
+
+  it("poddomena patri pod to iste pravidlo ako holy host", () => {
+    const sizes = parseSizeAvailability(LASTING_HILA, "https://sub.shop.lasting.eu/cs/nieco.html");
+    expect(sizes).not.toBeNull();
+  });
+});
+
+describe("matchSizeLabel — issue 224: parovanie NASHO size_label na dodavatela", () => {
+  it("presna zhoda po odstraneni oddelovacov", () => {
+    expect(matchSizeLabel("S-M", ["S/M", "L/XL"])).toBe("S/M");
+  });
+
+  it("tolerantne na skratenie POSLEDNEJ casti — nas 'L-X' je dodavatelovo 'L/XL'", () => {
+    expect(matchSizeLabel("L-X", ["S/M", "L/XL"])).toBe("L/XL");
+  });
+
+  it("velkost, ktoru dodavatel vobec nema, sa nesparuje", () => {
+    expect(matchSizeLabel("XS", ["S", "M", "L", "XL"])).toBeNull();
+  });
+
+  it("rozny pocet casti sa nikdy nepovazuje za zhodu", () => {
+    expect(matchSizeLabel("L-X", ["XL"])).toBeNull();
+  });
+
+  it("viacnasobna zhoda je nejednoznacna — nikdy sa neuhadne", () => {
+    expect(matchSizeLabel("X", ["XS", "XL"])).toBeNull();
   });
 });

--- a/apps/api/src/modules/supplier-stock/parse.ts
+++ b/apps/api/src/modules/supplier-stock/parse.ts
@@ -19,7 +19,7 @@
 // neprepne produkt (issue 213).
 
 export type SupplierAvailability = "available" | "unavailable" | "unknown";
-export type SupplierStockSource = "json_ld" | "meta" | "text" | "none";
+export type SupplierStockSource = "json_ld" | "meta" | "text" | "size_list" | "none";
 
 export interface ParsedPage {
   readonly availability: SupplierAvailability;
@@ -316,6 +316,99 @@ function visibleAvailabilityFor(url: string, html: string): VisibleAvailabilityH
   if (host === "") return null;
   const rule = VISIBLE_AVAILABILITY_RULES.find((r) => host === r.host || host.endsWith(`.${r.host}`));
   return rule === undefined ? null : rule.read(html);
+}
+
+export interface SizeAvailability {
+  /** Presný text veľkosti u DODÁVATEĽA (napr. "L/XL"), nie náš vlastný size_label. */
+  readonly sizeLabel: string;
+  readonly availability: "available" | "unavailable";
+}
+
+interface SizeAvailabilityRule {
+  readonly host: string;
+  readonly read: (html: string) => readonly SizeAvailability[];
+}
+
+/**
+ * shop.lasting.eu (issue 224): PrestaShop nesie dostupnosť KAŽDEJ veľkosti
+ * v triede `<li>` veľkostného zoznamu — `sklademANO`/`sklademNE` — skutočná
+ * veľkosť je v `title=""` atribúte vnoreného `<input>`. Stránkové JSON-LD
+ * hlási dostupnosť len JEDNEJ (predvolenej/`checked`) veľkosti a vie byť
+ * priamo v rozpore s týmto zoznamom (živý dôkaz, issue 224: JSON-LD hlási
+ * InStock pre veľkosť, ktorej vlastný zoznam hovorí `sklademNE`) — preto sa
+ * JSON-LD pri viacveľkostnom produkte na tejto doméne NIKDY neberie ako
+ * dostupnosť KONKRÉTNEJ veľkosti (`parsePage` sa pre tento odkaz vôbec
+ * nepoužije, viď `run.ts`).
+ */
+function lastingSizeList(html: string): readonly SizeAvailability[] {
+  const items = [...html.matchAll(/<li\b[^>]*class="[^"]*(sklademANO|sklademNE)[^"]*"[^>]*>([\s\S]*?)<\/li>/gi)];
+  const result: SizeAvailability[] = [];
+  for (const [, cls, inner] of items) {
+    const title = /title="([^"]*)"/.exec(inner ?? "")?.[1]?.trim();
+    if (title === undefined || title === "") continue;
+    result.push({ sizeLabel: title, availability: cls === "sklademANO" ? "available" : "unavailable" });
+  }
+  return result;
+}
+
+const SIZE_AVAILABILITY_RULES: readonly SizeAvailabilityRule[] = Object.freeze([
+  { host: "shop.lasting.eu", read: lastingSizeList },
+]);
+
+function sizeAvailabilityRuleFor(url: string): SizeAvailabilityRule | null {
+  const host = hostOf(url);
+  if (host === "") return null;
+  return SIZE_AVAILABILITY_RULES.find((rule) => host === rule.host || host.endsWith(`.${rule.host}`)) ?? null;
+}
+
+/**
+ * Zoznam veľkostí a ich dostupnosti PRIAMO zo stránky (issue 224), alebo
+ * `null`, keď doména nemá overené pravidlo ALEBO stránka žiadny takýto
+ * zoznam neobsahuje (napr. jednoveľkostný produkt). `null` je zámerne INÝ
+ * výsledok než prázdne pole — prázdne pole by znamenalo "zoznam sa hľadal a
+ * je prázdny" (nemalo by nastať), `null` znamená "túto úroveň čítania nemá
+ * na tejto stránke zmysel skúšať".
+ */
+export function parseSizeAvailability(html: string, url: string): readonly SizeAvailability[] | null {
+  const rule = sizeAvailabilityRuleFor(url);
+  if (rule === null) return null;
+  const sizes = rule.read(html);
+  return sizes.length > 0 ? sizes : null;
+}
+
+/** Rozdelí veľkostné označenie na porovnateľné časti — oddeľovače (`/`, `-`,
+ * medzera, ...) preč, každá časť veľkými písmenami. Prázdne označenie nemá
+ * žiadnu časť (nikdy sa nespáruje so žiadnou veľkosťou). */
+function sizeTokens(label: string): readonly string[] {
+  return label
+    .toUpperCase()
+    .split(/[^A-Z0-9]+/)
+    .filter((part) => part !== "");
+}
+
+/**
+ * Spáruje NÁŠ `variant.size_label` (napr. "L-X") s presne JEDNOU veľkosťou
+ * zo zoznamu dodávateľa (napr. "L/XL") — issue 224. Zámerne TOLERANTNÉ na
+ * skrátenie: náš Shoptet-ov `size_label` niekedy nesie skrátený tvar tej
+ * istej veľkosti (overené naživo v produkčnej DB: "L-X" u nás = "L/XL" u
+ * dodávateľa) — zhoda platí, keď majú OBE strany rovnaký POČET častí a na
+ * KAŽDEJ pozícii sú časti buď PRESNE zhodné, alebo je jedna PREFIXOM
+ * druhej. Nikdy iný počet častí, nikdy iný prvý znak — to by už bol dohad.
+ * Viac než JEDNA zhoda je nejednoznačná a počíta sa ako ŽIADNA — nikdy sa
+ * neuhádne, ktorá je správna (rovnaká disciplína ako `unknown` v `parsePage`).
+ */
+export function matchSizeLabel(ourSizeLabel: string, supplierSizeLabels: readonly string[]): string | null {
+  const ours = sizeTokens(ourSizeLabel);
+  if (ours.length === 0) return null;
+  const matches = supplierSizeLabels.filter((candidate) => {
+    const theirs = sizeTokens(candidate);
+    if (theirs.length !== ours.length) return false;
+    return ours.every((part, i) => {
+      const other = theirs[i] ?? "";
+      return part === other || part.startsWith(other) || other.startsWith(part);
+    });
+  });
+  return matches.length === 1 ? (matches[0] ?? null) : null;
 }
 
 /**

--- a/apps/api/src/modules/supplier-stock/parse.ts
+++ b/apps/api/src/modules/supplier-stock/parse.ts
@@ -329,6 +329,16 @@ interface SizeAvailabilityRule {
   readonly read: (html: string) => readonly SizeAvailability[];
 }
 
+// Živo overené (issue 224 code review): `class="clearfix product-variants-item"`
+// NIE JE unikátna pre veľkosť — TÁ ISTÁ trieda nesie aj "Odstín"/"Barva"
+// (odtieň/farba) skupinu na tej istej stránke (3 skupiny na overenej vzorke
+// shop.lasting.eu). Rozlišuje ich AŽ vlastný popisok
+// `<span class="control-label">VELIKOST…`. Bez tohto rozlíšenia by čítač
+// (presne ako issue 223's huntingshop.eu karuselová kolízia) mohol zobrať
+// veľkosti z INEJ skupiny — alebo, keby stránka niekde nižšie ukazovala
+// súvisiaci produkt s vlastným plným výberom veľkostí, aj z NEHO.
+const VELIKOST_GROUP_START_RE = /<div\b[^>]*class="[^"]*product-variants-item[^"]*"[^>]*>/gi;
+
 /**
  * shop.lasting.eu (issue 224): PrestaShop nesie dostupnosť KAŽDEJ veľkosti
  * v triede `<li>` veľkostného zoznamu — `sklademANO`/`sklademNE` — skutočná
@@ -338,10 +348,26 @@ interface SizeAvailabilityRule {
  * InStock pre veľkosť, ktorej vlastný zoznam hovorí `sklademNE`) — preto sa
  * JSON-LD pri viacveľkostnom produkte na tejto doméne NIKDY neberie ako
  * dostupnosť KONKRÉTNEJ veľkosti (`parsePage` sa pre tento odkaz vôbec
- * nepoužije, viď `run.ts`).
+ * nepoužije, viď `run.ts`). Čítanie je OHRANIČENÉ na výrez medzi popiskom
+ * "VELIKOST" a ZAČIATKOM ĎALŠEJ `product-variants-item` skupiny (alebo
+ * koncom stránky) — nikdy na celý dokument.
  */
 function lastingSizeList(html: string): readonly SizeAvailability[] {
-  const items = [...html.matchAll(/<li\b[^>]*class="[^"]*(sklademANO|sklademNE)[^"]*"[^>]*>([\s\S]*?)<\/li>/gi)];
+  const groups = [...html.matchAll(VELIKOST_GROUP_START_RE)];
+  // Kontrola popisku je ukotvená (`^`) HNEĎ za otváracou značkou TEJTO
+  // skupiny — nikdy len "obsahuje niekde v okolí", inak by krátka
+  // predchádzajúca skupina (napr. "Odstín") nechtiac zasiahla do popisku
+  // NASLEDUJÚCEJ skupiny cez široké okno.
+  const sizeGroupIndex = groups.findIndex((m) => {
+    const afterOpenTag = html.slice(m.index + m[0].length, m.index + m[0].length + 200);
+    return /^\s*<span\b[^>]*class="[^"]*control-label[^"]*"[^>]*>\s*VELIKOST/i.test(afterOpenTag);
+  });
+  if (sizeGroupIndex === -1) return [];
+  const sizeStart = groups[sizeGroupIndex]?.index ?? 0;
+  const sizeEnd = groups[sizeGroupIndex + 1]?.index ?? html.length;
+  const region = html.slice(sizeStart, sizeEnd);
+
+  const items = [...region.matchAll(/<li\b[^>]*class="[^"]*(sklademANO|sklademNE)[^"]*"[^>]*>([\s\S]*?)<\/li>/gi)];
   const result: SizeAvailability[] = [];
   for (const [, cls, inner] of items) {
     const title = /title="([^"]*)"/.exec(inner ?? "")?.[1]?.trim();

--- a/apps/api/src/modules/supplier-stock/queries.ts
+++ b/apps/api/src/modules/supplier-stock/queries.ts
@@ -8,6 +8,8 @@ import type { Database } from "../../db/client.js";
 import { supplierStock } from "../../db/schema.js";
 
 export interface SupplierStockOverview {
+  // issue 224: počíta ZÁZNAMY (dvojica odkaz+veľkosť), nie unikátne odkazy —
+  // odkaz s pravidlom na veľkosti prispieva viac než jedným záznamom.
   readonly total: number;
   readonly available: number;
   readonly unavailable: number;

--- a/apps/api/src/modules/supplier-stock/queries.ts
+++ b/apps/api/src/modules/supplier-stock/queries.ts
@@ -18,11 +18,14 @@ export interface SupplierStockOverview {
 
 export interface SupplierStockRow {
   readonly link: string;
+  // '' = dostupnosť CELÉHO odkazu (issue 224) — jednoveľkostný produkt,
+  // alebo doména bez pravidla na čítanie zoznamu veľkostí.
+  readonly sizeLabel: string;
   readonly host: string;
   readonly availability: "available" | "unavailable" | "unknown";
   readonly availabilityText: string;
   readonly price: string | null;
-  readonly source: "json_ld" | "meta" | "text" | "none";
+  readonly source: "json_ld" | "meta" | "text" | "size_list" | "none";
   readonly ok: boolean;
   readonly error: string | null;
   readonly httpStatus: number | null;
@@ -30,12 +33,19 @@ export interface SupplierStockRow {
   readonly confirmedAt: Date | null;
 }
 
+/** Ukážkový odkaz + KTORÁ naša veľkosť sa naň nepodarilo spárovať (issue 224). */
+export interface UnreadableSample {
+  readonly link: string;
+  /** '' = celý odkaz (bez rozlíšenia veľkosti), nikdy nesúčasť `href`u. */
+  readonly sizeLabel: string;
+}
+
 /** Jeden riadok na doménu, ktorú sa nedarí čítať — karta pre majiteľa. */
 export interface UnreadableHost {
   readonly host: string;
   readonly count: number;
-  /** Ukážkové linky (max 5), aby sa dalo hneď kliknúť a pozrieť sa. */
-  readonly samples: readonly string[];
+  /** Ukážky (max 5), aby sa dalo hneď kliknúť a pozrieť sa. */
+  readonly samples: readonly UnreadableSample[];
 }
 
 export async function getSupplierStockOverview(db: Database): Promise<SupplierStockOverview> {
@@ -58,6 +68,7 @@ export async function listSupplierStock(db: Database, limit = 500): Promise<read
   return db
     .select({
       link: supplierStock.link,
+      sizeLabel: supplierStock.sizeLabel,
       host: supplierStock.host,
       availability: supplierStock.availability,
       availabilityText: supplierStock.availabilityText,
@@ -70,7 +81,7 @@ export async function listSupplierStock(db: Database, limit = 500): Promise<read
       confirmedAt: supplierStock.confirmedAt,
     })
     .from(supplierStock)
-    .orderBy(asc(supplierStock.host), asc(supplierStock.link))
+    .orderBy(asc(supplierStock.host), asc(supplierStock.link), asc(supplierStock.sizeLabel))
     .limit(limit);
 }
 
@@ -82,19 +93,22 @@ export async function listSupplierStock(db: Database, limit = 500): Promise<read
  */
 export async function listUnreadableHosts(db: Database): Promise<readonly UnreadableHost[]> {
   const rows = await db
-    .select({ host: supplierStock.host, link: supplierStock.link })
+    .select({ host: supplierStock.host, link: supplierStock.link, sizeLabel: supplierStock.sizeLabel })
     .from(supplierStock)
     .where(or(eq(supplierStock.ok, false), eq(supplierStock.availability, "unknown")))
-    .orderBy(asc(supplierStock.host), asc(supplierStock.link));
+    .orderBy(asc(supplierStock.host), asc(supplierStock.link), asc(supplierStock.sizeLabel));
 
-  const byHost = new Map<string, string[]>();
+  const byHost = new Map<string, UnreadableSample[]>();
   for (const row of rows) {
-    const links = byHost.get(row.host) ?? [];
-    links.push(row.link);
-    byHost.set(row.host, links);
+    const samples = byHost.get(row.host) ?? [];
+    // Pri odkaze s pravidlom na veľkosti (issue 224) môže na tú istú linku
+    // pripadnúť viac neprečítaných veľkostí naraz — každá je VLASTNÁ ukážka,
+    // aby bolo vidno KTORÁ veľkosť sa neprečítala, nie len odkaz.
+    samples.push({ link: row.link, sizeLabel: row.sizeLabel });
+    byHost.set(row.host, samples);
   }
   return [...byHost.entries()]
-    .map(([host, links]) => ({ host, count: links.length, samples: links.slice(0, 5) }))
+    .map(([host, samples]) => ({ host, count: samples.length, samples: samples.slice(0, 5) }))
     .sort((a, b) => b.count - a.count || a.host.localeCompare(b.host));
 }
 
@@ -103,6 +117,7 @@ export async function listRecentChecks(db: Database, limit = 10): Promise<readon
   return db
     .select({
       link: supplierStock.link,
+      sizeLabel: supplierStock.sizeLabel,
       host: supplierStock.host,
       availability: supplierStock.availability,
       availabilityText: supplierStock.availabilityText,

--- a/apps/api/src/modules/supplier-stock/run.ts
+++ b/apps/api/src/modules/supplier-stock/run.ts
@@ -257,12 +257,24 @@ async function runSupplierStockLocked(options: RunSupplierStockOptions): Promise
 
 type SupplierStockInsert = typeof supplierStock.$inferInsert;
 
+// `Pick<Database, "insert" | "delete">` (nie celý `Database`) — rovnaký vzor
+// ako `audit/service.ts`'s `AuditExecutor` (`.claude/rules/database.md`):
+// `tx` z `db.transaction(async (tx) => ...)` má `PgTransaction`, ktorý má
+// `.insert()`/`.delete()` rovnakého tvaru, ale chýba mu `Database`'s vlastné
+// `$client`, takže by ho `tsc` odmietol ako argument typu `Database`.
+type SupplierStockWriter = Pick<Database, "insert" | "delete">;
+
 /**
  * Zapíše VŠETKY riadky tejto linky pre tento beh a vymaže zvyšné (issue 224)
  * — inak by po zmene stratégie (napr. produkt medzičasom dostal viac
  * veľkostí, alebo naopak) ostal v tabuľke zavádzajúci riadok z predošlého
  * behu, ktorý by `restock/queries.ts`'s JOIN mohol nesprávne spárovať s
- * iným variantom (fallback na `size_label=''`).
+ * iným variantom (fallback na `size_label=''`). Mazanie + zápisy bežia v
+ * JEDNEJ transakcii (code review, issue 224) — inak by prerušený beh (pád
+ * procesu) mohol nechať linku len s ČASŤOU jej veľkostí zapísanou; taká
+ * čiastočná množina by `isLinkFresh` vyhodnotil ako "čerstvá" (všetky
+ * PRÍTOMNÉ riadky sú fresh) a chýbajúce veľkosti by sa neskúsili znova až do
+ * vypršania `MAX_AGE_HOURS`.
  */
 async function writeSupplierStockRows(
   db: Database,
@@ -278,30 +290,32 @@ async function writeSupplierStockRows(
 ): Promise<void> {
   const { link, host, now, ok, error, httpStatus, rows } = args;
   const wantedSizes = rows.map((r) => r.sizeLabel);
-  await db.delete(supplierStock).where(and(eq(supplierStock.link, link), notInArray(supplierStock.sizeLabel, wantedSizes)));
-  for (const row of rows) {
-    await upsert(db, {
-      link,
-      sizeLabel: row.sizeLabel,
-      host,
-      availability: row.availability,
-      availabilityText: row.availabilityText,
-      price: row.price === null ? null : row.price.toFixed(2),
-      source: row.source,
-      ok,
-      error,
-      httpStatus,
-      checkedAt: now,
-      // Iba SKUTOČNE určená dostupnosť je potvrdenie. `unknown` znamená
-      // „stránka sa načítala, ale nič sme sa nedozvedeli" — to nesmie
-      // predlžovať platnosť predošlého „skladom". Zlyhaná kontrola (ok=false)
-      // rovnako nikdy nepotvrdzuje.
-      confirmedAt: ok && row.availability !== "unknown" ? now : null,
-    });
-  }
+  await db.transaction(async (tx) => {
+    await tx.delete(supplierStock).where(and(eq(supplierStock.link, link), notInArray(supplierStock.sizeLabel, wantedSizes)));
+    for (const row of rows) {
+      await upsert(tx, {
+        link,
+        sizeLabel: row.sizeLabel,
+        host,
+        availability: row.availability,
+        availabilityText: row.availabilityText,
+        price: row.price === null ? null : row.price.toFixed(2),
+        source: row.source,
+        ok,
+        error,
+        httpStatus,
+        checkedAt: now,
+        // Iba SKUTOČNE určená dostupnosť je potvrdenie. `unknown` znamená
+        // „stránka sa načítala, ale nič sme sa nedozvedeli" — to nesmie
+        // predlžovať platnosť predošlého „skladom". Zlyhaná kontrola (ok=false)
+        // rovnako nikdy nepotvrdzuje.
+        confirmedAt: ok && row.availability !== "unknown" ? now : null,
+      });
+    }
+  });
 }
 
-async function upsert(db: Database, row: SupplierStockInsert): Promise<void> {
+async function upsert(db: SupplierStockWriter, row: SupplierStockInsert): Promise<void> {
   await db
     .insert(supplierStock)
     .values(row)

--- a/apps/api/src/modules/supplier-stock/run.ts
+++ b/apps/api/src/modules/supplier-stock/run.ts
@@ -1,16 +1,23 @@
-// Beh scrapera dostupnosti u dodávateľa (issue 212).
+// Beh scrapera dostupnosti u dodávateľa (issue 212, per veľkosť issue 224).
 //
 // Sériový, zámerne: 969 z 1 210 riadkov reálneho exportu je JEDNA doména
 // (`huntingshop.eu`), takže paralelné sťahovanie by na ňu vyzeralo ako útok.
 // Medzi dvomi požiadavkami na tú istú doménu je pauza (`PER_HOST_DELAY_MS`).
 
-import { isNotNull } from "drizzle-orm";
+import { and, eq, isNotNull, notInArray } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
-import { products, supplierStock } from "../../db/schema.js";
+import { products, supplierStock, variants } from "../../db/schema.js";
 import { extractSupplierLink } from "../catalog/supplier-link.js";
 import { MAX_AGE_HOURS, PER_HOST_DELAY_MS, SUPPLIER_STOCK_RUN_LOCK_KEY } from "./constants.js";
 import type { PageFetcher } from "./page-fetcher.js";
-import { hostOf, parsePage } from "./parse.js";
+import {
+  hostOf,
+  matchSizeLabel,
+  parsePage,
+  parseSizeAvailability,
+  type SupplierAvailability,
+  type SupplierStockSource,
+} from "./parse.js";
 
 export interface SupplierStockRunResult {
   /** Koľko unikátnych liniek katalóg vôbec obsahuje. */
@@ -18,10 +25,14 @@ export interface SupplierStockRunResult {
   /** Preskočené, lebo majú čerstvú úspešnú kontrolu. */
   readonly skipped: number;
   readonly checked: number;
+  /** Počty sú za ZAPÍSANÉ riadky (link, veľkosť), nie za linky — rovnaká
+   * jednotka ako `getSupplierStockOverview` (`queries.ts`), takže si oba
+   * súhlasia. Jednoveľkostná/blanket linka prispieva presne 1, linka s
+   * pravidlom na veľkosti prispieva po jednej za KAŽDÚ našu veľkosť. */
   readonly available: number;
   readonly unavailable: number;
   readonly unknown: number;
-  /** Kontrola sama zlyhala (sieť, časový limit, HTTP chyba). */
+  /** Kontrola sama zlyhala (sieť, časový limit, HTTP chyba) — za LINKU. */
   readonly failed: number;
   readonly hosts: readonly string[];
 }
@@ -56,6 +67,32 @@ export async function collectSupplierLinks(db: Database): Promise<readonly strin
 }
 
 /**
+ * NAŠE `variant.size_label` hodnoty zoskupené podľa dodávateľskej linky
+ * (issue 224) — čo touto linkou treba spárovať, keď má doména pravidlo na
+ * čítanie zoznamu veľkostí (`parseSizeAvailability`). Variant bez veľkosti
+ * (`null`/prázdne) sa NEZAHRNIE — nedal by sa spárovať a písal by
+ * zavádzajúci blanket (`''`) riadok popri riadkoch ostatných veľkostí tej
+ * istej linky (viď `writeSupplierStockRows`).
+ */
+async function collectOurSizesByLink(db: Database): Promise<Map<string, readonly string[]>> {
+  const rows = await db
+    .select({ internalNote: products.internalNote, sizeLabel: variants.sizeLabel })
+    .from(variants)
+    .innerJoin(products, eq(variants.productKey, products.key));
+  const byLink = new Map<string, Set<string>>();
+  for (const row of rows) {
+    const url = extractSupplierLink(row.internalNote).url;
+    if (url === null || hostOf(url) === "") continue;
+    const label = (row.sizeLabel ?? "").trim();
+    if (label === "") continue;
+    const set = byLink.get(url) ?? new Set<string>();
+    set.add(label);
+    byLink.set(url, set);
+  }
+  return new Map([...byLink].map(([link, set]) => [link, [...set]]));
+}
+
+/**
  * `true`, keď má linka ÚSPEŠNÚ kontrolu mladšiu než `MAX_AGE_HOURS`.
  * Zlyhaná kontrola sa zámerne NEPOČÍTA — inak by stránka, ktorá stabilne
  * padá na časovom limite, ostala „čerstvá" a nikdy by sa neskúsila znova.
@@ -82,15 +119,38 @@ export async function runSupplierStock(options: RunSupplierStockOptions): Promis
   }
 }
 
+interface StockRowInput {
+  readonly sizeLabel: string;
+  readonly availability: SupplierAvailability;
+  readonly availabilityText: string;
+  readonly price: number | null;
+  readonly source: SupplierStockSource;
+}
+
 async function runSupplierStockLocked(options: RunSupplierStockOptions): Promise<SupplierStockRunResult> {
   const { db, now, fetchPage } = options;
   const sleep = options.sleep ?? defaultSleep;
 
   const links = await collectSupplierLinks(db);
+  const ourSizesByLink = await collectOurSizesByLink(db);
+  // Všetky riadky tej istej linky sa píšu/aktualizujú v TOM ISTOM behu
+  // (`writeSupplierStockRows`), takže "je táto linka čerstvá" musí platiť
+  // pre KAŽDÝ jej riadok naraz — keby čo i len jedna veľkosť ešte nemala
+  // čerstvé potvrdenie, celá linka sa musí skúsiť znova (jeden fetch aj tak
+  // vždy prepíše všetky veľkosti tej istej linky).
   const existing = await db
     .select({ link: supplierStock.link, ok: supplierStock.ok, confirmedAt: supplierStock.confirmedAt })
     .from(supplierStock);
-  const previousByLink = new Map(existing.map((row) => [row.link, row]));
+  const rowsByLink = new Map<string, { readonly ok: boolean; readonly confirmedAt: Date | null }[]>();
+  for (const row of existing) {
+    const rows = rowsByLink.get(row.link) ?? [];
+    rows.push(row);
+    rowsByLink.set(row.link, rows);
+  }
+  const isLinkFresh = (link: string): boolean => {
+    const rows = rowsByLink.get(link);
+    return rows !== undefined && rows.length > 0 && rows.every((row) => isFresh(row, now));
+  };
 
   const counts = { available: 0, unavailable: 0, unknown: 0, failed: 0 };
   const hosts = new Set<string>();
@@ -101,7 +161,7 @@ async function runSupplierStockLocked(options: RunSupplierStockOptions): Promise
   for (const link of links) {
     const host = hostOf(link);
     hosts.add(host);
-    if (isFresh(previousByLink.get(link), now)) {
+    if (isLinkFresh(link)) {
       skipped += 1;
       continue;
     }
@@ -123,41 +183,63 @@ async function runSupplierStockLocked(options: RunSupplierStockOptions): Promise
 
     if (!fetched.ok) {
       counts.failed += 1;
-      await upsert(db, {
+      // Zlyhaná kontrola vymaže PRÍPADNÉ predošlé per-veľkostné riadky tejto
+      // linky a nahradí ich jediným blanket "neviem" riadkom (rovnaká
+      // filozofia ako pôvodný jednoriadkový model — `ok=false` samo osebe
+      // vylučuje kandidatúru v `restock/queries.ts` bez ohľadu na
+      // dostupnosť, takže to nič neoslabuje). Nasledujúci ÚSPEŠNÝ beh riadky
+      // po veľkostiach znova odvodí.
+      await writeSupplierStockRows(db, {
         link,
         host,
-        availability: "unknown",
-        availabilityText: "",
-        price: null,
-        source: "none",
+        now,
         ok: false,
         error: fetched.error,
         httpStatus: fetched.httpStatus,
-        checkedAt: now,
-        // Zlyhaná kontrola NIKDY neposúva `confirmedAt` — staré potvrdenie
-        // musí zostarnúť a automatizácia ho prestane brať (issue 213).
-        confirmedAt: null,
+        rows: [{ sizeLabel: "", availability: "unknown", availabilityText: "", price: null, source: "none" }],
       });
       continue;
     }
 
-    const parsed = parsePage(fetched.html, link);
-    counts[parsed.availability] += 1;
-    await upsert(db, {
+    const ourSizes = ourSizesByLink.get(link) ?? [];
+    const sizeList = parseSizeAvailability(fetched.html, link);
+
+    let rows: readonly StockRowInput[];
+    if (sizeList !== null && ourSizes.length > 0) {
+      const pageParsed = parsePage(fetched.html, link);
+      rows = ourSizes.map((ourLabel) => {
+        const matched = matchSizeLabel(ourLabel, sizeList.map((s) => s.sizeLabel));
+        const hit = matched === null ? null : (sizeList.find((s) => s.sizeLabel === matched) ?? null);
+        return {
+          sizeLabel: ourLabel,
+          availability: hit?.availability ?? "unknown",
+          availabilityText: hit?.sizeLabel ?? "",
+          price: pageParsed.price,
+          source: hit !== null ? "size_list" : "none",
+        };
+      });
+    } else {
+      const pageParsed = parsePage(fetched.html, link);
+      rows = [
+        {
+          sizeLabel: "",
+          availability: pageParsed.availability,
+          availabilityText: pageParsed.availabilityText,
+          price: pageParsed.price,
+          source: pageParsed.source,
+        },
+      ];
+    }
+
+    for (const row of rows) counts[row.availability] += 1;
+    await writeSupplierStockRows(db, {
       link,
       host,
-      availability: parsed.availability,
-      availabilityText: parsed.availabilityText,
-      price: parsed.price === null ? null : parsed.price.toFixed(2),
-      source: parsed.source,
+      now,
       ok: true,
       error: null,
       httpStatus: fetched.httpStatus,
-      checkedAt: now,
-      // Iba SKUTOČNE určená dostupnosť je potvrdenie. `unknown` znamená
-      // „stránka sa načítala, ale nič sme sa nedozvedeli" — to nesmie
-      // predlžovať platnosť predošlého „skladom".
-      confirmedAt: parsed.availability === "unknown" ? null : now,
+      rows,
     });
   }
 
@@ -173,14 +255,58 @@ async function runSupplierStockLocked(options: RunSupplierStockOptions): Promise
   };
 }
 
-type SupplierStockRow = typeof supplierStock.$inferInsert;
+type SupplierStockInsert = typeof supplierStock.$inferInsert;
 
-async function upsert(db: Database, row: SupplierStockRow): Promise<void> {
+/**
+ * Zapíše VŠETKY riadky tejto linky pre tento beh a vymaže zvyšné (issue 224)
+ * — inak by po zmene stratégie (napr. produkt medzičasom dostal viac
+ * veľkostí, alebo naopak) ostal v tabuľke zavádzajúci riadok z predošlého
+ * behu, ktorý by `restock/queries.ts`'s JOIN mohol nesprávne spárovať s
+ * iným variantom (fallback na `size_label=''`).
+ */
+async function writeSupplierStockRows(
+  db: Database,
+  args: {
+    readonly link: string;
+    readonly host: string;
+    readonly now: Date;
+    readonly ok: boolean;
+    readonly error: string | null;
+    readonly httpStatus: number | null;
+    readonly rows: readonly StockRowInput[];
+  },
+): Promise<void> {
+  const { link, host, now, ok, error, httpStatus, rows } = args;
+  const wantedSizes = rows.map((r) => r.sizeLabel);
+  await db.delete(supplierStock).where(and(eq(supplierStock.link, link), notInArray(supplierStock.sizeLabel, wantedSizes)));
+  for (const row of rows) {
+    await upsert(db, {
+      link,
+      sizeLabel: row.sizeLabel,
+      host,
+      availability: row.availability,
+      availabilityText: row.availabilityText,
+      price: row.price === null ? null : row.price.toFixed(2),
+      source: row.source,
+      ok,
+      error,
+      httpStatus,
+      checkedAt: now,
+      // Iba SKUTOČNE určená dostupnosť je potvrdenie. `unknown` znamená
+      // „stránka sa načítala, ale nič sme sa nedozvedeli" — to nesmie
+      // predlžovať platnosť predošlého „skladom". Zlyhaná kontrola (ok=false)
+      // rovnako nikdy nepotvrdzuje.
+      confirmedAt: ok && row.availability !== "unknown" ? now : null,
+    });
+  }
+}
+
+async function upsert(db: Database, row: SupplierStockInsert): Promise<void> {
   await db
     .insert(supplierStock)
     .values(row)
     .onConflictDoUpdate({
-      target: supplierStock.link,
+      target: [supplierStock.link, supplierStock.sizeLabel],
       set: {
         host: row.host,
         availability: row.availability,

--- a/apps/api/tests/helpers/orders.ts
+++ b/apps/api/tests/helpers/orders.ts
@@ -88,6 +88,9 @@ export async function insertTestVariantForProduct(
     // issue 176: náhradné produkty (`product.related_codes`) — default
     // `undefined` necháva stĺpec `null` (žiadny existujúci test ho potreboval).
     readonly relatedCodes?: readonly string[] | null;
+    // issue 224: dodávateľská linka na PRODUKTE — potrebné pre testy, kde má
+    // JEDEN produkt VIAC variantov (veľkostí) zdieľajúcich tú istú linku.
+    readonly internalNote?: string | null;
   } = {},
 ): Promise<void> {
   const snapshotId = await insertTestSnapshot(db);
@@ -102,6 +105,7 @@ export async function insertTestVariantForProduct(
       // (default "Test dodávateľ") od "zadané ako null" (skutočne bez
       // dodávateľa — potrebné pre testy ručného priradenia dodávateľa).
       supplier: "supplier" in options ? options.supplier : "Test dodávateľ",
+      internalNote: options.internalNote ?? null,
       relatedCodes: options.relatedCodes === undefined || options.relatedCodes === null ? null : [...options.relatedCodes],
       firstSeenAt: new Date("2026-01-01T00:00:00Z"),
       lastSeenAt: new Date("2026-01-01T00:00:00Z"),

--- a/apps/api/tests/restock-run.integration.test.ts
+++ b/apps/api/tests/restock-run.integration.test.ts
@@ -59,22 +59,31 @@ describe("prepínanie Vypredané → Skladom", () => {
       readonly productVisibility?: string;
       readonly internalNote?: string | null;
       readonly missingSince?: Date | null;
+      // issue 224: viac variantov (veľkostí) toho istého produktu, keď
+      // zdieľajú tú istú linku, potrebuje SPOLOČNÝ productKey — inak by
+      // každý `code` dostal vlastný produkt s vlastným `internalNote`.
+      readonly productKey?: string;
+      readonly sizeLabel?: string | null;
     } = {},
   ): Promise<void> => {
-    const productKey = `prod-${code}`;
-    await db.insert(products).values({
-      key: productKey,
-      name: `Produkt ${code}`,
-      supplier: "Dodávateľ",
-      internalNote: over.internalNote === undefined ? LINK : over.internalNote,
-      firstSeenAt: NOW,
-      lastSeenAt: NOW,
-      lastSeenSnapshotId: snapshotId,
-    });
+    const productKey = over.productKey ?? `prod-${code}`;
+    await db
+      .insert(products)
+      .values({
+        key: productKey,
+        name: `Produkt ${code}`,
+        supplier: "Dodávateľ",
+        internalNote: over.internalNote === undefined ? LINK : over.internalNote,
+        firstSeenAt: NOW,
+        lastSeenAt: NOW,
+        lastSeenSnapshotId: snapshotId,
+      })
+      .onConflictDoNothing();
     await db.insert(variants).values({
       code,
       productKey,
       guid: productKey,
+      sizeLabel: over.sizeLabel ?? null,
       name: `Produkt ${code}`,
       stock: 0,
       availabilityInStockText: "Skladom",
@@ -103,6 +112,20 @@ describe("prepínanie Vypredané → Skladom", () => {
     const [event] = await db.select().from(restockEvents).where(eq(restockEvents.variantCode, "A1"));
     expect(event?.supplierLink).toBe(LINK);
     expect(event?.supplierAvailabilityText).toBe("skladom");
+  });
+
+  // issue 224: jedna linka môže niesť VIAC riadkov naraz (jeden na každú
+  // veľkosť) — variant sa smie prepnúť LEN keď je dostupný RIADOK jeho
+  // VLASTNEJ veľkosti, nikdy podľa dostupnosti inej veľkosti tej istej linky.
+  it("z linky s viacerými veľkosťami sa prepne LEN variant svojej vlastnej dostupnej veľkosti", async () => {
+    await seedSupplierStock({ sizeLabel: "L-X", availability: "available" });
+    await seedSupplierStock({ sizeLabel: "S-M", availability: "unavailable" });
+    await seedVariant("16707/L-X", { productKey: "prod-16707", sizeLabel: "L-X" });
+    await seedVariant("16707/S-M", { productKey: "prod-16707", sizeLabel: "S-M" });
+
+    const { picked } = await selectRestockCandidates(db, NOW);
+
+    expect(picked.map((c) => c.variantCode)).toEqual(["16707/L-X"]);
   });
 
   // TOTO je hlavná bezpečnostná podmienka celej úlohy: `detailOnly` je vedomé

--- a/apps/api/tests/supplier-stock-run.integration.test.ts
+++ b/apps/api/tests/supplier-stock-run.integration.test.ts
@@ -1,11 +1,27 @@
-import { eq } from "drizzle-orm";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { and, eq } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { Database } from "../src/db/client.js";
 import { supplierStock } from "../src/db/schema.js";
 import type { PageFetchResult } from "../src/modules/supplier-stock/page-fetcher.js";
 import { runSupplierStock } from "../src/modules/supplier-stock/run.js";
 import { withCleanDb } from "./helpers/db.js";
-import { insertTestVariant } from "./helpers/orders.js";
+import { insertTestVariant, insertTestVariantForProduct } from "./helpers/orders.js";
+
+function fixture(name: string): string {
+  return readFileSync(
+    fileURLToPath(new URL(`../src/modules/supplier-stock/fixtures/${name}`, import.meta.url)),
+    "utf8",
+  );
+}
+
+const LASTING_BONY = fixture("lasting-bony-cepica-l-xl.html");
+const LASTING_HILA = fixture("lasting-hila-tricko-bez-xs.html");
+const LASTING_BONY_URL =
+  "https://shop.lasting.eu/cs/cepice/19937-59938-lasting-merino-cepice-bony-cerna-8595067820460.html";
+const LASTING_HILA_URL =
+  "https://shop.lasting.eu/cs/trika-kratky-rukav-mqc/16926-56344-hila-damske-merino-triko-s-tiskem-8995067844631.html";
 
 // Žiadny test nesmie siahnuť na skutočnú stránku dodávateľa — sťahovanie je
 // vždy vlastná implementácia, nikdy `fetchSupplierPage`.
@@ -168,5 +184,97 @@ describe("beh dodávateľského skladu", () => {
 
     expect(result.total).toBe(1);
     expect(volani).toBe(1);
+  });
+});
+
+// issue 224 — dostupnosť sa berie za KONKRÉTNU veľkosť, nie za celý odkaz.
+// Oba príklady priamo z ticketu, na uložených vzorkách reálnych stránok.
+describe("beh dodávateľského skladu — issue 224: dostupnosť po veľkosti", () => {
+  let db: Database;
+  let close: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ db, close } = await withCleanDb());
+  });
+  afterEach(async () => {
+    await close();
+  });
+
+  const rowFor = async (
+    link: string,
+    sizeLabel: string,
+  ): Promise<typeof supplierStock.$inferSelect | undefined> => {
+    const [found] = await db
+      .select()
+      .from(supplierStock)
+      .where(and(eq(supplierStock.link, link), eq(supplierStock.sizeLabel, sizeLabel)));
+    return found;
+  };
+
+  it("16707/L-X (nas 'L-X' = dodavatelovo 'L/XL', sklademNE) je unavailable, nie available z JSON-LD", async () => {
+    await insertTestVariantForProduct(db, "16707", "16707/L-X", {
+      sizeLabel: "L-X",
+      internalNote: LASTING_BONY_URL,
+    });
+    await insertTestVariantForProduct(db, "16707", "16707/S-M", { sizeLabel: "S-M" });
+
+    await runSupplierStock({
+      db,
+      now: NOW,
+      sleep: noSleep,
+      fetchPage: () => Promise.resolve(okPage(LASTING_BONY)),
+    });
+
+    const lx = await rowFor(LASTING_BONY_URL, "L-X");
+    expect(lx?.availability).toBe("unavailable");
+    expect(lx?.source).toBe("size_list");
+    expect(lx?.availabilityText).toBe("L/XL");
+
+    // Druhá veľkosť tej istej linky sa spáruje NEZÁVISLE — dodávateľ ju má
+    // skladom, hoci L/XL nie.
+    const sm = await rowFor(LASTING_BONY_URL, "S-M");
+    expect(sm?.availability).toBe("available");
+  });
+
+  it("16710/XS (dodavatel tuto velkost vobec nema) je unknown, nikdy dohad", async () => {
+    await insertTestVariantForProduct(db, "16710", "16710/XS", {
+      sizeLabel: "XS",
+      internalNote: LASTING_HILA_URL,
+    });
+    await insertTestVariantForProduct(db, "16710", "16710/L", { sizeLabel: "L" });
+
+    await runSupplierStock({
+      db,
+      now: NOW,
+      sleep: noSleep,
+      fetchPage: () => Promise.resolve(okPage(LASTING_HILA)),
+    });
+
+    const xs = await rowFor(LASTING_HILA_URL, "XS");
+    expect(xs?.availability).toBe("unknown");
+    expect(xs?.confirmedAt).toBeNull();
+
+    const l = await rowFor(LASTING_HILA_URL, "L");
+    expect(l?.availability).toBe("available");
+  });
+
+  it("jednoveľkostný odkaz na doméne s pravidlom stále funguje ako blanket riadok", async () => {
+    // Bez DRUHÉHO variantu na tej istej linke sa `ourSizes.length` rovná 1,
+    // nie 0 — čítač sa STÁLE pokúsi spárovať jedinú veľkosť, presne ako pri
+    // viacerých variantoch.
+    await insertTestVariantForProduct(db, "16707solo", "16707solo/L-X", {
+      sizeLabel: "L-X",
+      internalNote: LASTING_BONY_URL,
+    });
+
+    await runSupplierStock({
+      db,
+      now: NOW,
+      sleep: noSleep,
+      fetchPage: () => Promise.resolve(okPage(LASTING_BONY)),
+    });
+
+    const lx = await rowFor(LASTING_BONY_URL, "L-X");
+    expect(lx?.availability).toBe("unavailable");
   });
 });

--- a/apps/web/src/components/SupplierStockSection.test.tsx
+++ b/apps/web/src/components/SupplierStockSection.test.tsx
@@ -16,6 +16,8 @@ vi.mock("../supplierStockApi.js", async (importOriginal) => {
 
 const { SupplierStockUnauthorizedError } = await import("../supplierStockApi.js");
 
+const LASTING_LINK = "https://shop.lasting.eu/cepice/bony";
+
 const STATUS = {
   overview: {
     total: 238,
@@ -28,6 +30,7 @@ const STATUS = {
   rows: [
     {
       link: "https://huntingshop.eu/bunda",
+      sizeLabel: "",
       host: "huntingshop.eu",
       availability: "available" as const,
       availabilityText: "skladom",
@@ -39,8 +42,24 @@ const STATUS = {
       checkedAt: "2026-08-03T04:20:00.000Z",
       confirmedAt: "2026-08-03T04:20:00.000Z",
     },
+    {
+      link: LASTING_LINK,
+      sizeLabel: "L-X",
+      host: "shop.lasting.eu",
+      availability: "unavailable" as const,
+      availabilityText: "L/XL",
+      price: "15.90",
+      source: "size_list" as const,
+      ok: true,
+      error: null,
+      httpStatus: 200,
+      checkedAt: "2026-08-03T04:20:00.000Z",
+      confirmedAt: "2026-08-03T04:20:00.000Z",
+    },
   ],
-  unreadable: [{ host: "dogtrace.com", count: 2, samples: ["https://dogtrace.com/obojok"] }],
+  unreadable: [
+    { host: "dogtrace.com", count: 2, samples: [{ link: "https://dogtrace.com/obojok", sizeLabel: "" }] },
+  ],
   lastRun: {
     startedAt: "2026-08-03T04:20:00.000Z",
     finishedAt: "2026-08-03T04:41:00.000Z",
@@ -128,4 +147,38 @@ it("vypršaná relácia odhlási, nezobrazí chybu", async () => {
   await waitFor(() => {
     expect(onSessionExpired).toHaveBeenCalledTimes(1);
   });
+});
+
+// issue 224: jedna linka môže mať teraz VIAC riadkov (jeden na každú našu
+// veľkosť) — kľúč aj testid musia niesť aj veľkosť, inak by React zlúčil
+// dva rôzne riadky do jedného.
+it("odkaz s viacerými veľkosťami ukáže KAŽDÚ veľkosť ako vlastný riadok", async () => {
+  const spolocnyRiadok = {
+    link: LASTING_LINK,
+    host: "shop.lasting.eu",
+    availabilityText: "",
+    price: "15.90",
+    source: "size_list" as const,
+    ok: true,
+    error: null,
+    httpStatus: 200,
+    checkedAt: "2026-08-03T04:20:00.000Z",
+    confirmedAt: "2026-08-03T04:20:00.000Z",
+  };
+  const dveVelkosti = {
+    ...STATUS,
+    rows: [
+      { ...spolocnyRiadok, sizeLabel: "L-X", availability: "unavailable" as const },
+      { ...spolocnyRiadok, sizeLabel: "S-M", availability: "available" as const },
+    ],
+  };
+  fetchSupplierStockStatus.mockResolvedValue(dveVelkosti);
+  render(<SupplierStockSection role="admin" onSessionExpired={vi.fn()} />);
+
+  const lX = await screen.findByTestId(`ss-row-${LASTING_LINK}-L-X`);
+  const sM = await screen.findByTestId(`ss-row-${LASTING_LINK}-S-M`);
+  expect(lX.textContent).toContain("L-X");
+  expect(lX.textContent).toContain("Vypredané");
+  expect(sM.textContent).toContain("S-M");
+  expect(sM.textContent).toContain("Skladom");
 });

--- a/apps/web/src/components/SupplierStockSection.tsx
+++ b/apps/web/src/components/SupplierStockSection.tsx
@@ -63,8 +63,12 @@ export function SupplierStockSection({
     setRunNotice("");
     runSupplierStockNow()
       .then((result) => {
+        // issue 224: `checked` je počet ODKAZOV, ale skladom/vypredané/neviem
+        // sú počty ZÁZNAMOV (odkaz × veľkosť) — odkaz s viacerými veľkosťami
+        // prispieva do rozpisu viac než raz, takže sa nesmú tváriť ako súčet
+        // rovnakej jednotky.
         setRunNotice(
-          `Skontrolovaných ${String(result.checked)} odkazov · skladom ${String(result.available)} · vypredané ${String(result.unavailable)} · neviem ${String(result.unknown)} · zlyhalo ${String(result.failed)}.`,
+          `Skontrolovaných ${String(result.checked)} odkazov · zlyhalo ${String(result.failed)}. Záznamy: skladom ${String(result.available)} · vypredané ${String(result.unavailable)} · neviem ${String(result.unknown)}.`,
         );
         load();
       })

--- a/apps/web/src/components/SupplierStockSection.tsx
+++ b/apps/web/src/components/SupplierStockSection.tsx
@@ -96,7 +96,10 @@ export function SupplierStockSection({
 
       <div className="autohead">
         <span className="chip" data-testid="ss-total">
-          Sledovaných odkazov: {overview.total}
+          {/* issue 224: `overview.total` počíta RIADKY (dvojica odkaz+veľkosť),
+              nie unikátne odkazy — odkaz s pravidlom na veľkosti prispieva
+              viac než jedným záznamom, takže "odkazov" by bolo zavádzajúce. */}
+          Sledovaných záznamov: {overview.total}
         </span>
         <span className="chip" data-testid="ss-available">
           Skladom: {overview.available}

--- a/apps/web/src/components/SupplierStockSection.tsx
+++ b/apps/web/src/components/SupplierStockSection.tsx
@@ -155,11 +155,12 @@ export function SupplierStockSection({
                   <td>{host.host}</td>
                   <td>{host.count}</td>
                   <td>
-                    {host.samples.map((link) => (
-                      <div key={link}>
-                        <a href={link} target="_blank" rel="noreferrer noopener">
-                          {link}
+                    {host.samples.map((sample) => (
+                      <div key={`${sample.link}|${sample.sizeLabel}`}>
+                        <a href={sample.link} target="_blank" rel="noreferrer noopener">
+                          {sample.link}
                         </a>
+                        {sample.sizeLabel !== "" && ` [${sample.sizeLabel}]`}
                       </div>
                     ))}
                   </td>
@@ -180,6 +181,7 @@ export function SupplierStockSection({
               <tr>
                 <th scope="col">Dodávateľ</th>
                 <th scope="col">Odkaz</th>
+                <th scope="col">Veľkosť</th>
                 <th scope="col">Dostupnosť</th>
                 <th scope="col">Cena</th>
                 <th scope="col">Kontrolované</th>
@@ -187,13 +189,16 @@ export function SupplierStockSection({
             </thead>
             <tbody>
               {rows.map((row) => (
-                <tr key={row.link} data-testid={`ss-row-${row.link}`}>
+                // Kľúč MUSÍ niesť aj veľkosť — odkaz s pravidlom na veľkosti
+                // (issue 224) má pre TÚ ISTÚ linku viac riadkov naraz.
+                <tr key={`${row.link}|${row.sizeLabel}`} data-testid={`ss-row-${row.link}-${row.sizeLabel}`}>
                   <td>{row.host}</td>
                   <td>
                     <a href={row.link} target="_blank" rel="noreferrer noopener">
                       {row.link}
                     </a>
                   </td>
+                  <td>{row.sizeLabel === "" ? "—" : row.sizeLabel}</td>
                   <td>
                     {row.ok ? AVAILABILITY_LABEL[row.availability] : "Kontrola zlyhala"}
                     {row.availabilityText !== "" && ` (${row.availabilityText})`}

--- a/apps/web/src/supplierStockApi.ts
+++ b/apps/web/src/supplierStockApi.ts
@@ -8,11 +8,14 @@ export type SupplierAvailability = z.infer<typeof availabilitySchema>;
 
 const rowSchema = z.object({
   link: z.string(),
+  // '' = dostupnosť CELÉHO odkazu (issue 224) — jednoveľkostný produkt,
+  // alebo doména bez pravidla na čítanie zoznamu veľkostí.
+  sizeLabel: z.string(),
   host: z.string(),
   availability: availabilitySchema,
   availabilityText: z.string(),
   price: z.string().nullable(),
-  source: z.enum(["json_ld", "meta", "text", "none"]),
+  source: z.enum(["json_ld", "meta", "text", "size_list", "none"]),
   ok: z.boolean(),
   error: z.string().nullable(),
   httpStatus: z.number().nullable(),
@@ -21,10 +24,13 @@ const rowSchema = z.object({
 });
 export type SupplierStockRow = z.infer<typeof rowSchema>;
 
+const unreadableSampleSchema = z.object({ link: z.string(), sizeLabel: z.string() });
+export type UnreadableSample = z.infer<typeof unreadableSampleSchema>;
+
 const unreadableSchema = z.object({
   host: z.string(),
   count: z.number(),
-  samples: z.array(z.string()),
+  samples: z.array(unreadableSampleSchema),
 });
 export type UnreadableHost = z.infer<typeof unreadableSchema>;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.131",
+  "version": "0.3.0-dev.132",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Čo sa opravuje

issue 224: `supplier_stock` bola kľúčovaná len na `link` (jedna dostupnosť
pre celý dodávateľský odkaz), hoci 965 z 2179 odkazov pokrýva viac našich
variantov (rôzne veľkosti) a dodávateľ hlási dostupnosť po veľkosti.
Dôsledok: dostupnosť náhodne prečítanej veľkosti (zvyčajne stránkové
JSON-LD, ktoré reflektuje len JEDNU/predvolenú veľkosť) sa aplikovala na
VŠETKY varianty toho odkazu naraz.

## Čo sa mení

- `supplier_stock`: nový stĺpec `size_label` (default `''` = celý odkaz,
  spätne kompatibilné) + zložený primárny kľúč `(link, size_label)`.
  Migrácia `0029_supplier_stock_size_label.sql`.
- `parse.ts`: `parseSizeAvailability` číta zoznam veľkostí priamo zo
  stránky pre `shop.lasting.eu` (PrestaShop, trieda `sklademANO`/
  `sklademNE`) — JSON-LD sa pre takýto odkaz vôbec nepoužije.
  `matchSizeLabel` spáruje náš `variant.size_label` (napr. "L-X") s
  dodávateľovým textom (napr. "L/XL"), tolerantne na skrátenie poslednej
  časti, nikdy na iný počet častí ani nejednoznačnú zhodu.
- `run.ts`: pre odkaz s pravidlom zapíše samostatný riadok za KAŽDÚ našu
  veľkosť; inak jeden blanket riadok ako doteraz. Staré riadky tej istej
  linky sa vždy vymažú, aby nikdy nezostal zavádzajúci zvyšok z predošlej
  stratégie.
- `restock/queries.ts`: JOIN sa páruje na vlastnú veľkosť variantu ALEBO na
  blanket riadok — obe vetvy sa pre ten istý odkaz nikdy nestretnú naraz.
- `apps/web`: obrazovka "Dodávateľský sklad" zobrazuje stĺpec Veľkosť,
  riadok aj karta nečitateľných stránok nesú veľkosť v kľúči/ukážke.

## Testy

- `parse.test.ts`: `parseSizeAvailability`/`matchSizeLabel` na uložených
  vzorkách oboch reálnych stránok z ticketu.
- `supplier-stock-run.integration.test.ts`: end-to-end oba príklady z
  ticketu — `16707/L-X` → `unavailable`, `16710/XS` → `unknown`.
- `restock-run.integration.test.ts`: z linky s dvomi veľkosťami sa prepne
  LEN variant svojej vlastnej dostupnej veľkosti.
- Všetky existujúce testy (529 unit + integration, 370 web) prechádzajú
  bez zmeny správania pre jednoveľkostné odkazy.

Súvisiace: issue 224. Predošlé dve príčiny tej istej trojice (huntingshop.eu
pätička, odimon.sk klamlivé JSON-LD) sú vyriešené v PR #229 (issue 223 +
issue 225).
