### PR TITLE
fix: MAX_PAGE_BYTES orezaval velkostny zoznam na realne velkych strankach (issue 224)

### DIFF
--- a/apps/api/src/modules/supplier-stock/constants.test.ts
+++ b/apps/api/src/modules/supplier-stock/constants.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { MAX_PAGE_BYTES } from "./constants.js";
+
+describe("MAX_PAGE_BYTES", () => {
+  // issue 224: naživo po nasadení (post-deploy overenie) sa ukázalo, že
+  // shop.lasting.eu's BONY produkt má CELÚ stránku 2 180 285 bajtov — takmer
+  // výhradne z opakovaného whitespace v PrestaShop šablóne skupiny "Odstín".
+  // Veľkostný zoznam (`parseSizeAvailability`) je na stránke AŽ ZA touto
+  // skupinou — pôvodný 2 000 000 strop ho odrezával a veľkosť L/XL (presne
+  // tá, ktorú má tento ticket dokázať ako "unavailable") zo zoznamu úplne
+  // zmizla. Tento test drží strop nad zmeranou realitou, aby sa regresia
+  // nevrátila tichým znížením konštanty v budúcnosti.
+  it("má rezervu nad naživo zmeranou veľkosťou shop.lasting.eu BONY stránky", () => {
+    expect(MAX_PAGE_BYTES).toBeGreaterThan(2_180_285);
+  });
+});

--- a/apps/api/src/modules/supplier-stock/constants.ts
+++ b/apps/api/src/modules/supplier-stock/constants.ts
@@ -28,7 +28,18 @@ export const REQUEST_TIMEOUT_MS = 15_000;
 // Strop na veľkosť stiahnutej stránky — číta sa po častiach a nad týmto sa
 // spojenie prerušie (rovnaká úvaha ako `catalog/fetcher.ts`'s `readBounded`:
 // strop musí platiť POČAS čítania, nie až po zbufferovaní celého tela).
-export const MAX_PAGE_BYTES = 2_000_000;
+//
+// Zvýšené z pôvodných 2 000 000 (issue 224, naživo overené na produkcii po
+// nasadení): `shop.lasting.eu`'s BONY čiapka má CELÚ stránku 2 180 285 bajtov
+// — takmer výhradne z opakovaného whitespace v PrestaShop šablóne skupiny
+// "Odstín" (po zošmiznutí opakovaných medzier/tabov klesne skutočný obsah na
+// ~168 000 bajtov). Veľkostný zoznam (`parseSizeAvailability`, issue 224) je
+// na stránke AŽ ZA touto skupinou, takže pôvodný 2 MB strop ho odrezával —
+// L/XL veľkosť (presne tá, ktorú má ticket dokázať ako `unavailable`)
+// zmizla úplne, kým JSON-LD (blízko začiatku `<head>`) strop nikdy
+// nezasiahol. Nový strop necháva rezervu nad zmeranou veľkosťou tejto
+// konkrétnej stránky bez neobmedzeného rastu.
+export const MAX_PAGE_BYTES = 5_000_000;
 
 // Vlastný User-Agent s kontaktom — dodávateľ musí vedieť, kto mu chodí na
 // stránku a komu napísať, keby mu to prekážalo.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.132",
+  "version": "0.3.0-dev.133",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Čo sa opravuje

Nadväzuje na PR #232 (issue 224), ktoré už zmergované/nasadené. Post-deploy
overenie naživo (nie test) ukázalo, že veľkostný zoznam sa na REÁLNEJ
produkčnej `shop.lasting.eu` BONY stránke NEZAPARSOVAL úplne — chýbala
veľkosť L/XL, tá istá, ktorú má ticket dokázať ako `unavailable`.

## Príčina

`shop.lasting.eu`'s BONY čiapka má celú stránku 2 180 285 bajtov — takmer
výhradne z opakovaného whitespace v PrestaShop šablóne skupiny "Odstín"
(po zošmiznutí opakovaných medzier klesne skutočný obsah na ~168 000
bajtov — dátová/šablónová chyba na strane dodávateľa, nie niečo, čo
vieme ovplyvniť). Veľkostný zoznam (`parseSizeAvailability`, PR #232) je
na stránke AŽ ZA touto skupinou, takže existujúci strop na veľkosť
stiahnutej stránky (`MAX_PAGE_BYTES = 2 000 000`, zavedený už s pôvodným
scraperom, issue 212) ho odrezával. JSON-LD (blízko začiatku `<head>`)
strop nikdy nezasiahol — preto to unit/integračné testy na orezaných
fixtúrach nezachytili; odhalilo to až živé overenie proti nasadenej appke.

## Čo sa mení

- `MAX_PAGE_BYTES`: `2 000 000` → `5 000 000`, s rezervou nad zmeranou
  realitou tejto konkrétnej stránky.
- Regresný test (`constants.test.ts`) drží strop nad zmeranou hodnotou.

Súvisiace: issue 224 (naväzuje na #232).
