### PR TITLE
docs: playbook + autopilot-log pre issue 230 (trigona.sk textovy vyrez)

### DIFF
--- a/.claude/rules/supplier-stock.md
+++ b/.claude/rules/supplier-stock.md
@@ -145,3 +145,30 @@ paths:
   vlastné čerstvé zápisy z prvého behu, vyhodnotil ich ako platné potvrdenia
   a preskočil VŠETKY odkazy — testy padli na „skipped 2, checked 0" bez
   akejkoľvek zmeny kódu.
+- **`fetchSupplierPage` (`page-fetcher.ts`) dekóduje KAŽDÚ stránku ako
+  `TextDecoder("utf-8")`, bez ohľadu na skutočnú `Content-Type; charset=`
+  hlavičku.** `trigona.sk` (issue 230) posiela `windows-1250` — pri UTF-8
+  dekódovaní windows-1250 bajtov sa diakritika (á/é/š/ť/…) zmení na mojibake
+  (nesprávne, ale DETERMINISTICKY nesprávne znaky), zatiaľ čo ČISTO ASCII
+  úseky (hex farby, triedy, číselné ID) ostávajú nedotknuté — ASCII bajty sú
+  v UTF-8 aj vo windows-1250 identické. **Nový `extractRegion`/text-based
+  extraktor na doméne s neznámou/nie-UTF-8 charset hlavičkou preto NESMIE
+  hľadať/porovnávať diakritický text priamo z `html`** (napr. "Na sklade"
+  ako reťazec by na trigona.sk fungoval len náhodou) — over `Content-Type`
+  hlavičku (`curl -sI`) PRED písaním extraktora, a ak je iná než UTF-8,
+  postav rozlíšenie na ASCII-only signáli (farba, trieda, číselné ID), nikdy
+  na diakritickom texte. `trigonaStockRegion` preto číta farbu `#00b020`/
+  `#024bbd` z `style="color: …"` namiesto porovnávania slov "Na sklade"/
+  "1 - 4 týždne" priamo.
+- **Overený PROTIPÓL sa niekedy nedá nájsť aj napriek dôkladnému hľadaniu —
+  vtedy sa pravidlo NEPRIDÁVA, nie hádá.** Issue 230: pre `trigona.sk` sa
+  naživo overili OBE polarity (31 vzoriek, farba `#00b020`/`#024bbd`
+  krížovo overená proti JSON-LD na TOM ISTOM produkte) → pravidlo pridané.
+  Pre `wetland.sk` sa naživo overilo 67+ reálnych produktových stránok
+  naprieč 3 kategóriami a VŽDY mal produkt rovnaký ("success") štítok —
+  ani JEDEN overený vypredaný príklad sa nenašiel (6 `unknown` riadkov v
+  produkčnej DB boli všetky HTTP 404 mŕtve odkazy, nie živé vypredané
+  stránky). Záver: pravidlo pre `wetland.sk` sa NEPRIDALO, doména ostáva
+  `unknown` presne ako predtým — dokumentované v `constants.ts` aj na
+  ticket-e, nie tichá medzera. Vzor na ĎALŠIU doménu bez overeného
+  protipólu: rovnaký postup, nie dohad podľa analógie s inou doménou.

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -2545,3 +2545,19 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   `unavailable` (spárované na dodávateľovo "L/XL"), `16710/XS` → `unknown`
   (dodávateľ tú veľkosť nemá). Issue zavreté ručne s dôkazom, Discord
   run-card odoslaná.
+
+- issue 230 (wetland.sk/trigona.sk textová dostupnosť po issue 223):
+  version bump `b135fd8` (0.3.0-dev.136). RED `8f406c5` (`parse.test.ts`:
+  trigona.sk StockCountText fixtúry, oba stavy). GREEN `8ec6c51`
+  (`trigonaStockRegion` — farba `#00b020`/`#024bbd` → "skladom"/"vypredané",
+  `whenRegionMissing: "unknown"`; wetland.sk zámerne BEZ pravidla — 67+
+  naživo overených stránok malo vždy len "success" štítok, žiadny overený
+  vypredaný príklad). PR #236, code review (`requesting-code-review`,
+  independent live fetch verify): 1 Important (extractRegion nedostáva url,
+  filed #241, cross-cutting, neopravené v tomto PR) + 2 Minor (regex
+  rigidita, chýbajúca negatívna host assercia — oba opravené `3d43e1b`).
+  Merge `f0b56e5`. Post-deploy overené proti nasadenej appke
+  (0.3.0-dev.136): živé URL → `source: json_ld` (JSON-LD dnes pokrýva
+  takmer všetko), trimmed fixtúry bez JSON-LD → `source: text`, obe
+  polarity aj chýbajúci štítok správne. Issue zavreté ručne s dôkazom,
+  Discord run-card odoslaná.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.136",
+  "version": "0.3.0-dev.137",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Čo rieši

Playbook (`.claude/rules/supplier-stock.md`) a `docs/autopilot-log.md`
zápis pre issue 230 (trigona.sk textový výrez dostupnosti, PR #236,
zmergnuté). Rovnaký vzor ako doc-only PR #234 pri issue 224 — dokumentácia
ide vlastným malým PR-om, nie súčasťou feature PR.

## Čo sa zmenilo

- Poučenie: `fetchSupplierPage` dekóduje KAŽDÚ stránku ako UTF-8 bez ohľadu
  na `Content-Type; charset=` — trigona.sk posiela `windows-1250`, takže
  budúci text-based extraktor na doméne s iným charsetom sa musí spoľahnúť
  na ASCII signál (farba, trieda, ID), nikdy na diakritický text.
- Precedens: overený protipól sa niekedy nedá nájsť aj napriek dôkladnému
  hľadaniu — vtedy sa pravidlo NEPRIDÁVA (`wetland.sk`), nie hádá.
- `docs/autopilot-log.md` záznam pre issue 230.

Žiadna zmena produkčného kódu.
