### PR TITLE
Krížová kontrola stavu proti feedu Shoptetu (issue 226)

### DIFF
--- a/.claude/rules/shop-feed.md
+++ b/.claude/rules/shop-feed.md
@@ -22,6 +22,28 @@ paths:
   padne na vyhľadávanie podľa kódu). Zmena na `INNER JOIN` by zo zoznamu, podľa
   ktorého majiteľ rozhoduje, ticho vyhodila stovky riadkov — presne tá trieda
   chyby, ktorú riešilo issue 219.
+- **`shop_product_url` odteraz nesie aj `g:availability`
+  (`availability`, nullable text, issue 226) — Shoptetova VLASTNÁ dostupnosť,
+  nezávislý zdroj pravdy na krížovú kontrolu proti nášmu odvodenému
+  `variant.state`** (`modules/catalog/feed-cross-check.ts`). Živo overené
+  4. 8. 2026: len dve reálne hodnoty na tomto e-shope, `"in stock"`/
+  `"out of stock"` (7 449/139 z 7 679 položiek), zvyšných 91 má prázdnu
+  značku → `null`. `runShopFeed`'s UPSERT PREPISUJE `availability` na
+  KAŽDOM behu (vrátane `null`), inak by stará hodnota z predošlého behu
+  ticho prežívala a krížová kontrola by porovnávala proti zastaranému
+  signálu.
+- **Nová "koreňová" tabuľka pridaná do TRUNCATE zoznamu (`.claude/rules/
+  testing.md`) MUSÍ pribudnúť do OBOCH zoznamov, aj keď existuje už dávno —
+  `shop_product_url` (issue 220) chýbala v `scripts/e2e-setup.ts`'s vlastnom
+  TRUNCATE reťazci celé mesiace, lebo dovtedy do nej žiadny e2e seed
+  nezapisoval.** Odhalené AŽ issue 226, keď prvý e2e seed (`PREP-2`'s
+  rozporová `availability`) do tejty tabuľky skutočne zapísal — bez FK na
+  `variant` (tabuľka je zámerne PLOCHÁ) sa jej riadky NEVYPRÁZDNIA cez
+  `variant`'s CASCADE, takže by ticho prežívali medzi e2e behmi. Test pri
+  KAŽDEJ tabuľke bez FK, ktorú založí SKORŠÍ ticket: skús do nej niečo
+  zapísať v `scripts/e2e-setup.ts` a over `grep shop_product_url
+  scripts/e2e-setup.ts` (alebo cieľovú tabuľku) PRED spoliehaním sa na to,
+  že tam už je.
 - **Rozoberač je zámerne regulárny výraz bez novej závislosti na XML parseri.**
   Tvar feedu je plochý (`<entry>` s textovými deťmi). Hlavička feedu má
   `<link href="…" />` s adresou vzorového webu — preto vzor hľadá `<link>` s

--- a/.claude/rules/supplier-stock.md
+++ b/.claude/rules/supplier-stock.md
@@ -160,6 +160,23 @@ paths:
   na diakritickom texte. `trigonaStockRegion` preto číta farbu `#00b020`/
   `#024bbd` z `style="color: …"` namiesto porovnávania slov "Na sklade"/
   "1 - 4 týždne" priamo.
+- **Krížová kontrola nášho odvodeného stavu proti Shoptetovmu vlastnému feedu
+  (issue 226) sa počíta VŽDY NAŽIVO (`modules/catalog/feed-cross-check.ts`'s
+  `findFeedStateConflicts`), nikdy do vlastnej perzistovanej tabuľky.**
+  Dôvod: `shop_product_url` sa obnovuje DENNE (03:50), katalógový import
+  HODINOVO (:20, `.claude/rules/scheduler.md`) — perzistovaná snímka
+  rozporov spred hodiny by bola presne ten istý problém ("zastaraný
+  odvodený stav"), aký sa touto funkciou rieši. Rovnaký architektonický vzor
+  ako `allRestockCandidates`/`listRestockWaiting` nižšie — vždy odvoď zo
+  živého stavu DB. `restock/queries.ts`'s kandidát (vždy `out_of_stock`) sa
+  vylúči len keď feed hovorí `"in stock"` (`FEED_IN_STOCK`, exportované z
+  `feed-cross-check.ts`, nikdy vlastný literál v `restock/queries.ts` —
+  jeden zdroj pravdy pre string) — opačný smer rozporu (naše `sellable`
+  proti feedovému `"out of stock"`) je pre KANDIDÁTOV irelevantný (kandidát
+  je vždy `out_of_stock`), ale stále sa počíta do celkového čísla na
+  obrazovke. Chýbajúci feed riadok (626 variantov, issue 220) sa MUSÍ
+  vylúčiť explicitným `isNull(...) OR ne(...)` — samotné `!= 'in stock'`
+  proti NULL vyhodnotí SQL na NULL, čo WHERE ticho zahodí (nie `false`).
 - **Overený PROTIPÓL sa niekedy nedá nájsť aj napriek dôkladnému hľadaniu —
   vtedy sa pravidlo NEPRIDÁVA, nie hádá.** Issue 230: pre `trigona.sk` sa
   naživo overili OBE polarity (31 vzoriek, farba `#00b020`/`#024bbd`

--- a/apps/api/drizzle/0030_cuddly_gravity.sql
+++ b/apps/api/drizzle/0030_cuddly_gravity.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "shop_product_url" ADD COLUMN "availability" text;

--- a/apps/api/drizzle/meta/0030_snapshot.json
+++ b/apps/api/drizzle/meta/0030_snapshot.json
@@ -1,0 +1,2496 @@
+{
+  "id": "913d9139-cb59-4ec6-b41e-484cb721838d",
+  "prevId": "c5b91146-fc24-47e0-b03c-9ad09d93d301",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "related_codes": {
+          "name": "related_codes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_code": {
+          "name": "external_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_open_status": {
+      "name": "order_open_status",
+      "schema": "",
+      "columns": {
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Vybavuje sa'"
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop_remark": {
+          "name": "shop_remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shoptet_order_id": {
+          "name": "shoptet_order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_updated_at": {
+          "name": "comment_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_synced_at": {
+          "name": "comment_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_carrier_name": {
+          "name": "shipping_carrier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_link_override": {
+      "name": "product_supplier_link_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_link_override_product_key_product_key_fk": {
+          "name": "product_supplier_link_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_link_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_override": {
+      "name": "product_supplier_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_override_product_key_product_key_fk": {
+          "name": "product_supplier_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing": {
+      "name": "pairing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_url": {
+          "name": "supplier_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "pairing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'navrhnute'"
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pairing_state_idx": {
+          "name": "pairing_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_confirmed_by_idx": {
+          "name": "pairing_confirmed_by_idx",
+          "columns": [
+            {
+              "expression": "confirmed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_variant_code_variant_code_fk": {
+          "name": "pairing_variant_code_variant_code_fk",
+          "tableFrom": "pairing",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pairing_confirmed_by_users_id_fk": {
+          "name": "pairing_confirmed_by_users_id_fk",
+          "tableFrom": "pairing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pairing_variant_code_unique": {
+          "name": "pairing_variant_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pairing_confirmation_ck": {
+          "name": "pairing_confirmation_ck",
+          "value": "(\"pairing\".\"state\" = 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)\n        OR (\"pairing\".\"state\" != 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NULL AND \"pairing\".\"confirmed_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier": {
+      "name": "supplier",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wholesale_base_url": {
+          "name": "wholesale_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_key": {
+          "name": "adapter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_settings": {
+      "name": "posta_uncollected_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_state": {
+      "name": "posta_uncollected_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notify_count": {
+          "name": "notify_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_state": {
+          "name": "terminal_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_settings": {
+      "name": "order_reminder_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_state": {
+      "name": "order_reminder_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_state": {
+      "name": "nedostupne_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "nedostupne_email_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nedostupne_state_order_variant_type_uq": {
+          "name": "nedostupne_state_order_variant_type_uq",
+          "columns": [
+            {
+              "expression": "order_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template_history": {
+      "name": "mail_template_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "mail_template_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_template_history_key_idx": {
+          "name": "mail_template_history_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_template_history_changed_by_user_id_users_id_fk": {
+          "name": "mail_template_history_changed_by_user_id_users_id_fk",
+          "tableFrom": "mail_template_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template": {
+      "name": "mail_template",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail_template_updated_by_user_id_users_id_fk": {
+          "name": "mail_template_updated_by_user_id_users_id_fk",
+          "tableFrom": "mail_template",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_log": {
+      "name": "mail_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "mail_log_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_log_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "mail_log_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_log_created_idx": {
+          "name": "mail_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_log_source_created_idx": {
+          "name": "mail_log_source_created_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_log_actor_user_id_users_id_fk": {
+          "name": "mail_log_actor_user_id_users_id_fk",
+          "tableFrom": "mail_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_stock": {
+      "name": "supplier_stock",
+      "schema": "",
+      "columns": {
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "supplier_availability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "supplier_stock_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "supplier_stock_host_idx": {
+          "name": "supplier_stock_host_idx",
+          "columns": [
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "supplier_stock_avail_idx": {
+          "name": "supplier_stock_avail_idx",
+          "columns": [
+            {
+              "expression": "availability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "supplier_stock_link_size_label_pk": {
+          "name": "supplier_stock_link_size_label_pk",
+          "columns": [
+            "link",
+            "size_label"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_event": {
+      "name": "restock_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_link": {
+          "name": "supplier_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_availability_text": {
+          "name": "supplier_availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "supplier_price": {
+          "name": "supplier_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "restock_event_at_idx": {
+          "name": "restock_event_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "restock_event_variant_idx": {
+          "name": "restock_event_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_settings": {
+      "name": "restock_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shop_product_url": {
+      "name": "shop_product_url",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne"
+      ]
+    },
+    "public.pairing_state": {
+      "name": "pairing_state",
+      "schema": "public",
+      "values": [
+        "navrhnute",
+        "potvrdene"
+      ]
+    },
+    "public.nedostupne_email_type": {
+      "name": "nedostupne_email_type",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "alternativa"
+      ]
+    },
+    "public.mail_template_action": {
+      "name": "mail_template_action",
+      "schema": "public",
+      "values": [
+        "save",
+        "reset"
+      ]
+    },
+    "public.mail_log_source": {
+      "name": "mail_log_source",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "posta_uncollected",
+        "order_reminder",
+        "supplier_order"
+      ]
+    },
+    "public.mail_log_status": {
+      "name": "mail_log_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.mail_log_trigger": {
+      "name": "mail_log_trigger",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "manual"
+      ]
+    },
+    "public.supplier_availability": {
+      "name": "supplier_availability",
+      "schema": "public",
+      "values": [
+        "available",
+        "unavailable",
+        "unknown"
+      ]
+    },
+    "public.supplier_stock_source": {
+      "name": "supplier_stock_source",
+      "schema": "public",
+      "values": [
+        "json_ld",
+        "meta",
+        "text",
+        "size_list",
+        "none"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -211,6 +211,13 @@
       "when": 1785846514944,
       "tag": "0029_supplier_stock_size_label",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1785861317276,
+      "tag": "0030_cuddly_gravity",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema-shop-feed.ts
+++ b/apps/api/src/db/schema-shop-feed.ts
@@ -13,6 +13,12 @@ import { pgTable, text, timestamp } from "drizzle-orm/pg-core";
 export const shopProductUrl = pgTable("shop_product_url", {
   code: text("code").primaryKey(),
   url: text("url").notNull(),
+  // Shoptetova VLASTNÁ dostupnosť z feedu (issue 226) — surový text
+  // `<g:availability>` ("in stock"/"out of stock"), `null` keď je značka
+  // prázdna. Nezávislý zdroj pravdy na krížovú kontrolu nášho odvodeného
+  // `variant.state` (`modules/catalog/feed-cross-check.ts`) — issue 219
+  // ukázalo, že naša vlastná dedukcia sa vie rozísť s realitou.
+  availability: text("availability"),
   // Čas behu, ktorý riadok naposledy potvrdil — keď feed na strane Shoptetu
   // zamrzne, na obrazovke je vidieť, že mapa starne.
   fetchedAt: timestamp("fetched_at", { withTimezone: true }).notNull(),

--- a/apps/api/src/http/restock-routes.ts
+++ b/apps/api/src/http/restock-routes.ts
@@ -6,6 +6,7 @@ import type { Database } from "../db/client.js";
 import { jobRuns, restockEvents } from "../db/schema.js";
 import { log } from "../logger.js";
 import { record } from "../modules/audit/service.js";
+import { findFeedStateConflicts } from "../modules/catalog/feed-cross-check.js";
 import { MAX_PER_RUN, RESTOCK_JOB_NAME } from "../modules/restock/constants.js";
 import { listRestockWaiting, selectRestockCandidates } from "../modules/restock/queries.js";
 import type { RestockRunResult, RunRestockOptions } from "../modules/restock/run.js";
@@ -63,11 +64,15 @@ async function runAndRecord(db: Database, deps: RestockRunDeps, now: Date): Prom
 export function registerRestockRoutes(app: Hono<AppBindings>, db: Database, deps: RestockRunDeps): void {
   app.get("/api/restock", requireUser(db), async (c) => {
     const now = new Date();
-    const [enabled, lastRun, candidates, events] = await Promise.all([
+    const [enabled, lastRun, candidates, events, feedConflicts] = await Promise.all([
       isRestockEnabled(db),
       getLatestJobRun(db, RESTOCK_JOB_NAME),
       selectRestockCandidates(db, now),
       db.select().from(restockEvents).orderBy(desc(restockEvents.at)).limit(200),
+      // issue 226: krížová kontrola nášho stavu proti Shoptetovmu feedu —
+      // varovanie s číslom a zoznamom priamo na tejto obrazovke, nikdy len
+      // tichý zápis do logu.
+      findFeedStateConflicts(db),
     ]);
     return c.json({
       enabled,
@@ -75,6 +80,7 @@ export function registerRestockRoutes(app: Hono<AppBindings>, db: Database, deps
       // Koľko by sa prepol NAJBLIŽŠÍ beh — majiteľ tak vidí dopredu, čo ho
       // čaká, nielen čo sa už stalo.
       waiting: { now: candidates.picked.length, overLimit: candidates.overLimit },
+      feedConflicts,
       events,
       lastRun:
         lastRun === null

--- a/apps/api/src/modules/catalog/feed-cross-check.test.ts
+++ b/apps/api/src/modules/catalog/feed-cross-check.test.ts
@@ -1,0 +1,46 @@
+// issue 226: krížová kontrola nášho odvodeného `variant.state` proti
+// Shoptetovej VLASTNEJ dostupnosti z feedu pre porovnávače (`g:availability`).
+// `compareStateToFeed` je čistá funkcia — žiadna databáza, žiadna sieť.
+
+import { describe, expect, it } from "vitest";
+import { compareStateToFeed } from "./feed-cross-check.js";
+
+describe("compareStateToFeed", () => {
+  it("feed 'in stock' + naše sellable = zhoda", () => {
+    expect(compareStateToFeed("sellable", "in stock")).toBe("match");
+  });
+
+  it("feed 'in stock' + naše out_of_stock = rozpor", () => {
+    expect(compareStateToFeed("out_of_stock", "in stock")).toBe("mismatch");
+  });
+
+  it("feed 'in stock' + naše discontinued = rozpor", () => {
+    expect(compareStateToFeed("discontinued", "in stock")).toBe("mismatch");
+  });
+
+  it("feed 'out of stock' + naše out_of_stock = zhoda", () => {
+    expect(compareStateToFeed("out_of_stock", "out of stock")).toBe("match");
+  });
+
+  it("feed 'out of stock' + naše discontinued = zhoda (obe znamenajú nekúpiteľné)", () => {
+    expect(compareStateToFeed("discontinued", "out of stock")).toBe("match");
+  });
+
+  it("feed 'out of stock' + naše sellable = rozpor", () => {
+    expect(compareStateToFeed("sellable", "out of stock")).toBe("mismatch");
+  });
+
+  it("chýbajúci feed signál (null) = žiadny rozpor, nikdy zhoda ani rozpor", () => {
+    expect(compareStateToFeed("sellable", null)).toBe("no_signal");
+    expect(compareStateToFeed("out_of_stock", null)).toBe("no_signal");
+  });
+
+  it("prázdny/neznámy text sa berie ako chýbajúci signál, nikdy ako rozpor", () => {
+    expect(compareStateToFeed("sellable", "")).toBe("no_signal");
+    expect(compareStateToFeed("out_of_stock", "preorder")).toBe("no_signal");
+  });
+
+  it("je tolerantná na veľké písmená a okrajové medzery (nepreverené v realite, ale vzor iných polí)", () => {
+    expect(compareStateToFeed("sellable", "  In Stock  ")).toBe("match");
+  });
+});

--- a/apps/api/src/modules/catalog/feed-cross-check.ts
+++ b/apps/api/src/modules/catalog/feed-cross-check.ts
@@ -1,0 +1,125 @@
+// Krížová kontrola nášho odvodeného `variant.state` proti Shoptetovej VLASTNEJ
+// dostupnosti z feedu pre porovnávače (issue 226).
+//
+// `variant.state` je LEN naša dedukcia z CSV textu (`availability.ts`) —
+// issue 219 ukázalo, že sa vie rozísť s realitou. Feed nesie Shoptetov
+// vlastný, NEZÁVISLÝ úsudok (`<g:availability>`, uložené v
+// `shop_product_url.availability` od issue 226) — porovnanie oboch je druhý,
+// nezávislý zdroj pravdy.
+//
+// Zámerne POČÍTANÉ NAŽIVO z aktuálneho stavu DB, nikdy do vlastnej tabuľky:
+// `shop_product_url` sa obnovuje DENNE (03:50), katalógový import HODINOVO
+// (:20) — perzistovaná snímka rozporov by sa medzi behmi rozišla od reality,
+// presne ten istý problém, ktorý sa tu rieši. Rovnaký vzor ako
+// `restock/queries.ts`'s `allRestockCandidates`.
+
+import { eq, sql } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { shopProductUrl, variants } from "../../db/schema.js";
+import { log } from "../../logger.js";
+import type { VariantState } from "./availability.js";
+
+// Presne tie dve hodnoty, ktoré Shoptet do `<g:availability>` píše (overené
+// živým stiahnutím `google.xml` 4. 8. 2026: 7 449× "in stock", 139×
+// "out of stock", 91× prázdne — žiadna iná hodnota). Google Merchant feed
+// spec pozná aj "preorder"/"backorder" — tie sa berú ako `no_signal`, nikdy
+// ako rozpor, presne ako neznámy/prázdny text.
+// Exportované (nie `const` súkromná) — `restock/queries.ts` potrebuje TÚ ISTÚ
+// hodnotu na vylúčenie kandidátov priamo v SQL WHERE, aby literál nikdy
+// nerozišiel od tohto porovnávača.
+export const FEED_IN_STOCK = "in stock";
+const FEED_OUT_OF_STOCK = "out of stock";
+
+export type FeedComparisonResult = "match" | "mismatch" | "no_signal";
+
+/**
+ * `"in stock"` očakáva `sellable`; `"out of stock"` očakáva NIE-`sellable`
+ * (`out_of_stock` aj `discontinued` sú z pohľadu zákazníka rovnako
+ * nekúpiteľné). Chýbajúci/prázdny/neznámy signál nikdy nič nerozhoduje.
+ */
+export function compareStateToFeed(
+  state: VariantState,
+  feedAvailability: string | null,
+): FeedComparisonResult {
+  const normalized = (feedAvailability ?? "").trim().toLowerCase();
+  if (normalized === FEED_IN_STOCK) return state === "sellable" ? "match" : "mismatch";
+  if (normalized === FEED_OUT_OF_STOCK) return state === "sellable" ? "mismatch" : "match";
+  return "no_signal";
+}
+
+export interface FeedStateConflict {
+  readonly variantCode: string;
+  readonly productName: string;
+  readonly ourState: VariantState;
+  readonly feedAvailability: string;
+  /** Priama adresa z feedu — vždy nenulová (bez feed riadku by tu žiadny rozpor nebol). */
+  readonly ourUrl: string;
+}
+
+export interface FeedConflictSummary {
+  readonly total: number;
+  readonly rows: readonly FeedStateConflict[];
+}
+
+// Karta na obrazovke je varovanie na ručné preverenie, nie pracovný zoznam —
+// strop drží odpoveď v rozumnej veľkosti, aj keby sa (ako pri issue 219)
+// odvodenie znova rozišlo naprieč tisíckami variantov naraz.
+const MAX_CONFLICT_ROWS = 200;
+
+/**
+ * INNER JOIN zámerne — variant bez feed riadku (626 viditeľných, issue 220)
+ * sa do výsledku nedostane vôbec, presne ako "nepočíta sa ako rozpor" žiada.
+ */
+export async function findFeedStateConflicts(db: Pick<Database, "select">): Promise<FeedConflictSummary> {
+  const rows = await db
+    .select({
+      variantCode: variants.code,
+      productName: variants.name,
+      state: variants.state,
+      availability: shopProductUrl.availability,
+      url: shopProductUrl.url,
+    })
+    .from(variants)
+    .innerJoin(shopProductUrl, eq(shopProductUrl.code, variants.code))
+    .orderBy(sql`${variants.code}`);
+
+  const conflicts: FeedStateConflict[] = [];
+  for (const row of rows) {
+    if (compareStateToFeed(row.state, row.availability) !== "mismatch") continue;
+    conflicts.push({
+      variantCode: row.variantCode,
+      productName: row.productName,
+      ourState: row.state,
+      feedAvailability: row.availability ?? "",
+      ourUrl: row.url,
+    });
+  }
+
+  return { total: conflicts.length, rows: conflicts.slice(0, MAX_CONFLICT_ROWS) };
+}
+
+/**
+ * Voliteľné doplnkové logovanie PO KAŽDOM prijatom katalógovom importe
+ * (volané z `ingest.ts`, mimo jeho transakcie) — nikdy nevyhodí, aby chyba
+ * tejto čisto diagnostickej funkcie neohrozila už úspešne prijatý import.
+ * Obrazovka (`/api/restock`) číta `findFeedStateConflicts` priamo a vždy
+ * aktuálne — tento log je len doplnkový, ľahko dohľadateľný záznam.
+ */
+export async function logFeedConflictsAfterImport(
+  db: Pick<Database, "select">,
+  snapshotId: string,
+): Promise<void> {
+  try {
+    const conflicts = await findFeedStateConflicts(db);
+    log.info(
+      { snapshotId, feedConflictCount: conflicts.total },
+      "krížová kontrola voči Shoptetovmu feedu po importe",
+    );
+  } catch (error) {
+    const rawErrorMessage = error instanceof Error ? error.message : String(error);
+    log.error(
+      { snapshotId, rawErrorMessage },
+      "krížová kontrola voči Shoptetovmu feedu zlyhala — import to neovplyvňuje",
+    );
+  }
+}

--- a/apps/api/src/modules/catalog/ingest.ts
+++ b/apps/api/src/modules/catalog/ingest.ts
@@ -4,6 +4,7 @@ import type { Database } from "../../db/client.js";
 import { catalogSnapshots, ingestIssues, products, variants } from "../../db/schema.js";
 import { log } from "../../logger.js";
 import { decodeCp1250, parseDelimited } from "./csv.js";
+import { logFeedConflictsAfterImport } from "./feed-cross-check.js";
 import { redactSourceLabel } from "./fetcher.js";
 import { mapRow, type RowIssue, type VariantRecord } from "./map-row.js";
 import { storeRawSnapshot } from "./raw-store.js";
@@ -571,5 +572,13 @@ export async function ingestCatalog(
     }
     throw error;
   }
+
+  // issue 226: krížová kontrola nášho odvodeného stavu proti Shoptetovmu
+  // feedu — BEŽÍ PO commite, mimo transakcie vyššie, aby prípadná chyba tejto
+  // ČISTO DIAGNOSTICKEJ funkcie nikdy neohrozila samotný (už úspešne prijatý)
+  // import; sama nikdy nevyhodí. Obrazovka (`/api/restock`) ukazuje ten istý
+  // údaj vždy aktuálne, nezávisle od tohto logu.
+  if (result.status === "accepted") await logFeedConflictsAfterImport(db, result.snapshotId);
+
   return result;
 }

--- a/apps/api/src/modules/restock/queries.ts
+++ b/apps/api/src/modules/restock/queries.ts
@@ -4,9 +4,10 @@
 // e-shope produkt, ktorý majiteľ vedome vypol. Preto sa každá podmienka
 // kontroluje pozitívne (musí platiť), nikdy sa nič nepredpokladá.
 
-import { and, asc, eq, isNull, or, sql } from "drizzle-orm";
+import { and, asc, eq, isNull, ne, or, sql } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
 import { products, shopProductUrl, supplierStock, variants } from "../../db/schema.js";
+import { FEED_IN_STOCK } from "../catalog/feed-cross-check.js";
 import {
   CONFIRMATION_MAX_AGE_HOURS,
   MAX_PER_RUN,
@@ -63,7 +64,13 @@ const NO_SUPPLIER_LABEL = "(bez dodávateľa)";
  *  - variant nechýba z exportu (`missing_since IS NULL`) — zapnúť niečo, čo
  *    Shoptet už nevidí, nedáva zmysel;
  *  - dodávateľská linka má ÚSPEŠNÚ kontrolu (`ok`), dostupnosť `available`
- *    a potvrdenie nie staršie než `CONFIRMATION_MAX_AGE_HOURS`.
+ *    a potvrdenie nie staršie než `CONFIRMATION_MAX_AGE_HOURS`;
+ *  - Shoptetov VLASTNÝ feed pre porovnávače (issue 226) NEHOVORÍ "in stock" —
+ *    keď feed hlási skladom pre variant, ktorý MY vedieme ako vypredaný, naše
+ *    odvodenie je podozrivé (presne trieda chyby z issue 219) a kandidátom sa
+ *    nesmie stať, kým sa rozpor nevysvetlí. Chýbajúci feed riadok (626
+ *    viditeľných variantov, issue 220) NIE JE rozpor — kandidát sa vyberie
+ *    ako predtým.
  *
  * `unknown` (stránka sa načítala, ale nič sa z nej nedalo vyčítať) ani
  * zlyhaná kontrola NIKDY neprepnú produkt — to je celý zmysel toho, že sme
@@ -126,6 +133,11 @@ async function allRestockCandidates(db: Database, now: Date): Promise<readonly R
         sql`${supplierStock.confirmedAt} is not null`,
         sql`${supplierStock.confirmedAt} >= ${oldestAcceptable}`,
         sql`${supplierStock.confirmedAt} <= ${now}`,
+        // issue 226: kandidát je vždy `out_of_stock` (podmienka vyššie), takže
+        // jediný relevantný smer rozporu je feed hlásiaci "in stock". `IS
+        // NULL` musí byť explicitné — `!= 'in stock'` samo o sebe vyhodnotí
+        // NULL (žiadny feed riadok) na NULL, čo by WHERE ticho zahodilo.
+        or(isNull(shopProductUrl.availability), ne(shopProductUrl.availability, FEED_IN_STOCK)),
       ),
     )
     // Stabilné poradie: najstaršie potvrdenie prvé, potom podľa kódu — pri

--- a/apps/api/src/modules/shop-feed/parse.test.ts
+++ b/apps/api/src/modules/shop-feed/parse.test.ts
@@ -11,10 +11,40 @@ const sample = readFileSync(
 describe("parseShopFeed", () => {
   it("vráti dvojicu kód → adresa pre každú použiteľnú položku", () => {
     expect(parseShopFeed(sample)).toEqual([
-      { code: "40237/M", url: "https://www.forestshop.sk/polovnicke-nohavice-forest-1003/?variantId=106" },
-      { code: "15314", url: "https://www.forestshop.sk/polovnicky-ruksak-hart-spean-25/" },
-      { code: "10125/41", url: "https://www.forestshop.sk/obuv/?variantId=9&utm=feed" },
+      {
+        code: "40237/M",
+        url: "https://www.forestshop.sk/polovnicke-nohavice-forest-1003/?variantId=106",
+        availability: "in stock",
+      },
+      {
+        code: "15314",
+        url: "https://www.forestshop.sk/polovnicky-ruksak-hart-spean-25/",
+        availability: "out of stock",
+      },
+      {
+        code: "10125/41",
+        url: "https://www.forestshop.sk/obuv/?variantId=9&utm=feed",
+        // issue 226: prázdne <g:availability></g:availability> → null, nikdy
+        // prázdny reťazec — chýbajúci signál sa nesmie dať zameniť s
+        // hodnotou, ktorá by sa dala porovnávať proti "in stock"/"out of stock".
+        availability: null,
+      },
     ]);
+  });
+
+  // issue 226: krížová kontrola nášho stavu proti feedu potrebuje aj
+  // Shoptetovu VLASTNÚ dostupnosť, nie len kód/adresu.
+  it("vyparsuje <g:availability> ku každej položke", () => {
+    const rows = parseShopFeed(sample);
+    expect(rows.find((r) => r.code === "40237/M")?.availability).toBe("in stock");
+    expect(rows.find((r) => r.code === "15314")?.availability).toBe("out of stock");
+  });
+
+  it("položka bez <g:availability> vôbec (chýbajúca značka) dostane null", () => {
+    // "99999" v fixtúre má <g:availability>in stock</g:availability> ale bez
+    // <link> — preskočí sa celá. Preto pre tento prípad vlastný vstup.
+    const xml = "<feed><entry><g:id>ABC</g:id><link>https://x.sk/p/</link></entry></feed>";
+    expect(parseShopFeed(xml)).toEqual([{ code: "ABC", url: "https://x.sk/p/", availability: null }]);
   });
 
   it("nepoužije hlavičkový <link href=…> feedu ako adresu produktu", () => {

--- a/apps/api/src/modules/shop-feed/parse.ts
+++ b/apps/api/src/modules/shop-feed/parse.ts
@@ -13,6 +13,11 @@
 export interface ShopFeedEntry {
   readonly code: string;
   readonly url: string;
+  // Shoptetova VLASTNÁ dostupnosť (issue 226) — surový text ("in stock"/
+  // "out of stock"), `null` keď je `<g:availability>` prázdna ALEBO chýba
+  // celkom. Chýbajúci signál sa NIKDY nezamieňa s prázdnym reťazcom — obe
+  // musia byť rovnako "žiadny rozpor", nikdy porovnateľná hodnota.
+  readonly availability: string | null;
 }
 
 const ENTRY = /<entry>([\s\S]*?)<\/entry>/g;
@@ -20,6 +25,7 @@ const CODE = /<g:id>([\s\S]*?)<\/g:id>/;
 // Zámerne `<link>` s koncovou značkou — hlavička feedu má `<link href="…" />`
 // (samostatne uzavretý, adresa vzorového webu), ktorý sa takto nikdy nechytí.
 const URL_TAG = /<link>([\s\S]*?)<\/link>/;
+const AVAILABILITY_TAG = /<g:availability>([\s\S]*?)<\/g:availability>/;
 
 const ENTITIES: Readonly<Record<string, string>> = {
   "&amp;": "&",
@@ -52,7 +58,8 @@ export function parseShopFeed(xml: string): readonly ShopFeedEntry[] {
     if (code === "" || url === "") continue;
     if (seen.has(code)) continue;
     seen.add(code);
-    rows.push({ code, url });
+    const rawAvailability = decode(AVAILABILITY_TAG.exec(entry)?.[1] ?? "");
+    rows.push({ code, url, availability: rawAvailability === "" ? null : rawAvailability });
   }
 
   return rows;

--- a/apps/api/src/modules/shop-feed/run.ts
+++ b/apps/api/src/modules/shop-feed/run.ts
@@ -45,7 +45,15 @@ export async function runShopFeed(options: RunShopFeedOptions): Promise<ShopFeed
       .values(chunk)
       .onConflictDoUpdate({
         target: shopProductUrl.code,
-        set: { url: sql`excluded.url`, fetchedAt: sql`excluded.fetched_at` },
+        set: {
+          url: sql`excluded.url`,
+          // issue 226: dostupnosť sa PREPÍŠE na aktuálnu hodnotu z tohto behu
+          // (vrátane NULL, keď feed teraz nesie prázdnu značku) — inak by
+          // stará hodnota z predošlého behu tíško prežívala a krížová
+          // kontrola by porovnávala proti zastaranému signálu.
+          availability: sql`excluded.availability`,
+          fetchedAt: sql`excluded.fetched_at`,
+        },
       });
   }
 

--- a/apps/api/tests/catalog-feed-cross-check.integration.test.ts
+++ b/apps/api/tests/catalog-feed-cross-check.integration.test.ts
@@ -1,0 +1,123 @@
+// issue 226: `findFeedStateConflicts` naživo porovná AKTUÁLNY `variant.state`
+// proti Shoptetovej vlastnej dostupnosti z feedu (`shop_product_url.availability`).
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Database } from "../src/db/client.js";
+import { products, shopProductUrl, variants } from "../src/db/schema.js";
+import { findFeedStateConflicts } from "../src/modules/catalog/feed-cross-check.js";
+import { insertTestSnapshot } from "./helpers/catalog.js";
+import { withCleanDb } from "./helpers/db.js";
+
+const NOW = new Date("2026-08-04T10:00:00Z");
+
+describe("findFeedStateConflicts", () => {
+  let db: Database;
+  let close: () => Promise<void>;
+  let snapshotId: string;
+
+  beforeEach(async () => {
+    ({ db, close } = await withCleanDb());
+    snapshotId = await insertTestSnapshot(db);
+  });
+  afterEach(async () => {
+    await close();
+  });
+
+  const seedVariant = async (
+    code: string,
+    state: "sellable" | "out_of_stock" | "discontinued",
+  ): Promise<void> => {
+    const productKey = `prod-${code}`;
+    await db
+      .insert(products)
+      .values({
+        key: productKey,
+        name: `Produkt ${code}`,
+        supplier: null,
+        internalNote: null,
+        firstSeenAt: NOW,
+        lastSeenAt: NOW,
+        lastSeenSnapshotId: snapshotId,
+      })
+      .onConflictDoNothing();
+    await db.insert(variants).values({
+      code,
+      productKey,
+      guid: productKey,
+      sizeLabel: null,
+      name: `Produkt ${code}`,
+      stock: 0,
+      availabilityInStockText: "",
+      availabilityOutOfStockText: "",
+      availabilityText: "",
+      productVisibility: "visible",
+      state,
+      firstSeenAt: NOW,
+      lastSeenAt: NOW,
+      lastSeenSnapshotId: snapshotId,
+    });
+  };
+
+  const seedFeed = async (code: string, availability: string | null): Promise<void> => {
+    await db.insert(shopProductUrl).values({
+      code,
+      url: `https://www.forestshop.sk/${code}/`,
+      availability,
+      fetchedAt: NOW,
+    });
+  };
+
+  it("nevráti nič, keď naša strana sedí s feedom", async () => {
+    await seedVariant("A1", "sellable");
+    await seedFeed("A1", "in stock");
+    await seedVariant("A2", "out_of_stock");
+    await seedFeed("A2", "out of stock");
+
+    const result = await findFeedStateConflicts(db);
+    expect(result).toEqual({ total: 0, rows: [] });
+  });
+
+  // Práve TOTO je nebezpečný smer, ktorý issue 219 spôsobilo — naše
+  // odvodenie vraví "vypredané", ale live feed hovorí "skladom".
+  it("nájde variant, kde naše vypredané odporuje feedovému 'skladom'", async () => {
+    await seedVariant("B1", "out_of_stock");
+    await seedFeed("B1", "in stock");
+
+    const result = await findFeedStateConflicts(db);
+    expect(result.total).toBe(1);
+    expect(result.rows).toEqual([
+      { variantCode: "B1", productName: "Produkt B1", ourState: "out_of_stock", feedAvailability: "in stock", ourUrl: "https://www.forestshop.sk/B1/" },
+    ]);
+  });
+
+  it("nájde aj opačný smer — naše sellable, feed hovorí vypredané", async () => {
+    await seedVariant("C1", "sellable");
+    await seedFeed("C1", "out of stock");
+
+    const result = await findFeedStateConflicts(db);
+    expect(result.rows.map((r) => r.variantCode)).toEqual(["C1"]);
+  });
+
+  it("variant mimo feedu (626-typ z issue 220) sa nepočíta ako rozpor", async () => {
+    await seedVariant("D1", "out_of_stock");
+    // Žiadny shopProductUrl riadok pre D1.
+
+    const result = await findFeedStateConflicts(db);
+    expect(result.total).toBe(0);
+  });
+
+  it("prázdne <g:availability> (null) sa nepočíta ako rozpor", async () => {
+    await seedVariant("E1", "out_of_stock");
+    await seedFeed("E1", null);
+
+    const result = await findFeedStateConflicts(db);
+    expect(result.total).toBe(0);
+  });
+
+  it("discontinued sa berie ako 'nekúpiteľné' rovnako ako out_of_stock proti feedu", async () => {
+    await seedVariant("F1", "discontinued");
+    await seedFeed("F1", "out of stock");
+
+    expect((await findFeedStateConflicts(db)).total).toBe(0);
+  });
+});

--- a/apps/api/tests/restock-run.integration.test.ts
+++ b/apps/api/tests/restock-run.integration.test.ts
@@ -290,4 +290,41 @@ describe("prepínanie Vypredané → Skladom", () => {
     expect(result).toMatchObject({ status: "nothing_to_do" });
     expect(import_).not.toHaveBeenCalled();
   });
+
+  // issue 226: keď Shoptetov VLASTNÝ feed hovorí "skladom" pre variant, ktorý
+  // MY vedieme ako vypredané, naše odvodenie je podozrivé — kandidátom sa
+  // nesmie stať, kým sa rozpor nevysvetlí (rovnaký princíp ako "unknown"
+  // v issue 213 — radšej sa nedotknúť, než hádať).
+  it("nevyberie kandidáta, ktorého náš vypredaný stav odporuje feedu 'skladom'", async () => {
+    await seedSupplierStock();
+    await seedVariant("Z1");
+    await db.insert(shopProductUrl).values({
+      code: "Z1",
+      url: "https://www.forestshop.sk/z1/",
+      availability: "in stock",
+      fetchedAt: NOW,
+    });
+
+    expect((await selectRestockCandidates(db, NOW)).picked).toHaveLength(0);
+  });
+
+  it("VYBERIE kandidáta, ktorého feed potvrdzuje 'vypredané' (zhoda, nie rozpor)", async () => {
+    await seedSupplierStock();
+    await seedVariant("Z2");
+    await db.insert(shopProductUrl).values({
+      code: "Z2",
+      url: "https://www.forestshop.sk/z2/",
+      availability: "out of stock",
+      fetchedAt: NOW,
+    });
+
+    expect((await selectRestockCandidates(db, NOW)).picked.map((c) => c.variantCode)).toEqual(["Z2"]);
+  });
+
+  it("kandidát bez feed riadku (mimo feedu) sa vyberie ako predtým — chýbajúci signál nie je rozpor", async () => {
+    await seedSupplierStock();
+    await seedVariant("Z3");
+
+    expect((await selectRestockCandidates(db, NOW)).picked.map((c) => c.variantCode)).toEqual(["Z3"]);
+  });
 });

--- a/apps/api/tests/shop-feed-run.integration.test.ts
+++ b/apps/api/tests/shop-feed-run.integration.test.ts
@@ -10,11 +10,15 @@ import { withCleanDb } from "./helpers/db.js";
 
 const NOW = new Date("2026-08-04T03:50:00Z");
 
-function feedWith(rows: readonly { code: string; availability: string }[]): string {
+function feedWith(rows: readonly { code: string; availability: string | null }[]): string {
   const entries = rows
     .map(
       (r) =>
-        `<entry><g:id>${r.code}</g:id><link>https://www.forestshop.sk/${r.code}/</link><g:availability>${r.availability}</g:availability></entry>`,
+        // `null` = <g:availability> značka CELKOM chýba (nie len prázdna) —
+        // presne ten tvar, ktorým Shoptet feed vie prestať dostupnosť niesť.
+        `<entry><g:id>${r.code}</g:id><link>https://www.forestshop.sk/${r.code}/</link>${
+          r.availability === null ? "" : `<g:availability>${r.availability}</g:availability>`
+        }</entry>`,
     )
     .join("");
   // MIN_ENTRIES je 1000 — vypĺň zvyšok bezvýznamnými, ale platnými položkami.
@@ -77,5 +81,27 @@ describe("runShopFeed — ukladanie dostupnosti (issue 226)", () => {
       .from(shopProductUrl)
       .where(eq(shopProductUrl.code, "Q1"));
     expect(row?.availability).toBe("in stock");
+  });
+
+  // Code review issue 226: `run.ts`'s komentár tvrdí, že explicitný
+  // `set: { availability: sql\`excluded.availability\` }` existuje PRÁVE
+  // preto, aby sa stará hodnota prepísala na `null`, keď feed značku
+  // stratí — dovtedy to netestoval žiadny test.
+  it("keď feed <g:availability> značku STRATÍ, uložená hodnota sa prepíše na null (nezostane stará)", async () => {
+    const runOnce = (availability: string | null) =>
+      runShopFeed({
+        db,
+        now: NOW,
+        fetchFeed: () => Promise.resolve(feedWith([{ code: "R1", availability }])),
+      });
+
+    await runOnce("in stock");
+    await runOnce(null);
+
+    const [row] = await db
+      .select({ availability: shopProductUrl.availability })
+      .from(shopProductUrl)
+      .where(eq(shopProductUrl.code, "R1"));
+    expect(row?.availability).toBeNull();
   });
 });

--- a/apps/api/tests/shop-feed-run.integration.test.ts
+++ b/apps/api/tests/shop-feed-run.integration.test.ts
@@ -1,0 +1,81 @@
+// issue 226: `runShopFeed` musí uložiť aj `g:availability`, nielen kód/adresu
+// — nezávislý zdroj pravdy pre krížovú kontrolu proti nášmu odvodenému stavu.
+
+import { asc, eq, inArray } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Database } from "../src/db/client.js";
+import { shopProductUrl } from "../src/db/schema.js";
+import { runShopFeed } from "../src/modules/shop-feed/run.js";
+import { withCleanDb } from "./helpers/db.js";
+
+const NOW = new Date("2026-08-04T03:50:00Z");
+
+function feedWith(rows: readonly { code: string; availability: string }[]): string {
+  const entries = rows
+    .map(
+      (r) =>
+        `<entry><g:id>${r.code}</g:id><link>https://www.forestshop.sk/${r.code}/</link><g:availability>${r.availability}</g:availability></entry>`,
+    )
+    .join("");
+  // MIN_ENTRIES je 1000 — vypĺň zvyšok bezvýznamnými, ale platnými položkami.
+  const filler = Array.from(
+    { length: 1_000 },
+    (_unused, i) => `<entry><g:id>F${String(i)}</g:id><link>https://www.forestshop.sk/f${String(i)}/</link></entry>`,
+  ).join("");
+  return `<feed>${entries}${filler}</feed>`;
+}
+
+describe("runShopFeed — ukladanie dostupnosti (issue 226)", () => {
+  let db: Database;
+  let close: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ db, close } = await withCleanDb());
+  });
+  afterEach(async () => {
+    await close();
+  });
+
+  it("uloží g:availability spolu s kódom a adresou", async () => {
+    await runShopFeed({
+      db,
+      now: NOW,
+      fetchFeed: () =>
+        Promise.resolve(
+          feedWith([
+            { code: "P1", availability: "in stock" },
+            { code: "P2", availability: "out of stock" },
+          ]),
+        ),
+    });
+
+    const rows = await db
+      .select({ code: shopProductUrl.code, availability: shopProductUrl.availability })
+      .from(shopProductUrl)
+      .where(inArray(shopProductUrl.code, ["P1", "P2"]))
+      .orderBy(asc(shopProductUrl.code));
+
+    expect(rows).toEqual([
+      { code: "P1", availability: "in stock" },
+      { code: "P2", availability: "out of stock" },
+    ]);
+  });
+
+  it("pri opakovanom behu PREPÍŠE staršiu dostupnosť novou (UPSERT)", async () => {
+    const runOnce = (availability: string) =>
+      runShopFeed({
+        db,
+        now: NOW,
+        fetchFeed: () => Promise.resolve(feedWith([{ code: "Q1", availability }])),
+      });
+
+    await runOnce("out of stock");
+    await runOnce("in stock");
+
+    const [row] = await db
+      .select({ availability: shopProductUrl.availability })
+      .from(shopProductUrl)
+      .where(eq(shopProductUrl.code, "Q1"));
+    expect(row?.availability).toBe("in stock");
+  });
+});

--- a/apps/web/src/components/RestockSection.test.tsx
+++ b/apps/web/src/components/RestockSection.test.tsx
@@ -220,11 +220,16 @@ it("ukáže varovanie o rozpore nášho stavu s feedom, s počtom aj zoznamom", 
           ourUrl: "https://www.forestshop.sk/bunda-forest/",
         },
         {
+          // issue 226 review: `ourUrl` je v `feedConflictRowSchema` VŽDY
+          // nenulový reťazec — rozpor existuje len pre variant, ktorý MÁ
+          // riadok vo feede (INNER JOIN, `feed-cross-check.ts`), takže mock
+          // musí niesť skutočnú adresu, nikdy `null` (na rozdiel od
+          // `RestockWaitingRow.ourUrl`, ktoré nullable JE).
           variantCode: "C1",
           productName: "Nohavice X",
           ourState: "sellable" as const,
           feedAvailability: "out of stock",
-          ourUrl: null,
+          ourUrl: "https://www.forestshop.sk/nohavice-x/",
         },
       ],
     },

--- a/apps/web/src/components/RestockSection.test.tsx
+++ b/apps/web/src/components/RestockSection.test.tsx
@@ -55,6 +55,9 @@ const STATUS = {
   enabled: false,
   maxPerRun: 50,
   waiting: { now: 12, overLimit: 0 },
+  // issue 226: prázdny predvolený stav — testy, ktoré rozpor priamo
+  // nepotrebujú, ho takto nemusia riešiť.
+  feedConflicts: { total: 0, rows: [] },
   events: [
     {
       id: "e1",
@@ -199,6 +202,47 @@ it("ukáže, koľkátý úsek zo všetkých čakajúcich práve pozeráš", asyn
   render(<RestockSection role="admin" onSessionExpired={vi.fn()} />);
 
   expect((await screen.findByTestId("restock-waiting-range")).textContent).toContain("z 250");
+});
+
+// issue 226: krížová kontrola proti Shoptetovmu feedu — rozpor sa MUSÍ ukázať
+// na obrazovke ako varovanie s číslom a zoznamom, nikdy len v logu.
+it("ukáže varovanie o rozpore nášho stavu s feedom, s počtom aj zoznamom", async () => {
+  fetchRestockStatus.mockResolvedValue({
+    ...STATUS,
+    feedConflicts: {
+      total: 2,
+      rows: [
+        {
+          variantCode: "B1",
+          productName: "Bunda Forest",
+          ourState: "out_of_stock" as const,
+          feedAvailability: "in stock",
+          ourUrl: "https://www.forestshop.sk/bunda-forest/",
+        },
+        {
+          variantCode: "C1",
+          productName: "Nohavice X",
+          ourState: "sellable" as const,
+          feedAvailability: "out of stock",
+          ourUrl: null,
+        },
+      ],
+    },
+  });
+  render(<RestockSection role="admin" onSessionExpired={vi.fn()} />);
+
+  const karta = await screen.findByTestId("restock-feed-conflicts");
+  expect(karta.textContent).toContain("2");
+  expect(karta.textContent).toContain("Bunda Forest");
+  expect(karta.textContent).toContain("Nohavice X");
+});
+
+it("bez rozporov ukáže, že sa všetko zhoduje", async () => {
+  fetchRestockStatus.mockResolvedValue(STATUS);
+  render(<RestockSection role="admin" onSessionExpired={vi.fn()} />);
+
+  const karta = await screen.findByTestId("restock-feed-conflicts");
+  expect(karta.textContent).toMatch(/žiadne|zhod/i);
 });
 
 it("role „čítanie\" ovládacie tlačidlá neponúkne", async () => {

--- a/apps/web/src/components/RestockSection.tsx
+++ b/apps/web/src/components/RestockSection.tsx
@@ -19,6 +19,13 @@ const PAGE_SIZE = 100;
 // (`requireRole("admin", "manazer")`, `restock-routes.ts`).
 const CONTROL_ROLES: ReadonlySet<Me["role"]> = new Set(["admin", "manazer"]);
 
+// issue 226: ľudské popisky nášho `variant.state` pre kartu rozporov s feedom.
+const STATE_LABEL: Readonly<Record<"sellable" | "out_of_stock" | "discontinued", string>> = {
+  sellable: "predajné",
+  out_of_stock: "vypredané",
+  discontinued: "ukončený predaj",
+};
+
 function formatDateTime(iso: string): string {
   const date = new Date(iso);
   return Number.isNaN(date.getTime()) ? "—" : date.toLocaleString("sk-SK");
@@ -130,7 +137,7 @@ export function RestockSection({
   if (!loaded) return <p role="status">Načítavam…</p>;
   if (status === null) return <p role="alert">{error === "" ? "Nepodarilo sa načítať." : error}</p>;
 
-  const { enabled, maxPerRun, waiting, events, lastRun } = status;
+  const { enabled, maxPerRun, waiting, feedConflicts, events, lastRun } = status;
 
   return (
     <div data-testid="restock-section">
@@ -180,6 +187,50 @@ export function RestockSection({
         </p>
       )}
       {runNotice !== "" && <p role="status">{runNotice}</p>}
+
+      {/* issue 226: Shoptetov VLASTNÝ feed pre porovnávače hovorí niečo iné,
+          než náš odvodený stav — nezávislý dôkaz, že sa odvodenie znova
+          rozišlo s realitou (presne trieda chyby z issue 219). Rozporný
+          variant sa NESTANE kandidátom na prepnutie, kým sa nevysvetlí. */}
+      <div className="card" data-testid="restock-feed-conflicts">
+        <h3>Rozpory nášho stavu s feedom Shoptetu{feedConflicts.total > 0 && ` (${String(feedConflicts.total)})`}</h3>
+        {feedConflicts.total === 0 ? (
+          <p className="empty">Žiadne — náš stav sa všade zhoduje s feedom.</p>
+        ) : (
+          <>
+            <p>
+              Feed pre porovnávače hovorí niečo iné než my — tieto varianty sa nestanú kandidátmi na
+              prepnutie, kým sa rozpor nevysvetlí.
+            </p>
+            <table>
+              <thead>
+                <tr>
+                  <th scope="col">Kód</th>
+                  <th scope="col">Názov</th>
+                  <th scope="col">Náš stav</th>
+                  <th scope="col">Feed hovorí</th>
+                  <th scope="col">Náš produkt</th>
+                </tr>
+              </thead>
+              <tbody>
+                {feedConflicts.rows.map((row) => (
+                  <tr key={row.variantCode} data-testid={`restock-feed-conflict-${row.variantCode}`}>
+                    <td>{row.variantCode}</td>
+                    <td>{row.productName}</td>
+                    <td>{STATE_LABEL[row.ourState]}</td>
+                    <td>{row.feedAvailability}</td>
+                    <td>
+                      <a href={row.ourUrl} target="_blank" rel="noreferrer noopener">
+                        náš ↗
+                      </a>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </>
+        )}
+      </div>
 
       <div className="card">
         <h3>Prepnuté produkty</h3>

--- a/apps/web/src/restockApi.ts
+++ b/apps/web/src/restockApi.ts
@@ -34,10 +34,25 @@ const runResultSchema = z.union([
 ]);
 export type RestockRunResult = z.infer<typeof runResultSchema>;
 
+// issue 226: krížová kontrola nášho stavu proti Shoptetovmu feedu.
+const feedConflictRowSchema = z.object({
+  variantCode: z.string(),
+  productName: z.string(),
+  ourState: z.enum(["sellable", "out_of_stock", "discontinued"]),
+  feedAvailability: z.string(),
+  ourUrl: z.string(),
+});
+const feedConflictsSchema = z.object({
+  total: z.number(),
+  rows: z.array(feedConflictRowSchema),
+});
+export type FeedConflictRow = z.infer<typeof feedConflictRowSchema>;
+
 const statusSchema = z.object({
   enabled: z.boolean(),
   maxPerRun: z.number(),
   waiting: z.object({ now: z.number(), overLimit: z.number() }),
+  feedConflicts: feedConflictsSchema,
   events: z.array(eventSchema),
   lastRun: z
     .object({

--- a/apps/web/tests/e2e/catalog.spec.ts
+++ b/apps/web/tests/e2e/catalog.spec.ts
@@ -24,12 +24,13 @@ test("manažér vidí stav katalógu, vyhľadá variant a konzola je čistá", a
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
-  // 36 = 35 riadkov fixtúry + 1 seedovaný kandidát na prepnutie ("PREP-1",
-  // issue 217, `scripts/e2e-setup.ts`). Je v stave `out_of_stock`, takže
-  // filtre "sellable"(7 od issue 219) a "missing"(1) nižšie sa ním nemenia.
+  // 37 = 35 riadkov fixtúry + 2 seedované kandidáty na prepnutie ("PREP-1",
+  // issue 217; "PREP-2", issue 226 — rozpor voči feedu, `scripts/e2e-setup.ts`).
+  // Oba sú v stave `out_of_stock`, takže filtre "sellable"(7 od issue 219) a
+  // "missing"(1) nižšie sa nimi nemenia.
   await expect(page.getByTestId("snapshot")).toContainText("Posledný import: prijatý");
-  await expect(page.getByTestId("counts")).toContainText("Variantov v katalógu (vrátane chýbajúcich): 36");
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 36");
+  await expect(page.getByTestId("counts")).toContainText("Variantov v katalógu (vrátane chýbajúcich): 37");
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 37");
 
   await page.getByLabel("Kód alebo názov").fill("40237/3XL");
   await page.getByRole("button", { name: "Hľadať" }).click();
@@ -49,7 +50,7 @@ test("filter podľa stavu zúži zoznam na predajné varianty", async ({ page })
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 36");
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 37");
   await page.getByLabel("Stav", { exact: true }).selectOption("sellable");
   await page.getByRole("button", { name: "Hľadať" }).click();
 
@@ -68,7 +69,7 @@ test("filter 'Chýbajúce' nájde presne označený variant a riadok ukazuje, od
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 36");
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 37");
   await page.getByLabel("Stav", { exact: true }).selectOption("missing");
   await page.getByRole("button", { name: "Hľadať" }).click();
 

--- a/apps/web/tests/e2e/restock-waiting.spec.ts
+++ b/apps/web/tests/e2e/restock-waiting.spec.ts
@@ -48,3 +48,36 @@ test("zoznam pripravených na prepnutie ponúkne odkaz na náš produkt aj k dod
 
   expect(chyby).toEqual([]);
 });
+
+// issue 226: "PREP-2" (seedované v `scripts/e2e-setup.ts`) je vypredané u nás,
+// ALE feed pre porovnávače ho hlási ako "in stock" — presný rozpor, ktorý sa
+// nesmie stať kandidátom, a MUSÍ sa ukázať ako varovanie s číslom a zoznamom.
+test("rozpor nášho stavu s feedom sa ukáže ako varovanie a kandidáta vylúči; konzola je čistá", async ({
+  page,
+}) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/");
+  await page.getByLabel("E-mail").fill(E2E_PREPINANIE_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+
+  await page.getByRole("button", { name: "Vypredané → Skladom" }).click();
+  await expect(page.getByTestId("restock-waiting-list")).toBeVisible();
+
+  const karta = page.getByTestId("restock-feed-conflicts");
+  await expect(karta).toBeVisible();
+  await expect(karta).toContainText("PREP-2");
+  await expect(karta).toContainText("E2E Bunda s rozporom voči feedu");
+
+  // Rozporový variant NESMIE byť medzi kandidátmi na prepnutie.
+  await expect(page.getByTestId("restock-waiting-PREP-2")).toHaveCount(0);
+
+  expect(chyby).toEqual([]);
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.137",
+  "version": "0.3.0-dev.138",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -9,7 +9,7 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { createDb } from "../apps/api/src/db/client.js";
-import { jobRuns, mailLog, orderLines, orderOpenStatuses, orderReminderSettings, orders, pairings, postaUncollectedSettings, products, supplierStock, users, variants } from "../apps/api/src/db/schema.js";
+import { jobRuns, mailLog, orderLines, orderOpenStatuses, orderReminderSettings, orders, pairings, postaUncollectedSettings, products, shopProductUrl, supplierStock, users, variants } from "../apps/api/src/db/schema.js";
 import { CATALOG_IMPORT_JOB_NAME } from "../apps/api/src/modules/scheduler/jobs.js";
 import { hashPassword } from "../apps/api/src/modules/auth/passwords.js";
 import { ingestCatalog } from "../apps/api/src/modules/catalog/ingest.js";
@@ -188,7 +188,7 @@ await db.execute(
   // takže CASCADE ich nikdy nestrhne. Bez nich by potvrdenia dodávateľa z
   // PREDOŠLÉHO e2e behu prežili do ďalšieho (presne past popísaná v
   // `.claude/rules/supplier-stock.md`, tam pre `tests/helpers/db.ts`).
-  'TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, mail_template, mail_template_history, supplier_stock, restock_settings, restock_event RESTART IDENTITY CASCADE',
+  'TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, mail_template, mail_template_history, supplier_stock, restock_settings, restock_event, shop_product_url RESTART IDENTITY CASCADE',
 );
 // Rovnaký dôvod ako `tests/helpers/db.ts`: bez tohto by "Na objednanie" bolo
 // v CELOM e2e behu prázdne pre KAŽDÚ objednávku (žiadny nastavený otvorený
@@ -668,6 +668,55 @@ await db.insert(supplierStock).values({
   checkedAt: teraz,
   // Potvrdenie musí byť čerstvé (do 48 h), inak kandidát vypadne z výberu.
   confirmedAt: new Date(teraz.getTime() - 3_600_000),
+});
+
+// issue 226: DRUHÝ produkt (VLASTNÝ kód, aby sa nezrazil s vyššie seedovaným
+// "PREP-1") — máme ho ako vypredaný a dodávateľ ho potvrdene má, ALE feed pre
+// porovnávače hovorí "in stock" (Shoptet ho už zobrazuje ako skladom). Toto je
+// presne ten rozpor, ktorý MUSÍ vylúčiť z kandidátov aj z overovacieho
+// zoznamu a MUSÍ sa ukázať na obrazovke ako varovanie.
+const ROZPOR_ODKAZ = "https://huntingshop.eu/e2e-rozpor";
+await db.insert(products).values({
+  key: "e2e-rozpor",
+  name: "E2E Bunda s rozporom voči feedu",
+  supplier: "DODAVATEL-PREPINANIE",
+  internalNote: `Dodávateľ: ${ROZPOR_ODKAZ}`,
+  firstSeenAt: teraz,
+  lastSeenAt: teraz,
+  lastSeenSnapshotId: snapshotPrepinanie,
+});
+await db.insert(variants).values({
+  code: "PREP-2",
+  productKey: "e2e-rozpor",
+  guid: "e2e-rozpor",
+  name: "E2E Bunda s rozporom voči feedu",
+  stock: 0,
+  availabilityInStockText: "Skladom",
+  availabilityOutOfStockText: "Vypredané",
+  availabilityText: "Vypredané",
+  productVisibility: "visible",
+  state: "out_of_stock",
+  firstSeenAt: teraz,
+  lastSeenAt: teraz,
+  lastSeenSnapshotId: snapshotPrepinanie,
+});
+await db.insert(supplierStock).values({
+  link: ROZPOR_ODKAZ,
+  host: "huntingshop.eu",
+  availability: "available",
+  availabilityText: "skladom",
+  price: "39.90",
+  source: "json_ld",
+  ok: true,
+  httpStatus: 200,
+  checkedAt: teraz,
+  confirmedAt: new Date(teraz.getTime() - 3_600_000),
+});
+await db.insert(shopProductUrl).values({
+  code: "PREP-2",
+  url: "https://www.forestshop.sk/e2e-rozpor/",
+  availability: "in stock",
+  fetchedAt: teraz,
 });
 
 await pool.end();

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -622,96 +622,63 @@ await db.insert(mailLog).values({
   reason: "už bolo odoslané skôr — druhý e-mail sa neposiela",
 });
 
-// issue 217: JEDEN kandidát na prepnutie „Vypredané → Skladom", aby overovacia
-// obrazovka mala naživo čo ukázať. Zámerne VLASTNÝ produkt + variant s kódom,
-// ktorý sa v žiadnom inom spec súbore nevyskytuje, a BEZ objednávkového riadku —
-// nepridáva teda nič do „Na objednanie" ani do parovania, kde iné testy počítajú
-// presné počty. `supplier_stock` je nová tabuľka, ktorú nesleduje žiadny iný test.
-const PREPINANIE_ODKAZ = "https://huntingshop.eu/e2e-prepinanie";
+// issue 217: kandidáti na prepnutie „Vypredané → Skladom", aby overovacia
+// obrazovka mala naživo čo ukázať. Zámerne VLASTNÉ produkty + varianty s
+// kódmi, ktoré sa v žiadnom inom spec súbore nevyskytujú, a BEZ objednávkového
+// riadku — nepridávajú teda nič do „Na objednanie" ani do parovania, kde iné
+// testy počítajú presné počty. `supplier_stock` je tabuľka, ktorú nesleduje
+// žiadny iný test.
 // `vysledok.snapshotId` (import fixtúry vyššie) namiesto vlastného dopytu —
 // priamy import z "drizzle-orm" v `scripts/` hlási falošné `no-unsafe-*`
 // (`.claude/rules/testing.md`), takže sa mu tu vyhýbame úplne.
 const snapshotPrepinanie = vysledok.snapshotId;
-await db.insert(products).values({
-  key: "e2e-prepinanie",
-  name: "E2E Bunda na prepnutie",
-  supplier: "DODAVATEL-PREPINANIE",
-  internalNote: `Dodávateľ: ${PREPINANIE_ODKAZ}`,
-  firstSeenAt: teraz,
-  lastSeenAt: teraz,
-  lastSeenSnapshotId: snapshotPrepinanie,
-});
-await db.insert(variants).values({
-  code: "PREP-1",
-  productKey: "e2e-prepinanie",
-  guid: "e2e-prepinanie",
-  name: "E2E Bunda na prepnutie",
-  stock: 0,
-  availabilityInStockText: "Skladom",
-  availabilityOutOfStockText: "Vypredané",
-  availabilityText: "Vypredané",
-  productVisibility: "visible",
-  state: "out_of_stock",
-  firstSeenAt: teraz,
-  lastSeenAt: teraz,
-  lastSeenSnapshotId: snapshotPrepinanie,
-});
-await db.insert(supplierStock).values({
-  link: PREPINANIE_ODKAZ,
-  host: "huntingshop.eu",
-  availability: "available",
-  availabilityText: "skladom",
-  price: "49.90",
-  source: "json_ld",
-  ok: true,
-  httpStatus: 200,
-  checkedAt: teraz,
-  // Potvrdenie musí byť čerstvé (do 48 h), inak kandidát vypadne z výberu.
-  confirmedAt: new Date(teraz.getTime() - 3_600_000),
-});
+async function seedPrepinanieKandidata(key: string, code: string, name: string, odkaz: string, cena: string): Promise<void> {
+  await db.insert(products).values({
+    key,
+    name,
+    supplier: "DODAVATEL-PREPINANIE",
+    internalNote: `Dodávateľ: ${odkaz}`,
+    firstSeenAt: teraz,
+    lastSeenAt: teraz,
+    lastSeenSnapshotId: snapshotPrepinanie,
+  });
+  await db.insert(variants).values({
+    code,
+    productKey: key,
+    guid: key,
+    name,
+    stock: 0,
+    availabilityInStockText: "Skladom",
+    availabilityOutOfStockText: "Vypredané",
+    availabilityText: "Vypredané",
+    productVisibility: "visible",
+    state: "out_of_stock",
+    firstSeenAt: teraz,
+    lastSeenAt: teraz,
+    lastSeenSnapshotId: snapshotPrepinanie,
+  });
+  await db.insert(supplierStock).values({
+    link: odkaz,
+    host: "huntingshop.eu",
+    availability: "available",
+    availabilityText: "skladom",
+    price: cena,
+    source: "json_ld",
+    ok: true,
+    httpStatus: 200,
+    checkedAt: teraz,
+    // Potvrdenie musí byť čerstvé (do 48 h), inak kandidát vypadne z výberu.
+    confirmedAt: new Date(teraz.getTime() - 3_600_000),
+  });
+}
+await seedPrepinanieKandidata("e2e-prepinanie", "PREP-1", "E2E Bunda na prepnutie", "https://huntingshop.eu/e2e-prepinanie", "49.90");
 
-// issue 226: DRUHÝ produkt (VLASTNÝ kód, aby sa nezrazil s vyššie seedovaným
-// "PREP-1") — máme ho ako vypredaný a dodávateľ ho potvrdene má, ALE feed pre
-// porovnávače hovorí "in stock" (Shoptet ho už zobrazuje ako skladom). Toto je
-// presne ten rozpor, ktorý MUSÍ vylúčiť z kandidátov aj z overovacieho
-// zoznamu a MUSÍ sa ukázať na obrazovke ako varovanie.
-const ROZPOR_ODKAZ = "https://huntingshop.eu/e2e-rozpor";
-await db.insert(products).values({
-  key: "e2e-rozpor",
-  name: "E2E Bunda s rozporom voči feedu",
-  supplier: "DODAVATEL-PREPINANIE",
-  internalNote: `Dodávateľ: ${ROZPOR_ODKAZ}`,
-  firstSeenAt: teraz,
-  lastSeenAt: teraz,
-  lastSeenSnapshotId: snapshotPrepinanie,
-});
-await db.insert(variants).values({
-  code: "PREP-2",
-  productKey: "e2e-rozpor",
-  guid: "e2e-rozpor",
-  name: "E2E Bunda s rozporom voči feedu",
-  stock: 0,
-  availabilityInStockText: "Skladom",
-  availabilityOutOfStockText: "Vypredané",
-  availabilityText: "Vypredané",
-  productVisibility: "visible",
-  state: "out_of_stock",
-  firstSeenAt: teraz,
-  lastSeenAt: teraz,
-  lastSeenSnapshotId: snapshotPrepinanie,
-});
-await db.insert(supplierStock).values({
-  link: ROZPOR_ODKAZ,
-  host: "huntingshop.eu",
-  availability: "available",
-  availabilityText: "skladom",
-  price: "39.90",
-  source: "json_ld",
-  ok: true,
-  httpStatus: 200,
-  checkedAt: teraz,
-  confirmedAt: new Date(teraz.getTime() - 3_600_000),
-});
+// issue 226: DRUHÝ kandidát (vlastný kód, nezrazí sa s "PREP-1") — máme ho ako
+// vypredaný a dodávateľ ho potvrdene má, ALE feed pre porovnávače hovorí
+// "in stock" (Shoptet ho už zobrazuje ako skladom). Presne ten rozpor, ktorý
+// MUSÍ vylúčiť z kandidátov aj z overovacieho zoznamu a MUSÍ sa ukázať na
+// obrazovke ako varovanie.
+await seedPrepinanieKandidata("e2e-rozpor", "PREP-2", "E2E Bunda s rozporom voči feedu", "https://huntingshop.eu/e2e-rozpor", "39.90");
 await db.insert(shopProductUrl).values({
   code: "PREP-2",
   url: "https://www.forestshop.sk/e2e-rozpor/",


### PR DESCRIPTION
## Súhrn

issue 226: krížová kontrola nášho odvodeného `variant.state` proti Shoptetovej
VLASTNEJ dostupnosti z feedu pre porovnávače (`google.xml`) — nezávislý zdroj
pravdy, ktorý dokáže zachytiť, keď sa naša dedukcia stavu znova rozíde s
realitou (trieda chyby z issue 219).

- `shop_product_url` ukladá aj `g:availability` z feedu (migrácia 0030).
- `modules/catalog/feed-cross-check.ts`: `compareStateToFeed` (čistá funkcia)
  + `findFeedStateConflicts` (naživo z aktuálnej DB, nikdy perzistovaná
  snímka — pozri zdôvodnenie v komentári design decision na tickete).
- Po každom prijatom katalógovom importe sa počet rozporov zaloguje
  (`logFeedConflictsAfterImport`, mimo hlavnej transakcie, nikdy ju
  neohrozí).
- `/api/restock` + obrazovka "Vypredané → Skladom" ukazujú novú kartu
  "Rozpory nášho stavu s feedom Shoptetu" — číslo aj zoznam, nikdy len log.
- Kandidát na prepnutie (vždy `out_of_stock`) sa vylúči, keď feed hlási
  `"in stock"` — rovnaká funkcia napája nočný beh aj overovací zoznam.
- Variant mimo feedu (626 viditeľných, issue 220) sa NEPOČÍTA ako rozpor.

## Test plan

- [x] Unit: `compareStateToFeed` (9 prípadov), `parseShopFeed` (availability
      extrakcia vrátane prázdnej/chýbajúcej značky).
- [x] Integration: `findFeedStateConflicts` (6 scenárov vrátane oboch smerov
      rozporu), `runShopFeed` ukladanie/UPSERT/overwrite-na-null (3
      scenáre), restock exclusion (3 nové scenáre v
      `restock-run.integration.test.ts`).
- [x] Component: `RestockSection.test.tsx` — karta s rozpormi aj bez nich.
- [x] E2E: `restock-waiting.spec.ts` — rozporový kandidát (PREP-2) sa ukáže
      na karte a NIE je medzi kandidátmi; konzola čistá.
- [x] Lokálne: unit 546/546, integration 58 súborov/425 testov, e2e 32/32
      (serial run), lint aj typecheck čisté.
- [x] CI (dev): check, integration, e2e, docker-build, version-check — všetky
      zelené (run 30932942045).
- [x] Code review (`superpowers:requesting-code-review`, nezávislý subagent):
      0 🔴, 2 🟡 (opravené v tomto PR), 2 🔵 (mimo diffu).

issue 226
