### PR TITLE
feat: prehľad e-shopu + súhrn o objednávaní (issue 237)

### DIFF
--- a/.claude/rules/orders.md
+++ b/.claude/rules/orders.md
@@ -422,3 +422,58 @@ paths:
   `remark`/`shop_remark` (priamo prepísané pri re-importe) sú tieto ŠTYRI
   polia COALESCE-ované ako `shoptet_order_id` — plné odôvodnenie a
   regresný test v `.claude/rules/posta-uncollected.md`.**
+- **Issue 237 pridalo `order.total_price_with_vat` (celková suma s DPH,
+  export's `totalPriceWithVat` stĺpec) — rovnaká rodina ako `status_name`/
+  `remark`/`shop_remark` (VŽDY Shoptetovo pole, `mapOrderRow` berie prvý
+  riadok na objednávku, `ingest.ts` ho pri re-importe PRIAMO prepisuje,
+  nikdy COALESCE-uje). Parsuje sa zdieľaným `catalog/money.ts`'s
+  `parseDecimalComma` (Shoptet-ova desatinná ČIARKA) — žiadna nová
+  duplicitná money-parsovacia logika.**
+- **Dashboard "Prehľad e-shopu" (issue 237, `orders/overview.ts`) je
+  ZÁMERNE samostatný od "Na objednanie"'s zoznamu — číta PRIAMO `order`
+  tabuľku (nie cez `order_line` JOIN) a počíta VŠETKY objednávky bez
+  ohľadu na `status_name`, na rozdiel od `listOpenOrderLinesBySupplier`'s
+  open-status filtra.** Dôvod: ide o celoobchodnú štatistiku (rovnakú, akú
+  ukazuje Shoptet-ov vlastný dashboard), nie o dodávateľský pracovný
+  zoznam — uzavretá ("Vybavená") objednávka sa preto MUSÍ zarátať rovnako
+  ako otvorená (`orders-overview.integration.test.ts`'s dedikovaný test).
+  **Otvorená otázka pre budúce naživo overenie:** appka dnes zaráta AJ
+  prípadné storno/zrušené objednávky do "dnes/týždeň/mesiac" — nie je
+  overené, či Shoptet-ov vlastný dashboard robí to isté; ak naživo
+  porovnanie ukáže rozdiel, treba doplniť filter do `overview.ts`'s
+  `getOrdersDashboardOverview`, nie predpokladať zhodu.
+- **Hranice "dnes"/"tento týždeň" (pondelok)/"tento mesiac" v Europe/
+  Bratislava (`overview.ts`'s `computeBratislavaPeriodBoundaries`) ZNOVA
+  POUŽÍVAJÚ `parser.ts`'s `parseShopLocalDateTime`** (zostaví kandidátny
+  `"YYYY-MM-DD 00:00:00"` reťazec a nechá ho previesť už existujúcou, DST-
+  otestovanou funkciou) — nikdy nereimplementuj tú istú UTC-konverznú
+  offset aritmetiku druhýkrát. Prvý pokus autora TOTO pravidlo porušil
+  (vlastná offset-počítacia funkcia LEN s dátumovými, nie časovými,
+  `Intl.DateTimeFormat` poľami) a dal ŠPATNÝ výsledok — polnoc formátovaná
+  cez date-only polia stratí celý hodinový posun zóny (viď dôkaz nižšie),
+  odhalené AŽ pri ručnom prepočte cez `TZ=Europe/Bratislava date`, nie
+  testom (test by len potvrdil vlastnú chybnú implementáciu). Súčet peňazí
+  (`sumMoneyCents`) beží cez BigInt centy, nikdy cez `number` — rovnaká
+  disciplína ako `catalog/money.ts`.
+- **Test na KAŽDÝ ĎALŠÍ "naivný lokálny čas → UTC" výpočet v tomto module:
+  over HODNOTU (nie len že kód "vyzerá správne") ručným prepočtom
+  `date -u -d @$(TZ=Europe/Bratislava date -d "<Y-M-D> 00:00:00" +%s)
+  +"%Y-%m-%dT%H:%M:%SZ"` PRED napísaním testu s očakávanou hodnotou** —
+  inak test len potvrdí to, čo kód práve robí, aj keby to bolo o hodinu
+  posunuté. Konkrétny nájdený omyl (opravený pred commitom): pre "dnes" =
+  2026-08-04 (utorok) autor najprv napísal test očakávajúci, že "týždeň"
+  (pondelok toho istého týždňa, 2026-08-03) dá TEN ISTÝ UTC okamih ako
+  "dnes" — nesprávne, sú to DVA rôzne kalendárne dni, teda dva rôzne
+  okamihy (`2026-08-02T22:00:00Z`, nie `2026-08-03T22:00:00Z`).
+- **Slovenské skloňovanie POČTU objednávok potrebuje TROJTVAROVÝ (paucal)
+  pomocník, nie holé "N objednávok".** Code review PR #244 (issue 237):
+  `OrdersOverviewTiles.tsx` pôvodne vypisovala vždy "N objednávok", čo je
+  gramaticky zle pre 1 ("objednávka") a 2-4 ("objednávky"). Fix:
+  `apps/web/src/ordersSummary.ts`'s `formatOrderCount` — priamy náprotivok
+  `apps/api/src/modules/orders/ingest.ts`'s (neexportovanej) `formatCount`
+  (1 → jednotné číslo, 2-4 → málopočetné, 0/5+ vrátane 22/23/24… → rodový
+  pád množného čísla, slovenčina neodvodzuje tvar z poslednej číslice na
+  rozdiel od ruštiny/poľštiny). KAŽDÝ ĎALŠÍ text, čo appka skloňuje priamo
+  v UI (nie len spolu s neutrálnou jednotkou ako `formatVariantTotalChip`'s
+  "N ks"), potrebuje rovnaký trojtvarový pomocník, nikdy šablónový
+  reťazec s jedným pevným tvarom podstatného mena.

--- a/apps/api/drizzle/0031_handy_talon.sql
+++ b/apps/api/drizzle/0031_handy_talon.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "order" ADD COLUMN "total_price_with_vat" numeric(12, 2);

--- a/apps/api/drizzle/meta/0031_snapshot.json
+++ b/apps/api/drizzle/meta/0031_snapshot.json
@@ -1,0 +1,2502 @@
+{
+  "id": "6d57c0db-8a70-4b26-b6b4-0889f18810cb",
+  "prevId": "913d9139-cb59-4ec6-b41e-484cb721838d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "related_codes": {
+          "name": "related_codes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_code": {
+          "name": "external_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_open_status": {
+      "name": "order_open_status",
+      "schema": "",
+      "columns": {
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Vybavuje sa'"
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop_remark": {
+          "name": "shop_remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shoptet_order_id": {
+          "name": "shoptet_order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_updated_at": {
+          "name": "comment_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_synced_at": {
+          "name": "comment_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_carrier_name": {
+          "name": "shipping_carrier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_price_with_vat": {
+          "name": "total_price_with_vat",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_link_override": {
+      "name": "product_supplier_link_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_link_override_product_key_product_key_fk": {
+          "name": "product_supplier_link_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_link_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_override": {
+      "name": "product_supplier_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_override_product_key_product_key_fk": {
+          "name": "product_supplier_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing": {
+      "name": "pairing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_url": {
+          "name": "supplier_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "pairing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'navrhnute'"
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pairing_state_idx": {
+          "name": "pairing_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_confirmed_by_idx": {
+          "name": "pairing_confirmed_by_idx",
+          "columns": [
+            {
+              "expression": "confirmed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_variant_code_variant_code_fk": {
+          "name": "pairing_variant_code_variant_code_fk",
+          "tableFrom": "pairing",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pairing_confirmed_by_users_id_fk": {
+          "name": "pairing_confirmed_by_users_id_fk",
+          "tableFrom": "pairing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pairing_variant_code_unique": {
+          "name": "pairing_variant_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pairing_confirmation_ck": {
+          "name": "pairing_confirmation_ck",
+          "value": "(\"pairing\".\"state\" = 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)\n        OR (\"pairing\".\"state\" != 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NULL AND \"pairing\".\"confirmed_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier": {
+      "name": "supplier",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wholesale_base_url": {
+          "name": "wholesale_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_key": {
+          "name": "adapter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_settings": {
+      "name": "posta_uncollected_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_state": {
+      "name": "posta_uncollected_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notify_count": {
+          "name": "notify_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_state": {
+          "name": "terminal_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_settings": {
+      "name": "order_reminder_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_state": {
+      "name": "order_reminder_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_state": {
+      "name": "nedostupne_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "nedostupne_email_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nedostupne_state_order_variant_type_uq": {
+          "name": "nedostupne_state_order_variant_type_uq",
+          "columns": [
+            {
+              "expression": "order_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template_history": {
+      "name": "mail_template_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "mail_template_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_template_history_key_idx": {
+          "name": "mail_template_history_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_template_history_changed_by_user_id_users_id_fk": {
+          "name": "mail_template_history_changed_by_user_id_users_id_fk",
+          "tableFrom": "mail_template_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template": {
+      "name": "mail_template",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail_template_updated_by_user_id_users_id_fk": {
+          "name": "mail_template_updated_by_user_id_users_id_fk",
+          "tableFrom": "mail_template",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_log": {
+      "name": "mail_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "mail_log_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_log_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "mail_log_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_log_created_idx": {
+          "name": "mail_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_log_source_created_idx": {
+          "name": "mail_log_source_created_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_log_actor_user_id_users_id_fk": {
+          "name": "mail_log_actor_user_id_users_id_fk",
+          "tableFrom": "mail_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_stock": {
+      "name": "supplier_stock",
+      "schema": "",
+      "columns": {
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "supplier_availability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "supplier_stock_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "supplier_stock_host_idx": {
+          "name": "supplier_stock_host_idx",
+          "columns": [
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "supplier_stock_avail_idx": {
+          "name": "supplier_stock_avail_idx",
+          "columns": [
+            {
+              "expression": "availability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "supplier_stock_link_size_label_pk": {
+          "name": "supplier_stock_link_size_label_pk",
+          "columns": [
+            "link",
+            "size_label"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_event": {
+      "name": "restock_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_link": {
+          "name": "supplier_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_availability_text": {
+          "name": "supplier_availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "supplier_price": {
+          "name": "supplier_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "restock_event_at_idx": {
+          "name": "restock_event_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "restock_event_variant_idx": {
+          "name": "restock_event_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_settings": {
+      "name": "restock_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shop_product_url": {
+      "name": "shop_product_url",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne"
+      ]
+    },
+    "public.pairing_state": {
+      "name": "pairing_state",
+      "schema": "public",
+      "values": [
+        "navrhnute",
+        "potvrdene"
+      ]
+    },
+    "public.nedostupne_email_type": {
+      "name": "nedostupne_email_type",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "alternativa"
+      ]
+    },
+    "public.mail_template_action": {
+      "name": "mail_template_action",
+      "schema": "public",
+      "values": [
+        "save",
+        "reset"
+      ]
+    },
+    "public.mail_log_source": {
+      "name": "mail_log_source",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "posta_uncollected",
+        "order_reminder",
+        "supplier_order"
+      ]
+    },
+    "public.mail_log_status": {
+      "name": "mail_log_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.mail_log_trigger": {
+      "name": "mail_log_trigger",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "manual"
+      ]
+    },
+    "public.supplier_availability": {
+      "name": "supplier_availability",
+      "schema": "public",
+      "values": [
+        "available",
+        "unavailable",
+        "unknown"
+      ]
+    },
+    "public.supplier_stock_source": {
+      "name": "supplier_stock_source",
+      "schema": "public",
+      "values": [
+        "json_ld",
+        "meta",
+        "text",
+        "size_list",
+        "none"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -218,6 +218,13 @@
       "when": 1785861317276,
       "tag": "0030_cuddly_gravity",
       "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "7",
+      "when": 1785866205378,
+      "tag": "0031_handy_talon",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema-orders.ts
+++ b/apps/api/src/db/schema-orders.ts
@@ -4,6 +4,7 @@ import {
   check,
   index,
   integer,
+  numeric,
   pgEnum,
   pgTable,
   text,
@@ -33,9 +34,13 @@ export type OrderLineState = (typeof orderLineState.enumValues)[number];
 
 // Identita objednávky je Shoptet-ovo číslo objednávky (`externalOrderId`) —
 // budúci importer (#21) ho potrebuje na idempotentné párovanie, rovnaký vzor
-// ako `catalog_snapshot.content_sha256` unique. Cena/mena na riadku sa
-// ZÁMERNE nepridáva teraz (viď komentár k `orderLines` nižšie) — pozri
-// zamietnutú alternatívu #2 v návrhovom komentári na tickete.
+// ako `catalog_snapshot.content_sha256` unique.
+//
+// AKTUALIZÁCIA (issue 237, 2026-08-04): pôvodný komentár tu znel "Cena/mena
+// na riadku sa ZÁMERNE nepridáva teraz" — to rozhodnutie je TERAZ prekonané,
+// viď `totalPriceWithVat` nižšie. Dôvod zmeny: dashboard "Na objednanie"
+// potrebuje tržbu zodpovedajúcu Shoptet dashboardu, ktorá sa bez uloženej
+// sumy vôbec nedá dopočítať.
 export const orders = pgTable(
   "order",
   {
@@ -124,6 +129,18 @@ export const orders = pgTable(
     phone: text("phone"),
     packageNumber: text("package_number"),
     shippingCarrierName: text("shipping_carrier_name"),
+    // issue 237: celková suma objednávky S DPH (export's `totalPriceWithVat`
+    // stĺpec) — order-level pole, opakované na KAŽDOM riadku exportu tej istej
+    // objednávky (rovnaká rodina ako `customerName`/`statusName` vyššie,
+    // `ingest.ts`'s `orderInfo` mapa berie prvý výskyt). VŽDY Shoptetovo pole
+    // (rovnaký zámer ako `statusName`/`remark`/`shopRemark` — nikdy appkou/
+    // manažérom vlastnené), re-import ho preto vždy OSVIEŽÍ. Nullable —
+    // Shoptet ho gramaticky nijako neviaže a appka radšej zahodí nečitateľnú
+    // hodnotu (`parseDecimalComma` z `catalog/money.ts`, zdieľaný Shoptet-
+    // čiarkový money parser), než by transakcia spadla na jednom zlom riadku.
+    // Používa sa VÝHRADNE na dashboardovú tržbu (`orders/overview.ts`) —
+    // appka doteraz žiadnu peňažnú sumu neukladala vôbec.
+    totalPriceWithVat: numeric("total_price_with_vat", { precision: 12, scale: 2 }),
   },
   (t) => [index("order_placed_at_idx").on(t.placedAt)],
 );

--- a/apps/api/src/http/orders-routes.ts
+++ b/apps/api/src/http/orders-routes.ts
@@ -7,6 +7,7 @@ import { log } from "../logger.js";
 import { record } from "../modules/audit/service.js";
 import { ORDERS_EXPORT_URL_NOT_CONFIGURED, type OrdersIngestResult, type RunOrdersIngest } from "../modules/orders/ingest.js";
 import { listKnownStatusNames, listOpenStatusNames, replaceOpenStatusNames } from "../modules/orders/open-statuses.js";
+import { getOrdersDashboardOverview } from "../modules/orders/overview.js";
 import { getOrderDetail, listOpenOrderLinesBySupplier } from "../modules/orders/queries.js";
 import { assignOrderLineSupplier } from "../modules/orders/supplier-assignment.js";
 import { setProductSupplierLink } from "../modules/orders/supplier-link-assignment.js";
@@ -89,6 +90,13 @@ export function registerOrdersRoutes(
   app.get("/api/orders/open", requireUser(db), async (c) =>
     c.json({ suppliers: await listOpenOrderLinesBySupplier(db, adminBaseUrl) }),
   );
+
+  // issue 237: "Prehľad e-shopu" (dnes/tento týždeň/tento mesiac) — literálna
+  // cesta, MUSÍ byť zaregistrovaná PRED `GET /api/orders/:id` nižšie
+  // (`.claude/rules/http-routes.md`'s past, rovnaký dôvod ako
+  // "open-statuses" pod týmto komentárom). Rovnaké oprávnenie ako zvyšok
+  // čítania na tejto obrazovke (`requireUser`, žiadne obmedzenie roly).
+  app.get("/api/orders/overview", requireUser(db), async (c) => c.json(await getOrdersDashboardOverview(db, new Date())));
 
   // issue 59: nastavenie, ktoré Shoptet stavy sa počítajú ako "objednávka sa
   // ešte vybavuje" (rozhoduje o obsahu `/api/orders/open` vyššie). MUSÍ byť

--- a/apps/api/src/modules/orders/ingest.ts
+++ b/apps/api/src/modules/orders/ingest.ts
@@ -234,7 +234,16 @@ export async function ingestOrders(db: Database, options: OrdersIngestOptions): 
   // kolidovať s obsahom niektorého z oboch reťazcov.
   const orderInfo = new Map<
     string,
-    { customerName: string; placedAt: Date; statusName: string; remark: string | null; shopRemark: string | null }
+    {
+      customerName: string;
+      placedAt: Date;
+      statusName: string;
+      remark: string | null;
+      shopRemark: string | null;
+      // issue 237: rovnaký "prvý riadok na objednávku vyhráva" vzor ako
+      // `customerName`/`statusName`/`remark`/`shopRemark` vyššie.
+      totalPriceWithVat: string | null;
+    }
   >();
   const lineTotals = new Map<string, Map<string, { externalOrderId: string; variantCode: string; quantity: number }>>();
   for (const candidate of candidates) {
@@ -245,6 +254,7 @@ export async function ingestOrders(db: Database, options: OrdersIngestOptions): 
         statusName: candidate.statusName,
         remark: candidate.remark,
         shopRemark: candidate.shopRemark,
+        totalPriceWithVat: candidate.totalPriceWithVat,
       });
     }
     let byVariant = lineTotals.get(candidate.externalOrderId);
@@ -327,6 +337,7 @@ export async function ingestOrders(db: Database, options: OrdersIngestOptions): 
                 statusName: info.statusName,
                 remark: info.remark,
                 shopRemark: info.shopRemark,
+                totalPriceWithVat: info.totalPriceWithVat,
                 placedAt: info.placedAt,
                 shoptetOrderId: orderIdsByCode.get(externalOrderId) ?? null,
                 email: extra.email,
@@ -369,6 +380,11 @@ export async function ingestOrders(db: Database, options: OrdersIngestOptions): 
               statusName: sql`excluded.status_name`,
               remark: sql`excluded.remark`,
               shopRemark: sql`excluded.shop_remark`,
+              // issue 237: rovnaká rodina ako `status_name`/`remark`/
+              // `shop_remark` vyššie — VŽDY Shoptetovo pole, priamo prepísané
+              // (nie COALESCE-ované), re-import ho musí osviežiť na aktuálnu
+              // sumu (napr. dodatočná zľava/storno položky v Shoptete).
+              totalPriceWithVat: sql`excluded.total_price_with_vat`,
               placedAt: sql`excluded.placed_at`,
               shoptetOrderId: sql`coalesce(excluded.shoptet_order_id, "order"."shoptet_order_id")`,
               email: sql`coalesce(excluded.email, "order"."email")`,

--- a/apps/api/src/modules/orders/overview.test.ts
+++ b/apps/api/src/modules/orders/overview.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { computeBratislavaPeriodBoundaries, sumMoneyCents } from "./overview.js";
+
+describe("computeBratislavaPeriodBoundaries", () => {
+  // 2026-08-04 12:00 UTC je v lete (CEST, UTC+2) 2026-08-04 14:00 miestneho —
+  // "dnes" preto začína 2026-08-03T22:00:00Z (miestna polnoc).
+  it("dnes = miestna polnoc (CEST, leto)", () => {
+    const { today } = computeBratislavaPeriodBoundaries(new Date("2026-08-04T12:00:00Z"));
+    expect(today.toISOString()).toBe("2026-08-03T22:00:00.000Z");
+  });
+
+  // 2026-08-04 je utorok — najbližší (predchádzajúci) pondelok je 2026-08-03,
+  // ktorého miestna polnoc je 2026-08-02T22:00:00Z (o deň skôr než "dnes").
+  it("týždeň = miestna polnoc najbližšieho pondelka", () => {
+    const { week } = computeBratislavaPeriodBoundaries(new Date("2026-08-04T12:00:00Z"));
+    expect(week.toISOString()).toBe("2026-08-02T22:00:00.000Z");
+  });
+
+  // Nedeľa je koniec ISO týždňa — pondelok toho istého týždňa je 6 dní SPÄŤ.
+  // 2026-08-09 je nedeľa toho istého týždňa ako 2026-08-04 (utorok) vyššie —
+  // obe musia ukázať na TEN ISTÝ pondelok (2026-08-03).
+  it("týždeň v nedeľu ukazuje na pondelok toho istého týždňa (6 dní dozadu)", () => {
+    const { week } = computeBratislavaPeriodBoundaries(new Date("2026-08-09T12:00:00Z"));
+    expect(week.toISOString()).toBe("2026-08-02T22:00:00.000Z");
+  });
+
+  it("mesiac = miestna polnoc 1. dňa toho istého mesiaca", () => {
+    const { month } = computeBratislavaPeriodBoundaries(new Date("2026-08-04T12:00:00Z"));
+    expect(month.toISOString()).toBe("2026-07-31T22:00:00.000Z");
+  });
+
+  // Zimný čas (CET, UTC+1) — offset sa MUSÍ prejaviť inak než v lete.
+  it("dnes = miestna polnoc (CET, zima)", () => {
+    const { today } = computeBratislavaPeriodBoundaries(new Date("2026-01-15T12:00:00Z"));
+    expect(today.toISOString()).toBe("2026-01-14T23:00:00.000Z");
+  });
+
+  // Prvý deň mesiaca je zároveň jeho vlastný začiatok.
+  it("mesiac v 1. deň mesiaca je zhodný s dnes", () => {
+    const now = new Date("2026-09-01T05:00:00Z");
+    const { today, month } = computeBratislavaPeriodBoundaries(now);
+    expect(month.toISOString()).toBe(today.toISOString());
+  });
+});
+
+describe("sumMoneyCents", () => {
+  it("sčíta zoznam kladných súm presne (bez plávajúcej čiarky)", () => {
+    expect(sumMoneyCents(["238.20", "85.80", "0.00"])).toBe("324.00");
+  });
+
+  it("null hodnoty preskočí (nezaráta ako 0, nezhodí výpočet)", () => {
+    expect(sumMoneyCents(["100.00", null, "50.50"])).toBe("150.50");
+  });
+
+  it("prázdny zoznam vráti 0.00", () => {
+    expect(sumMoneyCents([])).toBe("0.00");
+  });
+
+  it("samé null vráti 0.00", () => {
+    expect(sumMoneyCents([null, null])).toBe("0.00");
+  });
+
+  // Klasický binárny zaokrúhľovací problém (0.1 + 0.2 !== 0.3 v `number`) —
+  // dôkaz, že súčet beží cez BigInt centy, nie cez plávajúcu čiarku.
+  it("nestratí presnosť na hodnotách, ktoré cez number zaokrúhľujú nesprávne", () => {
+    expect(sumMoneyCents(["0.10", "0.20"])).toBe("0.30");
+  });
+
+  it("záporná hodnota (storno) sa odpočíta správne", () => {
+    expect(sumMoneyCents(["100.00", "-30.00"])).toBe("70.00");
+  });
+
+  it("veľký počet malých súm sa sčíta bez straty centu", () => {
+    const values = Array.from({ length: 1000 }, () => "1.11");
+    expect(sumMoneyCents(values)).toBe("1110.00");
+  });
+});

--- a/apps/api/src/modules/orders/overview.ts
+++ b/apps/api/src/modules/orders/overview.ts
@@ -1,0 +1,129 @@
+import { gte } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { orders } from "../../db/schema.js";
+import { parseShopLocalDateTime } from "./parser.js";
+
+// issue 237: "Prehľad e-shopu" na obrazovke "Na objednanie" — počet
+// objednávok + tržba za dnes/tento týždeň/tento mesiac, presne to, čo ukazuje
+// Shoptet-ov vlastný dashboard. Zámerne SAMOSTATNÝ modul od `queries.ts` (ten
+// je celý o "Na objednanie"'s OPEN-status pracovnom zozname cez `order_line`
+// JOIN) — tento dopyt číta PRIAMO `order` tabuľku, bez ohľadu na
+// `status_name`, lebo ide o celoobchodnú štatistiku, nie o dodávateľský
+// zoznam.
+
+/**
+ * Hranice "dnes"/"tento týždeň" (pondelok)/"tento mesiac" v Europe/Bratislava,
+ * vrátené ako UTC `Date` (dolná hranica intervalu `>= hranica`). Zámerne
+ * ZNOVA POUŽÍVA `parser.ts`'s `parseShopLocalDateTime` (naivný lokálny čas →
+ * UTC, DST-vedomé, `Intl.DateTimeFormat`-guess-format-diff trik) namiesto
+ * vlastnej reimplementácie tej istej offset aritmetiky — vytvorí kandidátny
+ * "YYYY-MM-DD 00:00:00" reťazec a nechá ho previesť už existujúcou,
+ * otestovanou funkciou.
+ */
+export function computeBratislavaPeriodBoundaries(
+  now: Date,
+  timeZone = "Europe/Bratislava",
+): { readonly today: Date; readonly week: Date; readonly month: Date } {
+  const dtf = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+  const parts = dtf.formatToParts(now);
+  const get = (type: string): number => Number(parts.find((p) => p.type === type)?.value ?? "0");
+  const year = get("year");
+  const month = get("month");
+  const day = get("day");
+
+  const pad = (n: number): string => String(n).padStart(2, "0");
+  const localMidnightUtc = (y: number, mo: number, d: number): Date => {
+    // `parseShopLocalDateTime` nikdy nevráti `null` pre vstup, ktorý SAMA
+    // táto funkcia zostavila v presnom `DATETIME_RE` tvare.
+    return parseShopLocalDateTime(`${String(y)}-${pad(mo)}-${pad(d)} 00:00:00`, timeZone) as Date;
+  };
+
+  const today = localMidnightUtc(year, month, day);
+
+  // `getUTCDay()` na ČISTOM kalendárnom dátume (bez časovej zložky, teda bez
+  // zónového posunu) — 0 = nedeľa .. 6 = sobota. ISO týždeň začína
+  // pondelkom, takže `(dow + 6) % 7` je počet dní od najbližšieho pondelka.
+  const dow = new Date(Date.UTC(year, month - 1, day)).getUTCDay();
+  const daysSinceMonday = (dow + 6) % 7;
+  const weekDate = new Date(Date.UTC(year, month - 1, day - daysSinceMonday));
+  const week = localMidnightUtc(weekDate.getUTCFullYear(), weekDate.getUTCMonth() + 1, weekDate.getUTCDate());
+
+  const monthStart = localMidnightUtc(year, month, 1);
+
+  return { today, week, month: monthStart };
+}
+
+/**
+ * Súčet `numeric` reťazcov (`"1234.56"`, drizzle ich drží ako reťazec) CEZ
+ * BigInt centy — nikdy cez `number`, rovnaká disciplína ako `catalog/
+ * money.ts` (žiadna binárna chyba zaokrúhlenia pri sčítaní desiatok/stoviek
+ * súm). `null`/nečitateľná hodnota sa do súčtu nezaráta (0), nikdy nezhodí
+ * celý výpočet — dashboard má radšej čiastočnú tržbu než žiadnu.
+ */
+export function sumMoneyCents(values: readonly (string | null)[]): string {
+  let totalCents = 0n;
+  for (const raw of values) {
+    if (raw === null) continue;
+    const negative = raw.startsWith("-");
+    const unsigned = negative ? raw.slice(1) : raw;
+    const dot = unsigned.indexOf(".");
+    const intPart = dot === -1 ? unsigned : unsigned.slice(0, dot);
+    const fracPart = (dot === -1 ? "" : unsigned.slice(dot + 1)).padEnd(2, "0").slice(0, 2);
+    if (!/^\d+$/.test(intPart) || !/^\d*$/.test(fracPart)) continue;
+    const cents = BigInt(intPart) * 100n + BigInt(fracPart === "" ? "0" : fracPart);
+    totalCents += negative ? -cents : cents;
+  }
+  const negative = totalCents < 0n;
+  const abs = negative ? -totalCents : totalCents;
+  const centsStr = abs.toString().padStart(3, "0");
+  const intOut = centsStr.slice(0, -2);
+  const fracOut = centsStr.slice(-2);
+  return `${negative ? "-" : ""}${intOut}.${fracOut}`;
+}
+
+export interface OrdersPeriodStats {
+  readonly orderCount: number;
+  readonly revenue: string;
+}
+
+export interface OrdersDashboardOverview {
+  readonly today: OrdersPeriodStats;
+  readonly week: OrdersPeriodStats;
+  readonly month: OrdersPeriodStats;
+}
+
+/**
+ * "Prehľad e-shopu" — počet objednávok + tržba (`total_price_with_vat`) za
+ * dnes/tento týždeň/tento mesiac, počítané zo VŠETKÝCH objednávok v danom
+ * okne (bez ohľadu na `status_name`), presne ako Shoptet-ov vlastný
+ * dashboard. Jeden dopyt (najširšie okno = mesiac), bucketovanie do troch
+ * období beží v JS — objem (rádovo stovky objednávok/mesiac) je malý, žiadny
+ * dôvod na tri samostatné dopyty/SQL `FILTER`.
+ */
+export async function getOrdersDashboardOverview(db: Database, now: Date): Promise<OrdersDashboardOverview> {
+  const boundaries = computeBratislavaPeriodBoundaries(now);
+
+  const rows = await db
+    .select({ placedAt: orders.placedAt, totalPriceWithVat: orders.totalPriceWithVat })
+    .from(orders)
+    .where(gte(orders.placedAt, boundaries.month));
+
+  const bucket = (from: Date): OrdersPeriodStats => {
+    const inBucket = rows.filter((r) => r.placedAt >= from);
+    return {
+      orderCount: inBucket.length,
+      revenue: sumMoneyCents(inBucket.map((r) => r.totalPriceWithVat)),
+    };
+  };
+
+  return {
+    today: bucket(boundaries.today),
+    week: bucket(boundaries.week),
+    month: bucket(boundaries.month),
+  };
+}

--- a/apps/api/src/modules/orders/parser.test.ts
+++ b/apps/api/src/modules/orders/parser.test.ts
@@ -168,6 +168,46 @@ describe("mapOrderRow — reálna položka", () => {
     expect(mapped.record?.shopRemark).toBe("vybaviť prednostne");
   });
 
+  // issue 237: celková suma objednávky s DPH — Shoptet-ova čiarková desatinná
+  // čiarka (`parseDecimalComma`, zdieľané s katalógovým importom).
+  it("totalPriceWithVat sa parsuje z čiarkového desatinného tvaru", () => {
+    const mapped = mapOrderRow({
+      code: "20300010",
+      date: "2026-06-16 08:00:00",
+      billFullName: "X",
+      itemName: "Y",
+      itemAmount: "1",
+      itemCode: "40238/M",
+      totalPriceWithVat: "238,20",
+    });
+    expect(mapped.record?.totalPriceWithVat).toBe("238.20");
+  });
+
+  it("prázdny/chýbajúci totalPriceWithVat sa mapuje na null (nikdy nevyhodí)", () => {
+    const mapped = mapOrderRow({
+      code: "20300011",
+      date: "2026-06-16 08:00:00",
+      billFullName: "X",
+      itemName: "Y",
+      itemAmount: "1",
+      itemCode: "40238/M",
+    });
+    expect(mapped.record?.totalPriceWithVat).toBeNull();
+  });
+
+  it("nečitateľný totalPriceWithVat (napr. text) sa mapuje na null, nikdy nevyhodí", () => {
+    const mapped = mapOrderRow({
+      code: "20300012",
+      date: "2026-06-16 08:00:00",
+      billFullName: "X",
+      itemName: "Y",
+      itemAmount: "1",
+      itemCode: "40238/M",
+      totalPriceWithVat: "neplatna hodnota",
+    });
+    expect(mapped.record?.totalPriceWithVat).toBeNull();
+  });
+
   // issue 59: normalizácia (NFC + orez) musí bežať aj v `mapOrderRow`, nie
   // len v `normalizeStatusName` samostatne — inak by porovnanie s
   // `order_open_status` (nastavené presne cez rovnakú funkciu,

--- a/apps/api/src/modules/orders/parser.ts
+++ b/apps/api/src/modules/orders/parser.ts
@@ -2,6 +2,11 @@
 // Shoptetu má zalomenia riadkov vnútri zacitovaných buniek (napr. `remark`), a
 // beží nad reťazcom stiahnutým celý naraz, takže potrebujeme generátor.
 
+// issue 237: zdieľaný Shoptet-čiarkový money parser (`totalPriceWithVat`
+// nižšie) — rovnaká logika, akú katalógový import už používa pre
+// `price`/`standardPrice`/…, žiadna nová duplicitná implementácia.
+import { parseDecimalComma } from "../catalog/money.js";
+
 export function decodeCp1250(body: Buffer): string {
   // Node 24 má plné ICU, takže windows-1250 je vstavané — žiadna závislosť navyše.
   return new TextDecoder("windows-1250").decode(body);
@@ -310,6 +315,11 @@ export interface OrderLineCandidate {
   // `queries.ts`), nikdy tu. Nepovinný stĺpec, rovnaký null-mapping ako
   // `remark`.
   readonly shopRemark: string | null;
+  // issue 237: celková suma objednávky S DPH (export's `totalPriceWithVat`
+  // stĺpec) — `numeric`-kompatibilný reťazec (`parseDecimalComma`) alebo
+  // `null`, keď je stĺpec prázdny/nečitateľný/mimo rozsahu. VŽDY Shoptetovo
+  // pole, rovnaká rodina ako `statusName`/`remark`/`shopRemark` vyššie.
+  readonly totalPriceWithVat: string | null;
   readonly placedAt: Date;
   readonly variantCode: string;
   readonly quantity: number;
@@ -388,6 +398,12 @@ export function mapOrderRow(row: Readonly<Record<string, string>>): {
 
   const rawRemark = (row["remark"] ?? "").trim();
   const rawShopRemark = (row["shopRemark"] ?? "").trim();
+  // issue 237: rovnaký `maxIntegerDigits` predvolený limit ako katalógov
+  // peňažné stĺpce (`money.ts`'s `MONEY_MAX_INTEGER_DIGITS = 10`) — presne
+  // zodpovedá `numeric(12, 2)` DB stĺpcu. Nečitateľná/mimo-rozsahu hodnota sa
+  // ticho zahodí na `null` (rovnaký zámer ako `remark`/`shopRemark` —
+  // nepovinné, informačné pole, nikdy dôvod zahodiť celý riadok).
+  const totalPriceWithVat = parseDecimalComma(row["totalPriceWithVat"] ?? "");
 
   return {
     record: {
@@ -396,6 +412,7 @@ export function mapOrderRow(row: Readonly<Record<string, string>>): {
       statusName: normalizeStatusName(row["statusName"] ?? ""),
       remark: rawRemark === "" ? null : rawRemark,
       shopRemark: rawShopRemark === "" ? null : rawShopRemark,
+      totalPriceWithVat,
       placedAt,
       variantCode,
       quantity,

--- a/apps/api/tests/orders-ingest-total-price.integration.test.ts
+++ b/apps/api/tests/orders-ingest-total-price.integration.test.ts
@@ -1,0 +1,131 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { eq } from "drizzle-orm";
+import { afterEach, expect, it } from "vitest";
+import { orders } from "../src/db/schema.js";
+import { ingestOrders, type OrdersExportFetcher } from "../src/modules/orders/ingest.js";
+import { insertTestVariant } from "./helpers/orders.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 237: `totalPriceWithVat` (celková suma objednávky s DPH, dashboardová
+// tržba `orders/overview.ts`) je VŽDY Shoptetovo pole (rovnaká rodina ako
+// `remark`/`shop_remark`/`status_name`, `orders-ingest.integration.test.ts`)
+// — re-import ho MUSÍ osviežiť. Vydelené do vlastného súboru (rovnaký dôvod/
+// vzor ako `orders-ingest-posta-fields.integration.test.ts`'s split), aby
+// pridanie tohto testu neposlalo `orders-ingest.integration.test.ts` cez
+// eslint `max-lines: 400`.
+const WINDOW_START = new Date("2020-01-01T00:00:00Z");
+const WINDOW_END = new Date("2030-01-01T00:00:00Z");
+const NOW = new Date("2026-07-30T10:00:00Z");
+
+let close: (() => Promise<void>) | undefined;
+let rawDir: string | undefined;
+
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  if (rawDir !== undefined) await rm(rawDir, { recursive: true, force: true });
+  rawDir = undefined;
+});
+
+async function boot(): Promise<{ db: Awaited<ReturnType<typeof withCleanDb>>["db"]; dir: string }> {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  rawDir = await mkdtemp(join(tmpdir(), "forestshop-orders-total-price-raw-"));
+  return { db: ctx.db, dir: rawDir };
+}
+
+function fetcherOf(body: Buffer): OrdersExportFetcher {
+  return () => Promise.resolve({ body, sourceLabel: "fixtúra" });
+}
+
+// Rovnaký ASCII-only dôvod ako `orders-ingest.integration.test.ts`'s
+// `buildCsv` (`.claude/rules/orders.md`) — `ingestOrders` vždy dekóduje ako
+// windows-1250, diakritika priamo tu by na druhej strane vyšla pokazená.
+function buildCsv(header: readonly string[], rows: readonly Record<string, string>[]): Buffer {
+  const esc = (v: string): string => `"${v.replaceAll('"', '""')}"`;
+  const lines = [header.map(esc).join(";") + ";"];
+  for (const row of rows) {
+    lines.push(header.map((c) => esc(row[c] ?? "")).join(";") + ";");
+  }
+  return Buffer.from(lines.join("\r\n") + "\r\n", "utf-8");
+}
+
+const HEADER = [
+  "code",
+  "date",
+  "statusName",
+  "billFullName",
+  "itemName",
+  "itemAmount",
+  "itemCode",
+  "totalPriceWithVat",
+] as const;
+
+it("totalPriceWithVat je Shoptetovo pole a re-import ho osvieži, keď sa suma v Shoptete zmení", async () => {
+  const { db, dir } = await boot();
+  await insertTestVariant(db, "40237/XL");
+
+  const bezSumy = buildCsv(HEADER, [
+    { code: "9104", date: "2026-07-01 10:00:00", statusName: "Vybavuje sa", billFullName: "X", itemName: "Y", itemAmount: "1", itemCode: "40237/XL" },
+  ]);
+  await ingestOrders(db, { fetchExport: fetcherOf(bezSumy), now: NOW, rawDir: dir, windowStart: WINDOW_START, windowEnd: WINDOW_END });
+  const [prvyRead] = await db.select().from(orders).where(eq(orders.externalOrderId, "9104"));
+  expect(prvyRead?.totalPriceWithVat).toBeNull();
+
+  const sSumou = buildCsv(HEADER, [
+    {
+      code: "9104",
+      date: "2026-07-01 10:00:00",
+      statusName: "Vybavuje sa",
+      billFullName: "X",
+      itemName: "Y",
+      itemAmount: "1",
+      itemCode: "40237/XL",
+      totalPriceWithVat: "238,20",
+    },
+  ]);
+  await ingestOrders(db, { fetchExport: fetcherOf(sSumou), now: NOW, rawDir: dir, windowStart: WINDOW_START, windowEnd: WINDOW_END });
+  const [druhyRead] = await db.select().from(orders).where(eq(orders.externalOrderId, "9104"));
+  expect(druhyRead?.totalPriceWithVat).toBe("238.20");
+
+  // Ďalší re-import s inou sumou musí OSVIEŽIŤ (nikdy nezachovať starú).
+  const inaSuma = buildCsv(HEADER, [
+    {
+      code: "9104",
+      date: "2026-07-01 10:00:00",
+      statusName: "Vybavuje sa",
+      billFullName: "X",
+      itemName: "Y",
+      itemAmount: "1",
+      itemCode: "40237/XL",
+      totalPriceWithVat: "199,90",
+    },
+  ]);
+  await ingestOrders(db, { fetchExport: fetcherOf(inaSuma), now: NOW, rawDir: dir, windowStart: WINDOW_START, windowEnd: WINDOW_END });
+  const [tretiRead] = await db.select().from(orders).where(eq(orders.externalOrderId, "9104"));
+  expect(tretiRead?.totalPriceWithVat).toBe("199.90");
+});
+
+it("chýbajúci/nečitateľný totalPriceWithVat sa uloží ako null, nikdy nezhodí import", async () => {
+  const { db, dir } = await boot();
+  await insertTestVariant(db, "40237/XL");
+
+  const neplatnaSuma = buildCsv(HEADER, [
+    {
+      code: "9105",
+      date: "2026-07-01 10:00:00",
+      statusName: "Vybavuje sa",
+      billFullName: "X",
+      itemName: "Y",
+      itemAmount: "1",
+      itemCode: "40237/XL",
+      totalPriceWithVat: "neplatna hodnota",
+    },
+  ]);
+  const result = await ingestOrders(db, { fetchExport: fetcherOf(neplatnaSuma), now: NOW, rawDir: dir, windowStart: WINDOW_START, windowEnd: WINDOW_END });
+  expect(result.status).toBe("accepted");
+  const [read] = await db.select().from(orders).where(eq(orders.externalOrderId, "9105"));
+  expect(read?.totalPriceWithVat).toBeNull();
+});

--- a/apps/api/tests/orders-ingest.integration.test.ts
+++ b/apps/api/tests/orders-ingest.integration.test.ts
@@ -232,6 +232,11 @@ it("shopRemark je Shoptetovo pole, re-import ho osvieži a uloží SUROVO (bez s
   expect(tretiRead?.shopRemark).toBe("Zmenene v Shoptete priamo");
 });
 
+// issue 237: `totalPriceWithVat` re-import refresh test presunutý do
+// `orders-ingest-total-price.integration.test.ts` — pridanie priamo sem by
+// poslalo tento súbor cez eslint `max-lines: 400` (rovnaký dôvod/vzor ako
+// `orders-ingest-posta-fields.integration.test.ts`'s split).
+
 // issue 120: `fetchOrderIds` je BEST-EFFORT obohatenie o interné Shoptet id
 // (XML export) — samostatná fáza od hlavného CSV importu vyššie.
 it("uloží interné Shoptet id z fetchOrderIds vedľa CSV importu", async () => {

--- a/apps/api/tests/orders-overview.integration.test.ts
+++ b/apps/api/tests/orders-overview.integration.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, expect, it } from "vitest";
+import { orders, users } from "../src/db/schema.js";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import { getOrdersDashboardOverview } from "../src/modules/orders/overview.js";
+import { withCleanDb } from "./helpers/db.js";
+
+const HESLO = "test-heslo-abc"; // testovacie údaje, nie tajomstvo
+
+let close: (() => Promise<void>) | undefined;
+
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  resetLoginRateLimit();
+});
+
+// `now` pevne 2026-08-04 12:00 UTC (utorok, leto/CEST) — rovnaké ako
+// `overview.test.ts`'s hranicové testy, aby sa dalo overiť presne, ktoré
+// objednávky do ktorého bucketu spadnú.
+const NOW = new Date("2026-08-04T12:00:00Z");
+// Miestna polnoc 2026-08-04 (dnes), 2026-08-03 (pondelok tohto týždňa) a
+// 2026-08-01 (začiatok mesiaca) — overené v `overview.test.ts`.
+const TODAY_START = new Date("2026-08-03T22:00:00Z");
+const WEEK_START = new Date("2026-08-02T22:00:00Z");
+
+async function insertOrder(
+  db: Awaited<ReturnType<typeof withCleanDb>>["db"],
+  externalOrderId: string,
+  placedAt: Date,
+  totalPriceWithVat: string | null,
+): Promise<void> {
+  await db.insert(orders).values({ externalOrderId, customerName: "Zákazník", placedAt, totalPriceWithVat });
+}
+
+it("zaradí objednávky do dnes/tento týždeň/tento mesiac podľa placedAt (Europe/Bratislava)", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const db = ctx.db;
+
+  // "dnes" — 1h po miestnej polnoci dneška.
+  await insertOrder(db, "9201", new Date(TODAY_START.getTime() + 60 * 60 * 1000), "100.00");
+  // "tento týždeň, ale nie dnes" — deň pred dneškom, ešte v tomto týždni.
+  await insertOrder(db, "9202", new Date(WEEK_START.getTime() + 60 * 60 * 1000), "50.00");
+  // "tento mesiac, ale nie tento týždeň" — 1. augusta (pred pondelkom týždňa).
+  await insertOrder(db, "9203", new Date("2026-08-01T10:00:00Z"), "20.00");
+  // Mimo okna — júl (nepočíta sa NIKDE).
+  await insertOrder(db, "9204", new Date("2026-07-20T10:00:00Z"), "999.00");
+  // Presne na hranici "dnes" (>= je INKLUZÍVNE).
+  await insertOrder(db, "9205", TODAY_START, "5.00");
+
+  const overview = await getOrdersDashboardOverview(db, NOW);
+
+  expect(overview.today).toEqual({ orderCount: 2, revenue: "105.00" }); // 9201 + 9205
+  expect(overview.week).toEqual({ orderCount: 3, revenue: "155.00" }); // + 9202
+  expect(overview.month).toEqual({ orderCount: 4, revenue: "175.00" }); // + 9203
+});
+
+it("objednávka bez totalPriceWithVat (null) sa zaráta do počtu, nie do tržby", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const db = ctx.db;
+
+  await insertOrder(db, "9210", new Date(TODAY_START.getTime() + 60 * 60 * 1000), null);
+  await insertOrder(db, "9211", new Date(TODAY_START.getTime() + 2 * 60 * 60 * 1000), "10.00");
+
+  const overview = await getOrdersDashboardOverview(db, NOW);
+
+  expect(overview.today).toEqual({ orderCount: 2, revenue: "10.00" });
+});
+
+it("prázdna DB vráti nuly na všetkých troch obdobiach", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const db = ctx.db;
+
+  const overview = await getOrdersDashboardOverview(db, NOW);
+
+  expect(overview).toEqual({
+    today: { orderCount: 0, revenue: "0.00" },
+    week: { orderCount: 0, revenue: "0.00" },
+    month: { orderCount: 0, revenue: "0.00" },
+  });
+});
+
+// issue 237: "Prehľad e-shopu" počíta VŠETKY objednávky, bez ohľadu na
+// `status_name` — na rozdiel od "Na objednanie" (open-status filter,
+// `orders-open-statuses.integration.test.ts`). Uzavretá objednávka ("Vybavená")
+// sa MUSÍ zarátať rovnako ako otvorená.
+it("zaráta objednávku bez ohľadu na status_name (uzavretá sa počíta rovnako ako otvorená)", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const db = ctx.db;
+
+  await db.insert(orders).values({
+    externalOrderId: "9220",
+    customerName: "Zákazník",
+    statusName: "Vybavená",
+    placedAt: new Date(TODAY_START.getTime() + 60 * 60 * 1000),
+    totalPriceWithVat: "42.00",
+  });
+
+  const overview = await getOrdersDashboardOverview(db, NOW);
+
+  expect(overview.today).toEqual({ orderCount: 1, revenue: "42.00" });
+});
+
+async function boot() {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const [pouzivatel] = await ctx.db
+    .insert(users)
+    .values({ email: "citanie@forestshop.sk", passwordHash: await hashPassword(HESLO), displayName: "Čítanie", role: "citanie" })
+    .returning({ id: users.id });
+  if (pouzivatel === undefined) throw new Error("testovací používateľ sa nepodarilo vložiť");
+
+  const app = createApp(ctx.db, { cookieSecure: false });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "citanie@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie, db: ctx.db };
+}
+
+it("GET /api/orders/overview bez prihlásenia vráti 401", async () => {
+  const { app } = await boot();
+  const res = await app.request("/api/orders/overview");
+  expect(res.status).toBe(401);
+});
+
+// issue 237: rovnaké oprávnenie ako `/api/orders/open` — čítanie (rola
+// `citanie`) smie vidieť prehľad, nie je vyhradené manažérom/adminom.
+it("GET /api/orders/overview vráti počty aj tržbu za dnes/týždeň/mesiac (rola 'citanie' smie čítať)", async () => {
+  const { app, cookie, db } = await boot();
+  await insertOrder(db, "9230", new Date(TODAY_START.getTime() + 60 * 60 * 1000), "77.50");
+
+  const res = await app.request("/api/orders/overview", { headers: { cookie } });
+  expect(res.status).toBe(200);
+  const telo = (await res.json()) as {
+    today: { orderCount: number; revenue: string };
+    week: { orderCount: number; revenue: string };
+    month: { orderCount: number; revenue: string };
+  };
+  expect(telo.today).toEqual({ orderCount: 1, revenue: "77.50" });
+  expect(telo.week.orderCount).toBeGreaterThanOrEqual(1);
+  expect(telo.month.orderCount).toBeGreaterThanOrEqual(1);
+});
+
+// `.claude/rules/http-routes.md`: literálna cesta `/api/orders/overview`
+// MUSÍ byť zaregistrovaná PRED `GET /api/orders/:id` — inak by "overview"
+// spadlo do `:id` parametra a zlyhalo na neplatnom UUID namiesto toho, aby
+// sa dostalo k svojmu vlastnému handleru. Dôkaz reachability, nie len
+// existencie.
+it("/api/orders/overview je dosiahnuteľná (nekolíduje s /api/orders/:id)", async () => {
+  const { app, cookie } = await boot();
+  const res = await app.request("/api/orders/overview", { headers: { cookie } });
+  expect(res.status).toBe(200);
+  const telo = (await res.json()) as { today: unknown };
+  expect(telo).toHaveProperty("today");
+});

--- a/apps/web/src/components/OrderLineRow.adminLink.test.tsx
+++ b/apps/web/src/components/OrderLineRow.adminLink.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, render, screen, within } from "@testing-library/react";
-import { afterEach, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { OrdersSection } from "./OrdersSection.js";
 
 // issue 99: číslo objednávky sa stalo klikateľným odkazom do administrácie
@@ -7,11 +7,12 @@ import { OrdersSection } from "./OrdersSection.js";
 // `OrdersSection.test.tsx` je už na eslint `max-lines: 400` hranici
 // (`.claude/rules/frontend-design.md`'s zavedený vzor: nový tematický súbor
 // namiesto pridávania do veľkého existujúceho).
-const { fetchOpenOrders } = vi.hoisted(() => ({ fetchOpenOrders: vi.fn() }));
+const { fetchOpenOrders, fetchOrdersOverview } = vi.hoisted(() => ({ fetchOpenOrders: vi.fn(), fetchOrdersOverview: vi.fn() }));
 
 vi.mock("../ordersApi.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../ordersApi.js")>();
-  return { ...actual, fetchOpenOrders };
+  return { ...actual, fetchOpenOrders,
+    fetchOrdersOverview };
 });
 
 const LINE = {
@@ -36,6 +37,10 @@ const LINE = {
   supplierAssignable: false,
   manualSupplierOverride: null,
 };
+
+beforeEach(() => {
+  fetchOrdersOverview.mockResolvedValue({ today: { orderCount: 0, revenue: "0.00" }, week: { orderCount: 0, revenue: "0.00" }, month: { orderCount: 0, revenue: "0.00" } });
+});
 
 afterEach(() => {
   cleanup();

--- a/apps/web/src/components/OrderLineRow.remarkCell.test.tsx
+++ b/apps/web/src/components/OrderLineRow.remarkCell.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, render, screen, within } from "@testing-library/react";
-import { afterEach, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { OrdersSection } from "./OrdersSection.js";
 
 // issue 111 bod 4: `.ord-remark-cell` predtým VŽDY vykresľovala holú
@@ -8,11 +8,12 @@ import { OrdersSection } from "./OrdersSection.js";
 // odstránilo zo susednej bunky priradenia dodávateľa. Vlastný súbor — rovnaký
 // vzor ako `OrderLineRow.supplierAssignCell.test.tsx`
 // (`.claude/rules/frontend-design.md`).
-const { fetchOpenOrders } = vi.hoisted(() => ({ fetchOpenOrders: vi.fn() }));
+const { fetchOpenOrders, fetchOrdersOverview } = vi.hoisted(() => ({ fetchOpenOrders: vi.fn(), fetchOrdersOverview: vi.fn() }));
 
 vi.mock("../ordersApi.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../ordersApi.js")>();
-  return { ...actual, fetchOpenOrders };
+  return { ...actual, fetchOpenOrders,
+    fetchOrdersOverview };
 });
 
 const ZAKLAD = {
@@ -49,6 +50,10 @@ const RIADOK_S_POZNAMKOU = {
   remark: "Zavolať pred doručením",
   shopRemark: null,
 };
+
+beforeEach(() => {
+  fetchOrdersOverview.mockResolvedValue({ today: { orderCount: 0, revenue: "0.00" }, week: { orderCount: 0, revenue: "0.00" }, month: { orderCount: 0, revenue: "0.00" } });
+});
 
 afterEach(() => {
   cleanup();

--- a/apps/web/src/components/OrderLineRow.shopRemarkCell.test.tsx
+++ b/apps/web/src/components/OrderLineRow.shopRemarkCell.test.tsx
@@ -1,15 +1,16 @@
 import { cleanup, render, screen, within } from "@testing-library/react";
-import { afterEach, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { OrdersSection } from "./OrdersSection.js";
 
 // issue 164: INTERNÁ poznámka e-shopu (`shopRemark`, UŽ odvodená — LEN cudzí
 // text, appkin vlastný blok nikdy neobsahuje) — vlastný súbor, rovnaký vzor
 // ako `OrderLineRow.remarkCell.test.tsx` (`.claude/rules/frontend-design.md`).
-const { fetchOpenOrders } = vi.hoisted(() => ({ fetchOpenOrders: vi.fn() }));
+const { fetchOpenOrders, fetchOrdersOverview } = vi.hoisted(() => ({ fetchOpenOrders: vi.fn(), fetchOrdersOverview: vi.fn() }));
 
 vi.mock("../ordersApi.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../ordersApi.js")>();
-  return { ...actual, fetchOpenOrders };
+  return { ...actual, fetchOpenOrders,
+    fetchOrdersOverview };
 });
 
 const ZAKLAD = {
@@ -45,6 +46,10 @@ const RIADOK_S_POZNAMKOU = {
   externalOrderId: "20261501",
   shopRemark: "Zákazník je stavebná firma, vybaviť prednostne",
 };
+
+beforeEach(() => {
+  fetchOrdersOverview.mockResolvedValue({ today: { orderCount: 0, revenue: "0.00" }, week: { orderCount: 0, revenue: "0.00" }, month: { orderCount: 0, revenue: "0.00" } });
+});
 
 afterEach(() => {
   cleanup();

--- a/apps/web/src/components/OrderLineRow.supplierAssignCell.test.tsx
+++ b/apps/web/src/components/OrderLineRow.supplierAssignCell.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, render, screen, within } from "@testing-library/react";
-import { afterEach, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { OrdersSection } from "./OrdersSection.js";
 
 // issue 107 bod 3: majiteľ, komentár #1: "neviem čo tam je Priradenie
@@ -10,11 +10,12 @@ import { OrdersSection } from "./OrdersSection.js";
 // vôbec (žiadny prvok v DOM), radiťeľný riadok ho vykreslí AJ s viditeľným
 // popisom (nielen placeholderom). Vlastný súbor — rovnaký vzor ako
 // `OrderLineRow.adminLink.test.tsx` (`.claude/rules/frontend-design.md`).
-const { fetchOpenOrders } = vi.hoisted(() => ({ fetchOpenOrders: vi.fn() }));
+const { fetchOpenOrders, fetchOrdersOverview } = vi.hoisted(() => ({ fetchOpenOrders: vi.fn(), fetchOrdersOverview: vi.fn() }));
 
 vi.mock("../ordersApi.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../ordersApi.js")>();
-  return { ...actual, fetchOpenOrders };
+  return { ...actual, fetchOpenOrders,
+    fetchOrdersOverview };
 });
 
 const ZAKLAD = {
@@ -50,6 +51,10 @@ const RIADOK_RADITELNY = {
   externalOrderId: "20261301",
   supplierAssignable: true,
 };
+
+beforeEach(() => {
+  fetchOrdersOverview.mockResolvedValue({ today: { orderCount: 0, revenue: "0.00" }, week: { orderCount: 0, revenue: "0.00" }, month: { orderCount: 0, revenue: "0.00" } });
+});
 
 afterEach(() => {
   cleanup();

--- a/apps/web/src/components/OrderLineRow.supplierLinkEditCell.test.tsx
+++ b/apps/web/src/components/OrderLineRow.supplierLinkEditCell.test.tsx
@@ -1,19 +1,20 @@
 import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
-import { afterEach, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { OrdersSection } from "./OrdersSection.js";
 
 // issue 121: majiteľ, doslovne "ak na produkt nie je odkaz na dodavatela, tak
 // tam ma byt moznost ho doplnit... pri kazdom produkte ma byt moznost upravit
 // link". Vlastný súbor — rovnaký vzor ako `OrderLineRow.supplierAssignCell
 // .test.tsx` (`.claude/rules/frontend-design.md`).
-const { fetchOpenOrders, setProductSupplierLink } = vi.hoisted(() => ({
-  fetchOpenOrders: vi.fn(),
+const { fetchOpenOrders, fetchOrdersOverview, setProductSupplierLink } = vi.hoisted(() => ({
+  fetchOpenOrders: vi.fn(), fetchOrdersOverview: vi.fn(),
   setProductSupplierLink: vi.fn(),
 }));
 
 vi.mock("../ordersApi.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../ordersApi.js")>();
-  return { ...actual, fetchOpenOrders, setProductSupplierLink };
+  return { ...actual, fetchOpenOrders,
+    fetchOrdersOverview, setProductSupplierLink };
 });
 
 const ZAKLAD = {
@@ -44,6 +45,10 @@ const RIADOK_S_ODKAZOM = {
   externalOrderId: "20261401",
   supplierUrl: "https://dodavatel.example.com/produkt",
 };
+
+beforeEach(() => {
+  fetchOrdersOverview.mockResolvedValue({ today: { orderCount: 0, revenue: "0.00" }, week: { orderCount: 0, revenue: "0.00" }, month: { orderCount: 0, revenue: "0.00" } });
+});
 
 afterEach(() => {
   cleanup();

--- a/apps/web/src/components/OrdersOverviewTiles.test.tsx
+++ b/apps/web/src/components/OrdersOverviewTiles.test.tsx
@@ -1,0 +1,121 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { OrdersOverviewTiles } from "./OrdersOverviewTiles.js";
+import type { OrderLine, SupplierOpenOrders } from "../ordersApi.js";
+
+const { fetchOrdersOverview } = vi.hoisted(() => ({ fetchOrdersOverview: vi.fn() }));
+
+// `OrdersUnauthorizedError` ostáva SKUTOČNÁ trieda z reálneho modulu —
+// rovnaký dôvod ako `OrderOpenStatusesPanel.test.tsx`: `instanceof` v
+// komponente musí fungovať aj v teste.
+vi.mock("../ordersApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../ordersApi.js")>();
+  return { ...actual, fetchOrdersOverview };
+});
+
+const { OrdersUnauthorizedError } = await import("../ordersApi.js");
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+const makeLine = (overrides: Partial<OrderLine> = {}): OrderLine => ({
+  lineId: overrides.lineId ?? "l1",
+  orderId: overrides.orderId ?? "o1",
+  externalOrderId: "1001",
+  customerName: "Zákazník",
+  comment: null,
+  remark: null,
+  shopRemark: null,
+  adminUrl: "https://www.forestshop.sk/admin/vyhladavanie/?string=1001&src=orders",
+  placedAt: "2026-07-01T00:00:00.000Z",
+  variantCode: "A-1",
+  variantName: "Produkt",
+  sizeLabel: null,
+  quantity: 1,
+  state: "objednane",
+  ordered: false,
+  supplierUrl: null,
+  supplierNote: null,
+  externalCode: null,
+  supplierAssignable: false,
+  manualSupplierOverride: null,
+  ...overrides,
+});
+
+const OVERVIEW = {
+  today: { orderCount: 3, revenue: "150.00" },
+  week: { orderCount: 10, revenue: "980.50" },
+  month: { orderCount: 42, revenue: "3120.00" },
+};
+
+it("zobrazí tri dlaždice 'Prehľad e-shopu' s počtom objednávok aj tržbou", async () => {
+  fetchOrdersOverview.mockResolvedValue(OVERVIEW);
+  render(<OrdersOverviewTiles suppliers={[]} onSessionExpired={() => {}} />);
+
+  await waitFor(() => {
+    expect(screen.getByTestId("overview-shop-today").textContent).toContain("3 objednávok");
+  });
+  expect(screen.getByTestId("overview-shop-today").textContent).toContain("150.00 €");
+  expect(screen.getByTestId("overview-shop-week").textContent).toContain("10 objednávok");
+  expect(screen.getByTestId("overview-shop-week").textContent).toContain("980.50 €");
+  expect(screen.getByTestId("overview-shop-month").textContent).toContain("42 objednávok");
+  expect(screen.getByTestId("overview-shop-month").textContent).toContain("3120.00 €");
+});
+
+it("chyba pri načítaní prehľadu e-shopu zobrazí hlášku, nikdy nespadne", async () => {
+  fetchOrdersOverview.mockRejectedValue(new Error("network"));
+  render(<OrdersOverviewTiles suppliers={[]} onSessionExpired={() => {}} />);
+
+  await waitFor(() => {
+    expect(screen.getByRole("alert").textContent).toBe("Prehľad e-shopu sa nepodarilo načítať.");
+  });
+});
+
+it("401 pri načítaní prehľadu e-shopu zavolá onSessionExpired", async () => {
+  fetchOrdersOverview.mockRejectedValue(new OrdersUnauthorizedError());
+  const onSessionExpired = vi.fn();
+  render(<OrdersOverviewTiles suppliers={[]} onSessionExpired={onSessionExpired} />);
+
+  await waitFor(() => {
+    expect(onSessionExpired).toHaveBeenCalledTimes(1);
+  });
+});
+
+// issue 237: "Súhrn o objednávaní" — počítaný ČISTO zo `suppliers`, nezávisle
+// od `fetchOrdersOverview` (ktorý tu nikdy nedobehne — dôkaz, že tento blok
+// nepotrebuje sieť vôbec).
+it("'Súhrn o objednávaní' počíta zo suppliers bez ohľadu na to, či prehľad e-shopu ešte dobehol", () => {
+  fetchOrdersOverview.mockReturnValue(new Promise(() => {})); // nikdy sa nevyrieši
+  const suppliers: readonly SupplierOpenOrders[] = [
+    {
+      supplier: "Dodávateľ Alfa",
+      email: null,
+      lines: [
+        makeLine({ lineId: "a1", orderId: "oa", state: "objednane", ordered: false, placedAt: "2026-01-15T00:00:00.000Z" }),
+        makeLine({ lineId: "a2", orderId: "oa", state: "objednane", ordered: false, placedAt: "2026-06-01T00:00:00.000Z" }),
+        makeLine({ lineId: "a3", orderId: "ob", state: "objednane", ordered: true }), // vybavené
+      ],
+    },
+  ];
+
+  render(<OrdersOverviewTiles suppliers={suppliers} onSessionExpired={() => {}} />);
+
+  // 2 nevybavené riadky (a1, a2), obe v TEJ ISTEJ objednávke "oa" → 1
+  // dotknutá objednávka, 1 už objednaná (a3), najstaršia čakajúca 2026-01-15.
+  expect(screen.getByTestId("overview-ordering-remaining").textContent).toContain("2");
+  expect(screen.getByTestId("overview-ordering-affected-orders").textContent).toContain("1");
+  expect(screen.getByTestId("overview-ordering-already-ordered").textContent).toContain("1");
+  expect(screen.getByTestId("overview-ordering-oldest").textContent).toContain(
+    new Date("2026-01-15T00:00:00.000Z").toLocaleDateString("sk-SK"),
+  );
+});
+
+it("bez žiadneho nevybaveného riadku ukáže '—' namiesto dátumu najstaršej čakajúcej", () => {
+  fetchOrdersOverview.mockReturnValue(new Promise(() => {}));
+  render(<OrdersOverviewTiles suppliers={[]} onSessionExpired={() => {}} />);
+
+  expect(screen.getByTestId("overview-ordering-oldest").textContent).toContain("—");
+  expect(screen.getByTestId("overview-ordering-remaining").textContent).toContain("0");
+});

--- a/apps/web/src/components/OrdersOverviewTiles.test.tsx
+++ b/apps/web/src/components/OrdersOverviewTiles.test.tsx
@@ -55,7 +55,9 @@ it("zobrazí tri dlaždice 'Prehľad e-shopu' s počtom objednávok aj tržbou",
   render(<OrdersOverviewTiles suppliers={[]} onSessionExpired={() => {}} />);
 
   await waitFor(() => {
-    expect(screen.getByTestId("overview-shop-today").textContent).toContain("3 objednávok");
+    // issue 237 (code review): 3 spadá do slovenského "málopočetného" (paucal)
+    // tvaru 2-4 → "objednávky", nie "objednávok" (`formatOrderCount`).
+    expect(screen.getByTestId("overview-shop-today").textContent).toContain("3 objednávky");
   });
   expect(screen.getByTestId("overview-shop-today").textContent).toContain("150.00 €");
   expect(screen.getByTestId("overview-shop-week").textContent).toContain("10 objednávok");

--- a/apps/web/src/components/OrdersOverviewTiles.tsx
+++ b/apps/web/src/components/OrdersOverviewTiles.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useState, type JSX } from "react";
+import { fetchOrdersOverview, OrdersUnauthorizedError, type OrdersOverview, type SupplierOpenOrders } from "../ordersApi.js";
+import { countAffectedOrders, oldestWaitingPlacedAt, summarizeOrderLines } from "../ordersSummary.js";
+
+// issue 237: blok dlaždíc NAD zoznamom na obrazovke "Na objednanie" — dve
+// skupiny. "Prehľad e-shopu" (dnes/tento týždeň/tento mesiac, presne ako
+// Shoptet-ov vlastný dashboard) je NEZÁVISLÝ od dodávateľského pracovného
+// zoznamu — vlastný fetch (rovnaký tvar ako `OrderOpenStatusesPanel.tsx`:
+// `useEffect`/`onSessionExpired`), lebo potrebuje VŠETKY objednávky (aj
+// uzavreté), nie len OPEN-status podmnožinu, akú appka už má v `suppliers`.
+// "Súhrn o objednávaní" NEPOTREBUJE žiadny nový fetch — počíta sa čisto z
+// UŽ načítaných `suppliers` (rovnaké zdieľané funkcie ako `OrdersToolbar.tsx`
+// používa pre svoj filter-viazaný súhrn, `ordersSummary.ts`).
+//
+// Dlaždice sú PREHĽAD, nikdy filter — kliknutie na ne nemení obsah zoznamu
+// nižšie (ticketova explicitná požiadavka).
+export function OrdersOverviewTiles({
+  suppliers,
+  onSessionExpired,
+}: {
+  readonly suppliers: readonly SupplierOpenOrders[];
+  readonly onSessionExpired: () => void;
+}): JSX.Element {
+  const [overview, setOverview] = useState<OrdersOverview | null>(null);
+  const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    fetchOrdersOverview()
+      .then((result) => {
+        setOverview(result);
+        setLoaded(true);
+      })
+      .catch((err: unknown) => {
+        setLoaded(true);
+        if (err instanceof OrdersUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setError("Prehľad e-shopu sa nepodarilo načítať.");
+      });
+  }, [onSessionExpired]);
+
+  const allLines = suppliers.flatMap((group) => group.lines);
+  const ordering = summarizeOrderLines(allLines);
+  const affectedOrders = countAffectedOrders(allLines);
+  const oldestPlacedAt = oldestWaitingPlacedAt(allLines);
+
+  return (
+    <div className="orders-overview" data-testid="orders-overview">
+      <div className="overview-group">
+        <h2 className="overview-group-title">Prehľad e-shopu</h2>
+        {error !== "" && <p role="alert">{error}</p>}
+        {!loaded && error === "" && <p>Načítavam prehľad…</p>}
+        {overview !== null && (
+          <div className="overview-tiles">
+            <OverviewTile testId="overview-shop-today" label="Dnes" orderCount={overview.today.orderCount} revenue={overview.today.revenue} />
+            <OverviewTile testId="overview-shop-week" label="Tento týždeň" orderCount={overview.week.orderCount} revenue={overview.week.revenue} />
+            <OverviewTile testId="overview-shop-month" label="Tento mesiac" orderCount={overview.month.orderCount} revenue={overview.month.revenue} />
+          </div>
+        )}
+      </div>
+      <div className="overview-group">
+        <h2 className="overview-group-title">Súhrn o objednávaní</h2>
+        <div className="overview-tiles">
+          <SimpleTile testId="overview-ordering-remaining" label="Položiek na objednanie" value={String(ordering.remaining)} />
+          <SimpleTile testId="overview-ordering-affected-orders" label="Dotknutých objednávok" value={String(affectedOrders)} />
+          <SimpleTile testId="overview-ordering-already-ordered" label="Už objednané" value={String(ordering.ordered)} />
+          <SimpleTile
+            testId="overview-ordering-oldest"
+            label="Najstaršia čakajúca"
+            value={oldestPlacedAt === null ? "—" : new Date(oldestPlacedAt).toLocaleDateString("sk-SK")}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function OverviewTile({
+  testId,
+  label,
+  orderCount,
+  revenue,
+}: {
+  readonly testId: string;
+  readonly label: string;
+  readonly orderCount: number;
+  readonly revenue: string;
+}): JSX.Element {
+  return (
+    <div className="overview-tile" data-testid={testId}>
+      <p className="overview-tile-label">{label}</p>
+      <p className="overview-tile-value">{`${String(orderCount)} objednávok`}</p>
+      <p className="overview-tile-sub">{`${revenue} €`}</p>
+    </div>
+  );
+}
+
+function SimpleTile({ testId, label, value }: { readonly testId: string; readonly label: string; readonly value: string }): JSX.Element {
+  return (
+    <div className="overview-tile" data-testid={testId}>
+      <p className="overview-tile-label">{label}</p>
+      <p className="overview-tile-value">{value}</p>
+    </div>
+  );
+}

--- a/apps/web/src/components/OrdersOverviewTiles.tsx
+++ b/apps/web/src/components/OrdersOverviewTiles.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, type JSX } from "react";
 import { fetchOrdersOverview, OrdersUnauthorizedError, type OrdersOverview, type SupplierOpenOrders } from "../ordersApi.js";
-import { countAffectedOrders, oldestWaitingPlacedAt, summarizeOrderLines } from "../ordersSummary.js";
+import { countAffectedOrders, formatOrderCount, oldestWaitingPlacedAt, summarizeOrderLines } from "../ordersSummary.js";
 
 // issue 237: blok dlaždíc NAD zoznamom na obrazovke "Na objednanie" — dve
 // skupiny. "Prehľad e-shopu" (dnes/tento týždeň/tento mesiac, presne ako
@@ -91,7 +91,7 @@ function OverviewTile({
   return (
     <div className="overview-tile" data-testid={testId}>
       <p className="overview-tile-label">{label}</p>
-      <p className="overview-tile-value">{`${String(orderCount)} objednávok`}</p>
+      <p className="overview-tile-value">{formatOrderCount(orderCount)}</p>
       <p className="overview-tile-sub">{`${revenue} €`}</p>
     </div>
   );

--- a/apps/web/src/components/OrdersSection.assignSupplier.test.tsx
+++ b/apps/web/src/components/OrdersSection.assignSupplier.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { afterEach, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { OrdersSection } from "./OrdersSection.js";
 
 // issue 63: ručné priradenie dodávateľa riadku bez dodávateľa. Vydelené z
@@ -11,8 +11,8 @@ import { OrdersSection } from "./OrdersSection.js";
 // meniť vo frontende, nebolo ničím kryté. Tento súbor dokazuje aj refetch po
 // zamietnutí (predtým sa `load()` volalo LEN v úspešnej vetve).
 
-const { fetchOpenOrders, assignOrderLineSupplier } = vi.hoisted(() => ({
-  fetchOpenOrders: vi.fn(),
+const { fetchOpenOrders, fetchOrdersOverview, assignOrderLineSupplier } = vi.hoisted(() => ({
+  fetchOpenOrders: vi.fn(), fetchOrdersOverview: vi.fn(),
   assignOrderLineSupplier: vi.fn(),
 }));
 
@@ -21,6 +21,7 @@ vi.mock("../ordersApi.js", async (importOriginal) => {
   return {
     ...actual,
     fetchOpenOrders,
+    fetchOrdersOverview,
     assignOrderLineSupplier,
   };
 });
@@ -47,6 +48,10 @@ const LINE_BEZ_DODAVATELA = {
   supplierAssignable: true,
   manualSupplierOverride: null,
 };
+
+beforeEach(() => {
+  fetchOrdersOverview.mockResolvedValue({ today: { orderCount: 0, revenue: "0.00" }, week: { orderCount: 0, revenue: "0.00" }, month: { orderCount: 0, revenue: "0.00" } });
+});
 
 afterEach(() => {
   cleanup();

--- a/apps/web/src/components/OrdersSection.comment.test.tsx
+++ b/apps/web/src/components/OrdersSection.comment.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { afterEach, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { OrdersSection } from "./OrdersSection.js";
 
 // issue 64: manažérova voľná poznámka k CELEJ objednávke. Vydelené z
@@ -7,8 +7,8 @@ import { OrdersSection } from "./OrdersSection.js";
 // `OrdersSection.ordered.test.tsx`/`OrdersSection.assignSupplier.test.tsx`
 // splity, `.claude/rules/testing.md`).
 
-const { fetchOpenOrders, updateOrderComment } = vi.hoisted(() => ({
-  fetchOpenOrders: vi.fn(),
+const { fetchOpenOrders, fetchOrdersOverview, updateOrderComment } = vi.hoisted(() => ({
+  fetchOpenOrders: vi.fn(), fetchOrdersOverview: vi.fn(),
   updateOrderComment: vi.fn(),
 }));
 
@@ -17,6 +17,7 @@ vi.mock("../ordersApi.js", async (importOriginal) => {
   return {
     ...actual,
     fetchOpenOrders,
+    fetchOrdersOverview,
     updateOrderComment,
   };
 });
@@ -50,6 +51,10 @@ const RIADOK_1 = {
 };
 
 const RIADOK_2 = { ...RIADOK_1, lineId: "22222222-4444-4444-4444-444444444444", variantCode: "D-2" };
+
+beforeEach(() => {
+  fetchOrdersOverview.mockResolvedValue({ today: { orderCount: 0, revenue: "0.00" }, week: { orderCount: 0, revenue: "0.00" }, month: { orderCount: 0, revenue: "0.00" } });
+});
 
 afterEach(() => {
   cleanup();

--- a/apps/web/src/components/OrdersSection.hideResolvedEditorGuard.test.tsx
+++ b/apps/web/src/components/OrdersSection.hideResolvedEditorGuard.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { afterEach, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { OrdersSection } from "./OrdersSection.js";
 
 // issue 149 — riadok s otvorenou/rozpísanou úpravou (komentár alebo ručné
@@ -10,15 +10,16 @@ import { OrdersSection } from "./OrdersSection.js";
 // editor.spec.ts`) pokrýva TRETÍ editor (odkaz na dodávateľa, toggle
 // open/close) end-to-end cez skutočný prehliadač.
 
-const { fetchOpenOrders, updateOrderComment, updateOrderLineOrdered } = vi.hoisted(() => ({
-  fetchOpenOrders: vi.fn(),
+const { fetchOpenOrders, fetchOrdersOverview, updateOrderComment, updateOrderLineOrdered } = vi.hoisted(() => ({
+  fetchOpenOrders: vi.fn(), fetchOrdersOverview: vi.fn(),
   updateOrderComment: vi.fn(),
   updateOrderLineOrdered: vi.fn(),
 }));
 
 vi.mock("../ordersApi.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../ordersApi.js")>();
-  return { ...actual, fetchOpenOrders, updateOrderComment, updateOrderLineOrdered };
+  return { ...actual, fetchOpenOrders,
+    fetchOrdersOverview, updateOrderComment, updateOrderLineOrdered };
 });
 
 const LINE = {
@@ -43,6 +44,10 @@ const LINE = {
   supplierAssignable: false,
   manualSupplierOverride: null,
 };
+
+beforeEach(() => {
+  fetchOrdersOverview.mockResolvedValue({ today: { orderCount: 0, revenue: "0.00" }, week: { orderCount: 0, revenue: "0.00" }, month: { orderCount: 0, revenue: "0.00" } });
+});
 
 afterEach(() => {
   cleanup();

--- a/apps/web/src/components/OrdersSection.mailActions.test.tsx
+++ b/apps/web/src/components/OrdersSection.mailActions.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { afterEach, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { OrdersSection } from "./OrdersSection.js";
 
 // issue 118: majiteľ, doslovne "📋 Kopírovať objednávku ✉️ Poslať objednávku
@@ -13,8 +13,8 @@ import { OrdersSection } from "./OrdersSection.js";
 // zapnutým.
 vi.mock("./orderScreenFlags.js", () => ({ SHOW_ORDER_MAIL_ACTIONS: true }));
 
-const { fetchOpenOrders, setSupplierEmail, fetchSupplierOrderMailPreview, sendSupplierOrderMail } = vi.hoisted(() => ({
-  fetchOpenOrders: vi.fn(),
+const { fetchOpenOrders, fetchOrdersOverview, setSupplierEmail, fetchSupplierOrderMailPreview, sendSupplierOrderMail } = vi.hoisted(() => ({
+  fetchOpenOrders: vi.fn(), fetchOrdersOverview: vi.fn(),
   setSupplierEmail: vi.fn(),
   fetchSupplierOrderMailPreview: vi.fn(),
   sendSupplierOrderMail: vi.fn(),
@@ -25,6 +25,7 @@ vi.mock("../ordersApi.js", async (importOriginal) => {
   return {
     ...actual,
     fetchOpenOrders,
+    fetchOrdersOverview,
     setSupplierEmail,
     fetchSupplierOrderMailPreview,
     sendSupplierOrderMail,
@@ -58,6 +59,10 @@ const LINE_STARA = {
 // `outstandingState` v `SupplierActionsPanel.tsx` je `"objednane"`, takže
 // skupina BEZ ani jedného takého riadku nemá čo poslať, aj keď má e-mail.
 const LINE_VYBAVENA = { ...LINE_STARA, lineId: "22222222-1111-1111-1111-111111111111", state: "caka_sa" as const };
+
+beforeEach(() => {
+  fetchOrdersOverview.mockResolvedValue({ today: { orderCount: 0, revenue: "0.00" }, week: { orderCount: 0, revenue: "0.00" }, month: { orderCount: 0, revenue: "0.00" } });
+});
 
 afterEach(() => {
   cleanup();

--- a/apps/web/src/components/OrdersSection.ordered.test.tsx
+++ b/apps/web/src/components/OrdersSection.ordered.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { afterEach, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { OrdersSection } from "./OrdersSection.js";
 
 // issue 60: odškrtávacie políčko "objednané u dodávateľa" — per riadok aj
@@ -9,8 +9,8 @@ import { OrdersSection } from "./OrdersSection.js";
 // `orders-http.integration.test.ts` / `orders-http-state.integration.test.ts`
 // split na strane API testov.
 
-const { fetchOpenOrders, updateOrderLineOrdered, setSupplierLinesOrdered } = vi.hoisted(() => ({
-  fetchOpenOrders: vi.fn(),
+const { fetchOpenOrders, fetchOrdersOverview, updateOrderLineOrdered, setSupplierLinesOrdered } = vi.hoisted(() => ({
+  fetchOpenOrders: vi.fn(), fetchOrdersOverview: vi.fn(),
   updateOrderLineOrdered: vi.fn(),
   setSupplierLinesOrdered: vi.fn(),
 }));
@@ -20,6 +20,7 @@ vi.mock("../ordersApi.js", async (importOriginal) => {
   return {
     ...actual,
     fetchOpenOrders,
+    fetchOrdersOverview,
     updateOrderLineOrdered,
     setSupplierLinesOrdered,
   };
@@ -70,6 +71,10 @@ const LINE_NOVA = {
   supplierAssignable: false,
   manualSupplierOverride: null,
 };
+
+beforeEach(() => {
+  fetchOrdersOverview.mockResolvedValue({ today: { orderCount: 0, revenue: "0.00" }, week: { orderCount: 0, revenue: "0.00" }, month: { orderCount: 0, revenue: "0.00" } });
+});
 
 afterEach(() => {
   cleanup();

--- a/apps/web/src/components/OrdersSection.selectedSupplierPersistence.test.tsx
+++ b/apps/web/src/components/OrdersSection.selectedSupplierPersistence.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { afterEach, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { OrdersSection } from "./OrdersSection.js";
 
 // issue 148 — vyňaté do vlastného súboru (rovnaký vzor ako existujúce
@@ -11,11 +11,12 @@ import { OrdersSection } from "./OrdersSection.js";
 // unit test v tomto súbore — zámerne priamo cez skutočnú jsdom
 // `window.localStorage`, nie mock, aby overil SKUTOČNÝ read/write cyklus.
 
-const { fetchOpenOrders } = vi.hoisted(() => ({ fetchOpenOrders: vi.fn() }));
+const { fetchOpenOrders, fetchOrdersOverview } = vi.hoisted(() => ({ fetchOpenOrders: vi.fn(), fetchOrdersOverview: vi.fn() }));
 
 vi.mock("../ordersApi.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../ordersApi.js")>();
-  return { ...actual, fetchOpenOrders };
+  return { ...actual, fetchOpenOrders,
+    fetchOrdersOverview };
 });
 
 const STORAGE_KEY = "forestshop.orders.selectedSupplier";
@@ -44,6 +45,10 @@ const LINE_ALFA = {
 };
 
 const LINE_BETA = { ...LINE_ALFA, lineId: "22222222-2222-2222-2222-222222222148", variantCode: "P-2" };
+
+beforeEach(() => {
+  fetchOrdersOverview.mockResolvedValue({ today: { orderCount: 0, revenue: "0.00" }, week: { orderCount: 0, revenue: "0.00" }, month: { orderCount: 0, revenue: "0.00" } });
+});
 
 afterEach(() => {
   cleanup();

--- a/apps/web/src/components/OrdersSection.supplierLinkValidation.test.tsx
+++ b/apps/web/src/components/OrdersSection.supplierLinkValidation.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { afterEach, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { OrdersSection } from "./OrdersSection.js";
 
 // issue 153: OKAMŽITÁ kontrola odkazu v prehliadači — PRED akýmkoľvek
@@ -7,14 +7,15 @@ import { OrdersSection } from "./OrdersSection.js";
 // `OrdersSection.writeFailures.test.tsx`/`OrdersSection.assignSupplier.test
 // .tsx` splity (`.claude/rules/testing.md`).
 
-const { fetchOpenOrders, setProductSupplierLink } = vi.hoisted(() => ({
-  fetchOpenOrders: vi.fn(),
+const { fetchOpenOrders, fetchOrdersOverview, setProductSupplierLink } = vi.hoisted(() => ({
+  fetchOpenOrders: vi.fn(), fetchOrdersOverview: vi.fn(),
   setProductSupplierLink: vi.fn(),
 }));
 
 vi.mock("../ordersApi.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../ordersApi.js")>();
-  return { ...actual, fetchOpenOrders, setProductSupplierLink };
+  return { ...actual, fetchOpenOrders,
+    fetchOrdersOverview, setProductSupplierLink };
 });
 
 const LINE_ALFA = {
@@ -39,6 +40,10 @@ const LINE_ALFA = {
   supplierAssignable: false,
   manualSupplierOverride: null,
 };
+
+beforeEach(() => {
+  fetchOrdersOverview.mockResolvedValue({ today: { orderCount: 0, revenue: "0.00" }, week: { orderCount: 0, revenue: "0.00" }, month: { orderCount: 0, revenue: "0.00" } });
+});
 
 afterEach(() => {
   cleanup();

--- a/apps/web/src/components/OrdersSection.test.tsx
+++ b/apps/web/src/components/OrdersSection.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
-import { afterEach, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { OrdersSection } from "./OrdersSection.js";
 
 // `updateOrderLineOrdered`/`setSupplierLinesOrdered` mocks moved to
@@ -9,8 +9,8 @@ import { OrdersSection } from "./OrdersSection.js";
 // `OrdersSection.mailActions.test.tsx` the same way — this file no longer
 // has any test exercising the (now hidden-by-default) mail preview/send
 // flow.
-const { fetchOpenOrders, updateOrderLineState, setSupplierEmail } = vi.hoisted(() => ({
-  fetchOpenOrders: vi.fn(),
+const { fetchOpenOrders, fetchOrdersOverview, updateOrderLineState, setSupplierEmail } = vi.hoisted(() => ({
+  fetchOpenOrders: vi.fn(), fetchOrdersOverview: vi.fn(),
   updateOrderLineState: vi.fn(),
   setSupplierEmail: vi.fn(),
 }));
@@ -23,6 +23,7 @@ vi.mock("../ordersApi.js", async (importOriginal) => {
   return {
     ...actual,
     fetchOpenOrders,
+    fetchOrdersOverview,
     updateOrderLineState,
     setSupplierEmail,
   };
@@ -75,6 +76,10 @@ const LINE_NOVA = {
   supplierAssignable: false,
   manualSupplierOverride: null,
 };
+
+beforeEach(() => {
+  fetchOrdersOverview.mockResolvedValue({ today: { orderCount: 0, revenue: "0.00" }, week: { orderCount: 0, revenue: "0.00" }, month: { orderCount: 0, revenue: "0.00" } });
+});
 
 afterEach(() => {
   cleanup();

--- a/apps/web/src/components/OrdersSection.tsx
+++ b/apps/web/src/components/OrdersSection.tsx
@@ -16,6 +16,7 @@ import { useSupplierEmailEditing } from "../useSupplierEmailEditing.js";
 import { useSupplierLinkSave } from "../useSupplierLinkSave.js";
 import { useSupplierMailActions } from "../useSupplierMailActions.js";
 import { OrderOpenStatusesPanel } from "./OrderOpenStatusesPanel.js";
+import { OrdersOverviewTiles } from "./OrdersOverviewTiles.js";
 import { OrdersToolbar } from "./OrdersToolbar.js";
 import { OrderWriteFailuresBanner } from "./OrderWriteFailuresBanner.js";
 import { SupplierOrderGroup } from "./SupplierOrderGroup.js";
@@ -389,6 +390,11 @@ export function OrdersSection({
     <section className="orders-section">
       {!loaded && <p>Načítavam otvorené objednávky…</p>}
       {error !== "" && <p role="alert">{error}</p>}
+      {/* issue 237: blok dlaždíc NAD zoznamom — nezávislý od `loaded`/
+          `totalLines` (vlastný stav vnútri), lebo "Prehľad e-shopu" má
+          zmysel zobraziť aj keď "Na objednanie" nemá momentálne žiadny
+          otvorený riadok. */}
+      <OrdersOverviewTiles suppliers={suppliers} onSessionExpired={onSessionExpired} />
       <OrderWriteFailuresBanner
         failures={writeFailures}
         onDismiss={() => {

--- a/apps/web/src/components/OrdersSection.writeFailures.test.tsx
+++ b/apps/web/src/components/OrdersSection.writeFailures.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { afterEach, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { OrdersSection } from "./OrdersSection.js";
 
 // issue 66: dôkaz jadra ticketu — DVE NEZÁVISLÉ zlyhania (rôzne riadky, rôzne
@@ -9,15 +9,16 @@ import { OrdersSection } from "./OrdersSection.js";
 // .tsx`/`OrdersSection.assignSupplier.test.tsx` splity (`.claude/rules/
 // testing.md`), aby žiadny súbor nenarástol cez eslint `max-lines: 400`.
 
-const { fetchOpenOrders, updateOrderLineState, updateOrderLineOrdered } = vi.hoisted(() => ({
-  fetchOpenOrders: vi.fn(),
+const { fetchOpenOrders, fetchOrdersOverview, updateOrderLineState, updateOrderLineOrdered } = vi.hoisted(() => ({
+  fetchOpenOrders: vi.fn(), fetchOrdersOverview: vi.fn(),
   updateOrderLineState: vi.fn(),
   updateOrderLineOrdered: vi.fn(),
 }));
 
 vi.mock("../ordersApi.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../ordersApi.js")>();
-  return { ...actual, fetchOpenOrders, updateOrderLineState, updateOrderLineOrdered };
+  return { ...actual, fetchOpenOrders,
+    fetchOrdersOverview, updateOrderLineState, updateOrderLineOrdered };
 });
 
 const LINE_ALFA = {
@@ -51,6 +52,10 @@ const LINE_BETA = {
   customerName: "Zákazník Beta",
   variantCode: "B-1",
 };
+
+beforeEach(() => {
+  fetchOrdersOverview.mockResolvedValue({ today: { orderCount: 0, revenue: "0.00" }, week: { orderCount: 0, revenue: "0.00" }, month: { orderCount: 0, revenue: "0.00" } });
+});
 
 afterEach(() => {
   cleanup();

--- a/apps/web/src/ordersApi.ts
+++ b/apps/web/src/ordersApi.ts
@@ -167,6 +167,27 @@ export async function fetchOpenOrders(): Promise<readonly SupplierOpenOrders[]> 
   return parsed.suppliers;
 }
 
+// issue 237: "Prehľad e-shopu" (dnes/tento týždeň/tento mesiac) — zrkadlí
+// `apps/api/src/modules/orders/overview.ts`'s `OrdersDashboardOverview`.
+// `revenue` je `numeric`-reťazec (`"1234.56"`, presne dve desatinné miesta) —
+// zobrazuje sa priamo, rovnaký vzor ako `SupplierStockSection.tsx`'s
+// `${row.price} €`.
+const periodStatsSchema = z.object({ orderCount: z.number(), revenue: z.string() });
+
+const ordersOverviewSchema = z.object({
+  today: periodStatsSchema,
+  week: periodStatsSchema,
+  month: periodStatsSchema,
+});
+
+export type OrdersPeriodStats = z.infer<typeof periodStatsSchema>;
+export type OrdersOverview = z.infer<typeof ordersOverviewSchema>;
+
+export async function fetchOrdersOverview(): Promise<OrdersOverview> {
+  const response = await fetch("/api/orders/overview");
+  return ordersOverviewSchema.parse(await readJson(response, "Prehľad e-shopu sa nepodarilo načítať"));
+}
+
 // #25: zmena stavu riadku objednávky — `lineId` je globálne unikátne (UUID
 // primárny kľúč `order_line.id`), netreba aj `orderId`.
 export async function updateOrderLineState(

--- a/apps/web/src/ordersSummary.test.ts
+++ b/apps/web/src/ordersSummary.test.ts
@@ -2,6 +2,7 @@ import { expect, it } from "vitest";
 import {
   computeVariantTotals,
   countAffectedOrders,
+  formatOrderCount,
   formatOrderSummaryText,
   formatVariantTotalChip,
   isLineHiddenByFilter,
@@ -269,4 +270,25 @@ it("oldestWaitingPlacedAt — ignoruje VYBAVENÉ riadky, aj keby boli staršie",
 it("oldestWaitingPlacedAt — žiadny nevybavený riadok vráti null", () => {
   expect(oldestWaitingPlacedAt([overviewLine("O1", "objednane", true)])).toBeNull();
   expect(oldestWaitingPlacedAt([])).toBeNull();
+});
+
+// issue 237 (code review, minor): slovenský počítateľný tvar — 1 → jednotné
+// číslo, 2-4 → málopočetné (paucal), 0/5+ (vrátane 22/23/24…) → rodový pád
+// množného čísla.
+it("formatOrderCount — 1 je jednotné číslo", () => {
+  expect(formatOrderCount(1)).toBe("1 objednávka");
+});
+
+it("formatOrderCount — 2, 3, 4 sú málopočetné (paucal)", () => {
+  expect(formatOrderCount(2)).toBe("2 objednávky");
+  expect(formatOrderCount(3)).toBe("3 objednávky");
+  expect(formatOrderCount(4)).toBe("4 objednávky");
+});
+
+it("formatOrderCount — 0, 5+ (vrátane 22/23/24) sú rodový pád množného čísla", () => {
+  expect(formatOrderCount(0)).toBe("0 objednávok");
+  expect(formatOrderCount(5)).toBe("5 objednávok");
+  expect(formatOrderCount(22)).toBe("22 objednávok");
+  expect(formatOrderCount(23)).toBe("23 objednávok");
+  expect(formatOrderCount(24)).toBe("24 objednávok");
 });

--- a/apps/web/src/ordersSummary.test.ts
+++ b/apps/web/src/ordersSummary.test.ts
@@ -1,11 +1,13 @@
 import { expect, it } from "vitest";
 import {
   computeVariantTotals,
+  countAffectedOrders,
   formatOrderSummaryText,
   formatVariantTotalChip,
   isLineHiddenByFilter,
   isLineResolved,
   isStaleOrderLine,
+  oldestWaitingPlacedAt,
   orderLineAgeDays,
   STALE_ORDER_LINE_DAYS,
   summarizeOrderLines,
@@ -15,6 +17,13 @@ const line = (state: "objednane" | "caka_sa" | "skladom" | "nedostupne", ordered
   state,
   ordered,
 });
+
+const overviewLine = (
+  orderId: string,
+  state: "objednane" | "caka_sa" | "skladom" | "nedostupne",
+  ordered: boolean,
+  placedAt = "2026-01-01T00:00:00.000Z",
+) => ({ orderId, state, ordered, placedAt });
 
 const variantLine = (
   variantCode: string,
@@ -212,3 +221,52 @@ it("isStaleOrderLine — čerstvý nevybavený riadok nedostane badge", () => {
 // funkciou samotnou — issue 117 zrušilo jej jediné volanie miesto
 // (`OrderLineRow.tsx`'s KÓD stĺpec), takže ostala nepoužitá (code review
 // PR #124).
+
+// issue 237: "Súhrn o objednávaní" — počet DOTKNUTÝCH objednávok a dátum
+// najstaršej čakajúcej.
+
+it("countAffectedOrders — dve nevybavené riadky TEJ ISTEJ objednávky sa počítajú raz", () => {
+  const lines = [overviewLine("O1", "objednane", false), overviewLine("O1", "caka_sa", false)];
+  expect(countAffectedOrders(lines)).toBe(1);
+});
+
+it("countAffectedOrders — nevybavené riadky RÔZNYCH objednávok sa počítajú zvlášť", () => {
+  const lines = [overviewLine("O1", "objednane", false), overviewLine("O2", "objednane", false)];
+  expect(countAffectedOrders(lines)).toBe(2);
+});
+
+it("countAffectedOrders — vybavený riadok (odškrtnutý alebo posunutý stav) sa nepočíta", () => {
+  const lines = [overviewLine("O1", "objednane", true), overviewLine("O2", "skladom", false)];
+  expect(countAffectedOrders(lines)).toBe(0);
+});
+
+it("countAffectedOrders — objednávka s VYBAVENÝM aj NEVYBAVENÝM riadkom sa počíta raz (má aspoň jeden nevybavený)", () => {
+  const lines = [overviewLine("O1", "objednane", true), overviewLine("O1", "objednane", false)];
+  expect(countAffectedOrders(lines)).toBe(1);
+});
+
+it("countAffectedOrders — prázdny zoznam vráti 0", () => {
+  expect(countAffectedOrders([])).toBe(0);
+});
+
+it("oldestWaitingPlacedAt — vráti placedAt najstaršieho NEVYBAVENÉHO riadku", () => {
+  const lines = [
+    overviewLine("O1", "objednane", false, "2026-06-01T00:00:00.000Z"),
+    overviewLine("O2", "objednane", false, "2026-01-15T00:00:00.000Z"),
+    overviewLine("O3", "objednane", false, "2026-03-10T00:00:00.000Z"),
+  ];
+  expect(oldestWaitingPlacedAt(lines)).toBe("2026-01-15T00:00:00.000Z");
+});
+
+it("oldestWaitingPlacedAt — ignoruje VYBAVENÉ riadky, aj keby boli staršie", () => {
+  const lines = [
+    overviewLine("O1", "objednane", true, "2020-01-01T00:00:00.000Z"), // vybavené, staršie
+    overviewLine("O2", "objednane", false, "2026-01-15T00:00:00.000Z"),
+  ];
+  expect(oldestWaitingPlacedAt(lines)).toBe("2026-01-15T00:00:00.000Z");
+});
+
+it("oldestWaitingPlacedAt — žiadny nevybavený riadok vráti null", () => {
+  expect(oldestWaitingPlacedAt([overviewLine("O1", "objednane", true)])).toBeNull();
+  expect(oldestWaitingPlacedAt([])).toBeNull();
+});

--- a/apps/web/src/ordersSummary.ts
+++ b/apps/web/src/ordersSummary.ts
@@ -158,3 +158,46 @@ export function isStaleOrderLine(
 // stĺpec (jej jediné volanie miesto v `OrderLineRow.tsx`), takže funkcia
 // ostala nepoužitá mŕtva produkčná logika (code review PR #124, MVP
 // philosophy: "remove unused code aggressively").
+
+// issue 237: "Súhrn o objednávaní" na obrazovke "Na objednanie" — počet
+// DOTKNUTÝCH objednávok (nie riadkov) a dátum najstaršej čakajúcej
+// objednávky. Obe funkcie počítajú NAD CELOU (nefiltrovanou) množinou
+// riadkov naprieč VŠETKÝMI dodávateľmi — volajúci (`OrdersOverviewTiles.tsx`)
+// posiela vždy VŠETKY riadky zo `suppliers`, nikdy pohľad zúžený prepínačom
+// "skryť vybavené" alebo vybraným dodávateľom (rovnaký zámer ako
+// `computeVariantTotals` vyššie). Obe používajú TEN ISTÝ kanonický predikát
+// `isLineResolved` — žiadna nová/duplicitná definícia "vybavené".
+
+/**
+ * Počet ROZLIŠNÝCH objednávok (`orderId`), ktoré majú aspoň jeden NEVYBAVENÝ
+ * riadok. Priamy náprotivok `summarizeOrderLines(...).remaining` (počet
+ * RIADKOV), len na úrovni OBJEDNÁVKY — jedna objednávka môže mať viacero
+ * nevybavených riadkov (rôzne varianty/dodávatelia), počíta sa len raz.
+ */
+export function countAffectedOrders(
+  lines: readonly Pick<OrderLine, "ordered" | "state" | "orderId">[],
+): number {
+  const orderIds = new Set<string>();
+  for (const line of lines) {
+    if (!isLineResolved(line)) orderIds.add(line.orderId);
+  }
+  return orderIds.size;
+}
+
+/**
+ * `placedAt` (ISO 8601 reťazec) najstaršieho NEVYBAVENÉHO riadku, alebo
+ * `null`, keď nie je žiadny nevybavený riadok. `placedAt` je vždy ISO 8601
+ * (`queries.ts`'s `.toISOString()`), takže reťazcové porovnanie zodpovedá
+ * chronologickému poradiu bez parsovania (rovnaký zámer ako `queries.ts`'s
+ * zoskupovacie triedenie).
+ */
+export function oldestWaitingPlacedAt(
+  lines: readonly Pick<OrderLine, "ordered" | "state" | "placedAt">[],
+): string | null {
+  let oldest: string | null = null;
+  for (const line of lines) {
+    if (isLineResolved(line)) continue;
+    if (oldest === null || line.placedAt < oldest) oldest = line.placedAt;
+  }
+  return oldest;
+}

--- a/apps/web/src/ordersSummary.ts
+++ b/apps/web/src/ordersSummary.ts
@@ -201,3 +201,17 @@ export function oldestWaitingPlacedAt(
   }
   return oldest;
 }
+
+// issue 237 (code review, minor): slovenčina má pri počítateľných
+// podstatných menách TRI tvary (1 → jednotné číslo, 2-4 → málopočetné
+// (paucal), 0/5+ vrátane 22/23/24… → rodový pád množného čísla — na rozdiel
+// od ruštiny/poľštiny sa tvar NEODVODZUJE z poslednej číslice). Priamy
+// náprotivok `apps/api/src/modules/orders/ingest.ts`'s (neexportovanej)
+// `formatCount` — rovnaká sadzba, len na frontende, kde appka počet
+// objednávok skloňuje priamo v texte dlaždice ("Prehľad e-shopu"), nie len
+// spolu s neutrálnou jednotkou ako `formatVariantTotalChip`'s "N ks".
+export function formatOrderCount(n: number): string {
+  if (n === 1) return "1 objednávka";
+  if (n === 2 || n === 3 || n === 4) return `${String(n)} objednávky`;
+  return `${String(n)} objednávok`;
+}

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -723,6 +723,55 @@ tr:last-child td {
   gap: var(--fs-space-1);
 }
 
+/* issue 237: blok dlaždíc NAD zoznamom "Na objednanie" — dve skupiny
+   ("Prehľad e-shopu" + "Súhrn o objednávaní"). Dlaždice sú PREHĽAD, nikdy
+   klikateľný filter (žiadny `cursor: pointer`/`onClick`). */
+.orders-overview {
+  display: flex;
+  flex-direction: column;
+  gap: var(--fs-space-4);
+  margin-bottom: var(--fs-space-5);
+}
+.overview-group-title {
+  font-size: var(--fs-text-sm);
+  font-weight: var(--fs-weight-semibold);
+  color: var(--fs-ink-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  margin: 0 0 var(--fs-space-2);
+}
+.overview-tiles {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--fs-space-3);
+}
+.overview-tile {
+  flex: 1 1 10rem;
+  min-width: 10rem;
+  background: var(--fs-surface);
+  border: 1px solid var(--fs-border-soft);
+  border-radius: var(--fs-radius-md);
+  box-shadow: var(--fs-shadow-sm);
+  padding: var(--fs-space-3) var(--fs-space-4);
+}
+.overview-tile-label {
+  font-size: var(--fs-text-xs);
+  color: var(--fs-ink-muted);
+  margin: 0 0 var(--fs-space-1);
+}
+.overview-tile-value {
+  font-size: var(--fs-text-lg);
+  font-weight: var(--fs-weight-bold);
+  color: var(--fs-ink);
+  margin: 0;
+}
+.overview-tile-sub {
+  font-size: var(--fs-text-sm);
+  color: var(--fs-brand);
+  font-weight: var(--fs-weight-medium);
+  margin: var(--fs-space-1) 0 0;
+}
+
 /* issue 61: filtrovacie štítky dodávateľov + súhrn "ostáva vybaviť" +
    prepínač "skryť vybavené" — vlastný jazyk tejto appky (issue výslovne
    žiada dizajn podľa NOVEJ appky, nie prevzaté farby starej). */

--- a/apps/web/tests/e2e/orders-overview.spec.ts
+++ b/apps/web/tests/e2e/orders-overview.spec.ts
@@ -55,9 +55,9 @@ test("blok 'Prehľad e-shopu' + 'Súhrn o objednávaní' sa zobrazí a čísla z
   // reálnych dát `/api/orders/open` (rovnaká autentifikovaná session, čo
   // appka sama načítava) — nie hardcoded číslo, ktoré by závisel od poradia
   // spustenia ostatných spec súborov v tom istom e2e behu.
-  const { suppliers } = (await page.evaluate(() =>
+  const { suppliers } = await page.evaluate(() =>
     fetch("/api/orders/open").then((r) => r.json() as Promise<{ suppliers: readonly RawSupplierGroup[] }>),
-  )) as { suppliers: readonly RawSupplierGroup[] };
+  );
   const allLines = suppliers.flatMap((g) => g.lines);
   const isResolved = (l: RawOrderLine): boolean => l.ordered || l.state !== "objednane";
   const nevybavene = allLines.filter((l) => !isResolved(l));

--- a/apps/web/tests/e2e/orders-overview.spec.ts
+++ b/apps/web/tests/e2e/orders-overview.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test } from "@playwright/test";
+
+const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
+const E2E_PREHLAD_EMAIL = "e2e-prehlad@forestshop.sk";
+
+interface RawOrderLine {
+  readonly orderId: string;
+  readonly ordered: boolean;
+  readonly state: "objednane" | "caka_sa" | "skladom" | "nedostupne";
+  readonly placedAt: string;
+}
+interface RawSupplierGroup {
+  readonly lines: readonly RawOrderLine[];
+}
+
+// issue 237: blok dlaždíc nad zoznamom "Na objednanie" — "Prehľad e-shopu"
+// (dnes/tento týždeň/tento mesiac) + "Súhrn o objednávaní". VLASTNÝ izolovaný
+// účet (`scripts/e2e-setup.ts`'s komentár k `E2E_PREHLAD_EMAIL` — zdieľaný
+// balík je už na hranici `MAX_ATTEMPTS`).
+test("blok 'Prehľad e-shopu' + 'Súhrn o objednávaní' sa zobrazí a čísla zodpovedajú reálnym dátam z /api/orders/open, konzola je čistá", async ({
+  page,
+}) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/?tab=orders");
+  await page.getByLabel("E-mail").fill(E2E_PREHLAD_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await expect(page.getByRole("heading", { name: "Na objednanie" })).toBeVisible();
+
+  // "Prehľad e-shopu" — `scripts/e2e-setup.ts` seeduje PRESNE JEDNU objednávku
+  // (externalOrderId "9009", ŽIADNY order_line) s `placedAt: teraz` a
+  // `totalPriceWithVat: "77.50"` — jediná objednávka, ktorá je isto "dnes",
+  // takže dlaždica DNES má DETERMINISTICKÉ, presne overiteľné číslo.
+  const dnesDlazdica = page.getByTestId("overview-shop-today");
+  await expect(dnesDlazdica).toBeVisible();
+  await expect(dnesDlazdica).toContainText("1 objednávok");
+  await expect(dnesDlazdica).toContainText("77.50 €");
+
+  // Tento týždeň/mesiac VŽDY obsahuje aspoň dnešnú objednávku — presný počet
+  // by závisel od toho, KEDY presne e2e beh prebehne voči ostatným
+  // (staršie dátumované) seedovaným objednávkam, preto len dolná hranica.
+  const tyzdenDlazdica = page.getByTestId("overview-shop-week");
+  const mesiacDlazdica = page.getByTestId("overview-shop-month");
+  await expect(tyzdenDlazdica).toContainText("objednávok");
+  await expect(mesiacDlazdica).toContainText("objednávok");
+
+  // "Súhrn o objednávaní" — porovnané NEZÁVISLE vypočítanou hodnotou z
+  // reálnych dát `/api/orders/open` (rovnaká autentifikovaná session, čo
+  // appka sama načítava) — nie hardcoded číslo, ktoré by závisel od poradia
+  // spustenia ostatných spec súborov v tom istom e2e behu.
+  const { suppliers } = (await page.evaluate(() =>
+    fetch("/api/orders/open").then((r) => r.json() as Promise<{ suppliers: readonly RawSupplierGroup[] }>),
+  )) as { suppliers: readonly RawSupplierGroup[] };
+  const allLines = suppliers.flatMap((g) => g.lines);
+  const isResolved = (l: RawOrderLine): boolean => l.ordered || l.state !== "objednane";
+  const nevybavene = allLines.filter((l) => !isResolved(l));
+  const ocakavaneRemaining = nevybavene.length;
+  const ocakavaneAffected = new Set(nevybavene.map((l) => l.orderId)).size;
+  const ocakavaneOrdered = allLines.filter((l) => l.ordered).length;
+
+  await expect(page.getByTestId("overview-ordering-remaining")).toContainText(String(ocakavaneRemaining));
+  await expect(page.getByTestId("overview-ordering-affected-orders")).toContainText(String(ocakavaneAffected));
+  await expect(page.getByTestId("overview-ordering-already-ordered")).toContainText(String(ocakavaneOrdered));
+
+  // Seed dáta (`scripts/e2e-setup.ts`) vždy nechávajú aspoň jeden nevybavený
+  // riadok, takže dlaždica "Najstaršia čakajúca" musí ukázať SKUTOČNÝ dátum
+  // (obsahuje číslicu), nikdy zástupnú pomlčku.
+  expect(ocakavaneRemaining).toBeGreaterThan(0);
+  await expect(page.getByTestId("overview-ordering-oldest")).not.toHaveText("—");
+  await expect(page.getByTestId("overview-ordering-oldest")).toContainText(/\d/);
+
+  // Dlaždice sú PREHĽAD, nikdy filter — klik na "Súhrn o objednávaní" tlačidlá
+  // (nie sú klikateľné vôbec) nemení obsah zoznamu; overuje sa tu jednoducho
+  // tak, že blok nemá žiadny `<button>` element.
+  await expect(page.getByTestId("orders-overview").locator("button")).toHaveCount(0);
+
+  expect(chyby).toEqual([]);
+});

--- a/apps/web/tests/e2e/orders-overview.spec.ts
+++ b/apps/web/tests/e2e/orders-overview.spec.ts
@@ -40,7 +40,7 @@ test("blok 'Prehľad e-shopu' + 'Súhrn o objednávaní' sa zobrazí a čísla z
   // takže dlaždica DNES má DETERMINISTICKÉ, presne overiteľné číslo.
   const dnesDlazdica = page.getByTestId("overview-shop-today");
   await expect(dnesDlazdica).toBeVisible();
-  await expect(dnesDlazdica).toContainText("1 objednávok");
+  await expect(dnesDlazdica).toContainText("1 objednávka");
   await expect(dnesDlazdica).toContainText("77.50 €");
 
   // Tento týždeň/mesiac VŽDY obsahuje aspoň dnešnú objednávku — presný počet
@@ -48,8 +48,12 @@ test("blok 'Prehľad e-shopu' + 'Súhrn o objednávaní' sa zobrazí a čísla z
   // (staršie dátumované) seedovaným objednávkam, preto len dolná hranica.
   const tyzdenDlazdica = page.getByTestId("overview-shop-week");
   const mesiacDlazdica = page.getByTestId("overview-shop-month");
-  await expect(tyzdenDlazdica).toContainText("objednávok");
-  await expect(mesiacDlazdica).toContainText("objednávok");
+  // "objednáv" (spoločný prefix) namiesto presného tvaru — počet v týchto
+  // dvoch dlaždiciach môže padnúť do ktoréhokoľvek z troch slovenských tvarov
+  // (`formatOrderCount`: 1/2-4/5+), podľa toho, koľko ĎALŠÍCH seedovaných
+  // objednávok práve v momente behu spadá do tohto týždňa/mesiaca.
+  await expect(tyzdenDlazdica).toContainText(/\d+\s+objednáv/);
+  await expect(mesiacDlazdica).toContainText(/\d+\s+objednáv/);
 
   // "Súhrn o objednávaní" — porovnané NEZÁVISLE vypočítanou hodnotou z
   // reálnych dát `/api/orders/open` (rovnaká autentifikovaná session, čo

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -2561,3 +2561,32 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   takmer všetko), trimmed fixtúry bez JSON-LD → `source: text`, obe
   polarity aj chýbajúci štítok správne. Issue zavreté ručne s dôkazom,
   Discord run-card odoslaná.
+
+- issue 226 (krížová kontrola nášho stavu proti Shoptetovej dostupnosti z
+  feedu google.xml): version bump `1d6c36a` (0.3.0-dev.138). RED `913b800`
+  (parse.test.ts g:availability extrakcia, nový feed-cross-check.test.ts,
+  nový catalog-feed-cross-check.integration.test.ts, restock-run.integration
+  .test.ts Z1/Z2/Z3, RestockSection.test.tsx karta, e2e PREP-2 + catalog.spec
+  .ts počty 36→37 — všetko zámerne padajúce, feature ešte neexistovala).
+  GREEN `3d8204e` (migrácia 0030 `shop_product_url.availability`,
+  `parseShopFeed`/`runShopFeed` ukladajú g:availability, nový
+  `modules/catalog/feed-cross-check.ts` — `compareStateToFeed` čistá funkcia
+  + `findFeedStateConflicts` naživo z DB, nikdy perzistovaná snímka +
+  `logFeedConflictsAfterImport` mimo hlavnej transakcie; `restock/queries.ts`
+  vylúči kandidáta keď feed hovorí "in stock"; `/api/restock` +
+  RestockSection.tsx nová karta s počtom aj zoznamom; scripts/e2e-setup.ts
+  doplnilo shop_product_url do TRUNCATE zoznamu — chýbalo tam od issue 220).
+  PR #243, code review (`superpowers:requesting-code-review`, nezávislý
+  subagent): 0 Critical, 2 Important (test-hygiene: `ourUrl: null` mock
+  proti nenulovej schéme, chýbajúci test na prepis dostupnosti na null pri
+  strate značky) — obe opravené `5ef9923`. Merge `e658a7b`. Deploy prvý
+  pokus zlyhal na známom transientnom containerd/overlayfs jave
+  (`.claude/rules/deploy.md`, "failed commit on ref ... no such file or
+  directory") — `gh run rerun --failed` prešiel na druhý pokus. Naživo
+  overené proti nasadenej appke (0.3.0-dev.138): dočasný zásah do
+  `shop_product_url.availability` na reálnych variantoch (60031/XXL,
+  61276/M) ukázal kartu rozporov aj vylúčenie z kandidátov presne podľa
+  očakávania, oba vrátené na pôvodné `null` po overení (Pripravených na
+  prepnutie späť na 2, Rozpory: Žiadne). Issue zavreté ručne s dôkazom,
+  Discord run-card odoslaná. Playbook doplnený v GREEN commite
+  (`.claude/rules/shop-feed.md`, `.claude/rules/supplier-stock.md`).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.138",
+  "version": "0.3.0-dev.139",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -158,6 +158,11 @@ const E2E_KNIHA_EMAIL = "e2e-kniha@forestshop.sk"; // musí sa zhodovať s hodno
 // spec súbor (`restock-waiting.spec.ts`) dostáva VLASTNÝ izolovaný účet.
 const E2E_PREPINANIE_EMAIL = "e2e-prepinanie@forestshop.sk"; // musí sa zhodovať s hodnotou v restock-waiting.spec.ts
 
+// issue 237: rovnaký mechanizmus a dôvod ako `E2E_PREPINANIE_EMAIL` vyššie —
+// nový spec súbor (`orders-overview.spec.ts` — blok dlaždíc "Prehľad
+// e-shopu"/"Súhrn o objednávaní") dostáva VLASTNÝ izolovaný účet.
+const E2E_PREHLAD_EMAIL = "e2e-prehlad@forestshop.sk"; // musí sa zhodovať s hodnotou v orders-overview.spec.ts
+
 const { db, pool } = createDb();
 // Konštantný literál bez interpolácie — obyčajný reťazec je tu rovnako bezpečný
 // ako `sql` tagovaná šablóna (tú používa ekvivalentný apps/api/tests/helpers/db.ts),
@@ -319,6 +324,12 @@ await db.insert(users).values({
 });
 await db.insert(users).values({
   email: E2E_PREPINANIE_EMAIL,
+  passwordHash: await hashPassword(E2E_HESLO),
+  displayName: "E2E Manažér",
+  role: "manazer",
+});
+await db.insert(users).values({
+  email: E2E_PREHLAD_EMAIL,
   passwordHash: await hashPassword(E2E_HESLO),
   displayName: "E2E Manažér",
   role: "manazer",
@@ -684,6 +695,23 @@ await db.insert(shopProductUrl).values({
   url: "https://www.forestshop.sk/e2e-rozpor/",
   availability: "in stock",
   fetchedAt: teraz,
+});
+
+// issue 237: JEDNA objednávka pre "Prehľad e-shopu" (dnes/tento
+// týždeň/tento mesiac) — `placedAt: teraz` (rovnaké "teraz" ako mail_log
+// riadky vyššie), aby vždy spadla do "dnes" bez ohľadu na to, kedy e2e beh
+// skutočne prebehne. ZÁMERNE bez akéhokoľvek `order_line` — dashboard
+// "Prehľad e-shopu" číta priamo `order` tabuľku (`orders/overview.ts`), nie
+// cez `order_line` JOIN ako "Na objednanie" — objednávka bez riadku sa preto
+// v `listOpenOrderLinesBySupplier` (INNER JOIN) vôbec nezobrazí a NEMENÍ
+// žiadny existujúci "Všetci (N)"/"(bez dodávateľa) (N)" počet, ktorý ostatné
+// testy overujú presne.
+await db.insert(orders).values({
+  externalOrderId: "9009",
+  customerName: "E2E Zákazník Prehľad",
+  statusName: DEFAULT_ORDER_OPEN_STATUS,
+  placedAt: teraz,
+  totalPriceWithVat: "77.50",
 });
 
 await pool.end();


### PR DESCRIPTION
## Čo pridáva

Blok dlaždíc NAD zoznamom na obrazovke "Na objednanie" — dve skupiny:

1. **Prehľad e-shopu** — počet objednávok + tržba (s DPH) za dnes/tento
   týždeň/tento mesiac, presne ako Shoptet-ov vlastný dashboard. Nová
   `orders.total_price_with_vat` sa extrahuje z exportu (Shoptet-ovo pole,
   vždy osviežené pri re-importe).
2. **Súhrn o objednávaní** — koľko položiek treba objednať, koľkých
   objednávok sa to týka, koľko je už objednaných, dátum najstaršej
   čakajúcej objednávky. Počítané čisto z už načítaných dát, žiadna nová
   trasa.

## Overenie

- Unit: `apps/api/src/modules/orders/overview.test.ts` (13),
  `apps/web/src/ordersSummary.test.ts` (33, vrátane 2 nových funkcií),
  `apps/web/src/components/OrdersOverviewTiles.test.tsx` (5).
- Integration: `apps/api/tests/orders-overview.integration.test.ts` (7),
  `apps/api/tests/orders-ingest-total-price.integration.test.ts` (2).
- E2E: `apps/web/tests/e2e/orders-overview.spec.ts` — porovnáva zobrazené
  čísla proti `/api/orders/open` naživo.
- Celá lokálna sada (unit + integration + e2e) zelená pred pushom.

## Poznámka k zatvoreniu ticketu

Ticket 237 má akceptačnú podmienku "naživo overené na
forestshop-novy.newlevel.media proti Shoptetu" — to sa deje AŽ po merge +
deployi, preto telo tohto PR zámerne nemá `Closes #237`. Zatvorí sa ručne
po živom overení.
