### PR TITLE
Nedostupné tovary: ručné odkazy náhrad, prekliky, upraviteľný text e-mailu

### DIFF
--- a/.claude/rules/mail-templates.md
+++ b/.claude/rules/mail-templates.md
@@ -74,3 +74,11 @@ paths:
   testoch, takže vlastný izolovaný účet pre nový spec súbor je stále povinný.
   **Nový e2e test aj tak nepridávaj s vlastným prihlásením zbytočne** — dva
   scenáre v jednom teste sú lacnejšie než dve prihlásenia.
+- **issue 238: `samples.ts`'s "náhľad na skutočných dátach" pre
+  `nedostupne_alternativa`'s `zoznam_nahrad` teraz vychádza z
+  `nedostupne_replacement_link` (majiteľove ručné odkazy), nie z pôvodného
+  `product.relatedCodes` návrhu.** `productSample` vracia aj `variant.code`
+  (predtým len `name`) — presne TEN variant, ktorého manuálne odkazy
+  `replacementLinkSample` vyhľadá. Rovnaký "vzorka nikdy nespadne, len
+  ukáže ukážkovú hodnotu z registra" kontrakt platí ďalej (nič nezmenené v
+  `try/catch` obale `previewContext`u).

--- a/.claude/rules/nedostupne.md
+++ b/.claude/rules/nedostupne.md
@@ -26,16 +26,40 @@ paths:
   `GET /api/nedostupne` je VŽDY živý DB dopyt, nikdy `job_run.detail` cache.
   Jednoduchšie, žiadna zbytočná zložitosť (MVP) — nová podobná automatizácia
   BEZ plánovaného behu by mala rovnako vynechať settings/`job_run` vrstvu.
-- **`product.related_codes` (text[]) — návrh náhrady zo Shoptetu, populovaný
-  pri katalogovom importe z CSV `relatedProduct`/`relatedProduct2..8`**
-  (`catalog/map-row.ts`'s `extractRelatedCodes`/`MAX_ALTERNATIVES=8`) — PRVÝ
-  stĺpec je bare `relatedProduct` (NIE `relatedProduct1`), overené priamo na
-  reálnej fixtúre. Vlastnosť PRODUKTU (rovnaký first-wins vzor ako
-  `internalNote`/`supplier` v `ingest.ts`), nie variantu. Appka NEMÁ zdroj
-  skutočnej Shoptet produktovej URL (overené na exporte — žiadny `url`/
-  `seoUrl` stĺpec) — alternatívy dostávajú VŽDY klikateľný vyhľadávací
-  fallback (`alternativeSearchUrl`), nikdy sa neintegroval starý marketingový
-  XML feed (zámerne zamietnuté ako zbytočná nová externá závislosť).
+- **PREKONANÉ issue 238-om (2026-08-04, ponechané pre históriu): `product.
+  related_codes` (text[]) — automatický návrh náhrady zo Shoptetu (CSV
+  `relatedProduct`/`relatedProduct2..8`, `catalog/map-row.ts`'s
+  `extractRelatedCodes`/`MAX_ALTERNATIVES=8`), s `alternativeSearchUrl`
+  vyhľadávacím fallbackom, keď appka nemala skutočnú produktovú URL.**
+  Majiteľ tento CELÝ mechanizmus zamietol: *"nechcem aby to uvádzalo tieto
+  náhrady - je to blbosť, to sú súvisiace produkty - nie podobné, nie
+  náhrady"*. Nahradené RUČNÝMI odkazmi (bod nižšie) — `product.related_codes`
+  stĺpec + jeho import (`map-row.ts`/`ingest.ts`) ostávajú v kóde (mimo scope
+  cross-cutting zásahu do katalógového importu), ale appka ich už NIKDE
+  nečíta — follow-up na úplné odstránenie: issue 245.
+- **issue 238: majiteľove RUČNE vložené odkazy náhrad —
+  `nedostupne_replacement_link` (`variant_code` PLAIN text bez FK, rovnaká
+  konvencia ako `nedostupne_state`; `url`; ŽIADNY unique index).** Kľúčované
+  VARIANTOM (nie `product.key` ako `product_supplier_link_override`) — screen
+  aj e-mail sú per-variant granularita (`NedostupneGroup`), majiteľov nákres
+  dáva pole PRI KAŽDOM TOVARE (skupina), nie pri každom čakajúcom
+  zákazníckom riadku. Viac riadkov s rovnakým `variant_code` = zoznam liniek
+  (`modules/nedostupne/replacement-links.ts`, zoradené `asc(createdAt)` —
+  poradie vloženia, prvý pridaný je zvyčajne najviac odporúčaný). Appka k
+  ručne vloženému odkazu nepozná žiadny názov/kód produktu, preto e-mailový
+  `zoznam_nahrad`'s `label` je SAMOTNÁ url (`logic.ts`'s
+  `buildAlternativeEmail`). Prežije nočný katalógový reimport bez ďalšej
+  práce — import sa tejto tabuľky vôbec nedotýka (rovnaký zámer ako
+  `nedostupne_state`/`mail_template`).
+- **issue 238: preklik na náš e-shop (názov produktu) NEPOUŽÍVA
+  `shopLinks.ts`'s `ourProductLink` vyhľadávací fallback, na rozdiel od
+  `restock` obrazovky** — ticket žiada explicitne "ak adresu nemáme, názov
+  ostane neaktívny, nikdy nevyrábať odhadom", takže `queries.ts` číta priamo
+  `shop_product_url.url` (LEFT JOIN podľa `variantCode`) a frontend
+  vykreslí `<a>` LEN keď nie je `null`, inak plain text. Preklik na kód
+  produktu (dodávateľ) naopak ZDIEĽA existujúcu `resolveEffectiveSupplierLink`
+  (`orders/effective-supplier-link.ts`) — rovnaká funkcia ako "Na
+  objednanie", žiadna duplicitná logika.
 - **Dedup (`nedostupne_state`) je serializovaný `NEDOSTUPNE_SEND_LOCK_KEY`
   (`787_878_006`) — bez zámku by dva súbežné klik-y na TEN ISTÝ (objednávka,
   variant, typ) mohli OBA prejsť dedup-check pred zápisom a poslať e-mail

--- a/apps/api/drizzle/0032_tiresome_matthew_murdock.sql
+++ b/apps/api/drizzle/0032_tiresome_matthew_murdock.sql
@@ -1,0 +1,8 @@
+CREATE TABLE "nedostupne_replacement_link" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"variant_code" text NOT NULL,
+	"url" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "nedostupne_replacement_link_variant_idx" ON "nedostupne_replacement_link" USING btree ("variant_code");

--- a/apps/api/drizzle/meta/0032_snapshot.json
+++ b/apps/api/drizzle/meta/0032_snapshot.json
@@ -1,0 +1,2557 @@
+{
+  "id": "5ed2f876-136a-49be-96b3-e78844a7d70c",
+  "prevId": "6d57c0db-8a70-4b26-b6b4-0889f18810cb",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "related_codes": {
+          "name": "related_codes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_code": {
+          "name": "external_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_open_status": {
+      "name": "order_open_status",
+      "schema": "",
+      "columns": {
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Vybavuje sa'"
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop_remark": {
+          "name": "shop_remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shoptet_order_id": {
+          "name": "shoptet_order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_updated_at": {
+          "name": "comment_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_synced_at": {
+          "name": "comment_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_carrier_name": {
+          "name": "shipping_carrier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_price_with_vat": {
+          "name": "total_price_with_vat",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_link_override": {
+      "name": "product_supplier_link_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_link_override_product_key_product_key_fk": {
+          "name": "product_supplier_link_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_link_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_override": {
+      "name": "product_supplier_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_override_product_key_product_key_fk": {
+          "name": "product_supplier_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing": {
+      "name": "pairing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_url": {
+          "name": "supplier_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "pairing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'navrhnute'"
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pairing_state_idx": {
+          "name": "pairing_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_confirmed_by_idx": {
+          "name": "pairing_confirmed_by_idx",
+          "columns": [
+            {
+              "expression": "confirmed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_variant_code_variant_code_fk": {
+          "name": "pairing_variant_code_variant_code_fk",
+          "tableFrom": "pairing",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pairing_confirmed_by_users_id_fk": {
+          "name": "pairing_confirmed_by_users_id_fk",
+          "tableFrom": "pairing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pairing_variant_code_unique": {
+          "name": "pairing_variant_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pairing_confirmation_ck": {
+          "name": "pairing_confirmation_ck",
+          "value": "(\"pairing\".\"state\" = 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)\n        OR (\"pairing\".\"state\" != 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NULL AND \"pairing\".\"confirmed_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier": {
+      "name": "supplier",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wholesale_base_url": {
+          "name": "wholesale_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_key": {
+          "name": "adapter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_settings": {
+      "name": "posta_uncollected_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_state": {
+      "name": "posta_uncollected_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notify_count": {
+          "name": "notify_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_state": {
+          "name": "terminal_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_settings": {
+      "name": "order_reminder_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_state": {
+      "name": "order_reminder_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_replacement_link": {
+      "name": "nedostupne_replacement_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nedostupne_replacement_link_variant_idx": {
+          "name": "nedostupne_replacement_link_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_state": {
+      "name": "nedostupne_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "nedostupne_email_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nedostupne_state_order_variant_type_uq": {
+          "name": "nedostupne_state_order_variant_type_uq",
+          "columns": [
+            {
+              "expression": "order_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template_history": {
+      "name": "mail_template_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "mail_template_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_template_history_key_idx": {
+          "name": "mail_template_history_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_template_history_changed_by_user_id_users_id_fk": {
+          "name": "mail_template_history_changed_by_user_id_users_id_fk",
+          "tableFrom": "mail_template_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template": {
+      "name": "mail_template",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail_template_updated_by_user_id_users_id_fk": {
+          "name": "mail_template_updated_by_user_id_users_id_fk",
+          "tableFrom": "mail_template",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_log": {
+      "name": "mail_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "mail_log_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_log_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "mail_log_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_log_created_idx": {
+          "name": "mail_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_log_source_created_idx": {
+          "name": "mail_log_source_created_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_log_actor_user_id_users_id_fk": {
+          "name": "mail_log_actor_user_id_users_id_fk",
+          "tableFrom": "mail_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_stock": {
+      "name": "supplier_stock",
+      "schema": "",
+      "columns": {
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "supplier_availability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "supplier_stock_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "supplier_stock_host_idx": {
+          "name": "supplier_stock_host_idx",
+          "columns": [
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "supplier_stock_avail_idx": {
+          "name": "supplier_stock_avail_idx",
+          "columns": [
+            {
+              "expression": "availability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "supplier_stock_link_size_label_pk": {
+          "name": "supplier_stock_link_size_label_pk",
+          "columns": [
+            "link",
+            "size_label"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_event": {
+      "name": "restock_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_link": {
+          "name": "supplier_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_availability_text": {
+          "name": "supplier_availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "supplier_price": {
+          "name": "supplier_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "restock_event_at_idx": {
+          "name": "restock_event_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "restock_event_variant_idx": {
+          "name": "restock_event_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_settings": {
+      "name": "restock_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shop_product_url": {
+      "name": "shop_product_url",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne"
+      ]
+    },
+    "public.pairing_state": {
+      "name": "pairing_state",
+      "schema": "public",
+      "values": [
+        "navrhnute",
+        "potvrdene"
+      ]
+    },
+    "public.nedostupne_email_type": {
+      "name": "nedostupne_email_type",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "alternativa"
+      ]
+    },
+    "public.mail_template_action": {
+      "name": "mail_template_action",
+      "schema": "public",
+      "values": [
+        "save",
+        "reset"
+      ]
+    },
+    "public.mail_log_source": {
+      "name": "mail_log_source",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "posta_uncollected",
+        "order_reminder",
+        "supplier_order"
+      ]
+    },
+    "public.mail_log_status": {
+      "name": "mail_log_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.mail_log_trigger": {
+      "name": "mail_log_trigger",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "manual"
+      ]
+    },
+    "public.supplier_availability": {
+      "name": "supplier_availability",
+      "schema": "public",
+      "values": [
+        "available",
+        "unavailable",
+        "unknown"
+      ]
+    },
+    "public.supplier_stock_source": {
+      "name": "supplier_stock_source",
+      "schema": "public",
+      "values": [
+        "json_ld",
+        "meta",
+        "text",
+        "size_list",
+        "none"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1785866205378,
       "tag": "0031_handy_talon",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1785874055555,
+      "tag": "0032_tiresome_matthew_murdock",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema-nedostupne.ts
+++ b/apps/api/src/db/schema-nedostupne.ts
@@ -1,4 +1,4 @@
-import { pgEnum, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { index, pgEnum, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
 
 // issue 176: "Nedostupné tovary" — dva e-mailové typy (bez náhrady / s
 // návrhom náhrady), rovnaký zámer ako stará appka's `nedostupne.py`'s
@@ -26,4 +26,30 @@ export const nedostupneState = pgTable(
   (t) => [
     uniqueIndex("nedostupne_state_order_variant_type_uq").on(t.orderCode, t.variantCode, t.emailType),
   ],
+);
+
+// issue 238: majiteľ, doslovne "nechcem aby to uvádzalo tieto náhrady - je to
+// blbosť, to sú súvisiace produkty - nie podobné, nie náhrady" — automatický
+// návrh (`product.related_codes`, vyššie zavrhnutý celý mechanizmus) sa ruší
+// a nahrádza RUČNÝMI odkazmi, ktoré majiteľ sám vloží. Kľúčovaná
+// `variant_code` (PLAIN text, BEZ FK — rovnaká konvencia ako `nedostupne_state`
+// vyššie), NIE dvojicou (objednávka, variant): obrazovka zoskupuje podľa
+// VARIANTU (`NedostupneGroup`), majiteľov nákres dáva pole PRI KAŽDOM TOVARE
+// (skupina), nie pri každom čakajúcom zákazníckom riadku — inak by musel ten
+// istý odkaz vpisovať znova pre každú objednávku toho istého tovaru. ŽIADNY
+// unique index na `variant_code` — viac riadkov s rovnakým kódom = viac
+// liniek na ten istý tovar, presne požiadavka "musí sa dať vložiť viac".
+// Prežije nočný katalógový reimport rovnako ako `nedostupne_state`/
+// `mail_template` — import sa tejto tabuľky vôbec nedotýka (`product.
+// related_codes`/jeho import OSTÁVA nedotknutý, len appka ho už nikde
+// nečíta — zámerné mimo scope, viď návrhový komentár na tickete).
+export const nedostupneReplacementLinks = pgTable(
+  "nedostupne_replacement_link",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    variantCode: text("variant_code").notNull(),
+    url: text("url").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [index("nedostupne_replacement_link_variant_idx").on(t.variantCode)],
 );

--- a/apps/api/src/http/nedostupne-routes.ts
+++ b/apps/api/src/http/nedostupne-routes.ts
@@ -6,8 +6,10 @@ import { record } from "../modules/audit/service.js";
 import { EMAIL_TYPES } from "../modules/nedostupne/constants.js";
 import { consumePreviewToken, issuePreviewToken } from "../modules/nedostupne/preview-tokens.js";
 import { listNedostupneGroups } from "../modules/nedostupne/queries.js";
+import { addReplacementLink, removeReplacementLink } from "../modules/nedostupne/replacement-links.js";
 import { buildEmailForType, findNedostupneContext, sendNedostupneEmail } from "../modules/nedostupne/send.js";
 import type { MailTransport } from "../modules/mail/transport.js";
+import { startsWithFormulaChar } from "../modules/shoptet-writeback/formula-guard.js";
 import { requireRole, requireUser, type AppBindings } from "./middleware.js";
 import { requireSameOrigin } from "./origin-check.js";
 
@@ -24,6 +26,25 @@ const previewBody = z.object({ orderCode: z.string().min(1), variantCode: z.stri
 // `preview-tokens.ts`. Bez tohto by priame volanie API (mimo React UI) mohlo
 // poslať e-mail bez toho, aby čokoľvek jeho obsah niekedy zobrazilo.
 const sendBody = previewBody.extend({ previewToken: z.string().min(1) });
+
+// issue 238: majiteľov RUČNE vložený odkaz náhrady — validovaný ako URL
+// (rovnaká disciplína ako `orders-routes.ts`'s `orderLineSupplierLinkBody`,
+// issue 121/153): odkaz sa vykresľuje priamo ako `<a href>` v e-maile
+// zákazníkovi, takže potrebuje TÚ ISTÚ obranu (http(s)-only regex + formula-
+// injection `.refine`), nielen holé `.url()`.
+const replacementLinkBody = z.object({
+  variantCode: z.string().trim().min(1).max(200),
+  url: z
+    .string()
+    .trim()
+    .url()
+    .max(2000)
+    .regex(/^https?:\/\//)
+    .refine((v) => !startsWithFormulaChar(v), {
+      message: "odkaz nesmie začínať znakom vzorca (=, +, -, @) — možný pokus o CSV-injection",
+    }),
+});
+const replacementLinkParam = z.object({ id: z.string().uuid() });
 
 function bccMissing(deps: NedostupneRunDeps): boolean {
   return deps.bccEmail === undefined || deps.bccEmail.trim() === "";
@@ -125,6 +146,61 @@ export function registerNedostupneRoutes(app: Hono<AppBindings>, db: Database, d
         data: { orderCode, variantCode, emailType },
       });
       return c.json({ ok: true as const });
+    },
+  );
+
+  // issue 238: majiteľ pridá ručný odkaz náhrady — rovnaké oprávnenie ako
+  // `/send` (admin/manazer, `.claude/rules/nedostupne.md`'s dizajnový
+  // komentár), rovnaký jednoduchý insert+audit vzor ako
+  // `orders/supplier-link-assignment.ts`'s `setProductSupplierLink`.
+  app.post(
+    "/api/nedostupne/replacement-links",
+    requireSameOrigin(),
+    requireUser(db),
+    requireRole("admin", "manazer"),
+    zValidator("json", replacementLinkBody),
+    async (c) => {
+      const { variantCode, url } = c.req.valid("json");
+      const user = c.get("user");
+      const now = new Date();
+      const link = await addReplacementLink(db, variantCode, url, now);
+      await record(db, {
+        at: now,
+        actorUserId: user.userId,
+        action: "nedostupne.replacement_link.added",
+        entity: "nedostupne_replacement_link",
+        entityId: link.id,
+        data: { variantCode, url },
+      });
+      return c.json({ ok: true as const, link });
+    },
+  );
+
+  // Zmazanie — rovnaké oprávnenie. `id` neznáme/už zmazané je NEŠKODNÉ
+  // (rovnaká disciplína ako `.claude/rules/testing.md`'s "bežné, OČAKÁVANÉ
+  // zlyhanie vracia 200 {ok:false}", nikdy 4xx) — dvojklik na "zmazať" je
+  // bežná používateľská udalosť, nie chyba.
+  app.delete(
+    "/api/nedostupne/replacement-links/:id",
+    requireSameOrigin(),
+    requireUser(db),
+    requireRole("admin", "manazer"),
+    zValidator("param", replacementLinkParam),
+    async (c) => {
+      const { id } = c.req.valid("param");
+      const user = c.get("user");
+      const removed = await removeReplacementLink(db, id);
+      if (removed) {
+        await record(db, {
+          at: new Date(),
+          actorUserId: user.userId,
+          action: "nedostupne.replacement_link.removed",
+          entity: "nedostupne_replacement_link",
+          entityId: id,
+          data: { id },
+        });
+      }
+      return c.json({ ok: true as const, removed });
     },
   );
 }

--- a/apps/api/src/modules/mail-templates/samples.ts
+++ b/apps/api/src/modules/mail-templates/samples.ts
@@ -2,7 +2,7 @@ import { desc, isNotNull } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
 import { orders, products, variants } from "../../db/schema.js";
 import { log } from "../../logger.js";
-import { alternativeSearchUrl } from "../nedostupne/constants.js";
+import { listReplacementLinksByVariant } from "../nedostupne/replacement-links.js";
 import { itemsWord } from "../orders/pluralize.js";
 import { trackingLink } from "../posta-uncollected/constants.js";
 import { textValue } from "./context.js";
@@ -35,11 +35,18 @@ async function latestOrderWithPackage(db: Database): Promise<{ customerName: str
   return row?.packageNumber == null ? null : { customerName: row.customerName, packageNumber: row.packageNumber };
 }
 
-async function productSample(db: Database): Promise<{ name: string; relatedCodes: readonly string[] } | null> {
-  const [row] = await db.select({ name: variants.name, productKey: variants.productKey }).from(variants).limit(1);
-  if (row === undefined) return null;
-  const [prod] = await db.select({ relatedCodes: products.relatedCodes }).from(products).limit(1);
-  return { name: row.name, relatedCodes: prod?.relatedCodes ?? [] };
+async function productSample(db: Database): Promise<{ name: string; code: string } | null> {
+  const [row] = await db.select({ name: variants.name, code: variants.code }).from(variants).limit(1);
+  return row ?? null;
+}
+
+// issue 238: vzorka pre "zoznam_nahrad" teraz vychádza z majiteľových
+// RUČNE vložených odkazov (`nedostupne_replacement_link`), nie z pôvodného
+// automatického `product.relatedCodes` návrhu — ten istý variant, ktorého
+// meno použije `nazov_tovaru` vyššie.
+async function replacementLinkSample(db: Database, variantCode: string): Promise<readonly string[]> {
+  const map = await listReplacementLinksByVariant(db, [variantCode]);
+  return (map.get(variantCode) ?? []).map((link) => link.url);
 }
 
 async function supplierSample(db: Database): Promise<string | null> {
@@ -66,11 +73,12 @@ export async function previewContext(db: Database, key: MailTemplateKey): Promis
         const product = await productSample(db);
         if (product !== null) {
           ctx["nazov_tovaru"] = textValue(product.name);
-          if (product.relatedCodes.length > 0) {
+          const links = await replacementLinkSample(db, product.code);
+          if (links.length > 0) {
             ctx["zoznam_nahrad"] = {
               kind: "list",
               textPrefix: "- ",
-              items: product.relatedCodes.map((code) => ({ label: code, url: alternativeSearchUrl(code) })),
+              items: links.map((url) => ({ label: url, url })),
             };
           }
         }

--- a/apps/api/src/modules/nedostupne/constants.ts
+++ b/apps/api/src/modules/nedostupne/constants.ts
@@ -7,17 +7,10 @@ export const TYPE_ALTERNATIVE = "alternativa" as const;
 export const EMAIL_TYPES = [TYPE_UNAVAILABLE, TYPE_ALTERNATIVE] as const;
 export type NedostupneEmailType = (typeof EMAIL_TYPES)[number];
 
-
-// Klikateľný fallback na vyhľadávanie podľa kódu — appka nemá žiadny zdroj
-// SKUTOČNEJ Shoptet produktovej URL (overené priamo na exporte: žiadny
-// `url`/`seoUrl` stĺpec), takže sa používa VŽDY (rovnaký fallback ako stará
-// appka's `_resolve_alternatives`, keď jej marketingový XML-feed lookup
-// nenašiel zhodu — "always clickable"). Návrhový komentár na issue 176:
-// import starého marketingového feedu bol zámerne zamietnutý ako nová,
-// nepotrebná externá integrácia len kvôli jednému nepovinnému bodu ticketu.
-export function alternativeSearchUrl(code: string): string {
-  return `https://www.forestshop.sk/vyhladavanie/?string=${encodeURIComponent(code)}`;
-}
+// issue 238: pôvodný automatický vyhľadávací fallback (`alternativeSearchUrl`)
+// je preč spolu s celým `product.relatedCodes`-based návrhom — majiteľ teraz
+// vkladá skutočné odkazy sám (`nedostupne_replacement_link`), appka už
+// žiadny odkaz sama neskladá.
 
 // Ďalší voľný kľúč v registri `.claude/rules/scheduler.md`
 // (787_878_001/002/003/004/005/100 sú obsadené) — serializuje KAŽDÉ

--- a/apps/api/src/modules/nedostupne/logic.test.ts
+++ b/apps/api/src/modules/nedostupne/logic.test.ts
@@ -59,7 +59,7 @@ describe("buildAlternativeEmail", () => {
     expect(built.html).not.toContain("<ul>");
   });
 
-  it("HTML-escapuje názov produktu (odkazy samotné sú vždy appkou vygenerované URL, nie voľný text)", () => {
+  it("HTML-escapuje názov produktu (odkazy samotné sú validované ako http(s) URL na HTTP hranici, nie voľný text)", () => {
     const built = buildAlternativeEmail(ALTERNATIVA, "Ján", "<i>Prod</i>", ["https://www.forestshop.sk/x/"]);
     expect(built.html).not.toContain("<i>Prod</i>");
     expect(built.html).toContain("&lt;i&gt;Prod&lt;/i&gt;");

--- a/apps/api/src/modules/nedostupne/logic.test.ts
+++ b/apps/api/src/modules/nedostupne/logic.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { alternativeSearchUrl } from "./constants.js";
 import { MAIL_TEMPLATE_KINDS } from "../mail-templates/registry.js";
-import { buildAlternativeEmail, buildAlternatives, buildUnavailableEmail } from "./logic.js";
+import { buildAlternativeEmail, buildUnavailableEmail } from "./logic.js";
 
 // issue 192: znenie žije v upraviteľnej šablóne — tieto testy overujú PÔVODNÉ
 // znenie, teda presne to, čo appka použije, kým majiteľ nič nezmení.
@@ -30,44 +29,39 @@ describe("buildUnavailableEmail", () => {
   });
 });
 
-describe("buildAlternatives", () => {
-  it("neznámy kód padá späť na SEBA SAMÉHO ako meno (nikdy sa nezahodí)", () => {
-    const alts = buildAlternatives(["60297"], new Map());
-    expect(alts).toEqual([{ code: "60297", name: "60297", url: alternativeSearchUrl("60297") }]);
-  });
-
-  it("známy kód dostane rozlíšené meno z mapy", () => {
-    const alts = buildAlternatives(["60116/90"], new Map([["60116/90", "Podkolienky BOBR"]]));
-    expect(alts).toEqual([{ code: "60116/90", name: "Podkolienky BOBR", url: alternativeSearchUrl("60116/90") }]);
-  });
-
-  it("prázdny zoznam kódov → prázdny zoznam alternatív", () => {
-    expect(buildAlternatives([], new Map())).toEqual([]);
-  });
-});
-
+// issue 238: automatický návrh (`product.relatedCodes` → `buildAlternatives`)
+// je preč — `buildAlternativeEmail` teraz dostáva PRIAMO majiteľove ručne
+// vložené odkazy (holé URL, appka k nim nepozná žiadny názov/kód), preto sa
+// v e-maile zobrazí samotný odkaz ako klikateľný text (`label === url`).
 describe("buildAlternativeEmail", () => {
-  it("s alternatívami vypíše odkazy na KAŽDÚ z nich", () => {
-    const alts = buildAlternatives(["60116/90"], new Map([["60116/90", "Podkolienky BOBR"]]));
-    const built = buildAlternativeEmail(ALTERNATIVA, "Ján Zákazník", "Nohavice FOREST 1003", alts);
+  it("s ručnými odkazmi vypíše KAŽDÝ z nich (label je samotná URL, appka nepozná názov)", () => {
+    const built = buildAlternativeEmail(ALTERNATIVA, "Ján Zákazník", "Nohavice FOREST 1003", [
+      "https://www.forestshop.sk/nahradny-produkt/",
+    ]);
     expect(built.subject).toBe("Alternatívy k vášmu tovaru — Forestshop.sk");
     expect(built.html).toContain("Nohavice FOREST 1003");
-    expect(built.html).toContain("Podkolienky BOBR");
-    expect(built.html).toContain(alternativeSearchUrl("60116/90"));
-    expect(built.text).toContain("Podkolienky BOBR");
+    expect(built.html).toContain("https://www.forestshop.sk/nahradny-produkt/");
+    expect(built.text).toContain("https://www.forestshop.sk/nahradny-produkt/");
   });
 
-  it("bez alternatív ponúkne kontaktnú vetu namiesto zoznamu", () => {
+  it("viac odkazov naraz — každý dostane svoju položku v zozname", () => {
+    const built = buildAlternativeEmail(ALTERNATIVA, "Ján", "Bunda", [
+      "https://www.forestshop.sk/a/",
+      "https://www.forestshop.sk/b/",
+    ]);
+    expect(built.html).toContain("https://www.forestshop.sk/a/");
+    expect(built.html).toContain("https://www.forestshop.sk/b/");
+  });
+
+  it("bez odkazov ponúkne kontaktnú vetu namiesto zoznamu", () => {
     const built = buildAlternativeEmail(ALTERNATIVA, "Ján Zákazník", "Nohavice FOREST 1003", []);
     expect(built.html).toContain("Radi vám pomôžeme nájsť vhodnú alternatívu");
     expect(built.html).not.toContain("<ul>");
   });
 
-  it("HTML-escapuje meno alternatívy aj názov produktu", () => {
-    const alts = buildAlternatives(["X"], new Map([["X", "<b>Zlý</b> názov"]]));
-    const built = buildAlternativeEmail(ALTERNATIVA, "Ján", '<i>Prod</i>', alts);
-    expect(built.html).not.toContain("<b>Zlý</b>");
-    expect(built.html).toContain("&lt;b&gt;Zlý&lt;/b&gt;");
+  it("HTML-escapuje názov produktu (odkazy samotné sú vždy appkou vygenerované URL, nie voľný text)", () => {
+    const built = buildAlternativeEmail(ALTERNATIVA, "Ján", "<i>Prod</i>", ["https://www.forestshop.sk/x/"]);
     expect(built.html).not.toContain("<i>Prod</i>");
+    expect(built.html).toContain("&lt;i&gt;Prod&lt;/i&gt;");
   });
 });

--- a/apps/api/src/modules/nedostupne/logic.ts
+++ b/apps/api/src/modules/nedostupne/logic.ts
@@ -1,6 +1,5 @@
 import { globalContext, textValue } from "../mail-templates/context.js";
 import { renderTemplate, type MailTemplateText, type RenderedEmail } from "../mail-templates/render.js";
-import { alternativeSearchUrl } from "./constants.js";
 
 // Čistá logika (žiadna DB, žiadna sieť). Znenie e-mailu už NIE je natvrdo tu —
 // issue 192 ho presunulo do upraviteľných šablón (`mail-templates/registry.ts`
@@ -21,31 +20,18 @@ export function buildUnavailableEmail(template: MailTemplateText, customerName: 
   });
 }
 
-export interface EmailAlternative {
-  readonly code: string;
-  readonly name: string;
-  readonly url: string;
-}
-
-/** Vytvorí zoznam náhradných produktov z RAW kódov (`product.related_codes`)
- * + rozlíšeného mena (`namesByCode` — vopred vyriešené DB dopytom,
- * `queries.ts`'s `resolveAlternativeNames`). Neznámy kód (nikdy nevidený
- * variant/pairCode) padá späť na SEBA SAMÉHO ako meno — rovnaký zámer ako
- * stará appka's `code2name.get(rc, rc)`, nikdy sa nezahadzuje. URL je vždy
- * klikateľný vyhľadávací fallback (`alternativeSearchUrl`, `constants.ts`).*/
-export function buildAlternatives(codes: readonly string[], namesByCode: ReadonlyMap<string, string>): readonly EmailAlternative[] {
-  return codes.map((code) => ({ code, name: namesByCode.get(code) ?? code, url: alternativeSearchUrl(code) }));
-}
-
-/** E-mail s návrhom náhrady — produkt je nedostupný + priamo priradené
- * alternatívy (relatedProduct*), rovnaký zámer ako stará appka's
- * `build_alternative_email`. Prázdny zoznam náhrad je v šablóne podmienka
+/** E-mail s návrhom náhrady — produkt je nedostupný + majiteľove RUČNE
+ * vložené odkazy na náhradné produkty (issue 238 — nahrádza pôvodný
+ * automatický návrh z `product.relatedCodes`, ktorý majiteľ zamietol ako
+ * "súvisiace produkty, nie náhrady"). Appka k ručne vloženému odkazu nepozná
+ * žiadny názov/kód, preto je `label` samotná URL (klikateľný text = presne
+ * to, čo majiteľ vložil). Prázdny zoznam náhrad je v šablóne podmienka
  * (`{{#ak zoznam_nahrad}}`), nie osobitná vetva v kóde. */
 export function buildAlternativeEmail(
   template: MailTemplateText,
   customerName: string,
   itemName: string,
-  alternatives: readonly EmailAlternative[],
+  replacementUrls: readonly string[],
 ): BuiltNedostupneEmail {
   return renderTemplate(template, {
     ...globalContext(),
@@ -54,7 +40,7 @@ export function buildAlternativeEmail(
     zoznam_nahrad: {
       kind: "list",
       textPrefix: "- ",
-      items: alternatives.map((a) => ({ label: a.name.trim() || a.code, url: a.url })),
+      items: replacementUrls.map((url) => ({ label: url, url })),
     },
   });
 }

--- a/apps/api/src/modules/nedostupne/queries.ts
+++ b/apps/api/src/modules/nedostupne/queries.ts
@@ -1,9 +1,10 @@
-import { and, desc, eq, inArray, or } from "drizzle-orm";
+import { and, desc, eq, inArray } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
-import { orderLines, orders, products, variants } from "../../db/schema.js";
+import { orderLines, orders, products, productSupplierLinkOverrides, shopProductUrl, variants } from "../../db/schema.js";
+import { resolveEffectiveSupplierLink } from "../orders/effective-supplier-link.js";
 import { buildShoptetAdminOrderUrl } from "../orders/queries.js";
 import { listOpenStatusNames } from "../orders/open-statuses.js";
-import { buildAlternatives, type EmailAlternative } from "./logic.js";
+import { listReplacementLinksByVariant, type ReplacementLink } from "./replacement-links.js";
 import { loadSentNedostupne, sentKey } from "./state.js";
 
 export interface NedostupneOrderRow {
@@ -21,28 +22,18 @@ export interface NedostupneGroup {
   readonly variantCode: string;
   readonly itemName: string;
   readonly sizeLabel: string | null;
-  readonly alternatives: readonly EmailAlternative[];
+  // issue 238: preklik na náš e-shop — `null` = adresu vo feede pre
+  // porovnávače nemáme, meno ZOSTÁVA NEAKTÍVNE (žiadny vyhľadávací
+  // fallback, na rozdiel od `shopLinks.ts`'s `ourProductLink` — ticket to
+  // žiada explicitne: "nikdy nevyrábať adresu odhadom").
+  readonly ourProductUrl: string | null;
+  // issue 238: preklik na dodávateľa (rovnaká funkcia ako "Na objednanie",
+  // `resolveEffectiveSupplierLink`) — `null` = appka žiadny odkaz nemá.
+  readonly supplierUrl: string | null;
+  // issue 238: majiteľove RUČNE vložené odkazy náhrad — nahrádza pôvodný
+  // automatický zoznam z `product.relatedCodes`.
+  readonly replacementLinks: readonly ReplacementLink[];
   readonly orders: readonly NedostupneOrderRow[];
-}
-
-/** Meno pre KAŽDÝ RAW náhradný kód (`product.related_codes`) — hľadá sa
- * PODĽA `variant.code` AJ `variant.pairCode` (relatedProduct hodnota môže
- * byť jedno alebo druhé, rovnaký zámer ako stará appka's
- * `_ensure_nedostupne_catalog`). Neznáme kódy jednoducho chýbajú z mapy —
- * `buildAlternatives` (`logic.ts`) padá vtedy späť na kód samotný. */
-export async function resolveAlternativeNames(db: Pick<Database, "select">, codes: readonly string[]): Promise<ReadonlyMap<string, string>> {
-  if (codes.length === 0) return new Map();
-  const wanted = new Set(codes);
-  const rows = await db
-    .select({ code: variants.code, pairCode: variants.pairCode, name: variants.name })
-    .from(variants)
-    .where(or(inArray(variants.code, [...codes]), inArray(variants.pairCode, [...codes])));
-  const map = new Map<string, string>();
-  for (const row of rows) {
-    if (wanted.has(row.code)) map.set(row.code, row.name);
-    if (row.pairCode !== null && wanted.has(row.pairCode) && !map.has(row.pairCode)) map.set(row.pairCode, row.name);
-  }
-  return map;
 }
 
 /**
@@ -62,7 +53,9 @@ export async function listNedostupneGroups(db: Database, adminBaseUrl: string): 
       quantity: orderLines.quantity,
       itemName: variants.name,
       sizeLabel: variants.sizeLabel,
-      relatedCodes: products.relatedCodes,
+      internalNote: products.internalNote,
+      supplierLinkOverride: productSupplierLinkOverrides.url,
+      ourProductUrl: shopProductUrl.url,
       orderCode: orders.externalOrderId,
       customerName: orders.customerName,
       email: orders.email,
@@ -73,23 +66,30 @@ export async function listNedostupneGroups(db: Database, adminBaseUrl: string): 
     .innerJoin(orders, eq(orderLines.orderId, orders.id))
     .innerJoin(variants, eq(orderLines.variantCode, variants.code))
     .innerJoin(products, eq(variants.productKey, products.key))
+    .leftJoin(productSupplierLinkOverrides, eq(productSupplierLinkOverrides.productKey, products.key))
+    .leftJoin(shopProductUrl, eq(shopProductUrl.code, orderLines.variantCode))
     .where(and(eq(orderLines.state, "nedostupne"), inArray(orders.statusName, [...openStatuses])))
     .orderBy(desc(orders.placedAt));
 
   if (rows.length === 0) return [];
 
   const sent = await loadSentNedostupne(db);
-  const allCodes = [...new Set(rows.flatMap((r) => r.relatedCodes ?? []))];
-  const names = await resolveAlternativeNames(db, allCodes);
+  const replacementLinksByVariant = await listReplacementLinksByVariant(db, [...new Set(rows.map((r) => r.variantCode))]);
 
   const groups = new Map<
     string,
-    { itemName: string; sizeLabel: string | null; relatedCodes: readonly string[]; orders: NedostupneOrderRow[] }
+    { itemName: string; sizeLabel: string | null; ourProductUrl: string | null; supplierUrl: string | null; orders: NedostupneOrderRow[] }
   >();
   for (const row of rows) {
     let group = groups.get(row.variantCode);
     if (group === undefined) {
-      group = { itemName: row.itemName, sizeLabel: row.sizeLabel, relatedCodes: row.relatedCodes ?? [], orders: [] };
+      group = {
+        itemName: row.itemName,
+        sizeLabel: row.sizeLabel,
+        ourProductUrl: row.ourProductUrl,
+        supplierUrl: resolveEffectiveSupplierLink(row.internalNote, row.supplierLinkOverride).url,
+        orders: [],
+      };
       groups.set(row.variantCode, group);
     }
     group.orders.push({
@@ -114,7 +114,9 @@ export async function listNedostupneGroups(db: Database, adminBaseUrl: string): 
       variantCode,
       itemName: g.itemName,
       sizeLabel: g.sizeLabel,
-      alternatives: buildAlternatives(g.relatedCodes, names),
+      ourProductUrl: g.ourProductUrl,
+      supplierUrl: g.supplierUrl,
+      replacementLinks: replacementLinksByVariant.get(variantCode) ?? [],
       orders: g.orders,
     }))
     .sort((a, b) => {

--- a/apps/api/src/modules/nedostupne/replacement-links.ts
+++ b/apps/api/src/modules/nedostupne/replacement-links.ts
@@ -1,0 +1,59 @@
+import { asc, eq, inArray } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { nedostupneReplacementLinks } from "../../db/schema.js";
+
+// issue 238: majiteľove RUČNE vložené odkazy na náhradné produkty — nahrádza
+// automatický návrh z `product.relatedCodes` (majiteľ: "nechcem aby to
+// uvádzalo tieto náhrady - je to blbosť, to sú súvisiace produkty - nie
+// podobné, nie náhrady"). Kľúčované `variantCode` (plain, bez FK — rovnaká
+// konvencia ako `nedostupne_state`, `.claude/rules/nedostupne.md`), viac
+// riadkov na ten istý kód = viac liniek na ten istý tovar.
+
+export interface ReplacementLink {
+  readonly id: string;
+  readonly url: string;
+}
+
+/** Zoradenie podľa VLOŽENIA (najstarší prvý) — majiteľ vkladá odkazy v
+ * poradí, v akom má zmysel ich zákazníkovi ukázať (prvý pridaný = zvyčajne
+ * najviac odporúčaný), nie abecedne/náhodne. `asc(id)` je len deterministický
+ * tie-break pre riadky vložené v tej istej transakcii/millisekunde. */
+export async function listReplacementLinksByVariant(
+  db: Pick<Database, "select">,
+  variantCodes: readonly string[],
+): Promise<ReadonlyMap<string, ReplacementLink[]>> {
+  const map = new Map<string, ReplacementLink[]>();
+  if (variantCodes.length === 0) return map;
+  const rows = await db
+    .select({ id: nedostupneReplacementLinks.id, variantCode: nedostupneReplacementLinks.variantCode, url: nedostupneReplacementLinks.url })
+    .from(nedostupneReplacementLinks)
+    .where(inArray(nedostupneReplacementLinks.variantCode, [...variantCodes]))
+    .orderBy(asc(nedostupneReplacementLinks.createdAt), asc(nedostupneReplacementLinks.id));
+  for (const row of rows) {
+    const list = map.get(row.variantCode);
+    const link = { id: row.id, url: row.url };
+    if (list === undefined) map.set(row.variantCode, [link]);
+    else list.push(link);
+  }
+  return map;
+}
+
+export async function listReplacementLinksForVariant(db: Pick<Database, "select">, variantCode: string): Promise<readonly ReplacementLink[]> {
+  return (await listReplacementLinksByVariant(db, [variantCode])).get(variantCode) ?? [];
+}
+
+export async function addReplacementLink(db: Database, variantCode: string, url: string, now: Date): Promise<ReplacementLink> {
+  const [row] = await db
+    .insert(nedostupneReplacementLinks)
+    .values({ variantCode, url, createdAt: now })
+    .returning({ id: nedostupneReplacementLinks.id, url: nedostupneReplacementLinks.url });
+  if (row === undefined) throw new Error("odkaz náhrady sa nepodarilo vložiť");
+  return row;
+}
+
+/** `true` = riadok reálne existoval a bol zmazaný; `false` = neznáme `id`
+ * (napr. dvojklik na "zmazať", medzičasom už zmazané inou žiadosťou). */
+export async function removeReplacementLink(db: Database, id: string): Promise<boolean> {
+  const deleted = await db.delete(nedostupneReplacementLinks).where(eq(nedostupneReplacementLinks.id, id)).returning({ id: nedostupneReplacementLinks.id });
+  return deleted.length > 0;
+}

--- a/apps/api/src/modules/nedostupne/send.ts
+++ b/apps/api/src/modules/nedostupne/send.ts
@@ -1,15 +1,15 @@
 import { and, eq } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
 import { log } from "../../logger.js";
-import { orderLines, orders, products, variants } from "../../db/schema.js";
+import { orderLines, orders, variants } from "../../db/schema.js";
 import type { MailTransport } from "../mail/transport.js";
 import { DUPLICATE_REASON } from "../mail-log/queries.js";
 import { recordSkippedMail, sendLoggedMail, type MailLogContext } from "../mail-log/service.js";
 import { resolveTemplate } from "../mail-templates/store.js";
 import { listOpenStatusNames } from "../orders/open-statuses.js";
 import { NEDOSTUPNE_SEND_LOCK_KEY, TYPE_ALTERNATIVE, type NedostupneEmailType } from "./constants.js";
-import { buildAlternativeEmail, buildAlternatives, buildUnavailableEmail, type BuiltNedostupneEmail, type EmailAlternative } from "./logic.js";
-import { resolveAlternativeNames } from "./queries.js";
+import { buildAlternativeEmail, buildUnavailableEmail, type BuiltNedostupneEmail } from "./logic.js";
+import { listReplacementLinksForVariant } from "./replacement-links.js";
 import { hasSentNedostupne, markSentNedostupne } from "./state.js";
 
 export interface NedostupneEmailContext {
@@ -18,7 +18,9 @@ export interface NedostupneEmailContext {
   readonly customerName: string;
   readonly email: string;
   readonly itemName: string;
-  readonly alternatives: readonly EmailAlternative[];
+  // issue 238: majiteľove RUČNE vložené odkazy náhrad (nahrádza pôvodný
+  // automatický `product.relatedCodes` návrh).
+  readonly replacementUrls: readonly string[];
 }
 
 /**
@@ -36,7 +38,6 @@ export async function findNedostupneContext(db: Database, orderCode: string, var
   const [row] = await db
     .select({
       itemName: variants.name,
-      relatedCodes: products.relatedCodes,
       customerName: orders.customerName,
       email: orders.email,
       statusName: orders.statusName,
@@ -44,20 +45,19 @@ export async function findNedostupneContext(db: Database, orderCode: string, var
     .from(orderLines)
     .innerJoin(orders, eq(orderLines.orderId, orders.id))
     .innerJoin(variants, eq(orderLines.variantCode, variants.code))
-    .innerJoin(products, eq(variants.productKey, products.key))
     .where(and(eq(orders.externalOrderId, orderCode), eq(orderLines.variantCode, variantCode), eq(orderLines.state, "nedostupne")))
     .limit(1);
 
   if (row === undefined || !openStatuses.includes(row.statusName)) return null;
 
-  const names = await resolveAlternativeNames(db, row.relatedCodes ?? []);
+  const replacementLinks = await listReplacementLinksForVariant(db, variantCode);
   return {
     orderCode,
     variantCode,
     customerName: row.customerName,
     email: row.email ?? "",
     itemName: row.itemName,
-    alternatives: buildAlternatives(row.relatedCodes ?? [], names),
+    replacementUrls: replacementLinks.map((l) => l.url),
   };
 }
 
@@ -68,7 +68,7 @@ export async function findNedostupneContext(db: Database, orderCode: string, var
 export async function buildEmailForType(db: Database, ctx: NedostupneEmailContext, type: NedostupneEmailType): Promise<BuiltNedostupneEmail> {
   if (type === TYPE_ALTERNATIVE) {
     const template = await resolveTemplate(db, "nedostupne_alternativa");
-    return buildAlternativeEmail(template, ctx.customerName, ctx.itemName, ctx.alternatives);
+    return buildAlternativeEmail(template, ctx.customerName, ctx.itemName, ctx.replacementUrls);
   }
   return buildUnavailableEmail(await resolveTemplate(db, "nedostupne"), ctx.customerName);
 }

--- a/apps/api/tests/helpers/db.ts
+++ b/apps/api/tests/helpers/db.ts
@@ -60,7 +60,7 @@ export async function withCleanDb(): Promise<{ db: Database; close: () => Promis
     // predošlého behu potom vyzerá ako platné potvrdenie a beh preskočí
     // VŠETKY odkazy (presne to sa tu stalo pri druhom spustení).
     await db.execute(
-      sql`TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, mail_template, mail_template_history, supplier_stock, restock_settings, restock_event, shop_product_url RESTART IDENTITY CASCADE`,
+      sql`TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, nedostupne_replacement_link, mail_template, mail_template_history, supplier_stock, restock_settings, restock_event, shop_product_url RESTART IDENTITY CASCADE`,
     );
     // issue 59: `order_open_status` is a NEW table with real production
     // content (the migration seeds it) — TRUNCATE alone would leave every

--- a/apps/api/tests/nedostupne-http.integration.test.ts
+++ b/apps/api/tests/nedostupne-http.integration.test.ts
@@ -248,3 +248,70 @@ it("token je JEDNORAZOVÝ — druhé odoslanie s TÝM ISTÝM tokenom (iný typ) 
   expect(secondJson.ok).toBe(false);
   expect(sent).toHaveLength(1);
 });
+
+// issue 238: majiteľove RUČNE vložené odkazy náhrad — nahrádza pôvodný
+// automatický `product.relatedCodes` návrh.
+
+it("manazer pridá ručný odkaz náhrady — hneď vidno v GET zozname, viac odkazov na ten istý variant funguje", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await seedNedostupneLine(db, "17601010", "N176J");
+
+  const first = await app.request("/api/nedostupne/replacement-links", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ variantCode: "N176J", url: "https://www.forestshop.sk/prvy/" }),
+  });
+  expect(first.status).toBe(200);
+  const firstBody = (await first.json()) as { ok: boolean; link: { id: string; url: string } };
+  expect(firstBody.ok).toBe(true);
+  expect(firstBody.link.url).toBe("https://www.forestshop.sk/prvy/");
+
+  await app.request("/api/nedostupne/replacement-links", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ variantCode: "N176J", url: "https://www.forestshop.sk/druhy/" }),
+  });
+
+  const list = await app.request("/api/nedostupne", { headers: { cookie } });
+  const listBody = (await list.json()) as { groups: { variantCode: string; replacementLinks: { id: string; url: string }[] }[] };
+  const group = listBody.groups.find((g) => g.variantCode === "N176J");
+  expect(group?.replacementLinks.map((l) => l.url)).toEqual(["https://www.forestshop.sk/prvy/", "https://www.forestshop.sk/druhy/"]);
+});
+
+it("rola citanie NESMIE pridať odkaz náhrady (403)", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  await seedNedostupneLine(db, "17601011", "N176K");
+  const res = await app.request("/api/nedostupne/replacement-links", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ variantCode: "N176K", url: "https://www.forestshop.sk/x/" }),
+  });
+  expect(res.status).toBe(403);
+});
+
+it("neplatná URL (nie http/https) je odmietnutá — 400", async () => {
+  const { app, cookie } = await boot("manazer");
+  const res = await app.request("/api/nedostupne/replacement-links", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ variantCode: "N176L", url: "javascript:alert(1)" }),
+  });
+  expect(res.status).toBe(400);
+});
+
+it("manazer zmaže odkaz náhrady — zmizne z GET zoznamu; zmazanie neznámeho id vráti ok:true, removed:false", async () => {
+  const { app, cookie } = await boot("manazer");
+  const add = await app.request("/api/nedostupne/replacement-links", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ variantCode: "N176M", url: "https://www.forestshop.sk/zmazat/" }),
+  });
+  const addBody = (await add.json()) as { link: { id: string } };
+
+  const del = await app.request(`/api/nedostupne/replacement-links/${addBody.link.id}`, { method: "DELETE", headers: { cookie } });
+  expect(del.status).toBe(200);
+  expect((await del.json()) as { ok: boolean; removed: boolean }).toEqual({ ok: true, removed: true });
+
+  const delAgain = await app.request(`/api/nedostupne/replacement-links/${addBody.link.id}`, { method: "DELETE", headers: { cookie } });
+  expect((await delAgain.json()) as { ok: boolean; removed: boolean }).toEqual({ ok: true, removed: false });
+});

--- a/apps/api/tests/nedostupne-replacement-links.integration.test.ts
+++ b/apps/api/tests/nedostupne-replacement-links.integration.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, expect, it } from "vitest";
+import { addReplacementLink, listReplacementLinksByVariant, listReplacementLinksForVariant, removeReplacementLink } from "../src/modules/nedostupne/replacement-links.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 238: majiteľove RUČNE vložené odkazy na náhradné produkty — nahrádza
+// automatický `product.relatedCodes` návrh, ktorý majiteľ zamietol.
+
+let close: (() => Promise<void>) | undefined;
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+});
+
+async function boot() {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  return ctx.db;
+}
+
+it("prázdny variant nemá žiadne odkazy", async () => {
+  const db = await boot();
+  expect(await listReplacementLinksForVariant(db, "NEZNAMY")).toEqual([]);
+});
+
+it("pridanie odkazu ho hneď sprístupní cez zoznam", async () => {
+  const db = await boot();
+  const link = await addReplacementLink(db, "R238A", "https://www.forestshop.sk/nahrada-a/", new Date("2026-08-04T10:00:00Z"));
+  expect(link.url).toBe("https://www.forestshop.sk/nahrada-a/");
+
+  const links = await listReplacementLinksForVariant(db, "R238A");
+  expect(links).toEqual([{ id: link.id, url: "https://www.forestshop.sk/nahrada-a/" }]);
+});
+
+it("VIAC odkazov na ten istý variant — poradie podľa vloženia (najstarší prvý)", async () => {
+  const db = await boot();
+  await addReplacementLink(db, "R238B", "https://www.forestshop.sk/prvy/", new Date("2026-08-04T10:00:00Z"));
+  await addReplacementLink(db, "R238B", "https://www.forestshop.sk/druhy/", new Date("2026-08-04T10:01:00Z"));
+
+  const links = await listReplacementLinksForVariant(db, "R238B");
+  expect(links.map((l) => l.url)).toEqual(["https://www.forestshop.sk/prvy/", "https://www.forestshop.sk/druhy/"]);
+});
+
+it("zoznam podľa viacerých variantov naraz zoskupí presne podľa kódu", async () => {
+  const db = await boot();
+  await addReplacementLink(db, "R238C1", "https://www.forestshop.sk/c1/", new Date("2026-08-04T10:00:00Z"));
+  await addReplacementLink(db, "R238C2", "https://www.forestshop.sk/c2/", new Date("2026-08-04T10:00:00Z"));
+
+  const map = await listReplacementLinksByVariant(db, ["R238C1", "R238C2", "R238C3"]);
+  expect(map.get("R238C1")?.map((l) => l.url)).toEqual(["https://www.forestshop.sk/c1/"]);
+  expect(map.get("R238C2")?.map((l) => l.url)).toEqual(["https://www.forestshop.sk/c2/"]);
+  expect(map.has("R238C3")).toBe(false);
+});
+
+it("zmazanie odkazu ho odstráni zo zoznamu; zmazanie neznámeho id vráti false", async () => {
+  const db = await boot();
+  const link = await addReplacementLink(db, "R238D", "https://www.forestshop.sk/d/", new Date("2026-08-04T10:00:00Z"));
+
+  expect(await removeReplacementLink(db, link.id)).toBe(true);
+  expect(await listReplacementLinksForVariant(db, "R238D")).toEqual([]);
+  expect(await removeReplacementLink(db, link.id)).toBe(false);
+});

--- a/apps/api/tests/nedostupne-run.integration.test.ts
+++ b/apps/api/tests/nedostupne-run.integration.test.ts
@@ -1,9 +1,10 @@
 import { eq } from "drizzle-orm";
 import pg from "pg";
 import { afterEach, expect, it } from "vitest";
-import { nedostupneState, orderLines, orders } from "../src/db/schema.js";
+import { nedostupneState, orderLines, orders, productSupplierLinkOverrides, shopProductUrl } from "../src/db/schema.js";
 import type { MailMessage } from "../src/modules/mail/transport.js";
 import { NEDOSTUPNE_SEND_LOCK_KEY } from "../src/modules/nedostupne/constants.js";
+import { addReplacementLink } from "../src/modules/nedostupne/replacement-links.js";
 import { listNedostupneGroups } from "../src/modules/nedostupne/queries.js";
 import { findNedostupneContext, sendNedostupneEmail } from "../src/modules/nedostupne/send.js";
 import { DEFAULT_ORDER_OPEN_STATUS } from "../src/modules/orders/open-statuses.js";
@@ -92,23 +93,71 @@ it("nedostupný riadok v UZAVRETEJ objednávke sa nezobrazí (nikdy neotravuj z�
   expect(await listNedostupneGroups(db, ADMIN_BASE_URL)).toEqual([]);
 });
 
-it("náhradné produkty (relatedCodes) sa resolvujú na meno cez variant.code aj cez pairCode, neznámy kód padá na seba", async () => {
+// issue 238: automatický `relatedCodes` návrh je preč — `listNedostupneGroups`
+// vracia majiteľove RUČNE vložené odkazy (`nedostupne_replacement_link`),
+// zoradené podľa vloženia, žiadny automatický "meno cez pairCode" lookup viac.
+it("RUČNÉ odkazy náhrad (nedostupne_replacement_link) sa vrátia v poradí vloženia, zoskupené podľa variantu", async () => {
   const db = await boot();
-  // "P176D2" má pairCode "PC-D2" — relatedCodes odkazuje na "PC-D2" (nie na code priamo).
-  await insertTestVariantForProduct(db, "P176D2-key", "P176D2", { productName: "Náhrada Podľa PairCode", pairCode: "PC-D2" });
-  await insertTestVariantForProduct(db, "P176D", "P176D/M", {
-    productName: "Nohavice s náhradou",
-    relatedCodes: ["PC-D2", "NEZNAMY-KOD"],
-  });
+  await insertTestVariantForProduct(db, "P176D", "P176D/M", { productName: "Nohavice s náhradou" });
   const orderId = await insertOrder(db, "17600004");
   await db.insert(orderLines).values({ orderId, variantCode: "P176D/M", quantity: 1, state: "nedostupne" });
+  await addReplacementLink(db, "P176D/M", "https://www.forestshop.sk/prvy/", new Date("2026-08-04T10:00:00Z"));
+  await addReplacementLink(db, "P176D/M", "https://www.forestshop.sk/druhy/", new Date("2026-08-04T10:01:00Z"));
 
   const groups = await listNedostupneGroups(db, ADMIN_BASE_URL);
   const group = groups.find((g) => g.variantCode === "P176D/M");
-  expect(group?.alternatives).toEqual([
-    { code: "PC-D2", name: "Náhrada Podľa PairCode", url: "https://www.forestshop.sk/vyhladavanie/?string=PC-D2" },
-    { code: "NEZNAMY-KOD", name: "NEZNAMY-KOD", url: "https://www.forestshop.sk/vyhladavanie/?string=NEZNAMY-KOD" },
-  ]);
+  expect(group?.replacementLinks.map((l) => l.url)).toEqual(["https://www.forestshop.sk/prvy/", "https://www.forestshop.sk/druhy/"]);
+});
+
+it("variant bez ručných odkazov má prázdny zoznam náhrad (žiadny automatický fallback)", async () => {
+  const db = await boot();
+  await insertTestVariantForProduct(db, "P176D3", "P176D3", { productName: "Bez náhrad" });
+  const orderId = await insertOrder(db, "17600013");
+  await db.insert(orderLines).values({ orderId, variantCode: "P176D3", quantity: 1, state: "nedostupne" });
+
+  const groups = await listNedostupneGroups(db, ADMIN_BASE_URL);
+  const group = groups.find((g) => g.variantCode === "P176D3");
+  expect(group?.replacementLinks).toEqual([]);
+});
+
+// issue 238: preklik na náš e-shop (`shop_product_url`, feed pre porovnávače)
+// a preklik na dodávateľa (`internalNote`/`product_supplier_link_override`,
+// rovnaká funkcia ako "Na objednanie") — bez feedovej adresy zostáva `null`
+// (nikdy vyhľadávací fallback, `.claude/rules/nedostupne.md`).
+it("preklik na náš e-shop + na dodávateľa: null keď appka adresu nemá, vyplnené keď má", async () => {
+  const db = await boot();
+  await insertTestVariantForProduct(db, "P176M-key", "P176M", { productName: "Bez odkazov" });
+  const orderId1 = await insertOrder(db, "17600014");
+  await db.insert(orderLines).values({ orderId: orderId1, variantCode: "P176M", quantity: 1, state: "nedostupne" });
+
+  await insertTestVariantForProduct(db, "P176N-key", "P176N", { productName: "S odkazmi", internalNote: "https://dodavatel.example/produkt" });
+  await db.insert(shopProductUrl).values({ code: "P176N", url: "https://www.forestshop.sk/p176n/", fetchedAt: new Date("2026-08-04T09:00:00Z") });
+  const orderId2 = await insertOrder(db, "17600015");
+  await db.insert(orderLines).values({ orderId: orderId2, variantCode: "P176N", quantity: 1, state: "nedostupne" });
+
+  const groups = await listNedostupneGroups(db, ADMIN_BASE_URL);
+  const bezOdkazov = groups.find((g) => g.variantCode === "P176M");
+  expect(bezOdkazov?.ourProductUrl).toBeNull();
+  expect(bezOdkazov?.supplierUrl).toBeNull();
+
+  const sOdkazmi = groups.find((g) => g.variantCode === "P176N");
+  expect(sOdkazmi?.ourProductUrl).toBe("https://www.forestshop.sk/p176n/");
+  expect(sOdkazmi?.supplierUrl).toBe("https://dodavatel.example/produkt");
+});
+
+// issue 121: ručné prepísanie odkazu na dodávateľa (`product_supplier_link_override`)
+// má prednosť pred extrahovaným `internalNote` — rovnaká disciplína ako
+// "Na objednanie" (`resolveEffectiveSupplierLink`).
+it("preklik na dodávateľa uprednostní RUČNÝ override pred extrahovaným internalNote", async () => {
+  const db = await boot();
+  await insertTestVariantForProduct(db, "P176O-key", "P176O", { productName: "S override-om", internalNote: "https://stary-dodavatel.example/x" });
+  await db.insert(productSupplierLinkOverrides).values({ productKey: "P176O-key", url: "https://novy-dodavatel.example/y", updatedAt: new Date("2026-08-04T09:00:00Z") });
+  const orderId = await insertOrder(db, "17600016");
+  await db.insert(orderLines).values({ orderId, variantCode: "P176O", quantity: 1, state: "nedostupne" });
+
+  const groups = await listNedostupneGroups(db, ADMIN_BASE_URL);
+  const group = groups.find((g) => g.variantCode === "P176O");
+  expect(group?.supplierUrl).toBe("https://novy-dodavatel.example/y");
 });
 
 it("preview a odoslanie použijú ROVNAKÚ funkciu (`findNedostupneContext`/`buildEmailForType`) — obsah sa nikdy nerozíde", async () => {

--- a/apps/web/src/components/NedostupneSection.test.tsx
+++ b/apps/web/src/components/NedostupneSection.test.tsx
@@ -2,26 +2,33 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 import { afterEach, expect, it, vi } from "vitest";
 import { NedostupneSection } from "./NedostupneSection.js";
 
-const { fetchNedostupneList, fetchNedostupnePreview, sendNedostupneEmail } = vi.hoisted(() => ({
+const { fetchNedostupneList, fetchNedostupnePreview, sendNedostupneEmail, addReplacementLink, removeReplacementLink } = vi.hoisted(() => ({
   fetchNedostupneList: vi.fn(),
   fetchNedostupnePreview: vi.fn(),
   sendNedostupneEmail: vi.fn(),
+  addReplacementLink: vi.fn(),
+  removeReplacementLink: vi.fn(),
 }));
 
 // `NedostupneUnauthorizedError` ostáva SKUTOČNÁ trieda (rovnaký dôvod ako
 // `OrderReminderSection.test.tsx` — `instanceof` v komponente musí fungovať).
 vi.mock("../nedostupneApi.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../nedostupneApi.js")>();
-  return { ...actual, fetchNedostupneList, fetchNedostupnePreview, sendNedostupneEmail };
+  return { ...actual, fetchNedostupneList, fetchNedostupnePreview, sendNedostupneEmail, addReplacementLink, removeReplacementLink };
 });
 
 const { NedostupneUnauthorizedError } = await import("../nedostupneApi.js");
 
+// issue 238: automatický "Náhrada:" zoznam (`alternatives`) je preč —
+// nahradený majiteľovými RUČNE vloženými odkazmi (`replacementLinks`) +
+// preklikom na náš e-shop (`ourProductUrl`) a na dodávateľa (`supplierUrl`).
 const GROUP = {
   variantCode: "40237/L",
   itemName: "Nohavice FOREST 1003",
   sizeLabel: "L",
-  alternatives: [{ code: "60116/90", name: "Podkolienky BOBR", url: "https://www.forestshop.sk/vyhladavanie/?string=60116%2F90" }],
+  ourProductUrl: "https://www.forestshop.sk/nohavice-forest-1003/",
+  supplierUrl: "https://dodavatel.example/nohavice-1003",
+  replacementLinks: [{ id: "link-1", url: "https://www.forestshop.sk/nahradny-produkt/" }],
   orders: [
     {
       orderCode: "17600001",
@@ -56,14 +63,91 @@ it("chýbajúca BCC/mail konfigurácia zobrazí obe upozornenia", async () => {
   await screen.findByTestId("nedostupne-mail-not-configured");
 });
 
-it("zobrazí kartu variantu s náhradou aj objednávkou zákazníka", async () => {
+it("zobrazí kartu variantu s ručným odkazom náhrady aj objednávkou zákazníka", async () => {
   fetchNedostupneList.mockResolvedValue(LIST_WITH_GROUP);
   render(<NedostupneSection role="manazer" onSessionExpired={vi.fn()} />);
   await screen.findByTestId("nedostupne-group-40237/L");
   expect(screen.getByText(/Nohavice FOREST 1003/)).not.toBeNull();
   expect(screen.getByText(/veľkosť L/)).not.toBeNull();
-  expect(screen.getByText("Podkolienky BOBR")).not.toBeNull();
+  expect(screen.getByText("https://www.forestshop.sk/nahradny-produkt/")).not.toBeNull();
   expect(screen.getByText("Ján Novák")).not.toBeNull();
+});
+
+// issue 238: preklik na náš e-shop (názov produktu) a na dodávateľa (kód) —
+// `null` = ostáva NEAKTÍVNY plain text, nikdy vyhľadávací fallback.
+it("názov produktu a kód sú preklikateľné, keď appka odkazy pozná", async () => {
+  fetchNedostupneList.mockResolvedValue(LIST_WITH_GROUP);
+  render(<NedostupneSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("nedostupne-group-40237/L");
+
+  const shopLink = screen.getByTestId("nedostupne-shop-link-40237/L");
+  expect(shopLink.getAttribute("href")).toBe("https://www.forestshop.sk/nohavice-forest-1003/");
+  const supplierLink = screen.getByTestId("nedostupne-supplier-link-40237/L");
+  expect(supplierLink.getAttribute("href")).toBe("https://dodavatel.example/nohavice-1003");
+});
+
+it("bez odkazu na e-shop/dodávateľa ostáva názov aj kód NEAKTÍVNY plain text", async () => {
+  fetchNedostupneList.mockResolvedValue({
+    groups: [{ ...GROUP, ourProductUrl: null, supplierUrl: null, replacementLinks: [] }],
+    bccMissing: false,
+    mailNotConfigured: false,
+  });
+  render(<NedostupneSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("nedostupne-group-40237/L");
+  expect(screen.queryByTestId("nedostupne-shop-link-40237/L")).toBeNull();
+  expect(screen.queryByTestId("nedostupne-supplier-link-40237/L")).toBeNull();
+  expect(screen.getByText(/Nohavice FOREST 1003/)).not.toBeNull();
+  expect(screen.getByText("40237/L")).not.toBeNull();
+});
+
+it("rola citanie VIDÍ ručné odkazy náhrad, ale nesmie ich pridávať/mazať", async () => {
+  fetchNedostupneList.mockResolvedValue(LIST_WITH_GROUP);
+  render(<NedostupneSection role="citanie" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("nedostupne-group-40237/L");
+  expect(screen.getByText("https://www.forestshop.sk/nahradny-produkt/")).not.toBeNull();
+  expect(screen.queryByTestId("nedostupne-replacement-link-add-40237/L")).toBeNull();
+  expect(screen.queryByTestId("nedostupne-replacement-link-remove-link-1")).toBeNull();
+});
+
+it("manazer pridá ručný odkaz náhrady — vstup sa vyprázdni a zoznam sa znova načíta", async () => {
+  fetchNedostupneList.mockResolvedValueOnce(LIST_WITH_GROUP).mockResolvedValueOnce({
+    groups: [{ ...GROUP, replacementLinks: [...GROUP.replacementLinks, { id: "link-2", url: "https://www.forestshop.sk/druhy/" }] }],
+    bccMissing: false,
+    mailNotConfigured: false,
+  });
+  addReplacementLink.mockResolvedValue({ id: "link-2", url: "https://www.forestshop.sk/druhy/" });
+  render(<NedostupneSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("nedostupne-group-40237/L");
+
+  const input = screen.getByTestId("nedostupne-replacement-link-input-40237/L");
+  fireEvent.change(input, { target: { value: "https://www.forestshop.sk/druhy/" } });
+  fireEvent.click(screen.getByTestId("nedostupne-replacement-link-add-40237/L"));
+
+  await waitFor(() => {
+    expect(addReplacementLink).toHaveBeenCalledWith("40237/L", "https://www.forestshop.sk/druhy/");
+  });
+  await screen.findByText("https://www.forestshop.sk/druhy/");
+  expect((input as HTMLInputElement).value).toBe("");
+});
+
+it("manazer zmaže ručný odkaz náhrady — zoznam sa znova načíta bez neho", async () => {
+  fetchNedostupneList.mockResolvedValueOnce(LIST_WITH_GROUP).mockResolvedValueOnce({
+    groups: [{ ...GROUP, replacementLinks: [] }],
+    bccMissing: false,
+    mailNotConfigured: false,
+  });
+  removeReplacementLink.mockResolvedValue(undefined);
+  render(<NedostupneSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("nedostupne-group-40237/L");
+
+  fireEvent.click(screen.getByTestId("nedostupne-replacement-link-remove-link-1"));
+
+  await waitFor(() => {
+    expect(removeReplacementLink).toHaveBeenCalledWith("link-1");
+  });
+  await waitFor(() => {
+    expect(screen.queryByText("https://www.forestshop.sk/nahradny-produkt/")).toBeNull();
+  });
 });
 
 it("rola citanie NEVIDÍ žiadne akčné tlačidlá (len admin/manazer smie odosielať)", async () => {

--- a/apps/web/src/components/NedostupneSection.tsx
+++ b/apps/web/src/components/NedostupneSection.tsx
@@ -1,9 +1,11 @@
 import { useCallback, useEffect, useRef, useState, type JSX } from "react";
 import type { Me } from "../api.js";
 import {
+  addReplacementLink,
   fetchNedostupneList,
   fetchNedostupnePreview,
   NedostupneUnauthorizedError,
+  removeReplacementLink,
   sendNedostupneEmail,
   type NedostupneEmailType,
   type NedostupneGroup,
@@ -40,6 +42,12 @@ export function NedostupneSection({ role, onSessionExpired }: { readonly role: M
   // dialógu by sa nemal kam vrátiť (naživo overené na produkcii).
   const triggerRef = useRef<HTMLElement | null>(null);
   const canControl = CONTROL_ROLES.has(role);
+  // issue 238: majiteľove RUČNE vložené odkazy náhrad — draft rozpísaného
+  // odkazu je per-GROUP (variantCode), nie globálny; `busyKey` vyššie je
+  // vyhradený pre náhľad/odoslanie, preto má tento blok VLASTNÝ busy stav
+  // (rôzne akcie na tej istej karte sa nesmú vzájomne blokovať).
+  const [linkDrafts, setLinkDrafts] = useState<Record<string, string>>({});
+  const [linkBusy, setLinkBusy] = useState("");
 
   const load = useCallback(() => {
     fetchNedostupneList()
@@ -108,6 +116,54 @@ export function NedostupneSection({ role, onSessionExpired }: { readonly role: M
       });
   }, [pending, load, onSessionExpired]);
 
+  // issue 238: pridanie majiteľovho ručného odkazu náhrady — po úspechu sa
+  // draft vyprázdni a zoznam sa znova načíta (server je zdroj pravdy, žiadny
+  // optimistický lokálny insert).
+  const addLink = useCallback(
+    (variantCode: string) => {
+      const url = (linkDrafts[variantCode] ?? "").trim();
+      if (url === "") return;
+      setActionError("");
+      setLinkBusy(variantCode);
+      addReplacementLink(variantCode, url)
+        .then(() => {
+          setLinkDrafts((drafts) => ({ ...drafts, [variantCode]: "" }));
+          load();
+        })
+        .catch((err: unknown) => {
+          if (err instanceof NedostupneUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setActionError(err instanceof Error ? err.message : "Odkaz sa nepodarilo pridať.");
+        })
+        .finally(() => {
+          setLinkBusy("");
+        });
+    },
+    [linkDrafts, load, onSessionExpired],
+  );
+
+  const removeLink = useCallback(
+    (id: string) => {
+      setActionError("");
+      setLinkBusy(id);
+      removeReplacementLink(id)
+        .then(load)
+        .catch((err: unknown) => {
+          if (err instanceof NedostupneUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setActionError(err instanceof Error ? err.message : "Odkaz sa nepodarilo zmazať.");
+        })
+        .finally(() => {
+          setLinkBusy("");
+        });
+    },
+    [load, onSessionExpired],
+  );
+
   if (!loaded) return <p>Načítavam…</p>;
   if (error !== "") return <p role="alert">{error}</p>;
   if (list === null) return <p role="alert">Nedostupné tovary sa nepodarilo načítať.</p>;
@@ -135,21 +191,84 @@ export function NedostupneSection({ role, onSessionExpired }: { readonly role: M
           {list.groups.map((group) => (
             <div className="card" key={group.variantCode} data-testid={`nedostupne-group-${group.variantCode}`}>
               <div className="nedostupne-group-header">
-                <span className="nedostupne-group-name">{itemLabel(group)}</span>
-                <span className="pill off">{group.variantCode}</span>
+                {/* issue 238: preklik na náš e-shop — `null` = adresu vo
+                    feede nemáme, meno ostáva NEAKTÍVNY plain text (nikdy
+                    vyhľadávací fallback, majiteľova výslovná podmienka). */}
+                <span className="nedostupne-group-name">
+                  {group.ourProductUrl !== null ? (
+                    <a href={group.ourProductUrl} target="_blank" rel="noreferrer" data-testid={`nedostupne-shop-link-${group.variantCode}`}>
+                      {itemLabel(group)}
+                    </a>
+                  ) : (
+                    itemLabel(group)
+                  )}
+                </span>
+                {/* issue 238: preklik na dodávateľa — rovnaká funkcia ako
+                    "Na objednanie" (`resolveEffectiveSupplierLink`). */}
+                {group.supplierUrl !== null ? (
+                  <a className="pill off" href={group.supplierUrl} target="_blank" rel="noreferrer" data-testid={`nedostupne-supplier-link-${group.variantCode}`}>
+                    {group.variantCode}
+                  </a>
+                ) : (
+                  <span className="pill off">{group.variantCode}</span>
+                )}
               </div>
 
-              {group.alternatives.length > 0 && (
-                <ul className="nedostupne-alternatives" data-testid={`nedostupne-alternatives-${group.variantCode}`}>
-                  {group.alternatives.map((a) => (
-                    <li key={a.code}>
-                      Náhrada:{" "}
-                      <a href={a.url} target="_blank" rel="noreferrer">
-                        {a.name}
+              {/* issue 238: majiteľove RUČNE vložené odkazy náhrad — nahrádza
+                  pôvodný automatický "Náhrada:" zoznam z `product.relatedCodes`
+                  (majiteľ ho zamietol ako "súvisiace produkty, nie náhrady").
+                  Zoznam je viditeľný VŠETKÝM (rovnaká úroveň ako čítanie
+                  zvyšku karty); pridanie/zmazanie je gated na `canControl`. */}
+              {group.replacementLinks.length > 0 && (
+                <ul className="nedostupne-replacement-links" data-testid={`nedostupne-replacement-links-${group.variantCode}`}>
+                  {group.replacementLinks.map((link) => (
+                    <li key={link.id} data-testid={`nedostupne-replacement-link-${link.id}`}>
+                      <a href={link.url} target="_blank" rel="noreferrer">
+                        {link.url}
                       </a>
+                      {canControl && (
+                        <button
+                          type="button"
+                          className="btn sm ghost"
+                          disabled={linkBusy === link.id}
+                          onClick={() => {
+                            removeLink(link.id);
+                          }}
+                          data-testid={`nedostupne-replacement-link-remove-${link.id}`}
+                        >
+                          ✕ zmazať
+                        </button>
+                      )}
                     </li>
                   ))}
                 </ul>
+              )}
+
+              {canControl && (
+                <div className="nedostupne-replacement-link-add">
+                  <input
+                    type="url"
+                    placeholder="Odkaz na náhradný produkt (https://…)"
+                    value={linkDrafts[group.variantCode] ?? ""}
+                    onChange={(e) => {
+                      const value = e.target.value;
+                      setLinkDrafts((drafts) => ({ ...drafts, [group.variantCode]: value }));
+                    }}
+                    aria-label={`Pridať odkaz náhrady pre ${itemLabel(group)}`}
+                    data-testid={`nedostupne-replacement-link-input-${group.variantCode}`}
+                  />
+                  <button
+                    type="button"
+                    className="btn sm ghost"
+                    disabled={linkBusy === group.variantCode || (linkDrafts[group.variantCode] ?? "").trim() === ""}
+                    onClick={() => {
+                      addLink(group.variantCode);
+                    }}
+                    data-testid={`nedostupne-replacement-link-add-${group.variantCode}`}
+                  >
+                    + Pridať odkaz
+                  </button>
+                </div>
               )}
 
               {group.orders.map((order) => {

--- a/apps/web/src/nedostupneApi.ts
+++ b/apps/web/src/nedostupneApi.ts
@@ -3,7 +3,10 @@ import { z } from "zod";
 // issue 176: "Nedostupné tovary" — zrkadlí `NedostupneGroup`/`NedostupneOrderRow`
 // (`apps/api/src/modules/nedostupne/queries.ts`).
 
-const alternativeSchema = z.object({ code: z.string(), name: z.string(), url: z.string() });
+// issue 238: majiteľove RUČNE vložené odkazy náhrad (nahrádza pôvodný
+// automatický `product.relatedCodes` návrh — appka k odkazu nepozná meno).
+const replacementLinkSchema = z.object({ id: z.string(), url: z.string() });
+export type ReplacementLink = z.infer<typeof replacementLinkSchema>;
 
 const orderRowSchema = z.object({
   orderCode: z.string(),
@@ -20,7 +23,11 @@ const groupSchema = z.object({
   variantCode: z.string(),
   itemName: z.string(),
   sizeLabel: z.string().nullable(),
-  alternatives: z.array(alternativeSchema),
+  // issue 238: `null` = adresu/odkaz appka nemá — meno/kód ZOSTÁVA
+  // NEAKTÍVNY (nikdy vyhľadávací fallback).
+  ourProductUrl: z.string().nullable(),
+  supplierUrl: z.string().nullable(),
+  replacementLinks: z.array(replacementLinkSchema),
   orders: z.array(orderRowSchema),
 });
 export type NedostupneGroup = z.infer<typeof groupSchema>;
@@ -98,4 +105,23 @@ export async function sendNedostupneEmail(
   });
   if (response.status === 401) throw new NedostupneUnauthorizedError();
   return sendResultSchema.parse(await response.json());
+}
+
+// issue 238: majiteľove RUČNE vložené odkazy náhrad — pridanie/zmazanie.
+const addReplacementLinkResultSchema = z.object({ ok: z.literal(true), link: replacementLinkSchema });
+
+export async function addReplacementLink(variantCode: string, url: string): Promise<ReplacementLink> {
+  const response = await fetch("/api/nedostupne/replacement-links", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ variantCode, url }),
+  });
+  if (response.status === 401) throw new NedostupneUnauthorizedError();
+  return addReplacementLinkResultSchema.parse(await readJson(response, "Odkaz sa nepodarilo pridať")).link;
+}
+
+export async function removeReplacementLink(id: string): Promise<void> {
+  const response = await fetch(`/api/nedostupne/replacement-links/${encodeURIComponent(id)}`, { method: "DELETE" });
+  if (response.status === 401) throw new NedostupneUnauthorizedError();
+  await readJson(response, "Odkaz sa nepodarilo zmazať");
 }

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -1812,13 +1812,32 @@ tr:last-child td {
   font-size: var(--fs-text-md);
   font-weight: var(--fs-weight-bold);
 }
-.nedostupne-alternatives {
+/* issue 238: majiteľove RUČNE vložené odkazy náhrad — nahrádza pôvodný
+   automatický "Náhrada:" zoznam (`.nedostupne-alternatives`, odstránené
+   spolu s `product.relatedCodes`-based návrhom). */
+.nedostupne-replacement-links {
   margin: 0 0 var(--fs-space-3);
   padding-left: var(--fs-space-5);
   display: flex;
   flex-direction: column;
   gap: var(--fs-space-1);
   font-size: var(--fs-text-sm);
+}
+.nedostupne-replacement-links li {
+  display: flex;
+  align-items: center;
+  gap: var(--fs-space-2);
+  flex-wrap: wrap;
+}
+.nedostupne-replacement-link-add {
+  display: flex;
+  gap: var(--fs-space-2);
+  flex-wrap: wrap;
+  margin: 0 0 var(--fs-space-3);
+}
+.nedostupne-replacement-link-add input {
+  flex: 1 1 16rem;
+  min-width: 12rem;
 }
 .nedostupne-order-row {
   display: flex;

--- a/apps/web/tests/e2e/nedostupne.spec.ts
+++ b/apps/web/tests/e2e/nedostupne.spec.ts
@@ -11,10 +11,15 @@ const E2E_NEDOSTUPNE_EMAIL = "e2e-nedostupne@forestshop.sk"; // musí sa zhodova
 // nenastavuje `MAIL_HOST`, takže `mailTransport` je v tomto behu `undefined`
 // (rovnaká úvaha ako `order-reminder.spec.ts`/`posta-uncollected.spec.ts`).
 // Fixtúrová objednávka "9008" (`scripts/e2e-setup.ts`) má riadok variantu
-// "40287" v stave 'nedostupne' — ten istý variant, ktorého katalógová
-// fixtúra reálne nesie `relatedProduct = "60297"`, takže náhrada sa dá
-// overiť naživo bez ďalšej fixtúry.
-test("zoznam zobrazí nedostupný variant s náhradou, povinný náhľad predchádza odoslaniu, konzola je čistá", async ({ page }) => {
+// "40287" v stave 'nedostupne', s pripraveným prekliku na náš e-shop
+// (`shop_product_url`) a na dodávateľa (`product_supplier_link_override`).
+//
+// issue 238: automatický "Náhrada: 60297" návrh (`product.relatedCodes`) je
+// preč — tento test overuje RUČNÉ pridanie/zmazanie odkazu náhrady namiesto
+// neho, prekliky na e-shop/dodávateľa, a že OBIDVE preview tlačidlá stále
+// ukazujú upraviteľné znenie e-mailu (existujúci `mail-templates` mechanizmus,
+// issue 192 — táto zmena mení len ZDROJ zoznamu náhrad, nie mechanizmus).
+test("ručné odkazy náhrad, prekliky na e-shop/dodávateľa, povinný náhľad predchádza odoslaniu, konzola je čistá", async ({ page }) => {
   const chyby: string[] = [];
   page.on("console", (m) => {
     if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
@@ -33,17 +38,67 @@ test("zoznam zobrazí nedostupný variant s náhradou, povinný náhľad predch�
   await expect(page.getByTestId("nedostupne-bcc-missing")).toBeVisible();
   await expect(page.getByTestId("nedostupne-mail-not-configured")).toBeVisible();
 
-  // Fixtúrová karta variantu "40287" s náhradou "60297" (neznámy kód —
-  // padá späť na seba samého ako meno, `.claude/rules/nedostupne` návrhový
-  // komentár na tickete).
   const group = page.getByTestId("nedostupne-group-40287");
   await expect(group).toBeVisible();
-  await expect(group.getByText("60297")).toBeVisible();
   await expect(group.getByText("E2E Zákazník Nedostupné")).toBeVisible();
 
-  // Klik na "náhľad" otvorí povinný náhľad e-mailu PRED akýmkoľvek odoslaním.
-  await page.getByTestId("nedostupne-send-9008-40287").click();
+  // issue 238: automatický návrh je PREČ — katalógová fixtúra stále nesie
+  // `relatedProduct = "60297"` pre tento variant, appka ho už nesmie
+  // zobraziť nikde na karte.
+  await expect(group.getByText("60297")).toHaveCount(0);
+
+  // Preklik na náš e-shop (názov produktu) a na dodávateľa (kód variantu) —
+  // obe pripravené vo fixtúre (`scripts/e2e-setup.ts`).
+  const shopLink = page.getByTestId("nedostupne-shop-link-40287");
+  await expect(shopLink).toBeVisible();
+  await expect(shopLink).toHaveAttribute("href", "https://www.forestshop.sk/e2e-nedostupne-40287/");
+  const supplierLink = page.getByTestId("nedostupne-supplier-link-40287");
+  await expect(supplierLink).toBeVisible();
+  await expect(supplierLink).toHaveAttribute("href", "https://dodavatel.example/e2e-nedostupne-40287");
+
+  // Ručné pridanie odkazu náhrady — pole musí prijať VIAC liniek na ten istý
+  // tovar (ticketova akceptačná podmienka).
+  const linkInput = group.getByTestId("nedostupne-replacement-link-input-40287");
+  await linkInput.fill("https://www.forestshop.sk/e2e-nahrada-1/");
+  await group.getByTestId("nedostupne-replacement-link-add-40287").click();
+  await expect(group.getByText("https://www.forestshop.sk/e2e-nahrada-1/")).toBeVisible();
+  await expect(linkInput).toHaveValue("");
+
+  await linkInput.fill("https://www.forestshop.sk/e2e-nahrada-2/");
+  await group.getByTestId("nedostupne-replacement-link-add-40287").click();
+  await expect(group.getByText("https://www.forestshop.sk/e2e-nahrada-2/")).toBeVisible();
+
+  // Odkazy prežijú znovunačítanie stránky (uložené v DB, nie len lokálny stav).
+  await page.reload();
+  await expect(page.getByRole("heading", { name: "Nedostupné tovary" })).toBeVisible();
+  const groupAfterReload = page.getByTestId("nedostupne-group-40287");
+  await expect(groupAfterReload.getByText("https://www.forestshop.sk/e2e-nahrada-1/")).toBeVisible();
+  await expect(groupAfterReload.getByText("https://www.forestshop.sk/e2e-nahrada-2/")).toBeVisible();
+
+  // Náhľad "S náhradou" ukáže PRESNE tieto ručné odkazy (nikdy automatický
+  // návrh) — a stále cez existujúci upraviteľný `mail-templates` mechanizmus
+  // (issue 192), táto zmena mení len zdroj `zoznam_nahrad`.
+  await groupAfterReload.getByTestId("nedostupne-alt-send-9008-40287").click();
   const preview = page.getByTestId("nedostupne-preview");
+  await expect(preview).toBeVisible();
+  await expect(preview).toContainText("https://www.forestshop.sk/e2e-nahrada-1/");
+  await expect(preview).toContainText("https://www.forestshop.sk/e2e-nahrada-2/");
+  await page.getByTestId("nedostupne-preview-cancel").click();
+  await expect(preview).toBeHidden();
+
+  // Zmazanie jedného odkazu — ostatné zostávajú.
+  const links = groupAfterReload.locator(".nedostupne-replacement-links li");
+  await expect(links).toHaveCount(2);
+  await groupAfterReload
+    .locator(".nedostupne-replacement-links li", { hasText: "e2e-nahrada-1" })
+    .getByRole("button", { name: /zmazať/ })
+    .click();
+  await expect(groupAfterReload.getByText("https://www.forestshop.sk/e2e-nahrada-1/")).toHaveCount(0);
+  await expect(groupAfterReload.getByText("https://www.forestshop.sk/e2e-nahrada-2/")).toBeVisible();
+
+  // Klik na "náhľad" (bez náhrady) otvorí povinný náhľad e-mailu PRED
+  // akýmkoľvek odoslaním.
+  await groupAfterReload.getByTestId("nedostupne-send-9008-40287").click();
   await expect(preview).toBeVisible();
   await expect(preview).toContainText("e2e-nedostupne@forestshop.sk");
 

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -2590,3 +2590,34 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   prepnutie späť na 2, Rozpory: Žiadne). Issue zavreté ručne s dôkazom,
   Discord run-card odoslaná. Playbook doplnený v GREEN commite
   (`.claude/rules/shop-feed.md`, `.claude/rules/supplier-stock.md`).
+
+- issue 237 (prehľad e-shopu + súhrn o objednávaní nad zoznamom "Na
+  objednanie"): nový `orders.total_price_with_vat numeric(12,2)` (migrácia
+  0031), extrahovaný v `parser.ts` cez zdieľaný `catalog/money.ts`'s
+  `parseDecimalComma`, vždy osviežený pri re-importe (rovnaká rodina ako
+  `status_name`/`remark`/`shop_remark`). Nový modul `orders/overview.ts`
+  (Europe/Bratislava deň/týždeň/mesiac hranice cez znovupoužité
+  `parseShopLocalDateTime`, BigInt-cent-presný súčet peňazí,
+  `getOrdersDashboardOverview` číta VŠETKY objednávky bez ohľadu na
+  `status_name`) + nová trasa `GET /api/orders/overview` (registrovaná
+  PRED `:id`). Frontend: `OrdersOverviewTiles.tsx` nad `OrdersToolbar` —
+  "Prehľad e-shopu" (vlastný fetch) + "Súhrn o objednávaní" (čisto zo
+  `suppliers`, nové `countAffectedOrders`/`oldestWaitingPlacedAt`/
+  `formatOrderCount` v `ordersSummary.ts`). 14 existujúcich
+  `OrdersSection*`/`OrderLineRow*.test.tsx` súborov doplnených o mock
+  `fetchOrdersOverview`. Testy: `overview.test.ts` (13),
+  `orders-overview.integration.test.ts` (7),
+  `orders-ingest-total-price.integration.test.ts` (2, vydelené aby
+  `orders-ingest.integration.test.ts` neprešlo cez eslint `max-lines:
+  400`), `ordersSummary.test.ts` (+21), `OrdersOverviewTiles.test.tsx` (5),
+  nový e2e `orders-overview.spec.ts` (porovnáva proti `/api/orders/open`
+  naživo, nie hardcoded čísla). PR #244, code review
+  (`superpowers:requesting-code-review`, nezávislý subagent, sám si
+  spustil celú lokálnu sadu vrátane 6 zdieľaných e2e specov): 0 Critical, 2
+  Important (storno-objednávky otázka pre naživo overenie — zdokumentované
+  v `.claude/rules/orders.md`; playbook zápis — doplnený), 1 Minor
+  (slovenské skloňovanie "1 objednávok" → oprava `formatOrderCount`, paucal
+  tvar). Merge `227f94d`. Naživo overené proti Shoptet administrácii
+  (`/admin/statistiky-objednavek-a-obratu/`, filter "Dnes") — PRESNÁ ZHODA:
+  8 objednávok, 446,90 € oboma stranami. Issue zavreté ručne s dôkazom,
+  Discord run-card odoslaná. Playbook doplnený (`.claude/rules/orders.md`).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.139",
+  "version": "0.3.0-dev.140",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -9,7 +9,7 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { createDb } from "../apps/api/src/db/client.js";
-import { jobRuns, mailLog, orderLines, orderOpenStatuses, orderReminderSettings, orders, pairings, postaUncollectedSettings, products, shopProductUrl, supplierStock, users, variants } from "../apps/api/src/db/schema.js";
+import { jobRuns, mailLog, orderLines, orderOpenStatuses, orderReminderSettings, orders, pairings, postaUncollectedSettings, productSupplierLinkOverrides, products, shopProductUrl, supplierStock, users, variants } from "../apps/api/src/db/schema.js";
 import { CATALOG_IMPORT_JOB_NAME } from "../apps/api/src/modules/scheduler/jobs.js";
 import { hashPassword } from "../apps/api/src/modules/auth/passwords.js";
 import { ingestCatalog } from "../apps/api/src/modules/catalog/ingest.js";
@@ -550,13 +550,18 @@ if (objednavkaOdkaz === undefined) throw new Error("E2E objednávka (odkaz) sa n
 await db.insert(orderLines).values({ orderId: objednavkaOdkaz.id, variantCode: "278", quantity: 1 });
 
 // issue 176: JEDNA objednávka s riadkom v stave 'nedostupne' — variant
-// "40287" (rovnaký variant ako 9002/9003, katalógová fixtúra ho reálne nesie
-// s `relatedProduct = "60297"` po `ingestCatalog` nižšie, `.claude/rules/
-// catalog.md`), takže "Nedostupné tovary" (`nedostupne.spec.ts`) má naživo
-// čo zobraziť VRÁTANE náhradného produktu, bez potreby ďalšej fixtúry.
-// Pridáva GLOBÁLNE 1 riadok do "Na objednanie" (`orders.spec.ts`'s prvý test
-// preto počíta so "Všetci (8)"/"(bez dodávateľa) (5)" a s "Nedostupné 1" v
-// súhrne — "40287" nemá dodávateľa, rovnaký zámer ako 9002/9003).
+// "40287" (rovnaký variant ako 9002/9003), takže "Nedostupné tovary"
+// (`nedostupne.spec.ts`) má naživo čo zobraziť. Pridáva GLOBÁLNE 1 riadok do
+// "Na objednanie" (`orders.spec.ts`'s prvý test preto počíta so "Všetci (8)"/
+// "(bez dodávateľa) (5)" a s "Nedostupné 1" v súhrne — "40287" nemá
+// dodávateľa, rovnaký zámer ako 9002/9003).
+// AKTUALIZÁCIA (issue 238, 2026-08-04): automatický `relatedProduct` návrh
+// (`product.relatedCodes`, katalógová fixtúra ho stále nesie ako "60297",
+// appka ho už NEČÍTA) je nahradený majiteľovými RUČNÝMI odkazmi
+// (`nedostupne_replacement_link`, pridané cez UI priamo v e2e teste) —
+// nižšie pribúda `shop_product_url` (preklik na náš e-shop) a RUČNÝ
+// `product_supplier_link_override` (preklik na dodávateľa — fixtúra má pre
+// tento variant PRÁZDNy `internalNote`, overené priamo na CSV).
 const [objednavkaNedostupne] = await db
   .insert(orders)
   .values({
@@ -569,6 +574,24 @@ const [objednavkaNedostupne] = await db
   .returning();
 if (objednavkaNedostupne === undefined) throw new Error("E2E objednávka (nedostupné) sa nepodarila vložiť");
 await db.insert(orderLines).values({ orderId: objednavkaNedostupne.id, variantCode: "40287", quantity: 1, state: "nedostupne" });
+
+// issue 238: preklik na náš e-shop (názov produktu) a na dodávateľa (kód) na
+// obrazovke "Nedostupné tovary" — variant "40287" (rovnaký ako vyššie) má vo
+// fixtúre PRÁZDNY `internalNote` (overené priamo na fixtúre, `.claude/rules/
+// catalog.md`), takže preklik na dodávateľa musí ísť cez RUČNÝ override
+// (`product_supplier_link_override`), nie extrahovaný odkaz. Produktkey je
+// exportov `guid` stĺpec (identita produktu, `.claude/rules/catalog.md`),
+// overené priamym dopytom proti reálne naimportovanej fixtúre.
+await db.insert(shopProductUrl).values({
+  code: "40287",
+  url: "https://www.forestshop.sk/e2e-nedostupne-40287/",
+  fetchedAt: new Date("2026-07-27T09:00:00Z"),
+});
+await db.insert(productSupplierLinkOverrides).values({
+  productKey: "d63e07c9-3c48-11e6-8a3b-0cc47a6c92bc",
+  url: "https://dodavatel.example/e2e-nedostupne-40287",
+  updatedAt: new Date("2026-07-27T09:00:00Z"),
+});
 
 // F4 (#45): jeden UŽ NAVRHNUTÝ (nepotvrdený) pairing kandidát — simuluje to,
 // čo by inak vložilo #46 (automatické hľadanie kandidátov, ešte

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -193,7 +193,7 @@ await db.execute(
   // takže CASCADE ich nikdy nestrhne. Bez nich by potvrdenia dodávateľa z
   // PREDOŠLÉHO e2e behu prežili do ďalšieho (presne past popísaná v
   // `.claude/rules/supplier-stock.md`, tam pre `tests/helpers/db.ts`).
-  'TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, mail_template, mail_template_history, supplier_stock, restock_settings, restock_event, shop_product_url RESTART IDENTITY CASCADE',
+  'TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, nedostupne_replacement_link, mail_template, mail_template_history, supplier_stock, restock_settings, restock_event, shop_product_url RESTART IDENTITY CASCADE',
 );
 // Rovnaký dôvod ako `tests/helpers/db.ts`: bez tohto by "Na objednanie" bolo
 // v CELOM e2e behu prázdne pre KAŽDÚ objednávku (žiadny nastavený otvorený


### PR DESCRIPTION
## Čo sa mení

Prepracovanie obrazovky **Nedostupné tovary** podľa majiteľovho nákresu, issue 238.

1. Automatický návrh náhrad (`product.relatedCodes`, Shoptetovo "súvisiace
   produkty") je preč — majiteľ ho odmietol ako blbosť.
2. Namiesto neho: pole na RUČNÉ pridanie odkazov náhrad (viac na jeden
   tovar), nová tabuľka `nedostupne_replacement_link`.
3. Tri prekliky: názov produktu → náš e-shop (`shop_product_url`, `null` =
   ostáva neaktívny, nikdy vyhľadávací fallback), kód produktu → dodávateľ
   (`resolveEffectiveSupplierLink`, rovnaká funkcia ako "Na objednanie"),
   číslo objednávky → objednávka (už existovalo).
4. Editovateľný text e-mailu pri oboch tlačidlách náhľadu — už existujúci
   `mail-templates` mechanizmus (issue 192), len zdroj `zoznam_nahrad` sa
   mení na majiteľove ručné odkazy.
5. Riadok so zákazníkom ostáva nezmenený.

## Testy

- Unit: `logic.test.ts` (RED→GREEN), `replacement-links` integračné testy,
  HTTP integračné testy pre nové endpointy, `NedostupneSection.test.tsx`.
- E2E (`nedostupne.spec.ts`): pridanie/zmazanie ručného odkazu, prežitie
  reloadu, oba prekliky, obsah preview e-mailu, konzola bez chýb.

## Poznámky

- `product.related_codes`/jeho import v katalógu OSTÁVA nedotknutý (mimo
  scope — cross-cutting zásah do import pipeline), teraz nečítaný nikde —
  follow-up issue 245.
- Design + validácia zdokumentované priamo na issue 238 (komentáre).

issue 238
