### PR TITLE
Eshop → Párovanie produktov: doplniť chýbajúce dodávateľské linky (issue 239)

### DIFF
--- a/apps/api/src/http/app.ts
+++ b/apps/api/src/http/app.ts
@@ -20,6 +20,7 @@ import { registerNedostupneRoutes, type NedostupneRunDeps } from "./nedostupne-r
 import { requireSameOrigin } from "./origin-check.js";
 import { registerPairingRoutes } from "./pairing-routes.js";
 import { registerPostaUncollectedRoutes, type PostaUncollectedRunDeps } from "./posta-uncollected-routes.js";
+import { registerProductLinksRoutes } from "./product-links-routes.js";
 import type { PageFetcher, PageFetchResult } from "../modules/supplier-stock/page-fetcher.js";
 import { registerSupplierStockRoutes } from "./supplier-stock-routes.js";
 import { registerRestockRoutes, type RestockRunDeps } from "./restock-routes.js";
@@ -179,6 +180,11 @@ export function createApp(
   registerSchedulerRoutes(app, db);
   registerSupplierRoutes(app, db, options.sendSupplierMail);
   registerPairingRoutes(app, db);
+  // issue 239: "Eshop → Párovanie produktov" — zoznam produktov bez
+  // dodávateľskej linky + doplnenie/oprava (zapisuje do rovnakej
+  // `product_supplier_link_override` tabuľky ako #121, žiadna nová cesta do
+  // Shoptetu).
+  registerProductLinksRoutes(app, db);
   registerPostaUncollectedRoutes(
     app,
     db,

--- a/apps/api/src/http/orders-routes.ts
+++ b/apps/api/src/http/orders-routes.ts
@@ -10,8 +10,7 @@ import { listKnownStatusNames, listOpenStatusNames, replaceOpenStatusNames } fro
 import { getOrdersDashboardOverview } from "../modules/orders/overview.js";
 import { getOrderDetail, listOpenOrderLinesBySupplier } from "../modules/orders/queries.js";
 import { assignOrderLineSupplier } from "../modules/orders/supplier-assignment.js";
-import { setProductSupplierLink } from "../modules/orders/supplier-link-assignment.js";
-import { startsWithFormulaChar } from "../modules/shoptet-writeback/formula-guard.js";
+import { setProductSupplierLink, supplierLinkUrlBody } from "../modules/orders/supplier-link-assignment.js";
 import { setOrderComment, setOrderLineOrdered, setOrderLineState } from "../modules/orders/state.js";
 import { requireRole, requireUser, type AppBindings } from "./middleware.js";
 import { requireSameOrigin } from "./origin-check.js";
@@ -31,33 +30,11 @@ const orderLineOrderedBody = z.object({ ordered: z.boolean() });
 // v projekte (`catalog-routes.ts`, `pairing-routes.ts`) — hodnota sa neskôr
 // vkladá aj do mailu dodávateľovi, chýbajúci limit bol prehliadnutá medzera.
 const orderLineSupplierBody = z.object({ supplier: z.string().trim().min(1).max(200) });
-// issue 121: manuálny odkaz na dodávateľa — validovaný ako URL (ticketova
-// akceptačná podmienka), `.max(2000)` rovnaká horná hranica ako ostatné voľné
-// URL/textové vstupy v projekte (`orderCommentBody` nižšie). `.url()` samo o
-// sebe by prijalo aj syntakticky platnú, ale nebezpečnú schému (napr.
-// `javascript:...`) — hodnota sa vykresľuje priamo ako `<a href>`
-// (`OrderLineRow.tsx`), preto NAVYŠE `.regex` vynucuje http(s), rovnaký vzor
-// ako `adminUrl`/existujúci `supplierUrl` vo frontendovej `ordersApi.ts`
-// schéme (issue 70's "druhá vrstva overenia" zásada).
-// issue 153: `.refine` navyše — samostatná, POMENOVANÁ formula-injection
-// kontrola (`formula-guard.ts`, zdieľaná s CSV-sink ochranou v `csv.ts`).
-// Pre TOTO pole je dnes logicky prekrytá `.regex`om nižšie (hodnota
-// začínajúca `=`/`+`/`-`/`@` nikdy nemôže zároveň začínať `http`), ale ide o
-// obranu do hĺbky: chráni pred budúcim uvoľnením http(s) pravidla, ktoré by
-// inak potichu znovu otvorilo CSV-injection dieru (`internalNote` v
-// generovanom CSV, `select-changes.ts`) bez toho, aby si to niekto všimol —
-// viď ticketov design komentár.
-const orderLineSupplierLinkBody = z.object({
-  url: z
-    .string()
-    .trim()
-    .url()
-    .max(2000)
-    .regex(/^https?:\/\//)
-    .refine((v) => !startsWithFormulaChar(v), {
-      message: "odkaz nesmie začínať znakom vzorca (=, +, -, @) — možný pokus o CSV-injection",
-    }),
-});
+// issue 121/153: validácia tela presunutá do `supplier-link-assignment.ts`'s
+// zdieľaného `supplierLinkUrlBody` (issue 239 ju potrebuje ZNOVA pre
+// `POST /api/product-links/:productKey`, rovnaká URL+http(s)+formula-guard
+// kontrola) — pôvodný komentár k dôvodu jednotlivých pravidiel je tam.
+const orderLineSupplierLinkBody = supplierLinkUrlBody;
 // issue 64: manažérova voľná poznámka k CELEJ objednávke — na rozdiel od
 // `orderLineSupplierBody` vyššie ZÁMERNE bez `.min(1)` (prázdny orezaný vstup
 // je platný spôsob, ako poznámku vymazať, route ho mapuje na `null`). Cap

--- a/apps/api/src/http/product-links-routes.ts
+++ b/apps/api/src/http/product-links-routes.ts
@@ -1,0 +1,66 @@
+import { zValidator } from "@hono/zod-validator";
+import type { Hono } from "hono";
+import { z } from "zod";
+import type { Database } from "../db/client.js";
+import { log } from "../logger.js";
+import { listProductLinks } from "../modules/product-links/queries.js";
+import { setProductSupplierLinkForProduct, supplierLinkUrlBody } from "../modules/orders/supplier-link-assignment.js";
+import { requireRole, requireUser, type AppBindings } from "./middleware.js";
+import { requireSameOrigin } from "./origin-check.js";
+
+// Prázdna hodnota (`page=`) sa má správať ako neprítomný parameter, rovnaký
+// vzor ako `catalog-routes.ts`/`pairing-routes.ts`'s `pageParam`.
+const pageParam = z.preprocess(
+  (value) => (value === "" ? undefined : value),
+  z.coerce.number().int().min(1).max(100_000).default(1),
+);
+
+// Predvolené `state: "missing"` — ticket žiada primárne zoznam produktov BEZ
+// linky; "all"/"linked" umožňujú aj OPRAVU existujúcej (ticketova akceptačná
+// podmienka "existujúcu linku sa musí dať aj opraviť").
+const productLinksQuery = z.object({
+  q: z.string().max(200).default(""),
+  state: z.enum(["all", "missing", "linked"]).default("missing"),
+  page: pageParam,
+  pageSize: z.coerce.number().int().min(1).max(200).default(50),
+});
+
+// `productKey` je export's `guid` (`schema-catalog.ts`'s komentár k
+// `products.key`) — UUID-tvar bez lomky, bezpečné ako cestový segment (na
+// rozdiel od `variantCode`, ktorý lomku nesie, viď `pairing-routes.ts`'s
+// komentár prečo TEN parameter ide v tele).
+const productLinkParam = z.object({ productKey: z.string().min(1).max(200) });
+
+export function registerProductLinksRoutes(app: Hono<AppBindings>, db: Database): void {
+  // Čítanie — rovnaké oprávnenie ako katalóg/objednávky/párovanie
+  // (`requireUser`, žiadne obmedzenie roly): každý prihlásený smie vidieť,
+  // ktoré produkty nemajú dodávateľskú linku.
+  app.get("/api/product-links", requireUser(db), zValidator("query", productLinksQuery), async (c) =>
+    c.json(await listProductLinks(db, c.req.valid("query"))),
+  );
+
+  // Doplnenie/oprava linky — rovnaké oprávnenie ako existujúci
+  // `POST /api/orders/lines/:lineId/supplier-link` (issue 121):
+  // `requireRole("admin", "manazer")`.
+  app.post(
+    "/api/product-links/:productKey",
+    requireSameOrigin(),
+    requireUser(db),
+    requireRole("admin", "manazer"),
+    zValidator("param", productLinkParam),
+    zValidator("json", supplierLinkUrlBody),
+    async (c) => {
+      const { productKey } = c.req.valid("param");
+      const { url } = c.req.valid("json");
+      const user = c.get("user");
+      const now = new Date();
+
+      const result = await setProductSupplierLinkForProduct(db, { productKey, url, actorUserId: user.userId, now });
+      if (result === "not_found") {
+        return c.json({ error: "Produkt sa nenašiel" }, 404);
+      }
+      log.info({ actorUserId: user.userId, productKey, url }, "úprava odkazu na dodávateľa produktu (Párovanie produktov)");
+      return c.json({ ok: true as const, url });
+    },
+  );
+}

--- a/apps/api/src/modules/orders/supplier-link-assignment.ts
+++ b/apps/api/src/modules/orders/supplier-link-assignment.ts
@@ -1,7 +1,9 @@
 import { eq } from "drizzle-orm";
+import { z } from "zod";
 import type { Database } from "../../db/client.js";
-import { orderLines, productSupplierLinkOverrides, variants } from "../../db/schema.js";
+import { orderLines, productSupplierLinkOverrides, products, variants } from "../../db/schema.js";
 import { record } from "../audit/service.js";
+import { startsWithFormulaChar } from "../shoptet-writeback/formula-guard.js";
 
 export type SetProductSupplierLinkResult = "ok" | "not_found";
 
@@ -12,6 +14,80 @@ export interface SetProductSupplierLinkInput {
   readonly url: string;
   readonly actorUserId: string;
   readonly now: Date;
+}
+
+// issue 239: zdieľaná zod schéma pre TELO "ulož odkaz na dodávateľa" — dnes
+// dve trasy (`POST /api/orders/lines/:lineId/supplier-link` z #121 a
+// `POST /api/product-links/:productKey` z #239), obe overujú TÚ ISTÚ vec
+// (URL, http(s) schéma, žiadny formula-injection znak na začiatku, #153).
+// Predtým bola definovaná len lokálne v `orders-routes.ts` — presunuté sem,
+// aby ju nová trasa nemusela duplikovať/rozísť sa s ňou.
+export const supplierLinkUrlBody = z.object({
+  url: z
+    .string()
+    .trim()
+    .url()
+    .max(2000)
+    .regex(/^https?:\/\//)
+    .refine((v) => !startsWithFormulaChar(v), {
+      message: "odkaz nesmie začínať znakom vzorca (=, +, -, @) — možný pokus o CSV-injection",
+    }),
+});
+
+// Zúžený parameter (rovnaký vzor ako `audit/service.ts`'s `AuditExecutor`,
+// `.claude/rules/database.md`) — musí bežať aj s `tx` (`PgTransaction`),
+// ktorý zdieľa `.select()`/`.insert()` s `Database`, ale nemá jej `$client`.
+type UpsertExecutor = Pick<Database, "select" | "insert">;
+
+interface UpsertProductSupplierLinkInput {
+  readonly productKey: string;
+  readonly url: string;
+  readonly actorUserId: string;
+  readonly now: Date;
+  // `null` keď zápis nejde cez konkrétny riadok objednávky (issue 239's
+  // `setProductSupplierLinkForProduct` — produkt bez otvorenej objednávky).
+  readonly lineId: string | null;
+}
+
+// Zdieľané jadro OBOCH zápisových ciest nižšie (`setProductSupplierLink`
+// cez `lineId`, `setProductSupplierLinkForProduct` cez priamy `productKey`)
+// — rovnaký upsert + audit záznam, líšia sa len v tom, AKO sa `productKey`
+// zistí a či existuje `lineId` na zaznamenanie do auditu.
+async function upsertProductSupplierLink(
+  tx: UpsertExecutor,
+  input: UpsertProductSupplierLinkInput,
+): Promise<"ok"> {
+  const [previous] = await tx
+    .select({ url: productSupplierLinkOverrides.url })
+    .from(productSupplierLinkOverrides)
+    .where(eq(productSupplierLinkOverrides.productKey, input.productKey))
+    .limit(1);
+
+  await tx
+    .insert(productSupplierLinkOverrides)
+    .values({ productKey: input.productKey, url: input.url, updatedAt: input.now })
+    .onConflictDoUpdate({
+      target: productSupplierLinkOverrides.productKey,
+      set: { url: input.url, updatedAt: input.now },
+    });
+
+  // Audit nesie AJ pôvodnú hodnotu (kto/kedy/z čoho/na čo — ticketova
+  // akceptačná podmienka), `null` keď doteraz žiadna nebola nastavená.
+  await record(tx, {
+    at: input.now,
+    actorUserId: input.actorUserId,
+    action: "product_supplier_link_override.changed",
+    entity: "product_supplier_link_override",
+    entityId: input.productKey,
+    data: {
+      productKey: input.productKey,
+      lineId: input.lineId,
+      previousUrl: previous?.url ?? null,
+      newUrl: input.url,
+    },
+  });
+
+  return "ok";
 }
 
 // issue 121: majiteľ, doslovne "pri kazdom produkte ma byt moznost upravit
@@ -43,36 +119,46 @@ export async function setProductSupplierLink(
       .limit(1);
     if (line === undefined) return "not_found";
 
-    const [previous] = await tx
-      .select({ url: productSupplierLinkOverrides.url })
-      .from(productSupplierLinkOverrides)
-      .where(eq(productSupplierLinkOverrides.productKey, line.productKey))
-      .limit(1);
-
-    await tx
-      .insert(productSupplierLinkOverrides)
-      .values({ productKey: line.productKey, url: input.url, updatedAt: input.now })
-      .onConflictDoUpdate({
-        target: productSupplierLinkOverrides.productKey,
-        set: { url: input.url, updatedAt: input.now },
-      });
-
-    // Audit nesie AJ pôvodnú hodnotu (kto/kedy/z čoho/na čo — ticketova
-    // akceptačná podmienka), `null` keď doteraz žiadna nebola nastavená.
-    await record(tx, {
-      at: input.now,
+    return upsertProductSupplierLink(tx, {
+      productKey: line.productKey,
+      url: input.url,
       actorUserId: input.actorUserId,
-      action: "product_supplier_link_override.changed",
-      entity: "product_supplier_link_override",
-      entityId: line.productKey,
-      data: {
-        productKey: line.productKey,
-        lineId: input.lineId,
-        previousUrl: previous?.url ?? null,
-        newUrl: input.url,
-      },
+      now: input.now,
+      lineId: input.lineId,
     });
+  });
+}
 
-    return "ok";
+export type SetProductSupplierLinkForProductResult = "ok" | "not_found";
+
+export interface SetProductSupplierLinkForProductInput {
+  readonly productKey: string;
+  readonly url: string;
+  readonly actorUserId: string;
+  readonly now: Date;
+}
+
+// issue 239: priamy náprotivok `setProductSupplierLink` vyššie, PRE PRODUKT
+// bez sprostredkovania cez konkrétny riadok objednávky — obrazovka "Eshop →
+// Párovanie produktov" vypisuje produkty (aj tie BEZ otvorenej objednávky),
+// takže potrebuje zapisovať priamo podľa `productKey`, nie `lineId`. Zdieľa
+// rovnaké jadro (`upsertProductSupplierLink`) s `setProductSupplierLink` —
+// jediný rozdiel je, ako sa `productKey` overí (tu priamo cez `products`
+// tabuľku, nie cez JOIN na `orderLines`/`variants`).
+export async function setProductSupplierLinkForProduct(
+  db: Database,
+  input: SetProductSupplierLinkForProductInput,
+): Promise<SetProductSupplierLinkForProductResult> {
+  return db.transaction(async (tx) => {
+    const [product] = await tx.select({ key: products.key }).from(products).where(eq(products.key, input.productKey)).limit(1);
+    if (product === undefined) return "not_found";
+
+    return upsertProductSupplierLink(tx, {
+      productKey: input.productKey,
+      url: input.url,
+      actorUserId: input.actorUserId,
+      now: input.now,
+      lineId: null,
+    });
   });
 }

--- a/apps/api/src/modules/product-links/queries.ts
+++ b/apps/api/src/modules/product-links/queries.ts
@@ -1,0 +1,99 @@
+import { eq, sql } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { productSupplierLinkOverrides, products, variants } from "../../db/schema.js";
+import { resolveEffectiveSupplierLink } from "../orders/effective-supplier-link.js";
+
+// issue 239: "Eshop → Párovanie produktov" — zoznam PRODUKTOV (nie variantov,
+// na rozdiel od `pairing/queries.ts`'s `listPairings`), ktoré NEMAJÚ efektívnu
+// dodávateľskú linku, s možnosťou ju doplniť/opraviť. Kľúčované `product.key`,
+// rovnaké kľúčovanie ako `product_supplier_link_override` (issue 121/122) —
+// zámerne INÝ dátový model než skrytá `pairing` záložka (variant-kľúčovaný
+// stavový automat pre budúce #46/#48, viď návrhový komentár na ticket).
+export type ProductLinkState = "all" | "missing" | "linked";
+
+export interface ProductLinkItem {
+  readonly productKey: string;
+  readonly productName: string;
+  readonly supplier: string | null;
+  readonly variantCount: number;
+  /** Efektívna linka (`resolveEffectiveSupplierLink` — override MÁ vždy prednosť
+   * pred extrahovaným `internalNote` odkazom), `null` = appka žiadnu nepozná. */
+  readonly url: string | null;
+  readonly updatedAt: string | null;
+  /** `null` = ešte nikdy odoslané do Shoptetu (`shoptet-writeback` job, #122). */
+  readonly syncedAt: string | null;
+}
+
+export interface ProductLinkSearchInput {
+  readonly q: string;
+  readonly state: ProductLinkState;
+  readonly page: number;
+  readonly pageSize: number;
+}
+
+export interface ProductLinkSearchResult {
+  readonly total: number;
+  /** Koľko produktov CELKOVO (nezávisle od `q`/`state` filtra vyššie) nemá
+   * efektívnu linku — ticketova akceptačná podmienka "nech je vidno, koľko
+   * ich celkovo zostáva". */
+  readonly missingTotal: number;
+  readonly items: readonly ProductLinkItem[];
+}
+
+// Efektívna linka sa vyhodnocuje AŽ v JS (`resolveEffectiveSupplierLink` je
+// čistá regexová funkcia nad `internalNote`, nedá sa vyjadriť ako SQL
+// predikát bez duplicity logiky) — rovnaký vzor ako `supplier-stock/run.ts`'s
+// `collectSupplierLinks`. Celý katalóg (rádovo tisícky produktov) sa preto
+// načíta a filtruje v pamäti — prijateľné pre riadkovú manažérsku obrazovku
+// (MVP filozofia), nie hot-path.
+export async function listProductLinks(db: Database, input: ProductLinkSearchInput): Promise<ProductLinkSearchResult> {
+  const productRows = await db
+    .select({
+      productKey: products.key,
+      productName: products.name,
+      supplier: products.supplier,
+      internalNote: products.internalNote,
+      overrideUrl: productSupplierLinkOverrides.url,
+      updatedAt: productSupplierLinkOverrides.updatedAt,
+      syncedAt: productSupplierLinkOverrides.syncedAt,
+    })
+    .from(products)
+    .leftJoin(productSupplierLinkOverrides, eq(productSupplierLinkOverrides.productKey, products.key));
+
+  const countRows = await db
+    .select({ productKey: variants.productKey, count: sql<number>`count(*)`.mapWith(Number) })
+    .from(variants)
+    .groupBy(variants.productKey);
+  const variantCountByProduct = new Map(countRows.map((row) => [row.productKey, row.count]));
+
+  const allItems: ProductLinkItem[] = productRows.map((row) => {
+    const effective = resolveEffectiveSupplierLink(row.internalNote, row.overrideUrl);
+    return {
+      productKey: row.productKey,
+      productName: row.productName,
+      supplier: row.supplier,
+      variantCount: variantCountByProduct.get(row.productKey) ?? 0,
+      url: effective.url,
+      updatedAt: row.updatedAt?.toISOString() ?? null,
+      syncedAt: row.syncedAt?.toISOString() ?? null,
+    };
+  });
+
+  const missingTotal = allItems.filter((item) => item.url === null).length;
+
+  const q = input.q.trim().toLowerCase();
+  const filtered = allItems.filter((item) => {
+    if (input.state === "missing" && item.url !== null) return false;
+    if (input.state === "linked" && item.url === null) return false;
+    if (q === "") return true;
+    return item.productKey.toLowerCase().includes(q) || item.productName.toLowerCase().includes(q);
+  });
+
+  filtered.sort((a, b) => a.productName.localeCompare(b.productName, "sk"));
+
+  const total = filtered.length;
+  const start = (input.page - 1) * input.pageSize;
+  const items = filtered.slice(start, start + input.pageSize);
+
+  return { total, missingTotal, items };
+}

--- a/apps/api/tests/orders-overview.integration.test.ts
+++ b/apps/api/tests/orders-overview.integration.test.ts
@@ -3,7 +3,7 @@ import { orders, users } from "../src/db/schema.js";
 import { createApp } from "../src/http/app.js";
 import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
 import { hashPassword } from "../src/modules/auth/passwords.js";
-import { getOrdersDashboardOverview } from "../src/modules/orders/overview.js";
+import { computeBratislavaPeriodBoundaries, getOrdersDashboardOverview } from "../src/modules/orders/overview.js";
 import { withCleanDb } from "./helpers/db.js";
 
 const HESLO = "test-heslo-abc"; // testovacie údaje, nie tajomstvo
@@ -133,9 +133,21 @@ it("GET /api/orders/overview bez prihlásenia vráti 401", async () => {
 
 // issue 237: rovnaké oprávnenie ako `/api/orders/open` — čítanie (rola
 // `citanie`) smie vidieť prehľad, nie je vyhradené manažérom/adminom.
+//
+// issue 239 (nájdené pri behu tohto balíka, nesúvisiaci s ním): NA ROZDIEL
+// od ostatných testov v tomto súbore (ktoré posielajú PEVNÉ `NOW`/
+// `TODAY_START` priamo do `getOrdersDashboardOverview`) táto trasa počíta
+// "dnes" zo SKUTOČNÉHO `new Date()` na serveri — pevný literál
+// `TODAY_START` (2026-08-03/04) preto po prekročení toho kalendárneho dňa
+// prestal byť "dnes" a test spoľahlivo zlyhal (pozorované naživo pri
+// prechode 2026-08-04 → 2026-08-05). Fix: rovnaká hranica, ale prepočítaná
+// zo SKUTOČNÉHO `new Date()` v momente behu testu (`computeBratislavaPeriodBoundaries`,
+// tá istá funkcia, akú používa aj samotná trasa) — test tak zostáva platný
+// v KTORÝKOĽVEK deň, nielen v deň napísania.
 it("GET /api/orders/overview vráti počty aj tržbu za dnes/týždeň/mesiac (rola 'citanie' smie čítať)", async () => {
   const { app, cookie, db } = await boot();
-  await insertOrder(db, "9230", new Date(TODAY_START.getTime() + 60 * 60 * 1000), "77.50");
+  const skutocneDnesStart = computeBratislavaPeriodBoundaries(new Date()).today;
+  await insertOrder(db, "9230", new Date(skutocneDnesStart.getTime() + 60 * 60 * 1000), "77.50");
 
   const res = await app.request("/api/orders/overview", { headers: { cookie } });
   expect(res.status).toBe(200);

--- a/apps/api/tests/product-links-http.integration.test.ts
+++ b/apps/api/tests/product-links-http.integration.test.ts
@@ -1,0 +1,190 @@
+import { eq } from "drizzle-orm";
+import { afterEach, expect, it } from "vitest";
+import { productSupplierLinkOverrides, users } from "../src/db/schema.js";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import type { UserRole } from "../src/modules/auth/service.js";
+import { insertTestVariant, insertTestVariantForProduct } from "./helpers/orders.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 239: "Eshop → Párovanie produktov" — zoznam produktov bez
+// dodávateľskej linky + doplnenie/oprava, zapisuje do TEJ ISTEJ
+// `product_supplier_link_override` tabuľky ako #121 (rovnaký vzor testov ako
+// `orders-supplier-link-assignment.integration.test.ts`, len nad NOVOU
+// PRODUKTOVOU trasou namiesto riadku objednávky).
+
+const HESLO = "test-heslo-abc"; // testovacie údaje, nie tajomstvo
+
+let close: (() => Promise<void>) | undefined;
+
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  resetLoginRateLimit();
+});
+
+async function boot(role: UserRole) {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const [pouzivatel] = await ctx.db
+    .insert(users)
+    .values({ email: "manazer@forestshop.sk", passwordHash: await hashPassword(HESLO), displayName: "Manažér", role })
+    .returning({ id: users.id });
+  if (pouzivatel === undefined) throw new Error("testovací používateľ sa nepodarilo vložiť");
+
+  const app = createApp(ctx.db, { cookieSecure: false });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "manazer@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie, db: ctx.db };
+}
+
+interface ListTelo {
+  readonly total: number;
+  readonly missingTotal: number;
+  readonly items: {
+    readonly productKey: string;
+    readonly productName: string;
+    readonly supplier: string | null;
+    readonly variantCount: number;
+    readonly url: string | null;
+    readonly updatedAt: string | null;
+    readonly syncedAt: string | null;
+  }[];
+}
+
+it("bez prihlásenia vráti 401 na oboch trasách", async () => {
+  const { app } = await boot("manazer");
+  expect((await app.request("/api/product-links")).status).toBe(401);
+  expect(
+    (
+      await app.request("/api/product-links/NEJAKY-KEY", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ url: "https://dodavatel.example.com" }),
+      })
+    ).status,
+  ).toBe(401);
+});
+
+it("produkt bez internalNote a bez override sa zobrazí v stave 'missing' s počtom variantov", async () => {
+  const { app, cookie, db } = await boot("citanie"); // čítanie smie vidieť zoznam
+  await insertTestVariantForProduct(db, "PL-1", "PL-1/S", { sizeLabel: "S" });
+  await insertTestVariantForProduct(db, "PL-1", "PL-1/M", { sizeLabel: "M" });
+
+  const res = await app.request("/api/product-links?state=missing", { headers: { cookie } });
+  expect(res.status).toBe(200);
+  const telo = (await res.json()) as ListTelo;
+  const item = telo.items.find((i) => i.productKey === "PL-1");
+  expect(item).toEqual({
+    productKey: "PL-1",
+    productName: "Test produkt PL-1",
+    supplier: "Test dodávateľ",
+    variantCount: 2,
+    url: null,
+    updatedAt: null,
+    syncedAt: null,
+  });
+});
+
+it("produkt s rozpoznateľným odkazom v internalNote sa NEzobrazí v stave 'missing', ale zobrazí v 'linked'", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  await insertTestVariant(db, "PL-2", "Dodávateľ", { internalNote: "https://dodavatel.example.com/produkt-2" });
+
+  const missing = (await (await app.request("/api/product-links?state=missing", { headers: { cookie } })).json()) as ListTelo;
+  expect(missing.items.some((i) => i.productKey === "PL-2")).toBe(false);
+
+  const linked = (await (await app.request("/api/product-links?state=linked", { headers: { cookie } })).json()) as ListTelo;
+  const item = linked.items.find((i) => i.productKey === "PL-2");
+  expect(item?.url).toBe("https://dodavatel.example.com/produkt-2");
+});
+
+it("missingTotal počíta CELÝ katalóg nezávisle od aktuálneho filtra/hľadania", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  await insertTestVariant(db, "PL-3", "Dodávateľ"); // bez linky
+  await insertTestVariant(db, "PL-4", "Dodávateľ", { internalNote: "https://dodavatel.example.com/produkt-4" }); // s linkou
+
+  const telo = (await (await app.request("/api/product-links?state=linked&q=PL-4", { headers: { cookie } })).json()) as ListTelo;
+  // `total` je vyfiltrovaný počet (len PL-4), `missingTotal` nezávisí od filtra.
+  expect(telo.items).toHaveLength(1);
+  expect(telo.missingTotal).toBeGreaterThanOrEqual(1);
+});
+
+it("uloženie novej linky priamo podľa productKey (bez riadku objednávky) sa zapíše a prežije opätovné načítanie", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await insertTestVariant(db, "PL-5", "Dodávateľ");
+
+  const pred = (await (await app.request("/api/product-links?q=PL-5", { headers: { cookie } })).json()) as ListTelo;
+  expect(pred.items[0]?.url).toBeNull();
+
+  const res = await app.request("/api/product-links/PL-5", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ url: "https://e2e-dodavatel.example.com/produkt-5" }),
+  });
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ ok: true, url: "https://e2e-dodavatel.example.com/produkt-5" });
+
+  // `state=all` — predvolený filter je "missing" a uložením linky sa PL-5
+  // presunie do "linked" (viac tak nezodpovedá predvolenému stavu).
+  const po = (await (await app.request("/api/product-links?q=PL-5&state=all", { headers: { cookie } })).json()) as ListTelo;
+  expect(po.items[0]?.url).toBe("https://e2e-dodavatel.example.com/produkt-5");
+  expect(po.items[0]?.syncedAt).toBeNull();
+
+  const [override] = await db.select().from(productSupplierLinkOverrides).where(eq(productSupplierLinkOverrides.productKey, "PL-5"));
+  expect(override?.url).toBe("https://e2e-dodavatel.example.com/produkt-5");
+});
+
+it("oprava UŽ existujúcej linky (aj zo Shoptetu) prepíše hodnotu bez gaty", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await insertTestVariant(db, "PL-6", "Dodávateľ", { internalNote: "https://stary.example.com" });
+
+  const res = await app.request("/api/product-links/PL-6", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ url: "https://novy.example.com" }),
+  });
+  expect(res.status).toBe(200);
+
+  const po = (await (await app.request("/api/product-links?q=PL-6&state=all", { headers: { cookie } })).json()) as ListTelo;
+  expect(po.items[0]?.url).toBe("https://novy.example.com");
+  void db;
+});
+
+it("neznámy productKey vráti 404", async () => {
+  const { app, cookie } = await boot("manazer");
+  const res = await app.request("/api/product-links/NEEXISTUJE", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ url: "https://dodavatel.example.com" }),
+  });
+  expect(res.status).toBe(404);
+});
+
+it("neplatná URL vráti 400", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await insertTestVariant(db, "PL-7", "Dodávateľ");
+  const res = await app.request("/api/product-links/PL-7", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ url: "nie je url" }),
+  });
+  expect(res.status).toBe(400);
+  void db;
+});
+
+it("rola citanie nesmie upraviť linku (403)", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  await insertTestVariant(db, "PL-8", "Dodávateľ");
+  const res = await app.request("/api/product-links/PL-8", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ url: "https://dodavatel.example.com" }),
+  });
+  expect(res.status).toBe(403);
+  void db;
+});

--- a/apps/web/src/components/SupplierLinksSection.test.tsx
+++ b/apps/web/src/components/SupplierLinksSection.test.tsx
@@ -1,0 +1,163 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { SupplierLinksSection } from "./SupplierLinksSection.js";
+
+const { searchProductLinks, saveProductLink } = vi.hoisted(() => ({
+  searchProductLinks: vi.fn(),
+  saveProductLink: vi.fn(),
+}));
+
+// `SupplierLinksUnauthorizedError` ostáva SKUTOČNÁ trieda z reálneho modulu —
+// rovnaký dôvod ako `PairingSection.test.tsx`'s `PairingUnauthorizedError`:
+// `instanceof` v komponente musí fungovať aj v teste.
+vi.mock("../supplierLinksApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../supplierLinksApi.js")>();
+  return { ...actual, searchProductLinks, saveProductLink };
+});
+
+const { SupplierLinksUnauthorizedError } = await import("../supplierLinksApi.js");
+
+const CHYBA = {
+  productKey: "PL-1",
+  productName: "Test produkt PL-1",
+  supplier: "Test dodávateľ",
+  variantCount: 2,
+  url: null,
+  updatedAt: null,
+  syncedAt: null,
+};
+
+const ULOZENY_NEODOSLANY = {
+  productKey: "PL-2",
+  productName: "Test produkt PL-2",
+  supplier: "Test dodávateľ",
+  variantCount: 1,
+  url: "https://dodavatel.example.com/pl-2",
+  updatedAt: "2026-08-01T09:00:00.000Z",
+  syncedAt: null,
+};
+
+const ODOSLANY = {
+  productKey: "PL-3",
+  productName: "Test produkt PL-3",
+  supplier: null,
+  variantCount: 1,
+  url: "https://dodavatel.example.com/pl-3",
+  updatedAt: "2026-08-01T09:00:00.000Z",
+  syncedAt: "2026-08-02T09:00:00.000Z",
+};
+
+const ZO_SHOPTETU = {
+  productKey: "PL-4",
+  productName: "Test produkt PL-4",
+  supplier: "Test dodávateľ",
+  variantCount: 1,
+  url: "https://shoptet-poznamka.example.com/pl-4",
+  updatedAt: null,
+  syncedAt: null,
+};
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+it("keď zoznam nezodpovedá žiadnemu produktu, zobrazí informačnú vetu namiesto holej tabuľky", async () => {
+  searchProductLinks.mockResolvedValue({ total: 0, missingTotal: 0, items: [] });
+
+  render(<SupplierLinksSection role="citanie" onSessionExpired={() => {}} />);
+
+  await screen.findByTestId("product-links-empty");
+  expect(screen.queryByRole("table")).toBeNull();
+});
+
+it("zobrazí kód, názov, dodávateľa, počet variantov a stav pre všetky štyri kombinácie", async () => {
+  searchProductLinks.mockResolvedValue({
+    total: 4,
+    missingTotal: 1,
+    items: [CHYBA, ULOZENY_NEODOSLANY, ODOSLANY, ZO_SHOPTETU],
+  });
+
+  render(<SupplierLinksSection role="citanie" onSessionExpired={() => {}} />);
+
+  const chybaRiadok = await screen.findByTestId("product-link-row-PL-1");
+  expect(chybaRiadok.textContent).toContain("Test produkt PL-1");
+  expect(chybaRiadok.textContent).toContain("Test dodávateľ");
+  expect(chybaRiadok.textContent).toContain("2");
+  expect(screen.getByTestId("product-link-status-PL-1").textContent).toBe("—");
+
+  expect(screen.getByTestId("product-link-status-PL-2").textContent).toContain("čaká na odoslanie");
+  expect(screen.getByTestId("product-link-status-PL-3").textContent).toContain("Odoslané do Shoptetu");
+  expect(screen.getByTestId("product-link-status-PL-4").textContent).toBe("zo Shoptetu");
+
+  expect(screen.getByTestId("product-links-missing-total").textContent).toContain("1");
+
+  const bezDodavatela = screen.getByTestId("product-link-row-PL-3");
+  expect(bezDodavatela.textContent).toContain("(bez dodávateľa)");
+});
+
+it("pri 401 zavolá onSessionExpired namiesto zobrazenia všeobecnej chyby", async () => {
+  searchProductLinks.mockRejectedValue(new SupplierLinksUnauthorizedError());
+  const onSessionExpired = vi.fn();
+
+  render(<SupplierLinksSection role="citanie" onSessionExpired={onSessionExpired} />);
+
+  await waitFor(() => {
+    expect(onSessionExpired).toHaveBeenCalledTimes(1);
+  });
+});
+
+it("rola citanie nevidí stĺpec Akcie", async () => {
+  searchProductLinks.mockResolvedValue({ total: 1, missingTotal: 1, items: [CHYBA] });
+
+  render(<SupplierLinksSection role="citanie" onSessionExpired={() => {}} />);
+
+  await screen.findByTestId("product-link-row-PL-1");
+  expect(screen.queryByTestId("product-link-edit-toggle-PL-1")).toBeNull();
+});
+
+it("rola manazer doplní chýbajúcu linku, uloženie ju pošle na server a obrazovka sa znova načíta", async () => {
+  const CHYBA_PO_ULOZENI = { ...CHYBA, url: "https://novy-dodavatel.example.com/pl-1", updatedAt: "2026-08-04T09:00:00.000Z", syncedAt: null };
+  searchProductLinks.mockResolvedValueOnce({ total: 1, missingTotal: 1, items: [CHYBA] });
+  searchProductLinks.mockResolvedValueOnce({ total: 1, missingTotal: 0, items: [CHYBA_PO_ULOZENI] });
+  saveProductLink.mockResolvedValue(undefined);
+
+  render(<SupplierLinksSection role="manazer" onSessionExpired={() => {}} />);
+
+  fireEvent.click(await screen.findByTestId("product-link-edit-toggle-PL-1"));
+  const vstup = screen.getByTestId("product-link-edit-input-PL-1");
+  fireEvent.change(vstup, { target: { value: "https://novy-dodavatel.example.com/pl-1" } });
+  fireEvent.click(screen.getByTestId("product-link-save-PL-1"));
+
+  await waitFor(() => {
+    expect(saveProductLink).toHaveBeenCalledWith("PL-1", "https://novy-dodavatel.example.com/pl-1");
+  });
+  await waitFor(() => {
+    expect(screen.getByTestId("product-link-url-PL-1").textContent).toBe("https://novy-dodavatel.example.com/pl-1");
+  });
+  expect(searchProductLinks).toHaveBeenCalledTimes(2); // druhé volanie po uložení
+});
+
+it("rola manazer opraví UŽ existujúcu linku (prefill draftu aktuálnou hodnotou)", async () => {
+  searchProductLinks.mockResolvedValue({ total: 1, missingTotal: 0, items: [ULOZENY_NEODOSLANY] });
+
+  render(<SupplierLinksSection role="manazer" onSessionExpired={() => {}} />);
+
+  fireEvent.click(await screen.findByTestId("product-link-edit-toggle-PL-2"));
+  const vstup = screen.getByTestId<HTMLInputElement>("product-link-edit-input-PL-2");
+  expect(vstup.value).toBe("https://dodavatel.example.com/pl-2");
+});
+
+it("neplatná URL sa odmietne OKAMŽITE v prehliadači, bez volania saveProductLink", async () => {
+  searchProductLinks.mockResolvedValue({ total: 1, missingTotal: 1, items: [CHYBA] });
+
+  render(<SupplierLinksSection role="manazer" onSessionExpired={() => {}} />);
+
+  fireEvent.click(await screen.findByTestId("product-link-edit-toggle-PL-1"));
+  const vstup = screen.getByTestId("product-link-edit-input-PL-1");
+  fireEvent.change(vstup, { target: { value: "nieje-url" } });
+  fireEvent.click(screen.getByTestId("product-link-save-PL-1"));
+
+  await screen.findByText("Odkaz musí byť platná adresa začínajúca http:// alebo https://.");
+  expect(saveProductLink).not.toHaveBeenCalled();
+});

--- a/apps/web/src/components/SupplierLinksSection.tsx
+++ b/apps/web/src/components/SupplierLinksSection.tsx
@@ -1,0 +1,316 @@
+import { useCallback, useEffect, useRef, useState, type SyntheticEvent, type JSX } from "react";
+import type { Me } from "../api.js";
+import { validateSupplierLinkUrl } from "../ordersApi.js";
+import {
+  saveProductLink,
+  searchProductLinks,
+  SupplierLinksUnauthorizedError,
+  type ProductLinkItem,
+  type ProductLinkState,
+} from "../supplierLinksApi.js";
+
+// issue 239: "Eshop → Párovanie produktov" — priamy náprotivok
+// `PairingSection.tsx`, ale kľúčovaný PRODUKTOM (nie variantom): jeden riadok
+// na produkt, žiadny potvrdzovací stavový automat (majiteľ len vkladá/opravuje
+// adresu), zápis ide do `product_supplier_link_override` (rovnaká tabuľka ako
+// #121's riadkové priradenie), ktorú existujúci `shoptet-writeback` job (#122)
+// odošle do Shoptetu — táto obrazovka doň nezapisuje žiadnou NOVOU cestou.
+const CAN_EDIT_ROLES: ReadonlySet<Me["role"]> = new Set(["admin", "manazer"]);
+
+function formatDateTime(iso: string | null): string {
+  if (iso === null) return "—";
+  const date = new Date(iso);
+  return Number.isNaN(date.getTime()) ? "—" : date.toLocaleString("sk-SK");
+}
+
+/**
+ * Stav "uložené vs. odoslané do Shoptetu" (ticketova akceptačná podmienka) sa
+ * dá vyvodiť LEN z `updatedAt`/`syncedAt` — `updatedAt === null` znamená
+ * žiadny NÁŠ override (odkaz, ak existuje, prišiel priamo zo Shoptet-ovho
+ * `internalNote`, appka ho nikdy neposielala, lebo tam už je). Rovnaké
+ * "čaká na odoslanie" kritérium ako `select-changes.ts`'s
+ * `synced_at IS NULL OR synced_at < updated_at`.
+ */
+function statusLabel(item: ProductLinkItem): string {
+  if (item.updatedAt === null) return item.url === null ? "—" : "zo Shoptetu";
+  const pending = item.syncedAt === null || item.syncedAt < item.updatedAt;
+  return pending ? "⏳ Uložené, čaká na odoslanie" : `✅ Odoslané do Shoptetu (${formatDateTime(item.syncedAt)})`;
+}
+
+export function SupplierLinksSection({
+  role,
+  onSessionExpired,
+}: {
+  readonly role: Me["role"];
+  readonly onSessionExpired: () => void;
+}): JSX.Element {
+  const [items, setItems] = useState<readonly ProductLinkItem[]>([]);
+  const [total, setTotal] = useState(0);
+  const [missingTotal, setMissingTotal] = useState(0);
+  const [searchLoaded, setSearchLoaded] = useState(false);
+  const [query, setQuery] = useState("");
+  const [state, setState] = useState<ProductLinkState>("missing");
+  const [searchError, setSearchError] = useState("");
+  const [actionError, setActionError] = useState("");
+  const canEdit = CAN_EDIT_ROLES.has(role);
+
+  const [editingKey, setEditingKey] = useState<string | null>(null);
+  const [urlDraft, setUrlDraft] = useState("");
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+
+  // Len najnovšia požiadavka smie zapísať výsledok — rovnaký dôvod ako
+  // `PairingSection.tsx`'s `searchSeq` (neindexovaný filter nad celým
+  // katalógom môže staršiu, širšiu odpoveď doručiť neskôr než novšiu, užšiu).
+  const searchSeq = useRef(0);
+
+  const search = useCallback(
+    (q: string, s: ProductLinkState) => {
+      const seq = (searchSeq.current += 1);
+      setSearchError("");
+      searchProductLinks({ q, state: s, page: 1 })
+        .then((result) => {
+          if (seq !== searchSeq.current) return; // medzitým prišla novšia požiadavka
+          setItems(result.items);
+          setTotal(result.total);
+          setMissingTotal(result.missingTotal);
+          setSearchLoaded(true);
+        })
+        .catch((err: unknown) => {
+          if (seq !== searchSeq.current) return;
+          setSearchLoaded(true);
+          if (err instanceof SupplierLinksUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setItems([]);
+          setTotal(0);
+          setSearchError("Zoznam produktov sa nepodarilo načítať.");
+        });
+    },
+    [onSessionExpired],
+  );
+
+  useEffect(() => {
+    search("", "missing");
+  }, [search]);
+
+  function submit(event: SyntheticEvent): void {
+    event.preventDefault();
+    search(query, state);
+  }
+
+  const refetch = useCallback(() => {
+    search(query, state);
+  }, [search, query, state]);
+
+  const startEdit = useCallback((item: ProductLinkItem) => {
+    setEditingKey(item.productKey);
+    setUrlDraft(item.url ?? "");
+    setActionError("");
+  }, []);
+
+  const cancelEdit = useCallback(() => {
+    setEditingKey(null);
+    setActionError("");
+  }, []);
+
+  const save = useCallback(
+    (productKey: string) => {
+      setActionError("");
+      // issue 153: OKAMŽITÁ kontrola V PREHLIADAČI, PRED zápisom na server —
+      // zdieľaná s `orders/supplier-link` obrazovkou (`ordersApi.ts`'s
+      // `validateSupplierLinkUrl`), rovnaké pravidlo na oboch miestach.
+      const validationError = validateSupplierLinkUrl(urlDraft);
+      if (validationError !== null) {
+        setActionError(validationError);
+        return;
+      }
+      setBusyKey(productKey);
+      saveProductLink(productKey, urlDraft.trim())
+        .then(() => {
+          setEditingKey(null);
+          refetch();
+        })
+        .catch((err: unknown) => {
+          if (err instanceof SupplierLinksUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setActionError(err instanceof Error ? err.message : "Uloženie odkazu sa nepodarilo.");
+        })
+        .finally(() => {
+          setBusyKey(null);
+        });
+    },
+    [refetch, onSessionExpired, urlDraft],
+  );
+
+  const showingAll = total === 0 || items.length >= total;
+
+  return (
+    <section data-testid="product-links-section">
+      <h2>Párovanie produktov</h2>
+      <p>
+        Produkty, ktoré nemajú dodávateľskú linku, nevie automat sledovať dostupnosť u dodávateľa —
+        preto nefunguje ani „Vypredané → Skladom“, ani „Na objednanie“ pre ne. Vložte alebo opravte
+        adresu produktu u dodávateľa, uloženie ju pošle do Shoptetu.
+      </p>
+
+      <p className="chip-row">
+        <span className="chip" data-testid="product-links-missing-total">
+          Bez linky celkom: {missingTotal}
+        </span>
+      </p>
+
+      <form onSubmit={submit}>
+        <label htmlFor="product-links-q">Hľadať produkt (kód alebo názov)</label>
+        <input
+          id="product-links-q"
+          type="search"
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+          }}
+        />
+        <label htmlFor="product-links-state">Zobraziť produkty</label>
+        <select
+          id="product-links-state"
+          value={state}
+          onChange={(e) => {
+            setState(e.target.value as ProductLinkState);
+          }}
+        >
+          <option value="missing">Bez linky</option>
+          <option value="linked">S linkou</option>
+          <option value="all">Všetky</option>
+        </select>
+        <button type="submit">Zobraziť</button>
+      </form>
+
+      {searchError !== "" && <p role="alert">{searchError}</p>}
+      {actionError !== "" && <p role="alert">{actionError}</p>}
+      <p data-testid="product-links-total">
+        {showingAll
+          ? `Nájdených: ${String(total)}`
+          : `Nájdených: ${String(total)} (zobrazených prvých ${String(items.length)})`}
+      </p>
+
+      {searchLoaded && total === 0 ? (
+        <p data-testid="product-links-empty">Hľadaniu nezodpovedá žiadny produkt.</p>
+      ) : (
+        <table>
+          <thead>
+            <tr>
+              <th>Kód</th>
+              <th>Názov</th>
+              <th>Dodávateľ</th>
+              <th>Variantov</th>
+              <th>Odkaz na dodávateľa</th>
+              <th>Stav</th>
+              {canEdit && <th>Akcie</th>}
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((item) => {
+              const editing = editingKey === item.productKey;
+              const busyHere = busyKey === item.productKey;
+              return (
+                <tr key={item.productKey} data-testid={`product-link-row-${item.productKey}`}>
+                  <td>{item.productKey}</td>
+                  <td>{item.productName}</td>
+                  <td>{item.supplier ?? "(bez dodávateľa)"}</td>
+                  <td>{item.variantCount}</td>
+                  <td>
+                    {editing ? (
+                      <div className="ord-supplier-link-edit" data-testid={`product-link-edit-${item.productKey}`}>
+                        <input
+                          type="url"
+                          className="ord-supplier-link-edit-input"
+                          data-testid={`product-link-edit-input-${item.productKey}`}
+                          aria-label={`Odkaz na dodávateľa produktu ${item.productName} / ${item.productKey}`}
+                          placeholder="https://…"
+                          value={urlDraft}
+                          disabled={busyHere}
+                          autoFocus
+                          onChange={(e) => {
+                            setUrlDraft(e.target.value);
+                          }}
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter") {
+                              e.preventDefault();
+                              save(item.productKey);
+                              return;
+                            }
+                            if (e.key === "Escape") {
+                              e.preventDefault();
+                              cancelEdit();
+                            }
+                          }}
+                        />
+                        <button
+                          type="button"
+                          className="btn sm good"
+                          data-testid={`product-link-save-${item.productKey}`}
+                          aria-label={`Uložiť odkaz na dodávateľa produktu ${item.productName} / ${item.productKey}`}
+                          disabled={busyHere || urlDraft.trim() === ""}
+                          onClick={() => {
+                            save(item.productKey);
+                          }}
+                        >
+                          💾
+                        </button>
+                        <button
+                          type="button"
+                          className="btn sm ghost"
+                          data-testid={`product-link-cancel-${item.productKey}`}
+                          aria-label="Zrušiť úpravu"
+                          disabled={busyHere}
+                          onClick={cancelEdit}
+                        >
+                          ✖
+                        </button>
+                      </div>
+                    ) : item.url !== null ? (
+                      <a
+                        href={item.url}
+                        target="_blank"
+                        rel="noreferrer noopener"
+                        data-testid={`product-link-url-${item.productKey}`}
+                      >
+                        {item.url}
+                      </a>
+                    ) : (
+                      <span data-testid={`product-link-url-${item.productKey}`}>—</span>
+                    )}
+                  </td>
+                  <td data-testid={`product-link-status-${item.productKey}`}>{statusLabel(item)}</td>
+                  {canEdit && (
+                    <td>
+                      {!editing && (
+                        <button
+                          type="button"
+                          className="btn sm ghost"
+                          data-testid={`product-link-edit-toggle-${item.productKey}`}
+                          aria-label={
+                            item.url !== null
+                              ? `Upraviť odkaz na dodávateľa — ${item.productName} (${item.productKey})`
+                              : `Doplniť odkaz na dodávateľa — ${item.productName} (${item.productKey})`
+                          }
+                          onClick={() => {
+                            startEdit(item);
+                          }}
+                        >
+                          {item.url !== null ? "✏️ Upraviť" : "✏️ Doplniť"}
+                        </button>
+                      )}
+                    </td>
+                  )}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/SupplierLinksSection.tsx
+++ b/apps/web/src/components/SupplierLinksSection.tsx
@@ -149,7 +149,6 @@ export function SupplierLinksSection({
 
   return (
     <section data-testid="product-links-section">
-      <h2>Párovanie produktov</h2>
       <p>
         Produkty, ktoré nemajú dodávateľskú linku, nevie automat sledovať dostupnosť u dodávateľa —
         preto nefunguje ani „Vypredané → Skladom“, ani „Na objednanie“ pre ne. Vložte alebo opravte

--- a/apps/web/src/nav.test.ts
+++ b/apps/web/src/nav.test.ts
@@ -6,18 +6,19 @@ import { DEFAULT_TAB_ID, HIDDEN_TABS, NAV, findTab, isVisibleTabId } from "./nav
 // presunulo "Nedostupné tovary" z Automatizácií pod "Eshop" (nemá naplánovanú
 // úlohu ani prepínač zapnuté/vypnuté, je to pracovná obrazovka), issue 192
 // pridalo "Texty e-mailov" do Systému (nastavenie spoločné pre VŠETKY
-// automatizácie). Tento test je
-// najbližšie k tomu, čo strojovo overiť dá (registrácia, nie DOM).
-it("NAV má tri priečinky (Systém/Eshop/Automatizácie), s 3/2/4 záložkami v poradí podľa dôležitosti", () => {
+// automatizácie). Issue 239 pridalo "Párovanie produktov" pod "Eshop"
+// (rovnaký dôvod ako "Nedostupné tovary" — pracovná obrazovka bez plánu).
+// Tento test je najbližšie k tomu, čo strojovo overiť dá (registrácia, nie DOM).
+it("NAV má tri priečinky (Systém/Eshop/Automatizácie), s 3/3/4 záložkami v poradí podľa dôležitosti", () => {
   expect(NAV).toHaveLength(3);
   expect(NAV.map((f) => f.label)).toEqual(["Systém", "Eshop", "Automatizácie"]);
   expect(NAV[0]?.tabs).toHaveLength(3);
-  expect(NAV[1]?.tabs).toHaveLength(2);
+  expect(NAV[1]?.tabs).toHaveLength(3);
   expect(NAV[2]?.tabs).toHaveLength(4);
   // issue 212: "Dodávateľský sklad" — scraper dostupnosti u dodávateľa;
   // patrí do Systému (zadanie majiteľa), nie medzi Automatizácie.
   expect(NAV[0]?.tabs.map((t) => t.label)).toEqual(["Sync zo Shoptetu", "Texty e-mailov", "Dodávateľský sklad"]);
-  expect(NAV[1]?.tabs.map((t) => t.label)).toEqual(["Na objednanie", "Nedostupné tovary"]);
+  expect(NAV[1]?.tabs.map((t) => t.label)).toEqual(["Na objednanie", "Nedostupné tovary", "Párovanie produktov"]);
   // issue 193: "Odoslané e-maily" — prehľad toho, čo automatizácie poslali.
   expect(NAV[2]?.tabs.map((t) => t.label)).toEqual([
     // issue 213: prepínanie vypredaných produktov späť na skladom.

--- a/apps/web/src/nav.ts
+++ b/apps/web/src/nav.ts
@@ -10,6 +10,7 @@ import { PairingSection } from "./components/PairingSection.js";
 import { PostaUncollectedSection } from "./components/PostaUncollectedSection.js";
 import { RestockSection } from "./components/RestockSection.js";
 import { SchedulerSection } from "./components/SchedulerSection.js";
+import { SupplierLinksSection } from "./components/SupplierLinksSection.js";
 import { SupplierStockSection } from "./components/SupplierStockSection.js";
 import { SyncSection } from "./components/SyncSection.js";
 
@@ -80,6 +81,11 @@ export const NAV: readonly NavFolder[] = [
     tabs: [
       { id: "orders", label: "Na objednanie", icon: "📦", Component: OrdersSection, wide: true },
       { id: "nedostupne", label: "Nedostupné tovary", icon: "🚫", Component: NedostupneSection, wide: true },
+      // issue 239: majiteľ, "vypisovat produkty ktore nemaju dodavatelsku
+      // linku, dat moznost ju tam rovno vlozit, a poslat do Shoptetu" — patrí
+      // sem (nie do Automatizácie), je to obrazovka, na ktorej obsluha
+      // pracuje, presne ako "Na objednanie"/"Nedostupné tovary".
+      { id: "supplier-links", label: "Párovanie produktov", icon: "🔗", Component: SupplierLinksSection, wide: true },
     ],
   },
   {

--- a/apps/web/src/supplierLinksApi.ts
+++ b/apps/web/src/supplierLinksApi.ts
@@ -1,0 +1,71 @@
+import { z } from "zod";
+
+// issue 239: "Eshop → Párovanie produktov" — zrkadlí
+// `GET/POST /api/product-links(...)` (`apps/api/src/http/product-links-routes.ts`).
+// Vlastná zod schéma namiesto zdieľaného typu, rovnaký vzor ako `pairingApi.ts`/
+// `ordersApi.ts` (frontend a backend sú samostatné balíčky).
+export type ProductLinkState = "all" | "missing" | "linked";
+
+const itemSchema = z.object({
+  productKey: z.string(),
+  productName: z.string(),
+  supplier: z.string().nullable(),
+  variantCount: z.number(),
+  url: z.string().nullable(),
+  updatedAt: z.string().nullable(),
+  syncedAt: z.string().nullable(),
+});
+export type ProductLinkItem = z.infer<typeof itemSchema>;
+
+const searchSchema = z.object({ total: z.number(), missingTotal: z.number(), items: z.array(itemSchema) });
+
+export const PAGE_SIZE = 50;
+
+/** Relácia medzitým vypršala (401) — rovnaký vzor ako `PairingUnauthorizedError`. */
+export class SupplierLinksUnauthorizedError extends Error {
+  constructor() {
+    super("Neprihlásený");
+  }
+}
+
+const errorBodySchema = z.object({ error: z.string() });
+
+async function serverErrorMessage(response: Response, fallback: string): Promise<string> {
+  try {
+    const parsed = errorBodySchema.safeParse(await response.json());
+    if (parsed.success) return parsed.data.error;
+  } catch {
+    // Telo nie je platný JSON (alebo chýba) — použi všeobecnú hlášku.
+  }
+  return fallback;
+}
+
+async function readJson(response: Response, fallback: string): Promise<unknown> {
+  if (response.status === 401) throw new SupplierLinksUnauthorizedError();
+  if (!response.ok) throw new Error(await serverErrorMessage(response, fallback));
+  return await response.json();
+}
+
+export async function searchProductLinks(input: {
+  readonly q: string;
+  readonly state: ProductLinkState;
+  readonly page: number;
+}): Promise<z.infer<typeof searchSchema>> {
+  const query = new URLSearchParams({
+    q: input.q,
+    state: input.state,
+    page: String(input.page),
+    pageSize: String(PAGE_SIZE),
+  });
+  const response = await fetch(`/api/product-links?${query.toString()}`);
+  return searchSchema.parse(await readJson(response, "Zoznam produktov sa nepodarilo načítať"));
+}
+
+export async function saveProductLink(productKey: string, url: string): Promise<void> {
+  const response = await fetch(`/api/product-links/${encodeURIComponent(productKey)}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ url }),
+  });
+  await readJson(response, "Uloženie odkazu na dodávateľa sa nepodarilo");
+}

--- a/apps/web/tests/e2e/catalog.spec.ts
+++ b/apps/web/tests/e2e/catalog.spec.ts
@@ -24,13 +24,16 @@ test("manažér vidí stav katalógu, vyhľadá variant a konzola je čistá", a
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
-  // 37 = 35 riadkov fixtúry + 2 seedované kandidáty na prepnutie ("PREP-1",
-  // issue 217; "PREP-2", issue 226 — rozpor voči feedu, `scripts/e2e-setup.ts`).
-  // Oba sú v stave `out_of_stock`, takže filtre "sellable"(7 od issue 219) a
-  // "missing"(1) nižšie sa nimi nemenia.
+  // 39 = 35 riadkov fixtúry + 2 seedované kandidáty na prepnutie ("PREP-1",
+  // issue 217; "PREP-2", issue 226 — rozpor voči feedu, `scripts/e2e-setup.ts`)
+  // + 2 seedované produkty pre "Párovanie produktov" ("E2E-PL-CHYBA"/
+  // "E2E-PL-OPRAVA", issue 239, `scripts/e2e-fixtures-product-links.ts`).
+  // Prví dvaja sú `out_of_stock` (nemenia "sellable"/"missing" nižšie), tí
+  // druhí dvaja sú `sellable` (posúvajú filter "sellable" 7→9 nižšie),
+  // "missing"(1) sa nemení ani jedným párom.
   await expect(page.getByTestId("snapshot")).toContainText("Posledný import: prijatý");
-  await expect(page.getByTestId("counts")).toContainText("Variantov v katalógu (vrátane chýbajúcich): 37");
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 37");
+  await expect(page.getByTestId("counts")).toContainText("Variantov v katalógu (vrátane chýbajúcich): 39");
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 39");
 
   await page.getByLabel("Kód alebo názov").fill("40237/3XL");
   await page.getByRole("button", { name: "Hľadať" }).click();
@@ -50,14 +53,14 @@ test("filter podľa stavu zúži zoznam na predajné varianty", async ({ page })
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 37");
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 39");
   await page.getByLabel("Stav", { exact: true }).selectOption("sellable");
   await page.getByRole("button", { name: "Hľadať" }).click();
 
-  // 7 od issue 219: variant "40237/L" má oba texty dostupnosti prázdne, čo
-  // znamená predvolenú dostupnosť Shoptetu (na tomto e-shope "Skladom"), nie
-  // vypredané — preto sa počíta medzi predajné.
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 7");
+  // 9 = 7 od issue 219 (variant "40237/L" má oba texty dostupnosti prázdne,
+  // čo znamená predvolenú dostupnosť Shoptetu — "Skladom", nie vypredané) +
+  // 2 sellable produkty issue 239's fixtúry ("E2E-PL-CHYBA"/"E2E-PL-OPRAVA").
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 9");
   await expect(page.getByTestId("variant-40237/M")).toBeVisible();
 });
 
@@ -69,7 +72,7 @@ test("filter 'Chýbajúce' nájde presne označený variant a riadok ukazuje, od
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 37");
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 39");
   await page.getByLabel("Stav", { exact: true }).selectOption("missing");
   await page.getByRole("button", { name: "Hľadať" }).click();
 

--- a/apps/web/tests/e2e/nav.spec.ts
+++ b/apps/web/tests/e2e/nav.spec.ts
@@ -13,9 +13,9 @@ const E2E_NAV_EMAIL = "e2e-nav@forestshop.sk";
 
 // #57 pôvodne chcel naľavo PRESNE dve položky. Issue 185 (2026-08-03) pridáva
 // tretí priečinok "Automatizácie" s tromi hotovými obrazovkami, dovtedy len v
-// `HIDDEN_TABS` bez odkazu v menu — tento test teraz overuje VŠETKÝCH PÄŤ
-// záložiek v troch priečinkoch.
-test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s deviatimi záložkami, klik prepne obrazovku, panel sa zbalí do lišty a stav si pamätá, konzola je čistá", async ({
+// `HIDDEN_TABS` bez odkazu v menu. Issue 239 (2026-08-04) pridáva "Párovanie
+// produktov" pod "Eshop" — desiata záložka.
+test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s desiatimi záložkami, klik prepne obrazovku, panel sa zbalí do lišty a stav si pamätá, konzola je čistá", async ({
   page,
 }) => {
   const chyby: string[] = [];
@@ -36,14 +36,15 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s deviatimi 
   await expect(page.getByRole("button", { name: "Eshop" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Automatizácie" })).toBeVisible();
 
-  // Presne šesť záložiek v CELOM menu.
-  await expect(page.locator(".side-nav .tab")).toHaveCount(9);
+  // Presne desať záložiek v CELOM menu.
+  await expect(page.locator(".side-nav .tab")).toHaveCount(10);
   await expect(page.getByRole("button", { name: "Sync zo Shoptetu" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Texty e-mailov" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Na objednanie" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Nevyzdvihnuté zásielky" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Pripomienky objednávok" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Nedostupné tovary" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Párovanie produktov" })).toBeVisible();
 
   // Predvolená obrazovka (bez kliknutia) je "Sync zo Shoptetu".
   await expect(page.getByRole("heading", { name: "Sync zo Shoptetu" })).toBeVisible();
@@ -94,6 +95,12 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s deviatimi 
   // požiadanie) — žiadny stavový odznak v menu, ani "Zastavené".
   await expect(page.getByTestId("nav-status-nedostupne")).toHaveCount(0);
 
+  // issue 239: rovnaký dôvod ako "Nedostupné tovary" vyššie — žiadny
+  // plán/zapnuté-vypnuté koncept, teda žiadny stavový odznak v menu.
+  await page.getByRole("button", { name: "Párovanie produktov" }).click();
+  await expect(page.getByRole("heading", { name: "Párovanie produktov" })).toBeVisible();
+  await expect(page.getByTestId("nav-status-supplier-links")).toHaveCount(0);
+
   // issue 190: zbalenie panela do úzkej lišty. Zámerne je to SÚČASŤ tohto
   // testu, nie samostatný test — každý ďalší test v tomto súbore by znamenal
   // ďalšie prihlásenie na zdieľanom `MAX_ATTEMPTS=10` rozpočte
@@ -114,9 +121,9 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s deviatimi 
   expect(panelZbaleny).toBeLessThan(panelRozbaleny);
   expect(obsahZbaleny).toBeGreaterThan(obsahRozbaleny);
 
-  // Hlavičky priečinkov zmiznú, ikony všetkých šiestich modulov ostanú.
+  // Hlavičky priečinkov zmiznú, ikony všetkých modulov ostanú.
   await expect(page.getByRole("button", { name: "Systém" })).toHaveCount(0);
-  await expect(page.locator(".side-nav .tab")).toHaveCount(9);
+  await expect(page.locator(".side-nav .tab")).toHaveCount(10);
   // Názov sa v lište ukáže bublinou pri prejdení myšou.
   await expect(page.getByRole("button", { name: "Na objednanie" })).toHaveAttribute(
     "title",

--- a/apps/web/tests/e2e/supplier-links.spec.ts
+++ b/apps/web/tests/e2e/supplier-links.spec.ts
@@ -1,0 +1,130 @@
+import { expect, test } from "@playwright/test";
+
+const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
+// VLASTNÝ izolovaný účet (rovnaký mechanizmus ako `E2E_PREHLAD_EMAIL`/ostatné,
+// `.claude/rules/frontend-design.md`) — zdieľaný `e2e@forestshop.sk` je už na
+// hranici `MAX_ATTEMPTS`. Musí sa zhodovať s `scripts/e2e-fixtures-product-
+// links.ts`'s `E2E_PAROVANIE_EMAIL`.
+const E2E_PAROVANIE_EMAIL = "e2e-parovanie@forestshop.sk";
+
+// issue 239: "Eshop → Párovanie produktov" — VIDITEĽNÁ záložka (`nav.ts`,
+// skupina Eshop). Fixtúry (`scripts/e2e-fixtures-product-links.ts`): produkt
+// "E2E-PL-CHYBA" (žiadny `internalNote`, žiadny override — "doplniť" cesta)
+// a "E2E-PL-OPRAVA" (už uložený, ešte NEODOSLANÝ override — "opraviť" cesta).
+
+test("produkt bez linky ponúka 'Doplniť', po uložení sa presunie do 'S linkou' a stav ukazuje čaká na odoslanie; existujúca linka sa dá opraviť, konzola je čistá", async ({
+  page,
+}) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/");
+  await page.getByLabel("E-mail").fill(E2E_PAROVANIE_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+
+  await page.getByRole("button", { name: "Párovanie produktov" }).click();
+  await expect(page.getByRole("heading", { name: "Párovanie produktov" })).toBeVisible();
+
+  // Predvolený filter je "Bez linky" — fixtúra "E2E-PL-CHYBA" sa tam nájde.
+  await page.getByLabel("Hľadať produkt (kód alebo názov)").fill("E2E-PL-CHYBA");
+  await page.getByRole("button", { name: "Zobraziť" }).click();
+
+  const riadok = page.getByTestId("product-link-row-E2E-PL-CHYBA");
+  await expect(riadok).toBeVisible();
+  await expect(riadok).toContainText("E2E Dodávateľ Párovanie");
+  await expect(page.getByTestId("product-link-status-E2E-PL-CHYBA")).toHaveText("—");
+
+  await riadok.getByTestId("product-link-edit-toggle-E2E-PL-CHYBA").click();
+  const vstup = page.getByTestId("product-link-edit-input-E2E-PL-CHYBA");
+  await expect(vstup).toBeVisible();
+  await expect(vstup).toHaveValue("");
+  await vstup.fill("https://e2e-dodavatel.example.com/parovanie-nova");
+  await page.getByTestId("product-link-save-E2E-PL-CHYBA").click();
+
+  // Po uložení produkt už MÁ linku — predvolený filter "Bez linky" ho už
+  // nezobrazí, treba prepnúť na "Všetky", aby bolo vidno stav.
+  await page.getByLabel("Zobraziť produkty").selectOption("all");
+  await page.getByRole("button", { name: "Zobraziť" }).click();
+  const riadokPoUlozeni = page.getByTestId("product-link-row-E2E-PL-CHYBA");
+  await expect(riadokPoUlozeni.getByTestId("product-link-url-E2E-PL-CHYBA")).toHaveAttribute(
+    "href",
+    "https://e2e-dodavatel.example.com/parovanie-nova",
+  );
+  await expect(page.getByTestId("product-link-status-E2E-PL-CHYBA")).toContainText("čaká na odoslanie");
+
+  // Pretrvanie po obnovení stránky — linka je v DB
+  // (`product_supplier_link_override`), nielen v optimistickom klientskom stave.
+  await page.reload();
+  await page.getByLabel("Zobraziť produkty").selectOption("all");
+  await page.getByLabel("Hľadať produkt (kód alebo názov)").fill("E2E-PL-CHYBA");
+  await page.getByRole("button", { name: "Zobraziť" }).click();
+  await expect(page.getByTestId("product-link-url-E2E-PL-CHYBA")).toHaveAttribute(
+    "href",
+    "https://e2e-dodavatel.example.com/parovanie-nova",
+  );
+
+  // Existujúca (fixtúrová) linka "E2E-PL-OPRAVA" — filter "S linkou", ✏️
+  // Upraviť ponúkne AKTUÁLNU hodnotu ako predvyplnenú, nová hodnota prepíše
+  // pôvodnú bez akejkoľvek "už má hodnotu" gaty.
+  await page.getByLabel("Zobraziť produkty").selectOption("linked");
+  await page.getByLabel("Hľadať produkt (kód alebo názov)").fill("E2E-PL-OPRAVA");
+  await page.getByRole("button", { name: "Zobraziť" }).click();
+  const riadokOprava = page.getByTestId("product-link-row-E2E-PL-OPRAVA");
+  await expect(riadokOprava.getByTestId("product-link-url-E2E-PL-OPRAVA")).toHaveAttribute(
+    "href",
+    "https://e2e-dodavatel.example.com/parovanie-oprava-povodna",
+  );
+  await expect(page.getByTestId("product-link-status-E2E-PL-OPRAVA")).toContainText("čaká na odoslanie");
+
+  await riadokOprava.getByTestId("product-link-edit-toggle-E2E-PL-OPRAVA").click();
+  const vstupOprava = page.getByTestId("product-link-edit-input-E2E-PL-OPRAVA");
+  await expect(vstupOprava).toHaveValue("https://e2e-dodavatel.example.com/parovanie-oprava-povodna");
+  await vstupOprava.fill("https://e2e-dodavatel.example.com/parovanie-oprava-nova");
+  await page.getByTestId("product-link-save-E2E-PL-OPRAVA").click();
+
+  await expect(page.getByTestId("product-link-url-E2E-PL-OPRAVA")).toHaveAttribute(
+    "href",
+    "https://e2e-dodavatel.example.com/parovanie-oprava-nova",
+  );
+
+  expect(chyby).toEqual([]);
+});
+
+// issue 153 (rovnaká disciplína ako `orders-supplier-link.spec.ts`): neplatný
+// odkaz sa odmietne HNEĎ v prehliadači — konzola musí zostať čistá (dôkaz, že
+// sa nikdy neodoslal skutočný request na server).
+test("neplatný odkaz sa odmietne HNEĎ, bez zápisu na server (konzola čistá)", async ({ page }) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/?tab=supplier-links");
+  await page.getByLabel("E-mail").fill(E2E_PAROVANIE_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await expect(page.getByRole("heading", { name: "Párovanie produktov" })).toBeVisible();
+
+  await page.getByLabel("Zobraziť produkty").selectOption("all");
+  await page.getByLabel("Hľadať produkt (kód alebo názov)").fill("E2E-PL-OPRAVA");
+  await page.getByRole("button", { name: "Zobraziť" }).click();
+
+  const riadok = page.getByTestId("product-link-row-E2E-PL-OPRAVA");
+  await riadok.getByTestId("product-link-edit-toggle-E2E-PL-OPRAVA").click();
+  const vstup = page.getByTestId("product-link-edit-input-E2E-PL-OPRAVA");
+  await vstup.fill("nieje-url");
+  await page.getByTestId("product-link-save-E2E-PL-OPRAVA").click();
+
+  await expect(page.getByText("Odkaz musí byť platná adresa začínajúca http:// alebo https://.")).toBeVisible();
+
+  expect(chyby).toEqual([]);
+});

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -2621,3 +2621,40 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   (`/admin/statistiky-objednavek-a-obratu/`, filter "Dnes") — PRESNÁ ZHODA:
   8 objednávok, 446,90 € oboma stranami. Issue zavreté ručne s dôkazom,
   Discord run-card odoslaná. Playbook doplnený (`.claude/rules/orders.md`).
+
+- issue 238 (Nedostupné tovary prepracované podľa majiteľovho nákresu):
+  automatický "Náhrada:" návrh (`product.relatedCodes`, Shoptetovo
+  "súvisiace produkty") zrušený, majiteľ ho zamietol ako blbosť. Nová
+  tabuľka `nedostupne_replacement_link` (migrácia 0032, `variant_code`
+  PLAIN bez FK — rovnaká konvencia ako `nedostupne_state`, ŽIADNY unique
+  index — viac riadkov = viac ručných liniek na tovar, zoradené podľa
+  vloženia) + nový modul `modules/nedostupne/replacement-links.ts` +
+  `POST`/`DELETE /api/nedostupne/replacement-links[/:id]` (rovnaké
+  oprávnenie ako `/send`, URL validovaná http(s)-only + formula-guard
+  rovnako ako existujúci `orderLineSupplierLinkBody`). Prekliky: názov
+  produktu → náš e-shop (`shop_product_url`, `null` = neaktívny, ŽIADEN
+  vyhľadávací fallback na rozdiel od `restock` obrazovky — ticket to žiadal
+  explicitne), kód produktu → dodávateľ (zdieľaná
+  `resolveEffectiveSupplierLink`, rovnaká funkcia ako "Na objednanie").
+  E-mail (`buildAlternativeEmail`) teraz berie holé URL priamo (label = url,
+  appka nepozná názov ručne vloženého odkazu). `mail-templates/samples.ts`'s
+  live-data náhľad prepnutý na vzorku z novej tabuľky namiesto
+  `product.relatedCodes`. TDD: `[red]`/`[green]` pár na `logic.test.ts`
+  (`buildAlternativeEmail`), + integračné testy pre nový modul + HTTP
+  trasy + e2e (pridanie/zmazanie odkazu, prežitie reloadu, oba prekliky,
+  obsah preview e-mailu). `product.related_codes` stĺpec/import v katalógu
+  ostáva nedotknutý (cross-cutting, mimo scope) — teraz mŕtvy kód, follow-up
+  na odstránenie: issue 245. Code review (self-audit + nezávislý
+  `superpowers:requesting-code-review` subagent): 0 Critical, 0 Important,
+  2 Minor (zastaraný komentár v teste — opravený; chýbajúci dedikovaný test
+  pre "ten istý variant vo viacerých objednávkach" — vyhodnotené ako
+  nízkoriziková a neoprávnená samostatná práca). PR #246, merge `db2a6b0`.
+  Naživo overené na `forestshop-novy.newlevel.media` (v0.3.0-dev.140) proti
+  REÁLNYM produkčným dátam (8 skutočných nedostupných tovarov): žiadny
+  automatický návrh nikde, ručný odkaz pridaný/prežil reload/objavil sa v
+  preview/zmazaný (upratané), všetky tri prekliky fungujú na reálnych
+  produktoch, jeden reálny produkt bez známej e-shop adresy ("Ocieľka
+  Victorinox 7.8213 - 20cm") správne ostal neaktívny plain text namiesto
+  vymyslenej adresy. Konzola čistá. Issue zavreté ručne s dôkazom, Discord
+  run-card odoslaná. Playbook doplnený (`.claude/rules/nedostupne.md`,
+  `.claude/rules/mail-templates.md`).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.140",
+  "version": "0.3.0-dev.141",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-fixtures-product-links.ts
+++ b/scripts/e2e-fixtures-product-links.ts
@@ -11,9 +11,23 @@
 // `apps/api` TS projektu, takže si nepožičiava testové pomôcky z
 // `apps/api/tests/helpers`.
 import type { Database } from "../apps/api/src/db/client.js";
-import { productSupplierLinkOverrides, products, variants } from "../apps/api/src/db/schema.js";
+import { productSupplierLinkOverrides, products, users, variants } from "../apps/api/src/db/schema.js";
+import { hashPassword } from "../apps/api/src/modules/auth/passwords.js";
 
-export async function seedProductLinksFixtures(db: Database, teraz: Date, snapshotId: string): Promise<void> {
+// Musí sa zhodovať s hodnotou v `apps/web/tests/e2e/supplier-links.spec.ts`
+// — VLASTNÝ izolovaný účet (rovnaký mechanizmus ako `e2e-setup.ts`'s
+// `E2E_PREHLAD_EMAIL`/ostatné — zdieľaný `e2e@forestshop.sk` je už na
+// hranici `MAX_ATTEMPTS`).
+export const E2E_PAROVANIE_EMAIL = "e2e-parovanie@forestshop.sk";
+
+export async function seedProductLinksFixtures(db: Database, teraz: Date, snapshotId: string, heslo: string): Promise<void> {
+  await db.insert(users).values({
+    email: E2E_PAROVANIE_EMAIL,
+    passwordHash: await hashPassword(heslo),
+    displayName: "E2E Manažér",
+    role: "manazer",
+  });
+
   async function seedParovanieProduktu(key: string): Promise<void> {
     await db.insert(products).values({
       key,

--- a/scripts/e2e-fixtures-product-links.ts
+++ b/scripts/e2e-fixtures-product-links.ts
@@ -1,0 +1,50 @@
+// issue 239: "Eshop → Párovanie produktov" — vyčlenené z `e2e-setup.ts`
+// (eslint `max-lines: 400`, `.claude/rules/testing.md`), rovnaký vzor ako
+// existujúci test-súborový split (`orders-http.integration.test.ts` /
+// `orders-http-state.integration.test.ts`). DVA VLASTNÉ, dovtedy nepoužité
+// jednovariantné produkty (žiadny `order_line` na ne odkazuje, takže sa
+// nedostanú do "Na objednanie"/žiadny iný test nad nimi nič nepočíta):
+// jeden BEZ efektívnej linky (žiadny `internalNote`, žiadny override — pre
+// "doplniť" cestu), druhý s UŽ ULOŽENÝM, ešte NEODOSLANÝM override (pre
+// "opraviť existujúcu" cestu). Priamy insert (rovnaký vzor ako
+// `e2e-setup.ts`'s `seedPrepinanieKandidata`) — tento skript je MIMO
+// `apps/api` TS projektu, takže si nepožičiava testové pomôcky z
+// `apps/api/tests/helpers`.
+import type { Database } from "../apps/api/src/db/client.js";
+import { productSupplierLinkOverrides, products, variants } from "../apps/api/src/db/schema.js";
+
+export async function seedProductLinksFixtures(db: Database, teraz: Date, snapshotId: string): Promise<void> {
+  async function seedParovanieProduktu(key: string): Promise<void> {
+    await db.insert(products).values({
+      key,
+      name: `E2E Produkt Párovanie ${key}`,
+      supplier: "E2E Dodávateľ Párovanie",
+      internalNote: null,
+      firstSeenAt: teraz,
+      lastSeenAt: teraz,
+      lastSeenSnapshotId: snapshotId,
+    });
+    await db.insert(variants).values({
+      code: key,
+      productKey: key,
+      guid: key,
+      name: `E2E Produkt Párovanie ${key}`,
+      stock: 5,
+      availabilityInStockText: "Skladom",
+      availabilityOutOfStockText: "Vypredané",
+      availabilityText: "Skladom",
+      productVisibility: "visible",
+      state: "sellable",
+      firstSeenAt: teraz,
+      lastSeenAt: teraz,
+      lastSeenSnapshotId: snapshotId,
+    });
+  }
+  await seedParovanieProduktu("E2E-PL-CHYBA");
+  await seedParovanieProduktu("E2E-PL-OPRAVA");
+  await db.insert(productSupplierLinkOverrides).values({
+    productKey: "E2E-PL-OPRAVA",
+    url: "https://e2e-dodavatel.example.com/parovanie-oprava-povodna",
+    updatedAt: new Date("2026-07-20T09:00:00Z"),
+  });
+}

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -738,8 +738,8 @@ await db.insert(orders).values({
   totalPriceWithVat: "77.50",
 });
 
-// issue 239: "Eshop → Párovanie produktov" — vyčlenené do vlastného súboru
-// (eslint `max-lines: 400`), viď jeho komentár pre detaily fixtúry.
-await seedProductLinksFixtures(db, teraz, snapshotPrepinanie);
+// issue 239: fixtúra (produkty + vlastný E2E účet) vyčlenená do vlastného
+// súboru (eslint max-lines).
+await seedProductLinksFixtures(db, teraz, snapshotPrepinanie, E2E_HESLO);
 
 await pool.end();

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -17,6 +17,7 @@ import { DEFAULT_SNAPSHOT_LIMITS } from "../apps/api/src/modules/catalog/validat
 import { DEFAULT_ORDER_OPEN_STATUS } from "../apps/api/src/modules/orders/open-statuses.js";
 import { POSTA_UNCOLLECTED_SETTINGS_ID } from "../apps/api/src/modules/posta-uncollected/settings.js";
 import { ORDER_REMINDER_SETTINGS_ID } from "../apps/api/src/modules/order-reminder/settings.js";
+import { seedProductLinksFixtures } from "./e2e-fixtures-product-links.js";
 
 const E2E_HESLO = "e2e-test-heslo"; // musí sa zhodovať s hodnotou v login.spec.ts/catalog.spec.ts/orders.spec.ts
 
@@ -736,5 +737,9 @@ await db.insert(orders).values({
   placedAt: teraz,
   totalPriceWithVat: "77.50",
 });
+
+// issue 239: "Eshop → Párovanie produktov" — vyčlenené do vlastného súboru
+// (eslint `max-lines: 400`), viď jeho komentár pre detaily fixtúry.
+await seedProductLinksFixtures(db, teraz, snapshotPrepinanie);
 
 await pool.end();


### PR DESCRIPTION
## Čo pridáva

Nová viditeľná záložka **Eshop → Párovanie produktov** (issue 239): zoznam
produktov bez dodávateľskej linky (predvolený filter, s prepínačom na
Všetky/S linkou), doplnenie/oprava linky priamo v riadku. Uloženie zapíše
`product_supplier_link_override` (rovnaká tabuľka ako existujúci #121) —
o odoslanie do Shoptetu sa naďalej stará existujúci `shoptet-writeback` job
(#122), žiadna nová cesta doň sa nepridáva. Stav "uložené"/"odoslané do
Shoptetu" sa v zozname odvodzuje z `updatedAt`/`syncedAt`.

Návrhové rozhodnutie (viď komentár na tickete PRED prvým commitom): postavené
ako SAMOSTATNÁ obrazovka, nie na existujúcej skrytej `pairing` záložke —
tá je koncepčne iná vec (variant-kľúčovaný stavový automat pre budúce
automatické párovanie s dodávateľom, #46/#48), nezapisuje do Shoptetu vôbec.

## Naviac v tomto PR

- Refaktor `supplier-link-assignment.ts`: zdieľané jadro
  (`upsertProductSupplierLink`) medzi existujúcim `setProductSupplierLink`
  (cez `lineId`) a novým `setProductSupplierLinkForProduct` (priamo cez
  `productKey`, keďže produkt bez otvorenej objednávky lineId nemá).
- Fix nesúvisiaceho, no CI-blokujúceho nálezu: `orders-overview.integration
  .test.ts` mal pevný dátumový literál ako "dnes", trasa počíta skutočný
  `new Date()` — po prechode kalendárneho dňa počas vývoja tohto ticketu
  test spoľahlivo spadol. Opravené na prepočet hranice pri behu testu.
- `nav.spec.ts`/`catalog.spec.ts`/`nav.test.ts` upravené na nové počty
  záložiek/variantov.

## Overenie

- `pnpm typecheck` / `pnpm lint` — čisto.
- `pnpm --filter @forestshop/api test` (560), `pnpm --filter @forestshop/web test` (400),
  `pnpm test:integration` (453) — všetko zelené.
- `pnpm --filter @forestshop/web e2e` (35 testov vrátane nového
  `supplier-links.spec.ts`) — zelené.

issue 239
