### PR TITLE
Eshop -> Vyhladat: najst produkt, otvorit ho a upravit dodavatelsku linku (issue 240)

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -28,6 +28,21 @@ paths:
   to visible = move its entry from `HIDDEN_TABS` to a `NAV` folder — the
   component itself needs no change (`findTab`/`isVisibleTabId` already
   handle both).
+- **A VISIBLE tab (in `NAV`, not `HIDDEN_TABS`) must NEVER render its own
+  `<h1>`/`<h2>` matching the tab's `label` — `App.tsx` renders that title
+  itself via `Topbar` for any `isVisibleTabId(activeTabId)` tab, so a
+  component-owned heading duplicates it (`getByRole("heading", {name})`
+  then resolves to 2 elements — found live on issue 239's brand-new
+  "Párovanie produktov" screen, which shipped with its own `<h2>` because
+  it was written as a fresh visible tab, not a hidden-tab migration). The
+  existing rule "moving hidden→visible removes the old `<h2>`"
+  (`nav.ts`'s own comment, `isVisibleTabId`) applies EQUALLY to a
+  brand-NEW visible tab written from scratch — never add a
+  `<h1>`/`<h2>` inside a section component whose tab already lives in
+  `NAV` (see `OrdersSection.tsx`/`NedostupneSection.tsx`/
+  `PostaUncollectedSection.tsx` for the established no-own-heading
+  pattern). Only `HIDDEN_TABS` components (`CatalogPage.tsx`/
+  `PairingSection.tsx`/`SchedulerSection.tsx`) keep their own heading.
 - **User account controls (greeting/logout/change-password) live in
   `Topbar.tsx` as a dropdown "user menu" in the HEADER — not the sidebar
   footer.** This was an explicit ticket decision (#57): "change-password

--- a/.claude/rules/product-links.md
+++ b/.claude/rules/product-links.md
@@ -1,0 +1,63 @@
+---
+paths:
+  - "apps/api/src/modules/product-links/**"
+  - "apps/api/src/http/product-links-routes.ts"
+  - "apps/api/tests/product-links-http.integration.test.ts"
+  - "apps/web/src/supplierLinksApi.ts"
+  - "apps/web/src/components/SupplierLinksSection.tsx"
+---
+
+# Párovanie produktov (issue 239)
+
+- **Zámerne SAMOSTATNÁ obrazovka od skrytej `pairing` záložky, nie
+  rozšírenie.** `pairing` (`.claude/rules/pairing.md`) je kľúčovaná
+  `variant.code` a má vlastný `navrhnute → potvrdene` stavový automat pre
+  BUDÚCE automatické hľadanie kandidátov u veľkoobchodného dodávateľa
+  (#46/#48) — nezapisuje do Shoptetu vôbec. Táto obrazovka je kľúčovaná
+  `product.key` (rovnako ako `product_supplier_link_override`, #121) a
+  zapisuje VÝHRADNE do tej istej override tabuľky, ktorú existujúci
+  `shoptet-writeback` job (#122) posiela do Shoptetu. Návrh na rozšírenie
+  `pairing` o "chýbajúce linky" mód bol zámerne zamietnutý — zmiešalo by to
+  dva nezávislé dátové modely do jednej tabuľky/obrazovky.
+- **Zápisové jadro je zdieľané s #121's riadkovou cestou.**
+  `supplier-link-assignment.ts`'s `upsertProductSupplierLink` (zúžený `tx`
+  parameter `Pick<Database, "select" | "insert">`, presne podľa
+  `.claude/rules/database.md`'s vzoru) je spoločné jadro pre
+  `setProductSupplierLink` (cez `lineId`, dopočíta `productKey` cez JOIN
+  na `orderLines`/`variants`) a `setProductSupplierLinkForProduct` (priamo
+  cez `productKey`, keďže produkt bez otvorenej objednávky `lineId` nemá).
+  Ďalšia zdieľaná zložka: `supplierLinkUrlBody` (zod schéma URL+http(s)+
+  formula-guard) — `orders-routes.ts` ju teraz len re-exportuje ako
+  `orderLineSupplierLinkBody`, nedupliuje.
+- **Efektívna linka sa počíta v JS, nie v SQL** (`queries.ts`'s
+  `listProductLinks`) — `resolveEffectiveSupplierLink` je čistá regexová
+  funkcia nad `internalNote`, rovnaký vzor ako `supplier-stock/run.ts`'s
+  `collectSupplierLinks`. Celý katalóg sa načíta a filtruje/stránkuje v
+  pamäti (prijateľné pre manažérsku obrazovku, živo overené na 4542
+  produktoch bez merateľného oneskorenia).
+- **Naživo overiť "insert/correct" bez porušenia "adresa sa nikdy
+  nedopĺňa odhadom" (ticketova bezpečnostná podmienka): NIKDY nevymýšľaj
+  URL pre reálny produkt, ani na test.** Namiesto vloženia vymyslenej
+  adresy do produktu, ktorý ju nemá, over "doplniť/opraviť" cestu na
+  produkte, ktorý UŽ MÁ efektívnu linku (filter "S linkou") — klikni
+  "Upraviť", nech sa predvyplní JEHO VLASTNÁ existujúca hodnota (zo
+  Shoptet-ovho `internalNote`), a ulož TÚ ISTÚ hodnotu späť cez nový
+  mechanizmus. Toto je skutočný, honestný dôkaz "insert path funguje" bez
+  rizika, že AI zapíše zlú/vymyslenú business dátu do živého Shoptet
+  poľa. Použité pri #239's post-deploy overení (produkt "01 Detské tričko
+  - Jeleň ručiaci").
+- **Manuálne spustenie `shoptet-writeback` jobu na produkcii** (na overenie,
+  že novo uložený override reálne dorazí do Shoptetu, nie len do našej DB)
+  ide identickým postupom ako `.claude/rules/shoptet-writeback.md`
+  dokumentuje pre #122/#123: malý `.mjs` skript importujúci
+  `./dist/db/client.js` + `./dist/modules/shoptet-writeback/run-writeback.js`
+  + `./dist/modules/shoptet-writeback/config.js`, skopírovaný cez `docker cp`
+  do `/app/apps/api/` VNÚTRI bežiaceho kontajnera (`docker exec -w
+  /app/apps/api forestshop-app-1 node <skript>.mjs`), prihlasovacie údaje
+  (`SHOPTET_ADMIN_USER`/`_PASSWORD`/`SHOPTET_ADMIN_BASE_URL`) číta priamo z
+  kontajnerovho prostredia. Výsledok `{"status":"ok","productCount":N,
+  "rowCount":M}` je PRIAMY dôkaz doručenia — `runShoptetWriteback` interne
+  potvrdzuje úspech AŽ spätným čítaním Shoptet-ovho vlastného Logu importov,
+  nikdy len "CSV sa odoslalo". Skript po overení zmazať (`docker exec -u
+  root ... rm`, rovnaký dôvod ako #122/#123 — súbory z `docker cp` patria
+  rootovi).

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -477,3 +477,23 @@ paths:
   pridaním filtra do testu — a nový endpoint, ktorého bežný očakávaný
   doménový výsledok je „nič"/neúspech, vracia 200 s telom (vzor `/api/me` a
   `POST /api/me/password`), nie 4xx.
+- **Integračný test, ktorý ide cez skutočnú HTTP trasu (nie priamo cez
+  funkciu s explicitným `now` parametrom) a vkladá fixtúrové dáta s PEVNÝM
+  dátumovým LITERÁLOM ako "dnes"/"tento týždeň", je časovaná bomba — spadne
+  presne v deň, keď skutočný kalendárny dátum prekročí ten literál.**
+  Zistené issue 239 (`orders-overview.integration.test.ts`): jediný test v
+  súbore, ktorý NEPOSIELA `NOW` priamo do `getOrdersDashboardOverview` (na
+  rozdiel od ostatných testov v tom istom súbore), ale ide cez
+  `GET /api/orders/overview`, ktorá si "dnes" počíta zo SKUTOČNÉHO
+  `new Date()` na serveri — vkladal fixtúru s `TODAY_START` pevne
+  `2026-08-03/04`. Test prešiel mesiace, kým vývoj tohto ticketu (2026-08-04
+  → 2026-08-05) skutočne neprekročil polnoc a test spadol so zdanlivo
+  nesúvisiacou chybou (`orderCount: 0` namiesto `1`). Fix: hranica sa
+  prepočíta PRI BEHU testu cez existujúcu `computeBratislavaPeriodBoundaries
+  (new Date())` (tá istá funkcia, akú používa aj samotná trasa), nie
+  literál napísaný v deň písania testu. **Test na KAŽDÝ ďalší
+  "dnes/týždeň/mesiac" integračný test, čo ide cez HTTP trasu (nie priamo
+  cez funkciu s explicitným `now`):** vkladá fixtúru s PEVNÝM dátumovým
+  literálom? Ak áno, a testovaná trasa/funkcia si "teraz" berie sama zo
+  systémového hodín, prepočítaj hranicu pri behu testu namiesto písania
+  literálu — inak test raz, nevyhnutne, prestane platiť.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,3 +101,4 @@ Per-area rules live in `.claude/rules/<area>.md` with `paths:` frontmatter.
   žiadne AI dohady) → `.claude/rules/supplier-stock.md`
 - adresy našich produktov z feedu google.xml (#220) → `.claude/rules/shop-feed.md`
 - Kniha odoslaných e-mailov (F193 — jediná odosielacia cesta, dedup okno preskočení) → `.claude/rules/mail-log.md`
+- Párovanie produktov (#239 — samostatná od `pairing`, zdieľaný upsert s #121, live-overenie bez AI-dohady) → `.claude/rules/product-links.md`

--- a/apps/api/src/http/app.ts
+++ b/apps/api/src/http/app.ts
@@ -21,6 +21,8 @@ import { requireSameOrigin } from "./origin-check.js";
 import { registerPairingRoutes } from "./pairing-routes.js";
 import { registerPostaUncollectedRoutes, type PostaUncollectedRunDeps } from "./posta-uncollected-routes.js";
 import { registerProductLinksRoutes } from "./product-links-routes.js";
+import { registerProductDetailRoutes } from "./product-detail-routes.js";
+import { registerSearchRoutes } from "./search-routes.js";
 import type { PageFetcher, PageFetchResult } from "../modules/supplier-stock/page-fetcher.js";
 import { registerSupplierStockRoutes } from "./supplier-stock-routes.js";
 import { registerRestockRoutes, type RestockRunDeps } from "./restock-routes.js";
@@ -185,6 +187,12 @@ export function createApp(
   // `product_supplier_link_override` tabuľky ako #121, žiadna nová cesta do
   // Shoptetu).
   registerProductLinksRoutes(app, db);
+  // issue 240: "Eshop → Vyhľadať" — hľadanie naprieč katalógom + objednávkami,
+  // a detail produktu (za výsledkom hľadania) so VŠETKÝMI jeho variantmi.
+  // Editácia dodávateľskej linky ide cez existujúcu `registerProductLinksRoutes`
+  // trasu vyššie (#239) — žiadna nová zapisovacia cesta.
+  registerProductDetailRoutes(app, db);
+  registerSearchRoutes(app, db, options.adminBaseUrl ?? "https://www.forestshop.sk");
   registerPostaUncollectedRoutes(
     app,
     db,

--- a/apps/api/src/http/product-detail-routes.ts
+++ b/apps/api/src/http/product-detail-routes.ts
@@ -1,0 +1,26 @@
+import { zValidator } from "@hono/zod-validator";
+import type { Hono } from "hono";
+import { z } from "zod";
+import type { Database } from "../db/client.js";
+import { getProductDetail } from "../modules/product-detail/queries.js";
+import { requireUser, type AppBindings } from "./middleware.js";
+
+// issue 240: rovnaké oprávnenie ako `/api/product-links` (#239) —
+// `requireUser`, žiadne obmedzenie roly, čítanie smie vidieť každý prihlásený.
+// Editácia dodávateľskej linky ide cez EXISTUJÚcu trasu
+// `POST /api/product-links/:productKey` (#239) — táto trasa je len na čítanie.
+const productKeyParam = z.object({ productKey: z.string().min(1).max(200) });
+
+export function registerProductDetailRoutes(app: Hono<AppBindings>, db: Database): void {
+  app.get(
+    "/api/product-detail/:productKey",
+    requireUser(db),
+    zValidator("param", productKeyParam),
+    async (c) => {
+      const { productKey } = c.req.valid("param");
+      const detail = await getProductDetail(db, productKey);
+      if (detail === null) return c.json({ error: "Produkt sa nenašiel" }, 404);
+      return c.json(detail);
+    },
+  );
+}

--- a/apps/api/src/http/search-routes.ts
+++ b/apps/api/src/http/search-routes.ts
@@ -1,0 +1,16 @@
+import { zValidator } from "@hono/zod-validator";
+import type { Hono } from "hono";
+import { z } from "zod";
+import type { Database } from "../db/client.js";
+import { globalSearch } from "../modules/search/queries.js";
+import { requireUser, type AppBindings } from "./middleware.js";
+
+// issue 240: rovnaké oprávnenie ako katalóg/objednávky/párovanie
+// (`requireUser`, žiadne obmedzenie roly) — každý prihlásený smie hľadať.
+const searchQuery = z.object({ q: z.string().max(200).default("") });
+
+export function registerSearchRoutes(app: Hono<AppBindings>, db: Database, adminBaseUrl: string): void {
+  app.get("/api/search", requireUser(db), zValidator("query", searchQuery), async (c) =>
+    c.json(await globalSearch(db, c.req.valid("query").q, adminBaseUrl)),
+  );
+}

--- a/apps/api/src/modules/product-detail/queries.ts
+++ b/apps/api/src/modules/product-detail/queries.ts
@@ -1,0 +1,150 @@
+import { asc, eq, inArray } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { productSupplierLinkOverrides, products, shopProductUrl, supplierStock, variants } from "../../db/schema.js";
+import type { VariantState } from "../catalog/availability.js";
+import { extractSupplierLink } from "../catalog/supplier-link.js";
+import { resolveEffectiveSupplierLink } from "../orders/effective-supplier-link.js";
+
+// issue 240: detail produktu za výsledkom hľadania — VŠETKY varianty
+// (veľkosti) toho istého produktu naraz, efektívna dodávateľská linka + jej
+// uložené/odoslané časy (rovnaká `resolveEffectiveSupplierLink` logika ako
+// #239/#121, žiadna nová), adresa u nás (`shop_product_url`, issue 220) a
+// dostupnosť u dodávateľa (`supplier_stock`, issue 212/224).
+//
+// Dostupnosť u dodávateľa sa páruje VÝHRADNE podľa linky extrahovanej z
+// `internalNote` (`extractSupplierLink`) — TEN ISTÝ zdroj, aký používa
+// scraper (`supplier-stock/run.ts`'s `collectSupplierLinks`) aj
+// `restock/queries.ts`. Scraper manažérov OVERRIDE nesleduje vôbec — to je
+// EXISTUJÚCE správanie (mimo rozsahu tohto ticketu, zapísané v návrhovom
+// komentári na #240), táto obrazovka ho len zobrazuje tak, ako je.
+export interface ProductDetailVariant {
+  readonly code: string;
+  readonly sizeLabel: string | null;
+  readonly name: string;
+  readonly state: VariantState;
+  readonly stock: number;
+  readonly price: string | null;
+  readonly currency: string | null;
+  readonly availabilityText: string;
+  readonly productVisibility: string;
+  readonly externalCode: string | null;
+  readonly missingSince: string | null;
+  /** Priama adresa detailu na NAŠOM e-shope (issue 220), `null` = kód nie je vo feede. */
+  readonly ourShopUrl: string | null;
+  /** `null` = appka o dostupnosti u dodávateľa nemá žiadny záznam. */
+  readonly supplierAvailability: "available" | "unavailable" | "unknown" | null;
+  readonly supplierAvailabilityText: string | null;
+}
+
+export interface ProductDetail {
+  readonly productKey: string;
+  readonly productName: string;
+  readonly supplier: string | null;
+  /** Efektívna linka — override MÁ vždy prednosť pred `internalNote` (rovnaká
+   * priorita ako `resolveEffectiveSupplierLink` všade inde v appke). */
+  readonly supplierLinkUrl: string | null;
+  readonly supplierLinkUpdatedAt: string | null;
+  readonly supplierLinkSyncedAt: string | null;
+  readonly variants: readonly ProductDetailVariant[];
+}
+
+export async function getProductDetail(db: Database, productKey: string): Promise<ProductDetail | null> {
+  const [product] = await db
+    .select({
+      key: products.key,
+      name: products.name,
+      supplier: products.supplier,
+      internalNote: products.internalNote,
+    })
+    .from(products)
+    .where(eq(products.key, productKey))
+    .limit(1);
+  if (product === undefined) return null;
+
+  const [override] = await db
+    .select({
+      url: productSupplierLinkOverrides.url,
+      updatedAt: productSupplierLinkOverrides.updatedAt,
+      syncedAt: productSupplierLinkOverrides.syncedAt,
+    })
+    .from(productSupplierLinkOverrides)
+    .where(eq(productSupplierLinkOverrides.productKey, productKey))
+    .limit(1);
+
+  const effective = resolveEffectiveSupplierLink(product.internalNote, override?.url ?? null);
+  const scrapedLink = extractSupplierLink(product.internalNote).url;
+
+  const variantRows = await db
+    .select({
+      code: variants.code,
+      sizeLabel: variants.sizeLabel,
+      name: variants.name,
+      state: variants.state,
+      stock: variants.stock,
+      price: variants.price,
+      currency: variants.currency,
+      availabilityText: variants.availabilityText,
+      productVisibility: variants.productVisibility,
+      externalCode: variants.externalCode,
+      missingSince: variants.missingSince,
+    })
+    .from(variants)
+    .where(eq(variants.productKey, productKey))
+    .orderBy(asc(variants.code));
+
+  const codes = variantRows.map((v) => v.code);
+  const shopUrlRows =
+    codes.length === 0
+      ? []
+      : await db
+          .select({ code: shopProductUrl.code, url: shopProductUrl.url })
+          .from(shopProductUrl)
+          .where(inArray(shopProductUrl.code, codes));
+  const shopUrlByCode = new Map(shopUrlRows.map((row) => [row.code, row.url]));
+
+  const supplierStockRows =
+    scrapedLink === null
+      ? []
+      : await db
+          .select({
+            sizeLabel: supplierStock.sizeLabel,
+            availability: supplierStock.availability,
+            availabilityText: supplierStock.availabilityText,
+          })
+          .from(supplierStock)
+          .where(eq(supplierStock.link, scrapedLink));
+  // issue 224: riadok bez rozlíšenia veľkosti nesie `size_label = ''` — použije
+  // sa ako záchranná sieť, keď variant NEMÁ vlastný riadok pre svoju veľkosť.
+  const supplierStockBySize = new Map(supplierStockRows.map((row) => [row.sizeLabel, row]));
+  const supplierStockBlanket = supplierStockBySize.get("") ?? null;
+
+  const variantDetails: ProductDetailVariant[] = variantRows.map((v) => {
+    const matched = supplierStockBySize.get((v.sizeLabel ?? "").trim()) ?? supplierStockBlanket;
+    return {
+      code: v.code,
+      sizeLabel: v.sizeLabel,
+      name: v.name,
+      state: v.state,
+      stock: v.stock,
+      price: v.price,
+      currency: v.currency,
+      availabilityText: v.availabilityText,
+      productVisibility: v.productVisibility,
+      externalCode: v.externalCode,
+      missingSince: v.missingSince?.toISOString() ?? null,
+      ourShopUrl: shopUrlByCode.get(v.code) ?? null,
+      supplierAvailability: matched?.availability ?? null,
+      supplierAvailabilityText: matched?.availabilityText ?? null,
+    };
+  });
+
+  return {
+    productKey: product.key,
+    productName: product.name,
+    supplier: product.supplier,
+    supplierLinkUrl: effective.url,
+    supplierLinkUpdatedAt: override?.updatedAt.toISOString() ?? null,
+    supplierLinkSyncedAt: override?.syncedAt?.toISOString() ?? null,
+    variants: variantDetails,
+  };
+}

--- a/apps/api/src/modules/search/queries.ts
+++ b/apps/api/src/modules/search/queries.ts
@@ -1,0 +1,114 @@
+import { asc, desc, eq, or, sql } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { orders, products, variants } from "../../db/schema.js";
+import { escapeLikePattern } from "../catalog/queries.js";
+import type { VariantState } from "../catalog/availability.js";
+import { buildShoptetAdminOrderUrl } from "../orders/queries.js";
+
+// issue 240: "Eshop → Vyhľadať" — JEDNO pole, ktoré hľadá naprieč appkou, ale
+// výsledky radí PREDNOSTNE produkty (ticketova požiadavka). Namiesto umelej
+// "relevance" logiky nad jedným zoradeným zoznamom appka vracia DVE oddelené
+// polia (`products`/`orders`) — front-end ich vykreslí ako dva viditeľne
+// oddelené bloky, produkty prirodzene PRED objednávkami, bez potreby
+// počítať skóre.
+//
+// Rozsah "hľadať všetko" (zapísané aj na ticket pri návrhu): prehľadáva sa
+// VÝHRADNE katalóg (kód variantu/názov/dodávateľ/kód u dodávateľa) a
+// objednávky (číslo objednávky/meno zákazníka/e-mail) — texty e-mailov,
+// kniha odoslaných e-mailov, história plánovača, nastavenia automatizácií,
+// surové riadky dodávateľského skladu, audit log a používatelia sa VEDOME
+// neprehľadávajú (nie sú to "tovar" ani "objednávka", ktoré ticket opisuje).
+export interface ProductSearchHit {
+  readonly productKey: string;
+  readonly variantCode: string;
+  readonly productName: string;
+  readonly sizeLabel: string | null;
+  readonly supplier: string | null;
+  readonly externalCode: string | null;
+  readonly state: VariantState;
+}
+
+export interface OrderSearchHit {
+  readonly orderId: string;
+  readonly externalOrderId: string;
+  readonly customerName: string;
+  readonly email: string | null;
+  readonly statusName: string;
+  readonly placedAt: string;
+  readonly adminUrl: string;
+}
+
+export interface GlobalSearchResult {
+  readonly products: readonly ProductSearchHit[];
+  readonly orders: readonly OrderSearchHit[];
+}
+
+// MVP horné stropy — táto obrazovka je "rýchla ruka" na jeden konkrétny kus
+// tovaru/objednávku (majiteľov vlastný opis, ticket), nie stránkovaný
+// zoznam ako katalóg/Na objednanie. Málo, presných výsledkov je tu cieľom,
+// nie úplnosť.
+const PRODUCT_LIMIT = 20;
+const ORDER_LIMIT = 10;
+
+export async function globalSearch(db: Database, q: string, adminBaseUrl: string): Promise<GlobalSearchResult> {
+  const trimmed = q.trim();
+  if (trimmed === "") return { products: [], orders: [] };
+  const pattern = `%${escapeLikePattern(trimmed)}%`;
+
+  const productRows = await db
+    .select({
+      productKey: variants.productKey,
+      variantCode: variants.code,
+      productName: variants.name,
+      sizeLabel: variants.sizeLabel,
+      supplier: products.supplier,
+      externalCode: variants.externalCode,
+      state: variants.state,
+    })
+    .from(variants)
+    .innerJoin(products, eq(products.key, variants.productKey))
+    .where(
+      or(
+        sql`${variants.code} ILIKE ${pattern}`,
+        sql`${variants.name} ILIKE ${pattern}`,
+        sql`${products.supplier} ILIKE ${pattern}`,
+        sql`${variants.externalCode} ILIKE ${pattern}`,
+      ),
+    )
+    .orderBy(asc(variants.name), asc(variants.code))
+    .limit(PRODUCT_LIMIT);
+
+  const orderRows = await db
+    .select({
+      orderId: orders.id,
+      externalOrderId: orders.externalOrderId,
+      customerName: orders.customerName,
+      email: orders.email,
+      statusName: orders.statusName,
+      placedAt: orders.placedAt,
+      shoptetOrderId: orders.shoptetOrderId,
+    })
+    .from(orders)
+    .where(
+      or(
+        sql`${orders.externalOrderId} ILIKE ${pattern}`,
+        sql`${orders.customerName} ILIKE ${pattern}`,
+        sql`${orders.email} ILIKE ${pattern}`,
+      ),
+    )
+    .orderBy(desc(orders.placedAt))
+    .limit(ORDER_LIMIT);
+
+  return {
+    products: productRows,
+    orders: orderRows.map((row) => ({
+      orderId: row.orderId,
+      externalOrderId: row.externalOrderId,
+      customerName: row.customerName,
+      email: row.email,
+      statusName: row.statusName,
+      placedAt: row.placedAt.toISOString(),
+      adminUrl: buildShoptetAdminOrderUrl(adminBaseUrl, row.externalOrderId, row.shoptetOrderId),
+    })),
+  };
+}

--- a/apps/api/tests/product-detail-http.integration.test.ts
+++ b/apps/api/tests/product-detail-http.integration.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, expect, it } from "vitest";
+import { productSupplierLinkOverrides, shopProductUrl, supplierStock, users } from "../src/db/schema.js";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import type { UserRole } from "../src/modules/auth/service.js";
+import { insertTestVariant, insertTestVariantForProduct } from "./helpers/orders.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 240: "Eshop → Vyhľadať" — detail produktu za výsledkom hľadania.
+// Editácia dodávateľskej linky ide cez EXISTUJÚcu trasu
+// `POST /api/product-links/:productKey` (#239, vlastné testy tam) — tento
+// súbor overuje LEN čítaciu stranu (`GET /api/product-detail/:productKey`).
+
+const HESLO = "test-heslo-abc"; // testovacie údaje, nie tajomstvo
+
+let close: (() => Promise<void>) | undefined;
+
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  resetLoginRateLimit();
+});
+
+async function boot(role: UserRole = "manazer") {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const [pouzivatel] = await ctx.db
+    .insert(users)
+    .values({ email: "manazer@forestshop.sk", passwordHash: await hashPassword(HESLO), displayName: "Manažér", role })
+    .returning({ id: users.id });
+  if (pouzivatel === undefined) throw new Error("testovací používateľ sa nepodarilo vložiť");
+
+  const app = createApp(ctx.db, { cookieSecure: false });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "manazer@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie, db: ctx.db };
+}
+
+interface DetailTelo {
+  readonly productKey: string;
+  readonly productName: string;
+  readonly supplier: string | null;
+  readonly supplierLinkUrl: string | null;
+  readonly supplierLinkUpdatedAt: string | null;
+  readonly supplierLinkSyncedAt: string | null;
+  readonly variants: {
+    readonly code: string;
+    readonly sizeLabel: string | null;
+    readonly stock: number;
+    readonly price: string | null;
+    readonly state: string;
+    readonly ourShopUrl: string | null;
+    readonly supplierAvailability: string | null;
+    readonly supplierAvailabilityText: string | null;
+  }[];
+}
+
+it("bez prihlásenia vráti 401", async () => {
+  const { app } = await boot();
+  expect((await app.request("/api/product-detail/NIEKTO")).status).toBe(401);
+});
+
+it("neznámy productKey vráti 404", async () => {
+  const { app, cookie } = await boot();
+  const res = await app.request("/api/product-detail/NEEXISTUJE", { headers: { cookie } });
+  expect(res.status).toBe(404);
+});
+
+it("produkt bez internalNote a bez override nemá efektívnu linku ani dostupnosť u dodávateľa", async () => {
+  const { app, cookie, db } = await boot();
+  await insertTestVariant(db, "PD-1", "Dodávateľ PD");
+
+  const res = await app.request("/api/product-detail/PD-1", { headers: { cookie } });
+  expect(res.status).toBe(200);
+  const telo = (await res.json()) as DetailTelo;
+  expect(telo.productKey).toBe("PD-1");
+  expect(telo.productName).toBe("Test produkt PD-1");
+  expect(telo.supplier).toBe("Dodávateľ PD");
+  expect(telo.supplierLinkUrl).toBeNull();
+  expect(telo.supplierLinkUpdatedAt).toBeNull();
+  expect(telo.supplierLinkSyncedAt).toBeNull();
+  expect(telo.variants).toHaveLength(1);
+  expect(telo.variants[0]).toMatchObject({
+    code: "PD-1",
+    sizeLabel: null,
+    stock: 5,
+    price: "10.00",
+    state: "sellable",
+    ourShopUrl: null,
+    supplierAvailability: null,
+    supplierAvailabilityText: null,
+  });
+});
+
+it("efektívna linka sa extrahuje z internalNote, keď override neexistuje", async () => {
+  const { app, cookie, db } = await boot();
+  await insertTestVariant(db, "PD-2", "Dodávateľ", {
+    internalNote: "Dodávateľ: Trigona - https://trigona.example.com/produkt-2",
+  });
+
+  const telo = (await (await app.request("/api/product-detail/PD-2", { headers: { cookie } })).json()) as DetailTelo;
+  expect(telo.supplierLinkUrl).toBe("https://trigona.example.com/produkt-2");
+  expect(telo.supplierLinkUpdatedAt).toBeNull(); // žiadny override riadok
+});
+
+it("override MÁ vždy prednosť pred linkou z internalNote", async () => {
+  const { app, cookie, db } = await boot();
+  await insertTestVariant(db, "PD-3", "Dodávateľ", { internalNote: "https://stary.example.com/PD-3" });
+  await db.insert(productSupplierLinkOverrides).values({
+    productKey: "PD-3",
+    url: "https://novy.example.com/PD-3",
+    updatedAt: new Date("2026-07-15T09:00:00Z"),
+    syncedAt: new Date("2026-07-15T10:00:00Z"),
+  });
+
+  const telo = (await (await app.request("/api/product-detail/PD-3", { headers: { cookie } })).json()) as DetailTelo;
+  expect(telo.supplierLinkUrl).toBe("https://novy.example.com/PD-3");
+  expect(telo.supplierLinkUpdatedAt).toBe(new Date("2026-07-15T09:00:00Z").toISOString());
+  expect(telo.supplierLinkSyncedAt).toBe(new Date("2026-07-15T10:00:00Z").toISOString());
+});
+
+it("adresa u nás (shop_product_url) sa priradí variantu podľa kódu", async () => {
+  const { app, cookie, db } = await boot();
+  await insertTestVariant(db, "PD-4", "Dodávateľ");
+  await db.insert(shopProductUrl).values({
+    code: "PD-4",
+    url: "https://www.forestshop.sk/pd-4/",
+    fetchedAt: new Date("2026-07-01T00:00:00Z"),
+  });
+
+  const telo = (await (await app.request("/api/product-detail/PD-4", { headers: { cookie } })).json()) as DetailTelo;
+  expect(telo.variants[0]?.ourShopUrl).toBe("https://www.forestshop.sk/pd-4/");
+});
+
+it("dostupnosť u dodávateľa (blanket riadok, size_label='') sa priradí jednovariantnému produktu", async () => {
+  const { app, cookie, db } = await boot();
+  await insertTestVariant(db, "PD-5", "Dodávateľ", { internalNote: "https://dodavatel.example.com/pd-5" });
+  await db.insert(supplierStock).values({
+    link: "https://dodavatel.example.com/pd-5",
+    sizeLabel: "",
+    host: "dodavatel.example.com",
+    availability: "available",
+    availabilityText: "Skladom u dodávateľa",
+    source: "text",
+    ok: true,
+    checkedAt: new Date("2026-07-20T00:00:00Z"),
+    confirmedAt: new Date("2026-07-20T00:00:00Z"),
+  });
+
+  const telo = (await (await app.request("/api/product-detail/PD-5", { headers: { cookie } })).json()) as DetailTelo;
+  expect(telo.variants[0]?.supplierAvailability).toBe("available");
+  expect(telo.variants[0]?.supplierAvailabilityText).toBe("Skladom u dodávateľa");
+});
+
+it("dostupnosť u dodávateľa PER VEĽKOSŤ — každý variant dostane svoj vlastný riadok, žiadne krížové zamiešanie", async () => {
+  const { app, cookie, db } = await boot();
+  const link = "https://dodavatel.example.com/pd-6";
+  await insertTestVariantForProduct(db, "PD-6", "PD-6/S", { sizeLabel: "S", internalNote: link });
+  await insertTestVariantForProduct(db, "PD-6", "PD-6/M", { sizeLabel: "M", internalNote: link });
+  await db.insert(supplierStock).values([
+    {
+      link,
+      sizeLabel: "S",
+      host: "dodavatel.example.com",
+      availability: "available",
+      availabilityText: "Skladom (S)",
+      source: "size_list",
+      ok: true,
+      checkedAt: new Date("2026-07-20T00:00:00Z"),
+      confirmedAt: new Date("2026-07-20T00:00:00Z"),
+    },
+    {
+      link,
+      sizeLabel: "M",
+      host: "dodavatel.example.com",
+      availability: "unavailable",
+      availabilityText: "Vypredané (M)",
+      source: "size_list",
+      ok: true,
+      checkedAt: new Date("2026-07-20T00:00:00Z"),
+      confirmedAt: new Date("2026-07-20T00:00:00Z"),
+    },
+  ]);
+
+  const telo = (await (await app.request("/api/product-detail/PD-6", { headers: { cookie } })).json()) as DetailTelo;
+  expect(telo.variants).toHaveLength(2);
+  const s = telo.variants.find((v) => v.code === "PD-6/S");
+  const m = telo.variants.find((v) => v.code === "PD-6/M");
+  expect(s?.supplierAvailability).toBe("available");
+  expect(m?.supplierAvailability).toBe("unavailable");
+});

--- a/apps/api/tests/search-http.integration.test.ts
+++ b/apps/api/tests/search-http.integration.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, expect, it } from "vitest";
+import { orders, users } from "../src/db/schema.js";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import type { UserRole } from "../src/modules/auth/service.js";
+import { insertTestVariant, insertTestVariantForProduct } from "./helpers/orders.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 240: "Eshop → Vyhľadať" — `GET /api/search?q=` hľadá naprieč
+// katalógom (produkty/varianty) aj objednávkami, vracia DVE oddelené polia
+// (produkty prirodzene pred objednávkami, žiadna umelá relevance logika).
+
+const HESLO = "test-heslo-abc"; // testovacie údaje, nie tajomstvo
+
+let close: (() => Promise<void>) | undefined;
+
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  resetLoginRateLimit();
+});
+
+async function boot(role: UserRole = "manazer") {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const [pouzivatel] = await ctx.db
+    .insert(users)
+    .values({ email: "manazer@forestshop.sk", passwordHash: await hashPassword(HESLO), displayName: "Manažér", role })
+    .returning({ id: users.id });
+  if (pouzivatel === undefined) throw new Error("testovací používateľ sa nepodarilo vložiť");
+
+  const app = createApp(ctx.db, { cookieSecure: false });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "manazer@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie, db: ctx.db };
+}
+
+interface SearchTelo {
+  readonly products: {
+    readonly productKey: string;
+    readonly variantCode: string;
+    readonly productName: string;
+    readonly sizeLabel: string | null;
+    readonly supplier: string | null;
+    readonly externalCode: string | null;
+    readonly state: string;
+  }[];
+  readonly orders: {
+    readonly orderId: string;
+    readonly externalOrderId: string;
+    readonly customerName: string;
+    readonly email: string | null;
+    readonly statusName: string;
+    readonly placedAt: string;
+    readonly adminUrl: string;
+  }[];
+}
+
+it("bez prihlásenia vráti 401", async () => {
+  const { app } = await boot();
+  expect((await app.request("/api/search?q=nieco")).status).toBe(401);
+});
+
+it("prázdne alebo chýbajúce q vráti obe polia prázdne", async () => {
+  const { app, cookie, db } = await boot();
+  await insertTestVariant(db, "SRCH-EMPTY", "Test dodávateľ");
+
+  const bezQ = (await (await app.request("/api/search", { headers: { cookie } })).json()) as SearchTelo;
+  expect(bezQ).toEqual({ products: [], orders: [] });
+
+  const prazdneQ = (await (await app.request("/api/search?q=", { headers: { cookie } })).json()) as SearchTelo;
+  expect(prazdneQ).toEqual({ products: [], orders: [] });
+});
+
+it("nájde produkt podľa kódu variantu", async () => {
+  const { app, cookie, db } = await boot();
+  await insertTestVariant(db, "SRCH-1", "Dodávateľ Hľadanie");
+
+  const telo = (await (await app.request("/api/search?q=SRCH-1", { headers: { cookie } })).json()) as SearchTelo;
+  expect(telo.products).toHaveLength(1);
+  expect(telo.products[0]).toEqual({
+    productKey: "SRCH-1",
+    variantCode: "SRCH-1",
+    productName: "Test produkt SRCH-1",
+    sizeLabel: null,
+    supplier: "Dodávateľ Hľadanie",
+    externalCode: null,
+    state: "sellable",
+  });
+  expect(telo.orders).toEqual([]);
+});
+
+it("nájde produkt podľa časti názvu (case-insensitive)", async () => {
+  const { app, cookie, db } = await boot();
+  await insertTestVariantForProduct(db, "SRCH-2", "SRCH-2", { productName: "Zvláštna Bunda Alfa" });
+
+  const telo = (await (await app.request("/api/search?q=bunda alfa", { headers: { cookie } })).json()) as SearchTelo;
+  expect(telo.products.some((p) => p.productKey === "SRCH-2")).toBe(true);
+});
+
+it("nájde produkt podľa dodávateľa", async () => {
+  const { app, cookie, db } = await boot();
+  await insertTestVariant(db, "SRCH-3", "Jedinečný Dodávateľ XYZ");
+
+  const telo = (await (await app.request("/api/search?q=Jedinečný Dodávateľ", { headers: { cookie } })).json()) as SearchTelo;
+  expect(telo.products.some((p) => p.productKey === "SRCH-3")).toBe(true);
+});
+
+it("nájde produkt podľa kódu u dodávateľa (externalCode)", async () => {
+  const { app, cookie, db } = await boot();
+  await insertTestVariant(db, "SRCH-4", "Dodávateľ", { externalCode: "EXT-JEDINECNY-KOD" });
+
+  const telo = (await (await app.request("/api/search?q=EXT-JEDINECNY-KOD", { headers: { cookie } })).json()) as SearchTelo;
+  expect(telo.products.some((p) => p.productKey === "SRCH-4")).toBe(true);
+});
+
+it("nájde objednávku podľa čísla objednávky, produkty ostanú prázdne", async () => {
+  const { app, cookie, db } = await boot();
+  const [objednavka] = await db
+    .insert(orders)
+    .values({
+      externalOrderId: "SRCH-ORDER-1",
+      customerName: "Nesúvisiaci Zákazník",
+      placedAt: new Date("2026-07-01T10:00:00Z"),
+    })
+    .returning();
+  expect(objednavka).toBeDefined();
+
+  const telo = (await (await app.request("/api/search?q=SRCH-ORDER-1", { headers: { cookie } })).json()) as SearchTelo;
+  expect(telo.products).toEqual([]);
+  expect(telo.orders).toHaveLength(1);
+  expect(telo.orders[0]?.externalOrderId).toBe("SRCH-ORDER-1");
+  expect(telo.orders[0]?.customerName).toBe("Nesúvisiaci Zákazník");
+  expect(telo.orders[0]?.adminUrl).toBe(
+    "https://www.forestshop.sk/admin/vyhladavanie/?string=SRCH-ORDER-1&src=orders",
+  );
+});
+
+it("nájde objednávku podľa mena zákazníka", async () => {
+  const { app, cookie, db } = await boot();
+  await db.insert(orders).values({
+    externalOrderId: "9501",
+    customerName: "Jedinečné Meno Testovacie",
+    placedAt: new Date("2026-07-01T10:00:00Z"),
+  });
+
+  const telo = (await (await app.request("/api/search?q=jedinečné meno", { headers: { cookie } })).json()) as SearchTelo;
+  expect(telo.orders.some((o) => o.externalOrderId === "9501")).toBe(true);
+});
+
+it("nájde objednávku podľa e-mailu zákazníka", async () => {
+  const { app, cookie, db } = await boot();
+  await db.insert(orders).values({
+    externalOrderId: "9502",
+    customerName: "Niekto Iný",
+    email: "unikatny-email@example.com",
+    placedAt: new Date("2026-07-01T10:00:00Z"),
+  });
+
+  const telo = (await (await app.request("/api/search?q=unikatny-email", { headers: { cookie } })).json()) as SearchTelo;
+  expect(telo.orders.some((o) => o.externalOrderId === "9502")).toBe(true);
+});
+
+it("produkt aj objednávka sa nájdu naraz ako dve oddelené polia", async () => {
+  const { app, cookie, db } = await boot();
+  await insertTestVariant(db, "SPOLOCNE-X", "Dodávateľ");
+  await db.insert(orders).values({
+    externalOrderId: "9503",
+    customerName: "Zákazník SPOLOCNE-X",
+    placedAt: new Date("2026-07-01T10:00:00Z"),
+  });
+
+  const telo = (await (await app.request("/api/search?q=SPOLOCNE-X", { headers: { cookie } })).json()) as SearchTelo;
+  expect(telo.products.some((p) => p.productKey === "SPOLOCNE-X")).toBe(true);
+  expect(telo.orders.some((o) => o.externalOrderId === "9503")).toBe(true);
+});
+
+it("hľadanie s internom Shoptet id objednávky použije priamy odkaz na detail", async () => {
+  const { app, cookie, db } = await boot();
+  await db.insert(orders).values({
+    externalOrderId: "9504",
+    customerName: "Priamy Odkaz",
+    shoptetOrderId: 555_111,
+    placedAt: new Date("2026-07-01T10:00:00Z"),
+  });
+
+  const telo = (await (await app.request("/api/search?q=9504", { headers: { cookie } })).json()) as SearchTelo;
+  expect(telo.orders[0]?.adminUrl).toBe("https://www.forestshop.sk/admin/objednavky-detail/?id=555111");
+});

--- a/apps/web/src/components/SearchSection.test.tsx
+++ b/apps/web/src/components/SearchSection.test.tsx
@@ -1,0 +1,243 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { SearchSection } from "./SearchSection.js";
+
+const { globalSearch, fetchProductDetail } = vi.hoisted(() => ({
+  globalSearch: vi.fn(),
+  fetchProductDetail: vi.fn(),
+}));
+const { saveProductLink } = vi.hoisted(() => ({ saveProductLink: vi.fn() }));
+
+// `SearchUnauthorizedError`/`SupplierLinksUnauthorizedError` ostávajú SKUTOČNÉ
+// triedy z reálnych modulov — rovnaký dôvod ako `SupplierLinksSection.test.tsx`:
+// `instanceof` v komponente musí fungovať aj v teste.
+vi.mock("../searchApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../searchApi.js")>();
+  return { ...actual, globalSearch, fetchProductDetail };
+});
+vi.mock("../supplierLinksApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../supplierLinksApi.js")>();
+  return { ...actual, saveProductLink };
+});
+
+const { SearchUnauthorizedError } = await import("../searchApi.js");
+const { SupplierLinksUnauthorizedError } = await import("../supplierLinksApi.js");
+
+const PRODUKT = {
+  productKey: "PD-1",
+  variantCode: "PD-1",
+  productName: "Test produkt PD-1",
+  sizeLabel: null,
+  supplier: "Test dodávateľ",
+  externalCode: "EXT-1",
+  state: "sellable" as const,
+};
+
+const OBJEDNAVKA = {
+  orderId: "order-1",
+  externalOrderId: "9001",
+  customerName: "Zákazník Alfa",
+  email: "alfa@example.com",
+  statusName: "Vybavuje sa",
+  placedAt: "2026-07-01T10:00:00.000Z",
+  adminUrl: "https://www.forestshop.sk/admin/vyhladavanie/?string=9001&src=orders",
+};
+
+const DETAIL_BEZ_LINKY = {
+  productKey: "PD-1",
+  productName: "Test produkt PD-1",
+  supplier: "Test dodávateľ",
+  supplierLinkUrl: null,
+  supplierLinkUpdatedAt: null,
+  supplierLinkSyncedAt: null,
+  variants: [
+    {
+      code: "PD-1",
+      sizeLabel: null,
+      name: "Test produkt PD-1",
+      state: "sellable" as const,
+      stock: 5,
+      price: "19.90",
+      currency: "EUR",
+      availabilityText: "Skladom",
+      productVisibility: "visible",
+      externalCode: "EXT-1",
+      missingSince: null,
+      ourShopUrl: "https://www.forestshop.sk/pd-1/",
+      supplierAvailability: null,
+      supplierAvailabilityText: null,
+    },
+  ],
+};
+
+function submitSearch(query: string): void {
+  fireEvent.change(screen.getByLabelText("Hľadať"), { target: { value: query } });
+  fireEvent.click(screen.getByRole("button", { name: "Hľadať" }));
+}
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+it("prázdny výsledok zobrazí informačnú vetu namiesto tabuliek", async () => {
+  globalSearch.mockResolvedValue({ products: [], orders: [] });
+
+  render(<SearchSection role="citanie" onSessionExpired={() => {}} />);
+  submitSearch("nieco-co-nikde-nie-je");
+
+  await screen.findByTestId("search-empty");
+  expect(screen.queryByTestId("search-products")).toBeNull();
+  expect(screen.queryByTestId("search-orders")).toBeNull();
+});
+
+it("produkty aj objednávky sa zobrazia ako dva oddelené bloky, produkty prvé", async () => {
+  globalSearch.mockResolvedValue({ products: [PRODUKT], orders: [OBJEDNAVKA] });
+
+  render(<SearchSection role="citanie" onSessionExpired={() => {}} />);
+  submitSearch("spolocne");
+
+  const produkty = await screen.findByTestId("search-products");
+  const objednavky = await screen.findByTestId("search-orders");
+  expect(produkty.textContent).toContain("Test produkt PD-1");
+  expect(objednavky.textContent).toContain("Zákazník Alfa");
+  // Produkty sa vykresľujú PRED objednávkami v DOM poradí.
+  expect(produkty.compareDocumentPosition(objednavky) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+});
+
+it("pri 401 pri hľadaní zavolá onSessionExpired", async () => {
+  globalSearch.mockRejectedValue(new SearchUnauthorizedError());
+  const onSessionExpired = vi.fn();
+
+  render(<SearchSection role="citanie" onSessionExpired={onSessionExpired} />);
+  submitSearch("hocico");
+
+  await waitFor(() => {
+    expect(onSessionExpired).toHaveBeenCalledTimes(1);
+  });
+});
+
+it("klik na 'Otvoriť' pri produkte otvorí detail so všetkými variantmi", async () => {
+  globalSearch.mockResolvedValue({ products: [PRODUKT], orders: [] });
+  fetchProductDetail.mockResolvedValue(DETAIL_BEZ_LINKY);
+
+  render(<SearchSection role="citanie" onSessionExpired={() => {}} />);
+  submitSearch("PD-1");
+
+  fireEvent.click(await screen.findByTestId("search-product-open-PD-1"));
+
+  await screen.findByTestId("search-detail-section");
+  expect(fetchProductDetail).toHaveBeenCalledWith("PD-1");
+  expect(screen.getByTestId("search-detail-name").textContent).toBe("Test produkt PD-1");
+  expect(screen.getByTestId("search-detail-variant-PD-1").textContent).toContain("19.90");
+  expect(screen.getByTestId("search-detail-shop-link-PD-1")).toHaveProperty("href", "https://www.forestshop.sk/pd-1/");
+});
+
+it("späť z detailu vráti na hľadanie", async () => {
+  globalSearch.mockResolvedValue({ products: [PRODUKT], orders: [] });
+  fetchProductDetail.mockResolvedValue(DETAIL_BEZ_LINKY);
+
+  render(<SearchSection role="citanie" onSessionExpired={() => {}} />);
+  submitSearch("PD-1");
+  fireEvent.click(await screen.findByTestId("search-product-open-PD-1"));
+  await screen.findByTestId("search-detail-section");
+
+  fireEvent.click(screen.getByTestId("search-back"));
+  await screen.findByTestId("search-section");
+});
+
+it("rola citanie nevidí tlačidlo na úpravu linky", async () => {
+  globalSearch.mockResolvedValue({ products: [PRODUKT], orders: [] });
+  fetchProductDetail.mockResolvedValue(DETAIL_BEZ_LINKY);
+
+  render(<SearchSection role="citanie" onSessionExpired={() => {}} />);
+  submitSearch("PD-1");
+  fireEvent.click(await screen.findByTestId("search-product-open-PD-1"));
+
+  await screen.findByTestId("search-detail-section");
+  expect(screen.queryByTestId("search-detail-link-edit-toggle")).toBeNull();
+});
+
+it("rola manazer doplní dodávateľskú linku, uloženie ju pošle na server a detail sa znova načíta so stavom", async () => {
+  globalSearch.mockResolvedValue({ products: [PRODUKT], orders: [] });
+  fetchProductDetail.mockResolvedValueOnce(DETAIL_BEZ_LINKY).mockResolvedValueOnce({
+    ...DETAIL_BEZ_LINKY,
+    supplierLinkUrl: "https://novy-dodavatel.example.com/pd-1",
+    supplierLinkUpdatedAt: "2026-08-04T09:00:00.000Z",
+    supplierLinkSyncedAt: null,
+  });
+  saveProductLink.mockResolvedValue(undefined);
+
+  render(<SearchSection role="manazer" onSessionExpired={() => {}} />);
+  submitSearch("PD-1");
+  fireEvent.click(await screen.findByTestId("search-product-open-PD-1"));
+  await screen.findByTestId("search-detail-section");
+
+  fireEvent.click(screen.getByTestId("search-detail-link-edit-toggle"));
+  const vstup = screen.getByTestId("search-detail-link-edit-input");
+  fireEvent.change(vstup, { target: { value: "https://novy-dodavatel.example.com/pd-1" } });
+  fireEvent.click(screen.getByTestId("search-detail-link-save"));
+
+  await waitFor(() => {
+    expect(saveProductLink).toHaveBeenCalledWith("PD-1", "https://novy-dodavatel.example.com/pd-1");
+  });
+  await waitFor(() => {
+    expect(screen.getByTestId("search-detail-link-value").textContent).toBe("https://novy-dodavatel.example.com/pd-1");
+  });
+  expect(screen.getByTestId("search-detail-link-status").textContent).toContain("čaká na odoslanie");
+  expect(fetchProductDetail).toHaveBeenCalledTimes(2);
+});
+
+it("neplatná URL sa odmietne OKAMŽITE, bez volania saveProductLink", async () => {
+  globalSearch.mockResolvedValue({ products: [PRODUKT], orders: [] });
+  fetchProductDetail.mockResolvedValue(DETAIL_BEZ_LINKY);
+
+  render(<SearchSection role="manazer" onSessionExpired={() => {}} />);
+  submitSearch("PD-1");
+  fireEvent.click(await screen.findByTestId("search-product-open-PD-1"));
+  await screen.findByTestId("search-detail-section");
+
+  fireEvent.click(screen.getByTestId("search-detail-link-edit-toggle"));
+  const vstup = screen.getByTestId("search-detail-link-edit-input");
+  fireEvent.change(vstup, { target: { value: "nieje-url" } });
+  fireEvent.click(screen.getByTestId("search-detail-link-save"));
+
+  await screen.findByText("Odkaz musí byť platná adresa začínajúca http:// alebo https://.");
+  expect(saveProductLink).not.toHaveBeenCalled();
+});
+
+it("pri 401 pri načítaní detailu zavolá onSessionExpired", async () => {
+  globalSearch.mockResolvedValue({ products: [PRODUKT], orders: [] });
+  fetchProductDetail.mockRejectedValue(new SearchUnauthorizedError());
+  const onSessionExpired = vi.fn();
+
+  render(<SearchSection role="citanie" onSessionExpired={onSessionExpired} />);
+  submitSearch("PD-1");
+  fireEvent.click(await screen.findByTestId("search-product-open-PD-1"));
+
+  await waitFor(() => {
+    expect(onSessionExpired).toHaveBeenCalledTimes(1);
+  });
+});
+
+it("pri 401 pri ukladaní linky zavolá onSessionExpired", async () => {
+  globalSearch.mockResolvedValue({ products: [PRODUKT], orders: [] });
+  fetchProductDetail.mockResolvedValue(DETAIL_BEZ_LINKY);
+  saveProductLink.mockRejectedValue(new SupplierLinksUnauthorizedError());
+  const onSessionExpired = vi.fn();
+
+  render(<SearchSection role="manazer" onSessionExpired={onSessionExpired} />);
+  submitSearch("PD-1");
+  fireEvent.click(await screen.findByTestId("search-product-open-PD-1"));
+  await screen.findByTestId("search-detail-section");
+
+  fireEvent.click(screen.getByTestId("search-detail-link-edit-toggle"));
+  fireEvent.change(screen.getByTestId("search-detail-link-edit-input"), {
+    target: { value: "https://novy.example.com/pd-1" },
+  });
+  fireEvent.click(screen.getByTestId("search-detail-link-save"));
+
+  await waitFor(() => {
+    expect(onSessionExpired).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/SearchSection.tsx
+++ b/apps/web/src/components/SearchSection.tsx
@@ -1,0 +1,434 @@
+import { useCallback, useRef, useState, type SyntheticEvent, type JSX } from "react";
+import type { Me } from "../api.js";
+import { validateSupplierLinkUrl } from "../ordersApi.js";
+import {
+  fetchProductDetail,
+  globalSearch,
+  SearchUnauthorizedError,
+  type GlobalSearchResult,
+  type ProductDetail,
+  type ProductDetailVariant,
+} from "../searchApi.js";
+import { saveProductLink, SupplierLinksUnauthorizedError } from "../supplierLinksApi.js";
+
+// issue 240: "Eshop → Vyhľadať" — jedno pole, ktoré hľadá naprieč katalógom aj
+// objednávkami; klik na produktový výsledok otvorí detail so VŠETKÝMI jeho
+// variantmi a editovateľnou dodávateľskou linkou. Editácia linky znovupoužíva
+// PRESNE ten istý zápis + stavový vzor ako `SupplierLinksSection.tsx` (#239) —
+// `saveProductLink` (`POST /api/product-links/:productKey`), žiadna nová
+// zapisovacia cesta. Rozsah hľadania (čo sa prehľadáva a čo vedome nie) je
+// zapísaný v návrhovom komentári na ticket, nie tu.
+const CAN_EDIT_ROLES: ReadonlySet<Me["role"]> = new Set(["admin", "manazer"]);
+
+const STATE_LABELS: Record<ProductDetailVariant["state"], string> = {
+  sellable: "Skladom",
+  out_of_stock: "Vypredané",
+  discontinued: "Predaj skončil",
+};
+
+const SUPPLIER_AVAILABILITY_LABELS: Record<"available" | "unavailable" | "unknown", string> = {
+  available: "Skladom u dodávateľa",
+  unavailable: "Vypredané u dodávateľa",
+  unknown: "Nezistené",
+};
+
+function formatDateTime(iso: string | null): string {
+  if (iso === null) return "—";
+  const date = new Date(iso);
+  return Number.isNaN(date.getTime()) ? "—" : date.toLocaleString("sk-SK");
+}
+
+/** Rovnaká "uložené vs. odoslané do Shoptetu" logika ako `SupplierLinksSection.tsx`'s
+ * `statusLabel` — vyvodená len z `supplierLinkUpdatedAt`/`supplierLinkSyncedAt`. */
+function linkStatusLabel(detail: ProductDetail): string {
+  if (detail.supplierLinkUpdatedAt === null) return detail.supplierLinkUrl === null ? "—" : "zo Shoptetu";
+  const pending = detail.supplierLinkSyncedAt === null || detail.supplierLinkSyncedAt < detail.supplierLinkUpdatedAt;
+  return pending
+    ? "⏳ Uložené, čaká na odoslanie"
+    : `✅ Odoslané do Shoptetu (${formatDateTime(detail.supplierLinkSyncedAt)})`;
+}
+
+function supplierAvailabilityLabel(variant: ProductDetailVariant): string {
+  if (variant.supplierAvailabilityText !== null && variant.supplierAvailabilityText !== "") {
+    return variant.supplierAvailabilityText;
+  }
+  if (variant.supplierAvailability === null) return "—";
+  return SUPPLIER_AVAILABILITY_LABELS[variant.supplierAvailability];
+}
+
+export function SearchSection({
+  role,
+  onSessionExpired,
+}: {
+  readonly role: Me["role"];
+  readonly onSessionExpired: () => void;
+}): JSX.Element {
+  const [query, setQuery] = useState("");
+  const [result, setResult] = useState<GlobalSearchResult>({ products: [], orders: [] });
+  const [searched, setSearched] = useState(false);
+  const [searchError, setSearchError] = useState("");
+  const canEdit = CAN_EDIT_ROLES.has(role);
+
+  const [selectedProductKey, setSelectedProductKey] = useState<string | null>(null);
+  const [detail, setDetail] = useState<ProductDetail | null>(null);
+  const [detailLoaded, setDetailLoaded] = useState(false);
+  const [detailError, setDetailError] = useState("");
+
+  const [editingLink, setEditingLink] = useState(false);
+  const [urlDraft, setUrlDraft] = useState("");
+  const [actionError, setActionError] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  // Len najnovšia požiadavka smie zapísať výsledok — rovnaký vzor ako
+  // `CatalogPage.tsx`/`SupplierLinksSection.tsx`'s `searchSeq`.
+  const searchSeq = useRef(0);
+  const detailSeq = useRef(0);
+
+  const search = useCallback(
+    (q: string) => {
+      const seq = (searchSeq.current += 1);
+      setSearchError("");
+      globalSearch(q)
+        .then((r) => {
+          if (seq !== searchSeq.current) return;
+          setResult(r);
+          setSearched(true);
+        })
+        .catch((err: unknown) => {
+          if (seq !== searchSeq.current) return;
+          setSearched(true);
+          if (err instanceof SearchUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setResult({ products: [], orders: [] });
+          setSearchError("Vyhľadávanie zlyhalo — server neodpovedal.");
+        });
+    },
+    [onSessionExpired],
+  );
+
+  function submit(event: SyntheticEvent): void {
+    event.preventDefault();
+    search(query);
+  }
+
+  const openDetail = useCallback(
+    (productKey: string) => {
+      setSelectedProductKey(productKey);
+      setDetail(null);
+      setDetailLoaded(false);
+      setDetailError("");
+      setEditingLink(false);
+      setActionError("");
+      const seq = (detailSeq.current += 1);
+      fetchProductDetail(productKey)
+        .then((d) => {
+          if (seq !== detailSeq.current) return;
+          setDetail(d);
+          setDetailLoaded(true);
+        })
+        .catch((err: unknown) => {
+          if (seq !== detailSeq.current) return;
+          setDetailLoaded(true);
+          if (err instanceof SearchUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setDetailError("Detail produktu sa nepodarilo načítať.");
+        });
+    },
+    [onSessionExpired],
+  );
+
+  const backToSearch = useCallback(() => {
+    setSelectedProductKey(null);
+    setDetail(null);
+  }, []);
+
+  const startEditLink = useCallback(() => {
+    setUrlDraft(detail?.supplierLinkUrl ?? "");
+    setEditingLink(true);
+    setActionError("");
+  }, [detail]);
+
+  const cancelEditLink = useCallback(() => {
+    setEditingLink(false);
+    setActionError("");
+  }, []);
+
+  const saveLink = useCallback(() => {
+    if (selectedProductKey === null) return;
+    // issue 153: rovnaká OKAMŽITÁ kontrola V PREHLIADAČI ako
+    // `SupplierLinksSection.tsx`/`OrderLineRow.tsx`, PRED zápisom na server.
+    const validationError = validateSupplierLinkUrl(urlDraft);
+    if (validationError !== null) {
+      setActionError(validationError);
+      return;
+    }
+    setBusy(true);
+    setActionError("");
+    const key = selectedProductKey;
+    saveProductLink(key, urlDraft.trim())
+      .then(() => {
+        setEditingLink(false);
+        return fetchProductDetail(key);
+      })
+      .then((d) => {
+        setDetail(d);
+      })
+      .catch((err: unknown) => {
+        if (err instanceof SupplierLinksUnauthorizedError || err instanceof SearchUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setActionError(err instanceof Error ? err.message : "Uloženie odkazu sa nepodarilo.");
+      })
+      .finally(() => {
+        setBusy(false);
+      });
+  }, [selectedProductKey, urlDraft, onSessionExpired]);
+
+  if (selectedProductKey !== null) {
+    return (
+      <section data-testid="search-detail-section">
+        <p>
+          <button type="button" className="btn sm ghost" data-testid="search-back" onClick={backToSearch}>
+            ← Späť na hľadanie
+          </button>
+        </p>
+
+        {!detailLoaded ? (
+          <p>Načítavam…</p>
+        ) : detail === null ? (
+          <p role="alert" data-testid="search-detail-not-found">
+            Produkt sa nenašiel.
+          </p>
+        ) : detailError !== "" ? (
+          <p role="alert">{detailError}</p>
+        ) : (
+          <>
+            <h3 data-testid="search-detail-name">{detail.productName}</h3>
+            <p data-testid="search-detail-supplier">Dodávateľ: {detail.supplier ?? "(bez dodávateľa)"}</p>
+
+            <div className="ord-supplier-row" data-testid="search-detail-link-row">
+              <strong>Dodávateľská linka: </strong>
+              {editingLink ? (
+                <div className="ord-supplier-link-edit" data-testid="search-detail-link-edit">
+                  <input
+                    type="url"
+                    className="ord-supplier-link-edit-input"
+                    data-testid="search-detail-link-edit-input"
+                    aria-label={`Odkaz na dodávateľa produktu ${detail.productName}`}
+                    placeholder="https://…"
+                    value={urlDraft}
+                    disabled={busy}
+                    autoFocus
+                    onChange={(e) => {
+                      setUrlDraft(e.target.value);
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === "Escape") {
+                        e.preventDefault();
+                        cancelEditLink();
+                      }
+                    }}
+                  />
+                  <button
+                    type="button"
+                    className="btn sm good"
+                    data-testid="search-detail-link-save"
+                    disabled={busy || urlDraft.trim() === ""}
+                    onClick={saveLink}
+                  >
+                    💾
+                  </button>
+                  <button
+                    type="button"
+                    className="btn sm ghost"
+                    data-testid="search-detail-link-cancel"
+                    disabled={busy}
+                    onClick={cancelEditLink}
+                  >
+                    ✖
+                  </button>
+                </div>
+              ) : detail.supplierLinkUrl !== null ? (
+                <a href={detail.supplierLinkUrl} target="_blank" rel="noreferrer noopener" data-testid="search-detail-link-value">
+                  {detail.supplierLinkUrl}
+                </a>
+              ) : (
+                <span data-testid="search-detail-link-value">—</span>
+              )}
+              {!editingLink && canEdit && (
+                <button
+                  type="button"
+                  className="ord-supplier-link-edit-toggle"
+                  data-testid="search-detail-link-edit-toggle"
+                  aria-label={
+                    detail.supplierLinkUrl !== null
+                      ? `Upraviť odkaz na dodávateľa — ${detail.productName}`
+                      : `Doplniť odkaz na dodávateľa — ${detail.productName}`
+                  }
+                  onClick={startEditLink}
+                >
+                  ✏️
+                </button>
+              )}
+              <span data-testid="search-detail-link-status"> {linkStatusLabel(detail)}</span>
+            </div>
+            {actionError !== "" && <p role="alert">{actionError}</p>}
+
+            <table>
+              <thead>
+                <tr>
+                  <th>Veľkosť</th>
+                  <th>Kód</th>
+                  <th>Cena</th>
+                  <th>Sklad</th>
+                  <th>Stav u nás</th>
+                  <th>Dostupnosť u dodávateľa</th>
+                  <th>Adresa u nás</th>
+                  <th>Kód u dodávateľa</th>
+                </tr>
+              </thead>
+              <tbody>
+                {detail.variants.map((v) => (
+                  <tr key={v.code} data-testid={`search-detail-variant-${v.code}`}>
+                    <td>{v.sizeLabel ?? "—"}</td>
+                    <td>{v.code}</td>
+                    <td>{v.price !== null ? `${v.price} ${v.currency ?? ""}` : "—"}</td>
+                    <td>{v.stock}</td>
+                    <td>
+                      {STATE_LABELS[v.state]} ({v.availabilityText})
+                    </td>
+                    <td data-testid={`search-detail-supplier-stock-${v.code}`}>{supplierAvailabilityLabel(v)}</td>
+                    <td>
+                      {v.ourShopUrl !== null ? (
+                        <a href={v.ourShopUrl} target="_blank" rel="noreferrer noopener" data-testid={`search-detail-shop-link-${v.code}`}>
+                          Otvoriť
+                        </a>
+                      ) : (
+                        "—"
+                      )}
+                    </td>
+                    <td>{v.externalCode ?? "—"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </>
+        )}
+      </section>
+    );
+  }
+
+  return (
+    <section data-testid="search-section">
+      <p>
+        Nájdite konkrétny tovar (podľa kódu, názvu, dodávateľa alebo kódu u dodávateľa) alebo objednávku
+        (podľa čísla, mena či e-mailu zákazníka). Kliknutím na produkt sa otvorí jeho detail, kde sa dá
+        rovno opraviť dodávateľská linka.
+      </p>
+
+      <form onSubmit={submit}>
+        <label htmlFor="search-q">Hľadať</label>
+        <input
+          id="search-q"
+          type="search"
+          value={query}
+          autoFocus
+          onChange={(e) => {
+            setQuery(e.target.value);
+          }}
+        />
+        <button type="submit">Hľadať</button>
+      </form>
+
+      {searchError !== "" && <p role="alert">{searchError}</p>}
+
+      {searched && result.products.length === 0 && result.orders.length === 0 && (
+        <p data-testid="search-empty">Hľadaniu nezodpovedá nič.</p>
+      )}
+
+      {result.products.length > 0 && (
+        <div data-testid="search-products">
+          <h3>Produkty</h3>
+          <table>
+            <thead>
+              <tr>
+                <th>Kód</th>
+                <th>Názov</th>
+                <th>Dodávateľ</th>
+                <th>Kód u dodávateľa</th>
+                <th>Stav</th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              {result.products.map((p) => (
+                <tr key={p.variantCode} data-testid={`search-product-${p.variantCode}`}>
+                  <td>{p.variantCode}</td>
+                  <td>{p.productName}</td>
+                  <td>{p.supplier ?? "(bez dodávateľa)"}</td>
+                  <td>{p.externalCode ?? "—"}</td>
+                  <td>{STATE_LABELS[p.state]}</td>
+                  <td>
+                    <button
+                      type="button"
+                      className="btn sm ghost"
+                      data-testid={`search-product-open-${p.variantCode}`}
+                      onClick={() => {
+                        openDetail(p.productKey);
+                      }}
+                    >
+                      Otvoriť
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {result.orders.length > 0 && (
+        <div data-testid="search-orders">
+          <h3>Objednávky</h3>
+          <table>
+            <thead>
+              <tr>
+                <th>Číslo</th>
+                <th>Zákazník</th>
+                <th>Stav</th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              {result.orders.map((o) => (
+                <tr key={o.orderId} data-testid={`search-order-${o.externalOrderId}`}>
+                  <td>{o.externalOrderId}</td>
+                  <td>
+                    {o.customerName}
+                    {o.email !== null && ` (${o.email})`}
+                  </td>
+                  <td>{o.statusName}</td>
+                  <td>
+                    <a
+                      href={o.adminUrl}
+                      target="_blank"
+                      rel="noreferrer noopener"
+                      data-testid={`search-order-admin-link-${o.externalOrderId}`}
+                    >
+                      Otvoriť v Shoptete
+                    </a>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/nav.test.ts
+++ b/apps/web/src/nav.test.ts
@@ -8,17 +8,23 @@ import { DEFAULT_TAB_ID, HIDDEN_TABS, NAV, findTab, isVisibleTabId } from "./nav
 // pridalo "Texty e-mailov" do Systému (nastavenie spoločné pre VŠETKY
 // automatizácie). Issue 239 pridalo "Párovanie produktov" pod "Eshop"
 // (rovnaký dôvod ako "Nedostupné tovary" — pracovná obrazovka bez plánu).
+// Issue 240 pridalo "Vyhľadať" pod "Eshop" z rovnakého dôvodu.
 // Tento test je najbližšie k tomu, čo strojovo overiť dá (registrácia, nie DOM).
-it("NAV má tri priečinky (Systém/Eshop/Automatizácie), s 3/3/4 záložkami v poradí podľa dôležitosti", () => {
+it("NAV má tri priečinky (Systém/Eshop/Automatizácie), s 3/4/4 záložkami v poradí podľa dôležitosti", () => {
   expect(NAV).toHaveLength(3);
   expect(NAV.map((f) => f.label)).toEqual(["Systém", "Eshop", "Automatizácie"]);
   expect(NAV[0]?.tabs).toHaveLength(3);
-  expect(NAV[1]?.tabs).toHaveLength(3);
+  expect(NAV[1]?.tabs).toHaveLength(4);
   expect(NAV[2]?.tabs).toHaveLength(4);
   // issue 212: "Dodávateľský sklad" — scraper dostupnosti u dodávateľa;
   // patrí do Systému (zadanie majiteľa), nie medzi Automatizácie.
   expect(NAV[0]?.tabs.map((t) => t.label)).toEqual(["Sync zo Shoptetu", "Texty e-mailov", "Dodávateľský sklad"]);
-  expect(NAV[1]?.tabs.map((t) => t.label)).toEqual(["Na objednanie", "Nedostupné tovary", "Párovanie produktov"]);
+  expect(NAV[1]?.tabs.map((t) => t.label)).toEqual([
+    "Na objednanie",
+    "Nedostupné tovary",
+    "Párovanie produktov",
+    "Vyhľadať",
+  ]);
   // issue 193: "Odoslané e-maily" — prehľad toho, čo automatizácie poslali.
   expect(NAV[2]?.tabs.map((t) => t.label)).toEqual([
     // issue 213: prepínanie vypredaných produktov späť na skladom.
@@ -41,6 +47,7 @@ it("findTab nájde viditeľnú aj skrytú záložku podľa id, neznáme id vrát
   expect(findTab("scheduler")?.label).toBe("Plánovač");
   expect(findTab("posta-uncollected")?.label).toBe("Nevyzdvihnuté zásielky");
   expect(findTab("order-reminder")?.label).toBe("Pripomienky objednávok");
+  expect(findTab("search")?.label).toBe("Vyhľadať");
   expect(findTab("neexistuje")).toBeUndefined();
 });
 
@@ -51,6 +58,8 @@ it("isVisibleTabId rozlíši viditeľné (NAV) od skrytých (HIDDEN_TABS)", () =
   expect(isVisibleTabId("posta-uncollected")).toBe(true);
   expect(isVisibleTabId("order-reminder")).toBe(true);
   expect(isVisibleTabId("nedostupne")).toBe(true);
+  // issue 240: nová viditeľná záložka "Vyhľadať".
+  expect(isVisibleTabId("search")).toBe(true);
   for (const hiddenId of Object.keys(HIDDEN_TABS)) {
     expect(isVisibleTabId(hiddenId)).toBe(false);
   }

--- a/apps/web/src/nav.ts
+++ b/apps/web/src/nav.ts
@@ -10,6 +10,7 @@ import { PairingSection } from "./components/PairingSection.js";
 import { PostaUncollectedSection } from "./components/PostaUncollectedSection.js";
 import { RestockSection } from "./components/RestockSection.js";
 import { SchedulerSection } from "./components/SchedulerSection.js";
+import { SearchSection } from "./components/SearchSection.js";
 import { SupplierLinksSection } from "./components/SupplierLinksSection.js";
 import { SupplierStockSection } from "./components/SupplierStockSection.js";
 import { SyncSection } from "./components/SyncSection.js";
@@ -86,6 +87,11 @@ export const NAV: readonly NavFolder[] = [
       // sem (nie do Automatizácie), je to obrazovka, na ktorej obsluha
       // pracuje, presne ako "Na objednanie"/"Nedostupné tovary".
       { id: "supplier-links", label: "Párovanie produktov", icon: "🔗", Component: SupplierLinksSection, wide: true },
+      // issue 240: "rýchla ruka" na JEDEN konkrétny kus tovaru/objednávku —
+      // nájsť + rovno opraviť dodávateľskú linku. Patrí sem z rovnakého
+      // dôvodu ako "Párovanie produktov" vyššie (obsluha na nej pracuje,
+      // žiadny plán/zapnuté-vypnuté koncept).
+      { id: "search", label: "Vyhľadať", icon: "🔍", Component: SearchSection, wide: true },
     ],
   },
   {

--- a/apps/web/src/searchApi.ts
+++ b/apps/web/src/searchApi.ts
@@ -1,0 +1,102 @@
+import { z } from "zod";
+
+// issue 240: "Eshop → Vyhľadať" — zrkadlí `GET /api/search`
+// (`apps/api/src/modules/search/queries.ts`) a `GET /api/product-detail/:productKey`
+// (`apps/api/src/modules/product-detail/queries.ts`). Vlastná zod schéma
+// namiesto zdieľaného typu, rovnaký vzor ako `catalogApi.ts`/`supplierLinksApi.ts`.
+
+const productHitSchema = z.object({
+  productKey: z.string(),
+  variantCode: z.string(),
+  productName: z.string(),
+  sizeLabel: z.string().nullable(),
+  supplier: z.string().nullable(),
+  externalCode: z.string().nullable(),
+  state: z.enum(["sellable", "out_of_stock", "discontinued"]),
+});
+export type ProductSearchHit = z.infer<typeof productHitSchema>;
+
+const orderHitSchema = z.object({
+  orderId: z.string(),
+  externalOrderId: z.string(),
+  customerName: z.string(),
+  email: z.string().nullable(),
+  statusName: z.string(),
+  placedAt: z.string(),
+  // Rovnaká druhá vrstva overenia ako `ordersApi.ts`'s `adminUrl` — `href`
+  // bezpečnosť by nemala závisieť LEN od backendovho zloženia URL.
+  adminUrl: z.string().regex(/^https?:\/\//),
+});
+export type OrderSearchHit = z.infer<typeof orderHitSchema>;
+
+const searchResultSchema = z.object({
+  products: z.array(productHitSchema),
+  orders: z.array(orderHitSchema),
+});
+export type GlobalSearchResult = z.infer<typeof searchResultSchema>;
+
+const variantDetailSchema = z.object({
+  code: z.string(),
+  sizeLabel: z.string().nullable(),
+  name: z.string(),
+  state: z.enum(["sellable", "out_of_stock", "discontinued"]),
+  stock: z.number(),
+  price: z.string().nullable(),
+  currency: z.string().nullable(),
+  availabilityText: z.string(),
+  productVisibility: z.string(),
+  externalCode: z.string().nullable(),
+  missingSince: z.string().nullable(),
+  ourShopUrl: z.string().nullable(),
+  supplierAvailability: z.enum(["available", "unavailable", "unknown"]).nullable(),
+  supplierAvailabilityText: z.string().nullable(),
+});
+export type ProductDetailVariant = z.infer<typeof variantDetailSchema>;
+
+const productDetailSchema = z.object({
+  productKey: z.string(),
+  productName: z.string(),
+  supplier: z.string().nullable(),
+  supplierLinkUrl: z.string().nullable(),
+  supplierLinkUpdatedAt: z.string().nullable(),
+  supplierLinkSyncedAt: z.string().nullable(),
+  variants: z.array(variantDetailSchema),
+});
+export type ProductDetail = z.infer<typeof productDetailSchema>;
+
+/** Relácia medzitým vypršala (401) — rovnaký vzor ako ostatné `*UnauthorizedError`. */
+export class SearchUnauthorizedError extends Error {
+  constructor() {
+    super("Neprihlásený");
+  }
+}
+
+const errorBodySchema = z.object({ error: z.string() });
+
+async function serverErrorMessage(response: Response, fallback: string): Promise<string> {
+  try {
+    const parsed = errorBodySchema.safeParse(await response.json());
+    if (parsed.success) return parsed.data.error;
+  } catch {
+    // Telo nie je platný JSON (alebo chýba) — použi všeobecnú hlášku.
+  }
+  return fallback;
+}
+
+async function readJson(response: Response, fallback: string): Promise<unknown> {
+  if (response.status === 401) throw new SearchUnauthorizedError();
+  if (!response.ok) throw new Error(await serverErrorMessage(response, fallback));
+  return await response.json();
+}
+
+export async function globalSearch(q: string): Promise<GlobalSearchResult> {
+  const query = new URLSearchParams({ q });
+  const response = await fetch(`/api/search?${query.toString()}`);
+  return searchResultSchema.parse(await readJson(response, "Vyhľadávanie zlyhalo — server neodpovedal"));
+}
+
+export async function fetchProductDetail(productKey: string): Promise<ProductDetail | null> {
+  const response = await fetch(`/api/product-detail/${encodeURIComponent(productKey)}`);
+  if (response.status === 404) return null;
+  return productDetailSchema.parse(await readJson(response, "Detail produktu sa nepodarilo načítať"));
+}

--- a/apps/web/tests/e2e/catalog.spec.ts
+++ b/apps/web/tests/e2e/catalog.spec.ts
@@ -24,19 +24,21 @@ test("manažér vidí stav katalógu, vyhľadá variant a konzola je čistá", a
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
-  // 39 = 35 riadkov fixtúry + 2 seedované kandidáty na prepnutie ("PREP-1",
+  // 40 = 35 riadkov fixtúry + 2 seedované kandidáty na prepnutie ("PREP-1",
   // issue 217; "PREP-2", issue 226 — rozpor voči feedu, `scripts/e2e-setup.ts`)
   // + 2 seedované produkty pre "Párovanie produktov" ("E2E-PL-CHYBA"/
-  // "E2E-PL-OPRAVA", issue 239, `scripts/e2e-fixtures-product-links.ts`).
-  // Prví dvaja sú `out_of_stock` (nemenia "sellable"/"missing" nižšie), tí
-  // druhí dvaja sú `sellable` (posúvajú filter "sellable" 7→9 nižšie),
-  // "missing"(1) sa nemení ani jedným párom.
+  // "E2E-PL-OPRAVA", issue 239, `scripts/e2e-fixtures-product-links.ts`)
+  // + 1 seedovaný produkt pre "Vyhľadať" ("E2E-SEARCH-1", issue 240,
+  // `scripts/e2e-fixtures-search.ts`).
+  // Prví dvaja sú `out_of_stock` (nemenia "sellable"/"missing" nižšie), zvyšní
+  // traja sú `sellable` (posúvajú filter "sellable" 7→10 nižšie), "missing"(1)
+  // sa nemení ani jedným z nich.
   await expect(page.getByTestId("snapshot")).toContainText("Posledný import: prijatý");
-  await expect(page.getByTestId("counts")).toContainText("Variantov v katalógu (vrátane chýbajúcich): 39");
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 39");
+  await expect(page.getByTestId("counts")).toContainText("Variantov v katalógu (vrátane chýbajúcich): 40");
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 40");
 
   await page.getByLabel("Kód alebo názov").fill("40237/3XL");
-  await page.getByRole("button", { name: "Hľadať" }).click();
+  await page.getByRole("button", { name: "Hľadať", exact: true }).click();
 
   await expect(page.getByTestId("total")).toHaveText("Nájdených: 1");
   const riadok = page.getByTestId("variant-40237/3XL");
@@ -53,14 +55,15 @@ test("filter podľa stavu zúži zoznam na predajné varianty", async ({ page })
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 39");
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 40");
   await page.getByLabel("Stav", { exact: true }).selectOption("sellable");
-  await page.getByRole("button", { name: "Hľadať" }).click();
+  await page.getByRole("button", { name: "Hľadať", exact: true }).click();
 
-  // 9 = 7 od issue 219 (variant "40237/L" má oba texty dostupnosti prázdne,
+  // 10 = 7 od issue 219 (variant "40237/L" má oba texty dostupnosti prázdne,
   // čo znamená predvolenú dostupnosť Shoptetu — "Skladom", nie vypredané) +
-  // 2 sellable produkty issue 239's fixtúry ("E2E-PL-CHYBA"/"E2E-PL-OPRAVA").
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 9");
+  // 2 sellable produkty issue 239's fixtúry ("E2E-PL-CHYBA"/"E2E-PL-OPRAVA")
+  // + 1 sellable produkt issue 240's fixtúry ("E2E-SEARCH-1").
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 10");
   await expect(page.getByTestId("variant-40237/M")).toBeVisible();
 });
 
@@ -72,9 +75,9 @@ test("filter 'Chýbajúce' nájde presne označený variant a riadok ukazuje, od
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 39");
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 40");
   await page.getByLabel("Stav", { exact: true }).selectOption("missing");
-  await page.getByRole("button", { name: "Hľadať" }).click();
+  await page.getByRole("button", { name: "Hľadať", exact: true }).click();
 
   await expect(page.getByTestId("total")).toHaveText("Nájdených: 1");
   const riadok = page.getByTestId("variant-40287");

--- a/apps/web/tests/e2e/nav.spec.ts
+++ b/apps/web/tests/e2e/nav.spec.ts
@@ -14,8 +14,9 @@ const E2E_NAV_EMAIL = "e2e-nav@forestshop.sk";
 // #57 pôvodne chcel naľavo PRESNE dve položky. Issue 185 (2026-08-03) pridáva
 // tretí priečinok "Automatizácie" s tromi hotovými obrazovkami, dovtedy len v
 // `HIDDEN_TABS` bez odkazu v menu. Issue 239 (2026-08-04) pridáva "Párovanie
-// produktov" pod "Eshop" — desiata záložka.
-test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s desiatimi záložkami, klik prepne obrazovku, panel sa zbalí do lišty a stav si pamätá, konzola je čistá", async ({
+// produktov" pod "Eshop" — desiata záložka. Issue 240 (2026-08-05) pridáva
+// "Vyhľadať" pod "Eshop" — jedenásta záložka.
+test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s jedenástimi záložkami, klik prepne obrazovku, panel sa zbalí do lišty a stav si pamätá, konzola je čistá", async ({
   page,
 }) => {
   const chyby: string[] = [];
@@ -36,8 +37,8 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s desiatimi 
   await expect(page.getByRole("button", { name: "Eshop" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Automatizácie" })).toBeVisible();
 
-  // Presne desať záložiek v CELOM menu.
-  await expect(page.locator(".side-nav .tab")).toHaveCount(10);
+  // Presne jedenásť záložiek v CELOM menu.
+  await expect(page.locator(".side-nav .tab")).toHaveCount(11);
   await expect(page.getByRole("button", { name: "Sync zo Shoptetu" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Texty e-mailov" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Na objednanie" })).toBeVisible();
@@ -45,6 +46,7 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s desiatimi 
   await expect(page.getByRole("button", { name: "Pripomienky objednávok" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Nedostupné tovary" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Párovanie produktov" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Vyhľadať" })).toBeVisible();
 
   // Predvolená obrazovka (bez kliknutia) je "Sync zo Shoptetu".
   await expect(page.getByRole("heading", { name: "Sync zo Shoptetu" })).toBeVisible();
@@ -101,6 +103,12 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s desiatimi 
   await expect(page.getByRole("heading", { name: "Párovanie produktov" })).toBeVisible();
   await expect(page.getByTestId("nav-status-supplier-links")).toHaveCount(0);
 
+  // issue 240: rovnaký dôvod ako "Párovanie produktov" vyššie — žiadny
+  // plán/zapnuté-vypnuté koncept, teda žiadny stavový odznak v menu.
+  await page.getByRole("button", { name: "Vyhľadať" }).click();
+  await expect(page.getByRole("heading", { name: "Vyhľadať" })).toBeVisible();
+  await expect(page.getByTestId("nav-status-search")).toHaveCount(0);
+
   // issue 190: zbalenie panela do úzkej lišty. Zámerne je to SÚČASŤ tohto
   // testu, nie samostatný test — každý ďalší test v tomto súbore by znamenal
   // ďalšie prihlásenie na zdieľanom `MAX_ATTEMPTS=10` rozpočte
@@ -123,7 +131,7 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s desiatimi 
 
   // Hlavičky priečinkov zmiznú, ikony všetkých modulov ostanú.
   await expect(page.getByRole("button", { name: "Systém" })).toHaveCount(0);
-  await expect(page.locator(".side-nav .tab")).toHaveCount(10);
+  await expect(page.locator(".side-nav .tab")).toHaveCount(11);
   // Názov sa v lište ukáže bublinou pri prejdení myšou.
   await expect(page.getByRole("button", { name: "Na objednanie" })).toHaveAttribute(
     "title",

--- a/apps/web/tests/e2e/search.spec.ts
+++ b/apps/web/tests/e2e/search.spec.ts
@@ -1,0 +1,94 @@
+import { expect, test } from "@playwright/test";
+
+const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
+// Vlastný, IZOLOVANÝ účet len pre tento súbor (rovnaký dôvod aj mechanizmus
+// ako `E2E_NAV_EMAIL`/`E2E_PAROVANIE_EMAIL`) — musí sa zhodovať s hodnotou
+// `E2E_VYHLADAT_EMAIL` v `scripts/e2e-fixtures-search.ts`.
+const E2E_VYHLADAT_EMAIL = "e2e-vyhladat@forestshop.sk";
+
+// issue 240: "Eshop → Vyhľadať" — nájsť produkt podľa kódu aj názvu a
+// objednávku podľa čísla, otvoriť detail produktu, zmeniť dodávateľskú
+// linku, uložiť a vidieť stav.
+test("nájde produkt podľa kódu, otvorí detail, zmení a uloží dodávateľskú linku so stavom, konzola je čistá", async ({
+  page,
+}) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/");
+  await page.getByLabel("E-mail").fill(E2E_VYHLADAT_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+
+  await page.getByRole("button", { name: "Vyhľadať" }).click();
+  await expect(page.getByRole("heading", { name: "Vyhľadať" })).toBeVisible();
+
+  // Hľadanie podľa PRESNÉHO kódu variantu.
+  await page.getByLabel("Hľadať").fill("E2E-SEARCH-1");
+  await page.getByRole("button", { name: "Hľadať", exact: true }).click();
+
+  const produktRiadok = page.getByTestId("search-product-E2E-SEARCH-1");
+  await expect(produktRiadok).toBeVisible();
+  await expect(produktRiadok).toContainText("E2E Vyhľadávací Produkt Alfa");
+  await expect(produktRiadok).toContainText("E2E Dodávateľ Vyhľadávanie");
+  // Objednávky sa nenašli pre tento dopyt — žiadny blok "Objednávky".
+  await expect(page.getByTestId("search-orders")).toHaveCount(0);
+
+  await page.getByTestId("search-product-open-E2E-SEARCH-1").click();
+
+  await expect(page.getByTestId("search-detail-name")).toHaveText("E2E Vyhľadávací Produkt Alfa");
+  await expect(page.getByTestId("search-detail-supplier")).toContainText("E2E Dodávateľ Vyhľadávanie");
+
+  const variantRiadok = page.getByTestId("search-detail-variant-E2E-SEARCH-1");
+  await expect(variantRiadok).toContainText("24.90");
+  await expect(variantRiadok).toContainText("EXT-VYHLADAT-1");
+  await expect(variantRiadok).toContainText("Skladom (Skladom)");
+  await expect(page.getByTestId("search-detail-supplier-stock-E2E-SEARCH-1")).toContainText(
+    "Skladom u e2e dodávateľa",
+  );
+  await expect(page.getByTestId("search-detail-shop-link-E2E-SEARCH-1")).toHaveAttribute(
+    "href",
+    "https://www.forestshop.sk/e2e-vyhladat-produkt/",
+  );
+
+  // Efektívna linka pred úpravou pochádza z internalNote (žiadny override
+  // ešte neexistuje) — vidno ju priamo, dá sa upraviť.
+  await expect(page.getByTestId("search-detail-link-value")).toContainText(
+    "https://e2e-dodavatel.example.com/vyhladat-produkt",
+  );
+  await expect(page.getByTestId("search-detail-link-status")).toHaveText("zo Shoptetu");
+
+  await page.getByTestId("search-detail-link-edit-toggle").click();
+  const linkInput = page.getByTestId("search-detail-link-edit-input");
+  await expect(linkInput).toHaveValue("https://e2e-dodavatel.example.com/vyhladat-produkt");
+  await linkInput.fill("https://e2e-dodavatel.example.com/vyhladat-produkt-novy");
+  await page.getByTestId("search-detail-link-save").click();
+
+  await expect(page.getByTestId("search-detail-link-value")).toHaveText(
+    "https://e2e-dodavatel.example.com/vyhladat-produkt-novy",
+  );
+  await expect(page.getByTestId("search-detail-link-status")).toContainText("čaká na odoslanie");
+
+  // Späť na hľadanie a nájsť objednávku podľa čísla.
+  await page.getByTestId("search-back").click();
+  await expect(page.getByTestId("search-section")).toBeVisible();
+
+  await page.getByLabel("Hľadať").fill("9101");
+  await page.getByRole("button", { name: "Hľadať", exact: true }).click();
+  const objednavkaRiadok = page.getByTestId("search-order-9101");
+  await expect(objednavkaRiadok).toBeVisible();
+  await expect(objednavkaRiadok).toContainText("E2E Zákazník Vyhľadávanie");
+  await expect(page.getByTestId("search-products")).toHaveCount(0);
+
+  // Hľadanie podľa ČASTI názvu produktu tiež nájde ten istý produkt.
+  await page.getByLabel("Hľadať").fill("Vyhľadávací Produkt");
+  await page.getByRole("button", { name: "Hľadať", exact: true }).click();
+  await expect(page.getByTestId("search-product-E2E-SEARCH-1")).toBeVisible();
+
+  expect(chyby).toEqual([]);
+});

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -2658,3 +2658,60 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   vymyslenej adresy. Konzola čistá. Issue zavreté ručne s dôkazom, Discord
   run-card odoslaná. Playbook doplnený (`.claude/rules/nedostupne.md`,
   `.claude/rules/mail-templates.md`).
+
+## 2026-08-04/05 — #239 (Eshop → Párovanie produktov — chýbajúce dodávateľské linky)
+
+- Solo ticket. Version bump `8fdf23e` (0.3.0-dev.140→.141), first commit.
+- Design comment BEFORE first code commit:
+  https://github.com/zbynekdrlik/forestshop-app/issues/239#issuecomment-5184875036
+  — rozhodnutie: SAMOSTATNÁ nová obrazovka, nie rozšírenie skrytej `pairing`
+  záložky (tá je variant-kľúčovaný stavový automat pre budúce automatické
+  párovanie s dodávateľom, #46/#48, nezapisuje do Shoptetu vôbec — odlišný
+  dátový model aj downstream konzument od tohto ticketu).
+- Backend `4b88111`: `apps/api/src/modules/product-links/queries.ts`
+  (`listProductLinks` — JS-side efektívna linka cez existujúce
+  `resolveEffectiveSupplierLink`, rovnaký vzor ako `supplier-stock/run.ts`),
+  `product-links-routes.ts`, refaktor `supplier-link-assignment.ts`
+  (zdieľané `upsertProductSupplierLink` jadro medzi `lineId`-cestou #121 a
+  novou `productKey`-cestou, zúžený `UpsertExecutor` tx-parameter presne
+  podľa `.claude/rules/database.md`), zdieľaná zod schéma `supplierLinkUrlBody`
+  (odstránená duplicita v `orders-routes.ts`). Integračné testy:
+  `product-links-http.integration.test.ts` (9 testov).
+- Frontend `fb7530d`: `SupplierLinksSection.tsx` + `supplierLinksApi.ts`,
+  nová VIDITEĽNÁ záložka v `nav.ts` (skupina Eshop, `supplier-links`),
+  `nav.spec.ts`/`nav.test.ts` prepočítané na 10 záložiek, nový e2e
+  `supplier-links.spec.ts` (vlastný izolovaný účet `e2e-parovanie@…`),
+  fixtúry vyčlenené do `scripts/e2e-fixtures-product-links.ts` (eslint
+  max-lines). `df4c288`: odstránený duplicitný `<h2>` (viditeľná záložka
+  dostáva titulok od Topbar-u, presne ako issue 185's poznámka v nav.ts
+  žiadala), `catalog.spec.ts` počty posunuté (37→39, 7→9) — nové e2e
+  fixtúrové produkty zdieľajú katalógový snapshot.
+- Nesúvisiaci CI-blokujúci nález opravený v tomto PR (`49f67d3`):
+  `orders-overview.integration.test.ts` mal pevný dátumový literál ako
+  "dnes" (2026-08-03/04), trasa počíta skutočný `new Date()` — pri
+  prechode kalendárneho dňa počas vývoja test spoľahlivo spadol. Fix:
+  hranica prepočítaná pri behu testu cez existujúci
+  `computeBratislavaPeriodBoundaries` — poučenie pre ĎALŠÍ podobný test:
+  hardcoded "dnes" literál oproti route, čo číta skutočný čas, je časovaná
+  bomba, nie jednorazová fixtúra.
+- Code review: vlastný `/review` prechod + nezávislý
+  `superpowers:requesting-code-review` subagent (base `db2a6b0` → head
+  `df4c288`) — obidva 0 Critical, 0 Important; len neblokujúce poznámky
+  (stránkovanie nad 50 riadkov ako existujúci vzor `PairingSection`,
+  `variantCount` nefiltrovaný podľa stavu ako existujúci `catalogStats`
+  vzor). PR #247, merge `6742cc5`.
+- Naživo overené na `forestshop-novy.newlevel.media` (v0.3.0-dev.141):
+  zoznam ukázal reálnych 2301 produktov bez linky (zodpovedá živému
+  rozboru pri validácii ticketu: 4542 produktov, 2241 s rozpoznateľnou
+  linkou, 2 override). Doplnenie/oprava vyskúšaná na REÁLNOM produkte
+  ("01 Detské tričko - Jeleň ručiaci") — keďže adresa sa nikdy nedopĺňa
+  odhadom, na overenie bola použitá JEHO VLASTNÁ už existujúca linka (zo
+  Shoptet-ovho `internalNote`, prefill cez "Upraviť"), nie vymyslená
+  hodnota. Stav sa zmenil "⏳ Uložené, čaká na odoslanie" → po ručnom
+  spustení `shoptet-writeback` jobu (dokumentovaný postup,
+  `.claude/rules/shoptet-writeback.md`, výsledok `{"status":"ok",
+  "productCount":1,"rowCount":5}`) → "✅ Odoslané do Shoptetu" — `runShoptetWriteback`
+  potvrdzuje úspech spätným čítaním Shoptet-ovho vlastného Logu, teda
+  reálny dôkaz, že linka dorazila do Shoptet administrácie. Konzola čistá
+  počas celého overovania. Issue zavreté ručne s dôkazom, Discord run-card
+  odoslaná.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.141",
+  "version": "0.3.0-dev.142",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-fixtures-search.ts
+++ b/scripts/e2e-fixtures-search.ts
@@ -1,0 +1,88 @@
+// issue 240: "Eshop → Vyhľadať" — vyčlenené do VLASTNÉHO súboru (rovnaký
+// dôvod ako `e2e-fixtures-product-links.ts`, issue 239 — eslint `max-lines:
+// 400`, `.claude/rules/testing.md`). VLASTNÝ, dovtedy nepoužitý produkt +
+// variant (nekoliduje so žiadnym existujúcim testom, ktorý by naň spoliehal
+// presným počtom/hodnotou) a VLASTNÁ objednávka BEZ `order_line` (aby sa
+// nedotkla `orders.spec.ts`'s presných "Všetci (N)" počtov ani
+// `orders-overview.spec.ts`'s "1 objednávka dnes" — `placedAt` je preto
+// zámerne PEVNÝ dátum v minulosti, nie "teraz").
+import type { Database } from "../apps/api/src/db/client.js";
+import { orders, products, shopProductUrl, supplierStock, users, variants } from "../apps/api/src/db/schema.js";
+import { hashPassword } from "../apps/api/src/modules/auth/passwords.js";
+import { DEFAULT_ORDER_OPEN_STATUS } from "../apps/api/src/modules/orders/open-statuses.js";
+
+// Musí sa zhodovať s hodnotou v `apps/web/tests/e2e/search.spec.ts` —
+// VLASTNÝ izolovaný účet (rovnaký mechanizmus ako `E2E_PAROVANIE_EMAIL` v
+// `e2e-fixtures-product-links.ts` — zdieľaný `e2e@forestshop.sk` je už na
+// hranici `MAX_ATTEMPTS`).
+export const E2E_VYHLADAT_EMAIL = "e2e-vyhladat@forestshop.sk";
+
+const PRODUCT_KEY = "E2E-SEARCH-1";
+const VARIANT_CODE = "E2E-SEARCH-1";
+const SUPPLIER_LINK = "https://e2e-dodavatel.example.com/vyhladat-produkt";
+
+export async function seedSearchFixtures(db: Database, teraz: Date, snapshotId: string, heslo: string): Promise<void> {
+  await db.insert(users).values({
+    email: E2E_VYHLADAT_EMAIL,
+    passwordHash: await hashPassword(heslo),
+    displayName: "E2E Manažér Vyhľadávanie",
+    role: "manazer",
+  });
+
+  await db.insert(products).values({
+    key: PRODUCT_KEY,
+    name: "E2E Vyhľadávací Produkt Alfa",
+    supplier: "E2E Dodávateľ Vyhľadávanie",
+    internalNote: `Dodávateľ: ${SUPPLIER_LINK}`,
+    firstSeenAt: teraz,
+    lastSeenAt: teraz,
+    lastSeenSnapshotId: snapshotId,
+  });
+  await db.insert(variants).values({
+    code: VARIANT_CODE,
+    productKey: PRODUCT_KEY,
+    guid: PRODUCT_KEY,
+    externalCode: "EXT-VYHLADAT-1",
+    name: "E2E Vyhľadávací Produkt Alfa",
+    currency: "EUR",
+    price: "24.90",
+    stock: 3,
+    availabilityInStockText: "Skladom",
+    availabilityOutOfStockText: "Vypredané",
+    availabilityText: "Skladom",
+    productVisibility: "visible",
+    state: "sellable",
+    firstSeenAt: teraz,
+    lastSeenAt: teraz,
+    lastSeenSnapshotId: snapshotId,
+  });
+
+  await db.insert(shopProductUrl).values({
+    code: VARIANT_CODE,
+    url: "https://www.forestshop.sk/e2e-vyhladat-produkt/",
+    fetchedAt: teraz,
+  });
+
+  await db.insert(supplierStock).values({
+    link: SUPPLIER_LINK,
+    sizeLabel: "",
+    host: "e2e-dodavatel.example.com",
+    availability: "available",
+    availabilityText: "Skladom u e2e dodávateľa",
+    source: "text",
+    ok: true,
+    checkedAt: teraz,
+    confirmedAt: teraz,
+  });
+
+  // Zámerne BEZ `order_line` (viď komentár na vrchu súboru) a s dátumom
+  // hlboko v minulosti — `orders.spec.ts`/`orders-overview.spec.ts` počítajú
+  // s presnými číslami, ktoré táto objednávka nesmie posunúť.
+  await db.insert(orders).values({
+    externalOrderId: "9101",
+    customerName: "E2E Zákazník Vyhľadávanie",
+    email: "e2e-vyhladat-zakaznik@example.com",
+    statusName: DEFAULT_ORDER_OPEN_STATUS,
+    placedAt: new Date("2026-07-10T09:00:00Z"),
+  });
+}

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -18,6 +18,7 @@ import { DEFAULT_ORDER_OPEN_STATUS } from "../apps/api/src/modules/orders/open-s
 import { POSTA_UNCOLLECTED_SETTINGS_ID } from "../apps/api/src/modules/posta-uncollected/settings.js";
 import { ORDER_REMINDER_SETTINGS_ID } from "../apps/api/src/modules/order-reminder/settings.js";
 import { seedProductLinksFixtures } from "./e2e-fixtures-product-links.js";
+import { seedSearchFixtures } from "./e2e-fixtures-search.js";
 
 const E2E_HESLO = "e2e-test-heslo"; // musí sa zhodovať s hodnotou v login.spec.ts/catalog.spec.ts/orders.spec.ts
 
@@ -206,12 +207,7 @@ await db.insert(postaUncollectedSettings).values({ id: POSTA_UNCOLLECTED_SETTING
 // issue 173: rovnaký dôvod — migrácia seeduje `order_reminder_settings`'s
 // singleton riadok (`enabled=false`), reseedovať ho treba aj tu.
 await db.insert(orderReminderSettings).values({ id: ORDER_REMINDER_SETTINGS_ID, enabled: false });
-await db.insert(users).values({
-  email: "e2e@forestshop.sk",
-  passwordHash: await hashPassword(E2E_HESLO),
-  displayName: "E2E Manažér",
-  role: "manazer",
-});
+await db.insert(users).values({ email: "e2e@forestshop.sk", passwordHash: await hashPassword(E2E_HESLO), displayName: "E2E Manažér", role: "manazer" });
 // Rovnaké počiatočné heslo a zobrazované meno ako vyššie (žiadny test naň
 // nespolieha ako na odlišujúci znak) — jediný rozdiel je e-mail, ktorý ho robí
 // SAMOSTATNÝM riadkom v `users`, izolovaným od zdieľaného účtu vyššie.
@@ -741,5 +737,8 @@ await db.insert(orders).values({
 // issue 239: fixtúra (produkty + vlastný E2E účet) vyčlenená do vlastného
 // súboru (eslint max-lines).
 await seedProductLinksFixtures(db, teraz, snapshotPrepinanie, E2E_HESLO);
+
+// issue 240: fixtúra vyčlenená do vlastného súboru, rovnaký dôvod ako vyššie.
+await seedSearchFixtures(db, teraz, snapshotPrepinanie, E2E_HESLO);
 
 await pool.end();


### PR DESCRIPTION
## Čo pridáva (issue 240)

Nová viditeľná záložka **Eshop → Vyhľadať** — jedno miesto, kde majiteľ nájde
konkrétny produkt (podľa kódu, názvu, dodávateľa alebo kódu u dodávateľa) alebo
objednávku (podľa čísla, mena či e-mailu zákazníka) a pri produkte rovno opraví
dodávateľskú linku.

- `GET /api/search?q=` — vráti `products`/`orders` ako dve oddelené polia
  (produkty prirodzene pred objednávkami).
- `GET /api/product-detail/:productKey` — všetky varianty produktu, efektívna
  dodávateľská linka + stav uložené/odoslané, adresa u nás, dostupnosť u
  dodávateľa. Editácia linky ide cez existujúcu `POST /api/product-links/:productKey`
  (issue 239) — žiadna nová zapisovacia cesta.
- Frontend `SearchSection.tsx` — hľadanie + detail s editovateľnou linkou,
  rovnaký ukladací vzor ako `SupplierLinksSection.tsx` (issue 239).
- Nová e2e fixtúra (`scripts/e2e-fixtures-search.ts`) + `search.spec.ts`.
- `nav.spec.ts`/`nav.test.ts` upravené na jedenásť záložiek; `catalog.spec.ts`
  počty variantov posunuté o +1 (nový sellable produkt fixtúry).

## Rozsah hľadania (zapísané aj v návrhovom komentári na tickete)

Prehľadáva sa VÝHRADNE katalóg (kód/názov/dodávateľ/kód u dodávateľa) a
objednávky (číslo/meno/e-mail) — texty e-mailov, kniha odoslaných e-mailov,
história plánovača, nastavenia automatizácií, surové riadky dodávateľského
skladu, audit log a používatelia sa vedome neprehľadávajú.

## Overenie

- `pnpm typecheck`, `pnpm lint` — čisté.
- `pnpm test` (bez DB) — 970 testov (api 560 + web 410) zelené.
- `pnpm test:integration` — 472 testov (64 súborov) zelené.
- `pnpm --filter @forestshop/web e2e` — celý balík, 36 testov, zelené.

Ticket issue 240 má akceptačnú podmienku "naživo overené na
forestshop-novy.newlevel.media", ktorú vieme potvrdiť až po nasadení — ticket
preto ostáva otvorený a zavrie sa ručne po živom overení.
