### PR TITLE
feat: podpora 5 dodávateľských domén + vylúčenie vlastného e-shopu (issue 227)

### DIFF
--- a/.claude/rules/search.md
+++ b/.claude/rules/search.md
@@ -1,0 +1,40 @@
+---
+paths:
+  - "apps/api/src/modules/search/**"
+  - "apps/api/src/modules/product-detail/**"
+  - "apps/api/src/http/search-routes.ts"
+  - "apps/api/src/http/product-detail-routes.ts"
+  - "apps/web/src/searchApi.ts"
+  - "apps/web/src/components/SearchSection.tsx"
+---
+
+# Eshop → Vyhľadať (issue 240)
+
+- **"Hľadať prednostne produkty, potom objednávky" sa rieši DVOMA
+  ODDELENÝMI poľami (`GlobalSearchResult.products`/`.orders`), NIE jedným
+  zoradeným zoznamom s relevance skóre.** Frontend ich vykreslí ako dva
+  vizuálne oddelené bloky v tomto poradí — produkty prirodzene skončia PRED
+  objednávkami bez toho, aby bolo treba počítať/porovnávať skóre naprieč
+  dvomi úplne odlišnými entitami (variant vs. objednávka). Rozšírenie o
+  ĎALŠIU prehľadávanú oblasť (napr. dodávateľov, e-maily) patrí ako TRETIE
+  samostatné pole, nie zamiešané do jedného z existujúcich dvoch.
+- **Editácia dodávateľskej linky na tejto obrazovke ide VÝHRADNE cez
+  existujúcu `POST /api/product-links/:productKey` (issue 239) —
+  `product-detail` trasa je LEN NA ČÍTANIE.** Nepridávaj sem druhú
+  zapisovaciu cestu do `product_supplier_link_override` — `saveProductLink`
+  (`supplierLinksApi.ts`) sa importuje a používa priamo z `SearchSection.tsx`.
+- **Dostupnosť u dodávateľa (`supplier_stock`) sa páruje VÝHRADNE podľa
+  linky extrahovanej z `product.internalNote` (`extractSupplierLink`),
+  NIKDY podľa manažérovho override.** Toto NIE JE bug ani nekonzistencia —
+  je to TEN ISTÝ zdroj, aký používa scraper (`supplier-stock/run.ts`'s
+  `collectSupplierLinks`) aj `restock/queries.ts` všade inde v appke.
+  Scraper override nesleduje vôbec (mimo rozsahu #240) — `getProductDetail`
+  (`product-detail/queries.ts`) preto číta `supplierStock` podľa
+  `scrapedLink` (z `internalNote`), zatiaľ čo zobrazená EFEKTÍVNA linka
+  (`supplierLinkUrl`) uprednostňuje override — dve rôzne premenné v tej istej
+  funkcii, zámerne.
+- **Nová viditeľná záložka v `nav.ts` (Sidebar je vždy namountovaný) môže
+  substring-om kolidovať s existujúcimi `getByRole("button", {...})`
+  dopytmi naprieč CELÝM e2e balíkom** — `.claude/rules/testing.md` má plný
+  detail a postup (issue 240: "Vyhľadať" vs. existujúce "Hľadať" tlačidlá v
+  `catalog.spec.ts`).

--- a/.claude/rules/supplier-stock.md
+++ b/.claude/rules/supplier-stock.md
@@ -189,3 +189,66 @@ paths:
   `unknown` presne ako predtým — dokumentované v `constants.ts` aj na
   ticket-e, nie tichá medzera. Vzor na ĎALŠIU doménu bez overeného
   protipólu: rovnaký postup, nie dohad podľa analógie s inou doménou.
+- **NÁŠ VLASTNÝ e-shop (`forestshop.sk`) sa dokáže omylom dostať do
+  `supplier_stock` presne tou istou cestou ako skutočný dodávateľ — issue
+  227, 21 odkazov** — `extractSupplierLink` (`catalog/supplier-link.ts`)
+  vytiahne AKÚKOĽVEK URL z `internalNote`, bez ohľadu na to, či ide o
+  dodávateľa. Fix: `run.ts`'s `collectSupplierLinks` vylučuje `hostOf(url)
+  === OWN_SHOP_HOST` (a jeho poddomény) PRI ZBERE, nikdy sa teda nedostane
+  ani do prvého fetchu; `runSupplierStockLocked` navyše pri KAŽDOM behu
+  vymaže staré riadky s týmto hostom (z behov PRED opravou) — inak by
+  tvárili ako "nečitateľná dodávateľská doména" navždy. Počet vylúčených
+  odkazov (`countOwnShopLinks`, živo z `internalNote`) sa ukazuje na
+  obrazovke ako „Vlastný e-shop (nie dodávateľ)" — vylúčenie NIKDY nie je
+  tiché. Ďalší podobný nález (iný vlastný/interný odkaz omylom vytiahnutý
+  z voľného textu): rovnaký vzor — vylúčiť PRI ZBERE podľa hosta, vyčistiť
+  staré riadky, ukázať počet, nikdy len ticho prestať zapisovať nové.
+- **Ten istý Shoptet FRONTEND ŠABLÓNOVÝ prvok (`<span class="availability-
+  label" ... data-testid="labelAvailability">`) sa opakuje NAPRIEČ VIACERÝMI
+  nezávislými doménami (issue 227: `virginiashop.sk`, `tenolix.cz`,
+  `luko.cz`) — jeden zdieľaný extraktor (`shoptetLabelAvailability` v
+  `parse.ts`) pokrýva všetky tri naraz, namiesto samostatného pravidla na
+  doménu.** Farba (`#009901`/`#cb0000`) rozhoduje len VIZUÁLNE — samotné
+  ČÍTANIE ide cez text vnútri `<span>` (napr. "Skladom"/"Skladem"/
+  "Momentálne(ě) nedostupné") a existujúci `availabilityFromText`, žiadna
+  nová farebná mapovacia logika netreba (na rozdiel od `trigona.sk`, kde
+  text sám osebe nestačil a rozhodovala farba). Tento `data-testid` sa
+  VÔBEC nevykresľuje na VIACVARIANTOVÝCH produktoch (viac veľkostí/farieb
+  naraz — každá veľkosť má VLASTNÝ `<span class="availability-label">` BEZ
+  `data-testid`, JS ich prepína cez `parameter-dependent`/`no-display`
+  triedy) — taký produkt ostáva `unknown` presne ako predtým
+  (`whenRegionMissing: "unknown"`), nikdy sa nehádaj z niektorej z
+  viacerých zhôd. `luko.cz` má tento jav VÄČŠINOVO (35 z 36 sledovaných
+  odkazov sú viacveľkostné košele) — čitateľnosť tejto domény preto ostáva
+  nízka aj po tejto zmene; skutočný pokrok by vyžadoval mapovanie
+  číselných JS parameter-ID na konkrétnu veľkosť (podobné, ale iné, než
+  `shop.lasting.eu`'s `title=""` atribút), mimo rozsahu tohto ticketu.
+- **Český tvar "Momentálně nedostupné" (mäkké `ě`) je INÝ reťazec než
+  slovenské "momentálne nedostupné" — `OUT_KEYWORDS` (`parse.ts`) potrebuje
+  OBA, `.includes()` porovnanie nevidí medzi nimi žiadnu podobnosť** (issue
+  227, `tenolix.cz`). Test na KAŽDÝ ďalší český text: over diakritiku
+  znak-po-znaku voči slovenskému tvaru, nikdy nepredpokladaj, že jeden
+  zoznam kľúčových slov pokryje obe reči automaticky.
+- **Rovnaká karuselová kolízia ako `huntingshop.eu` (issue 223) sa vie
+  zopakovať aj na SCHEMA.ORG MIKRODÁTACH (`<link itemprop="availability"
+  href="...">`), nielen na voľnom texte — `fomei.com` (issue 227) má túto
+  značku 10-11× na stránke (hlavný produkt + karusel "Súvisiace" nižšie).**
+  Fix je identický princíp ako `odimon.sk` (issue 225, "prvý výskyt patrí
+  hlavnému produktu"): hľadať LEN PRED nadpisom `>Súvisiace<`
+  (`fomeiAvailabilityRegion` v `parse.ts`). Rozhoduje TRIEDA
+  (`availability--inStock`/`availability--noStock`), nikdy viditeľný text —
+  ten sa medzi produktmi líši ("na dotaz" pri `noStock` nie je vždy rovnaké
+  slovo). Test na KAŽDÚ ďalšiu doménu s opakovaným mikrodátovým/textovým
+  prvkom naprieč stránkou: nájdi nadpis podobný "Súvisiace"/"Odporúčame" a
+  obmedz hľadanie na oblasť PRED ním, nikdy na celý dokument.
+- **`chiruca.sk` (issue 227) nesie veľkosť AJ dostupnosť v JEDNOM viditeľnom
+  texte `<option>` prvku (`<select id="simple-variants-select">`, "Veľkosť:
+  38 - Vypredané (€100)") — na rozdiel od `shop.lasting.eu` (issue 224) tu
+  netreba hľadať skupinovú hranicu ani popisok, celý `<select>` patrí
+  jednému produktu, každý `<option>` je presne jedna veľkosť.** Dostupnosť
+  sa číta z TEXTU (cez `availabilityFromText`), nikdy z `data-stock`
+  atribútu (`-1`/`-2`) — ten by bol dohad bez preukázateľného mapovania,
+  zatiaľ čo text je presne to, čo vidí zákazník. Naše `variant.size_label`
+  sú u `chiruca.sk` holé čísla ("37".."47"), zhodujú sa priamo s
+  dodávateľovým "Veľkosť: NN" bez potreby `matchSizeLabel`'s tolerantného
+  porovnávania.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -218,6 +218,34 @@ paths:
   `role="alert"`/`role="status"` pridanom do zdieľanej obrazovky: spusti
   CELÝ e2e balík (nie len nový spec súbor), presne ako pri `aria-label`
   vyššie.
+- **Rovnaká kolízna trieda platí aj pre NOVÚ ZÁLOŽKU v ľavom menu (`nav.ts`)
+  — jej tlačidlo je SÚČASŤOU KAŽDEJ stránky appky (Sidebar je vždy
+  namountovaný), takže jeho prístupné meno môže substring-om kolidovať s
+  `getByRole("button", {...})` v ĽUBOVOĽNOM inom e2e spec súbore, nielen v
+  tom, čo novú záložku pridáva.** Issue 240 (nová záložka "Vyhľadať"):
+  `page.getByRole("button", { name: "Hľadať" })` v `catalog.spec.ts` (3×,
+  existujúci submit button hľadania) začal padať na "strict mode violation
+  ... resolved to 2 elements" — `"Vyhľadať"` obsahuje `"Hľadať"` ako
+  substring (case-insensitive), presne ako v predošlých nálezoch vyššie.
+  Rovnaká oprava (na strane KOLÍDUJÚCEHO existujúceho locatora, nie
+  premenovaním novej záložky — jej meno je jej JEDINÝ zmysluplný popis):
+  `{ name: "Hľadať", exact: true }`. Test pri KAŽDEJ ďalšej novej záložke v
+  `nav.ts`: `grep -rn 'name: "<časť nového label-u>"' apps/web/tests/e2e/`
+  (bez `exact: true`) naprieč CELÝM e2e priečinkom, nie len v novo písanom
+  spec súbore — spusti aj celý balík (`pnpm --filter @forestshop/web e2e`),
+  nikdy len nový súbor.
+- **`scripts/e2e-setup.ts` sedí presne NA HRANICI eslint `max-lines: 400`
+  (skipBlankLines/skipComments) — pridanie čo i len JEDNÉHO nového importu +
+  JEDNÉHO volania `seedXFixtures(...)` (typický vzor pre novú fixtúru
+  vyčlenenú do vlastného súboru, viď issue 239/240) ju hneď prehodí cez
+  limit, aj keď sprievodný komentár nepočítaš** (komentáre/prázdne riadky
+  eslint nepočíta, takže ich skracovanie nepomôže). Fix nie je ďalšie
+  vyčleňovanie do súborov (fixtúra je už vyčlenená) — nájdi v súbore
+  existujúci viacriadkový `await db.insert(x).values({ ... })` s pár poľami
+  a zbaľ ho na JEDEN riadok (dlhé riadky sú v tomto súbore bežné, žiadne
+  `max-len` pravidlo nie je aktívne), čím uvoľníš presne toľko riadkov,
+  koľko tvoj nový kód pridáva. Over `pnpm lint` PRED pushom, nie až keď
+  spadne v CI.
 - **`job_run` tabuľka má od #115 JEDEN GLOBÁLNY, natrvalo seedovaný riadok**
   (`scripts/e2e-setup.ts`: umelo zostarnutý úspešný `catalog-import` beh z
   roku 2020) — kvôli `nav.spec.ts`'s staleness testu. Dôsledok: "Sync zo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,3 +102,4 @@ Per-area rules live in `.claude/rules/<area>.md` with `paths:` frontmatter.
 - adresy našich produktov z feedu google.xml (#220) → `.claude/rules/shop-feed.md`
 - Kniha odoslaných e-mailov (F193 — jediná odosielacia cesta, dedup okno preskočení) → `.claude/rules/mail-log.md`
 - Párovanie produktov (#239 — samostatná od `pairing`, zdieľaný upsert s #121, live-overenie bez AI-dohady) → `.claude/rules/product-links.md`
+- Eshop → Vyhľadať (#240 — dve oddelené polia produkty/objednávky, detail produktu, zdieľaná zapisovacia cesta s #239) → `.claude/rules/search.md`

--- a/apps/api/src/http/supplier-stock-routes.ts
+++ b/apps/api/src/http/supplier-stock-routes.ts
@@ -8,12 +8,13 @@ import { getLatestJobRun } from "../modules/scheduler/queries.js";
 import { SUPPLIER_STOCK_JOB_NAME } from "../modules/supplier-stock/constants.js";
 import type { PageFetcher } from "../modules/supplier-stock/page-fetcher.js";
 import {
+  getSupplierStockHostOverview,
   getSupplierStockOverview,
   listSupplierStock,
   listUnreadableHosts,
 } from "../modules/supplier-stock/queries.js";
 import type { SupplierStockRunResult } from "../modules/supplier-stock/run.js";
-import { runSupplierStock } from "../modules/supplier-stock/run.js";
+import { countOwnShopLinks, runSupplierStock } from "../modules/supplier-stock/run.js";
 import { requireRole, requireUser, type AppBindings } from "./middleware.js";
 import { requireSameOrigin } from "./origin-check.js";
 
@@ -69,16 +70,20 @@ export function registerSupplierStockRoutes(
   // čím chrániť. Prepínač má AŽ automatizácia, ktorá na základe týchto dát
   // zapisuje do Shoptetu (issue 213).
   app.get("/api/supplier-stock", requireUser(db), async (c) => {
-    const [overview, rows, unreadable, lastRun] = await Promise.all([
+    const [overview, rows, unreadable, hostOverview, ownShopLinksCount, lastRun] = await Promise.all([
       getSupplierStockOverview(db),
       listSupplierStock(db),
       listUnreadableHosts(db),
+      getSupplierStockHostOverview(db),
+      countOwnShopLinks(db),
       getLatestJobRun(db, SUPPLIER_STOCK_JOB_NAME),
     ]);
     return c.json({
       overview,
       rows,
       unreadable,
+      hostOverview,
+      ownShopLinksCount,
       lastRun:
         lastRun === null
           ? null

--- a/apps/api/src/modules/supplier-stock/constants.ts
+++ b/apps/api/src/modules/supplier-stock/constants.ts
@@ -59,3 +59,11 @@ export const USER_AGENT =
 // overených 67+ produktových stránok malo VŽDY rovnaký ("success") štítok,
 // takže sa nepodarilo nájsť overený "vypredaný" príklad a pridanie pravidla
 // by bol nepodložený dohad (viď issue 230 komentáre).
+
+// issue 227: 21 odkazov v `internalNote` omylom mieri na NÁŠ VLASTNÝ e-shop
+// (`extractSupplierLink`'s regex vytiahne akúkoľvek URL z voľného textu,
+// bez ohľadu na to, či ide o dodávateľa) — to nie je dodávateľský odkaz a
+// nemá zmysel ho scrapovať. Vylučuje sa podľa hosta (`hostOf`), nikdy podľa
+// presného reťazca URL — `www.forestshop.sk` aj `forestshop.sk` musia sedieť
+// rovnako (`hostOf` už `www.` odstraňuje).
+export const OWN_SHOP_HOST = "forestshop.sk";

--- a/apps/api/src/modules/supplier-stock/fixtures/chiruca-velkosti-cameros.html
+++ b/apps/api/src/modules/supplier-stock/fixtures/chiruca-velkosti-cameros.html
@@ -1,0 +1,11 @@
+<!-- issue 227: verné, orezané zachytenie skutočnej stránky (5. 8. 2026) —
+     jeden <option> na veľkosť, text nesie aj veľkosť aj dostupnosť naraz. -->
+<!doctype html>
+<html lang="sk">
+<head><title>Chiruca Cameros</title></head>
+<body>
+<div class="product-detail">
+  <select name="priceId" class="form-control" id="simple-variants-select" data-testid="selectVariant"><option value="" data-disable-button="1" data-disable-reason="Zvoľte variant" data-index="0"data-codeid="365">Zvoľte variant</option><option value="365" data-index="1"data-min="1"data-max="9999"data-decimals="0"data-codeid="365"data-stock="-2"data-customerprice="100"data-haspromotion="">Veľkosť: 38&nbsp;- Vypredané&nbsp; (€100)</option><option value="371" data-index="3"data-min="1"data-max="9999"data-decimals="0"data-codeid="371"data-stock="-1"data-customerprice="100"data-haspromotion="">Veľkosť: 40&nbsp;- Skladom&nbsp; (€100)</option><option value="377" data-index="5"data-min="1"data-max="9999"data-decimals="0"data-codeid="377"data-stock="-2"data-customerprice="100"data-haspromotion="">Veľkosť: 42&nbsp;- Vypredané&nbsp; (€100)</option></select>
+</div>
+</body>
+</html>

--- a/apps/api/src/modules/supplier-stock/fixtures/fomei-nadotaz-dalekohlad.html
+++ b/apps/api/src/modules/supplier-stock/fixtures/fomei-nadotaz-dalekohlad.html
@@ -1,0 +1,18 @@
+<!-- issue 227: verné, orezané zachytenie skutočnej stránky (5. 8. 2026) —
+     "na dotaz" (nedostupné, zákazník musí kontaktovať predajcu) má triedu
+     `availability--noStock`, nikdy sa nečíta z viditeľného textu priamo
+     (ten sa medzi produktmi líši), vždy z tejto triedy. -->
+<!doctype html>
+<html lang="sk">
+<head><title>FOMEI 10x52 FOREMAN PRO XLD ďalekohľad</title></head>
+<body>
+<div class="product__offers product__offers--detail">
+  <div class="cOffersInfoWrapper">
+    <div class="product__component product__avail">
+      <span class="availability availability--noStock c-na-dotaz">na dotaz</span>
+      <link itemprop="availability" href="http://schema.org/OutOfStock" />
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/apps/api/src/modules/supplier-stock/fixtures/fomei-skladom-puskohlad.html
+++ b/apps/api/src/modules/supplier-stock/fixtures/fomei-skladom-puskohlad.html
@@ -1,0 +1,28 @@
+<!-- issue 227: verné, orezané zachytenie skutočnej stránky (5. 8. 2026).
+     Rovnaká trieda "availability availability--…" sa OPAKUJE v karuseli
+     "Súvisiace" nižšie na stránke (rovnaká kolízia ako huntingshop.eu, issue
+     223) — čítač preto smie hľadať LEN PRED nadpisom "Súvisiace". -->
+<!doctype html>
+<html lang="sk">
+<head><title>FOMEI 1,7-10x42 FOREMAN HTC PRO G4 puškohľad</title></head>
+<body>
+<div class="product__offers product__offers--detail">
+  <div class="cOffersInfoWrapper">
+    <div class="product__component product__avail">
+      <span class="availability availability--inStock">Skladom</span>
+      <link itemprop="availability" href="http://schema.org/InStock" />
+    </div>
+  </div>
+</div>
+
+<h2 class="hidden-md-down">Súvisiace</h2>
+<div class="carouselOffers">
+  <div class="listBoxed">
+    <div class="productList productList--table">
+      <span class="availability availability--noStock c-na-dotaz">na dotaz</span>
+      <link itemprop="availability" href="http://schema.org/OutOfStock" />
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/apps/api/src/modules/supplier-stock/fixtures/luko-skladem-halenka.html
+++ b/apps/api/src/modules/supplier-stock/fixtures/luko-skladem-halenka.html
@@ -1,0 +1,16 @@
+<!-- issue 227: verné, orezané zachytenie skutočnej stránky (5. 8. 2026) —
+     jednoveľkostný produkt (bez viacveľkostného selektora). Rovnaká Shoptet
+     šablóna ako virginiashop.sk/tenolix.cz (`data-testid="labelAvailability"`). -->
+<!doctype html>
+<html lang="cs">
+<head><title>Dámská halenka s dlouhým rukávem model 162214</title></head>
+<body>
+<div class="product-detail">
+  <div class="availability">
+    <span class="availability-label" style="color: #009901" data-testid="labelAvailability">
+                    Skladem            </span>
+    <span class="availability-amount" data-testid="numberAvailabilityAmount">(3&nbsp;ks)</span>
+  </div>
+</div>
+</body>
+</html>

--- a/apps/api/src/modules/supplier-stock/fixtures/luko-viacvelkostna-bez-testid.html
+++ b/apps/api/src/modules/supplier-stock/fixtures/luko-viacvelkostna-bez-testid.html
@@ -1,0 +1,29 @@
+<!-- issue 227: viacveľkostný produkt (bežný prípad na luko.cz — košele s
+     veľkosťami) — BEZ `data-testid="labelAvailability"`, presne ako
+     virginiashop.sk's viacvariantový prípad. Ostáva `unknown`: mapovanie
+     číselných JS parameter-ID na konkrétnu veľkosť by vyžadovalo ďalší,
+     samostatný per-veľkostný extraktor (mimo rozsahu tohto ticketu, pozri
+     `.claude/rules/supplier-stock.md`). Overené naživo 5. 8. 2026. -->
+<!doctype html>
+<html lang="cs">
+<head><title>Bílá košile s výšivkou model 182115</title></head>
+<body>
+<div class="product-detail">
+  <div class="p-basic-info-block">
+    <span class="parameter-dependent no-display 22-181-4-1-5-59">
+      <span class="availability-label" style="color: #009901">
+                                            Skladem
+                                    </span>
+      <span class="availability-amount" data-testid="numberAvailabilityAmount">(2&nbsp;ks)</span>
+    </span>
+    <span class="parameter-dependent no-display 22-181-4-1-5-8">
+      <span class="availability-label" style="color: #009901">
+                                            Skladem
+                                    </span>
+    </span>
+    <span class="parameter-dependent default-variant">
+                        Zvolte variantu                    </span>
+  </div>
+</div>
+</body>
+</html>

--- a/apps/api/src/modules/supplier-stock/fixtures/tenolix-nedostupne-falcon.html
+++ b/apps/api/src/modules/supplier-stock/fixtures/tenolix-nedostupne-falcon.html
@@ -1,0 +1,15 @@
+<!-- issue 227: verné, orezané zachytenie skutočnej stránky (5. 8. 2026) —
+     česká diakritika "Momentálně" (mäkké ě), nie slovenské "Momentálne". -->
+<!doctype html>
+<html lang="cs">
+<head><title>HIKMICRO Falcon FQ25</title></head>
+<body>
+<div class="product-detail">
+  <div class="availability-value" title="Dostupnost">
+    <span class="availability-label" style="color: #cb0000" data-testid="labelAvailability">
+                    Momentálně nedostupné            </span>
+  </div>
+  <table class="detail-parameters"><tbody></tbody></table>
+</div>
+</body>
+</html>

--- a/apps/api/src/modules/supplier-stock/fixtures/tenolix-skladem-alpex.html
+++ b/apps/api/src/modules/supplier-stock/fixtures/tenolix-skladem-alpex.html
@@ -1,0 +1,14 @@
+<!-- issue 227: verné, orezané zachytenie skutočnej stránky (5. 8. 2026). -->
+<!doctype html>
+<html lang="cs">
+<head><title>HIKMICRO ALPEX 4K LRF A50EL</title></head>
+<body>
+<div class="product-detail">
+  <div class="availability-value" title="Dostupnost">
+    <span class="availability-label" style="color: #009901" data-testid="labelAvailability">
+                    Skladem            </span>
+  </div>
+  <table class="detail-parameters"><tbody></tbody></table>
+</div>
+</body>
+</html>

--- a/apps/api/src/modules/supplier-stock/fixtures/virginiashop-nedostupne-puzdro.html
+++ b/apps/api/src/modules/supplier-stock/fixtures/virginiashop-nedostupne-puzdro.html
@@ -1,0 +1,21 @@
+<!-- issue 227: verné, orezané zachytenie skutočnej stránky (5. 8. 2026). -->
+<!doctype html>
+<html lang="sk">
+<head><title>Kožené puzdro na doklady</title></head>
+<body>
+<div class="product-detail">
+  <table class="detail-parameters shipping-options-layout">
+    <tbody>
+      <tr>
+        <th><span class="row-header-label">Dostupnosť</span></th>
+        <td>
+          <span class="availability-label" style="color: #cb0000" data-testid="labelAvailability">
+                    Momentálne nedostupné            </span>
+        </td>
+      </tr>
+      <tr class="shipping-options-row"><td>Odosielame na dopyt</td></tr>
+    </tbody>
+  </table>
+</div>
+</body>
+</html>

--- a/apps/api/src/modules/supplier-stock/fixtures/virginiashop-skladom-noz.html
+++ b/apps/api/src/modules/supplier-stock/fixtures/virginiashop-skladom-noz.html
@@ -1,0 +1,22 @@
+<!-- issue 227: verné, orezané zachytenie skutočnej stránky (5. 8. 2026),
+     len tá časť, ktorá nesie dostupnosť pri produkte. -->
+<!doctype html>
+<html lang="sk">
+<head><title>Poľovnícky nôž</title></head>
+<body>
+<div class="product-detail">
+  <table class="detail-parameters shipping-options-layout">
+    <tbody>
+      <tr>
+        <th><span class="row-header-label">Dostupnosť</span></th>
+        <td>
+          <span class="availability-label" style="color: #009901" data-testid="labelAvailability">
+                    Skladom            </span>
+        </td>
+      </tr>
+      <tr class="delivery-time-row"><th><span>Doručenie</span></th></tr>
+    </tbody>
+  </table>
+</div>
+</body>
+</html>

--- a/apps/api/src/modules/supplier-stock/fixtures/virginiashop-viacvariantovy-bez-testid.html
+++ b/apps/api/src/modules/supplier-stock/fixtures/virginiashop-viacvariantovy-bez-testid.html
@@ -1,0 +1,35 @@
+<!-- issue 227: viacvariantový produkt (viac veľkostí/farieb naraz) — Shoptet
+     tu NEvykresľuje `data-testid="labelAvailability"` vôbec (rozdiel oproti
+     jednoveľkostným stránkam vyššie), takže sa nesmie nič uhádnuť: zostáva
+     `unknown`, presne ako pred touto zmenou. Overené naživo 5. 8. 2026. -->
+<!doctype html>
+<html lang="sk">
+<head><title>Ploskačka s pohárikmi</title></head>
+<body>
+<div class="product-detail">
+  <table class="detail-parameters shipping-options-layout">
+    <tbody>
+      <tr>
+        <th><span class="row-header-label">Dostupnosť</span></th>
+        <td>
+          <span class="parameter-dependent no-display 5-4611">
+            <span class="availability-label" style="color: #009901">
+                                            Skladom
+                                    </span>
+          </span>
+          <span class="parameter-dependent 5-4602">
+            <span class="availability-label" style="color: #009901">
+                                            Skladom
+                                    </span>
+          </span>
+          <span class="parameter-dependent default-variant no-display">
+            <span class="availability-label">
+                Zvoľte variant            </span>
+          </span>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+</body>
+</html>

--- a/apps/api/src/modules/supplier-stock/parse.test.ts
+++ b/apps/api/src/modules/supplier-stock/parse.test.ts
@@ -26,6 +26,16 @@ const LASTING_BONY = fixture("lasting-bony-cepica-l-xl.html");
 const LASTING_HILA = fixture("lasting-hila-tricko-bez-xs.html");
 const TRIGONA_SKLADOM = fixture("trigona-skladom-10x42-sahara.html");
 const TRIGONA_VYPREDANE = fixture("trigona-vypredane-8x56-ed-savannah.html");
+const VIRGINIASHOP_SKLADOM = fixture("virginiashop-skladom-noz.html");
+const VIRGINIASHOP_NEDOSTUPNE = fixture("virginiashop-nedostupne-puzdro.html");
+const VIRGINIASHOP_VIACVARIANTOVY = fixture("virginiashop-viacvariantovy-bez-testid.html");
+const TENOLIX_SKLADEM = fixture("tenolix-skladem-alpex.html");
+const TENOLIX_NEDOSTUPNE = fixture("tenolix-nedostupne-falcon.html");
+const LUKO_SKLADEM = fixture("luko-skladem-halenka.html");
+const LUKO_VIACVELKOSTNA = fixture("luko-viacvelkostna-bez-testid.html");
+const FOMEI_SKLADOM = fixture("fomei-skladom-puskohlad.html");
+const FOMEI_NA_DOTAZ = fixture("fomei-nadotaz-dalekohlad.html");
+const CHIRUCA_VELKOSTI = fixture("chiruca-velkosti-cameros.html");
 
 describe("hostOf / isTrustedTextHost", () => {
   it("odreze www a zmensi pismena", () => {
@@ -297,6 +307,90 @@ describe("parsePage — issue 230: trigona.sk cita farebny StockCountText stitok
       '<span id="StockCountText42"><span style="color: #ff9900">Na dopyt</span></span>';
     const result = parsePage(html, "https://www.trigona.sk/eshop/nieco/p-42.xhtml");
     expect(result.availability).toBe("unknown");
+  });
+});
+
+describe("parsePage — issue 227: virginiashop.sk/tenolix.cz/luko.cz zdieľaná Shoptet šablóna (data-testid=labelAvailability)", () => {
+  it("virginiashop.sk skladom je available (zelena farba, text 'Skladom')", () => {
+    const result = parsePage(VIRGINIASHOP_SKLADOM, "https://www.virginiashop.sk/polovnicke-noze/polovnicky-noz-kandar-motiv-diviak-23-11cm-puzdro/");
+    expect(result.availability).toBe("available");
+    expect(result.source).toBe("text");
+  });
+
+  it("virginiashop.sk 'Momentálne nedostupné' (cervena farba) je unavailable", () => {
+    const result = parsePage(
+      VIRGINIASHOP_NEDOSTUPNE,
+      "https://www.virginiashop.sk/penazenky-a-dokladovky/kozene-puzdro-na-plovnicke--doklady-motiv-jelen-sv--hubert/",
+    );
+    expect(result.availability).toBe("unavailable");
+  });
+
+  it("viacvariantovy produkt (bez data-testid) je unknown, nikdy dohad z niektorej z viacerych zhod", () => {
+    const result = parsePage(
+      VIRGINIASHOP_VIACVARIANTOVY,
+      "https://www.virginiashop.sk/ploskacky-s-poharikmi/ploskacka-4-pohariky-v-darcekovej-kazete-s-polovnickym-motivom-jelen-fj6-2/",
+    );
+    expect(result.availability).toBe("unknown");
+  });
+
+  it("tenolix.cz 'Skladem' (cesky tvar) je available", () => {
+    const result = parsePage(TENOLIX_SKLADEM, "https://www.tenolix.cz/nocni-videni/hikmicro-alpex-4k-lrf-a50el/");
+    expect(result.availability).toBe("available");
+  });
+
+  it("tenolix.cz 'Momentálně nedostupné' (mäkké č.ě, nie slovenské 'momentálne') je unavailable", () => {
+    const result = parsePage(TENOLIX_NEDOSTUPNE, "https://www.tenolix.cz/termovize/hikmicro-falcon-fq25/");
+    expect(result.availability).toBe("unavailable");
+  });
+
+  it("luko.cz jednoveľkostny produkt 'Skladem' je available", () => {
+    const result = parsePage(
+      LUKO_SKLADEM,
+      "https://www.luko.cz/halenky-s-dlouhym-rukavem/damska-halenka-s-dlouhym-rukavem-model-162214/",
+    );
+    expect(result.availability).toBe("available");
+  });
+
+  it("luko.cz viacveľkostny produkt (bez data-testid, beznejsi pripad) je unknown, nikdy dohad", () => {
+    const result = parsePage(
+      LUKO_VIACVELKOSTNA,
+      "https://www.luko.cz/myslivecke-a-outdoorove-kosile/bila-kosile--s-vysivkou-model-182115/",
+    );
+    expect(result.availability).toBe("unknown");
+  });
+});
+
+describe("parsePage — issue 227: fomei.com — mikrodata triedy PRED nadpisom 'Súvisiace', nikdy z karuselu", () => {
+  it("hlavny produkt 'availability--inStock' je available, aj ked karusel nizsie na stranke ma 'noStock'", () => {
+    const result = parsePage(
+      FOMEI_SKLADOM,
+      "https://www.fomei.com/sk/produkty-fomei-1-7-10x42-foreman-htc-pro-g4-puskohlad-detail-277806",
+    );
+    expect(result.availability).toBe("available");
+    expect(result.source).toBe("text");
+  });
+
+  it("hlavny produkt 'availability--noStock' ('na dotaz') je unavailable", () => {
+    const result = parsePage(
+      FOMEI_NA_DOTAZ,
+      "https://www.fomei.com/sk/produkty-fomei-10x52-foreman-pro-xld-dalekohlad-detail-249108",
+    );
+    expect(result.availability).toBe("unavailable");
+  });
+});
+
+describe("parseSizeAvailability — issue 227: chiruca.sk zoznam veľkostí v <select>", () => {
+  it("precita KAZDU velkost z <option> textu, nikdy stranku ako celok", () => {
+    const sizes = parseSizeAvailability(CHIRUCA_VELKOSTI, "https://www.chiruca.sk/cameros/");
+    expect(sizes).toEqual([
+      { sizeLabel: "38", availability: "unavailable" },
+      { sizeLabel: "40", availability: "available" },
+      { sizeLabel: "42", availability: "unavailable" },
+    ]);
+  });
+
+  it("stranka bez pravidla (ina domena) vracia null", () => {
+    expect(parseSizeAvailability(CHIRUCA_VELKOSTI, "https://www.huntingshop.eu/p/1")).toBeNull();
   });
 });
 

--- a/apps/api/src/modules/supplier-stock/parse.ts
+++ b/apps/api/src/modules/supplier-stock/parse.ts
@@ -86,6 +86,9 @@ const OUT_KEYWORDS: readonly string[] = Object.freeze([
   "neni skladem",
   "momentálne nedostupné",
   "momentalne nedostupne",
+  // Český tvar s mäkkým "ě" (issue 227, tenolix.cz) — INÝ reťazec než
+  // slovenské "momentálne" vyššie, obe sa musia kontrolovať samostatne.
+  "momentálně nedostupné",
   "dočasne nedostupné",
   "docasne nedostupne",
   "predaj skončil",
@@ -295,9 +298,57 @@ function trigonaStockRegion(html: string): string | null {
   return null;
 }
 
+/**
+ * virginiashop.sk/tenolix.cz/luko.cz (issue 227): rovnaká Shoptet šablóna,
+ * jednoveľkostný produkt nesie `<span class="availability-label" ...
+ * data-testid="labelAvailability">Skladom/Skladem/Momentálne(ě)
+ * nedostupné</span>` — text sa vracia AKO JE a ide cez existujúci
+ * `availabilityFromText` (žiadna nová farebná/triedová logika, na rozdiel od
+ * trigona.sk). Naživo overené OBE polarity priamo na virginiashop.sk aj
+ * tenolix.cz (rovnaká trieda, rovnaké farby #009901/#cb0000); luko.cz má
+ * naživo overenú len zelenú vetvu — jej sledované odkazy sú takmer vždy
+ * VIACVEĽKOSTNÉ produkty, ktoré tento `data-testid` vôbec nemajú (viď
+ * `whenRegionMissing` nižšie), takže ostávajú `unknown` presne ako predtým.
+ * Viacvariantový produkt (viac veľkostí/farieb naraz) tento `data-testid`
+ * NEVYKRESĽUJE vôbec — vtedy sa nesmie nič uhádnuť z niektorej z viacerých
+ * zhôd, preto `whenRegionMissing: "unknown"`.
+ */
+function shoptetLabelAvailability(html: string): string | null {
+  const match = /<span\b[^>]*data-testid="labelAvailability"[^>]*>([\s\S]*?)<\/span>/i.exec(html);
+  if (match === null) return null;
+  const text = (match[1] ?? "").replace(/\s+/g, " ").trim();
+  return text === "" ? null : text;
+}
+
+/**
+ * fomei.com (issue 227): JSON-LD na stránke nie je Product/Offer (len
+ * breadcrumb), ale schema.org MIKRODÁTA (`<span class="availability
+ * availability--inStock|noStock">`) sa OPAKUJÚ naprieč stránkou — hlavný
+ * produkt aj karusel "Súvisiace" nižšie majú ROVNAKÚ triedu (rovnaká
+ * kolízia ako huntingshop.eu, issue 223). Preto sa hľadá LEN PRED nadpisom
+ * "Súvisiace" (rovnaký "prvý patrí hlavnému produktu" princíp ako odimon.sk,
+ * issue 225) a rozhoduje TRIEDA (`inStock`/`noStock`), nikdy viditeľný text
+ * (ten sa medzi produktmi líši — "na dotaz" pri `noStock`). Neznáma trieda
+ * ani chýbajúci prvok sa nikdy nehádaju na žiadnu stranu.
+ */
+function fomeiAvailabilityRegion(html: string): string | null {
+  const relatedIndex = html.indexOf(">Súvisiace<");
+  const scope = relatedIndex === -1 ? html : html.slice(0, relatedIndex);
+  const match = /<span\b[^>]*class="[^"]*\bavailability--(inStock|noStock)\b[^"]*"[^>]*>/i.exec(scope);
+  if (match === null) return null;
+  const token = (match[1] ?? "").toLowerCase();
+  if (token === "instock") return "skladom";
+  if (token === "nostock") return "vypredané";
+  return null;
+}
+
 const TEXT_AVAILABILITY_RULES: readonly TextAvailabilityRule[] = Object.freeze([
   { host: "huntingshop.eu", extractRegion: huntingshopDetailBadges, whenRegionMissing: "unavailable" },
   { host: "trigona.sk", extractRegion: trigonaStockRegion, whenRegionMissing: "unknown" },
+  { host: "virginiashop.sk", extractRegion: shoptetLabelAvailability, whenRegionMissing: "unknown" },
+  { host: "tenolix.cz", extractRegion: shoptetLabelAvailability, whenRegionMissing: "unknown" },
+  { host: "luko.cz", extractRegion: shoptetLabelAvailability, whenRegionMissing: "unknown" },
+  { host: "fomei.com", extractRegion: fomeiAvailabilityRegion, whenRegionMissing: "unknown" },
 ]);
 
 function textAvailabilityRuleFor(url: string): TextAvailabilityRule | null {
@@ -412,8 +463,44 @@ function lastingSizeList(html: string): readonly SizeAvailability[] {
   return result;
 }
 
+const CHIRUCA_SELECT_RE = /<select\b[^>]*\bid="simple-variants-select"[^>]*>([\s\S]*?)<\/select>/i;
+const CHIRUCA_OPTION_RE = /<option\b[^>]*>([\s\S]*?)<\/option>/gi;
+const CHIRUCA_SIZE_TEXT_RE = /^Veľkosť:\s*([^-]+?)\s*-\s*(.+)$/i;
+
+/**
+ * chiruca.sk (issue 227): `<select id="simple-variants-select">` nesie
+ * PRESNE JEDEN `<option>` na veľkosť, s veľkosťou aj dostupnosťou v tom
+ * istom viditeľnom texte ("Veľkosť: 38 - Vypredané (€100)") — na rozdiel
+ * od shop.lasting.eu tu netreba hľadať skupinovú hranicu ani popisok, celý
+ * `<select>` patrí jednému produktu. Placeholder `<option>` ("Zvoľte
+ * variant") nezačína "Veľkosť:", takže sa jednoducho preskočí bez
+ * osobitného rozlíšenia. Dostupnosť sa číta cez existujúci
+ * `availabilityFromText` (rovnaké slová "Skladom"/"Vypredané" ako inde),
+ * nikdy z `data-stock` atribútu — ten by bol dohad bez preukázateľného
+ * mapovania (`-1`/`-2`), zatiaľ čo text je to, čo naozaj vidí zákazník.
+ */
+function chirucaSizeList(html: string): readonly SizeAvailability[] {
+  const selectMatch = CHIRUCA_SELECT_RE.exec(html);
+  if (selectMatch === null) return [];
+  const body = selectMatch[1] ?? "";
+  const result: SizeAvailability[] = [];
+  for (const [, raw] of body.matchAll(CHIRUCA_OPTION_RE)) {
+    const clean = (raw ?? "").replace(/&nbsp;/gi, " ").replace(/\s+/g, " ").trim();
+    const sizeMatch = CHIRUCA_SIZE_TEXT_RE.exec(clean);
+    if (sizeMatch === null) continue;
+    const sizeLabel = (sizeMatch[1] ?? "").trim();
+    const rest = sizeMatch[2] ?? "";
+    if (sizeLabel === "") continue;
+    const { availability } = availabilityFromText(rest);
+    if (availability === "unknown") continue;
+    result.push({ sizeLabel, availability });
+  }
+  return result;
+}
+
 const SIZE_AVAILABILITY_RULES: readonly SizeAvailabilityRule[] = Object.freeze([
   { host: "shop.lasting.eu", read: lastingSizeList },
+  { host: "chiruca.sk", read: chirucaSizeList },
 ]);
 
 function sizeAvailabilityRuleFor(url: string): SizeAvailabilityRule | null {

--- a/apps/api/src/modules/supplier-stock/queries.ts
+++ b/apps/api/src/modules/supplier-stock/queries.ts
@@ -114,6 +114,36 @@ export async function listUnreadableHosts(db: Database): Promise<readonly Unread
     .sort((a, b) => b.count - a.count || a.host.localeCompare(b.host));
 }
 
+/** Jeden riadok prehľadu podľa domény (issue 227) — koľko odkazov sledujeme,
+ * koľko z nich sa dá prečítať, koľko `unknown`/zlyhalo, kedy naposledy
+ * potvrdené. Na rozdiel od `listUnreadableHosts` (len domény S PROBLÉMOM,
+ * pre kartu "Stránky, ktoré neviem prečítať") toto zobrazuje VŠETKY domény,
+ * aby bolo vidno, ktorá sa oplatí doplniť ako ĎALŠIA (zoradené podľa počtu
+ * odkazov klesajúco — presne ako ticket žiada). */
+export interface SupplierStockHostOverviewRow {
+  readonly host: string;
+  readonly total: number;
+  readonly readable: number;
+  readonly unknown: number;
+  readonly failed: number;
+  readonly lastConfirmedAt: Date | null;
+}
+
+export async function getSupplierStockHostOverview(db: Database): Promise<readonly SupplierStockHostOverviewRow[]> {
+  return db
+    .select({
+      host: supplierStock.host,
+      total: sql<number>`count(*)::int`,
+      readable: sql<number>`count(*) filter (where ${supplierStock.ok} and ${supplierStock.availability} != 'unknown')::int`,
+      unknown: sql<number>`count(*) filter (where ${supplierStock.ok} and ${supplierStock.availability} = 'unknown')::int`,
+      failed: sql<number>`count(*) filter (where not ${supplierStock.ok})::int`,
+      lastConfirmedAt: sql<Date | null>`max(${supplierStock.confirmedAt})`,
+    })
+    .from(supplierStock)
+    .groupBy(supplierStock.host)
+    .orderBy(desc(sql`count(*)`), asc(supplierStock.host));
+}
+
 /** Najnovšie kontroly — malý zoznam pre hlavičku obrazovky. */
 export async function listRecentChecks(db: Database, limit = 10): Promise<readonly SupplierStockRow[]> {
   return db

--- a/apps/api/src/modules/supplier-stock/queries.ts
+++ b/apps/api/src/modules/supplier-stock/queries.ts
@@ -141,6 +141,12 @@ export async function getSupplierStockHostOverview(db: Database): Promise<readon
     })
     .from(supplierStock)
     .groupBy(supplierStock.host)
+    // Skúšané odkazovať na `total` aliasom zo `select` vyššie (code review) —
+    // Postgres to nad TOUTO otázkou odmietol ("column total does not exist",
+    // naživo overené integračným testom): drizzle generuje `count(*)` ako
+    // samostatný `filter`-ovaný výraz vo `FILTER`-klauzule, nie ako obyčajný
+    // stĺpec dostupný v ORDER BY pod menom aliasu. Opakovaný `count(*)` je
+    // preto zámerný, nie prehliadnutý duplikát.
     .orderBy(desc(sql`count(*)`), asc(supplierStock.host));
 }
 

--- a/apps/api/src/modules/supplier-stock/run.ts
+++ b/apps/api/src/modules/supplier-stock/run.ts
@@ -4,11 +4,11 @@
 // (`huntingshop.eu`), takže paralelné sťahovanie by na ňu vyzeralo ako útok.
 // Medzi dvomi požiadavkami na tú istú doménu je pauza (`PER_HOST_DELAY_MS`).
 
-import { and, eq, isNotNull, notInArray } from "drizzle-orm";
+import { and, eq, isNotNull, like, notInArray, or } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
 import { products, supplierStock, variants } from "../../db/schema.js";
 import { extractSupplierLink } from "../catalog/supplier-link.js";
-import { MAX_AGE_HOURS, PER_HOST_DELAY_MS, SUPPLIER_STOCK_RUN_LOCK_KEY } from "./constants.js";
+import { MAX_AGE_HOURS, OWN_SHOP_HOST, PER_HOST_DELAY_MS, SUPPLIER_STOCK_RUN_LOCK_KEY } from "./constants.js";
 import type { PageFetcher } from "./page-fetcher.js";
 import {
   hostOf,
@@ -52,7 +52,15 @@ const defaultSleep = (ms: number): Promise<void> =>
     setTimeout(resolve, ms);
   });
 
-/** Unikátne dodávateľské linky z katalógu, v stabilnom poradí. */
+/** `true`, keď host (alebo jeho poddoména) patrí NÁŠMU VLASTNÉMU e-shopu —
+ * také odkazy nie sú dodávateľ, nikdy sa nescrapujú (issue 227). */
+function isOwnShopHost(host: string): boolean {
+  return host === OWN_SHOP_HOST || host.endsWith(`.${OWN_SHOP_HOST}`);
+}
+
+/** Unikátne dodávateľské linky z katalógu, v stabilnom poradí. Odkazy na NÁŠ
+ * VLASTNÝ e-shop (issue 227 — omylom vytiahnuté z `internalNote` tým istým
+ * regexom ako skutočné odkazy) sa sem nikdy nedostanú. */
 export async function collectSupplierLinks(db: Database): Promise<readonly string[]> {
   const rows = await db
     .select({ internalNote: products.internalNote })
@@ -61,9 +69,30 @@ export async function collectSupplierLinks(db: Database): Promise<readonly strin
   const links = new Set<string>();
   for (const row of rows) {
     const url = extractSupplierLink(row.internalNote).url;
-    if (url !== null && hostOf(url) !== "") links.add(url);
+    const host = url === null ? "" : hostOf(url);
+    if (url !== null && host !== "" && !isOwnShopHost(host)) links.add(url);
   }
   return [...links].sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * Počet odkazov na NÁŠ VLASTNÝ e-shop, extrahovaných živo z `internalNote`
+ * (issue 227) — pre obrazovku, aby vylúčenie nebolo tiché: majiteľ vidí,
+ * koľko odkazov sa NEscrapuje a prečo ("toto nie je dodávateľský odkaz").
+ * Počíta UNIKÁTNE odkazy, rovnaká jednotka ako `collectSupplierLinks`.
+ */
+export async function countOwnShopLinks(db: Database): Promise<number> {
+  const rows = await db
+    .select({ internalNote: products.internalNote })
+    .from(products)
+    .where(isNotNull(products.internalNote));
+  const links = new Set<string>();
+  for (const row of rows) {
+    const url = extractSupplierLink(row.internalNote).url;
+    const host = url === null ? "" : hostOf(url);
+    if (url !== null && host !== "" && isOwnShopHost(host)) links.add(url);
+  }
+  return links.size;
 }
 
 /**
@@ -130,6 +159,14 @@ interface StockRowInput {
 async function runSupplierStockLocked(options: RunSupplierStockOptions): Promise<SupplierStockRunResult> {
   const { db, now, fetchPage } = options;
   const sleep = options.sleep ?? defaultSleep;
+
+  // issue 227: staré riadky z BEHOV PRED touto opravou (keď sa vlastný
+  // e-shop ešte scrapoval) sa vymažú pri KAŽDOM behu — nikdy nemajú dôvod
+  // v tabuľke byť, takže ich ponechanie by ich tvárilo ako "nečitateľnú
+  // dodávateľskú doménu" navždy namiesto toho, aby jednoducho zmizli.
+  await db
+    .delete(supplierStock)
+    .where(or(eq(supplierStock.host, OWN_SHOP_HOST), like(supplierStock.host, `%.${OWN_SHOP_HOST}`)));
 
   const links = await collectSupplierLinks(db);
   const ourSizesByLink = await collectOurSizesByLink(db);

--- a/apps/api/tests/supplier-stock-http.integration.test.ts
+++ b/apps/api/tests/supplier-stock-http.integration.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, expect, it } from "vitest";
+import { users } from "../src/db/schema.js";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import type { PageFetchResult } from "../src/modules/supplier-stock/page-fetcher.js";
+import { runSupplierStock } from "../src/modules/supplier-stock/run.js";
+import { withCleanDb } from "./helpers/db.js";
+import { insertTestVariant } from "./helpers/orders.js";
+
+// issue 227: HTTP vrstva pre prehľad podľa domény + vylúčenie vlastného
+// e-shopu. Falošný `fetchPage` — nikdy skutočná dodávateľská stránka.
+const HESLO = "test-heslo-abc";
+
+let close: (() => Promise<void>) | undefined;
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  resetLoginRateLimit();
+});
+
+const IN_STOCK = `<script type="application/ld+json">
+  {"@type":"Product","offers":{"@type":"Offer","availability":"https://schema.org/InStock"}}
+</script>`;
+
+async function boot() {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await ctx.db.insert(users).values({
+    email: "pouzivatel@forestshop.sk",
+    passwordHash: await hashPassword(HESLO),
+    displayName: "Test",
+    role: "citanie",
+  });
+  const app = createApp(ctx.db, {
+    cookieSecure: false,
+    fetchSupplierPage: (): Promise<PageFetchResult> => Promise.resolve({ ok: true, html: IN_STOCK, httpStatus: 200, error: null }),
+  });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "pouzivatel@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie, db: ctx.db };
+}
+
+interface HostOverviewRow {
+  readonly host: string;
+  readonly total: number;
+  readonly readable: number;
+  readonly unknown: number;
+  readonly failed: number;
+  readonly lastConfirmedAt: string | null;
+}
+
+it("GET bez prihlásenia vráti 401", async () => {
+  const { app } = await boot();
+  const res = await app.request("/api/supplier-stock");
+  expect(res.status).toBe(401);
+});
+
+it("prehľad podľa domény je zoradený podľa počtu klesajúco a NEobsahuje vlastný e-shop, aj keď má odkazy", async () => {
+  const { app, db, cookie } = await boot();
+  await insertTestVariant(db, "M1", "Dod A", { internalNote: "https://huntingshop.eu/a" });
+  await insertTestVariant(db, "M2", "Dod A", { internalNote: "https://huntingshop.eu/b" });
+  await insertTestVariant(db, "M3", "Dod B", { internalNote: "https://wetland.sk/c" });
+  await insertTestVariant(db, "M4", "Dod C", { internalNote: "https://www.forestshop.sk/nas-produkt/" });
+
+  await runSupplierStock({
+    db,
+    now: new Date("2026-08-05T00:00:00.000Z"),
+    sleep: () => Promise.resolve(),
+    fetchPage: (): Promise<PageFetchResult> => Promise.resolve({ ok: true, html: IN_STOCK, httpStatus: 200, error: null }),
+  });
+
+  const res = await app.request("/api/supplier-stock", { headers: { cookie } });
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { hostOverview: HostOverviewRow[]; ownShopLinksCount: number };
+
+  expect(body.hostOverview.map((r) => r.host)).toEqual(["huntingshop.eu", "wetland.sk"]);
+  expect(body.hostOverview[0]).toMatchObject({ host: "huntingshop.eu", total: 2, readable: 2, unknown: 0, failed: 0 });
+  expect(body.ownShopLinksCount).toBe(1);
+});

--- a/apps/api/tests/supplier-stock-run.integration.test.ts
+++ b/apps/api/tests/supplier-stock-run.integration.test.ts
@@ -167,6 +167,54 @@ describe("beh dodávateľského skladu", () => {
     expect(h?.checkedAt.toISOString()).toBe(neskor.toISOString());
   });
 
+  // issue 227: `forestshop.sk` je náš vlastný e-shop, nie dodávateľ — omylom
+  // vytiahnutý z `internalNote` tým istým regexom ako skutočné odkazy.
+  it("odkaz na náš vlastný e-shop (forestshop.sk) sa vôbec nesťahuje", async () => {
+    await insertTestVariant(db, "J1", "Dod 10", {
+      internalNote: "https://www.forestshop.sk/polovnicke-tricko-dr-s-motivom-srnec/",
+    });
+    await insertTestVariant(db, "J2", "Dod 11", { internalNote: "https://huntingshop.eu/j" });
+
+    let volani = 0;
+    const result = await runSupplierStock({
+      db,
+      now: NOW,
+      sleep: noSleep,
+      fetchPage: () => {
+        volani += 1;
+        return Promise.resolve(okPage(IN_STOCK));
+      },
+    });
+
+    expect(result.total).toBe(1);
+    expect(volani).toBe(1);
+    expect(await row("https://www.forestshop.sk/polovnicke-tricko-dr-s-motivom-srnec/")).toBeUndefined();
+  });
+
+  // Staré riadky (z behu PRED touto opravou) sa nesmú tváriť ako čitateľná
+  // dodávateľská domena navždy — každý ďalší beh ich vyčistí.
+  it("staré riadky z predošlého behu pre forestshop.sk sa pri ďalšom behu vymažú", async () => {
+    await insertTestVariant(db, "K1", "Dod 12", { internalNote: "https://huntingshop.eu/k" });
+    await db.insert(supplierStock).values({
+      link: "https://www.forestshop.sk/stary-odkaz/",
+      sizeLabel: "",
+      host: "forestshop.sk",
+      availability: "unknown",
+      availabilityText: "",
+      price: null,
+      source: "none",
+      ok: true,
+      error: null,
+      httpStatus: 200,
+      checkedAt: NOW,
+      confirmedAt: null,
+    });
+
+    await runSupplierStock({ db, now: NOW, sleep: noSleep, fetchPage: () => Promise.resolve(okPage(IN_STOCK)) });
+
+    expect(await row("https://www.forestshop.sk/stary-odkaz/")).toBeUndefined();
+  });
+
   it("tá istá linka na viacerých produktoch sa sťahuje len raz", async () => {
     await insertTestVariant(db, "I1", "Dod 9", { internalNote: "https://huntingshop.eu/spolocna" });
     await insertTestVariant(db, "I2", "Dod 9", { internalNote: "https://huntingshop.eu/spolocna" });

--- a/apps/web/src/components/SupplierStockSection.test.tsx
+++ b/apps/web/src/components/SupplierStockSection.test.tsx
@@ -60,6 +60,11 @@ const STATUS = {
   unreadable: [
     { host: "dogtrace.com", count: 2, samples: [{ link: "https://dogtrace.com/obojok", sizeLabel: "" }] },
   ],
+  hostOverview: [
+    { host: "huntingshop.eu", total: 200, readable: 195, unknown: 3, failed: 2, lastConfirmedAt: "2026-08-03T04:20:00.000Z" },
+    { host: "shop.lasting.eu", total: 38, readable: 20, unknown: 18, failed: 0, lastConfirmedAt: "2026-08-03T04:20:00.000Z" },
+  ],
+  ownShopLinksCount: 21,
   lastRun: {
     startedAt: "2026-08-03T04:20:00.000Z",
     finishedAt: "2026-08-03T04:41:00.000Z",
@@ -111,6 +116,40 @@ it("bez nečitateľných stránok povie, že je všetko v poriadku", async () =>
   render(<SupplierStockSection role="admin" onSessionExpired={vi.fn()} />);
 
   expect((await screen.findByTestId("ss-unreadable")).textContent).toContain("Zatiaľ žiadne");
+});
+
+// issue 227: prehľad podľa domény — koľko odkazov, koľko sa číta, aby bolo
+// vidno, ktorú doménu je najviac hodno doplniť ako ďalšiu.
+it("ukáže prehľad podľa domény zoradený podľa počtu odkazov klesajúco", async () => {
+  fetchSupplierStockStatus.mockResolvedValue(STATUS);
+  render(<SupplierStockSection role="admin" onSessionExpired={vi.fn()} />);
+
+  const karta = await screen.findByTestId("ss-host-overview");
+  expect(karta.textContent).toContain("huntingshop.eu");
+  expect(karta.textContent).toContain("shop.lasting.eu");
+  const domeny = karta.querySelectorAll("tbody tr");
+  expect(domeny[0]?.textContent).toContain("huntingshop.eu");
+  expect(domeny[1]?.textContent).toContain("shop.lasting.eu");
+  expect(screen.getByTestId("ss-host-huntingshop.eu").textContent).toContain("200");
+  expect(screen.getByTestId("ss-host-huntingshop.eu").textContent).toContain("195");
+});
+
+// Vylúčenie vlastného e-shopu (issue 227) nesmie byť tiché — majiteľ vidí,
+// koľko odkazov sa NEscrapuje a prečo.
+it("ukáže počet odkazov na vlastný e-shop, vylúčených z kontroly", async () => {
+  fetchSupplierStockStatus.mockResolvedValue(STATUS);
+  render(<SupplierStockSection role="admin" onSessionExpired={vi.fn()} />);
+
+  const notice = await screen.findByTestId("ss-own-shop-links");
+  expect(notice.textContent).toContain("21");
+});
+
+it("bez odkazov na vlastný e-shop sa upozornenie nezobrazí", async () => {
+  fetchSupplierStockStatus.mockResolvedValue({ ...STATUS, ownShopLinksCount: 0 });
+  render(<SupplierStockSection role="admin" onSessionExpired={vi.fn()} />);
+
+  await screen.findByTestId("ss-total");
+  expect(screen.queryByTestId("ss-own-shop-links")).toBeNull();
 });
 
 it("„Spustiť teraz\" spustí kontrolu a znovu načíta prehľad", async () => {

--- a/apps/web/src/components/SupplierStockSection.tsx
+++ b/apps/web/src/components/SupplierStockSection.tsx
@@ -87,7 +87,7 @@ export function SupplierStockSection({
   if (!loaded) return <p role="status">Načítavam…</p>;
   if (status === null) return <p role="alert">{error === "" ? "Nepodarilo sa načítať." : error}</p>;
 
-  const { overview, unreadable, rows, lastRun } = status;
+  const { overview, unreadable, rows, hostOverview, ownShopLinksCount, lastRun } = status;
 
   return (
     <div data-testid="supplier-stock-section">
@@ -130,6 +130,12 @@ export function SupplierStockSection({
         )}
       </div>
 
+      {ownShopLinksCount > 0 && (
+        <p data-testid="ss-own-shop-links">
+          Vlastný e-shop (nie dodávateľ): {ownShopLinksCount} odkazov vylúčených z kontroly.
+        </p>
+      )}
+
       <p data-testid="ss-last-checked">Naposledy kontrolované: {formatDateTime(overview.lastCheckedAt)}</p>
       {lastRun !== null && (
         <p data-testid="ss-last-run">
@@ -171,6 +177,41 @@ export function SupplierStockSection({
                       </div>
                     ))}
                   </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {/* issue 227: prehľad po doménach — na rozdiel od karty vyššie (len
+          domény S PROBLÉMOM) toto ukazuje VŠETKY sledované domény, aby bolo
+          vidno, ktorú sa oplatí doplniť ako ĎALŠIU. */}
+      <div className="card" data-testid="ss-host-overview">
+        <h3>Prehľad podľa domény</h3>
+        {hostOverview.length === 0 ? (
+          <p className="empty">Zatiaľ nič — kontrola ešte nebežala.</p>
+        ) : (
+          <table>
+            <thead>
+              <tr>
+                <th scope="col">Doména</th>
+                <th scope="col">Odkazov</th>
+                <th scope="col">Číta sa</th>
+                <th scope="col">Neviem</th>
+                <th scope="col">Zlyhalo</th>
+                <th scope="col">Naposledy potvrdené</th>
+              </tr>
+            </thead>
+            <tbody>
+              {hostOverview.map((host) => (
+                <tr key={host.host} data-testid={`ss-host-${host.host}`}>
+                  <td>{host.host}</td>
+                  <td>{host.total}</td>
+                  <td>{host.readable}</td>
+                  <td>{host.unknown}</td>
+                  <td>{host.failed}</td>
+                  <td>{formatDateTime(host.lastConfirmedAt)}</td>
                 </tr>
               ))}
             </tbody>

--- a/apps/web/src/supplierStockApi.ts
+++ b/apps/web/src/supplierStockApi.ts
@@ -34,6 +34,19 @@ const unreadableSchema = z.object({
 });
 export type UnreadableHost = z.infer<typeof unreadableSchema>;
 
+// issue 227: prehľad podľa domény — VŠETKY sledované domény (na rozdiel od
+// `unreadableSchema` vyššie, ktorá je len pre domény S PROBLÉMOM), zoradené
+// podľa počtu odkazov klesajúco.
+const hostOverviewRowSchema = z.object({
+  host: z.string(),
+  total: z.number(),
+  readable: z.number(),
+  unknown: z.number(),
+  failed: z.number(),
+  lastConfirmedAt: z.string().nullable(),
+});
+export type HostOverviewRow = z.infer<typeof hostOverviewRowSchema>;
+
 const runResultSchema = z.object({
   total: z.number(),
   skipped: z.number(),
@@ -57,6 +70,8 @@ const statusSchema = z.object({
   }),
   rows: z.array(rowSchema),
   unreadable: z.array(unreadableSchema),
+  hostOverview: z.array(hostOverviewRowSchema),
+  ownShopLinksCount: z.number(),
   lastRun: z
     .object({
       startedAt: z.string(),

--- a/apps/web/tests/e2e/supplier-stock.spec.ts
+++ b/apps/web/tests/e2e/supplier-stock.spec.ts
@@ -29,10 +29,15 @@ test("prehľad podľa domény ukáže virginiashop.sk aj upozornenie na vlastný
 
   const karta = page.getByTestId("ss-host-overview");
   await expect(karta).toBeVisible();
+  // Stĺpce (`SupplierStockSection.tsx`): Doména/Odkazov/Číta sa/Neviem/Zlyhalo/…
+  // — zámerne overené PO BUNKÁCH (nie len `toContainText` na celom riadku),
+  // aby zhoda netrafila náhodou aj časovú pečiatku v poslednom stĺpci.
   const riadokDomeny = page.getByTestId("ss-host-virginiashop.sk");
   await expect(riadokDomeny).toBeVisible();
-  await expect(riadokDomeny).toContainText("2"); // odkazov spolu
-  await expect(riadokDomeny).toContainText("1"); // z toho čitateľných
+  const bunky = riadokDomeny.locator("td");
+  await expect(bunky.nth(1)).toHaveText("2"); // odkazov spolu
+  await expect(bunky.nth(2)).toHaveText("1"); // z toho čitateľných
+  await expect(bunky.nth(3)).toHaveText("1"); // unknown
 
   // Vlastný e-shop sa nikdy nescrapuje, ale odkaz sa ukáže ako vylúčený.
   await expect(page.getByTestId("ss-own-shop-links")).toContainText("1");

--- a/apps/web/tests/e2e/supplier-stock.spec.ts
+++ b/apps/web/tests/e2e/supplier-stock.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "@playwright/test";
+
+const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
+const E2E_DOMENY_EMAIL = "e2e-domeny@forestshop.sk"; // musí sa zhodovať s hodnotou v scripts/e2e-setup.ts
+
+// issue 227: prehľad podľa domény + vylúčenie vlastného e-shopu. Seedovaná
+// v `scripts/e2e-setup.ts`: `virginiashop.sk` má DVA `supplier_stock` riadky
+// (jeden čitateľný, jeden `unknown`), tretí produkt má odkaz na
+// `www.forestshop.sk` (náš vlastný e-shop, nikdy sa nezapisuje do
+// `supplier_stock` — počíta sa živo z `internalNote`).
+test("prehľad podľa domény ukáže virginiashop.sk aj upozornenie na vlastný e-shop; konzola je čistá", async ({
+  page,
+}) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/");
+  await page.getByLabel("E-mail").fill(E2E_DOMENY_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+
+  await page.getByRole("button", { name: "Dodávateľský sklad" }).click();
+  await expect(page.getByRole("heading", { name: "Dodávateľský sklad" })).toBeVisible();
+
+  const karta = page.getByTestId("ss-host-overview");
+  await expect(karta).toBeVisible();
+  const riadokDomeny = page.getByTestId("ss-host-virginiashop.sk");
+  await expect(riadokDomeny).toBeVisible();
+  await expect(riadokDomeny).toContainText("2"); // odkazov spolu
+  await expect(riadokDomeny).toContainText("1"); // z toho čitateľných
+
+  // Vlastný e-shop sa nikdy nescrapuje, ale odkaz sa ukáže ako vylúčený.
+  await expect(page.getByTestId("ss-own-shop-links")).toContainText("1");
+
+  // forestshop.sk sa NESMIE objaviť medzi sledovanými doménami v prehľade.
+  await expect(page.getByTestId("ss-host-forestshop.sk")).toHaveCount(0);
+
+  expect(chyby).toEqual([]);
+});

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -2755,3 +2755,39 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   repozitár), žiadny produktový blok sa nezobrazil. Konzola čistá počas
   celého overovania. Issue zavreté ručne s dôkazom, Discord run-card
   odoslaná.
+
+## 2026-08-05 — #227 (Scraper — 5 nových domén + vylúčenie vlastného e-shopu)
+
+- Solo ticket. Overenie naživo (produkčná DB): `supplier_stock` 2305 riadkov,
+  629 `unknown` (mierne viac než ticket's 601 — nové odkazy medzičasom).
+  Design comment PRED prvým commitom:
+  https://github.com/zbynekdrlik/forestshop-app/issues/227#issuecomment-5186182379
+  — root cause: `parsePage` dôveruje voľnému textu/veľkostiam LEN na
+  registrovaných doménach (issue 223/225 disciplína), cieľové domény tam
+  jednoducho neboli. Zamietnutá alternatíva: slepo dôverovať JSON-LD/mikro-
+  dátam na celej stránke bez obmedzenia na hlavný produkt (rovnaká chyba,
+  akú issue 223/225 už raz opravili).
+- Version bump `d44fb6e` (0.3.0-dev.142→.143), prvý commit.
+- TDD (4 RED→GREEN páry): `94a2896`→`4c4d3f2` (5 domén v `parse.ts`:
+  virginiashop.sk/tenolix.cz/luko.cz zdieľaná Shoptet šablóna
+  `data-testid="labelAvailability"`, fomei.com mikrodata pred "Súvisiace",
+  chiruca.sk zoznam veľkostí v `<select>`), `1698bcd`→`2b97513` (vylúčenie
+  + čistenie forestshop.sk), `2f1bb0d`→`d2b455a` (GET vracia hostOverview/
+  ownShopLinksCount), `d68f2a2`→`9b313f6` (obrazovka — nová karta + upozor-
+  nenie). `pnpm test` (571+413), `pnpm test:integration` (476, novo
+  pridaný `supplier-stock-http.integration.test.ts` — dovtedy pre túto
+  trasu žiadny integračný test neexistoval), `pnpm --filter @forestshop/web
+  e2e` (37, nový `supplier-stock.spec.ts` s izolovaným účtom
+  `e2e-domeny@forestshop.sk`) — všetko zelené pred pushom.
+- `luko.cz` má naživo overenú len zelenú vetvu (35 z 36 sledovaných odkazov
+  sú viacveľkostné produkty bez `data-testid`, ostávajú `unknown`) —
+  zdokumentované ako zámerný, čiastočný pokrok v `.claude/rules/
+  supplier-stock.md`, nie tichá medzera.
+- `superpowers:requesting-code-review` (base `46a87eb8` → head `b977e50`):
+  0 Critical, 1 Important (chýbajúci tento log — doplnené týmto commitom),
+  5 Minor (duplicitná scan logika `collectSupplierLinks`/`countOwnShopLinks`
+  — ponechané, MVP filozofia, žiadny spoločný volajúci; redundantný
+  `count(*)` v ORDER BY — SKÚSENÉ nahradiť aliasom `total`, Postgres to
+  odmietol `column total does not exist` cez drizzle-ov `FILTER`-generovaný
+  SQL, vrátené späť a zdokumentované; slabšia e2e asercia na celý riadok —
+  spresnené na konkrétne `<td>` bunky). PR #249.

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -2715,3 +2715,43 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   reálny dôkaz, že linka dorazila do Shoptet administrácie. Konzola čistá
   počas celého overovania. Issue zavreté ručne s dôkazom, Discord run-card
   odoslaná.
+
+## Issue 240 — Eshop → Vyhľadať (nový, 2026-08-05)
+
+- Návrh (pred prvým commitom): dve oddelené polia `GET /api/search`
+  (produkty ILIKE kód/názov/dodávateľ/externalCode, objednávky ILIKE
+  číslo/meno/e-mail, žiadna umelá relevance logika) + nová READ-ONLY
+  `GET /api/product-detail/:productKey` (všetky varianty + efektívna linka
+  + adresa u nás + dostupnosť u dodávateľa). Editácia linky ide cez
+  EXISTUJÚcu `POST /api/product-links/:productKey` (#239) — žiadna nová
+  zapisovacia cesta. Zamietnutá alternatíva: rozšíriť skrytú `CatalogPage`
+  namiesto novej záložky (riziko regresie `catalog.spec.ts`, zliatie dvoch
+  odlišných úloh). Komentáre na tickete #240 (validácia + návrh + review).
+- TDD: `search-http.integration.test.ts` (11 testov), `product-detail-http
+  .integration.test.ts` (8 testov), `SearchSection.test.tsx` (10 testov),
+  `search.spec.ts` (e2e, find→open→edit→save→verify). `pnpm test` (970),
+  `pnpm test:integration` (472), `pnpm --filter @forestshop/web e2e` (36) —
+  všetko zelené pred pushom.
+- Nová záložka "Vyhľadať" v `nav.ts` kolidovala substring-om s existujúcimi
+  `getByRole("button", {name:"Hľadať"})` v `catalog.spec.ts` (Sidebar je
+  vždy namountovaný) — opravené `{exact:true}` na strane existujúceho
+  (užšieho) locatora, zapísané do `.claude/rules/testing.md`. `catalog
+  .spec.ts`'s pevné počty variantov posunuté +1 (nový sellable produkt
+  e2e fixtúry). `nav.test.ts`/`nav.spec.ts` na 11 záložiek.
+- `superpowers:requesting-code-review` (base `ca4c4fd` → head `f8b330e`):
+  0 Critical, 0 Important, 2 Minor (žiadny integračný test priamo pre
+  `escapeLikePattern` cez `/api/search`; kozmetické preformátovanie
+  jedného riadku v `e2e-setup.ts` kvôli eslint `max-lines`). PR #248,
+  merge `46a87eb8`.
+- Naživo overené na `forestshop-novy.newlevel.media` (v0.3.0-dev.142):
+  hľadanie podľa časti názvu ("OPASOK LYNX"/"Nohavice") našlo reálne
+  produkty, detail otvoril 6 variantov "01 Nohavice ALASKA YUKON" so
+  skutočnými cenami/skladom; efektívna linka produktu "OPASOK LYNX"
+  (`https://www.tthunt.sk/...`) sa zhodovala s "Párovanie produktov"'s
+  zobrazením toho istého produktu. Úprava (na tú istú hodnotu, aby sa
+  nezmenili reálne dáta) prešla, stav sa zmenil na "⏳ Uložené, čaká na
+  odoslanie". Hľadanie podľa reálneho čísla objednávky ("20261296") našlo
+  presne tú objednávku (meno/e-mail zákazníka zámerne nezverejnené, verejný
+  repozitár), žiadny produktový blok sa nezobrazil. Konzola čistá počas
+  celého overovania. Issue zavreté ručne s dôkazom, Discord run-card
+  odoslaná.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.142",
+  "version": "0.3.0-dev.143",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -165,6 +165,11 @@ const E2E_PREPINANIE_EMAIL = "e2e-prepinanie@forestshop.sk"; // musí sa zhodova
 // e-shopu"/"Súhrn o objednávaní") dostáva VLASTNÝ izolovaný účet.
 const E2E_PREHLAD_EMAIL = "e2e-prehlad@forestshop.sk"; // musí sa zhodovať s hodnotou v orders-overview.spec.ts
 
+// issue 227: rovnaký mechanizmus a dôvod ako `E2E_PREPINANIE_EMAIL` vyššie —
+// nový spec súbor (`supplier-stock.spec.ts` — prehľad podľa domény + vlastný
+// e-shop) dostáva VLASTNÝ izolovaný účet.
+const E2E_DOMENY_EMAIL = "e2e-domeny@forestshop.sk"; // musí sa zhodovať s hodnotou v supplier-stock.spec.ts
+
 const { db, pool } = createDb();
 // Konštantný literál bez interpolácie — obyčajný reťazec je tu rovnako bezpečný
 // ako `sql` tagovaná šablóna (tú používa ekvivalentný apps/api/tests/helpers/db.ts),
@@ -211,24 +216,9 @@ await db.insert(users).values({ email: "e2e@forestshop.sk", passwordHash: await 
 // Rovnaké počiatočné heslo a zobrazované meno ako vyššie (žiadny test naň
 // nespolieha ako na odlišujúci znak) — jediný rozdiel je e-mail, ktorý ho robí
 // SAMOSTATNÝM riadkom v `users`, izolovaným od zdieľaného účtu vyššie.
-await db.insert(users).values({
-  email: E2E_HESLO_ZMENA_EMAIL,
-  passwordHash: await hashPassword(E2E_HESLO),
-  displayName: "E2E Manažér",
-  role: "manazer",
-});
-await db.insert(users).values({
-  email: E2E_SKUPINY_EMAIL,
-  passwordHash: await hashPassword(E2E_HESLO),
-  displayName: "E2E Manažér",
-  role: "manazer",
-});
-await db.insert(users).values({
-  email: E2E_NAV_EMAIL,
-  passwordHash: await hashPassword(E2E_HESLO),
-  displayName: "E2E Manažér",
-  role: "manazer",
-});
+await db.insert(users).values({ email: E2E_HESLO_ZMENA_EMAIL, passwordHash: await hashPassword(E2E_HESLO), displayName: "E2E Manažér", role: "manazer" });
+await db.insert(users).values({ email: E2E_SKUPINY_EMAIL, passwordHash: await hashPassword(E2E_HESLO), displayName: "E2E Manažér", role: "manazer" });
+await db.insert(users).values({ email: E2E_NAV_EMAIL, passwordHash: await hashPassword(E2E_HESLO), displayName: "E2E Manažér", role: "manazer" });
 await db.insert(users).values({
   email: E2E_OTVORENE_STAVY_EMAIL,
   passwordHash: await hashPassword(E2E_HESLO),
@@ -330,6 +320,12 @@ await db.insert(users).values({
   passwordHash: await hashPassword(E2E_HESLO),
   displayName: "E2E Manažér",
   role: "manazer",
+});
+await db.insert(users).values({
+  email: E2E_DOMENY_EMAIL,
+  passwordHash: await hashPassword(E2E_HESLO),
+  displayName: "E2E Čítanie",
+  role: "citanie",
 });
 
 // Katalóg pre E2E: tá istá commitnutá fixtúra ako v jednotkových testoch, cez tú istú
@@ -716,6 +712,21 @@ await db.insert(shopProductUrl).values({
   availability: "in stock",
   fetchedAt: teraz,
 });
+
+// issue 227: dva produkty pre "Prehľad podľa domény" + vylúčenie vlastného
+// e-shopu — VLASTNÉ kódy, ktoré sa v žiadnom inom spec súbore nevyskytujú.
+// `virginiashop.sk` má DVA riadky v `supplier_stock` (jeden čitateľný, jeden
+// `unknown`), aby prehľad ukázal total=2/readable=1/unknown=1. Odkaz na
+// `forestshop.sk` sa NIKDY nezapisuje do `supplier_stock` (run.ts ho
+// vylučuje) — počíta sa živo z `internalNote`, žiadny riadok netreba.
+async function seedDomenaProdukt(key: string, name: string, internalNote: string): Promise<void> {
+  await db.insert(products).values({ key, name, internalNote, firstSeenAt: teraz, lastSeenAt: teraz, lastSeenSnapshotId: snapshotPrepinanie });
+}
+await seedDomenaProdukt("e2e-domeny-1", "E2E Nôž (virginiashop.sk)", "https://www.virginiashop.sk/e2e-domeny/noz-1/");
+await seedDomenaProdukt("e2e-domeny-2", "E2E Nôž (virginiashop.sk, druhý)", "https://www.virginiashop.sk/e2e-domeny/noz-2/");
+await seedDomenaProdukt("e2e-domeny-vlastny", "E2E Vlastný produkt (forestshop.sk)", "https://www.forestshop.sk/e2e-domeny-vlastny-produkt/");
+await db.insert(supplierStock).values({ link: "https://www.virginiashop.sk/e2e-domeny/noz-1/", host: "virginiashop.sk", availability: "available", availabilityText: "Skladom", source: "text", ok: true, httpStatus: 200, checkedAt: teraz, confirmedAt: teraz });
+await db.insert(supplierStock).values({ link: "https://www.virginiashop.sk/e2e-domeny/noz-2/", host: "virginiashop.sk", availability: "unknown", availabilityText: "", source: "none", ok: true, httpStatus: 200, checkedAt: teraz, confirmedAt: null });
 
 // issue 237: JEDNA objednávka pre "Prehľad e-shopu" (dnes/tento
 // týždeň/tento mesiac) — `placedAt: teraz` (rovnaké "teraz" ako mail_log


### PR DESCRIPTION
## Čo rieši (issue 227)

Scraper dodávateľskej dostupnosti nevedel prečítať 601+ odkazov (celé domény
bez podpory) a 21 odkazov omylom mieril na náš vlastný e-shop namiesto na
dodávateľa.

- **Vylúčenie vlastného e-shopu** — odkazy na `forestshop.sk` sa už nikdy
  nescrapujú (`collectSupplierLinks`), staré riadky sa pri každom behu
  vyčistia, počet vylúčených odkazov sa ukazuje na obrazovke.
- **5 nových domén** (podľa ticketu): `virginiashop.sk`, `tenolix.cz`,
  `luko.cz` (zdieľaná Shoptet šablóna `data-testid="labelAvailability"`),
  `fomei.com` (schema.org mikrodáta, čítané LEN pred nadpisom "Súvisiace" —
  rovnaká karuselová kolízia ako huntingshop.eu), `chiruca.sk` (zoznam
  veľkostí v `<select>`).
- **Prehľad podľa domény** na obrazovke — koľko odkazov, koľko sa číta, koľko
  `unknown`/zlyhalo, kedy naposledy potvrdené, zoradené podľa počtu klesajúco.

`luko.cz` má overenú len zelenú vetvu naživo a väčšina jej sledovaných
odkazov je viacveľkostných (bez `data-testid`), takže ostáva prevažne
`unknown` — zdokumentované v `.claude/rules/supplier-stock.md`, mimo rozsahu
tohto PR by bolo mapovanie číselných JS parameter-ID na veľkosť.

## Zvyšné nepodporené domény (naprieč zvyšnými ~30)

Naživo zmerané 5. 8. 2026 (`supplier_stock` po tomto nasadení bude mať tieto
ešte stále `unknown`, kým sa nedoplní podpora): `zubicek.cz` 134,
`tatragoat.sk` 22, `lovuzdar.cz` 21 (čiastočne), `rappa.cz` 21,
`rosler.sk` 20, `hunting24.cz` 20 (čiastočne), `soxland.sk` 13,
`b2b.orbis-textil.de` 11, `betalov.sk` 11, `werra.cz` 12, `huntingland.sk` 8,
`citrade.cz` 6, `chocolenka.cz` 5, `vreckovynoz.sk` 4, `termovel.sk` 4,
`b2b.outhunt.eu` 2, `b2b.emos.sk` 1, `vo.rapier.sk` 1, `b2b.lasting.eu` 1 —
zapísané aj do ticketu.

## Testy

- `parse.test.ts` — 8 nových testov (5 domén, obe polarity kde overené,
  karuselová kolízia fomei.com, viacvariantový fallback na `unknown`).
- `supplier-stock-run.integration.test.ts` — vylúčenie + čistenie starých
  riadkov.
- `supplier-stock-http.integration.test.ts` — nová (dosiaľ žiadna
  neexistovala) — GET vracia `hostOverview`/`ownShopLinksCount`.
- `SupplierStockSection.test.tsx` — nová karta + upozornenie.
- `supplier-stock.spec.ts` — nový e2e (izolovaný účet `e2e-domeny@…`),
  overuje prehľad + vylúčenie vlastného e-shopu naživo v prehliadači.

issue 227
