### PR TITLE
fix: extractRegion dostava url, trigonaStockRegion krizovo overi ID produktu (issue 241)

### DIFF
--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -196,3 +196,16 @@ paths:
   proti reálnej DB predtým, než tomu dôveruješ — "vyzerá to ako správny SQL
   text v zdrojáku" nestačí, JS parsing šablóny beží PRED tým, než sa
   reťazec vôbec dostane k drizzle.
+- **`.orderBy(...)` sa NESMIE odvolávať na `select`-ov ALIAS pomenovaný
+  agregátnym `count(*) filter (where ...)` výrazom cez `sql\`aliasMeno\``
+  — drizzle taký alias negeneruje ako bežný výstupný stĺpec, Postgres
+  vráti `column "aliasMeno" does not exist` (issue 227, naživo overené
+  integračným testom, `supplier-stock/queries.ts`'s
+  `getSupplierStockHostOverview`). Code review navrhol `desc(sql\`total\`)`
+  namiesto opakovaného `desc(sql\`count(*)\`)` ako "menej duplicitné" — pri
+  reálnom behu to zhodilo `GET /api/supplier-stock` na 500. Fix: vrátiť sa
+  k opakovanému `count(*)`/inému AGREGÁTNEMU VÝRAZU priamo v `ORDER BY`,
+  nikdy sa nespoliehať na alias z `FILTER`-ovaného `sql` výrazu. Test na
+  KAŽDÝ ĎALŠÍ pokus "zjednodušiť" `ORDER BY` odkazom na alias z podobného
+  agregátu: over PRIAMO integračným testom proti reálnej DB (nie len že
+  `tsc`/`eslint` prejdú) — statická kontrola typov toto nezachytí.

--- a/.claude/rules/deploy.md
+++ b/.claude/rules/deploy.md
@@ -288,3 +288,21 @@ paths:
   starý kontajner a nasadenie je v tej chvíli už hotové — neuprataný obraz
   nesmie zhodiť úspešný deploy. Krok beží PRED overením verzie, aby miesto
   uvoľnil ešte v tom istom behu.
+
+- **Cloudflare tunel má VLASTNÝ proxy timeout (~100 s) na verejnom
+  `forestshop-novy.newlevel.media` — dlho bežiaci manuálny POST (napr.
+  supplier-stock "⚡ Spustiť teraz" nad stovkami odkazov) dostane naň
+  klientsky HTTP 524, hoci appka na `app:3000` beh POKRAČUJE ĎALEJ
+  server-side (issue 227, naživo overené).** Node/Hono handler nesleduje
+  zatvorenie klientskeho spojenia (žiadny `req.on("close")`/abort-signal na
+  tejto ceste), takže Cloudflare-ov 524 NIE JE zlyhanie behu — je to len
+  strata KLIENTSKEJ odpovede. Overenie, či beh naozaj pokračuje/dobehol, ide
+  MIMO tunela, priamo cez SSH na dev2 (`.claude/rules/database.md`'s
+  `postgres` service dopyt) — `pg_locks` filtrovaný na konkrétny advisory
+  kľúč (`SELECT count(*) FROM pg_locks WHERE locktype='advisory' AND
+  ((classid::bigint << 32) | objid::bigint) = <kľúč>;`, `1` = stále beží,
+  `0` = dobehol) je spoľahlivejší dôkaz než čokoľvek, čo prehliadač po 524
+  ukáže. Test na KAŽDÝ ďalší manuálny "Spustiť teraz"/dlho bežiaci POST cez
+  tento tunel: neber klientsku chybu/timeout ako dôkaz zlyhania behu — over
+  server-side stav (advisory zámok, `job_run`, alebo priamo cieľová
+  tabuľka) predtým, než sa čokoľvek reštartuje/opakuje.

--- a/.claude/rules/supplier-stock.md
+++ b/.claude/rules/supplier-stock.md
@@ -223,6 +223,29 @@ paths:
   nízka aj po tejto zmene; skutočný pokrok by vyžadoval mapovanie
   číselných JS parameter-ID na konkrétnu veľkosť (podobné, ale iné, než
   `shop.lasting.eu`'s `title=""` atribút), mimo rozsahu tohto ticketu.
+- **Per-domain textový extraktor (`TextAvailabilityRule.extractRegion`,
+  `parse.ts`), ktorého markup nesie ČÍSELNÉ ID produktu (napr. trigona.sk's
+  `id="StockCountText<ID>"`), MUSÍ toto ID krížovo overiť proti ID/slugu v
+  scrapovanej `url` — nikdy sa nespoliehať LEN na empirický dôkaz "na N
+  vzorkách sa vyskytlo vždy práve raz" (issue 241, code review na issue
+  230).** `extractRegion` dostáva od issue 241 aj `url`
+  (`(html, url) => string | null`); `trigonaStockRegion` vytiahne číslo
+  produktu z `p-<ID>.xhtml` a cez `matchAll` (nie `.exec`) prejde VŠETKY
+  výskyty, vyberie ten, čo sedí — inak by súvisiaci produkt s rovnakou
+  značkou VYŠŠIE na stránke dal ISTO ZLÚ odpoveď, nie `unknown`. Dva
+  zhodné-ID výskyty s ROZDIELNOU farbou sú tiež nejednoznačné → `unknown`
+  (rovnaká disciplína ako `matchSizeLabel`). Extraktor BEZ takého ID v
+  markupe (napr. `huntingshopDetailBadges`'s CSS-triedové vylúčenie,
+  `fomeiAvailabilityRegion`'s "pred nadpisom Súvisiace") `url` nepotrebuje
+  a nemusí ho ani deklarovať vo svojej signatúre — funkcia s menej
+  parametrami je platný podtyp funkcie s viac parametrami v TypeScripte.
+  **Reálne uložené trigona.sk odkazy v tomto repozitári sú často
+  KATEGÓRIOVÉ** (`https://trigona.sk/smith-s/polovnicke/c199`,
+  `supplier-link.test.ts`), nie `p-<ID>.xhtml` — vtedy sa ID vôbec
+  nevytiahne a text fallback je vždy `unknown`, aj keď stránka nesie
+  platný štítok (zámerné, nie regresia — over pri ĎALŠOM podobnom
+  extraktore, či reálne uložené odkazy vôbec majú tvar, z ktorého sa dá
+  ID vytiahnuť).
 - **Český tvar "Momentálně nedostupné" (mäkké `ě`) je INÝ reťazec než
   slovenské "momentálne nedostupné" — `OUT_KEYWORDS` (`parse.ts`) potrebuje
   OBA, `.includes()` porovnanie nevidí medzi nimi žiadnu podobnosť** (issue

--- a/apps/api/src/modules/supplier-stock/fixtures/trigona-skladom-10x42-sahara.html
+++ b/apps/api/src/modules/supplier-stock/fixtures/trigona-skladom-10x42-sahara.html
@@ -4,10 +4,13 @@
   (v skutočnosti trigona.sk JSON-LD nesie a preto sa v produkcii takmer vždy
   vyhodnotí skôr — táto fixtúra izoluje LEN textovú/vizuálnu úroveň, presne
   ako existujúce huntingshop.eu fixtúry). `id="StockCountText<ID>"` nesie
-  ČÍSLO produktu (1217729 = z URL), takže žiadna kolízia s karuselom nehrozí
-  — na 31 naživo overených produktových stránkach sa tento prvok vyskytol
-  vždy práve raz. Zelená farba `#00b020` s textom "Na sklade" zodpovedá
-  JSON-LD `InStock` na TOM ISTOM produkte.
+  ČÍSLO produktu (1217729 = z URL) — pôvodne (issue 230) sa kolízia s
+  karuselom vylučovala len empiricky (31 naživo overených stránok, vždy
+  práve jeden výskyt); od issue 241 `trigonaStockRegion` toto ČÍSLO
+  KRÍŽOVO OVERUJE proti `p-<ID>.xhtml` v URL (štruktúrna záruka, nie len
+  empirický dôkaz) a vyberá si zhodný výskyt aj keby ich stránka niesla
+  viac. Zelená farba `#00b020` s textom "Na sklade" zodpovedá JSON-LD
+  `InStock` na TOM ISTOM produkte.
 -->
 <html lang="sk">
 <head><title>10x42 Sahara | Distribútor pre SR - TRIGONA.sk</title></head>

--- a/apps/api/src/modules/supplier-stock/parse.test.ts
+++ b/apps/api/src/modules/supplier-stock/parse.test.ts
@@ -323,7 +323,8 @@ describe("parsePage — issue 230: trigona.sk cita farebny StockCountText stitok
     // stranke (presne scenar z tela ticketu 241) — prvy stitok patri inemu
     // produktu (zelena/skladom), az druhy stitok sedi s ID v URL (modra/
     // vypredane). Bez ID krizovej kontroly by prvy-v-poradi vyhral a vratil
-    // by ISTO ZLU odpoved namiesto unknown.
+    // by ZLU odpoved ("available") namiesto spravnej odpovede z druheho
+    // stitku ("unavailable").
     const html =
       '<span id="StockCountText555">' +
       '<span style="color: #00b020">Na sklade</span></span>' +
@@ -331,6 +332,28 @@ describe("parsePage — issue 230: trigona.sk cita farebny StockCountText stitok
       '<span style="color: #024bbd">1 - 4 tyzdne</span></span>';
     const result = parsePage(html, "https://www.trigona.sk/eshop/8x56-ed-savannah/p-1215478.xhtml");
     expect(result.availability).toBe("unavailable");
+  });
+
+  it("issue 241: dva zhodne-ID stitky s ROZDIELNOU farbou su nejednoznacne — unknown, nikdy hadanie podla prveho", () => {
+    // Rovnaka disciplina ako matchSizeLabel (viac nez jedna zhoda = ziadna).
+    const html =
+      '<span id="StockCountText1217729">' +
+      '<span style="color: #00b020">Na sklade</span></span>' +
+      '<span id="StockCountText1217729">' +
+      '<span style="color: #024bbd">1 - 4 tyzdne</span></span>';
+    const result = parsePage(html, "https://www.trigona.sk/eshop/10x42-sahara/p-1217729.xhtml");
+    expect(result.availability).toBe("unknown");
+  });
+
+  it("issue 241: kategoriova URL (bez p-<ID>.xhtml, realny tvar ulozenych trigona odkazov) je vzdy unknown, aj ked stranka ma platny stitok", () => {
+    // Realne ulozene trigona.sk odkazy v tomto repozitari su casto
+    // KATEGORIOVE (napr. "https://trigona.sk/smith-s/polovnicke/c199",
+    // supplier-link.test.ts), nie produktove p-<ID>.xhtml — vtedy sa ID z
+    // URL vobec nevytiahne, takze sa nikdy nesmie hadat podla prveho
+    // stitku na stranke.
+    const html = '<span id="StockCountText1217729"><span style="color: #00b020">Na sklade</span></span>';
+    const result = parsePage(html, "https://trigona.sk/smith-s/polovnicke/c199");
+    expect(result.availability).toBe("unknown");
   });
 });
 

--- a/apps/api/src/modules/supplier-stock/parse.test.ts
+++ b/apps/api/src/modules/supplier-stock/parse.test.ts
@@ -308,6 +308,30 @@ describe("parsePage — issue 230: trigona.sk cita farebny StockCountText stitok
     const result = parsePage(html, "https://www.trigona.sk/eshop/nieco/p-42.xhtml");
     expect(result.availability).toBe("unknown");
   });
+
+  it("issue 241: StockCountText<ID> sa NEZHODUJE s ID v URL — unknown, nikdy dohad z prveho vyskytu", () => {
+    // Simuluje situaciu z tela ticketu: nasiel sa stitok, ale patri INEMU
+    // produktu (napr. suvisiaci produkt vyssie na stranke), nie tomu, ktory
+    // scrapujeme (url hovori o produkte 1217729, stitok je pre ine cislo).
+    const html = '<span id="StockCountText9999999"><span style="color: #00b020">Na sklade</span></span>';
+    const result = parsePage(html, "https://www.trigona.sk/eshop/10x42-sahara/p-1217729.xhtml");
+    expect(result.availability).toBe("unknown");
+  });
+
+  it("issue 241: dva StockCountText stitky na stranke — vyberie sa TEN, co sedi s ID v URL, nikdy prvy v poradi", () => {
+    // Hypoteticky karuselovy/suvisiaci produkt s rovnakym markupom VYSSIE na
+    // stranke (presne scenar z tela ticketu 241) — prvy stitok patri inemu
+    // produktu (zelena/skladom), az druhy stitok sedi s ID v URL (modra/
+    // vypredane). Bez ID krizovej kontroly by prvy-v-poradi vyhral a vratil
+    // by ISTO ZLU odpoved namiesto unknown.
+    const html =
+      '<span id="StockCountText555">' +
+      '<span style="color: #00b020">Na sklade</span></span>' +
+      '<span id="StockCountText1215478">' +
+      '<span style="color: #024bbd">1 - 4 tyzdne</span></span>';
+    const result = parsePage(html, "https://www.trigona.sk/eshop/8x56-ed-savannah/p-1215478.xhtml");
+    expect(result.availability).toBe("unavailable");
+  });
 });
 
 describe("parsePage — issue 227: virginiashop.sk/tenolix.cz/luko.cz zdieľaná Shoptet šablóna (data-testid=labelAvailability)", () => {

--- a/apps/api/src/modules/supplier-stock/parse.ts
+++ b/apps/api/src/modules/supplier-stock/parse.ts
@@ -295,25 +295,28 @@ const TRIGONA_PRODUCT_ID_RE = /\/p-(\d+)\.xhtml/i;
  * `OutOfStock`. Farba sa prekladá na kanonické slovo, aby prešlo
  * existujúcim `availabilityFromText` zoznamom kľúčových slov.
  *
- * Nerozpoznaná farba, nerozobrateľné ID z URL, ANI chýbajúci/nezhodný
- * prvok sa NEHÁDŽE na žiadnu stranu — vracia sa `null` (`whenRegionMissing:
- * "unknown"` nižšie). Na rozdiel od huntingshop.eu, kde je naživo overené,
- * že vypredaný produkt štítok vôbec nemá, sa na trigona.sk medzi overenými
- * vzorkami nikdy nevyskytla stránka bez tohto prvku — preto tu niet dôkazu,
- * čo by chýbajúci štítok znamenal.
+ * Nerozpoznaná farba, nerozobrateľné ID z URL, chýbajúci/nezhodný prvok,
+ * ANI DVA zhodné-ID výskyty s ROZDIELNOU farbou (nejednoznačné, rovnaká
+ * disciplína ako `matchSizeLabel`: viac než jedna zhoda sa počíta ako
+ * žiadna) sa NEHÁDŽU na žiadnu stranu — vracia sa `null`
+ * (`whenRegionMissing: "unknown"` nižšie). Na rozdiel od huntingshop.eu,
+ * kde je naživo overené, že vypredaný produkt štítok vôbec nemá, sa na
+ * trigona.sk medzi overenými vzorkami nikdy nevyskytla stránka bez tohto
+ * prvku — preto tu niet dôkazu, čo by chýbajúci štítok znamenal.
  */
 function trigonaStockRegion(html: string, url: string): string | null {
   const productId = TRIGONA_PRODUCT_ID_RE.exec(url)?.[1];
   if (productId === undefined) return null;
+  const resolved = new Set<string>();
   for (const match of html.matchAll(TRIGONA_STOCK_COUNT_RE)) {
     const [, id, colorRaw] = match;
     if (id !== productId) continue;
     const color = (colorRaw ?? "").toLowerCase();
-    if (color === "#00b020") return "skladom";
-    if (color === "#024bbd") return "vypredané";
-    return null;
+    if (color === "#00b020") resolved.add("skladom");
+    else if (color === "#024bbd") resolved.add("vypredané");
   }
-  return null;
+  const values = [...resolved];
+  return values.length === 1 ? (values[0] ?? null) : null;
 }
 
 /**

--- a/apps/api/src/modules/supplier-stock/parse.ts
+++ b/apps/api/src/modules/supplier-stock/parse.ts
@@ -239,8 +239,15 @@ export function fromMetaTags(html: string): SchemaHit | null {
 
 interface TextAvailabilityRule {
   readonly host: string;
-  /** Vyberie z CELEJ stránky LEN oblasť s dostupnosťou TOHTO produktu. `null` = oblasť sa nenašla. */
-  readonly extractRegion: (html: string) => string | null;
+  /**
+   * Vyberie z CELEJ stránky LEN oblasť s dostupnosťou TOHTO produktu. `null`
+   * = oblasť sa nenašla. `url` (issue 241) je k dispozícii pre extraktory,
+   * ktoré vedia krížovo overiť nájdenú oblasť proti ID/slugu SCRAPOVANÉHO
+   * produktu (napr. `trigonaStockRegion`) — extraktor, ktorý takú kontrolu
+   * nepotrebuje (má vlastnú štruktúrnu záruku inak, napr. CSS triedu), ho
+   * jednoducho nemusí deklarovať vo svojej signatúre.
+   */
+  readonly extractRegion: (html: string, url: string) => string | null;
   /** Čo znamená CHÝBAJÚCA oblasť (žiadny štítok pri produkte). */
   readonly whenRegionMissing: SupplierAvailability;
 }
@@ -264,37 +271,48 @@ function huntingshopDetailBadges(html: string): string | null {
   return texts.length > 0 ? texts.join(" ") : null;
 }
 
+const TRIGONA_STOCK_COUNT_RE =
+  /<span\b[^>]*\bid="StockCountText(\d+)"[^>]*>\s*<span\b[^>]*\bstyle="[^"]*color:\s*(#[0-9a-fA-F]{6})[^"]*"[^>]*>/gi;
+const TRIGONA_PRODUCT_ID_RE = /\/p-(\d+)\.xhtml/i;
+
 /**
- * trigona.sk (issue 230): dostupnosť PRI produkte nesie `<span
- * id="StockCountText<ID>">` s vnoreným `<span style="color: …">` — `<ID>`
- * je ČÍSLO KONKRÉTNEHO produktu z URL, takže na rozdiel od huntingshop.eu
- * tu nehrozí žiadna karuselová kolízia (overené naživo: na 31 rôznych
- * produktových stránkach naprieč viacerými kategóriami sa tento prvok
- * vyskytol VŽDY práve raz). Farba rozhoduje o dostupnosti — obe polarity sú
- * naživo overené proti JSON-LD na TOM ISTOM produkte: `#00b020` (zelená,
- * text "Na sklade") zodpovedá JSON-LD `InStock`; `#024bbd` (modrá, text
- * "1 - 4 týždne" — dodacia lehota, nie doslovné slovo "vypredané")
- * zodpovedá JSON-LD `OutOfStock`. Farba sa prekladá na kanonické slovo, aby
- * prešlo existujúcim `availabilityFromText` zoznamom kľúčových slov.
+ * trigona.sk (issue 230, ID krížová kontrola issue 241): dostupnosť PRI
+ * produkte nesie `<span id="StockCountText<ID>">` s vnoreným `<span
+ * style="color: …">` — `<ID>` je ČÍSLO KONKRÉTNEHO produktu, ktoré sa MUSÍ
+ * zhodovať s ID v URL (`.../p-<ID>.xhtml`), inak sa oblasť nepovažuje za
+ * patriacu scrapovanému produktu. Predtým (issue 230) sa bral PRVÝ výskyt v
+ * dokumente bez tejto kontroly — fungovalo to len vďaka empirickému dôkazu
+ * (31 naživo overených stránok, vždy práve jeden výskyt), nie vďaka
+ * štruktúrnej záruke. Keby trigona.sk niekedy pridala súvisiaci produkt s
+ * rovnakou značkou VYŠŠIE na stránke, prvý-v-poradí by bol ISTO ZLÁ
+ * odpoveď — preto sa teraz prechádzajú VŠETKY výskyty a vyberie sa ten,
+ * ktorého `<ID>` sedí s URL.
  *
- * Nerozpoznaná farba ANI chýbajúci prvok sa NEHÁDŽE na žiadnu stranu —
- * vracia sa `null` (`whenRegionMissing: "unknown"` nižšie). Na rozdiel od
- * huntingshop.eu, kde je naživo overené, že vypredaný produkt štítok vôbec
- * nemá, sa na trigona.sk medzi overenými vzorkami nikdy nevyskytla stránka
- * bez tohto prvku — preto tu niet dôkazu, čo by chýbajúci štítok znamenal.
+ * Farba rozhoduje o dostupnosti — obe polarity sú naživo overené proti
+ * JSON-LD na TOM ISTOM produkte: `#00b020` (zelená, text "Na sklade")
+ * zodpovedá JSON-LD `InStock`; `#024bbd` (modrá, text "1 - 4 týždne" —
+ * dodacia lehota, nie doslovné slovo "vypredané") zodpovedá JSON-LD
+ * `OutOfStock`. Farba sa prekladá na kanonické slovo, aby prešlo
+ * existujúcim `availabilityFromText` zoznamom kľúčových slov.
+ *
+ * Nerozpoznaná farba, nerozobrateľné ID z URL, ANI chýbajúci/nezhodný
+ * prvok sa NEHÁDŽE na žiadnu stranu — vracia sa `null` (`whenRegionMissing:
+ * "unknown"` nižšie). Na rozdiel od huntingshop.eu, kde je naživo overené,
+ * že vypredaný produkt štítok vôbec nemá, sa na trigona.sk medzi overenými
+ * vzorkami nikdy nevyskytla stránka bez tohto prvku — preto tu niet dôkazu,
+ * čo by chýbajúci štítok znamenal.
  */
-function trigonaStockRegion(html: string): string | null {
-  // `[^>]*` okolo id/style (rovnaký vzor ako huntingshopDetailBadges/
-  // odimonVisibleAvailability nižšie) toleruje ďalšie atribúty aj iné
-  // poradie — nie len presne ten tvar, aký mali naživo overené vzorky.
-  const match =
-    /<span\b[^>]*\bid="StockCountText\d+"[^>]*>\s*<span\b[^>]*\bstyle="[^"]*color:\s*(#[0-9a-fA-F]{6})[^"]*"[^>]*>/i.exec(
-      html,
-    );
-  if (match === null) return null;
-  const color = (match[1] ?? "").toLowerCase();
-  if (color === "#00b020") return "skladom";
-  if (color === "#024bbd") return "vypredané";
+function trigonaStockRegion(html: string, url: string): string | null {
+  const productId = TRIGONA_PRODUCT_ID_RE.exec(url)?.[1];
+  if (productId === undefined) return null;
+  for (const match of html.matchAll(TRIGONA_STOCK_COUNT_RE)) {
+    const [, id, colorRaw] = match;
+    if (id !== productId) continue;
+    const color = (colorRaw ?? "").toLowerCase();
+    if (color === "#00b020") return "skladom";
+    if (color === "#024bbd") return "vypredané";
+    return null;
+  }
   return null;
 }
 
@@ -605,7 +623,7 @@ export function parsePage(html: string, url: string): ParsedPage {
 
   const textRule = textAvailabilityRuleFor(url);
   if (textRule !== null) {
-    const region = textRule.extractRegion(html);
+    const region = textRule.extractRegion(html, url);
     if (region === null) {
       return { availability: textRule.whenRegionMissing, availabilityText: "", price: null, source: "text" };
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.143",
+  "version": "0.3.0-dev.144",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.144",
+  "version": "0.3.0-dev.145",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Čo a prečo

Code review na issue 230 (trigona.sk textový výrez dostupnosti) upozornil
na architektonickú medzeru: `TextAvailabilityRule.extractRegion` dostával
len `html`, nikdy `url` — žiadny extraktor nevedel overiť, či nájdená
oblasť dostupnosti patrí SKUTOČNE scrapovanému produktu. `trigonaStockRegion`
bral prvý `<span id="StockCountText<ID>">` výskyt v celom dokumente bez
kontroly ID — fungovalo to len vďaka empirickému dôkazu (31 naživo
overených stránok, vždy práve jeden výskyt), nie vďaka štruktúrnej záruke.

## Čo sa zmenilo

- `TextAvailabilityRule.extractRegion` je teraz `(html, url) => string |
  null`; `parsePage` posiela `url`, ktoré už malo v scope.
- `trigonaStockRegion` vytiahne číslo produktu z URL (`p-<ID>.xhtml`) a
  prejde VŠETKY `StockCountText<ID>` výskyty (`matchAll`), vyberie ten, čo
  sedí s URL — nezhoda ide na `unknown`, nikdy dohad z prvého výskytu.
- Ostatné extraktory (`huntingshopDetailBadges`, `shoptetLabelAvailability`,
  `fomeiAvailabilityRegion`) `url` nepotrebujú a signatúru nemenia — v
  TypeScripte je funkcia s menej parametrami platný podtyp funkcie s viac
  parametrami.
- `VisibleAvailabilityRule.read` (odimon.sk) sa nemení — jeho pravidlo už
  stavia na štruktúrnej záruke (dokumentový poriadok), odimon.sk-ove URL
  nemajú číselné ID na krížové overenie.

## Testy (RED → GREEN)

Dva nové prípady v `apps/api/src/modules/supplier-stock/parse.test.ts`:
1. Nezhodné ID medzi URL a `StockCountText<ID>` → `unknown` (predtým
   `available`, zlá odpoveď).
2. Dva `StockCountText` výskyty na stránke (simulácia karuselovej kolízie
   z tela ticketu) → vyberie sa ten, čo sedí s URL, nie prvý (predtým prvý
   vyhral, zlá odpoveď).

RED confirmed pred fixom (`git show 92b91af`), GREEN po ňom (`git show
8199e1b`).

## Lokálne overenie

- `pnpm typecheck` — čisté
- `pnpm lint` — čisté
- `pnpm --filter @forestshop/api test` — 573 pass
- `pnpm --filter @forestshop/api test:integration` — 476 pass
- `pnpm --filter @forestshop/web test` — 413 pass
- `pnpm --filter @forestshop/web e2e` — 37 pass

## Poznámka k zavretiu ticketu

Ticket issue 241 nemá post-deploy live-verifikačnú podmienku vyžadujúcu
CUDZIE prihlásenie — ale má vlastnú požiadavku overiť správanie proti
NASADENEJ appke po deploji (test proti reálnej trigona.sk HTML fixtúre
cez nasadený kontajner). Preto sa ticket NEZATVÁRA automaticky týmto PR —
telo zámerne nenesie žiadny "Closes"/"Fixes" tvar, zatvorí sa ručne po
post-deploy overení.

issue 241
