### PR TITLE
fix: odstranit mŕtvy stĺpec product.related_codes (issue 245)

### DIFF
--- a/.claude/rules/nedostupne.md
+++ b/.claude/rules/nedostupne.md
@@ -33,10 +33,11 @@ paths:
   vyhľadávacím fallbackom, keď appka nemala skutočnú produktovú URL.**
   Majiteľ tento CELÝ mechanizmus zamietol: *"nechcem aby to uvádzalo tieto
   náhrady - je to blbosť, to sú súvisiace produkty - nie podobné, nie
-  náhrady"*. Nahradené RUČNÝMI odkazmi (bod nižšie) — `product.related_codes`
-  stĺpec + jeho import (`map-row.ts`/`ingest.ts`) ostávajú v kóde (mimo scope
-  cross-cutting zásahu do katalógového importu), ale appka ich už NIKDE
-  nečíta — follow-up na úplné odstránenie: issue 245.
+  náhrady"*. Nahradené RUČNÝMI odkazmi (bod nižšie). **issue 245 (2026-08-05)
+  dokončilo follow-up: `product.related_codes` stĺpec + celé jeho populovanie
+  (`map-row.ts`'s `extractRelatedCodes`/`RELATED_COLUMNS`/`MAX_ALTERNATIVES`,
+  `ingest.ts`'s insert/upsert) sú ÚPLNE ODSTRÁNENÉ (incremental migrácia
+  `0033_breezy_manta.sql`) — v kóde už neexistujú vôbec, nielen nečítané.
 - **issue 238: majiteľove RUČNE vložené odkazy náhrad —
   `nedostupne_replacement_link` (`variant_code` PLAIN text bez FK, rovnaká
   konvencia ako `nedostupne_state`; `url`; ŽIADNY unique index).** Kľúčované
@@ -68,6 +69,6 @@ paths:
   `.claude/rules/scheduler.md`'s registry MUSÍ byť aktualizovaný pri KAŽDOM
   novom kľúči — 005 (`order-reminder`) aj 006 (toto issue) tam predtým
   chýbali, hoci kód sám kolízii predišiel správne.
-- **`insertTestVariantForProduct` (`tests/helpers/orders.ts`) teraz podporuje
-  `relatedCodes` — nová automatizácia/test potrebujúci alternatívy nemusí
-  vkladať produkt/variant ručne, len odovzdať `{ relatedCodes: [...] }`.**
+- **`insertTestVariantForProduct` (`tests/helpers/orders.ts`) NEMÁ od issue 245
+  `relatedCodes` voľbu — odstránená spolu s celým `product.related_codes`
+  stĺpcom (žiadny existujúci test ju reálne používal).**

--- a/apps/api/drizzle/0033_breezy_manta.sql
+++ b/apps/api/drizzle/0033_breezy_manta.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "product" DROP COLUMN "related_codes";

--- a/apps/api/drizzle/meta/0033_snapshot.json
+++ b/apps/api/drizzle/meta/0033_snapshot.json
@@ -1,0 +1,2551 @@
+{
+  "id": "fab63f79-cbf2-4f13-804e-aafddc6ec5d3",
+  "prevId": "5ed2f876-136a-49be-96b3-e78844a7d70c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_code": {
+          "name": "external_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_open_status": {
+      "name": "order_open_status",
+      "schema": "",
+      "columns": {
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Vybavuje sa'"
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop_remark": {
+          "name": "shop_remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shoptet_order_id": {
+          "name": "shoptet_order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_updated_at": {
+          "name": "comment_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_synced_at": {
+          "name": "comment_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_carrier_name": {
+          "name": "shipping_carrier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_price_with_vat": {
+          "name": "total_price_with_vat",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_link_override": {
+      "name": "product_supplier_link_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_link_override_product_key_product_key_fk": {
+          "name": "product_supplier_link_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_link_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_override": {
+      "name": "product_supplier_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_override_product_key_product_key_fk": {
+          "name": "product_supplier_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing": {
+      "name": "pairing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_url": {
+          "name": "supplier_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "pairing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'navrhnute'"
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pairing_state_idx": {
+          "name": "pairing_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_confirmed_by_idx": {
+          "name": "pairing_confirmed_by_idx",
+          "columns": [
+            {
+              "expression": "confirmed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_variant_code_variant_code_fk": {
+          "name": "pairing_variant_code_variant_code_fk",
+          "tableFrom": "pairing",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pairing_confirmed_by_users_id_fk": {
+          "name": "pairing_confirmed_by_users_id_fk",
+          "tableFrom": "pairing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pairing_variant_code_unique": {
+          "name": "pairing_variant_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pairing_confirmation_ck": {
+          "name": "pairing_confirmation_ck",
+          "value": "(\"pairing\".\"state\" = 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)\n        OR (\"pairing\".\"state\" != 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NULL AND \"pairing\".\"confirmed_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier": {
+      "name": "supplier",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wholesale_base_url": {
+          "name": "wholesale_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_key": {
+          "name": "adapter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_settings": {
+      "name": "posta_uncollected_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_state": {
+      "name": "posta_uncollected_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notify_count": {
+          "name": "notify_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_state": {
+          "name": "terminal_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_settings": {
+      "name": "order_reminder_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_state": {
+      "name": "order_reminder_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_replacement_link": {
+      "name": "nedostupne_replacement_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nedostupne_replacement_link_variant_idx": {
+          "name": "nedostupne_replacement_link_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_state": {
+      "name": "nedostupne_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "nedostupne_email_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nedostupne_state_order_variant_type_uq": {
+          "name": "nedostupne_state_order_variant_type_uq",
+          "columns": [
+            {
+              "expression": "order_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template_history": {
+      "name": "mail_template_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "mail_template_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_template_history_key_idx": {
+          "name": "mail_template_history_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_template_history_changed_by_user_id_users_id_fk": {
+          "name": "mail_template_history_changed_by_user_id_users_id_fk",
+          "tableFrom": "mail_template_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template": {
+      "name": "mail_template",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail_template_updated_by_user_id_users_id_fk": {
+          "name": "mail_template_updated_by_user_id_users_id_fk",
+          "tableFrom": "mail_template",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_log": {
+      "name": "mail_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "mail_log_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_log_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "mail_log_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_log_created_idx": {
+          "name": "mail_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_log_source_created_idx": {
+          "name": "mail_log_source_created_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_log_actor_user_id_users_id_fk": {
+          "name": "mail_log_actor_user_id_users_id_fk",
+          "tableFrom": "mail_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_stock": {
+      "name": "supplier_stock",
+      "schema": "",
+      "columns": {
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "supplier_availability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "supplier_stock_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "supplier_stock_host_idx": {
+          "name": "supplier_stock_host_idx",
+          "columns": [
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "supplier_stock_avail_idx": {
+          "name": "supplier_stock_avail_idx",
+          "columns": [
+            {
+              "expression": "availability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "supplier_stock_link_size_label_pk": {
+          "name": "supplier_stock_link_size_label_pk",
+          "columns": [
+            "link",
+            "size_label"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_event": {
+      "name": "restock_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_link": {
+          "name": "supplier_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_availability_text": {
+          "name": "supplier_availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "supplier_price": {
+          "name": "supplier_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "restock_event_at_idx": {
+          "name": "restock_event_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "restock_event_variant_idx": {
+          "name": "restock_event_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_settings": {
+      "name": "restock_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shop_product_url": {
+      "name": "shop_product_url",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne"
+      ]
+    },
+    "public.pairing_state": {
+      "name": "pairing_state",
+      "schema": "public",
+      "values": [
+        "navrhnute",
+        "potvrdene"
+      ]
+    },
+    "public.nedostupne_email_type": {
+      "name": "nedostupne_email_type",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "alternativa"
+      ]
+    },
+    "public.mail_template_action": {
+      "name": "mail_template_action",
+      "schema": "public",
+      "values": [
+        "save",
+        "reset"
+      ]
+    },
+    "public.mail_log_source": {
+      "name": "mail_log_source",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "posta_uncollected",
+        "order_reminder",
+        "supplier_order"
+      ]
+    },
+    "public.mail_log_status": {
+      "name": "mail_log_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.mail_log_trigger": {
+      "name": "mail_log_trigger",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "manual"
+      ]
+    },
+    "public.supplier_availability": {
+      "name": "supplier_availability",
+      "schema": "public",
+      "values": [
+        "available",
+        "unavailable",
+        "unknown"
+      ]
+    },
+    "public.supplier_stock_source": {
+      "name": "supplier_stock_source",
+      "schema": "public",
+      "values": [
+        "json_ld",
+        "meta",
+        "text",
+        "size_list",
+        "none"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1785874055555,
       "tag": "0032_tiresome_matthew_murdock",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1785902714427,
+      "tag": "0033_breezy_manta",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema-catalog.ts
+++ b/apps/api/src/db/schema-catalog.ts
@@ -97,17 +97,6 @@ export const products = pgTable(
     // (`modules/catalog/supplier-link.ts`), nikdy pri importe — žiadny ďalší
     // odvodený stĺpec, žiadne riziko rozídenia sa algoritmu a uložených dát.
     internalNote: text("internal_note"),
-    // issue 176: kódy NÁHRADNÝCH produktov, export's `relatedProduct`/
-    // `relatedProduct2`..`relatedProduct8` (stará appka's `nedostupne.py`'s
-    // `_RELATED_COLS` — PRVÝ je bare `relatedProduct`, nie `relatedProduct1`).
-    // Vlastnosť PRODUKTU (rovnaká úvaha ako `internalNote` vyššie — na
-    // reálnej fixtúre má KAŽDÁ veľkosť toho istého produktu zhodnú hodnotu),
-    // nie variantu. Každý kód je surový (variant `code` ALEBO `pairCode` —
-    // rieši sa až pri čítaní, `modules/nedostupne/queries.ts`), max 8 prvkov
-    // (`MAX_ALTERNATIVES`, `modules/catalog/map-row.ts`). `null` = žiadny
-    // náhradný tovar priradený (nikdy prázdne pole — rozlišuje "nevieme" od
-    // "explicitne žiadny", rovnaký zámer ako `internalNote`'s `null`).
-    relatedCodes: text("related_codes").array(),
     firstSeenAt: timestamp("first_seen_at", { withTimezone: true }).notNull(),
     lastSeenAt: timestamp("last_seen_at", { withTimezone: true }).notNull(),
     lastSeenSnapshotId: uuid("last_seen_snapshot_id")

--- a/apps/api/src/db/schema-nedostupne.ts
+++ b/apps/api/src/db/schema-nedostupne.ts
@@ -30,19 +30,18 @@ export const nedostupneState = pgTable(
 
 // issue 238: majiteľ, doslovne "nechcem aby to uvádzalo tieto náhrady - je to
 // blbosť, to sú súvisiace produkty - nie podobné, nie náhrady" — automatický
-// návrh (`product.related_codes`, vyššie zavrhnutý celý mechanizmus) sa ruší
-// a nahrádza RUČNÝMI odkazmi, ktoré majiteľ sám vloží. Kľúčovaná
-// `variant_code` (PLAIN text, BEZ FK — rovnaká konvencia ako `nedostupne_state`
-// vyššie), NIE dvojicou (objednávka, variant): obrazovka zoskupuje podľa
-// VARIANTU (`NedostupneGroup`), majiteľov nákres dáva pole PRI KAŽDOM TOVARE
-// (skupina), nie pri každom čakajúcom zákazníckom riadku — inak by musel ten
-// istý odkaz vpisovať znova pre každú objednávku toho istého tovaru. ŽIADNY
-// unique index na `variant_code` — viac riadkov s rovnakým kódom = viac
-// liniek na ten istý tovar, presne požiadavka "musí sa dať vložiť viac".
-// Prežije nočný katalógový reimport rovnako ako `nedostupne_state`/
-// `mail_template` — import sa tejto tabuľky vôbec nedotýka (`product.
-// related_codes`/jeho import OSTÁVA nedotknutý, len appka ho už nikde
-// nečíta — zámerné mimo scope, viď návrhový komentár na tickete).
+// návrh (pôvodne `product.related_codes`) sa ruší a nahrádza RUČNÝMI odkazmi,
+// ktoré majiteľ sám vloží. Kľúčovaná `variant_code` (PLAIN text, BEZ FK —
+// rovnaká konvencia ako `nedostupne_state` vyššie), NIE dvojicou (objednávka,
+// variant): obrazovka zoskupuje podľa VARIANTU (`NedostupneGroup`), majiteľov
+// nákres dáva pole PRI KAŽDOM TOVARE (skupina), nie pri každom čakajúcom
+// zákazníckom riadku — inak by musel ten istý odkaz vpisovať znova pre každú
+// objednávku toho istého tovaru. ŽIADNY unique index na `variant_code` — viac
+// riadkov s rovnakým kódom = viac liniek na ten istý tovar, presne požiadavka
+// "musí sa dať vložiť viac". Prežije nočný katalógový reimport rovnako ako
+// `nedostupne_state`/`mail_template` — import sa tejto tabuľky vôbec nedotýka.
+// `product.related_codes` samotný stĺpec (mŕtvy kód po tomto zrušení) bol
+// následne úplne odstránený issue 245.
 export const nedostupneReplacementLinks = pgTable(
   "nedostupne_replacement_link",
   {

--- a/apps/api/src/modules/catalog/ingest.ts
+++ b/apps/api/src/modules/catalog/ingest.ts
@@ -230,11 +230,11 @@ export async function ingestCatalog(
 
   // Beží bez ohľadu na úspech parsovania — pri zlyhaní je `records` prázdne pole,
   // takže je to no-op (nič sa neprepočítava druhýkrát).
-  const productValues = new Map<string, { name: string; supplier: string | null; internalNote: string | null; relatedCodes: readonly string[] }>();
+  const productValues = new Map<string, { name: string; supplier: string | null; internalNote: string | null }>();
   for (const record of records) {
     const known = productValues.get(record.productKey);
     if (known === undefined) {
-      productValues.set(record.productKey, { name: record.name, supplier: record.supplier, internalNote: record.internalNote, relatedCodes: record.relatedCodes });
+      productValues.set(record.productKey, { name: record.name, supplier: record.supplier, internalNote: record.internalNote });
       continue;
     }
     if (known.name !== record.name) {
@@ -370,8 +370,6 @@ export async function ingestCatalog(
               name: value.name,
               supplier: value.supplier,
               internalNote: value.internalNote,
-              // issue 176: prázdne pole → `null` (rovnaký zámer ako `internalNote`).
-              relatedCodes: value.relatedCodes.length === 0 ? null : [...value.relatedCodes],
               firstSeenAt: options.now,
               lastSeenAt: options.now,
               lastSeenSnapshotId: snapshotId,
@@ -383,7 +381,6 @@ export async function ingestCatalog(
               name: sql`excluded.name`,
               supplier: sql`excluded.supplier`,
               internalNote: sql`excluded.internal_note`,
-              relatedCodes: sql`excluded.related_codes`,
               lastSeenAt: options.now,
               lastSeenSnapshotId: snapshotId,
             },

--- a/apps/api/src/modules/catalog/map-row.test.ts
+++ b/apps/api/src/modules/catalog/map-row.test.ts
@@ -307,6 +307,15 @@ describe("mapRow — číselné hranice stĺpcov (mimo rozsah = anomália, riado
   });
 });
 
+// issue 245: `product.related_codes` je po #238 mŕtvy kód (žiadny čitateľ) —
+// `mapRow` už nesmie vracať pole `relatedCodes` vôbec.
+describe("mapRow už nevracia relatedCodes (issue 245)", () => {
+  it("record neobsahuje kľúč relatedCodes", () => {
+    const { record } = mapRow(fixtureRow("40287"));
+    expect(record).not.toHaveProperty("relatedCodes");
+  });
+});
+
 // issue 176: náhradné produkty (`relatedProduct`/`relatedProduct2..8`).
 describe("extractRelatedCodes / relatedCodes na reálnej fixtúre", () => {
   it("na fixtúre '40287' vráti jeden priradený náhradný kód", () => {

--- a/apps/api/src/modules/catalog/map-row.test.ts
+++ b/apps/api/src/modules/catalog/map-row.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { parseShoptetCsv } from "./csv.js";
-import { extractRelatedCodes, mapRow, splitCode } from "./map-row.js";
+import { mapRow, splitCode } from "./map-row.js";
 
 const FIXTURE = readFileSync(
   fileURLToPath(new URL("./fixtures/shoptet-sample.csv", import.meta.url)),
@@ -316,37 +316,3 @@ describe("mapRow už nevracia relatedCodes (issue 245)", () => {
   });
 });
 
-// issue 176: náhradné produkty (`relatedProduct`/`relatedProduct2..8`).
-describe("extractRelatedCodes / relatedCodes na reálnej fixtúre", () => {
-  it("na fixtúre '40287' vráti jeden priradený náhradný kód", () => {
-    const { record } = mapRow(fixtureRow("40287"));
-    expect(record?.relatedCodes).toEqual(["60297"]);
-  });
-
-  it("bez akéhokoľvek priradenia vráti prázdne pole (nikdy null/undefined)", () => {
-    expect(extractRelatedCodes(bareRow())).toEqual([]);
-  });
-
-  it("prvý stĺpec je bare 'relatedProduct' (NIE 'relatedProduct1')", () => {
-    expect(extractRelatedCodes(bareRow({ relatedProduct: "A1" }))).toEqual(["A1"]);
-  });
-
-  it("zbiera VIACERO stĺpcov v poradí exportu, preskakuje prázdne", () => {
-    const row = bareRow({ relatedProduct: "A1", relatedProduct2: "", relatedProduct3: "A3" });
-    expect(extractRelatedCodes(row)).toEqual(["A1", "A3"]);
-  });
-
-  it("orezáva na MAX_ALTERNATIVES (8), aj keby export niesol viac", () => {
-    const row = bareRow({
-      relatedProduct: "1",
-      relatedProduct2: "2",
-      relatedProduct3: "3",
-      relatedProduct4: "4",
-      relatedProduct5: "5",
-      relatedProduct6: "6",
-      relatedProduct7: "7",
-      relatedProduct8: "8",
-    });
-    expect(extractRelatedCodes(row)).toHaveLength(8);
-  });
-});

--- a/apps/api/src/modules/catalog/map-row.ts
+++ b/apps/api/src/modules/catalog/map-row.ts
@@ -41,10 +41,6 @@ export interface VariantRecord {
   // ako `supplier` nižšie), NIE `variant` — na reálnom exporte je v rámci
   // jedného produktu vždy rovnaké naprieč všetkými veľkosťami.
   readonly internalNote: string | null;
-  // issue 176: kódy náhradných produktov (`relatedCodes` — pozri `RELATED_
-  // COLUMNS`/`MAX_ALTERNATIVES` nižšie), vlastnosť PRODUKTU rovnako ako
-  // `internalNote` vyššie.
-  readonly relatedCodes: readonly string[];
   readonly currency: string | null;
   readonly price: string | null;
   readonly standardPrice: string | null;
@@ -83,28 +79,6 @@ export function splitCode(code: string): { readonly productKey: string; readonly
 
 function textOrNull(raw: string): string | null {
   return raw === "" ? null : raw;
-}
-
-// issue 176: max. počet náhradných produktov, ktoré appka niekedy zobrazí
-// (stará appka's `nedostupne.py`'s `MAX_ALTERNATIVES` — boss: relatedProduct1..8).
-export const MAX_ALTERNATIVES = 8;
-
-// export's stĺpce s náhradnými produktmi — PRVÝ je bare `relatedProduct`
-// (NIE `relatedProduct1`), potom `relatedProduct2`..`relatedProduct8` (stará
-// appka's `nedostupne.py`'s `_RELATED_COLS`, overené priamo na reálnej
-// fixtúre — export nemá stĺpec `relatedProduct1`).
-export const RELATED_COLUMNS: readonly string[] = ["relatedProduct", ...Array.from({ length: 7 }, (_, i) => `relatedProduct${String(i + 2)}`)];
-
-/** Neprázdne, orezané kódy z `RELATED_COLUMNS`, orezané na `MAX_ALTERNATIVES` —
- * poradie stĺpcov exportu sa zachováva (rovnaký zámer ako stará appka). */
-export function extractRelatedCodes(row: Readonly<Record<string, string>>): readonly string[] {
-  const codes: string[] = [];
-  for (const col of RELATED_COLUMNS) {
-    const value = (row[col] ?? "").trim();
-    if (value !== "") codes.push(value);
-    if (codes.length >= MAX_ALTERNATIVES) break;
-  }
-  return codes;
 }
 
 // `percent_vat` je `numeric(5, 2)` — najviac 3 číslice pred desatinnou čiarkou
@@ -221,7 +195,6 @@ export function mapRow(row: Readonly<Record<string, string>>): {
       name,
       supplier: textOrNull((row["supplier"] ?? "").trim()),
       internalNote: textOrNull((row["internalNote"] ?? "").trim()),
-      relatedCodes: extractRelatedCodes(row),
       currency,
       price,
       standardPrice,

--- a/apps/api/tests/catalog-schema.integration.test.ts
+++ b/apps/api/tests/catalog-schema.integration.test.ts
@@ -289,3 +289,15 @@ it("dovolí variant bez meny, keď žiadna suma nie je vyplnená (CHECK to má p
   expect(rows[0]?.currency).toBeNull();
   expect(rows[0]?.price).toBeNull();
 });
+
+// issue 245: `product.related_codes` bol po #238 mŕtvy stĺpec (žiadny čitateľ) —
+// odstránený incremental migráciou. Regresný dôkaz na úrovni DB, nielen Drizzle
+// typov (typy by len prestali kompilovať, toto overuje SKUTOČNÚ schému).
+it("stĺpec product.related_codes už v schéme neexistuje (issue 245)", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const result = await ctx.db.execute(
+    sql`SELECT column_name FROM information_schema.columns WHERE table_name = 'product' AND column_name = 'related_codes'`,
+  );
+  expect(result.rows).toHaveLength(0);
+});

--- a/apps/api/tests/helpers/orders.ts
+++ b/apps/api/tests/helpers/orders.ts
@@ -85,9 +85,6 @@ export async function insertTestVariantForProduct(
     // own row-matching column) — default null matches every existing call
     // (no prior test needed one).
     readonly pairCode?: string | null;
-    // issue 176: náhradné produkty (`product.related_codes`) — default
-    // `undefined` necháva stĺpec `null` (žiadny existujúci test ho potreboval).
-    readonly relatedCodes?: readonly string[] | null;
     // issue 224: dodávateľská linka na PRODUKTE — potrebné pre testy, kde má
     // JEDEN produkt VIAC variantov (veľkostí) zdieľajúcich tú istú linku.
     readonly internalNote?: string | null;
@@ -106,7 +103,6 @@ export async function insertTestVariantForProduct(
       // dodávateľa — potrebné pre testy ručného priradenia dodávateľa).
       supplier: "supplier" in options ? options.supplier : "Test dodávateľ",
       internalNote: options.internalNote ?? null,
-      relatedCodes: options.relatedCodes === undefined || options.relatedCodes === null ? null : [...options.relatedCodes],
       firstSeenAt: new Date("2026-01-01T00:00:00Z"),
       lastSeenAt: new Date("2026-01-01T00:00:00Z"),
       lastSeenSnapshotId: snapshotId,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.145",
+  "version": "0.3.0-dev.146",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Čo a prečo

issue 245: `product.related_codes` (kódy náhradných produktov, `issue 176`)
bol po zlúčení #238 mŕtvy kód — #238 zrušilo čítanie automatického návrhu
náhrad ("majiteľ: to sú súvisiace produkty, nie náhrady"), ale zdroj
(stĺpec + populovanie pri katalógovom importe) ostal bez konzumenta a nočný
import naďalej zbytočne počítal a ukladal dáta, ktoré nikto nečíta.

Odstránené kompletne:
- incremental Drizzle migrácia (`ALTER TABLE product DROP COLUMN related_codes`)
- `schema-catalog.ts` stĺpec
- `extractRelatedCodes`/`RELATED_COLUMNS`/`MAX_ALTERNATIVES` v `map-row.ts`
  a pole `relatedCodes` z `VariantRecord`
- populovanie v `ingest.ts` (insert aj onConflictDoUpdate)
- viazané testy (`map-row.test.ts`) a nepoužívaná fixtúrová voľba v
  `tests/helpers/orders.ts`

## Overenie

Re-verifikované PRED implementáciou (`gh issue comment` na tickete) —
grep `relatedCodes`/`related_codes` naprieč `apps/api/src`, `apps/web/src`,
oboma testovými priečinkami: jediné zostávajúce výskyty mimo odstránených
súborov boli historické komentáre vysvetľujúce zrušenie v #238, žiadny
skutočný čitateľ.

RED→GREEN (regresný test):
- `apps/api/src/modules/catalog/map-row.test.ts` — `mapRow` už nevracia
  `relatedCodes` (RED na `1eb998c`, GREEN na `7fffa72`)
- `apps/api/tests/catalog-schema.integration.test.ts` — stĺpec
  `product.related_codes` už v DB schéme neexistuje (RED na `1eb998c`,
  GREEN na `7fffa72`)

Lokálne zelené: `pnpm typecheck`, `pnpm lint`, api unit (571/571), api
integration (477/477, cez lokálnu Postgres na porte 5433), web unit
(413/413), web e2e (37/37 Playwright, konzola čistá).

Scope-gate: schema-migration (issue má vlastný `Scope-gate` riadok, preto
je toto SAMOSTATNÉ PR bez bundlovania s iným ticketom).

issue 245
