### PR TITLE
fix: supplier-links save-then-refetch race (issue 251)

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -706,3 +706,25 @@ paths:
   kontrola cez `td.scrollWidth` to nezachytila — treba merať orezanie na
   samotnom odkaze). Pri ďalšom hľadaní darcu preto meraj OREZANIE obsahu darcu,
   nielen výšku riadkov.
+- **Ref, ktorý má vždy niesť AKTUÁLNU hodnotu pre kód volaný z mikrotasky
+  (`.then()` callback), sa musí syncovať SYNCHRÓNNE v tele komponentu (počas
+  renderu), NIE cez `useEffect`.** Issue 251 (`SupplierLinksSection.tsx`'s
+  `queryRef`/`stateRef`, čítané `refetch()`'om volaným zo `save()`'s
+  `.then()`): `useEffect` beží AŽ PO commite ako pasívny efekt na
+  samostatnom priechode (React ho môže odložiť za `paint`) — medzi commitom
+  nového `query`/`state` a skutočným prebehnutím efektu existuje reálne
+  okno, počas ktorého ref ešte nesie STARÚ hodnotu. Keďže `.then()` je
+  mikrotaska, môže sa spustiť presne v tomto okne a prečítať zastaraný ref —
+  teda ten istý race, aký mal "latest ref" vzor (issue 151, `.claude/rules/
+  frontend-design.md`'s "derived value instead of stale local state")
+  odstrániť, len preložený o jednu vrstvu nižšie. Fix: priama synchrónna
+  aktualizácia (`queryRef.current = query;` hneď v tele komponentu, žiadny
+  `useEffect`, žiadne pole závislostí) — React zaručuje, že táto priradenie
+  prebehne skôr, než čokoľvek iné (vrátane akejkoľvek čakajúcej mikrotasky)
+  môže ref prečítať. **Test na KAŽDÝ ĎALŠÍ "latest ref" vzor v tomto
+  kódovej báze, kde ref číta kód spúšťaný z promise `.then()`/mikrotasky:**
+  je sync v `useEffect`e, alebo priamo v tele komponentu? `useEffect` je
+  správny LEN keď nič mikrotaskového ref nečíta pred ďalším renderom;
+  sibling výskyty rovnakého (pred-opravou) tvaru nájdené a zapísané ako
+  issue 254 (`PairingSection.tsx`'s `refetch`, `CatalogPage.tsx`'s
+  `runIngest`) — over ich pri práci na tomto ticket-e.

--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -728,3 +728,32 @@ paths:
   sibling výskyty rovnakého (pred-opravou) tvaru nájdené a zapísané ako
   issue 254 (`PairingSection.tsx`'s `refetch`, `CatalogPage.tsx`'s
   `runIngest`) — over ich pri práci na tomto ticket-e.
+- **Rovnaké "iba VLASTNÝ riadok" nedopatrenie sa dá skryť aj v busy-guarde,
+  nielen v ref-synchronizácii vyššie — `busyKey`/`disabled` musí zvážiť
+  vzťah k CUDZÍM riadkom, nie len k sebe.** Code review na issue 251's PR
+  (`SupplierLinksSection.tsx`): `busyKey` disabluje LEN tlačidlá riadku,
+  ktorého zápis prebieha — Upraviť/Doplniť na VŠETKÝCH ostatných riadkoch
+  ostáva aktívne. Keď užívateľ otvoril INÝ riadok, kým prvý ešte čakal na
+  PATCH odpoveď, jej `.then()`'s nepodmienené `setEditingKey(null)` ticho
+  zavrelo ten cudzí, práve otvorený editor. Fix — rovnaký "latest ref"
+  princíp ako záznam vyššie, len na `editingKey`: `editingKeyRef` sync
+  priamo v tele komponentu, `.then()` zavrie editor LEN ak
+  `editingKeyRef.current === productKey` (t.j. stále patrí TOMUTO zápisu).
+  Regresný dôkaz musí byť SIEŤOVO deterministický (`page.waitForResponse()`
+  na presnú POST URL), nie textová asercia stavu riadku — v zdieľanom e2e
+  súbore môže PREDCHÁDZAJÚCI test v tom istom súbore ten istý stavový text
+  ("čaká na odoslanie") už nastaviť skôr, takže by test prešiel aj keby sa
+  spoľahol na cudziu, staršiu mutáciu namiesto vlastnej akcie.
+- **`mountedRef`/unmount-guard vzor (`if (!mountedRef.current) return;` v
+  `.then()`/`.catch()`) POTREBUJE nastaviť `true` AJ v samotnom
+  `useEffect`'s TELE, nielen v `useRef(true)`'s počiatočnej hodnote.**
+  Issue 251 (finding 3, `search()`'s guard): appka beží pod `<StrictMode>`
+  (`main.tsx`) a vo VÝVOJOVOM móde (teda aj v `pnpm --filter @forestshop/web
+  e2e`, ktorá ide cez `vite dev`) React zámerne efekt spustí, zruší a znova
+  spustí — bez `mountedRef.current = true;` priamo v `useEffect`'s tele by
+  toto PRVÉ simulované zrušenie navždy nechalo ref na `false` a appka by
+  nikdy nezapísala žiadny výsledok vyhľadávania (živo namerané:
+  `expect(riadok).toBeVisible()` padalo s "element(s) not found" na úplne
+  PRVOM teste súboru). Vzor pre tento guard: `useEffect(() => {
+  mountedRef.current = true; return () => { mountedRef.current = false; };
+  }, [])` — nikdy len holý cleanup bez zodpovedajúceho "nastav true" v tele.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -525,3 +525,31 @@ paths:
   literálom? Ak áno, a testovaná trasa/funkcia si "teraz" berie sama zo
   systémového hodín, prepočítaj hranicu pri behu testu namiesto písania
   literálu — inak test raz, nevyhnutne, prestane platiť.
+- **Čakanie pridané DO e2e testu (napr. `await expect(prvok).toBeHidden()`)
+  môže test spraviť zeleným zo ZLÉHO dôvodu — zaručí bezpečné poradie
+  udalostí bez ohľadu na to, či je race v komponente skutočne opravený.**
+  Issue 251 (`supplier-links.spec.ts`): pôvodná verzia testu mala
+  `await expect(vstup).toBeHidden()` PRED prepnutím filtra — to zaručilo,
+  že `.then()`'s `refetch()` (a teda aj jeho `searchSeq`) prebehne SKÔR, než
+  test prepne filter, takže test prešiel AJ keby bola oprava komponentu
+  vrátená naspäť (empiricky overené: s vráteným produkčným fixom test s
+  týmto čakaním prešiel 4/4). Fix nie je len odstránenie čakania — je
+  **overenie testovej rozlišovacej sily**: po KAŽDEJ oprave race/timing bugu
+  dočasne vráť produkčný fix naspäť a potvrď, že test SPADNE (tu: 3/3
+  nezávislé behy zlyhali s presne nahláseným symptómom, keď bol fix
+  vrátený, a 6/6 prešlo s hotovým kódom). Samotný zelený beh nič
+  nedokazuje o tom, či test race skutočne testuje.
+- **Reprodukčná technika pre save-then-refetch/stale-closure race:
+  prepichnutý `window.fetch` cez `addInitScript`, ktorý REÁLNU odpoveď (nie
+  fake/mock) oneskorí o ~400ms, plus OPAKOVANÉ nezávislé behy s čerstvým DB
+  reseedom + reštartom API medzi nimi.** Issue 251 (rovnaký vzor ako
+  `orders-write-failures.spec.ts`, pozri jeho `addInitScript` blok vyššie v
+  tomto súbore — tu ale REÁLNA odpoveď je len oneskorená (`setTimeout` vo
+  wrapperi okolo `puvodny(...)`), nie reject/fake-response): oneskorenie
+  SKUTOČNEJ odpovede je nutné, lebo test musí overiť, ktorý REÁLNY výsledok
+  (aktuálny vs. zastaraný filter) `refetch()` skutočne zapíše — fake
+  response by netestovala nič o tom, čo server vrátil. Jeden zelený beh
+  nestačí na potvrdenie/vyvrátenie race fixu (flaky failure sa môže minúť)
+  — potrebné je NIEKOĽKO NEZÁVISLÝCH behov, každý s čerstvým DB reseedom
+  (`scripts/e2e-setup.ts`) a reštartom API servera, nie opakovanie v tom
+  istom procese/stave.

--- a/apps/web/src/components/SupplierLinksSection.tsx
+++ b/apps/web/src/components/SupplierLinksSection.tsx
@@ -63,12 +63,31 @@ export function SupplierLinksSection({
   // katalógom môže staršiu, širšiu odpoveď doručiť neskôr než novšiu, užšiu).
   const searchSeq = useRef(0);
 
+  // Code review (issue 251, finding 3): odpoveď na `search()` môže doraziť
+  // AŽ PO odmountovaní tejto sekcie (napr. užívateľ medzitým prepol
+  // záložku) — bez tejto stráže by `.then()`/`.catch()` zavolali `setState`
+  // na už odmountovanom komponente. Nastavenie `true` MUSÍ byť aj v samotnom
+  // efekte (nielen v `useRef(true)`'s počiatočnej hodnote) — React 18
+  // `StrictMode` (`main.tsx`) vo VÝVOJOVOM móde efekt zámerne spustí,
+  // zruší a znova spustí ("simulované odmountovanie/namountovanie"), takže
+  // BEZ tohto riadku by prvé (simulované) zrušenie navždy nechalo
+  // `mountedRef.current` na `false` a appka by v dev/e2e móde nikdy
+  // nezapísala žiadny výsledok vyhľadávania.
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
   const search = useCallback(
     (q: string, s: ProductLinkState) => {
       const seq = (searchSeq.current += 1);
       setSearchError("");
       searchProductLinks({ q, state: s, page: 1 })
         .then((result) => {
+          if (!mountedRef.current) return; // odmountované skôr, než odpoveď doletela
           if (seq !== searchSeq.current) return; // medzitým prišla novšia požiadavka
           setItems(result.items);
           setTotal(result.total);
@@ -76,6 +95,7 @@ export function SupplierLinksSection({
           setSearchLoaded(true);
         })
         .catch((err: unknown) => {
+          if (!mountedRef.current) return;
           if (seq !== searchSeq.current) return;
           setSearchLoaded(true);
           if (err instanceof SupplierLinksUnauthorizedError) {
@@ -126,6 +146,13 @@ export function SupplierLinksSection({
   // prečítať. Rovnaký "latest ref" princíp ako `.claude/rules/frontend-
   // design.md`'s "derived value instead of stale local state" (issue 151),
   // len cez ref namiesto zdvihnutia do rodiča (tu žiadny rodič netreba).
+  // Code review (issue 251, finding 2): táto priama ref-mutácia POČAS
+  // renderu (namiesto `useEffect`u, pozri komentár vyššie) je bezpečná LEN
+  // preto, že tento strom nepoužíva `startTransition`/Suspense ani žiadnu
+  // inú concurrent funkciu, ktorá by mohla render ZAHODIŤ predtým, než sa
+  // commitne — vtedy by tento priamy zápis ostal vykonaný napriek
+  // zahodenému renderu. Ak sa `startTransition` niekedy zavedie do tohto
+  // stromu, tento vzor (aj `editingKeyRef` nižšie) treba prehodnotiť.
   const queryRef = useRef(query);
   queryRef.current = query;
   const stateRef = useRef(state);
@@ -134,6 +161,16 @@ export function SupplierLinksSection({
   const refetch = useCallback(() => {
     search(queryRef.current, stateRef.current);
   }, [search]);
+
+  // Code review (issue 251, finding 1): `save()`'s `.then()` (nižšie) musí
+  // vedieť, KTORÝ riadok je PRÁVE editovaný V OKAMIHU, keď odpoveď doletí —
+  // nie ten, ktorý bol editovaný v momente KLIKNUTIA na Uložiť (`save` je
+  // sama osebe zafixovaná na `productKey` parametri cez uzáver, to je v
+  // poriadku; problém je čítanie `editingKey`). Rovnaký "latest ref" dôvod
+  // ako `queryRef`/`stateRef` vyššie — synchrónne priamo v tele komponentu,
+  // nie cez `useEffect`.
+  const editingKeyRef = useRef(editingKey);
+  editingKeyRef.current = editingKey;
 
   const startEdit = useCallback((item: ProductLinkItem) => {
     setEditingKey(item.productKey);
@@ -160,7 +197,13 @@ export function SupplierLinksSection({
       setBusyKey(productKey);
       saveProductLink(productKey, urlDraft.trim())
         .then(() => {
-          setEditingKey(null);
+          // issue 251 (finding 1): `busyKey` blokuje LEN tlačidlá TOHTO
+          // riadku — Upraviť/Doplniť na VŠETKÝCH ostatných riadkoch ostáva
+          // aktívne. Kým táto odpoveď čakala, užívateľ mohol otvoriť INÝ
+          // riadok (`editingKey` sa presunul na neho) — vtedy toto
+          // zatvorenie NESMIE prebehnúť, inak by ticho zavrelo CUDZÍ,
+          // práve rozpísaný editor.
+          if (editingKeyRef.current === productKey) setEditingKey(null);
           refetch();
         })
         .catch((err: unknown) => {

--- a/apps/web/src/components/SupplierLinksSection.tsx
+++ b/apps/web/src/components/SupplierLinksSection.tsx
@@ -109,17 +109,27 @@ export function SupplierLinksSection({
   // takýto neskorý-no-zastaraný refetch by mal VYŠŠIE číslo než medzitým
   // spustené korektné vyhľadanie a jeho (prázdny/starý) výsledok by ho
   // ticho prepísal — presne toto spôsobilo `element(s) not found` na main
-  // CI hneď po mergi issue 241. Refy namiesto priameho uzáveru zaručujú, že
-  // `refetch()` (nech je zavolaná odkiaľkoľvek a kedykoľvek) vždy prečíta
-  // NAJNOVŠIE hodnoty — rovnaký princíp ako `.claude/rules/frontend-
+  // CI hneď po mergi issue 241.
+  //
+  // Ref-sync PRIAMO v tele komponentu (počas renderu), NIE cez `useEffect`:
+  // `useEffect` beží AŽ PO commite ako pasívny efekt naplánovaný na
+  // samostatný priechod (React ho môže odložiť za `paint`) — medzi
+  // commitom nového `query`/`state` a skutočným prebehnutím efektu existuje
+  // reálne okno, počas ktorého by `queryRef.current`/`stateRef.current`
+  // ešte niesli STARÚ hodnotu. Keďže `save()`'s `.then()` je mikrotaska
+  // (promise callback), môže sa spustiť presne v tomto okne a prečítať
+  // zastaraný ref — teda rovnaký race, aký táto oprava má odstrániť, len
+  // preložený o jednu vrstvu nižšie. Priama synchrónna aktualizácia (žiadny
+  // efekt, žiadne plánovanie) zaručuje, že ref nesie AKTUÁLNU hodnotu hneď
+  // v momente, keď React túto funkciu tela komponentu zavolá — teda skôr,
+  // než čokoľvek iné (vrátane akejkoľvek čakajúcej mikrotasky) môže ref
+  // prečítať. Rovnaký "latest ref" princíp ako `.claude/rules/frontend-
   // design.md`'s "derived value instead of stale local state" (issue 151),
   // len cez ref namiesto zdvihnutia do rodiča (tu žiadny rodič netreba).
   const queryRef = useRef(query);
+  queryRef.current = query;
   const stateRef = useRef(state);
-  useEffect(() => {
-    queryRef.current = query;
-    stateRef.current = state;
-  }, [query, state]);
+  stateRef.current = state;
 
   const refetch = useCallback(() => {
     search(queryRef.current, stateRef.current);

--- a/apps/web/src/components/SupplierLinksSection.tsx
+++ b/apps/web/src/components/SupplierLinksSection.tsx
@@ -99,9 +99,31 @@ export function SupplierLinksSection({
     search(query, state);
   }
 
+  // issue 251: `refetch` MUSÍ vždy čítať AKTUÁLNY filter/dopyt, nie ten,
+  // ktorý bol platný v okamihu, keď bol `save()`'s uzáver (nižšie) vytvorený.
+  // `save()` je samostatná `useCallback` inštancia zafixovaná na tlačidle v
+  // momente kliknutia — ak sa medzitým (kým čaká na PATCH odpoveď) zmení
+  // filter/dopyt, `refetch` cez PRIAMY uzáver nad `query`/`state` by aj tak
+  // zavolal `search` so STARÝMI hodnotami, akonáhle zápis doletí. Keďže
+  // `searchSeq` prideľuje poradové číslo pri ZAVOLANÍ (nie pri odpovedi),
+  // takýto neskorý-no-zastaraný refetch by mal VYŠŠIE číslo než medzitým
+  // spustené korektné vyhľadanie a jeho (prázdny/starý) výsledok by ho
+  // ticho prepísal — presne toto spôsobilo `element(s) not found` na main
+  // CI hneď po mergi issue 241. Refy namiesto priameho uzáveru zaručujú, že
+  // `refetch()` (nech je zavolaná odkiaľkoľvek a kedykoľvek) vždy prečíta
+  // NAJNOVŠIE hodnoty — rovnaký princíp ako `.claude/rules/frontend-
+  // design.md`'s "derived value instead of stale local state" (issue 151),
+  // len cez ref namiesto zdvihnutia do rodiča (tu žiadny rodič netreba).
+  const queryRef = useRef(query);
+  const stateRef = useRef(state);
+  useEffect(() => {
+    queryRef.current = query;
+    stateRef.current = state;
+  }, [query, state]);
+
   const refetch = useCallback(() => {
-    search(query, state);
-  }, [search, query, state]);
+    search(queryRef.current, stateRef.current);
+  }, [search]);
 
   const startEdit = useCallback((item: ProductLinkItem) => {
     setEditingKey(item.productKey);

--- a/apps/web/tests/e2e/supplier-links.spec.ts
+++ b/apps/web/tests/e2e/supplier-links.spec.ts
@@ -79,20 +79,30 @@ test("produkt bez linky ponúka 'Doplniť', po uložení sa presunie do 'S linko
   await vstup.fill("https://e2e-dodavatel.example.com/parovanie-nova");
   await page.getByTestId("product-link-save-E2E-PL-CHYBA").click();
 
-  // issue 251: `save()` v `SupplierLinksSection.tsx` zavolá vo svojom
-  // `.then()` VLASTNÝ `refetch()`, ktorého uzáver má PRIVIAZANÝ filter
-  // ("Bez linky") z okamihu KLIKNUTIA na Uložiť — nie aktuálny filter. Ak
-  // test prepne filter a znova vyhľadá SKÔR, než sa PATCH zápis skutočne
-  // vráti, tento "starý" refetch sa zavolá AŽ NESKÔR (keď PATCH doletí) a
-  // keďže interné poradové číslo (`searchSeq`) sa prideľuje pri ZAVOLANÍ,
-  // nie pri odpovedi, tento neskorší-no-zastaraný refetch prepíše
-  // (zobrazí prázdny "Bez linky" výsledok) výsledok testovho VLASTNÉHO,
-  // správneho vyhľadania. Počkanie na zmiznutie edit-formulára garantuje,
-  // že `.then()` (a teda aj jeho `refetch()` volanie/poradové číslo) už
-  // prebehlo SKÔR, než test prepne filter — takže testov ĎALŠÍ dopyt má
-  // vždy VYŠŠIE poradové číslo a vyhráva bez ohľadu na to, kedy sieťovo
-  // doletí.
-  await expect(vstup).toBeHidden();
+  // issue 251: PRED opravou `save()` v `SupplierLinksSection.tsx` volal vo
+  // svojom `.then()` VLASTNÝ `refetch()`, ktorého uzáver mal PRIVIAZANÝ
+  // filter ("Bez linky") z okamihu KLIKNUTIA na Uložiť — nie aktuálny
+  // filter. Test tu ZÁMERNE prepína filter na "Všetky" a znova vyhľadáva
+  // BEZ ČAKANIA na potvrdenie zápisu (žiadne umelé oneskorenie kroku) — to
+  // je presne poradie udalostí, ktoré pôvodný bug reprodukovalo.
+  //
+  // Test je deterministický AJ BEZ tohto čakania (a teda aj bez ohľadu na
+  // to, či 400ms-oneskorená PATCH odpoveď doletí PRED alebo AŽ PO tomto
+  // prepnutí), lebo oprava odstránila samotný RACE, nie len jeho jedno
+  // konkrétne časovanie: `refetch()` teraz vždy číta AKTUÁLNY filter/dopyt
+  // (cez ref, pozri komentár pri `queryRef`/`stateRef` v komponente), nie
+  // ten zafixovaný v okamihu kliknutia na Uložiť. Ak teda `.then()`'s
+  // `refetch()` doletí AŽ PO tom, čo test prepol filter, zavolá `search`
+  // s TÝM ISTÝM ("Všetky") filtrom, aký použil aj testov vlastný dopyt —
+  // dve vyhľadania s ROVNAKÝM filtrom pretekajúce sa o `searchSeq` dávajú
+  // rovnaký (správny) výsledok bez ohľadu na to, ktoré vyhrá. Skorší tvar
+  // tohto testu mal namiesto tohto vysvetlenia `await
+  // expect(vstup).toBeHidden()` explicitné čakanie PRED prepnutím filtra —
+  // code review upozornil, že takéto čakanie zoslabuje testovaciu silu
+  // (test by prešiel, aj keby sa oprava komponentu vrátila naspäť, lebo by
+  // vždy garantovalo bezpečné poradie bez ohľadu na to, či je race v
+  // komponente skutočne opravený) — preto bolo odstránené a test teraz
+  // dokazuje SKUTOČNÚ opravu, nie len bezpečné testové časovanie.
 
   // Po uložení produkt už MÁ linku — predvolený filter "Bez linky" ho už
   // nezobrazí, treba prepnúť na "Všetky", aby bolo vidno stav.

--- a/apps/web/tests/e2e/supplier-links.spec.ts
+++ b/apps/web/tests/e2e/supplier-links.spec.ts
@@ -79,6 +79,21 @@ test("produkt bez linky ponúka 'Doplniť', po uložení sa presunie do 'S linko
   await vstup.fill("https://e2e-dodavatel.example.com/parovanie-nova");
   await page.getByTestId("product-link-save-E2E-PL-CHYBA").click();
 
+  // issue 251: `save()` v `SupplierLinksSection.tsx` zavolá vo svojom
+  // `.then()` VLASTNÝ `refetch()`, ktorého uzáver má PRIVIAZANÝ filter
+  // ("Bez linky") z okamihu KLIKNUTIA na Uložiť — nie aktuálny filter. Ak
+  // test prepne filter a znova vyhľadá SKÔR, než sa PATCH zápis skutočne
+  // vráti, tento "starý" refetch sa zavolá AŽ NESKÔR (keď PATCH doletí) a
+  // keďže interné poradové číslo (`searchSeq`) sa prideľuje pri ZAVOLANÍ,
+  // nie pri odpovedi, tento neskorší-no-zastaraný refetch prepíše
+  // (zobrazí prázdny "Bez linky" výsledok) výsledok testovho VLASTNÉHO,
+  // správneho vyhľadania. Počkanie na zmiznutie edit-formulára garantuje,
+  // že `.then()` (a teda aj jeho `refetch()` volanie/poradové číslo) už
+  // prebehlo SKÔR, než test prepne filter — takže testov ĎALŠÍ dopyt má
+  // vždy VYŠŠIE poradové číslo a vyhráva bez ohľadu na to, kedy sieťovo
+  // doletí.
+  await expect(vstup).toBeHidden();
+
   // Po uložení produkt už MÁ linku — predvolený filter "Bez linky" ho už
   // nezobrazí, treba prepnúť na "Všetky", aby bolo vidno stav.
   await page.getByLabel("Zobraziť produkty").selectOption("all");

--- a/apps/web/tests/e2e/supplier-links.spec.ts
+++ b/apps/web/tests/e2e/supplier-links.spec.ts
@@ -23,6 +23,38 @@ test("produkt bez linky ponúka 'Doplniť', po uložení sa presunie do 'S linko
     chyby.push(e.message);
   });
 
+  // issue 251 (regresný dôkaz, natrvalo): prehliadka na main CI hneď po
+  // mergi issue 241 ukázala presne tento test zlyhať s "element(s) not
+  // found" na `product-link-url-E2E-PL-CHYBA" — koreňová príčina je
+  // vysvetlená pri `save()` volaní nižšie. Skutočný sieťový race záviselo
+  // na náhodnom časovaní (na PR CI dvakrát prešiel, na main raz zlyhal,
+  // jeden rerun prešiel čisto), takže bez umelého oneskorenia by tento
+  // test regresiu nezachytil spoľahlivo. Tu sa REÁLNY zápis (`saveProduct
+  // Link`'s `POST /api/product-links/:productKey`) len o 400ms oneskorí —
+  // požiadavka ide naďalej na skutočný server cez pôvodný `fetch`
+  // (`puvodny`), žiadna odpoveď sa nefalšuje ani nezamieta, takže toto
+  // NIE JE prípad `.claude/rules/testing.md`'s zákazu `page.route()
+  // .abort()/.fulfill(4xx/5xx)` (simulácia ZLYHANIA) — ide o rovnaký
+  // `window.fetch`-prepichnutý vzor ako `orders-write-failures.spec.ts`,
+  // len s oneskorením namiesto s falošnou odpoveďou. Overené opakovane
+  // lokálne (`.claude/rules/testing.md`): BEZ opravy nižšie zlyhá
+  // spoľahlivo (3/3 samostatných behov), S opravou prejde spoľahlivo
+  // (6+/6 samostatných behov) — vždy s týmto oneskorením zapnutým.
+  await page.addInitScript(() => {
+    const puvodny = window.fetch.bind(window);
+    window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (init?.method === "POST" && url.includes("/api/product-links/")) {
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            resolve(puvodny(input, init));
+          }, 400);
+        });
+      }
+      return puvodny(input, init);
+    };
+  });
+
   await page.goto("/");
   await page.getByLabel("E-mail").fill(E2E_PAROVANIE_EMAIL);
   await page.getByLabel("Heslo").fill(E2E_HESLO);

--- a/apps/web/tests/e2e/supplier-links.spec.ts
+++ b/apps/web/tests/e2e/supplier-links.spec.ts
@@ -185,3 +185,93 @@ test("neplatný odkaz sa odmietne HNEĎ, bez zápisu na server (konzola čistá)
 
   expect(chyby).toEqual([]);
 });
+
+// issue 251 (code review finding 1, nájdené AŽ po merge PR #253): `busyKey`
+// blokuje LEN tlačidlá vlastného riadku — "Upraviť"/"Doplniť" na VŠETKÝCH
+// OSTATNÝCH riadkoch ostáva aktívne. Ak počas čakania na PATCH odpoveď
+// riadku A užívateľ otvorí editor riadku B, `editingKey` sa presunie na B —
+// keď A's `.then()` napokon doletí, jeho PÔVODNÝ (pred touto opravou)
+// nepodmienený `setEditingKey(null)` ticho ZATVORÍ B's PRÁVE otvorený
+// editor a stratí, čo tam bolo rozpísané. Rovnaký oneskorovací vzor ako
+// vyššie (`window.fetch` prepichnutý cez `addInitScript`, REÁLNA odpoveď
+// len o 400ms neskôr, žiadny fake/mock).
+test("uloženie riadku A (ešte čakajúce na odpoveď) nesmie zavrieť editor riadku B otvorený medzitým", async ({
+  page,
+}) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.addInitScript(() => {
+    const puvodny = window.fetch.bind(window);
+    window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (init?.method === "POST" && url.includes("/api/product-links/")) {
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            resolve(puvodny(input, init));
+          }, 400);
+        });
+      }
+      return puvodny(input, init);
+    };
+  });
+
+  await page.goto("/?tab=supplier-links");
+  await page.getByLabel("E-mail").fill(E2E_PAROVANIE_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await expect(page.getByRole("heading", { name: "Párovanie produktov" })).toBeVisible();
+
+  // "Všetky" + spoločný dopyt "E2E-PL" nájde OBA fixtúrové riadky naraz —
+  // netreba prepínať filter medzi otvorením A a B, čo by samo osebe
+  // vyvolalo ĎALŠIE vyhľadanie a scenár skomplikovalo.
+  await page.getByLabel("Zobraziť produkty").selectOption("all");
+  await page.getByLabel("Hľadať produkt (kód alebo názov)").fill("E2E-PL");
+  await page.getByRole("button", { name: "Zobraziť" }).click();
+
+  const riadokA = page.getByTestId("product-link-row-E2E-PL-CHYBA");
+  const riadokB = page.getByTestId("product-link-row-E2E-PL-OPRAVA");
+  await expect(riadokA).toBeVisible();
+  await expect(riadokB).toBeVisible();
+
+  // A: otvoriť editor, vyplniť platnú adresu, uložiť — reálna PATCH
+  // odpoveď beží 400ms na pozadí. `waitForResponse` sa musí založiť PRED
+  // kliknutím na Uložiť, aby nezmeškal odpoveď, ktorá môže doraziť skôr,
+  // než by sme naň začali čakať.
+  const odpovedA = page.waitForResponse(
+    (res) => res.request().method() === "POST" && res.url().includes("/api/product-links/E2E-PL-CHYBA"),
+  );
+  await riadokA.getByTestId("product-link-edit-toggle-E2E-PL-CHYBA").click();
+  await page
+    .getByTestId("product-link-edit-input-E2E-PL-CHYBA")
+    .fill("https://e2e-dodavatel.example.com/parovanie-cross-row");
+  await page.getByTestId("product-link-save-E2E-PL-CHYBA").click();
+
+  // B: kým A ešte čaká na odpoveď, otvoriť JEHO editor.
+  await riadokB.getByTestId("product-link-edit-toggle-E2E-PL-OPRAVA").click();
+  const vstupB = page.getByTestId("product-link-edit-input-E2E-PL-OPRAVA");
+  await expect(vstupB).toBeVisible();
+
+  // Počkať na SKUTOČNÚ sieťovú odpoveď A-čka (deterministické, nezávislé od
+  // toho, čo so stavovým riadkom urobili PREDCHÁDZAJÚCE testy v tomto
+  // súbore — na rozdiel od kontroly textu stavu, ktorý môže byť "čaká na
+  // odoslanie" už PRED touto akciou vďaka staršej fixtúrovej mutácii).
+  // Krátka rezerva navyše necháva doriešiť React-ov `.then()`/render
+  // reťazec, ktorý nasleduje AŽ PO tom, čo odpoveď doletí.
+  await odpovedA;
+  await page.waitForTimeout(200);
+
+  // B's editor musí ostať otvorený — A's `.then()` nesmie zavrieť CUDZÍ
+  // (v tomto momente už nesúvisiaci) editor. Toto je JEDNORAZOVÁ kontrola
+  // aktuálneho stavu (nie `expect().toBeVisible()`'s auto-retry, ktoré by
+  // stačilo zachytiť VIDITEĽNÝ prvok len na okamih a prešlo by aj keby sa
+  // hneď potom skryl).
+  expect(await vstupB.isVisible()).toBe(true);
+
+  expect(chyby).toEqual([]);
+});

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -2791,3 +2791,28 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   odmietol `column total does not exist` cez drizzle-ov `FILTER`-generovaný
   SQL, vrátené späť a zdokumentované; slabšia e2e asercia na celý riadok —
   spresnené na konkrétne `<td>` bunky). PR #249.
+
+## 2026-08-05 — #245 (product.related_codes je po #238 mŕtvy kód)
+
+- Solo ticket (Scope-gate: schema-migration, own PR, no bundling).
+- Version bump `b27c047` (0.3.0-dev.145→.146), first commit.
+- RED `1eb998c`: mapRow record must not have `relatedCodes` key
+  (`map-row.test.ts`, "mapRow už nevracia relatedCodes") + DB-level
+  regression (`catalog-schema.integration.test.ts`, "stĺpec
+  product.related_codes už v schéme neexistuje").
+- GREEN `7fffa72`: incremental migration `0033_breezy_manta.sql`
+  (`ALTER TABLE product DROP COLUMN related_codes`), removed
+  `extractRelatedCodes`/`RELATED_COLUMNS`/`MAX_ALTERNATIVES` +
+  `VariantRecord.relatedCodes` from `map-row.ts`, removed population
+  in `ingest.ts` (insert + onConflictDoUpdate), removed unused
+  `relatedCodes` fixture option from `tests/helpers/orders.ts`.
+- Code review (dispatched subagent) found `.claude/rules/nedostupne.md`
+  had two stale notes from #238 describing the column as "still in
+  code, follow-up: #245" — fixed in `8cbc129` (docs-only, `[no-design]`
+  bypass since it's a review-feedback playbook fix, not a new design
+  decision).
+- PR #252, merge `eb580d97`. Live-verified on dev2: `related_codes`
+  column gone from production `product` table (0 rows in
+  information_schema), row counts intact (4542 products / 14139
+  variants), manual "Stiahnuť teraz" catalog-import trigger completed
+  with no error, console clean. Deployed version `0.3.0-dev.146`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.146",
+  "version": "0.3.0-dev.147",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Čo bolo zlé

Main CI beh hneď po mergi issue 241 (PR #250) zlyhal na
`apps/web/tests/e2e/supplier-links.spec.ts`'s "produkt bez linky ponúka
'Doplniť'..." testom (`element(s) not found` na
`product-link-url-E2E-PL-CHYBA`). Skutočná príčina (podrobne v komentároch
na issue 251): `SupplierLinksSection.tsx`'s `save()` volá vo svojom
`.then()` VLASTNÝ `refetch()`, ktorého uzáver má priviazaný filter z
okamihu kliknutia na Uložiť — nie aktuálny. Ak sa filter medzitým zmení a
spustí sa nové (správne) vyhľadanie ešte pred doletením PATCH odpovede,
tento starý refetch sa zavolá AŽ NESKÔR a — keďže interné poradové číslo sa
prideľuje pri ZAVOLANÍ, nie pri odpovedi — ticho prepíše správny výsledok
zastaraným. Ide o skutočný race, nielen o testový artefakt (mohol by
zasiahnuť aj rýchleho reálneho používateľa).

## Čo sa zmenilo

- `[red]` regresný test (`d28ef3c`): existujúci prvý test v
  `supplier-links.spec.ts` teraz o 400 ms oneskorí (cez prepichnutý
  `window.fetch`, rovnaký vzor ako `orders-write-failures.spec.ts` — nič sa
  nesimuluje ako zlyhanie, ide naďalej na skutočný server) skutočnú
  `POST /api/product-links/:productKey` odpoveď, čo spoľahlivo reprodukuje
  presne nahlásený symptóm.
- `[green]` oprava (`e4e2d5b`): `refetch()` číta AKTUÁLNY filter/dopyt cez
  `useRef` namiesto priameho uzáveru — race je odstránený pre všetky
  poradia, nielen pre konkrétne testové časovanie.
- Sprísnenie po kontrole kódu (`f74a9b0`): refy sa synchronizujú
  SYNCHRÓNNE počas vykresľovania, nie cez `useEffect` (ten beží až po
  commite, takže medzi commitom a efektom ostávalo reálne okno, v ktorom
  mikroúloha z `.then()` prečítala ešte neaktualizovaný ref). Zároveň bolo
  z testu odstránené čakanie `toBeHidden()` pridané spolu s opravou —
  robilo test zeleným z NESPRÁVNEHO dôvodu (s vrátenou opravou test aj tak
  prešiel 4/4). Bez neho test bez opravy spoľahlivo padá (3/3 nezávislých
  behov) a s opravou spoľahlivo prechádza (6/6 nezávislých behov s čerstvým
  naplnením databázy a reštartom API medzi behmi).
- Playbook (`bd5db83`): poučenie zapísané do `.claude/rules/testing.md`
  (overovanie rozlišovacej schopnosti testu vrátením opravy; technika
  reprodukcie oneskorením skutočnej odpovede) a
  `.claude/rules/frontend-design.md` (ref čítaný mikroúlohou sa
  synchronizuje počas vykresľovania, nie cez `useEffect`).

## Druhé kolo — nálezy hĺbkovej kontroly kódu

Kontrola toho istého súboru našla ešte jednu skutočnú chybu rovnakého
druhu (1 🟡) a dve drobnosti (2 🔵) — všetky opravené tu, nie odložené:

- `[red]` (`116e92b`): nový test reprodukuje kolíziu MEDZI RIADKAMI — kým
  sa pri jednom produkte ukladá, používateľ otvorí úpravu pri INOM
  produkte; po doletení uloženia sa mu ten druhý formulár sám zavrel a
  rozpísané sa stratilo.
- `[green]` (`a0876a3`): zatvorenie editora je podmienené tým, že sa
  naozaj týka práve ukladaného riadku (`editingKeyRef`); `search()` má
  navyše poistku proti zápisu stavu po odpojení komponentu; k
  synchronizácii refov počas vykresľovania pribudol komentár o tom, za
  akých podmienok je bezpečná.
- Kontrola rozlišovacej schopnosti: s vrátenou opravou (a ponechaným
  testom) nový test spoľahlivo padá, po obnovení opravy je zase zelený.
- Playbook (`05e0596`): zapísaná aj pasca, na ktorej sa cestou stálo —
  `mountedRef` sa v React `StrictMode` musí nastavovať na `true` v tele
  efektu, inak ho vývojové dvojité spustenie efektov natrvalo prepne na
  `false`.

Celá e2e sada 38/38, typová kontrola aj lint čisté.

Súrodenci rovnakého tvaru v `PairingSection.tsx` a `CatalogPage.tsx` sú
založené ako issue 254 (mimo rozsahu tohto PR).

issue 251