### PR TITLE
fix: stale-closure refetch race v PairingSection + CatalogPage (issue 254)

### DIFF
--- a/apps/web/src/components/CatalogPage.tsx
+++ b/apps/web/src/components/CatalogPage.tsx
@@ -105,6 +105,23 @@ export function CatalogPage({
   // dokončenia by sa vykreslil zastaraný výsledok nad novým textom hľadania.
   const searchSeq = useRef(0);
 
+  // issue 254 (súrodenec issue 251's queryRef/stateRef nález, `.claude/
+  // rules/frontend-design.md`): `runIngest`u's `.then()` (nižšie) volá
+  // `search(query, state)` PRIAMO z uzáveru tejto konkrétnej vykresľovacej
+  // inštancie zafixovanej na `onClick`u v momente kliknutia na "Stiahnuť a
+  // naimportovať export". Import reálne trvá sekundy až desiatky sekúnd —
+  // ak manažér medzitým zmení filter/dopyt a spustí VLASTNÉ vyhľadanie,
+  // dokončený import by (bez tohto refu) neskôr TICHO prepísal jeho výsledok
+  // STARÝM filtrom — rovnaký mechanizmus ako `PairingSection.tsx`'s
+  // `refetch()`/`SupplierLinksSection.tsx`'s `refetch()` (issue 251). Ref sa
+  // syncuje PRIAMO V TELE komponentu (počas renderu), NIE cez `useEffect`
+  // (rovnaký dôvod ako tam — mikrotaska `.then()` by mohla prečítať ref v
+  // okne PRED tým, než by neskôr naplánovaný efekt stihol ref aktualizovať).
+  const queryRef = useRef(query);
+  queryRef.current = query;
+  const stateRef = useRef(state);
+  stateRef.current = state;
+
   const loadStats = useCallback(() => {
     fetchCatalogStats()
       .then((s) => {
@@ -164,7 +181,7 @@ export function CatalogPage({
       .then((result) => {
         setImportOutcome(describeIngestOutcome(result));
         loadStats();
-        search(query, state);
+        search(queryRef.current, stateRef.current);
       })
       .catch((err: unknown) => {
         if (err instanceof CatalogUnauthorizedError) {

--- a/apps/web/src/components/PairingSection.tsx
+++ b/apps/web/src/components/PairingSection.tsx
@@ -104,9 +104,34 @@ export function PairingSection({
   // `CatalogPage`'s `runIngest` (`loadStats(); search(query, state);`) — jediný
   // spôsob, ako zobraziť AUTORITATÍVNu hodnotu bez toho, aby si klient
   // "hádal" meno/čas.
+  //
+  // issue 254 (súrodenec issue 251's finding — `.claude/rules/frontend-
+  // design.md`'s "latest ref" záznam): `refetch` NESMIE čítať `query`/`state`
+  // priamo z uzáveru — `confirmAsIs`/`saveManualUrl`/`confirmGroupAsIs`/
+  // `saveManualUrlForGroup` sú KAŽDÁ zafixovaná na KONKRÉTNU inštanciu
+  // `refetch` v okamihu, keď bolo príslušné tlačidlo naposledy vykreslené
+  // (typicky v okamihu kliknutia). Ak sa medzitým (kým čaká na serverovú
+  // odpoveď) zmení filter/dopyt, `refetch()` volaný z neskoro doručeného
+  // `.then()` by aj tak zavolal `search` so STARÝMI hodnotami — a keďže
+  // `searchSeq` prideľuje poradové číslo pri ZAVOLANÍ (nie pri odpovedi),
+  // takýto neskorý-no-zastaraný refetch dostane VYŠŠIE číslo než medzitým
+  // spustené korektné vyhľadanie a jeho výsledok by ho ticho prepísal.
+  // `queryRef`/`stateRef` sa preto syncujú PRIAMO V TELE komponentu (počas
+  // renderu), NIE cez `useEffect` — ten beží AŽ PO commite ako pasívny efekt
+  // na samostatnom priechode, takže medzi commitom nového `query`/`state` a
+  // skutočným prebehnutím efektu existuje reálne okno, počas ktorého by ref
+  // ešte niesol STARÚ hodnotu; keďže `.then()` je mikrotaska, mohla by sa
+  // spustiť presne v tomto okne. Bezpečné len preto, že tento strom
+  // nepoužíva `startTransition`/Suspense (viď rovnaký komentár pri
+  // `SupplierLinksSection.tsx`'s `queryRef`/`stateRef`).
+  const queryRef = useRef(query);
+  queryRef.current = query;
+  const stateRef = useRef(state);
+  stateRef.current = state;
+
   const refetch = useCallback(() => {
-    search(query, state);
-  }, [search, query, state]);
+    search(queryRef.current, stateRef.current);
+  }, [search]);
 
   const groups = useMemo(() => groupPairingItems(items), [items]);
 
@@ -145,6 +170,16 @@ export function PairingSection({
     setActionError("");
   }, []);
 
+  // issue 254 (súrodenec issue 251's code-review finding 1): `busyCode`
+  // blokuje LEN tlačidlá VLASTNÉHO riadku — "✗ Zadať inú adresu" na VŠETKÝCH
+  // ostatných riadkoch ostáva aktívne. Ak počas čakania na odpoveď riadku A
+  // užívateľ otvorí editor riadku B, `editingCode` sa presunie na B — keby
+  // `saveManualUrl`'s `.then()` nepodmienene volalo `setEditingCode(null)`,
+  // ticho by zavrelo B's PRÁVE otvorený editor. Rovnaký "latest ref" princíp
+  // ako `queryRef`/`stateRef` vyššie, len na `editingCode`.
+  const editingKeyRef = useRef(editingCode);
+  editingKeyRef.current = editingCode;
+
   // "zamietni a zadaj inú adresu ručne" — server prepíše uloženú adresu touto
   // novou a rovno ju potvrdí (viď návrhový komentár na issue 45).
   const saveManualUrl = useCallback(
@@ -153,7 +188,7 @@ export function PairingSection({
       setBusyCode(variantCode);
       confirmPairing(variantCode, urlDraft.trim())
         .then(() => {
-          setEditingCode(null);
+          if (editingKeyRef.current === variantCode) setEditingCode(null);
           refetch();
         })
         .catch((err: unknown) => {

--- a/apps/web/tests/e2e/catalog.spec.ts
+++ b/apps/web/tests/e2e/catalog.spec.ts
@@ -2,6 +2,11 @@ import { expect, test } from "@playwright/test";
 
 const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
 
+// issue 254: VLASTNÝ izolovaný účet (rovnaký mechanizmus ako v
+// `pairing.spec.ts` — balík `e2e@forestshop.sk` je UŽ na hranici
+// `MAX_ATTEMPTS`), rola "manazer" pokrýva `IMPORT_ROLES`.
+const E2E_RACE_EMAIL = "e2e-race@forestshop.sk";
+
 // `GET /api/me` s odpoveďou 401 hneď po otvorení stránky. Rozpoznáva sa podľa
 // `location().url`, nie podľa textu — Chromium URL do textu „Failed to load
 // resource" nedáva. Rozširovanie výnimky na ďalšie cesty je zakázané.
@@ -83,4 +88,78 @@ test("filter 'Chýbajúce' nájde presne označený variant a riadok ukazuje, od
   const riadok = page.getByTestId("variant-40287");
   await expect(riadok).toBeVisible();
   await expect(riadok).toContainText("chýba od");
+});
+
+// issue 254 (súrodenec issue 251): `runIngest`'s `.then()` volalo
+// `search(query, state)` PRIAMO z uzáveru vykresľovacej inštancie zafixovanej
+// na klik na "Stiahnuť a naimportovať export". Reprodukcia NEMÔŽE nechať
+// požiadavku doletieť na SKUTOČNÝ server ako `pairing.spec.ts`/`supplier-
+// links.spec.ts` (len oneskorenú) — `SHOPTET_EXPORT_URL` nie je v E2E
+// prostredí nastavené (`.claude/rules/catalog.md`), takže reálny
+// `POST /api/catalog/ingest` vždy vráti 503 a `runIngest` by skončil v
+// `.catch()`, ktorý `search()` vôbec nevolá (chyba, nie race). Namiesto toho
+// FALOŠNÁ (nie reálna sieťová) oneskorená úspešná odpoveď — rovnaký
+// zaužívaný vzor ako `orders-write-failures.spec.ts`'s fake `Response`
+// (simuluje výsledok BEZ reálneho zápisu/zavolania servera, `.claude/rules/
+// testing.md`), len s pridaným `setTimeout` oneskorením.
+test("import (ešte prebiehajúci) nesmie prepísať MEDZITÝM zmenený filter zastaraným výsledkom (issue 254)", async ({
+  page,
+}) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.addInitScript(() => {
+    const puvodny = window.fetch.bind(window);
+    window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (init?.method === "POST" && url.includes("/api/catalog/ingest")) {
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            resolve(
+              new Response(JSON.stringify({ status: "duplicate", snapshotId: "e2e-issue-254-fake" }), {
+                status: 200,
+                headers: { "content-type": "application/json" },
+              }),
+            );
+          }, 400);
+        });
+      }
+      return puvodny(input, init);
+    };
+  });
+
+  await page.goto("/?tab=catalog");
+  await page.getByLabel("E-mail").fill(E2E_RACE_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 40");
+
+  await page.getByRole("button", { name: "Stiahnuť a naimportovať export" }).click();
+
+  // ZÁMERNE bez čakania na odpoveď — filter sa mení HNEĎ po kliknutí na
+  // import, presne to poradie udalostí, ktoré pôvodný bug reprodukovalo.
+  await page.getByLabel("Kód alebo názov").fill("40287");
+  await page.getByRole("button", { name: "Hľadať", exact: true }).click();
+
+  // `window.fetch` je tu ÚPLNE nahradené (falošná odpoveď, viď komentár
+  // vyššie) — nikdy neprejde cez skutočnú sieťovú vrstvu prehliadača, takže
+  // `page.waitForResponse` (počúva CDP sieťové udalosti) by naň nikdy
+  // nezareagovalo. Čaká sa preto priamym `waitForTimeout` (400ms oneskorenie
+  // + rezerva na `.then()`/render reťazec).
+  await page.waitForTimeout(700);
+
+  // S opravou: `runIngest`'s `.then()` číta AKTUÁLNY filter cez ref, takže
+  // jeho neskoro doručený výsledok žiada PRESNE ten istý filter ("40287"),
+  // aký použil aj testov vlastný dopyt. BEZ opravy by zastaraný `.then()`
+  // (uzáver s query="", state="all" z okamihu kliknutia na import) prepísal
+  // zoznam CELÝM (nefiltrovaným) výpisom.
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 1");
+  await expect(page.getByTestId("variant-40287")).toBeVisible();
+
+  expect(chyby).toEqual([]);
 });

--- a/apps/web/tests/e2e/pairing.spec.ts
+++ b/apps/web/tests/e2e/pairing.spec.ts
@@ -123,6 +123,166 @@ test("manažér potvrdí navrhnutú adresu jedným klikom, filter podľa stavu f
 // zbalený riadok (homogénne: všetkých 9 veľkostí má `supplierUrl: null`).
 const PRODUCT_KEY = "0a486205-d9e7-11e0-92ec-e1ef0b66e031";
 
+// issue 254: VLASTNÝ izolovaný účet (rovnaký mechanizmus ako
+// `E2E_SKUPINY_EMAIL` vyššie — balík je UŽ na hranici `MAX_ATTEMPTS`), pre
+// OBA nové race-testy nižšie (rola "manazer" pokrýva `CAN_CONFIRM_ROLES`).
+const E2E_RACE_EMAIL = "e2e-race@forestshop.sk";
+
+// issue 254: "Nohavice FOREST 5003" — 6 veľkostí (3XL, L, M, S, XL, XXL),
+// dovtedy NEPOUŽITÝ v žiadnom e2e spec súbore (overené grepom), VŠETKY bez
+// dodávateľa/adresy → homogénna skupina, zbalená pri prvom zobrazení.
+const FOREST_5003_PRODUCT_KEY = "b7727300-3927-11e6-8a3b-0cc47a6c92bc";
+
+// issue 254: "Pohonová bunda G7 Light" — 6 veľkostí (3XL, L, M, S, XL, XXL),
+// vo `.claude/rules/testing.md`'s zmysle dovtedy nepoužitý v ŽIADNOM
+// pairing teste (`60035/L`/`60035/M` sa používajú len v `orders-supplier-
+// assign.spec.ts` — INÁ tabuľka, `product_supplier_override`, nie
+// `pairing`) — samostatná skupina od `FOREST_5003_PRODUCT_KEY` vyššie, aby
+// cross-row test nezávisel od poradia behu so stale-closure testom.
+const G7_LIGHT_PRODUCT_KEY = "7d539b99-b0b4-11e6-968a-0cc47a6c92bc";
+
+// issue 254 (súrodenec issue 251): `refetch` v `PairingSection.tsx` mala
+// PRESNE ten istý (pred-opravou issue 251) tvar — priamy uzáver nad
+// `query`/`state`, žiadny ref. Rovnaká reprodukčná technika ako
+// `supplier-links.spec.ts`'s hlavný test: `window.fetch` prepichnutý cez
+// `addInitScript`, REÁLNA odpoveď (nie fake) len o 400ms oneskorená.
+test("uloženie manuálnej adresy (ešte čakajúce na odpoveď) nesmie prepísať MEDZITÝM zmenený filter zastaraným výsledkom (issue 254)", async ({
+  page,
+}) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.addInitScript(() => {
+    const puvodny = window.fetch.bind(window);
+    window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (init?.method === "POST" && url.includes("/api/pairing/confirm")) {
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            resolve(puvodny(input, init));
+          }, 400);
+        });
+      }
+      return puvodny(input, init);
+    };
+  });
+
+  await page.goto("/?tab=pairing");
+  await page.getByLabel("E-mail").fill(E2E_RACE_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await expect(page.getByRole("heading", { name: "Kontrola párovania" })).toBeVisible();
+
+  await page.getByTestId(`split-${FOREST_5003_PRODUCT_KEY}`).click();
+  const riadokM = page.getByTestId("pairing-40269/M");
+  await expect(riadokM).toBeVisible();
+  await riadokM.getByTestId("reject-40269/M").click();
+  await riadokM
+    .getByLabel("Adresa u dodávateľa pre 40269/M")
+    .fill("https://www.grube.sk/p/e2e-race-40269-m/1");
+
+  // `saveManualUrl` tu volané cez klik na Uložiť je zafixované na `refetch`
+  // inštanciu vykreslenú PRED nasledujúcou zmenou filtra — presne ten
+  // uzáver, ktorý issue 254 opravuje. `waitForResponse` sa zakladá PRED
+  // kliknutím, aby nezmeškal odpoveď doletiacu skôr, než by naň test začal čakať.
+  const odpoved = page.waitForResponse(
+    (res) => res.request().method() === "POST" && res.url().includes("/api/pairing/confirm"),
+  );
+  await riadokM.getByRole("button", { name: "Potvrdiť" }).click();
+
+  // ZÁMERNE bez čakania na odpoveď — zmena filtra a nové vyhľadanie hneď po
+  // kliknutí na Uložiť je presne to poradie udalostí, ktoré pôvodný bug
+  // reprodukovalo (rovnaký komentár ako `supplier-links.spec.ts`'s hlavný test).
+  await page.getByLabel("Kód variantu alebo produktu").fill("40269/L");
+  await page.getByRole("button", { name: "Filtrovať" }).click();
+
+  await odpoved;
+  await page.waitForTimeout(200); // rezerva na `.then()`/render reťazec
+
+  // S opravou: `refetch()` číta AKTUÁLNY filter cez ref, takže jeho neskoro
+  // doručený výsledok (ak vôbec dorazí až po tomto bode) žiada PRESNE ten
+  // istý filter ("40269/L"), aký použil aj testov vlastný dopyt — výsledok
+  // teda ostáva zúžený bez ohľadu na poradie doručenia odpovedí. BEZ opravy
+  // by zastaraný `refetch()` (uzáver s query="", state="all" z okamihu
+  // kliknutia na Uložiť) prepísal zoznam CELÝM (nefiltrovaným) výpisom.
+  await expect(page.getByTestId("pairing-total")).toHaveText("Nájdených: 1");
+  await expect(page.getByTestId("pairing-40269/L")).toBeVisible();
+  await expect(page.getByTestId("pairing-40269/M")).toHaveCount(0);
+
+  expect(chyby).toEqual([]);
+});
+
+// issue 254 (súrodenec issue 251's code-review finding 1): `saveManualUrl`'s
+// `.then()` malo PRESNE ten istý (pred-opravou issue 251) nepodmienený
+// `setEditingCode(null)` — riadku A's uloženie by ticho zavrelo riadok B's
+// PRÁVE otvorený editor, otvorený medzitým, kým A ešte čakalo na odpoveď.
+test("uloženie riadku A (ešte čakajúce na odpoveď) nesmie zavrieť editor riadku B otvorený medzitým (issue 254)", async ({
+  page,
+}) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.addInitScript(() => {
+    const puvodny = window.fetch.bind(window);
+    window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (init?.method === "POST" && url.includes("/api/pairing/confirm")) {
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            resolve(puvodny(input, init));
+          }, 400);
+        });
+      }
+      return puvodny(input, init);
+    };
+  });
+
+  await page.goto("/?tab=pairing");
+  await page.getByLabel("E-mail").fill(E2E_RACE_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await expect(page.getByRole("heading", { name: "Kontrola párovania" })).toBeVisible();
+
+  await page.getByTestId(`split-${G7_LIGHT_PRODUCT_KEY}`).click();
+  const riadokA = page.getByTestId("pairing-60035/S");
+  const riadokB = page.getByTestId("pairing-60035/XL");
+  await expect(riadokA).toBeVisible();
+  await expect(riadokB).toBeVisible();
+
+  const odpovedA = page.waitForResponse(
+    (res) => res.request().method() === "POST" && res.url().includes("/api/pairing/confirm"),
+  );
+  await riadokA.getByTestId("reject-60035/S").click();
+  await riadokA.getByLabel("Adresa u dodávateľa pre 60035/S").fill("https://www.grube.sk/p/e2e-race-a/1");
+  await riadokA.getByRole("button", { name: "Potvrdiť" }).click();
+
+  // B: kým A ešte čaká na odpoveď, otvoriť JEHO editor.
+  await riadokB.getByTestId("reject-60035/XL").click();
+  const vstupB = page.getByLabel("Adresa u dodávateľa pre 60035/XL");
+  await expect(vstupB).toBeVisible();
+
+  await odpovedA;
+  await page.waitForTimeout(200);
+
+  // B's editor musí ostať otvorený — A's `.then()` nesmie zavrieť CUDZÍ (v
+  // tomto momente už nesúvisiaci) editor. Jednorazová kontrola aktuálneho
+  // stavu (nie auto-retry `toBeVisible()`, ktoré by stačilo zachytiť prvok
+  // len na okamih).
+  expect(await vstupB.isVisible()).toBe(true);
+
+  expect(chyby).toEqual([]);
+});
+
 // VLASTNÝ účet (nie zdieľaný `e2e@forestshop.sk`) — `checkLoginRateLimit`
 // (`apps/api/src/http/login-rate-limit.ts`) počíta KAŽDÝ `POST /api/login`
 // proti dvojici (IP, e-mail), max. 10 v 5-minútovom okne, a celý e2e beh

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.147",
+  "version": "0.3.0-dev.148",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -170,6 +170,15 @@ const E2E_PREHLAD_EMAIL = "e2e-prehlad@forestshop.sk"; // musí sa zhodovať s h
 // e-shop) dostáva VLASTNÝ izolovaný účet.
 const E2E_DOMENY_EMAIL = "e2e-domeny@forestshop.sk"; // musí sa zhodovať s hodnotou v supplier-stock.spec.ts
 
+// issue 254: rovnaký mechanizmus a dôvod ako `E2E_DOMENY_EMAIL` vyššie —
+// nové race-testy (stale-closure refetch/search race + cross-row editor-close
+// guard) v `pairing.spec.ts`/`catalog.spec.ts` dostávajú VLASTNÝ izolovaný účet
+// namiesto ďalšieho prihlásenia pod zdieľaným `e2e@forestshop.sk` (balík je
+// UŽ na hranici `MAX_ATTEMPTS`, komentár vyššie pri `E2E_NAV_EMAIL`). Rola
+// "manazer" pokrýva `CAN_CONFIRM_ROLES` (párovanie) aj `IMPORT_ROLES`
+// (katalóg) — jeden účet stačí pre testy v OBOCH spec súboroch.
+const E2E_RACE_EMAIL = "e2e-race@forestshop.sk"; // musí sa zhodovať s hodnotou v pairing.spec.ts/catalog.spec.ts
+
 const { db, pool } = createDb();
 // Konštantný literál bez interpolácie — obyčajný reťazec je tu rovnako bezpečný
 // ako `sql` tagovaná šablóna (tú používa ekvivalentný apps/api/tests/helpers/db.ts),
@@ -326,6 +335,12 @@ await db.insert(users).values({
   passwordHash: await hashPassword(E2E_HESLO),
   displayName: "E2E Čítanie",
   role: "citanie",
+});
+await db.insert(users).values({
+  email: E2E_RACE_EMAIL,
+  passwordHash: await hashPassword(E2E_HESLO),
+  displayName: "E2E Manažér",
+  role: "manazer",
 });
 
 // Katalóg pre E2E: tá istá commitnutá fixtúra ako v jednotkových testoch, cez tú istú

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -336,12 +336,7 @@ await db.insert(users).values({
   displayName: "E2E Čítanie",
   role: "citanie",
 });
-await db.insert(users).values({
-  email: E2E_RACE_EMAIL,
-  passwordHash: await hashPassword(E2E_HESLO),
-  displayName: "E2E Manažér",
-  role: "manazer",
-});
+await db.insert(users).values({ email: E2E_RACE_EMAIL, passwordHash: await hashPassword(E2E_HESLO), displayName: "E2E Manažér", role: "manazer" });
 
 // Katalóg pre E2E: tá istá commitnutá fixtúra ako v jednotkových testoch, cez tú istú
 // službu importu — E2E tak overuje skutočnú cestu dát, nie ručne nasypané riadky.


### PR DESCRIPTION
## Čo bolo zlé

Rovnaké preteky, aké sa opravovali v issue 251, boli aj v súrodeneckých
obrazovkách:

- **`PairingSection.tsx`** — `refetch()` mal filter/dopyt priviazaný uzáverom z
  okamihu kliknutia (bajt za bajtom rovnaký tvar ako `SupplierLinksSection.tsx`
  pred opravou 251), takže po uložení mohol zastaraný refetch ticho prepísať
  správny výsledok. Navyše `saveManualUrl()` zatváral editor vo svojom `.then()`
  BEZPODMIENEČNE — keď si medzitým otvoril úpravu pri inom produkte, ten
  formulár sa sám zavrel a rozpísané sa stratilo.
- **`CatalogPage.tsx`** — `runIngest()` volal vo svojom `.then()` priamo
  `search(query, state)` z uzáveru, teda s hodnotami z času spustenia importu,
  nie s aktuálnymi.

## Čo sa zmenilo

- Zvýšenie verzie (`c373188`) na `0.3.0-dev.148` — po mergi issue 251 sa `dev`
  rovnal `main`.
- `[red]` testy (`36fc08a`): tri nové e2e testy reprodukujú všetky tri preteky;
  pred opravou spoľahlivo padajú.
- `[green]` oprava (`c5af00f`): `queryRef` / `stateRef` (synchronizované počas
  vykresľovania, nie cez `useEffect`) a poistka `editingKeyRef` pred zatvorením
  editora — presne podľa vzoru z opravy 251.
- Drobnosť (`4af615a`): jeden vložený blok v `e2e-setup.ts` na jeden riadok,
  aby súbor ostal pod eslint limitom `max-lines: 400`.

## Kontrola rozlišovacej schopnosti testov

Pri každom z troch nových testov bola oprava dočasne vrátená a overené, že test
naozaj padá:

- pretek v Párovaní: bez opravy `Nájdených: 40` namiesto `1`
- kolízia medzi riadkami: bez opravy je druhý formulár neviditeľný
- pretek v Katalógu: bez opravy `Nájdených: 40` namiesto `1`

Test pre Katalóg musel prejsť opravou aj sám: prvý pokus oneskoroval SKUTOČNÚ
odpoveď `/api/catalog/ingest`, lenže v e2e prostredí nie je nastavená
exportná adresa, takže endpoint vždy vráti 503 a `runIngest` skončí v `.catch()`
— žiadne preteky. Rieši sa to úplne falošnou oneskorenou odpoveďou (rovnaký vzor
ako `orders-write-failures.spec.ts`), skutočná sieť sa nepoužíva.

## Rozsah

Chýbajúca poistka pri odpojení komponentu (`mountedRef`) je v oboch súboroch,
ale je to iná trieda chyby (bezpečnosť pri odpojení, nie pretek uzáveru) a nie je
popísaná v tomto tickete — spolu s obdobnou kolíziou medzi riadkami v hromadnej
ceste `saveManualUrlForGroup` je založená ako issue 255.

Typová kontrola aj lint čisté, web unit testy 413/413, celá e2e sada 41/41.

issue 254
