### PR TITLE
Poistka proti zatvoreniu cudzieho hromadného editora + mountedRef (issue 255)

### DIFF
--- a/.claude/rules/pairing.md
+++ b/.claude/rules/pairing.md
@@ -92,3 +92,26 @@ paths:
   reconfirm.integration.test.ts` (ak súvisí s re-potvrdením) alebo ďalšieho
   nového `pairing-*.integration.test.ts` súboru (inak) — nie do
   jedného rastúceho monolitu.
+- **Fixtúra (`shoptet-sample.csv`) má LEN 5 viacvariantných produktových
+  skupín celkom — issue 255 zistilo, že po issue 47/254 zostáva len JEDNA
+  z nich (`01123126-3f69-11e6-8a3b-0cc47a6c92bc`, "60055/8,9,10")
+  NEDOTKNUTÁ žiadnym `pairing.spec.ts` testom, teda jediná bezpečne
+  homogénna skupina pre BUDÚCI test, ktorý potrebuje ĎALŠIU čerstvú
+  skupinu (`python3` + `csv.DictReader` zoskupené podľa `guid` je najrýchlejší
+  spôsob, ako si toto overiť namiesto hádania z komentárov).** Keď taký
+  test potrebuje DVE nezávislé homogénne skupiny naraz (napr. bulk
+  cross-row race, issue 255) a fixtúra má k dispozícii len jednu čerstvú —
+  bezpečná cesta je POZÍCIA v súbore (rovnaký princíp ako issue 61's
+  "vlož test PRED tie, čo dáta mutujú", `.claude/rules/testing.md`): nový
+  test sa vloží PRED existujúce testy, ktoré tie isté skupiny neskôr
+  rozdelia/zmutujú, a znova POUŽIJE ich (kým sú ešte pred-mutáciou
+  homogénne) — namiesto pridávania nových CSV riadkov (riskuje rozbiť
+  `catalog.spec.ts`'s pevné počty, `.claude/rules/testing.md`). Podmienka:
+  over, že novým testom vykonaná mutácia (bulk potvrdenie CELEJ skupiny
+  JEDNOU spoločnou adresou zostáva homogénne; OTVORENÝ ale NEODOSLANÝ bulk
+  editor nemutuje nič) je kompatibilná s tým, čo neskorší test v súbore
+  očakáva — issue 255's nový test preto skupinu B (editor len otvorený,
+  nikdy neuložený) nechal úplne nedotknutú a skupinu A bulk-potvrdil
+  JEDNOU adresou pre všetky veľkosti (zostáva homogénna), takže obe
+  neskoršie testy (issue 254's stale-closure/editor-close, ktoré tie isté
+  dve skupiny znova používajú) fungujú nezmenené.

--- a/apps/web/src/components/CatalogPage.tsx
+++ b/apps/web/src/components/CatalogPage.tsx
@@ -122,13 +122,27 @@ export function CatalogPage({
   const stateRef = useRef(state);
   stateRef.current = state;
 
+  // issue 255 (súrodenec issue 251's finding 3 — tento súbor je HIDDEN_TABS
+  // komponent, `nav.ts`, odmountuje sa pri prepnutí záložky): rovnaký vzor
+  // ako `SupplierLinksSection.tsx`'s `mountedRef`, vrátane StrictMode pasce
+  // (`true` musí byť nastavené AJ v efekte, nielen v `useRef(true)`).
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
   const loadStats = useCallback(() => {
     fetchCatalogStats()
       .then((s) => {
+        if (!mountedRef.current) return;
         setStats(s);
         setStatsLoaded(true);
       })
       .catch((err: unknown) => {
+        if (!mountedRef.current) return;
         setStatsLoaded(true);
         if (err instanceof CatalogUnauthorizedError) {
           onSessionExpired();
@@ -144,12 +158,14 @@ export function CatalogPage({
       setSearchError("");
       searchCatalogVariants({ q, state: s, page: 1 })
         .then((result) => {
+          if (!mountedRef.current) return; // odmountované skôr, než odpoveď doletela
           if (seq !== searchSeq.current) return; // medzitým prišla novšia požiadavka
           setItems(result.items);
           setTotal(result.total);
           setSearchLoaded(true);
         })
         .catch((err: unknown) => {
+          if (!mountedRef.current) return;
           if (seq !== searchSeq.current) return;
           setSearchLoaded(true);
           if (err instanceof CatalogUnauthorizedError) {

--- a/apps/web/src/components/PairingSection.tsx
+++ b/apps/web/src/components/PairingSection.tsx
@@ -61,18 +61,32 @@ export function PairingSection({
   // staršiu, širšiu odpoveď doručiť neskôr než novšiu, užšiu).
   const searchSeq = useRef(0);
 
+  // issue 255 (súrodenec issue 251's finding 3 — tento súbor je HIDDEN_TABS
+  // komponent, `nav.ts`, odmountuje sa pri prepnutí záložky): rovnaký vzor
+  // ako `SupplierLinksSection.tsx`'s `mountedRef`, vrátane StrictMode pasce
+  // (`true` musí byť nastavené AJ v efekte, nielen v `useRef(true)`).
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
   const search = useCallback(
     (q: string, s: PairingState) => {
       const seq = (searchSeq.current += 1);
       setSearchError("");
       searchPairings({ q, state: s, page: 1 })
         .then((result) => {
+          if (!mountedRef.current) return; // odmountované skôr, než odpoveď doletela
           if (seq !== searchSeq.current) return; // medzitým prišla novšia požiadavka
           setItems(result.items);
           setTotal(result.total);
           setSearchLoaded(true);
         })
         .catch((err: unknown) => {
+          if (!mountedRef.current) return;
           if (seq !== searchSeq.current) return;
           setSearchLoaded(true);
           if (err instanceof PairingUnauthorizedError) {
@@ -180,6 +194,12 @@ export function PairingSection({
   const editingKeyRef = useRef(editingCode);
   editingKeyRef.current = editingCode;
 
+  // issue 255 (rovnaký "latest ref" princíp ako `editingKeyRef` vyššie, len
+  // pre BULK/skupinovú cestu — `saveManualUrlForGroup`'s `.then()` nesmie
+  // zavrieť CUDZÍ, medzitým otvorený bulk editor INEJ skupiny).
+  const editingGroupKeyRef = useRef(editingGroupKey);
+  editingGroupKeyRef.current = editingGroupKey;
+
   // "zamietni a zadaj inú adresu ručne" — server prepíše uloženú adresu touto
   // novou a rovno ju potvrdí (viď návrhový komentár na issue 45).
   const saveManualUrl = useCallback(
@@ -254,7 +274,7 @@ export function PairingSection({
       const codes = group.variants.map((v) => v.variantCode);
       Promise.allSettled(codes.map((code) => confirmPairing(code, url)))
         .then((results) => {
-          setEditingGroupKey(null);
+          if (editingGroupKeyRef.current === group.productKey) setEditingGroupKey(null);
           refetch();
           assertBulkConfirmSucceeded(codes, results);
         })

--- a/apps/web/tests/e2e/pairing.spec.ts
+++ b/apps/web/tests/e2e/pairing.spec.ts
@@ -141,6 +141,82 @@ const FOREST_5003_PRODUCT_KEY = "b7727300-3927-11e6-8a3b-0cc47a6c92bc";
 // cross-row test nezávisel od poradia behu so stale-closure testom.
 const G7_LIGHT_PRODUCT_KEY = "7d539b99-b0b4-11e6-968a-0cc47a6c92bc";
 
+// issue 255 (súrodenec issue 251's finding 1 — nájdené pri issue 254, ale
+// mimo jej scope, tvar pre BULK/skupinovú cestu): `saveManualUrlForGroup`
+// v `PairingSection.tsx` mala PRESNE ten istý (pred-opravou) nepodmienený
+// `setEditingGroupKey(null)` ako `saveManualUrl` pred issue 251/254. Musí
+// bežať SKÔR než testy nižšie (ktoré tie isté dve skupiny mutujú
+// per-variantne) — obe skupiny sú tu ešte homogénne/nepotvrdené, jediné dve
+// viacvariantné skupiny vo fixtúre, ktoré nepoužíva žiadny INÝ test v tomto
+// súbore skôr.
+test("uloženie bulk adresy skupiny A (ešte čakajúce na odpoveď) nesmie zavrieť bulk editor skupiny B otvorený medzitým (issue 255)", async ({
+  page,
+}) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.addInitScript(() => {
+    const puvodny = window.fetch.bind(window);
+    window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (init?.method === "POST" && url.includes("/api/pairing/confirm")) {
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            resolve(puvodny(input, init));
+          }, 400);
+        });
+      }
+      return puvodny(input, init);
+    };
+  });
+
+  await page.goto("/?tab=pairing");
+  await page.getByLabel("E-mail").fill(E2E_RACE_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await expect(page.getByRole("heading", { name: "Kontrola párovania" })).toBeVisible();
+
+  const skupinaA = page.getByTestId(`pairing-group-${FOREST_5003_PRODUCT_KEY}`);
+  const skupinaB = page.getByTestId(`pairing-group-${G7_LIGHT_PRODUCT_KEY}`);
+  await expect(skupinaA).toBeVisible();
+  await expect(skupinaB).toBeVisible();
+
+  // A: bulk editor, vyplniť platnú adresu, uložiť (6 paralelných POST-ov,
+  // každý oneskorený 400ms).
+  const odpovedA = page.waitForResponse(
+    (res) => res.request().method() === "POST" && res.url().includes("/api/pairing/confirm"),
+  );
+  await skupinaA.getByTestId(`reject-group-${FOREST_5003_PRODUCT_KEY}`).click();
+  await skupinaA
+    .getByLabel("Adresa u dodávateľa pre Nohavice FOREST 5003 (všetky veľkosti)")
+    .fill("https://www.grube.sk/p/e2e-bulk-race-a/1");
+  await skupinaA.getByRole("button", { name: "Potvrdiť" }).click();
+
+  // B: kým A ešte čaká na odpoveď, otvoriť JEHO bulk editor.
+  await skupinaB.getByTestId(`reject-group-${G7_LIGHT_PRODUCT_KEY}`).click();
+  const vstupB = skupinaB.getByLabel("Adresa u dodávateľa pre Pohonová bunda G7 Light (všetky veľkosti)");
+  await expect(vstupB).toBeVisible();
+
+  // Počkať na SKUTOČNÚ sieťovú odpoveď A-čka + rezervu na dobehnutie
+  // zvyšných 5 paralelných POST-ov (`Promise.allSettled` čaká na VŠETKY) a
+  // na React-ov `.then()`/render reťazec.
+  await odpovedA;
+  await page.waitForTimeout(300);
+
+  // B's bulk editor musí ostať otvorený — A's `.then()` nesmie zavrieť
+  // CUDZÍ (v tomto momente už nesúvisiaci) bulk editor. Jednorazová
+  // kontrola aktuálneho stavu (nie auto-retry `toBeVisible()`, ktoré by
+  // stačilo zachytiť prvok len na okamih).
+  expect(await vstupB.isVisible()).toBe(true);
+
+  expect(chyby).toEqual([]);
+});
+
 // issue 254 (súrodenec issue 251): `refetch` v `PairingSection.tsx` mala
 // PRESNE ten istý (pred-opravou issue 251) tvar — priamy uzáver nad
 // `query`/`state`, žiadny ref. Rovnaká reprodukčná technika ako

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -2816,3 +2816,27 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   information_schema), row counts intact (4542 products / 14139
   variants), manual "Stiahnuť teraz" catalog-import trigger completed
   with no error, console clean. Deployed version `0.3.0-dev.146`.
+
+## Issue 255 — cross-row/unmount guard siblings (found during issue 254)
+
+- Version bump `c7e5f13` (0.3.0-dev.148 → 0.3.0-dev.149).
+- `[red]` test `dba794d`: `pairing.spec.ts` — bulk group-editor cross-row
+  race ("uloženie bulk adresy skupiny A ... nesmie zavrieť bulk editor
+  skupiny B otvorený medzitým"). Confirmed FAILS against unfixed code
+  (`vstupB.isVisible()` → `false`).
+- `[green]` fix `78a307b`: `PairingSection.tsx`'s `saveManualUrlForGroup`
+  gets an `editingGroupKeyRef` "latest ref" guard (mirrors the existing
+  `editingKeyRef` fix from issue 251/254, for the bulk/group path).
+  `PairingSection.tsx` + `CatalogPage.tsx` both get the `mountedRef`
+  unmount guard `SupplierLinksSection.tsx` got in issue 251 finding 3 —
+  no dedicated regression test for this half (investigated: no
+  React-18-observable difference exists — see design comment on the
+  issue and the commit body).
+- Both fixes reuse `FOREST_5003_PRODUCT_KEY`/`G7_LIGHT_PRODUCT_KEY`
+  (already declared for issue 254's per-variant race tests), positioned
+  BEFORE those tests in the file so both groups are still homogeneous —
+  see `.claude/rules/pairing.md`'s new entry (only one fully-unused
+  multi-variant group remains in the fixture after issue 47/254).
+- Local gates all green: `pnpm typecheck`, `pnpm lint`, `pnpm --filter
+  @forestshop/web test` (413 tests), `pnpm --filter @forestshop/web e2e`
+  (42/42).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.148",
+  "version": "0.3.0-dev.149",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Čo bolo zlé

Zvyšky po oprave pretekov z issue 254 — dve veci, ktoré ten ticket
nepokrýval:

- **`PairingSection.tsx`, hromadná cesta `saveManualUrlForGroup`** — jej
  `.then()` zatváral hromadný editor BEZPODMIENEČNE. Keď si počas ukladania
  skupiny A otvoril úpravu pri skupine B, formulár skupiny B sa sám zavrel a
  rozpísané sa stratilo. (Tá istá trieda chyby, akú v jednoriadkovej ceste
  opravovala issue 254.)
- **Chýbajúca poistka pri odpojení komponentu (`mountedRef`)** v
  `PairingSection.tsx` (`search`) aj `CatalogPage.tsx` (`search`, `loadStats`) —
  ani jeden zo súborov `mountedRef` vôbec nemal.

## Čo sa zmenilo

- Zvýšenie verzie (`c7e5f13`) na `0.3.0-dev.149` — po mergi issue 254 sa `dev`
  rovnal `main`.
- `[red]` test (`dba794d`): nový e2e test reprodukuje kolíziu medzi hromadnými
  editormi dvoch skupín.
- `[green]` oprava (`78a307b`): poistka `editingGroupKeyRef` pred zatvorením
  hromadného editora + `mountedRef` v oboch súboroch.
- Zápis do playbooku a autopilot logu (`65b2a51`).

## Kontrola rozlišovacej schopnosti testu

Nový test `pairing.spec.ts:152` — oprava (riadok s `editingGroupKeyRef`) bola
dočasne vrátená a test naozaj padol: `expect(await vstupB.isVisible()).toBe(true)`
vrátilo `false`, teda uloženie skupiny A zavrelo otvorený editor skupiny B. Po
obnovení opravy beh prešiel (42/42).

## Prečo `mountedRef` nemá vlastný test

React 18 odstránil varovanie o `setState` na odpojenom komponente a každé
prepnutie záložky vytvára nové inštancie `useState`, na ktoré starý oneskorený
`.then()` uzáver už nedosiahne — neexistuje pozorovateľné správanie, ktoré by
odlíšilo stav s poistkou od stavu bez nej. Poistka je pridaná pre konzistenciu
so `SupplierLinksSection.tsx` a ako obrana do hĺbky; dôvod je zapísaný v tele
`[green]` commitu aj v komentári na tickete.

Typová kontrola aj lint čisté, web unit testy 413/413, celá e2e sada 42/42.

issue 255
