### PR TITLE
Na objednanie: správny počet kusov, farebné odlíšenie riadkov, kompaktnejší prehľad (issues 260/259/258)

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -757,3 +757,28 @@ paths:
   PRVOM teste súboru). Vzor pre tento guard: `useEffect(() => {
   mountedRef.current = true; return () => { mountedRef.current = false; };
   }, [])` — nikdy len holý cleanup bez zodpovedajúceho "nastav true" v tele.
+
+- **Riadkové farebné odlíšenie v tabuľke "Na objednanie" prešlo z
+  3-stavového (`state-caka_sa`/`state-skladom`/`state-nedostupne`) na
+  BINÁRNE podľa kanonického `isLineResolved` (issue 259) — každý ĎALŠÍ
+  "farbi riadok podľa X" nápad na tejto tabuľke sa má najprv opýtať, či X
+  je skutočne to, čo majiteľ chce vidieť, alebo len jeho PROXY.** Pôvodné
+  3-stavové farbenie nechávalo VÄČŠINU riadkov (predvolený stav
+  "objednane", ešte neobjednané) úplne biele — presne tie, čo "treba
+  vybaviť" — a majiteľ to opísal ako "dnes sa nefarbí nič", hoci appka
+  TECHNICKY farbila 3 z 5 stavov. Nová trieda `.line-resolved`/
+  `.line-unresolved` (`app.css`) farbí podľa TOHO ISTÉHO predikátu, čo appka
+  všade inde používa na "je tento riadok hotový" — nie podľa nového
+  vlastného výpočtu. Farba NIKDY nie je jediný signál (existujúci stĺpec
+  "Stav" + checkbox "Objednané" ostávajú) — colour-blind-safe bez extra
+  UI prvku.
+- **Meranie/zmenšovanie výšky nekontextuálneho bloku (dlaždice, panel,
+  hlavička) naživo cez `page.addStyleTag` proti PRODUKCII je rovnako
+  použiteľné na VÝŠKU ako na `<colgroup>` percentá (doteraz zdokumentované
+  len pre tabuľkové stĺpce).** Issue 258 (dlaždice "Prehľad e-shopu"/"Súhrn
+  o objednávaní" príliš veľké): namerané PRED zmenou (103px/79.5px na
+  dlaždicu, blok 253.5px pri 1366×768), potom `page.addStyleTag` s
+  kandidátskym CSS priamo na živej stránke, opäť namerané (58.5px/dlaždicu,
+  169px blok, −33 %) — až PO potvrdení čísel sa kandidát preniesol do
+  `app.css`. Rovnaký postup funguje pre AKÝKOĽVEK "toto zaberá príliš veľa
+  miesta" ticket, nielen šírkové stĺpce.

--- a/.claude/rules/orders.md
+++ b/.claude/rules/orders.md
@@ -477,3 +477,20 @@ paths:
   v UI (nie len spolu s neutrálnou jednotkou ako `formatVariantTotalChip`'s
   "N ks"), potrebuje rovnaký trojtvarový pomocník, nikdy šablónový
   reťazec s jedným pevným tvarom podstatného mena.
+
+- **`summarizeOrderLines` (`ordersSummary.ts`) doteraz počítala RIADKY
+  (`lines.length`, `+= 1`), nie sčítanú `quantity` — ticho podčítala presne
+  vtedy, keď `ingest.ts` sčíta ten istý produkt v tej istej objednávke do
+  JEDNÉHO riadku s `quantity > 1` (issue 260, majiteľ: "sú tam 2 rovnaké
+  čelovky, ale ukazuje len jednu").** Fix: KAŽDÉ pole
+  (`total`/`remaining`/`ordered`/`waiting`/`stock`/`unavailable`) sčítava
+  `line.quantity`. **Výnimka, ktorú treba poznať pred ĎALŠOU zmenou tejto
+  funkcie:** `OrdersSection.tsx`'s nav-odznak (issue 147,
+  `OrdersRemainingCountContext`) má VLASTNÝ, samostatne testovaný zámer —
+  "počet NEVYBAVENÝCH RIADKOV" (test explicitne hovorí "nie celkový
+  počet") — preto NEJDE cez `summarizeOrderLines(...).remaining`, ale počíta
+  priamo `allLines.filter((l) => !isLineResolved(l)).length`. Test na
+  KAŽDÚ ĎALŠIU zmenu tejto funkcie: potrebuje niektoré volajúce miesto
+  POČET RIADKOV namiesto súčtu kusov? Ak áno, nech si to počíta samo cez
+  `isLineResolved`, nespoliehaj sa na to, že `summarizeOrderLines` uhádne
+  správny význam pre všetkých volajúcich naraz.

--- a/apps/web/src/components/OrderLineRow.rowColor.test.tsx
+++ b/apps/web/src/components/OrderLineRow.rowColor.test.tsx
@@ -1,0 +1,93 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { OrdersSection } from "./OrdersSection.js";
+
+// issue 259 — majiteľ (verbatim): "červenou to, čo už mám urobené, zelenou
+// to, čo treba vybaviť". Binárne podľa kanonického `isLineResolved`
+// (`ordersSummary.ts`), nie podľa jednotlivého `state` — pozri `app.css`'s
+// `.line-resolved`/`.line-unresolved` komentár. Vlastný súbor, rovnaký vzor
+// ako `OrderLineRow.adminLink.test.tsx` (`.claude/rules/frontend-design.md`).
+const { fetchOpenOrders, fetchOrdersOverview } = vi.hoisted(() => ({ fetchOpenOrders: vi.fn(), fetchOrdersOverview: vi.fn() }));
+
+vi.mock("../ordersApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../ordersApi.js")>();
+  return { ...actual, fetchOpenOrders, fetchOrdersOverview };
+});
+
+const LINE = {
+  lineId: "66666666-6666-6666-6666-666666666666",
+  orderId: "dddddddd-6666-6666-6666-666666666666",
+  externalOrderId: "20261300",
+  customerName: "Zákazník Delta",
+  comment: null,
+  remark: null,
+  shopRemark: null,
+  adminUrl: "https://www.forestshop.sk/admin/vyhladavanie/?string=20261300&src=orders",
+  placedAt: "2026-07-01T00:00:00.000Z",
+  variantCode: "D-1",
+  variantName: "Čelovka FOREST 4001",
+  sizeLabel: null,
+  quantity: 1,
+  state: "objednane" as const,
+  ordered: false,
+  supplierUrl: null,
+  supplierNote: null,
+  externalCode: null,
+  supplierAssignable: false,
+  manualSupplierOverride: null,
+};
+
+beforeEach(() => {
+  fetchOrdersOverview.mockResolvedValue({
+    today: { orderCount: 0, revenue: "0.00" },
+    week: { orderCount: 0, revenue: "0.00" },
+    month: { orderCount: 0, revenue: "0.00" },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+it("nevybavený riadok (predvolený stav, neodškrtnuté) dostane 'line-unresolved', nie 'line-resolved'", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Delta", lines: [LINE], email: null }]);
+
+  render(<OrdersSection role="citanie" onSessionExpired={() => {}} />);
+
+  const riadok = await screen.findByTestId(`order-line-${LINE.lineId}`);
+  expect(riadok.className).toContain("line-unresolved");
+  expect(riadok.className).not.toContain("line-resolved");
+});
+
+it("riadok vybavený ODŠKRTNUTÍM 'objednané' (state stále predvolený) dostane 'line-resolved'", async () => {
+  const ODSKRTNUTY = { ...LINE, lineId: "77777777-7777-7777-7777-777777777777", ordered: true };
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Delta", lines: [ODSKRTNUTY], email: null }]);
+
+  render(<OrdersSection role="citanie" onSessionExpired={() => {}} />);
+
+  const riadok = await screen.findByTestId(`order-line-${ODSKRTNUTY.lineId}`);
+  expect(riadok.className).toContain("line-resolved");
+  expect(riadok.className).not.toContain("line-unresolved");
+});
+
+it("riadok vybavený POSUNUTÝM stavom (napr. 'skladom', neodškrtnutý) tiež dostane 'line-resolved'", async () => {
+  const SKLADOM = { ...LINE, lineId: "88888888-8888-8888-8888-888888888888", state: "skladom" as const };
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Delta", lines: [SKLADOM], email: null }]);
+
+  render(<OrdersSection role="citanie" onSessionExpired={() => {}} />);
+
+  const riadok = await screen.findByTestId(`order-line-${SKLADOM.lineId}`);
+  expect(riadok.className).toContain("line-resolved");
+});
+
+// Farbosleposť: farba NIKDY nie je jediný signál — stĺpec "Stav" ukazuje
+// odlišný TEXT bez ohľadu na farbu (`.claude/rules/frontend-design.md`).
+it("farebné odlíšenie nie je jediný signál — textový štítok stavu ostáva viditeľný", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Delta", lines: [LINE], email: null }]);
+
+  render(<OrdersSection role="citanie" onSessionExpired={() => {}} />);
+
+  const riadok = await screen.findByTestId(`order-line-${LINE.lineId}`);
+  expect(riadok.textContent).toContain("Nevybavené");
+});

--- a/apps/web/src/components/OrderLineRow.tsx
+++ b/apps/web/src/components/OrderLineRow.tsx
@@ -1,7 +1,13 @@
 import { useEffect, useRef, useState, type JSX } from "react";
 import type { OrderLine } from "../ordersApi.js";
 import { STATE_LABELS } from "../orderLineStateLabels.js";
-import { formatVariantTotalChip, isStaleOrderLine, orderLineAgeDays, type VariantTotal } from "../ordersSummary.js";
+import {
+  formatVariantTotalChip,
+  isLineResolved,
+  isStaleOrderLine,
+  orderLineAgeDays,
+  type VariantTotal,
+} from "../ordersSummary.js";
 import { OrderLineStateButtons } from "./OrderLineStateButtons.js";
 
 // issue 162: počet stĺpcov "Na objednanie" tabuľky — MUSÍ sedieť s počtom
@@ -208,7 +214,10 @@ export function OrderLineRow({
   return (
     <>
       <tr
-        className={"order-row state-" + line.state + (line.ordered ? " ordered" : "")}
+        // issue 259: binárne červená/zelená podľa kanonického `isLineResolved`
+        // (`app.css`'s komentár pri `.line-resolved`/`.line-unresolved`
+        // vysvetľuje prečo nie podľa jednotlivého `state`).
+        className={"order-row " + (isLineResolved(line) ? "line-resolved" : "line-unresolved") + (line.ordered ? " ordered" : "")}
         data-testid={`order-line-${line.lineId}`}
       >
         <td>

--- a/apps/web/src/components/OrdersOverviewTiles.test.tsx
+++ b/apps/web/src/components/OrdersOverviewTiles.test.tsx
@@ -114,6 +114,30 @@ it("'Súhrn o objednávaní' počíta zo suppliers bez ohľadu na to, či prehľ
   );
 });
 
+// issue 260 — majiteľ: "sú tam 2 rovnaké čelovky, ale ukazuje len jednu".
+// `ingest.ts` sčíta ten istý produkt v tej istej objednávke do JEDNÉHO
+// `order_line` s `quantity: 2` (`.claude/rules/orders.md`) — "Položiek na
+// objednanie" preto MUSÍ ukázať súčet KUSOV (4), nie počet riadkov (2). Pred
+// opravou (`summarizeOrderLines` počítala `lines.length`) by táto asercia
+// zlyhala s "2" namiesto "4".
+it("'Položiek na objednanie' sčíta MNOŽSTVÁ riadkov, nie ich počet", () => {
+  fetchOrdersOverview.mockReturnValue(new Promise(() => {}));
+  const suppliers: readonly SupplierOpenOrders[] = [
+    {
+      supplier: "Dodávateľ Alfa",
+      email: null,
+      lines: [
+        makeLine({ lineId: "b1", orderId: "ob1", quantity: 2, state: "objednane", ordered: false }),
+        makeLine({ lineId: "b2", orderId: "ob2", quantity: 2, state: "objednane", ordered: false }),
+      ],
+    },
+  ];
+
+  render(<OrdersOverviewTiles suppliers={suppliers} onSessionExpired={() => {}} />);
+
+  expect(screen.getByTestId("overview-ordering-remaining").textContent).toContain("4");
+});
+
 it("bez žiadneho nevybaveného riadku ukáže '—' namiesto dátumu najstaršej čakajúcej", () => {
   fetchOrdersOverview.mockReturnValue(new Promise(() => {}));
   render(<OrdersOverviewTiles suppliers={[]} onSessionExpired={() => {}} />);

--- a/apps/web/src/components/OrdersSection.tsx
+++ b/apps/web/src/components/OrdersSection.tsx
@@ -7,7 +7,7 @@ import {
   readSelectedSupplierPreference,
 } from "../ordersDisplayPreferences.js";
 import { OrdersRemainingCountContext } from "../ordersRemainingCountContext.js";
-import { isLineHiddenByFilter, summarizeOrderLines } from "../ordersSummary.js";
+import { isLineHiddenByFilter, isLineResolved } from "../ordersSummary.js";
 import { clearWriteFailure, lineWhere, orderWhere, upsertWriteFailure, type OrderWriteFailure } from "../ordersWriteFailures.js";
 import { useDirtyEditorLineIds } from "../useDirtyEditorLineIds.js";
 import { useSelectedSupplierFallback } from "../useSelectedSupplierFallback.js";
@@ -131,15 +131,20 @@ export function OrdersSection({
 
   useEffect(load, [load]);
 
-  // issue 147: publikuje počet NEVYBAVENÝCH riadkov (naprieč VŠETKÝMI
+  // issue 147: publikuje počet NEVYBAVENÝCH RIADKOV (naprieč VŠETKÝMI
   // dodávateľmi) do ľavého menu cez `OrdersRemainingCountContext` — po KAŽDEJ
   // zmene `suppliers`, takže odznak je vždy aktuálny. Pred prvým úspešným
   // načítaním sa nevolá vôbec — Sidebar dovtedy odznak nevykreslí.
+  // issue 260: zámerne NEJDE cez `summarizeOrderLines(...).remaining` — tá
+  // odteraz sčítava KUSY (`quantity`), zatiaľ čo tento odznak má vlastný,
+  // samostatne zdokumentovaný zámer "počet riadkov" (viď test "publikuje
+  // počet nevybavených riadkov (nie celkový počet)"). Počíta sa preto priamo
+  // cez kanonický predikát `isLineResolved`.
   const { setCount: setOrdersRemainingCount } = useContext(OrdersRemainingCountContext);
   useEffect(() => {
     if (!loaded) return;
     const allLines = suppliers.flatMap((group) => group.lines);
-    setOrdersRemainingCount(summarizeOrderLines(allLines).remaining);
+    setOrdersRemainingCount(allLines.filter((l) => !isLineResolved(l)).length);
   }, [loaded, suppliers, setOrdersRemainingCount]);
 
   // issue 148 (vyňaté do `useSelectedSupplierFallback.ts`, issue 151 —

--- a/apps/web/src/ordersSummary.test.ts
+++ b/apps/web/src/ordersSummary.test.ts
@@ -14,9 +14,14 @@ import {
   summarizeOrderLines,
 } from "./ordersSummary.js";
 
-const line = (state: "objednane" | "caka_sa" | "skladom" | "nedostupne", ordered: boolean) => ({
+const line = (
+  state: "objednane" | "caka_sa" | "skladom" | "nedostupne",
+  ordered: boolean,
+  quantity = 1,
+) => ({
   state,
   ordered,
+  quantity,
 });
 
 const overviewLine = (
@@ -87,6 +92,37 @@ it("rozpis NIE JE rozklad total na disjunktné časti — riadok môže byť v O
   const summary = summarizeOrderLines([line("caka_sa", true)]);
 
   expect(summary).toEqual({ total: 1, remaining: 0, ordered: 1, waiting: 1, stock: 0, unavailable: 0 });
+});
+
+// issue 260 — majiteľ: "sú tam 2 rovnaké čelovky, ale ukazuje len jednu".
+// `ingest.ts` sčíta ten istý produkt v tej istej objednávke do JEDNÉHO
+// `order_line` s `quantity: 2` (`.claude/rules/orders.md`) — `total`/
+// `remaining` preto MUSIA sčítať `quantity`, nie počítať riadky. Pred
+// opravou by táto asercia zlyhala (`total`/`remaining` by boli 1, nie 2) —
+// dôkaz, že tento test naozaj chybu odhalí, nielen potvrdí kód.
+it("summarizeOrderLines sčíta MNOŽSTVÁ, nie počet riadkov — dva rovnaké kusy na JEDNOM riadku sa počítajú ako 2", () => {
+  const summary = summarizeOrderLines([line("objednane", false, 2)]);
+
+  expect(summary).toEqual({ total: 2, remaining: 2, ordered: 0, waiting: 0, stock: 0, unavailable: 0 });
+});
+
+// Druhý tvar toho istého bugu: dva RÔZNE riadky (rôzne objednávky) toho
+// istého produktu musia svoje množstvá tiež SČÍTAŤ, nielen spočítať riadky.
+it("summarizeOrderLines sčíta množstvá naprieč VIACERÝMI riadkami rovnakého produktu", () => {
+  const summary = summarizeOrderLines([line("objednane", false, 3), line("objednane", false, 1)]);
+
+  expect(summary.total).toBe(4);
+  expect(summary.remaining).toBe(4);
+});
+
+// `ordered`/`waiting`/`stock`/`unavailable` rozpis musí byť konzistentný s
+// `total`/`remaining` — aj TIETO bucket-y počítajú kusy, nie riadky (inak by
+// súčet rozpisu pri jednom viac-kusovom riadku pôsobil nezmyselne malý oproti
+// `total`).
+it("summarizeOrderLines — rozpis podľa stavu/odškrtnutia tiež sčíta množstvo, nie riadky", () => {
+  const summary = summarizeOrderLines([line("caka_sa", true, 5)]);
+
+  expect(summary).toEqual({ total: 5, remaining: 0, ordered: 5, waiting: 5, stock: 0, unavailable: 0 });
 });
 
 it("formatOrderSummaryText bez vybraného dodávateľa a bez rozpisu (žiadny bucket nenulový)", () => {

--- a/apps/web/src/ordersSummary.ts
+++ b/apps/web/src/ordersSummary.ts
@@ -25,6 +25,8 @@ export function isLineHiddenByFilter(
   return hideResolved && isLineResolved(line) && !dirtyEditorLineIds.has(line.lineId);
 }
 
+// issue 260: každé pole je súčet `quantity` (počet KUSOV naprieč riadkami),
+// nikdy počet riadkov — pozri `summarizeOrderLines`'s komentár nižšie.
 export interface OrderLinesSummary {
   readonly total: number;
   readonly remaining: number;
@@ -35,6 +37,15 @@ export interface OrderLinesSummary {
 }
 
 /**
+ * issue 260 (majiteľ: "sú tam 2 rovnaké čelovky, ale ukazuje len jednu"):
+ * KAŽDÉ pole tu je súčet `quantity` (počet KUSOV), NIE počet riadkov.
+ * `ingest.ts` sčíta ten istý produkt v tej istej objednávke do JEDNÉHO
+ * `order_line` s `quantity > 1` (`.claude/rules/orders.md`) — počítanie
+ * riadkov (`lines.length`/`+= 1`) preto podčíta presne v tomto prípade:
+ * dva kusy na jednom riadku by vyšli ako "1". Výnimka: `OrdersSection.tsx`'s
+ * nav-odznak (issue 147) zámerne NEPOUŽÍVA túto funkciu — jeho vlastný,
+ * samostatne zdokumentovaný zámer je počet NEVYBAVENÝCH RIADKOV, nie kusov.
+ *
  * Rozpis NIE JE rozklad `total` na disjunktné časti — jeden riadok môže byť
  * súčasne `ordered` AJ v inom stave než "objednane" (rovnaký zámer ako stará
  * appka's `toOrderSummary`, ktorej komentár to hovorí výslovne: "the
@@ -42,21 +53,23 @@ export interface OrderLinesSummary {
  * priamo cez `isLineResolved`, nikdy odčítaním súčtu rozpisu od `total`.
  */
 export function summarizeOrderLines(
-  lines: readonly Pick<OrderLine, "ordered" | "state">[],
+  lines: readonly Pick<OrderLine, "ordered" | "state" | "quantity">[],
 ): OrderLinesSummary {
   let ordered = 0;
   let waiting = 0;
   let stock = 0;
   let unavailable = 0;
   let remaining = 0;
+  let total = 0;
   for (const line of lines) {
-    if (line.ordered) ordered += 1;
-    if (line.state === "caka_sa") waiting += 1;
-    if (line.state === "skladom") stock += 1;
-    if (line.state === "nedostupne") unavailable += 1;
-    if (!isLineResolved(line)) remaining += 1;
+    total += line.quantity;
+    if (line.ordered) ordered += line.quantity;
+    if (line.state === "caka_sa") waiting += line.quantity;
+    if (line.state === "skladom") stock += line.quantity;
+    if (line.state === "nedostupne") unavailable += line.quantity;
+    if (!isLineResolved(line)) remaining += line.quantity;
   }
-  return { total: lines.length, remaining, ordered, waiting, stock, unavailable };
+  return { total, remaining, ordered, waiting, stock, unavailable };
 }
 
 const BREAKDOWN_PARTS: readonly (readonly ["ordered" | "waiting" | "stock" | "unavailable", string])[] = [

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -943,28 +943,37 @@ tr:last-child td {
    `min-height`) bol pre tento účel ZBYTOČNÝ a odstránený — nemenil by nič
    mimo tejto (zamietnutej) funkcie, len by natvrdo zväčšil výšku Topbaru na
    VŠETKÝCH obrazovkách bez dôvodu. Rozhodnutie zapísané aj na ticket #95. */
-/* Farby stavu riadku — sémantické (čaká/skladom/nedostupné), vlastná paleta
-   tejto appky (nie prevzaté hodnoty starej appky). */
-.orders-table tr.state-caka_sa {
-  background: var(--fs-warning-bg);
-}
-.orders-table tr.state-caka_sa td:first-child {
-  box-shadow: inset 3px 0 0 var(--fs-warning);
-}
-.orders-table tr.state-skladom {
-  background: var(--fs-success-bg);
-}
-.orders-table tr.state-skladom td:first-child {
-  box-shadow: inset 3px 0 0 var(--fs-success);
-}
-.orders-table tr.state-nedostupne {
+/* issue 259 — majiteľ VERBATIM: "červenou to, čo už mám urobené, zelenou to,
+   čo treba vybaviť". Binárne podľa KANONICKÉHO `isLineResolved` predikátu
+   (`ordersSummary.ts`), nie podľa jednotlivého `state` (predošlý dizajn,
+   issue 57) — ten farbil LEN caka_sa/skladom/nedostupne a nechával VÄČŠINU
+   riadkov (predvolený stav "objednane", ešte neobjednané) úplne biele, čo
+   majiteľ opísal ako "dnes sa nefarbí nič" (najčastejší, práve TEN dôležitý
+   prípad). `isLineResolved` (`ordered || state !== "objednane"`) zjednocuje
+   OBIDVA spôsoby, akými môže byť riadok "urobený" (odškrtnuté "objednané"
+   ALEBO posunutý stav) pod JEDNU farbu, presne ako to majiteľ chce vidieť.
+   Farba NIKDY nie je JEDINÝ signál — stĺpec "Stav" (`STATE_LABELS` text,
+   "Nevybavené"/"Čaká sa"/"Skladom"/"Nedostupné") a odškrtávacie políčko
+   "Objednané" ostávajú nezmenené vedľa nej, takže riadok sa dá rozlíšiť aj
+   bez farby (`.claude/rules/frontend-design.md` farbosleposť). Vlastná
+   paleta appky (--fs-danger/--fs-success token HODNOTY, nie nový hex) — len
+   použité v OPAČNOM zmysle, než ich meno naznačuje (danger-červená = "už
+   urobené", success-zelená = "treba vybaviť"), presne podľa majiteľovho
+   zadania. */
+.orders-table tr.line-resolved {
   background: var(--fs-danger-bg);
 }
-.orders-table tr.state-nedostupne td:first-child {
+.orders-table tr.line-resolved td:first-child {
   box-shadow: inset 3px 0 0 var(--fs-danger);
 }
+.orders-table tr.line-unresolved {
+  background: var(--fs-success-bg);
+}
+.orders-table tr.line-unresolved td:first-child {
+  box-shadow: inset 3px 0 0 var(--fs-success);
+}
 /* issue 60: odškrtnuté "objednané u dodávateľa" — stlmí CELÝ riadok bez
-   ohľadu na `state-*` farbu vyššie (rovnaká hodnota, akú appka už používa
+   ohľadu na farbu vyššie (rovnaká hodnota, akú appka už používa
    pre `.btn:disabled`, nie prevzaté zo starej appky). */
 .orders-table tr.ordered {
   opacity: 0.55;

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -725,51 +725,70 @@ tr:last-child td {
 
 /* issue 237: blok dlaždíc NAD zoznamom "Na objednanie" — dve skupiny
    ("Prehľad e-shopu" + "Súhrn o objednávaní"). Dlaždice sú PREHĽAD, nikdy
-   klikateľný filter (žiadny `cursor: pointer`/`onClick`). */
+   klikateľný filter (žiadny `cursor: pointer`/`onClick`). issue 258
+   (majiteľ: "je to strašne veľké... musím dosť rolovať dole... pre mna je to
+   len informatívna informácia") zmenšilo celý blok — pôvodné 3-riadkové
+   dlaždice (label/hodnota/vedľajší údaj, každý na vlastnom riadku, veľký
+   `--fs-text-lg` súčet + veľké odsadenie) namerané naživo
+   (`page.addStyleTag` kandidát proti produkcii, rovnaká metodika ako
+   `.claude/rules/frontend-design.md`'s `<colgroup>` merania) na 103px/79.5px
+   výšku dlaždice, celý blok 253.5px pri 1366×768. Fix: dlaždica je teraz
+   JEDEN riadok popisku + JEDEN riadok hodnoty (label si necháva vlastný
+   `flex: 1 1 100%`, aby sa vždy zalomil PRED hodnotou, nikdy vedľa nej pri
+   užšom okne), menšie písmo (`--fs-text-base` namiesto `--fs-text-lg`) aj
+   odsadenie (`--fs-space-2`/`--fs-space-3` namiesto `--fs-space-3`/
+   `--fs-space-4`) — namerané 58.5px/dlaždicu, blok 169px (−33 %), tabuľka
+   pod ním sa posunula o ~96px vyššie. Všetkých 7 čísel ostáva plne čitateľné
+   (žiadna hodnota sa neskrátila/neorezala) — len menšie, nie chýbajúce. */
 .orders-overview {
   display: flex;
   flex-direction: column;
-  gap: var(--fs-space-4);
-  margin-bottom: var(--fs-space-5);
+  gap: var(--fs-space-2);
+  margin-bottom: var(--fs-space-3);
 }
 .overview-group-title {
-  font-size: var(--fs-text-sm);
+  font-size: var(--fs-text-xs);
   font-weight: var(--fs-weight-semibold);
   color: var(--fs-ink-muted);
   text-transform: uppercase;
   letter-spacing: 0.03em;
-  margin: 0 0 var(--fs-space-2);
+  margin: 0 0 var(--fs-space-1);
 }
 .overview-tiles {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--fs-space-3);
+  gap: var(--fs-space-2);
 }
 .overview-tile {
-  flex: 1 1 10rem;
-  min-width: 10rem;
+  flex: 1 1 9rem;
+  min-width: 9rem;
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  column-gap: var(--fs-space-2);
   background: var(--fs-surface);
   border: 1px solid var(--fs-border-soft);
   border-radius: var(--fs-radius-md);
   box-shadow: var(--fs-shadow-sm);
-  padding: var(--fs-space-3) var(--fs-space-4);
+  padding: var(--fs-space-2) var(--fs-space-3);
 }
 .overview-tile-label {
+  flex: 1 1 100%;
   font-size: var(--fs-text-xs);
   color: var(--fs-ink-muted);
-  margin: 0 0 var(--fs-space-1);
+  margin: 0;
 }
 .overview-tile-value {
-  font-size: var(--fs-text-lg);
+  font-size: var(--fs-text-base);
   font-weight: var(--fs-weight-bold);
   color: var(--fs-ink);
   margin: 0;
 }
 .overview-tile-sub {
-  font-size: var(--fs-text-sm);
+  font-size: var(--fs-text-xs);
   color: var(--fs-brand);
   font-weight: var(--fs-weight-medium);
-  margin: var(--fs-space-1) 0 0;
+  margin: 0;
 }
 
 /* issue 61: filtrovacie štítky dodávateľov + súhrn "ostáva vybaviť" +

--- a/apps/web/tests/e2e/orders-overview.spec.ts
+++ b/apps/web/tests/e2e/orders-overview.spec.ts
@@ -8,6 +8,7 @@ interface RawOrderLine {
   readonly ordered: boolean;
   readonly state: "objednane" | "caka_sa" | "skladom" | "nedostupne";
   readonly placedAt: string;
+  readonly quantity: number;
 }
 interface RawSupplierGroup {
   readonly lines: readonly RawOrderLine[];
@@ -65,9 +66,13 @@ test("blok 'Prehľad e-shopu' + 'Súhrn o objednávaní' sa zobrazí a čísla z
   const allLines = suppliers.flatMap((g) => g.lines);
   const isResolved = (l: RawOrderLine): boolean => l.ordered || l.state !== "objednane";
   const nevybavene = allLines.filter((l) => !isResolved(l));
-  const ocakavaneRemaining = nevybavene.length;
+  // issue 260: "Položiek na objednanie"/"Už objednané" sčítavajú MNOŽSTVÁ
+  // (`summarizeOrderLines`), nie počet riadkov — `ocakavaneAffected` ostáva
+  // počtom RIADKOV/objednávok (`countAffectedOrders`), tá funkcia sa
+  // nemenila.
+  const ocakavaneRemaining = nevybavene.reduce((sum, l) => sum + l.quantity, 0);
   const ocakavaneAffected = new Set(nevybavene.map((l) => l.orderId)).size;
-  const ocakavaneOrdered = allLines.filter((l) => l.ordered).length;
+  const ocakavaneOrdered = allLines.filter((l) => l.ordered).reduce((sum, l) => sum + l.quantity, 0);
 
   await expect(page.getByTestId("overview-ordering-remaining")).toContainText(String(ocakavaneRemaining));
   await expect(page.getByTestId("overview-ordering-affected-orders")).toContainText(String(ocakavaneAffected));

--- a/apps/web/tests/e2e/orders.spec.ts
+++ b/apps/web/tests/e2e/orders.spec.ts
@@ -49,16 +49,23 @@ test("manažér filtruje podľa dodávateľa, vidí súhrn ostáva vybaviť a sk
   await expect(page.getByTestId("supplier-chip-(bez dodávateľa)")).toHaveText("(bez dodávateľa) (5)");
 
   const summary = page.getByTestId("orders-summary");
-  // Nový 'nedostupne' riadok je UŽ vybavený (`isLineResolved` — akýkoľvek
-  // stav iný než "objednane" sa počíta ako vybavený), takže "ostáva vybaviť"
-  // ostáva 6, len celkový počet stúpne na 8 a pribudne "Nedostupné 1".
-  await expect(summary).toHaveText("Ostáva vybaviť 6 z 8 · Čaká sa 1 · Nedostupné 1");
+  // issue 260: `orders-summary` (`formatOrderSummaryText`/`summarizeOrderLines`)
+  // sčíta MNOŽSTVÁ (`quantity`), nie počet riadkov — chip-y vyššie ("Všetci
+  // (8)" a pod.) ZOSTÁVAJÚ počtom riadkov (`group.lines.length`, nezmenené).
+  // Súčet kusov naprieč 8 riadkami: 4859/46 caka_sa=2, 40287(9002)
+  // objednane=1, 60055/10(9004)=3, 60055/10(9005)=2, 60035/L=1, 60035/M=1,
+  // 278=1, 40287(9008) nedostupne=1 → total 12, z toho nevybavené (všetky
+  // okrem caka_sa aj nedostupne) 1+3+2+1+1+1 = 9, "Čaká sa" 2 (caka_sa kus),
+  // "Nedostupné" 1.
+  await expect(summary).toHaveText("Ostáva vybaviť 9 z 12 · Čaká sa 2 · Nedostupné 1");
 
   // Klik na chip DODAVATEL-TEST-1 zúži zoznam len na jeho skupinu.
   await page.getByTestId("supplier-chip-DODAVATEL-TEST-1").click();
   await expect(page.getByTestId("supplier-DODAVATEL-TEST-1")).toBeVisible();
   await expect(page.getByTestId("supplier-(bez dodávateľa)")).not.toBeVisible();
-  await expect(summary).toHaveText("DODAVATEL-TEST-1: ostáva vybaviť 0 z 1 · Čaká sa 1");
+  // issue 260: jediný riadok tejto skupiny (4859/46) má `quantity: 2` —
+  // súhrn preto sčíta 2 kusy, nie 1 riadok.
+  await expect(summary).toHaveText("DODAVATEL-TEST-1: ostáva vybaviť 0 z 2 · Čaká sa 2");
 
   // issue 187: objednaná veľkosť musí byť na riadku VIDIEŤ — obsluha podľa
   // nej objednáva u dodávateľa. Fixtúrový variant "4859/46" má veľkosť "46"

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -2840,3 +2840,35 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
 - Local gates all green: `pnpm typecheck`, `pnpm lint`, `pnpm --filter
   @forestshop/web test` (413 tests), `pnpm --filter @forestshop/web e2e`
   (42/42).
+
+## Issues 260/259/258 — "Na objednanie": kusy, farby, kompaktné dlaždice (batch, one PR)
+
+- **#260 (bug):** `summarizeOrderLines` (`ordersSummary.ts`) counted LINES
+  (`lines.length`, `+= 1`), not summed `quantity` — two identical products
+  merged into one `order_line` with `quantity: 2` (`ingest.ts`'s known
+  same-product-same-order merge) showed as "1", not "2". RED
+  (`ffc7604`→`3cbbae8`) proved the exact symptom against unfixed code
+  (`{total:1,remaining:1}` vs expected `{total:2,remaining:2}`), GREEN
+  (`4058d02`) fixed every field to sum `line.quantity`. `OrdersSection.tsx`'s
+  nav badge (issue 147, its own documented "count of LINES" intent) was
+  deliberately given its OWN direct `isLineResolved` filter instead of
+  riding `summarizeOrderLines(...).remaining`, so it keeps its original
+  meaning unchanged.
+- **#259 (enhancement):** row coloring went from 3-state
+  (`state-caka_sa`/`state-skladom`/`state-nedostupne`) to BINARY red/green
+  keyed on the canonical `isLineResolved` predicate (`4c1ff17`) — owner's
+  verbatim mapping: red = already done, green = still to order. The old
+  3-state scheme left the DEFAULT/most-common "objednane" rows fully white,
+  which is what the owner meant by "nothing is colored today".
+- **#258 (enhancement):** overview tiles block compacted (`a656302`) —
+  measured live via `page.addStyleTag` against production: 103px/79.5px
+  tile → 58.5px, `.orders-overview` block 253.5px → 169px (−33%) at
+  1366×768, all 7 numbers stay fully readable.
+- Design/root-cause/rejected-alternative comments posted to all three
+  issues BEFORE their first code commit; STILL-VALID evidence comments
+  posted for each (live Playwright screenshots + measurements against
+  `forestshop-novy.newlevel.media`).
+- Local gates all green: `pnpm typecheck`, `pnpm lint`, `pnpm --filter
+  @forestshop/web test` (421 tests, 52 files), `pnpm --filter @forestshop/api
+  test` (571 tests), `pnpm --filter @forestshop/api test:integration` (477
+  tests), `pnpm --filter @forestshop/web e2e` (42/42).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.149",
+  "version": "0.3.0-dev.150",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Tri veci z obrazovky **Eshop → Na objednanie**, ktoré majiteľ nadiktoval 5. 8. 2026. Sú malé a všetky na tej istej obrazovke, tak idú v jednom PR a jednom behu CI.

## issue 260 — zlý celkový počet kusov (chyba)

**Príčina:** `apps/web/src/ordersSummary.ts`, funkcia `summarizeOrderLines` počítala RIADKY (`lines.length`, `+= 1`), nie množstvá. Import objednávok pritom ten istý produkt objednaný dvakrát v jednej objednávke zlučuje do JEDNÉHO riadku s `quantity: 2` — preto sa dve rovnaké čelovky ukazovali ako jedna.

**Oprava:** všetky polia súhrnu sčítavajú `quantity`. Odznak v bočnom menu si zámerne ponechal vlastnú sémantiku „počet riadkov" (issue 147) — dostal vlastný filter, aby ho zmena tejto funkcie neovplyvnila.

**Rozlišovacia schopnosť testu:** s vrátenou opravou `summarizeOrderLines([line("objednane", false, 2)])` vrátilo `{total: 1, remaining: 1}` namiesto očakávaného `{total: 2, remaining: 2}` — presne nahlásený príznak; druhý test padol s `"Položiek na objednanie2"` namiesto `"4"`. Po oprave oba prechádzajú.

## issue 259 — farebné odlíšenie riadkov

Naživo overené, že sa farbili len 3 z 5 stavov — predvolený stav „objednané" (teda väčšina riadkov, a práve tie, ktoré treba vybaviť) ostával biely. Teraz binárne podľa `isLineResolved`: **červená = hotové, zelená = treba vybaviť**, presne podľa zadania. Text stavu a zaškrtávacie políčko ostávajú ako záloha pre farbosleposť.

## issue 258 — menšie okienka prehľadu

Blok `.orders-overview` mal pri 1366×768 výšku 253,5 px (tabuľka začínala na y=601,5 px). Kandidát bol najprv nameraný naživo cez `page.addStyleTag`, až potom zapísaný do CSS: teraz **169 px (−33 %)**, všetkých 7 čísel ostáva plne čitateľných.

## Kontroly

Typová kontrola aj lint čisté. Web unit 421/421, API unit 571/571, API integračné 477/477, e2e 42/42.

issue 260, issue 259, issue 258
