### PR TITLE
Zlúčenie objednávok — nová záložka v Eshope (issue 257)

### DIFF
--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -209,3 +209,22 @@ paths:
   KAŽDÝ ĎALŠÍ pokus "zjednodušiť" `ORDER BY` odkazom na alias z podobného
   agregátu: over PRIAMO integračným testom proti reálnej DB (nie len že
   `tsc`/`eslint` prejdú) — statická kontrola typov toto nezachytí.
+- **Nová `pgEnum` hodnota (`ALTER TYPE ... ADD VALUE`, napr. `mail_log_source`)
+  je NA LOKÁLNEJ Postgres inštancii neviditeľná, kým nebeží `pnpm --filter
+  @forestshop/api db:migrate` — integračné testy/`e2e-setup.ts` proti nej
+  BEŽIA ĎALEJ BEZ CHYBY, len TICHO stratia riadok.** Issue 257
+  (`mail_log_source` pridalo `'order_merge'`): `mail-log/service.ts`'s
+  `insertEntry` zámerne NEVYHADZUJE pri zlyhanom zápise (len `log.error` +
+  `return` — "zlyhanie zápisu do knihy nesmie zhodiť samotné odosielanie"),
+  takže `POST /api/order-merge/send` proti neaktualizovanej lokálnej DB
+  vrátil `{ok:true}` (fake mail transport dostal správu), ale `SELECT *
+  FROM mail_log` vrátil 0 riadkov — vyzeralo to ako bug v novom kóde,
+  skutočná príčina bola len zabudnutý `db:migrate` po pridaní migrácie
+  (`.claude/rules/local-dev.md`'s bežný cyklus `db:migrate` → `test:
+  integration`, jednoducho preskočený uprostred session). CI toto nikdy
+  nezasiahne (ephemerálny Postgres, `db:migrate` je vlastný krok v
+  `ci.yml`) — past je čisto lokálna. Test na KAŽDÚ ďalšiu novú `pgEnum`
+  hodnotu pridanú migráciou: PRED spustením `test:integration` lokálne
+  vždy `pnpm --filter @forestshop/api db:migrate` proti tej istej
+  `DATABASE_URL` — a ak sa nejaký zápis "úspešne" prejde, ale zodpovedajúci
+  SELECT ukáže menej riadkov, než očakávaš, over NAJPRV toto, nie logiku.

--- a/.claude/rules/orders.md
+++ b/.claude/rules/orders.md
@@ -494,3 +494,25 @@ paths:
   POČET RIADKOV namiesto súčtu kusov? Ak áno, nech si to počíta samo cez
   `isLineResolved`, nespoliehaj sa na to, že `summarizeOrderLines` uhádne
   správny význam pre všetkých volajúcich naraz.
+- **"Zlúčenie objednávok" (issue 257, `modules/orders/merge-mail.ts`'s
+  `listMergeCandidateGroups`) číta VÝHRADNE tabuľku `orders` (`customer
+  IdentityKey` = e-mail orezaný/malé písmená, fallback na meno) — ŽIADEN
+  JOIN na `order_line`.** Dôsledok pre e2e fixtúry: dve otvorené objednávky
+  toho istého (fiktívneho) zákazníka sa dajú seedovať BEZ jediného
+  `order_line` riadku (`scripts/e2e-setup.ts`'s objednávky "9010"/"9011") —
+  nulové riziko rozbitia presných počtov v dodávateľských zoskupeniach,
+  ktoré `orders.spec.ts` overuje (`.claude/rules/testing.md`'s "nový
+  fixtúrový variant sa nesmie vybrať len podľa 'je nepoužitý'" pravidlo sa
+  tu vôbec netýka — žiadny variant sa nepoužíva). Test pre KAŽDÚ ĎALŠIU
+  funkciu, ktorá potrebuje len OBJEDNÁVKOVÚ (nie riadkovú) identitu: over,
+  či fixtúra skutočne potrebuje `order_line`, predtým než ho pridáš —
+  zbytočný riadok len zväčšuje riziko kolízie s existujúcimi presnými
+  počtami.
+- **Zoznam kariet kľúčovaný podľa SKUPINY (nie podľa jednej objednávky) si
+  `data-testid` vyberá z NAJNOVŠEJ objednávky skupiny, podľa jej VIDITEĽNÉHO
+  Shoptet čísla (`externalOrderId`), NIE podľa interného DB `orderId`
+  (UUID).** `OrderMergeSection.tsx`: `group.orders[0]` je po zoradení
+  najnovšia objednávka (rovnaké poradie ako `listMergeableOrders`), jej
+  `externalOrderId` je stabilné a čitateľné aj v e2e teste napísanom PRED
+  behom (UUID sa dozvieš až za behu). Rovnaký zámer ako
+  `NedostupneSection.tsx`'s `variantCode`-kľúčované testid.

--- a/apps/api/drizzle/0034_melodic_wild_child.sql
+++ b/apps/api/drizzle/0034_melodic_wild_child.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."mail_log_source" ADD VALUE 'order_merge';

--- a/apps/api/drizzle/meta/0034_snapshot.json
+++ b/apps/api/drizzle/meta/0034_snapshot.json
@@ -1,0 +1,2552 @@
+{
+  "id": "97006664-aaed-4c77-a464-8d771239c62d",
+  "prevId": "fab63f79-cbf2-4f13-804e-aafddc6ec5d3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_code": {
+          "name": "external_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_open_status": {
+      "name": "order_open_status",
+      "schema": "",
+      "columns": {
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Vybavuje sa'"
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop_remark": {
+          "name": "shop_remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shoptet_order_id": {
+          "name": "shoptet_order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_updated_at": {
+          "name": "comment_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_synced_at": {
+          "name": "comment_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_carrier_name": {
+          "name": "shipping_carrier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_price_with_vat": {
+          "name": "total_price_with_vat",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_link_override": {
+      "name": "product_supplier_link_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_link_override_product_key_product_key_fk": {
+          "name": "product_supplier_link_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_link_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_override": {
+      "name": "product_supplier_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_override_product_key_product_key_fk": {
+          "name": "product_supplier_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing": {
+      "name": "pairing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_url": {
+          "name": "supplier_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "pairing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'navrhnute'"
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pairing_state_idx": {
+          "name": "pairing_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_confirmed_by_idx": {
+          "name": "pairing_confirmed_by_idx",
+          "columns": [
+            {
+              "expression": "confirmed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_variant_code_variant_code_fk": {
+          "name": "pairing_variant_code_variant_code_fk",
+          "tableFrom": "pairing",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pairing_confirmed_by_users_id_fk": {
+          "name": "pairing_confirmed_by_users_id_fk",
+          "tableFrom": "pairing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pairing_variant_code_unique": {
+          "name": "pairing_variant_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pairing_confirmation_ck": {
+          "name": "pairing_confirmation_ck",
+          "value": "(\"pairing\".\"state\" = 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)\n        OR (\"pairing\".\"state\" != 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NULL AND \"pairing\".\"confirmed_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier": {
+      "name": "supplier",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wholesale_base_url": {
+          "name": "wholesale_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_key": {
+          "name": "adapter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_settings": {
+      "name": "posta_uncollected_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_state": {
+      "name": "posta_uncollected_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notify_count": {
+          "name": "notify_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_state": {
+          "name": "terminal_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_settings": {
+      "name": "order_reminder_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_state": {
+      "name": "order_reminder_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_replacement_link": {
+      "name": "nedostupne_replacement_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nedostupne_replacement_link_variant_idx": {
+          "name": "nedostupne_replacement_link_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_state": {
+      "name": "nedostupne_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "nedostupne_email_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nedostupne_state_order_variant_type_uq": {
+          "name": "nedostupne_state_order_variant_type_uq",
+          "columns": [
+            {
+              "expression": "order_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template_history": {
+      "name": "mail_template_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "mail_template_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_template_history_key_idx": {
+          "name": "mail_template_history_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_template_history_changed_by_user_id_users_id_fk": {
+          "name": "mail_template_history_changed_by_user_id_users_id_fk",
+          "tableFrom": "mail_template_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template": {
+      "name": "mail_template",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail_template_updated_by_user_id_users_id_fk": {
+          "name": "mail_template_updated_by_user_id_users_id_fk",
+          "tableFrom": "mail_template",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_log": {
+      "name": "mail_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "mail_log_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_log_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "mail_log_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_log_created_idx": {
+          "name": "mail_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_log_source_created_idx": {
+          "name": "mail_log_source_created_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_log_actor_user_id_users_id_fk": {
+          "name": "mail_log_actor_user_id_users_id_fk",
+          "tableFrom": "mail_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_stock": {
+      "name": "supplier_stock",
+      "schema": "",
+      "columns": {
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "supplier_availability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "supplier_stock_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "supplier_stock_host_idx": {
+          "name": "supplier_stock_host_idx",
+          "columns": [
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "supplier_stock_avail_idx": {
+          "name": "supplier_stock_avail_idx",
+          "columns": [
+            {
+              "expression": "availability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "supplier_stock_link_size_label_pk": {
+          "name": "supplier_stock_link_size_label_pk",
+          "columns": [
+            "link",
+            "size_label"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_event": {
+      "name": "restock_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_link": {
+          "name": "supplier_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_availability_text": {
+          "name": "supplier_availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "supplier_price": {
+          "name": "supplier_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "restock_event_at_idx": {
+          "name": "restock_event_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "restock_event_variant_idx": {
+          "name": "restock_event_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_settings": {
+      "name": "restock_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shop_product_url": {
+      "name": "shop_product_url",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne"
+      ]
+    },
+    "public.pairing_state": {
+      "name": "pairing_state",
+      "schema": "public",
+      "values": [
+        "navrhnute",
+        "potvrdene"
+      ]
+    },
+    "public.nedostupne_email_type": {
+      "name": "nedostupne_email_type",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "alternativa"
+      ]
+    },
+    "public.mail_template_action": {
+      "name": "mail_template_action",
+      "schema": "public",
+      "values": [
+        "save",
+        "reset"
+      ]
+    },
+    "public.mail_log_source": {
+      "name": "mail_log_source",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "posta_uncollected",
+        "order_reminder",
+        "supplier_order",
+        "order_merge"
+      ]
+    },
+    "public.mail_log_status": {
+      "name": "mail_log_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.mail_log_trigger": {
+      "name": "mail_log_trigger",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "manual"
+      ]
+    },
+    "public.supplier_availability": {
+      "name": "supplier_availability",
+      "schema": "public",
+      "values": [
+        "available",
+        "unavailable",
+        "unknown"
+      ]
+    },
+    "public.supplier_stock_source": {
+      "name": "supplier_stock_source",
+      "schema": "public",
+      "values": [
+        "json_ld",
+        "meta",
+        "text",
+        "size_list",
+        "none"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1785902714427,
       "tag": "0033_breezy_manta",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1785928327041,
+      "tag": "0034_melodic_wild_child",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema-mail-log.ts
+++ b/apps/api/src/db/schema-mail-log.ts
@@ -9,11 +9,14 @@ import { users } from "./schema-users.js";
 // beh v `job_run.detail` prepíše ten ďalší. Táto tabuľka je JEDNA spoločná
 // kniha odoslaných e-mailov pre VŠETKÝCH odosielateľov appky, aby majiteľ
 // vedel, čo sa v jeho mene odoslalo.
+// issue 257: "order_merge" — e-mail zákazníkovi o zlúčení viacerých jeho
+// objednávok do jednej zásielky (`modules/orders/merge-mail.ts`).
 export const mailLogSource = pgEnum("mail_log_source", [
   "nedostupne",
   "posta_uncollected",
   "order_reminder",
   "supplier_order",
+  "order_merge",
 ]);
 
 // `skipped` = appka SKUTOČNE chcela poslať a nemohla (chýba adresa, chýba

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -84,6 +84,12 @@ const envSchema = z.object({
   // `MAIL_BCC`). Chýbajúca = automatizácia NEPOŠLE ani jeden e-mail
   // zákazníkovi (fail-closed).
   NEDOSTUPNE_BCC_EMAIL: z.string().email().optional(),
+  // issue 257: "Zlúčenie objednávky" — e-mail zákazníkovi, keď sa jeho
+  // viaceré objednávky posielajú spolu ako jedna zásielka. Rovnaká úvaha ako
+  // `NEDOSTUPNE_BCC_EMAIL` vyššie (NEZÁVISLÁ, vyhradená premenná, nikdy
+  // zdieľané všeobecné `MAIL_BCC`). Chýbajúca = automatizácia NEPOŠLE ani
+  // jeden e-mail zákazníkovi (fail-closed).
+  ORDER_MERGE_BCC_EMAIL: z.string().email().optional(),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/apps/api/src/http/app.ts
+++ b/apps/api/src/http/app.ts
@@ -17,6 +17,7 @@ import { registerOrderReminderRoutes, type OrderReminderRunDeps } from "./order-
 import { registerMailLogRoutes } from "./mail-log-routes.js";
 import { registerMailTemplateRoutes } from "./mail-template-routes.js";
 import { registerNedostupneRoutes, type NedostupneRunDeps } from "./nedostupne-routes.js";
+import { registerOrderMergeRoutes, type OrderMergeRunDeps } from "./order-merge-routes.js";
 import { requireSameOrigin } from "./origin-check.js";
 import { registerPairingRoutes } from "./pairing-routes.js";
 import { registerPostaUncollectedRoutes, type PostaUncollectedRunDeps } from "./posta-uncollected-routes.js";
@@ -67,6 +68,11 @@ export function createApp(
     // vyššie: voliteľné, bezpečný default nižšie pre testy/lokálny vývoj,
     // `index.ts` v produkcii VŽDY nahradí reálnymi dependencies.
     readonly nedostupne?: NedostupneRunDeps;
+    // issue 257: "Zlúčenie objednávok" — nová záložka v Eshope. Voliteľné z
+    // rovnakého dôvodu ako `nedostupne` vyššie: bezpečný default pre testy/
+    // lokálny vývoj, `index.ts` v produkcii VŽDY nahradí reálnymi
+    // dependencies.
+    readonly orderMerge?: OrderMergeRunDeps;
     // issue 212: "Dodávateľský sklad" — sťahovanie stránky dodávateľa.
     // Voliteľné z rovnakého dôvodu ako `nedostupne` vyššie; testy dodajú
     // vlastnú implementáciu a NIKDY nechodia na skutočnú stránku dodávateľa.
@@ -232,6 +238,16 @@ export function createApp(
       mailTransport: undefined,
       bccEmail: undefined,
       adminBaseUrl: options.adminBaseUrl ?? "https://www.forestshop.sk",
+    },
+  );
+  // issue 257: "Zlúčenie objednávok" — bezpečný default z rovnakého dôvodu
+  // ako `nedostupne` vyššie.
+  registerOrderMergeRoutes(
+    app,
+    db,
+    options.orderMerge ?? {
+      mailTransport: undefined,
+      bccEmail: undefined,
     },
   );
 

--- a/apps/api/src/http/mail-log-routes.ts
+++ b/apps/api/src/http/mail-log-routes.ts
@@ -11,7 +11,7 @@ import { requireUser, type AppBindings } from "./middleware.js";
 const PERIOD_DAYS: Readonly<Record<string, number | null>> = { "7": 7, "30": 30, "90": 90, all: null };
 
 const listQuery = z.object({
-  source: z.enum(["nedostupne", "posta_uncollected", "order_reminder", "supplier_order"]).optional(),
+  source: z.enum(["nedostupne", "posta_uncollected", "order_reminder", "supplier_order", "order_merge"]).optional(),
   status: z.enum(["sent", "failed", "skipped"]).optional(),
   period: z.enum(["7", "30", "90", "all"]).default("30"),
 });

--- a/apps/api/src/http/order-merge-routes.ts
+++ b/apps/api/src/http/order-merge-routes.ts
@@ -1,0 +1,137 @@
+import { zValidator } from "@hono/zod-validator";
+import type { Hono } from "hono";
+import { z } from "zod";
+import type { Database } from "../db/client.js";
+import { record } from "../modules/audit/service.js";
+import type { MailTransport } from "../modules/mail/transport.js";
+import { consumeMergePreviewToken, issueMergePreviewToken } from "../modules/orders/merge-mail-preview-tokens.js";
+import { buildOrderMergeMailContent, listMergeCandidateGroups, sendOrderMergeMail } from "../modules/orders/merge-mail.js";
+import { requireRole, requireUser, type AppBindings } from "./middleware.js";
+import { requireSameOrigin } from "./origin-check.js";
+
+// issue 257: "Zlúčenie objednávok" — nová záložka v Eshope (majiteľova
+// korekcia zadania), rovnaký HTTP vzor ako `nedostupne-routes.ts` (povinný
+// server-side vynútený náhľad pred odoslaním, `.claude/rules/nedostupne.md`).
+export interface OrderMergeRunDeps {
+  readonly mailTransport: MailTransport | undefined;
+  readonly bccEmail: string | undefined;
+}
+
+const previewBody = z.object({ baseOrderId: z.string().uuid(), otherOrderIds: z.array(z.string().uuid()).min(1) });
+// `/send` musí priniesť token vydaný `/preview` PRE PRESNE tento (baseOrderId,
+// zoradený výber) — rovnaká disciplína ako `nedostupne-routes.ts`.
+const sendBody = previewBody.extend({ previewToken: z.string().min(1) });
+
+function bccMissing(deps: OrderMergeRunDeps): boolean {
+  return deps.bccEmail === undefined || deps.bccEmail.trim() === "";
+}
+
+function mailNotConfigured(deps: OrderMergeRunDeps): boolean {
+  return deps.mailTransport === undefined;
+}
+
+type SendMergeMailFailure = Exclude<Awaited<ReturnType<typeof sendOrderMergeMail>>, { readonly status: "sent" }>;
+
+function sendErrorMessage(result: SendMergeMailFailure): string {
+  switch (result.status) {
+    case "not_found":
+      return "Objednávka sa v aktuálnom zozname nenašla — pravdepodobne sa medzitým zmenil jej stav.";
+    case "invalid_selection":
+      return "Vybraný zoznam objednávok už nesedí s aktuálnym stavom — obnovte stránku a skúste znova.";
+    case "no_email":
+      return "Zákazník nemá e-mailovú adresu.";
+    case "not_configured":
+      return result.reason;
+    case "send_failed":
+      return "Odoslanie e-mailu zlyhalo — skúste to znova.";
+  }
+}
+
+export function registerOrderMergeRoutes(app: Hono<AppBindings>, db: Database, deps: OrderMergeRunDeps): void {
+  // Čítanie — každý prihlásený zamestnanec (rovnaká úroveň ako "Nedostupné
+  // tovary").
+  app.get("/api/order-merge/candidates", requireUser(db), async (c) => {
+    const groups = await listMergeCandidateGroups(db);
+    return c.json({ groups, bccMissing: bccMissing(deps), mailNotConfigured: mailNotConfigured(deps) });
+  });
+
+  // Povinný náhľad — počítaný ROVNAKOU funkciou, akú použije skutočné
+  // odoslanie nižšie (`nedostupne-routes.ts`'s vzor), a VYDÁ jednorazový
+  // token.
+  app.post(
+    "/api/order-merge/preview",
+    requireSameOrigin(),
+    requireUser(db),
+    zValidator("json", previewBody),
+    async (c) => {
+      const { baseOrderId, otherOrderIds } = c.req.valid("json");
+      const built = await buildOrderMergeMailContent(db, baseOrderId, otherOrderIds);
+      if (!built.ok) {
+        // 200 (nikdy 404) — rovnaká disciplína ako `nedostupne-routes.ts`
+        // (`.claude/rules/testing.md`'s Chromium console-error pravidlo).
+        const error =
+          built.error === "not_found"
+            ? "Objednávka sa v aktuálnom zozname nenašla — pravdepodobne sa medzitým zmenil jej stav."
+            : "Vybraný zoznam objednávok už nesedí s aktuálnym stavom — obnovte stránku a skúste znova.";
+        return c.json({ ok: false as const, error });
+      }
+      const previewToken = issueMergePreviewToken(baseOrderId, otherOrderIds, new Date());
+      return c.json({
+        ok: true as const,
+        subject: built.content.subject,
+        html: built.content.html,
+        recipient: built.content.to ?? "",
+        customerName: built.content.customerName,
+        orderNumbers: built.content.orderNumbers,
+        previewToken,
+      });
+    },
+  );
+
+  // Odoslanie — mutuje (zapíše do Knihy odoslaných e-mailov), rovnaká rola
+  // ako "Nedostupné tovary"'s odoslanie (admin/manazer).
+  app.post(
+    "/api/order-merge/send",
+    requireSameOrigin(),
+    requireUser(db),
+    requireRole("admin", "manazer"),
+    zValidator("json", sendBody),
+    async (c) => {
+      const { baseOrderId, otherOrderIds, previewToken } = c.req.valid("json");
+      const user = c.get("user");
+      const now = new Date();
+      // Server-side vynútenie povinného náhľadu — token sa KONZUMUJE
+      // (zmaže) hneď, bez ohľadu na výsledok.
+      if (!consumeMergePreviewToken(previewToken, baseOrderId, otherOrderIds, now)) {
+        return c.json({ ok: false as const, error: "Najprv si otvorte náhľad e-mailu — bez neho appka nepošle nič." });
+      }
+      const result = await sendOrderMergeMail({
+        db,
+        now,
+        baseOrderId,
+        otherOrderIds,
+        mailTransport: deps.mailTransport,
+        bccEmail: deps.bccEmail,
+        actorUserId: user.userId,
+      });
+      if (result.status !== "sent") {
+        return c.json({ ok: false as const, error: sendErrorMessage(result) });
+      }
+      // issue 257: žiadna vlastná dedup/stavová tabuľka pre túto
+      // automatizáciu (rozhodnuté v návrhovom komentári na tickete) —
+      // `entity`/`entityId` preto vzorujú `supplier-routes.ts`'s
+      // `orders.mail.send` (mailová akcia bez vlastnej mutovanej tabuľky,
+      // nie `nedostupne.send`'s `nedostupne_state`, kde entity sedí presne
+      // preto, lebo TA tabuľka sa reálne mení).
+      await record(db, {
+        at: now,
+        actorUserId: user.userId,
+        action: "order_merge.send",
+        entity: "order",
+        entityId: baseOrderId,
+        data: { baseOrderId, otherOrderIds, orderNumbers: result.orderNumbers, to: result.to },
+      });
+      return c.json({ ok: true as const });
+    },
+  );
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -204,6 +204,15 @@ const nedostupneDeps = {
   adminBaseUrl: env.SHOPTET_ADMIN_BASE_URL,
 };
 
+// issue 257: "Zlúčenie objednávok" — rovnaká úvaha ako `nedostupneDeps`
+// vyššie: zdieľaný `sendSupplierMail`, vlastná fail-closed BCC premenná,
+// žiadny `classifyClient` (žiadna AI klasifikácia, e-mail posiela človek
+// ručne po povinnom náhľade).
+const orderMergeDeps = {
+  mailTransport: sendSupplierMail,
+  bccEmail: env.ORDER_MERGE_BCC_EMAIL,
+};
+
 const app = createApp(db, {
   cookieSecure: env.SESSION_COOKIE_SECURE,
   ...(runIngest === undefined ? {} : { runIngest }),
@@ -213,6 +222,7 @@ const app = createApp(db, {
   postaUncollected: postaUncollectedDeps,
   orderReminder: orderReminderDeps,
   nedostupne: nedostupneDeps,
+  orderMerge: orderMergeDeps,
   fetchSupplierPage,
 });
 

--- a/apps/api/src/modules/mail-log/service.ts
+++ b/apps/api/src/modules/mail-log/service.ts
@@ -5,7 +5,7 @@ import { log } from "../../logger.js";
 import type { MailMessage, MailTransport } from "../mail/transport.js";
 import type { MailTemplateKey } from "../mail-templates/registry.js";
 
-export type MailLogSource = "nedostupne" | "posta_uncollected" | "order_reminder" | "supplier_order";
+export type MailLogSource = "nedostupne" | "posta_uncollected" | "order_reminder" | "supplier_order" | "order_merge";
 export type MailLogTrigger = "scheduled" | "manual";
 
 /** Spoločný popis "o čom ten e-mail bol" — každé pole je nepovinné, lebo

--- a/apps/api/src/modules/mail-templates/registry.ts
+++ b/apps/api/src/modules/mail-templates/registry.ts
@@ -24,6 +24,7 @@ export const MAIL_TEMPLATE_KEYS = [
   "posta_4",
   "order_reminder",
   "supplier_order",
+  "order_merge",
 ] as const;
 
 export type MailTemplateKey = (typeof MAIL_TEMPLATE_KEYS)[number];
@@ -257,6 +258,35 @@ const KINDS: readonly MailTemplateKind[] = [
       // zalomenie — presne tak, ako to appka posielala doteraz
       // (`[subject, ...lines].join("\n")`).
       body: "Objednávka — {{dodavatel}} ({{pocet_poloziek}} {{slovo_poloziek}})\n{{zoznam_poloziek}}",
+    },
+  },
+  {
+    key: "order_merge",
+    label: "Zlúčenie objednávky",
+    description: "E-mail zákazníkovi, keď sa jeho viaceré objednávky posielajú spolu ako jedna zásielka.",
+    // issue 257: `zoznam_objednavok` je OBYČAJNÝ TEXT (nie `list`) — ide o
+    // spojené čísla objednávok priamo vo vete ("vaše objednávky č. X a č. Y"),
+    // `list` by šablónový engine vykreslil ako samostatný `<ul>` blok a
+    // rozbil by plynulosť vety (`modules/orders/merge-mail.ts` skladá text).
+    ownPlaceholders: [
+      MENO,
+      {
+        name: "zoznam_objednavok",
+        label: "Čísla zlučovaných objednávok (spojený text)",
+        example: { kind: "text", text: "č. 20260123 a č. 20260124" },
+      },
+    ],
+    defaultText: {
+      subject: "Vaše objednávky spájame do jednej zásielky — Forestshop.sk",
+      body: [
+        "Dobrý deň, **{{meno_zakaznika}}**,",
+        "",
+        "radi by sme vás informovali, že vaše objednávky {{zoznam_objednavok}} spolu odosielame ako JEDNU zásielku — ušetríte tak na poštovnom aj na čakaní.",
+        "",
+        "Ak máte akékoľvek otázky, pokojne nás kontaktujte na {{kontakt_email}} alebo na telefónnom čísle {{kontakt_telefon}}.",
+        "",
+        PODPIS_TIM,
+      ].join("\n"),
     },
   },
 ];

--- a/apps/api/src/modules/orders/merge-mail-preview-tokens.ts
+++ b/apps/api/src/modules/orders/merge-mail-preview-tokens.ts
@@ -1,0 +1,74 @@
+// issue 257: rovnaký server-side vynútený "náhľad VŽDY pred odoslaním"
+// mechanizmus ako `modules/nedostupne/preview-tokens.ts` (viď návrhový
+// komentár na tickete + `.claude/rules/nedostupne.md`) — `/merge-mail/preview`
+// vydá jednorazový token viazaný na presne (baseOrderId, zoradená množina
+// vybraných orderId), `/merge-mail/send` ho musí priniesť späť a token sa
+// SKONZUMUJE (zmaže) pri prvom pokuse o odoslanie, bez ohľadu na zhodu. Bez
+// tohto by priame volanie API mohlo poslať e-mail zákazníkovi bez toho, aby
+// ho čokoľvek niekedy zobrazilo — presne ten gap, ktorý `nedostupne` opravil
+// pred mergom PR #182 (dôvod, prečo sa tu znovu zavádza TÁ ISTÁ obrana,
+// nikdy staršia slabšia konvencia `orders/mail.ts`'s dodávateľského náhľadu).
+const TOKEN_TTL_MS = 15 * 60 * 1000; // 15 minút — rovnaký strop ako nedostupne
+const MAX_ENTRIES = 1_000;
+const SWEEP_INTERVAL_MS = 60 * 1000;
+
+interface PreviewTokenEntry {
+  readonly baseOrderId: string;
+  readonly selectionKey: string;
+  readonly expiresAt: number;
+}
+
+const tokens = new Map<string, PreviewTokenEntry>();
+let lastSweepAtMs = 0;
+
+function sweepExpired(nowMs: number): void {
+  if (nowMs - lastSweepAtMs < SWEEP_INTERVAL_MS) return;
+  lastSweepAtMs = nowMs;
+  for (const [token, entry] of tokens) {
+    if (entry.expiresAt <= nowMs) tokens.delete(token);
+  }
+}
+
+/** Kanonický, poradie-nezávislý kľúč vybraných "ostatných" objednávok —
+ * `/preview` aj `/send` ho počítajú z rovnakého poľa `otherOrderIds`, takže
+ * poradie checkboxov v UI nikdy nerozhodne o (ne)zhode tokenu. */
+export function mergeSelectionKey(otherOrderIds: readonly string[]): string {
+  return [...otherOrderIds].sort().join(",");
+}
+
+/** Vydá nový jednorazový token pre presne túto (základná objednávka, výber) —
+ * volané `POST /api/orders/:id/merge-mail/preview`. */
+export function issueMergePreviewToken(baseOrderId: string, otherOrderIds: readonly string[], now: Date): string {
+  const nowMs = now.getTime();
+  sweepExpired(nowMs);
+  if (tokens.size >= MAX_ENTRIES) {
+    let oldestToken: string | undefined;
+    let oldestExpiresAt = Infinity;
+    for (const [token, entry] of tokens) {
+      if (entry.expiresAt < oldestExpiresAt) {
+        oldestExpiresAt = entry.expiresAt;
+        oldestToken = token;
+      }
+    }
+    if (oldestToken !== undefined) tokens.delete(oldestToken);
+  }
+  const token = crypto.randomUUID();
+  tokens.set(token, { baseOrderId, selectionKey: mergeSelectionKey(otherOrderIds), expiresAt: nowMs + TOKEN_TTL_MS });
+  return token;
+}
+
+/** Skonzumuje (zmaže) token a vráti, či bol platný PRE PRESNE tento (základná
+ * objednávka, výber) — `POST /api/orders/:id/merge-mail/send` volá TOTO pred
+ * akýmkoľvek odoslaním. Token sa maže VŽDY (aj pri nezhode) — jednorazový. */
+export function consumeMergePreviewToken(
+  token: string,
+  baseOrderId: string,
+  otherOrderIds: readonly string[],
+  now: Date,
+): boolean {
+  const entry = tokens.get(token);
+  tokens.delete(token);
+  if (entry === undefined) return false;
+  if (entry.expiresAt <= now.getTime()) return false;
+  return entry.baseOrderId === baseOrderId && entry.selectionKey === mergeSelectionKey(otherOrderIds);
+}

--- a/apps/api/src/modules/orders/merge-mail.test.ts
+++ b/apps/api/src/modules/orders/merge-mail.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { formatOrderNumbers } from "./merge-mail.js";
+
+// issue 257: čisto textové formátovanie ("č. X a č. Y" — plynulá veta pre
+// `{{zoznam_objednavok}}`, viď `mail-templates/registry.ts`'s komentár prečo
+// je toto pole OBYČAJNÝ text, nie `list`). Žiadna DB potrebná — patrí do
+// `src/**/*.test.ts` (`.claude/rules/testing.md`'s dve úrovne testov).
+describe("formatOrderNumbers", () => {
+  it("jedno číslo — bez spojky", () => {
+    expect(formatOrderNumbers(["20260123"])).toBe("č. 20260123");
+  });
+
+  it("dve čísla — spojené 'a'", () => {
+    expect(formatOrderNumbers(["20260123", "20260124"])).toBe("č. 20260123 a č. 20260124");
+  });
+
+  it("tri a viac čísel — čiarky, posledné spojené 'a'", () => {
+    expect(formatOrderNumbers(["20260123", "20260124", "20260125"])).toBe("č. 20260123, č. 20260124 a č. 20260125");
+  });
+
+  it("prázdny zoznam — prázdny reťazec (obranná vetva, appka ho nikdy takto nevolá)", () => {
+    expect(formatOrderNumbers([])).toBe("");
+  });
+});

--- a/apps/api/src/modules/orders/merge-mail.ts
+++ b/apps/api/src/modules/orders/merge-mail.ts
@@ -1,0 +1,277 @@
+import { inArray } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { orders } from "../../db/schema.js";
+import { log } from "../../logger.js";
+import { recordSkippedMail, sendLoggedMail, type MailLogContext } from "../mail-log/service.js";
+import { globalContext, textValue } from "../mail-templates/context.js";
+import { renderTemplate } from "../mail-templates/render.js";
+import { resolveTemplate } from "../mail-templates/store.js";
+import type { MailTransport } from "../mail/transport.js";
+import { listOpenStatusNames } from "./open-statuses.js";
+
+// issue 257: e-mail zákazníkovi, keď sa jeho viaceré objednávky posielajú
+// spolu ako jedna zásielka. Návrhový komentár na tickete: "ten istý zákazník"
+// = zhoda podľa `order.email` (orezané, malé písmená), keď objednávka e-mail
+// MÁ; inak fallback na `order.customerName` (orezané, malé písmená) —
+// staršie/hosťovské objednávky bez e-mailu (`order.email` je nepovinné,
+// `schema-orders.ts`) by inak nikdy nešlo zlúčiť, hoci zjavne patria tomu
+// istému zákazníkovi.
+function customerIdentityKey(email: string | null, customerName: string): string {
+  const trimmedEmail = (email ?? "").trim().toLowerCase();
+  if (trimmedEmail !== "") return `email:${trimmedEmail}`;
+  return `name:${customerName.trim().toLowerCase()}`;
+}
+
+export interface MergeCandidateOrder {
+  readonly orderId: string;
+  readonly externalOrderId: string;
+  readonly placedAt: string;
+}
+
+export interface MergeableOrders {
+  readonly orderId: string;
+  readonly externalOrderId: string;
+  readonly customerName: string;
+  // `null`/prázdne — appka email nikdy needukuje, len prenáša (rovnaký zámer
+  // ako `nedostupne`'s `NedostupneEmailContext`).
+  readonly email: string | null;
+  readonly candidates: readonly MergeCandidateOrder[];
+}
+
+// issue 257 (majiteľova korekcia, 2026-08-05): "malo by to byt zalozka v
+// eshope a mali by tam vyskocit ak su dve objedanvky na toho isteho
+// zakaznika" — záložka potrebuje vypísať VŠETKÝCH kandidátov naraz, nie
+// len kandidátov PRE jednu už vybranú objednávku (`listMergeableOrders`
+// vyššie zostáva, používa ho `buildOrderMergeMailContent` nižšie).
+export interface MergeCandidateGroup {
+  readonly customerName: string;
+  readonly email: string | null;
+  // Najnovšia objednávka prvá — rovnaké poradie ako `listMergeableOrders`'s
+  // `candidates`. Prvý prvok slúži ako `baseOrderId` pri odoslaní (server aj
+  // tak celú skupinu prepočíta nanovo podľa identity zákazníka, takže na
+  // tom, KTORÁ objednávka skupiny je "base", nezáleží).
+  readonly orders: readonly MergeCandidateOrder[];
+}
+
+/**
+ * Zákazníci s ≥2 OTVORENÝMI objednávkami — presne zoznam, ktorý nová
+ * záložka "Zlúčenie objednávok" vypíše. Skupiny zoradené od NAJVÄČŠEJ
+ * (najviac objednávok na zlúčenie), pri zhode abecedne podľa mena.
+ */
+export async function listMergeCandidateGroups(db: Database): Promise<readonly MergeCandidateGroup[]> {
+  const openOrders = await loadOpenOrders(db);
+  const byIdentity = new Map<string, OpenOrderRow[]>();
+  for (const order of openOrders) {
+    const key = customerIdentityKey(order.email, order.customerName);
+    const bucket = byIdentity.get(key);
+    if (bucket === undefined) byIdentity.set(key, [order]);
+    else bucket.push(order);
+  }
+  const groups: MergeCandidateGroup[] = [];
+  for (const bucket of byIdentity.values()) {
+    if (bucket.length < 2) continue;
+    const sorted = [...bucket].sort((a, b) => b.placedAt.getTime() - a.placedAt.getTime());
+    const first = sorted[0];
+    if (first === undefined) continue;
+    groups.push({
+      customerName: first.customerName,
+      email: first.email,
+      orders: sorted.map((o) => ({ orderId: o.id, externalOrderId: o.externalOrderId, placedAt: o.placedAt.toISOString() })),
+    });
+  }
+  groups.sort((a, b) => b.orders.length - a.orders.length || a.customerName.localeCompare(b.customerName, "sk"));
+  return groups;
+}
+
+interface OpenOrderRow {
+  readonly id: string;
+  readonly externalOrderId: string;
+  readonly customerName: string;
+  readonly email: string | null;
+  readonly placedAt: Date;
+}
+
+// Otvorené objednávky (`order.status_name` v nastavenom otvorenom zozname) —
+// TÁ ISTÁ definícia "otvorená" ako obrazovka "Na objednanie"
+// (`open-statuses.ts`), takže dialóg na výber ukáže presne to, čo appka
+// dnes považuje za ešte nevybavené.
+async function loadOpenOrders(db: Database): Promise<readonly OpenOrderRow[]> {
+  const openStatuses = await listOpenStatusNames(db);
+  if (openStatuses.length === 0) return [];
+  return db
+    .select({
+      id: orders.id,
+      externalOrderId: orders.externalOrderId,
+      customerName: orders.customerName,
+      email: orders.email,
+      placedAt: orders.placedAt,
+    })
+    .from(orders)
+    .where(inArray(orders.statusName, [...openStatuses]));
+}
+
+/**
+ * Základná objednávka + ostatné OTVORENÉ objednávky TOHO ISTÉHO zákazníka
+ * (`customerIdentityKey` vyššie) — presne zoznam, ktorý dialóg na výber
+ * zobrazí (zoradené od najnovšej). `null` = základná objednávka sa
+ * nenašla/už nie je otvorená.
+ */
+export async function listMergeableOrders(db: Database, orderId: string): Promise<MergeableOrders | null> {
+  const openOrders = await loadOpenOrders(db);
+  const base = openOrders.find((o) => o.id === orderId);
+  if (base === undefined) return null;
+  const baseKey = customerIdentityKey(base.email, base.customerName);
+  const candidates = openOrders
+    .filter((o) => o.id !== orderId && customerIdentityKey(o.email, o.customerName) === baseKey)
+    .sort((a, b) => b.placedAt.getTime() - a.placedAt.getTime())
+    .map((o) => ({ orderId: o.id, externalOrderId: o.externalOrderId, placedAt: o.placedAt.toISOString() }));
+  return { orderId: base.id, externalOrderId: base.externalOrderId, customerName: base.customerName, email: base.email, candidates };
+}
+
+export interface OrderMergeMailContent {
+  readonly to: string | null;
+  readonly customerName: string;
+  readonly subject: string;
+  readonly html: string;
+  readonly text: string;
+  readonly orderNumbers: readonly string[];
+}
+
+export type BuildOrderMergeMailResult =
+  | { readonly ok: true; readonly content: OrderMergeMailContent }
+  | { readonly ok: false; readonly error: "not_found" | "invalid_selection" };
+
+// "č. X" / "č. X a č. Y" / "č. X, č. Y a č. Z" — plynulá veta, nikdy
+// odrážkový zoznam (viď registry.ts's komentár k `zoznam_objednavok`).
+// Exportovaná — vlastný unit test (`merge-mail.test.ts`) overuje formátovanie
+// bez potreby DB.
+export function formatOrderNumbers(orderNumbers: readonly string[]): string {
+  const withPrefix = orderNumbers.map((n) => `č. ${n}`);
+  if (withPrefix.length <= 1) return withPrefix.join("");
+  const last = withPrefix[withPrefix.length - 1] ?? "";
+  return `${withPrefix.slice(0, -1).join(", ")} a ${last}`;
+}
+
+/** Náhľad aj odoslanie počítajú obsah TOU ISTOU cestou — server VŽDY
+ * prepočíta zo skutočného aktuálneho stavu DB, nikdy nedôveruje výberu, aký
+ * poslal klient (rovnaká disciplína ako `buildSupplierOrderMailContent`). */
+export async function buildOrderMergeMailContent(
+  db: Database,
+  baseOrderId: string,
+  otherOrderIds: readonly string[],
+): Promise<BuildOrderMergeMailResult> {
+  const mergeable = await listMergeableOrders(db, baseOrderId);
+  if (mergeable === null) return { ok: false, error: "not_found" };
+  const uniqueOtherIds = [...new Set(otherOrderIds)];
+  if (uniqueOtherIds.length === 0 || uniqueOtherIds.length !== otherOrderIds.length) {
+    return { ok: false, error: "invalid_selection" };
+  }
+  const candidateByOrderId = new Map(mergeable.candidates.map((c) => [c.orderId, c]));
+  for (const id of uniqueOtherIds) {
+    if (!candidateByOrderId.has(id)) return { ok: false, error: "invalid_selection" };
+  }
+
+  const orderNumbers = [
+    mergeable.externalOrderId,
+    ...uniqueOtherIds.map((id) => candidateByOrderId.get(id)?.externalOrderId ?? ""),
+  ]
+    .filter((n) => n !== "")
+    .sort((a, b) => a.localeCompare(b, "sk"));
+
+  const template = await resolveTemplate(db, "order_merge");
+  const rendered = renderTemplate(template, {
+    ...globalContext(),
+    meno_zakaznika: textValue(mergeable.customerName),
+    zoznam_objednavok: textValue(formatOrderNumbers(orderNumbers)),
+  });
+  const trimmedEmail = (mergeable.email ?? "").trim();
+  return {
+    ok: true,
+    content: {
+      to: trimmedEmail === "" ? null : trimmedEmail,
+      customerName: mergeable.customerName,
+      subject: rendered.subject,
+      html: rendered.html,
+      text: rendered.text,
+      orderNumbers,
+    },
+  };
+}
+
+export type SendOrderMergeMailResult =
+  | { readonly status: "sent"; readonly to: string; readonly orderNumbers: readonly string[] }
+  | { readonly status: "not_found" }
+  | { readonly status: "invalid_selection" }
+  | { readonly status: "no_email" }
+  | { readonly status: "not_configured"; readonly reason: string }
+  | { readonly status: "send_failed" };
+
+export interface SendOrderMergeMailOptions {
+  readonly db: Database;
+  readonly now: Date;
+  readonly baseOrderId: string;
+  readonly otherOrderIds: readonly string[];
+  readonly mailTransport: MailTransport | undefined;
+  readonly bccEmail: string | undefined;
+  // issue 193: kto tlačidlo stlačil — táto cesta je VŽDY ručná akcia
+  // zamestnanca.
+  readonly actorUserId?: string;
+}
+
+/**
+ * Fail-closed: chýbajúca BCC adresa ALEBO chýbajúci mail transport →
+ * NEPOŠLE NIČ (rovnaký zámer ako `nedostupne/send.ts` — majiteľ, "vsade
+ * zatial ma byt ked nieco posiela mail"). Žiadny advisory zámok — na rozdiel
+ * od `nedostupne` tu neexistuje "už raz odoslané" business pravidlo;
+ * jediná pretekárska situácia (dvojklik na TO ISTÉ odoslanie) je už
+ * vyriešená jednorazovou spotrebou preview tokenu
+ * (`merge-mail-preview-tokens.ts`, vynútené v `http/order-merge-routes.ts`).
+ */
+export async function sendOrderMergeMail(options: SendOrderMergeMailOptions): Promise<SendOrderMergeMailResult> {
+  const { db, now, baseOrderId, otherOrderIds, mailTransport, bccEmail, actorUserId } = options;
+  const built = await buildOrderMergeMailContent(db, baseOrderId, otherOrderIds);
+  if (!built.ok) return { status: built.error };
+
+  const logCtx: MailLogContext = {
+    source: "order_merge",
+    trigger: "manual",
+    templateKey: "order_merge",
+    orderCode: built.content.orderNumbers.join(","),
+    ...(actorUserId === undefined ? {} : { actorUserId }),
+  };
+
+  const { to } = built.content;
+  if (to === null) {
+    await recordSkippedMail(db, now, logCtx, "", "objednávka nemá e-mailovú adresu zákazníka");
+    return { status: "no_email" };
+  }
+
+  const bccMissing = bccEmail === undefined || bccEmail.trim() === "";
+  if (bccMissing) {
+    const reason = "chýba adresa pre skrytú kópiu majiteľovi (ORDER_MERGE_BCC_EMAIL)";
+    await recordSkippedMail(db, now, logCtx, to, reason);
+    return { status: "not_configured", reason };
+  }
+  if (mailTransport === undefined) {
+    const reason = "odosielanie e-mailov nie je nakonfigurované (chýba MAIL_HOST)";
+    await recordSkippedMail(db, now, logCtx, to, reason);
+    return { status: "not_configured", reason };
+  }
+
+  const sendResult = await sendLoggedMail(
+    db,
+    mailTransport,
+    { to, subject: built.content.subject, text: built.content.text, html: built.content.html, bcc: bccEmail },
+    now,
+    logCtx,
+  );
+  if (!sendResult.ok) {
+    log.error(
+      { baseOrderId, otherOrderIds, rawErrorMessage: sendResult.rawErrorMessage },
+      "Zlúčenie objednávky: odoslanie e-mailu zlyhalo",
+    );
+    return { status: "send_failed" };
+  }
+  log.info({ baseOrderId, otherOrderIds }, "Zlúčenie objednávky: e-mail odoslaný");
+  return { status: "sent", to, orderNumbers: built.content.orderNumbers };
+}

--- a/apps/api/tests/mail-templates.integration.test.ts
+++ b/apps/api/tests/mail-templates.integration.test.ts
@@ -53,7 +53,8 @@ it("zoznam vráti všetky druhy e-mailov s pôvodným znením, kým sa nič neup
   const res = await app.request("/api/mail-templates", { headers: { cookie } });
   expect(res.status).toBe(200);
   const payload = (await res.json()) as { templates: { key: string; subject: string; isCustomized: boolean; placeholders: unknown[] }[] };
-  expect(payload.templates).toHaveLength(8);
+  // issue 257: "order_merge" — deviaty druh e-mailu (Zlúčenie objednávky).
+  expect(payload.templates).toHaveLength(9);
   const nedostupne = payload.templates.find((t) => t.key === "nedostupne");
   expect(nedostupne?.isCustomized).toBe(false);
   expect(nedostupne?.subject).toBe(MAIL_TEMPLATE_KINDS["nedostupne"].defaultText.subject);

--- a/apps/api/tests/order-merge-http.integration.test.ts
+++ b/apps/api/tests/order-merge-http.integration.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, expect, it } from "vitest";
+import { mailLog, orders, users } from "../src/db/schema.js";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import type { UserRole } from "../src/modules/auth/service.js";
+import type { MailMessage } from "../src/modules/mail/transport.js";
+import { DEFAULT_ORDER_OPEN_STATUS } from "../src/modules/orders/open-statuses.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 257: HTTP vrstva "Zlúčenie objednávok". Falošný mail transport —
+// NIKDY skutočný SMTP (rovnaká majiteľova bezpečnostná podmienka ako
+// `nedostupne-http.integration.test.ts`). `listMergeCandidateGroups` číta
+// VÝHRADNE tabuľku `orders`, takže žiadny `order_line`/variant fixtúra tu
+// nie je potrebná.
+const HESLO = "test-heslo-abc";
+
+let close: (() => Promise<void>) | undefined;
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  resetLoginRateLimit();
+});
+
+async function boot(role: UserRole, options: { readonly sent?: MailMessage[]; readonly bccEmail?: string } = {}) {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await ctx.db.insert(users).values({
+    email: "pouzivatel@forestshop.sk",
+    passwordHash: await hashPassword(HESLO),
+    displayName: "Test",
+    role,
+  });
+
+  const app = createApp(ctx.db, {
+    cookieSecure: false,
+    orderMerge: {
+      mailTransport:
+        options.sent === undefined
+          ? undefined
+          : (m: MailMessage) => {
+              options.sent?.push(m);
+              return Promise.resolve();
+            },
+      bccEmail: options.bccEmail,
+    },
+  });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "pouzivatel@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie, db: ctx.db };
+}
+
+async function seedOrder(
+  db: Awaited<ReturnType<typeof boot>>["db"],
+  externalOrderId: string,
+  options: { readonly customerName?: string; readonly email?: string | null; readonly statusName?: string; readonly placedAt?: Date } = {},
+): Promise<string> {
+  const [order] = await db
+    .insert(orders)
+    .values({
+      externalOrderId,
+      customerName: options.customerName ?? "Zákazník Test",
+      email: options.email === undefined ? "zakaznik@example.sk" : options.email,
+      statusName: options.statusName ?? DEFAULT_ORDER_OPEN_STATUS,
+      placedAt: options.placedAt ?? new Date("2026-07-20T10:00:00Z"),
+    })
+    .returning({ id: orders.id });
+  if (order === undefined) throw new Error("test objednávka sa nepodarila vložiť");
+  return order.id;
+}
+
+it("GET candidates bez prihlásenia vráti 401", async () => {
+  const { app } = await boot("manazer");
+  const res = await app.request("/api/order-merge/candidates");
+  expect(res.status).toBe(401);
+});
+
+it("zákazník s 2 otvorenými objednávkami je kandidát, s 1 otvorenou NIE JE", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  // Dve objednávky TOHO ISTÉHO zákazníka (zhoda podľa e-mailu) — kandidát.
+  await seedOrder(db, "9101", { customerName: "Alfa Zákazník", email: "alfa@example.sk", placedAt: new Date("2026-07-20T10:00:00Z") });
+  await seedOrder(db, "9102", { customerName: "Alfa Zákazník", email: "alfa@example.sk", placedAt: new Date("2026-07-21T10:00:00Z") });
+  // Jedna objednávka INÉHO zákazníka — NIE kandidát (len 1 otvorená).
+  await seedOrder(db, "9103", { customerName: "Beta Zákazník", email: "beta@example.sk" });
+
+  const res = await app.request("/api/order-merge/candidates", { headers: { cookie } });
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { groups: { customerName: string; orders: { externalOrderId: string }[] }[] };
+  expect(body.groups).toHaveLength(1);
+  expect(body.groups[0]?.customerName).toBe("Alfa Zákazník");
+  const externalIds = (body.groups[0]?.orders ?? []).map((o) => o.externalOrderId).sort();
+  expect(externalIds).toEqual(["9101", "9102"]);
+});
+
+it("objednávka MIMO otvoreného zoznamu stavov sa do zoskupenia nepočíta", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  await seedOrder(db, "9104", { customerName: "Gama Zákazník", email: "gama@example.sk" });
+  await seedOrder(db, "9105", { customerName: "Gama Zákazník", email: "gama@example.sk", statusName: "Uzavretá — mimo zoznamu" });
+
+  const res = await app.request("/api/order-merge/candidates", { headers: { cookie } });
+  const body = (await res.json()) as { groups: unknown[] };
+  expect(body.groups).toHaveLength(0);
+});
+
+it("zákazník bez e-mailu sa zlučuje podľa MENA (fallback)", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  await seedOrder(db, "9106", { customerName: "Delta Bez Emailu", email: null, placedAt: new Date("2026-07-20T10:00:00Z") });
+  await seedOrder(db, "9107", { customerName: "Delta Bez Emailu", email: null, placedAt: new Date("2026-07-21T10:00:00Z") });
+
+  const res = await app.request("/api/order-merge/candidates", { headers: { cookie } });
+  const body = (await res.json()) as { groups: { customerName: string }[] };
+  expect(body.groups).toHaveLength(1);
+  expect(body.groups[0]?.customerName).toBe("Delta Bez Emailu");
+});
+
+it("bccMissing/mailNotConfigured — bez BCC ani mail transportu", async () => {
+  const { app, cookie } = await boot("citanie");
+  const res = await app.request("/api/order-merge/candidates", { headers: { cookie } });
+  const body = (await res.json()) as { bccMissing: boolean; mailNotConfigured: boolean };
+  expect(body.bccMissing).toBe(true);
+  expect(body.mailNotConfigured).toBe(true);
+});
+
+it("náhľad vráti obsah + token; odoslanie bez tokenu zlyhá; s tokenom uspeje a zapíše do Knihy odoslaných e-mailov; token je jednorazový", async () => {
+  const sent: MailMessage[] = [];
+  const { app, cookie, db } = await boot("manazer", { sent, bccEmail: "majitel@forestshop.sk" });
+  const baseId = await seedOrder(db, "9201", { customerName: "Epsilon Zákazník", email: "epsilon@example.sk", placedAt: new Date("2026-07-20T10:00:00Z") });
+  const otherId = await seedOrder(db, "9202", { customerName: "Epsilon Zákazník", email: "epsilon@example.sk", placedAt: new Date("2026-07-21T10:00:00Z") });
+
+  const previewRes = await app.request("/api/order-merge/preview", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ baseOrderId: baseId, otherOrderIds: [otherId] }),
+  });
+  expect(previewRes.status).toBe(200);
+  const previewBody = (await previewRes.json()) as { ok: boolean; previewToken: string; recipient: string; orderNumbers: string[] };
+  expect(previewBody.ok).toBe(true);
+  expect(previewBody.recipient).toBe("epsilon@example.sk");
+  expect(previewBody.orderNumbers.sort()).toEqual(["9201", "9202"]);
+
+  // Odoslanie BEZ tokenu (vymyslený reťazec) zlyhá — server-side vynútenie.
+  const sendBezTokenu = await app.request("/api/order-merge/send", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ baseOrderId: baseId, otherOrderIds: [otherId], previewToken: "vymyslený-token" }),
+  });
+  const bezTokenuBody = (await sendBezTokenu.json()) as { ok: boolean; error: string };
+  expect(bezTokenuBody.ok).toBe(false);
+  expect(sent).toHaveLength(0);
+
+  // Odoslanie SO správnym tokenom uspeje.
+  const sendRes = await app.request("/api/order-merge/send", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ baseOrderId: baseId, otherOrderIds: [otherId], previewToken: previewBody.previewToken }),
+  });
+  const sendBody = (await sendRes.json()) as { ok: boolean };
+  expect(sendBody.ok).toBe(true);
+  expect(sent).toHaveLength(1);
+  expect(sent[0]?.to).toBe("epsilon@example.sk");
+  expect(sent[0]?.bcc).toBe("majitel@forestshop.sk");
+
+  const logRows = await db.select({ source: mailLog.source, recipient: mailLog.recipient }).from(mailLog);
+  expect(logRows).toHaveLength(1);
+  expect(logRows[0]?.source).toBe("order_merge");
+  expect(logRows[0]?.recipient).toBe("epsilon@example.sk");
+
+  // Ten istý token DRUHÝKRÁT (jednorazová spotreba) zlyhá.
+  const druheOdoslanie = await app.request("/api/order-merge/send", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ baseOrderId: baseId, otherOrderIds: [otherId], previewToken: previewBody.previewToken }),
+  });
+  const druheBody = (await druheOdoslanie.json()) as { ok: boolean };
+  expect(druheBody.ok).toBe(false);
+  expect(sent).toHaveLength(1);
+});
+
+it("rola citanie NESMIE odoslať (403) — čítanie a náhľad áno, odosielanie len admin/manazer", async () => {
+  const { app, cookie, db } = await boot("citanie", { sent: [], bccEmail: "majitel@forestshop.sk" });
+  const baseId = await seedOrder(db, "9301", { customerName: "Zeta Zákazník", email: "zeta@example.sk" });
+  const otherId = await seedOrder(db, "9302", { customerName: "Zeta Zákazník", email: "zeta@example.sk" });
+
+  const previewRes = await app.request("/api/order-merge/preview", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ baseOrderId: baseId, otherOrderIds: [otherId] }),
+  });
+  expect(previewRes.status).toBe(200);
+  const previewBody = (await previewRes.json()) as { previewToken: string };
+
+  const res = await app.request("/api/order-merge/send", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ baseOrderId: baseId, otherOrderIds: [otherId], previewToken: previewBody.previewToken }),
+  });
+  expect(res.status).toBe(403);
+});

--- a/apps/web/src/components/OrderMergeSection.tsx
+++ b/apps/web/src/components/OrderMergeSection.tsx
@@ -1,0 +1,200 @@
+import { useCallback, useEffect, useRef, useState, type JSX } from "react";
+import type { Me } from "../api.js";
+import {
+  fetchOrderMergeCandidates,
+  fetchOrderMergePreview,
+  OrderMergeUnauthorizedError,
+  sendOrderMergeMail,
+  type MergeCandidateGroup,
+  type OrderMergeList,
+  type OrderMergePreview,
+} from "../orderMergeApi.js";
+import { MailPreviewDialog } from "./MailPreviewDialog.js";
+
+// issue 257: "Zlúčenie objednávok" — vlastná záložka v Eshope (majiteľova
+// korekcia: "malo by to byt zalozka v eshope a mali by tam vyskocit ak su
+// dve objedanvky na toho isteho zakaznika"). Rovnaká rolová úroveň ako
+// "Nedostupné tovary": čítanie vidí každý prihlásený, odoslanie len
+// admin/manazer.
+const CONTROL_ROLES: ReadonlySet<Me["role"]> = new Set(["admin", "manazer"]);
+
+interface PendingSend {
+  readonly group: MergeCandidateGroup;
+  readonly preview: OrderMergePreview;
+}
+
+function groupKey(group: MergeCandidateGroup): string {
+  return group.orders.map((o) => o.orderId).join(",");
+}
+
+export function OrderMergeSection({ role, onSessionExpired }: { readonly role: Me["role"]; readonly onSessionExpired: () => void }): JSX.Element {
+  const [list, setList] = useState<OrderMergeList | null>(null);
+  const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState("");
+  const [busyKey, setBusyKey] = useState("");
+  const [actionError, setActionError] = useState("");
+  const [pending, setPending] = useState<PendingSend | null>(null);
+  // issue 191's vzor (`NedostupneSection.tsx`) — spúšťacie tlačidlo sa počas
+  // načítania náhľadu stáva `disabled`, prehliadač z neho fokus zhodí.
+  const triggerRef = useRef<HTMLElement | null>(null);
+  const canControl = CONTROL_ROLES.has(role);
+
+  const load = useCallback(() => {
+    fetchOrderMergeCandidates()
+      .then((l) => {
+        setList(l);
+        setLoaded(true);
+      })
+      .catch((err: unknown) => {
+        setLoaded(true);
+        if (err instanceof OrderMergeUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setError("Zoznam kandidátov na zlúčenie sa nepodarilo načítať.");
+      });
+  }, [onSessionExpired]);
+
+  useEffect(load, [load]);
+
+  const openPreview = useCallback(
+    (group: MergeCandidateGroup) => {
+      const [base, ...rest] = group.orders;
+      if (base === undefined) return;
+      const key = groupKey(group);
+      triggerRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+      setActionError("");
+      setBusyKey(key);
+      fetchOrderMergePreview(
+        base.orderId,
+        rest.map((o) => o.orderId),
+      )
+        .then((preview) => {
+          setPending({ group, preview });
+        })
+        .catch((err: unknown) => {
+          if (err instanceof OrderMergeUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setActionError(err instanceof Error ? err.message : "Náhľad sa nepodarilo načítať.");
+        })
+        .finally(() => {
+          setBusyKey("");
+        });
+    },
+    [onSessionExpired],
+  );
+
+  const confirmSend = useCallback(() => {
+    if (pending === null) return;
+    const [base, ...rest] = pending.group.orders;
+    if (base === undefined) return;
+    const key = groupKey(pending.group);
+    setBusyKey(key);
+    sendOrderMergeMail(
+      base.orderId,
+      rest.map((o) => o.orderId),
+      pending.preview.previewToken,
+    )
+      .then((result) => {
+        if (!result.ok) {
+          setActionError(result.error);
+          return;
+        }
+        setPending(null);
+        load();
+      })
+      .catch((err: unknown) => {
+        if (err instanceof OrderMergeUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setActionError(err instanceof Error ? err.message : "Odoslanie zlyhalo.");
+      })
+      .finally(() => {
+        setBusyKey("");
+      });
+  }, [pending, load, onSessionExpired]);
+
+  if (!loaded) return <p>Načítavam…</p>;
+  if (error !== "") return <p role="alert">{error}</p>;
+  if (list === null) return <p role="alert">Zoznam kandidátov na zlúčenie sa nepodarilo načítať.</p>;
+
+  return (
+    <section>
+      <p>Zákazníci, ktorí majú viac ako jednu otvorenú objednávku — dá sa im poslať e-mail, že ich objednávky posielame spolu ako jednu zásielku.</p>
+
+      {list.bccMissing && (
+        <p role="alert" data-testid="order-merge-bcc-missing">
+          ⚠️ Chýba adresa pre skrytú kópiu majiteľovi (ORDER_MERGE_BCC_EMAIL) — automatizácia zatiaľ NEPOŠLE žiadny e-mail zákazníkovi.
+        </p>
+      )}
+      {list.mailNotConfigured && (
+        <p role="alert" data-testid="order-merge-mail-not-configured">
+          ⚠️ Odosielanie e-mailov nie je nakonfigurované (chýba MAIL_HOST).
+        </p>
+      )}
+      {actionError !== "" && <p role="alert">{actionError}</p>}
+
+      {list.groups.length === 0 ? (
+        <p data-testid="order-merge-empty">Momentálne žiadny zákazník nemá viac ako jednu otvorenú objednávku.</p>
+      ) : (
+        <div className="order-merge-groups" data-testid="order-merge-groups">
+          {list.groups.map((group) => {
+            const key = groupKey(group);
+            const busy = busyKey === key;
+            // Testid podľa VIDITEĽNÉHO Shoptet čísla objednávky (nie
+            // interného DB `orderId`, UUID) — rovnaký zámer ako
+            // `NedostupneSection.tsx`'s `variantCode`-kľúčované testid,
+            // stabilné a čitateľné aj v e2e teste napísanom vopred.
+            const testKey = group.orders[0]?.externalOrderId ?? key;
+            return (
+              <div className="card" key={key} data-testid={`order-merge-group-${testKey}`}>
+                <div className="order-merge-group-header">
+                  <span className="order-merge-customer">{group.customerName}</span>
+                  <span>{group.email === null || group.email === "" ? "(bez e-mailu)" : group.email}</span>
+                </div>
+                <ul className="order-merge-orders">
+                  {group.orders.map((o) => (
+                    <li key={o.orderId}>č. {o.externalOrderId}</li>
+                  ))}
+                </ul>
+                {canControl && (
+                  <button
+                    type="button"
+                    className="btn lg ghost"
+                    disabled={busy}
+                    onClick={() => {
+                      openPreview(group);
+                    }}
+                    data-testid={`order-merge-send-${testKey}`}
+                  >
+                    ✉️ Poslať e-mail o zlúčení — náhľad
+                  </button>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {pending !== null && (
+        <MailPreviewDialog
+          testId="order-merge-preview"
+          title="Náhľad e-mailu — povinné pred odoslaním"
+          recipient={pending.preview.recipient}
+          subject={pending.preview.subject}
+          html={pending.preview.html}
+          confirmLabel="📧 Odoslať zákazníkovi"
+          confirmDisabled={busyKey !== ""}
+          onConfirm={confirmSend}
+          returnFocusRef={triggerRef}
+          onClose={() => {
+            setPending(null);
+          }}
+        />
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/mailLogApi.ts
+++ b/apps/web/src/mailLogApi.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 // issue 193: obrazovka "Odoslané e-maily" — zrkadlí `http/mail-log-routes.ts`.
 // Len čítanie, žiadny zápis (do knihy zapisujú samy odosielacie cesty).
 
-export const MAIL_LOG_SOURCES = ["nedostupne", "posta_uncollected", "order_reminder", "supplier_order"] as const;
+export const MAIL_LOG_SOURCES = ["nedostupne", "posta_uncollected", "order_reminder", "supplier_order", "order_merge"] as const;
 export type MailLogSource = (typeof MAIL_LOG_SOURCES)[number];
 
 // Popisky sú TU (nie na serveri) z rovnakého dôvodu ako pri stavoch riadkov
@@ -13,6 +13,7 @@ export const MAIL_LOG_SOURCE_LABELS: Readonly<Record<MailLogSource, string>> = {
   posta_uncollected: "Nevyzdvihnuté zásielky",
   order_reminder: "Pripomienky objednávok",
   supplier_order: "Objednávka dodávateľovi",
+  order_merge: "Zlúčenie objednávky",
 };
 
 const rowSchema = z.object({

--- a/apps/web/src/nav.test.ts
+++ b/apps/web/src/nav.test.ts
@@ -8,13 +8,15 @@ import { DEFAULT_TAB_ID, HIDDEN_TABS, NAV, findTab, isVisibleTabId } from "./nav
 // pridalo "Texty e-mailov" do Systému (nastavenie spoločné pre VŠETKY
 // automatizácie). Issue 239 pridalo "Párovanie produktov" pod "Eshop"
 // (rovnaký dôvod ako "Nedostupné tovary" — pracovná obrazovka bez plánu).
-// Issue 240 pridalo "Vyhľadať" pod "Eshop" z rovnakého dôvodu.
+// Issue 240 pridalo "Vyhľadať" pod "Eshop" z rovnakého dôvodu. Issue 257
+// pridalo "Zlúčenie objednávok" pod "Eshop" z rovnakého dôvodu (majiteľ:
+// vlastná záložka, nie tlačidlo pri objednávke).
 // Tento test je najbližšie k tomu, čo strojovo overiť dá (registrácia, nie DOM).
-it("NAV má tri priečinky (Systém/Eshop/Automatizácie), s 3/4/4 záložkami v poradí podľa dôležitosti", () => {
+it("NAV má tri priečinky (Systém/Eshop/Automatizácie), s 3/5/4 záložkami v poradí podľa dôležitosti", () => {
   expect(NAV).toHaveLength(3);
   expect(NAV.map((f) => f.label)).toEqual(["Systém", "Eshop", "Automatizácie"]);
   expect(NAV[0]?.tabs).toHaveLength(3);
-  expect(NAV[1]?.tabs).toHaveLength(4);
+  expect(NAV[1]?.tabs).toHaveLength(5);
   expect(NAV[2]?.tabs).toHaveLength(4);
   // issue 212: "Dodávateľský sklad" — scraper dostupnosti u dodávateľa;
   // patrí do Systému (zadanie majiteľa), nie medzi Automatizácie.
@@ -24,6 +26,7 @@ it("NAV má tri priečinky (Systém/Eshop/Automatizácie), s 3/4/4 záložkami v
     "Nedostupné tovary",
     "Párovanie produktov",
     "Vyhľadať",
+    "Zlúčenie objednávok",
   ]);
   // issue 193: "Odoslané e-maily" — prehľad toho, čo automatizácie poslali.
   expect(NAV[2]?.tabs.map((t) => t.label)).toEqual([

--- a/apps/web/src/nav.ts
+++ b/apps/web/src/nav.ts
@@ -4,6 +4,7 @@ import { CatalogPage } from "./components/CatalogPage.js";
 import { MailLogSection } from "./components/MailLogSection.js";
 import { MailTemplatesSection } from "./components/MailTemplatesSection.js";
 import { NedostupneSection } from "./components/NedostupneSection.js";
+import { OrderMergeSection } from "./components/OrderMergeSection.js";
 import { OrderReminderSection } from "./components/OrderReminderSection.js";
 import { OrdersSection } from "./components/OrdersSection.js";
 import { PairingSection } from "./components/PairingSection.js";
@@ -92,6 +93,11 @@ export const NAV: readonly NavFolder[] = [
       // dôvodu ako "Párovanie produktov" vyššie (obsluha na nej pracuje,
       // žiadny plán/zapnuté-vypnuté koncept).
       { id: "search", label: "Vyhľadať", icon: "🔍", Component: SearchSection, wide: true },
+      // issue 257: majiteľ, "malo by to byt zalozka v eshope a mali by tam
+      // vyskocit ak su dve objedanvky na toho isteho zakaznika" — patrí sem
+      // z rovnakého dôvodu ako "Párovanie produktov"/"Vyhľadať" vyššie
+      // (obsluha na nej pracuje, žiadny plán/zapnuté-vypnuté koncept).
+      { id: "order-merge", label: "Zlúčenie objednávok", icon: "🔀", Component: OrderMergeSection, wide: true },
     ],
   },
   {

--- a/apps/web/src/orderMergeApi.ts
+++ b/apps/web/src/orderMergeApi.ts
@@ -1,0 +1,92 @@
+import { z } from "zod";
+
+// issue 257: "Zlúčenie objednávok" — zrkadlí `apps/api/src/http/order-merge-routes.ts`.
+// Rovnaký tvar ako `nedostupneApi.ts`.
+
+const candidateOrderSchema = z.object({ orderId: z.string(), externalOrderId: z.string(), placedAt: z.string() });
+export type MergeCandidateOrder = z.infer<typeof candidateOrderSchema>;
+
+const groupSchema = z.object({
+  customerName: z.string(),
+  email: z.string().nullable(),
+  orders: z.array(candidateOrderSchema),
+});
+export type MergeCandidateGroup = z.infer<typeof groupSchema>;
+
+const listSchema = z.object({ groups: z.array(groupSchema), bccMissing: z.boolean(), mailNotConfigured: z.boolean() });
+export type OrderMergeList = z.infer<typeof listSchema>;
+
+const previewResultSchema = z.union([
+  z.object({
+    ok: z.literal(true),
+    subject: z.string(),
+    html: z.string(),
+    recipient: z.string(),
+    customerName: z.string(),
+    orderNumbers: z.array(z.string()),
+    previewToken: z.string(),
+  }),
+  z.object({ ok: z.literal(false), error: z.string() }),
+]);
+export type OrderMergePreview = Extract<z.infer<typeof previewResultSchema>, { readonly ok: true }>;
+
+const sendResultSchema = z.union([z.object({ ok: z.literal(true) }), z.object({ ok: z.literal(false), error: z.string() })]);
+export type OrderMergeSendResult = z.infer<typeof sendResultSchema>;
+
+export class OrderMergeUnauthorizedError extends Error {
+  constructor() {
+    super("Neprihlásený");
+  }
+}
+
+const errorBodySchema = z.object({ error: z.string() });
+
+async function serverErrorMessage(response: Response, fallback: string): Promise<string> {
+  try {
+    const parsed = errorBodySchema.safeParse(await response.json());
+    if (parsed.success) return parsed.data.error;
+  } catch {
+    // telo nie je platný JSON — použi všeobecnú hlášku
+  }
+  return fallback;
+}
+
+async function readJson(response: Response, fallback: string): Promise<unknown> {
+  if (response.status === 401) throw new OrderMergeUnauthorizedError();
+  if (!response.ok) throw new Error(await serverErrorMessage(response, fallback));
+  return await response.json();
+}
+
+export async function fetchOrderMergeCandidates(): Promise<OrderMergeList> {
+  const response = await fetch("/api/order-merge/candidates");
+  return listSchema.parse(await readJson(response, "Zoznam sa nepodarilo načítať"));
+}
+
+export async function fetchOrderMergePreview(baseOrderId: string, otherOrderIds: readonly string[]): Promise<OrderMergePreview> {
+  const response = await fetch("/api/order-merge/preview", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ baseOrderId, otherOrderIds }),
+  });
+  const parsed = previewResultSchema.parse(await readJson(response, "Náhľad sa nepodarilo načítať"));
+  if (!parsed.ok) throw new Error(parsed.error);
+  return parsed;
+}
+
+// Server VYŽADUJE `previewToken` vydaný `/preview` PRE PRESNE tento
+// (baseOrderId, výber) — server-side vynútenie povinného náhľadu
+// (`merge-mail-preview-tokens.ts`). Volajúci preto musí odoslať TEN ISTÝ
+// token, aký dostal z `fetchOrderMergePreview`.
+export async function sendOrderMergeMail(
+  baseOrderId: string,
+  otherOrderIds: readonly string[],
+  previewToken: string,
+): Promise<OrderMergeSendResult> {
+  const response = await fetch("/api/order-merge/send", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ baseOrderId, otherOrderIds, previewToken }),
+  });
+  if (response.status === 401) throw new OrderMergeUnauthorizedError();
+  return sendResultSchema.parse(await response.json());
+}

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -1891,6 +1891,35 @@ tr:last-child td {
   overflow-x: auto;
 }
 
+/* ---------------- 16. ZLÚČENIE OBJEDNÁVOK (issue 257) ---------------- */
+/* Rovnaký "zoznam kariet" vzor ako Nedostupné tovary vyššie — jedna karta =
+   jeden zákazník s ≥2 otvorenými objednávkami. */
+.order-merge-groups {
+  display: flex;
+  flex-direction: column;
+  gap: var(--fs-space-5);
+  margin-top: var(--fs-space-4);
+}
+.order-merge-group-header {
+  display: flex;
+  align-items: baseline;
+  gap: var(--fs-space-3);
+  flex-wrap: wrap;
+  margin-bottom: var(--fs-space-2);
+}
+.order-merge-customer {
+  font-size: var(--fs-text-md);
+  font-weight: var(--fs-weight-bold);
+}
+.order-merge-orders {
+  display: flex;
+  gap: var(--fs-space-3);
+  flex-wrap: wrap;
+  margin: 0 0 var(--fs-space-3);
+  padding-left: var(--fs-space-5);
+  color: var(--fs-ink-muted);
+}
+
 /* ---------------- MODÁLNY DIALÓG (issue 191) ----------------
    Náhľad e-mailu pred odoslaním sa už nerozbaľuje na spodku stránky —
    otvorí sa cez obrazovku, takže je okamžite v zornom poli. `z-index`

--- a/apps/web/tests/e2e/nav.spec.ts
+++ b/apps/web/tests/e2e/nav.spec.ts
@@ -15,8 +15,11 @@ const E2E_NAV_EMAIL = "e2e-nav@forestshop.sk";
 // tretí priečinok "Automatizácie" s tromi hotovými obrazovkami, dovtedy len v
 // `HIDDEN_TABS` bez odkazu v menu. Issue 239 (2026-08-04) pridáva "Párovanie
 // produktov" pod "Eshop" — desiata záložka. Issue 240 (2026-08-05) pridáva
-// "Vyhľadať" pod "Eshop" — jedenásta záložka.
-test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s jedenástimi záložkami, klik prepne obrazovku, panel sa zbalí do lišty a stav si pamätá, konzola je čistá", async ({
+// "Vyhľadať" pod "Eshop" — jedenásta záložka. Issue 257 (2026-08-05) pridáva
+// "Zlúčenie objednávok" pod "Eshop" — dvanásta záložka (funkčný test v
+// samostatnom `order-merge.spec.ts`, rovnaký vzor ako "Vyhľadať"/
+// `search.spec.ts`).
+test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s dvanástimi záložkami, klik prepne obrazovku, panel sa zbalí do lišty a stav si pamätá, konzola je čistá", async ({
   page,
 }) => {
   const chyby: string[] = [];
@@ -37,8 +40,8 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s jedenásti
   await expect(page.getByRole("button", { name: "Eshop" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Automatizácie" })).toBeVisible();
 
-  // Presne jedenásť záložiek v CELOM menu.
-  await expect(page.locator(".side-nav .tab")).toHaveCount(11);
+  // Presne dvanásť záložiek v CELOM menu.
+  await expect(page.locator(".side-nav .tab")).toHaveCount(12);
   await expect(page.getByRole("button", { name: "Sync zo Shoptetu" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Texty e-mailov" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Na objednanie" })).toBeVisible();
@@ -47,6 +50,7 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s jedenásti
   await expect(page.getByRole("button", { name: "Nedostupné tovary" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Párovanie produktov" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Vyhľadať" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Zlúčenie objednávok" })).toBeVisible();
 
   // Predvolená obrazovka (bez kliknutia) je "Sync zo Shoptetu".
   await expect(page.getByRole("heading", { name: "Sync zo Shoptetu" })).toBeVisible();
@@ -109,6 +113,12 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s jedenásti
   await expect(page.getByRole("heading", { name: "Vyhľadať" })).toBeVisible();
   await expect(page.getByTestId("nav-status-search")).toHaveCount(0);
 
+  // issue 257: rovnaký dôvod ako "Vyhľadať" vyššie — žiadny plán/zapnuté-
+  // vypnuté koncept, teda žiadny stavový odznak v menu.
+  await page.getByRole("button", { name: "Zlúčenie objednávok" }).click();
+  await expect(page.getByRole("heading", { name: "Zlúčenie objednávok" })).toBeVisible();
+  await expect(page.getByTestId("nav-status-order-merge")).toHaveCount(0);
+
   // issue 190: zbalenie panela do úzkej lišty. Zámerne je to SÚČASŤ tohto
   // testu, nie samostatný test — každý ďalší test v tomto súbore by znamenal
   // ďalšie prihlásenie na zdieľanom `MAX_ATTEMPTS=10` rozpočte
@@ -131,7 +141,7 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s jedenásti
 
   // Hlavičky priečinkov zmiznú, ikony všetkých modulov ostanú.
   await expect(page.getByRole("button", { name: "Systém" })).toHaveCount(0);
-  await expect(page.locator(".side-nav .tab")).toHaveCount(11);
+  await expect(page.locator(".side-nav .tab")).toHaveCount(12);
   // Názov sa v lište ukáže bublinou pri prejdení myšou.
   await expect(page.getByRole("button", { name: "Na objednanie" })).toHaveAttribute(
     "title",

--- a/apps/web/tests/e2e/order-merge.spec.ts
+++ b/apps/web/tests/e2e/order-merge.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "@playwright/test";
+
+const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
+const E2E_ZLUCENIE_EMAIL = "e2e-zlucenie@forestshop.sk"; // musí sa zhodovať s hodnotou v scripts/e2e-setup.ts
+
+// issue 257: "Zlúčenie objednávok" — VIDITEĽNÁ záložka v "Eshop" (majiteľova
+// korekcia zadania: vlastná záložka, ktorá SAMA vypíše zákazníkov s ≥2
+// otvorenými objednávkami, nikdy tlačidlo pri jednotlivej objednávke).
+//
+// Toto NEKONTAKTUJE skutočný SMTP: `playwright.config.ts`'s API `webServer`
+// nenastavuje `MAIL_HOST`/`ORDER_MERGE_BCC_EMAIL`, takže `mailTransport` je v
+// tomto behu `undefined` (rovnaká úvaha ako `nedostupne.spec.ts`). Fixtúrové
+// objednávky "9010"/"9011" (`scripts/e2e-setup.ts`) patria TOMU ISTÉMU
+// (fiktívnemu) zákazníkovi — jediný kandidát na zlúčenie v celom e2e behu.
+test("záložka vypíše zákazníkov s ≥2 otvorenými objednávkami, povinný náhľad predchádza odoslaniu, konzola je čistá", async ({ page }) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/?tab=order-merge");
+  await page.getByLabel("E-mail").fill(E2E_ZLUCENIE_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await expect(page.getByRole("heading", { name: "Zlúčenie objednávok" })).toBeVisible();
+
+  // Chýbajúca BCC/mail konfigurácia (E2E beh) sa zobrazí ako varovania —
+  // rovnaký vzor ako "Nedostupné tovary".
+  await expect(page.getByTestId("order-merge-bcc-missing")).toBeVisible();
+  await expect(page.getByTestId("order-merge-mail-not-configured")).toBeVisible();
+
+  const group = page.getByTestId("order-merge-group-9011");
+  await expect(group).toBeVisible();
+  await expect(group).toContainText("E2E Zákazník Zlúčenie");
+  await expect(group).toContainText("e2e-zakaznik-zlucenie@example.sk");
+  await expect(group).toContainText("č. 9010");
+  await expect(group).toContainText("č. 9011");
+
+  // Klik otvorí POVINNÝ náhľad PRED akýmkoľvek odoslaním (rovnaký kontrakt
+  // ako "Nedostupné tovary" — server-side vynútený token).
+  await group.getByTestId("order-merge-send-9011").click();
+  const preview = page.getByTestId("order-merge-preview");
+  await expect(preview).toBeVisible();
+  await expect(preview).toContainText("e2e-zakaznik-zlucenie@example.sk");
+  await expect(preview).toContainText("9010");
+  await expect(preview).toContainText("9011");
+
+  // Zavrieť klávesom Esc bez odoslania — nič sa nezmení.
+  await page.keyboard.press("Escape");
+  await expect(preview).toBeHidden();
+
+  // Znovu otvoriť a potvrdiť — bez nakonfigurovaného mailu vráti graceful
+  // chybu (fail-closed, žiadny skutočný pokus o SMTP spojenie); BCC kontrola
+  // beží PRED mail-transport kontrolou (`merge-mail.ts`), takže táto hláška
+  // sa zobrazí.
+  await group.getByTestId("order-merge-send-9011").click();
+  await expect(preview).toBeVisible();
+  await page.getByTestId("order-merge-preview-confirm").click();
+  await expect(page.getByText("chýba adresa pre skrytú kópiu majiteľovi (ORDER_MERGE_BCC_EMAIL)", { exact: true })).toBeVisible();
+
+  // Neúspešné odoslanie náhľad ZÁMERNE nezatvára (obsluha vidí dôvod) —
+  // zavrie ho až tlačidlo "Zrušiť".
+  await expect(preview).toBeVisible();
+  await page.getByTestId("order-merge-preview-cancel").click();
+  await expect(preview).toBeHidden();
+
+  expect(chyby).toEqual([]);
+});

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -126,6 +126,11 @@ services:
       # Chýbajúca = automatizácia NEPOŠLE ani jeden e-mail zákazníkovi
       # (fail-closed, majiteľova jediná bezpečnostná podmienka).
       ORDER_REMINDER_BCC_EMAIL:
+      # issue 257: "Zlúčenie objednávok" — skrytá kópia (BCC) majiteľovi,
+      # NEZÁVISLÁ vyhradená premenná (rovnaký dôvod ako ostatné *_BCC_EMAIL
+      # vyššie). Chýbajúca = automatizácia NEPOŠLE ani jeden e-mail
+      # zákazníkovi (fail-closed).
+      ORDER_MERGE_BCC_EMAIL:
     volumes:
       - catalog-raw:/data/catalog-raw
       - orders-raw:/data/orders-raw

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -2872,3 +2872,28 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   @forestshop/web test` (421 tests, 52 files), `pnpm --filter @forestshop/api
   test` (571 tests), `pnpm --filter @forestshop/api test:integration` (477
   tests), `pnpm --filter @forestshop/web e2e` (42/42).
+
+## Issue 257 — Zlúčenie objednávok (majiteľova korekcia: záložka, nie tlačidlo)
+
+- Prevzaté od pozastaveného workera: verzia už bola bumpnutá (0.3.0-dev.151,
+  4c3e582), salvage mail-log/mail-templates/env.ts infra + preview-token
+  modul + migrácia `0034_melodic_wild_child` (zostali nezmenené — nezávislé
+  od vstupného bodu).
+- Commit `17de3be` — backend: `listMergeCandidateGroups` (merge-mail.ts) +
+  HTTP trasy `GET/POST /api/order-merge/*` + wiring do app.ts/index.ts +
+  mail-log-routes.ts enum + docker-compose.prod.yml BCC premenná. Unit test
+  `formatOrderNumbers` (src), integration test `order-merge-http
+  .integration.test.ts` (kandidáti/preview/send/role-gating).
+- Commit `8cc6e9c` — frontend: `OrderMergeSection.tsx` + `orderMergeApi.ts`
+  + nová záložka v `nav.ts`'s Eshop priečinku (12. záložka) + e2e fixtúra
+  (dve objednávky bez `order_line`) + `order-merge.spec.ts`.
+- Design comment na tickete (root cause, salvage vs. zmena, alternatívy)
+  pred prvým kódovým commitom.
+- Lokálne gates: `pnpm typecheck`, `pnpm lint` čisté; web unit 421/421 (52
+  súborov), API unit 579/579 (36 súborov), API integration 484/484 (66
+  súborov, po `db:migrate`), e2e 43/43.
+- Playbook: `.claude/rules/database.md` (nová `pgEnum` hodnota potrebuje
+  `db:migrate` PRED `test:integration`, inak `insertEntry`'s tiché
+  prehltnutie zápisu vyzerá ako bug), `.claude/rules/orders.md`
+  (`listMergeCandidateGroups` nepotrebuje `order_line` + testid podľa
+  `externalOrderId`, nie UUID).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.150",
+  "version": "0.3.0-dev.151",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -179,6 +179,14 @@ const E2E_DOMENY_EMAIL = "e2e-domeny@forestshop.sk"; // musí sa zhodovať s hod
 // (katalóg) — jeden účet stačí pre testy v OBOCH spec súboroch.
 const E2E_RACE_EMAIL = "e2e-race@forestshop.sk"; // musí sa zhodovať s hodnotou v pairing.spec.ts/catalog.spec.ts
 
+// issue 257: rovnaký mechanizmus a dôvod ako `E2E_RACE_EMAIL` vyššie — nový
+// spec súbor (`order-merge.spec.ts` — "Zlúčenie objednávok") dostáva VLASTNÝ
+// izolovaný účet namiesto ďalšieho prihlásenia pod zdieľaným
+// `e2e@forestshop.sk` (balík je už na hranici `MAX_ATTEMPTS`, komentár
+// vyššie pri `E2E_NAV_EMAIL`). Rola "manazer" — táto obrazovka vyžaduje
+// `admin`/`manazer` na odoslanie, rovnaká úroveň ako "Nedostupné tovary".
+const E2E_ZLUCENIE_EMAIL = "e2e-zlucenie@forestshop.sk"; // musí sa zhodovať s hodnotou v order-merge.spec.ts
+
 const { db, pool } = createDb();
 // Konštantný literál bez interpolácie — obyčajný reťazec je tu rovnako bezpečný
 // ako `sql` tagovaná šablóna (tú používa ekvivalentný apps/api/tests/helpers/db.ts),
@@ -337,6 +345,7 @@ await db.insert(users).values({
   role: "citanie",
 });
 await db.insert(users).values({ email: E2E_RACE_EMAIL, passwordHash: await hashPassword(E2E_HESLO), displayName: "E2E Manažér", role: "manazer" });
+await db.insert(users).values({ email: E2E_ZLUCENIE_EMAIL, passwordHash: await hashPassword(E2E_HESLO), displayName: "E2E Manažér", role: "manazer" });
 
 // Katalóg pre E2E: tá istá commitnutá fixtúra ako v jednotkových testoch, cez tú istú
 // službu importu — E2E tak overuje skutočnú cestu dát, nie ručne nasypané riadky.
@@ -472,37 +481,32 @@ await db.insert(orderLines).values({
 // "Σ spolu" (issue 62) tak pri prvom vykreslení ukazuje CELÉ dopytované
 // množstvo ako zostávajúce (3 + 2 = 5 ks), presne to, čo e2e test tohto
 // ticketu overuje pred aj po prepnutí stavu jedného z riadkov.
-const [objednavkaSucetPrva] = await db
-  .insert(orders)
-  .values({
-    externalOrderId: "9004",
-    customerName: "E2E Zákazník Súčet Prvá",
-    statusName: DEFAULT_ORDER_OPEN_STATUS,
-    placedAt: new Date("2026-07-23T09:00:00Z"),
-  })
-  .returning();
+const [objednavkaSucetPrva] = await db.insert(orders).values({ externalOrderId: "9004", customerName: "E2E Zákazník Súčet Prvá", statusName: DEFAULT_ORDER_OPEN_STATUS, placedAt: new Date("2026-07-23T09:00:00Z") }).returning();
 if (objednavkaSucetPrva === undefined) throw new Error("E2E objednávka (súčet, prvá) sa nepodarila vložiť");
-await db.insert(orderLines).values({
-  orderId: objednavkaSucetPrva.id,
-  variantCode: "60055/10",
-  quantity: 3,
-});
+await db.insert(orderLines).values({ orderId: objednavkaSucetPrva.id, variantCode: "60055/10", quantity: 3 });
 
-const [objednavkaSucetDruha] = await db
-  .insert(orders)
-  .values({
-    externalOrderId: "9005",
-    customerName: "E2E Zákazník Súčet Druhá",
-    statusName: DEFAULT_ORDER_OPEN_STATUS,
-    placedAt: new Date("2026-07-24T09:00:00Z"),
-  })
-  .returning();
+const [objednavkaSucetDruha] = await db.insert(orders).values({ externalOrderId: "9005", customerName: "E2E Zákazník Súčet Druhá", statusName: DEFAULT_ORDER_OPEN_STATUS, placedAt: new Date("2026-07-24T09:00:00Z") }).returning();
 if (objednavkaSucetDruha === undefined) throw new Error("E2E objednávka (súčet, druhá) sa nepodarila vložiť");
-await db.insert(orderLines).values({
-  orderId: objednavkaSucetDruha.id,
-  variantCode: "60055/10",
-  quantity: 2,
-});
+await db.insert(orderLines).values({ orderId: objednavkaSucetDruha.id, variantCode: "60055/10", quantity: 2 });
+
+// issue 257: DVE otvorené objednávky TOHO ISTÉHO (fiktívneho) zákazníka —
+// presne jeden kandidát na zlúčenie, ktorý nová záložka "Zlúčenie
+// objednávok" má vypísať. `listMergeCandidateGroups` (`orders/merge-mail.ts`)
+// číta VÝHRADNE tabuľku `orders` (customerIdentityKey podľa e-mailu), takže
+// tieto dve objednávky ZÁMERNE nemajú ŽIADEN `order_line` riadok — nulový
+// dopad na presné počty riadkov/dodávateľských skupín, ktoré iné testy v
+// `orders.spec.ts` overujú (`.claude/rules/testing.md`'s "nový fixtúrový
+// variant sa nesmie vybrať len podľa 'je nepoužitý'" poučenie sa tu netýka,
+// lebo žiadny variant sa vôbec nepoužíva).
+// Žiadne `.returning()`/id netreba — nič ďalšie v tomto skripte sa naň
+// neodkazuje (na rozdiel od objednávok vyššie, ktoré potrebujú vlastný `id`
+// pre `order_line`).
+await db
+  .insert(orders)
+  .values({ externalOrderId: "9010", customerName: "E2E Zákazník Zlúčenie", email: "e2e-zakaznik-zlucenie@example.sk", statusName: DEFAULT_ORDER_OPEN_STATUS, placedAt: new Date("2026-07-25T09:00:00Z") });
+await db
+  .insert(orders)
+  .values({ externalOrderId: "9011", customerName: "E2E Zákazník Zlúčenie", email: "e2e-zakaznik-zlucenie@example.sk", statusName: DEFAULT_ORDER_OPEN_STATUS, placedAt: new Date("2026-07-26T09:00:00Z") });
 
 // issue 63: DVE riadky BEZ dodávateľa nad DVOMA veľkosťami TOHO ISTÉHO
 // produktu ("60035/L", "60035/M" — CSV fixtúra ich nesie s prázdnym


### PR DESCRIPTION
## Čo to robí

Nová záložka **Zlúčenie objednávok** v sekcii Eshop.

Záložka sama vypíše zákazníkov, ktorí majú **dve alebo viac otvorených objednávok** — teda kandidátov na zlúčenie zásielky. Majiteľ nič nevyhľadáva: otvorí záložku, vidí zoznam, pri konkrétnom zákazníkovi si pozrie náhľad e-mailu a odošle ho.

## Ako to funguje

- Zoznam kandidátov: otvorené objednávky sa zoskupia podľa zákazníka (e-mail, ak chýba tak meno) a vrátia sa len skupiny s dvomi a viac objednávkami.
- Text e-mailu je upraviteľná šablóna v Systém → Texty e-mailov, so zástupnými poľami (číslo objednávky, meno).
- Náhľad si vyžiada jednorazový token; odoslanie ho spotrebuje, takže sa nedá odoslať omylom dvakrát z jedného náhľadu.
- Odoslanie ide **jedinou existujúcou odosielacou cestou**, takže e-mail pribudne do Knihy odoslaných e-mailov (nový zdroj `order_merge`, dá sa podľa neho filtrovať). BCC na majiteľa.
- Odoslať smie len rola admin alebo manažér.

## Poznámka

Zákazník bez e-mailovej adresy má tlačidlo dostupné, ale odoslanie skončí hláškou „Zákazník nemá e-mailovú adresu" — rovnako ako to funguje v Nedostupných tovaroch.

## Overenie

- `pnpm typecheck`, `pnpm lint` — čisté
- web unit 421/421, api unit 579/579, api integračné 484/484, e2e 43/43

issue 257
