### PR TITLE
Nastavenie farieb: koliesko vpravo hore s paletou a živým náhľadom (issue 264)

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -818,3 +818,32 @@ paths:
   najprv skontroluj, či niektorá z existujúcich fixtúrových skupín (grep
   `state:`/`ordered:` okolo insertov objednávok v `scripts/e2e-setup.ts`)
   už ten stav nemá PRIRODZENE, než siahneš po mutácii cez UI.
+- **Popup/dialóg s ASYNC Uložiť/Obnoviť A tlačidlom Zrušiť/Esc/klik-na-pozadie
+  potrebuje `close()` ako NO-OP počas `busy`, inak vzniká race medzi
+  "zavri a vráť live náhľad na baseline" a "požiadavka práve teraz úspešne
+  doběhla".** Issue 264 (`ThemeColorPicker.tsx`, code review — nájdené DRUHÝM,
+  hlbším prechodom, nie prvým): kliknutie na Zrušiť/Esc PO odoslaní Uložiť,
+  ale PRED jeho odpoveďou, okamžite prepísalo živý CSS náhľad späť na
+  hodnoty pri otvorení — a keď server medzitým úspešne uložil NOVÉ farby,
+  jeho `.then()` si nastavil `baseline`, ale NIKDY znova nezavolal
+  `applyThemeColors(draft)` (predpokladal, že náhľad je stále aktuálny).
+  Appka tak ukazovala staré farby, hoci server aj `baseline` už mali nové,
+  až do reloadu. Fix: `close()` skontroluje `busy` a nič nespraví, kým je
+  `true`; tlačidlo Zrušiť dostane aj `disabled={busy}` (viditeľná spätná
+  väzba, `close()`'ov guard je skutočná poistka, keďže Esc/backdrop-click
+  tlačidlo obchádzajú). Rovnaký test na KAŽDÝ ĎALŠÍ popup v tejto appke s
+  async zápisom + samostatným zrušením: môže užívateľ zavrieť/zrušiť PRESNE
+  v okne medzi odoslaním a odpoveďou? Ak áno, `close()` potrebuje ten istý
+  `busy`-guard, nie len zablokované tlačidlo Uložiť/Obnoviť.
+- **Reopen toho istého popupu (druhé a ďalšie otvorenie) musí vynulovať
+  predchádzajúci načítaný stav PRED novým fetchom, inak zlyhaný refetch
+  necháva STARÝ draft/baseline vykresľovať sa ako čerstvý.** Issue 264:
+  `openPicker()` teraz volá `setColors(null); setDraft({}); setBaseline({})`
+  pred `fetchThemeColors()` — bez toho by neúspešný refetch (sieťový
+  výpadok) ticho preskočil "Načítavam…" stav (keďže `colors !== null` z
+  MINULÉHO otvorenia) a užívateľ by mohol uložiť zastaraný draft bez
+  varovania. Rovnaký `fetchSeqRef`-štýl guard (inkrementovaný pri KAŽDOM
+  otvorení, `.then()` sa uplatní len ak je stále najnovší) chráni pred
+  opačným prípadom — STARŠIA odpoveď z PRED zavretého+znovu otvoreného
+  popupu prepisujúca NOVŠÍ stav (rovnaká trieda race ako issue 151/251,
+  pozri "latest ref" záznamy vyššie v tomto súbore).

--- a/apps/api/drizzle/0035_sturdy_darkstar.sql
+++ b/apps/api/drizzle/0035_sturdy_darkstar.sql
@@ -1,0 +1,8 @@
+CREATE TABLE "theme_color" (
+	"key" text PRIMARY KEY NOT NULL,
+	"value" text NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL,
+	"updated_by_user_id" uuid
+);
+--> statement-breakpoint
+ALTER TABLE "theme_color" ADD CONSTRAINT "theme_color_updated_by_user_id_users_id_fk" FOREIGN KEY ("updated_by_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;

--- a/apps/api/drizzle/meta/0035_snapshot.json
+++ b/apps/api/drizzle/meta/0035_snapshot.json
@@ -1,0 +1,2603 @@
+{
+  "id": "20565cd7-e053-4206-853a-6ed9224925bc",
+  "prevId": "97006664-aaed-4c77-a464-8d771239c62d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_code": {
+          "name": "external_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_open_status": {
+      "name": "order_open_status",
+      "schema": "",
+      "columns": {
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Vybavuje sa'"
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop_remark": {
+          "name": "shop_remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shoptet_order_id": {
+          "name": "shoptet_order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_updated_at": {
+          "name": "comment_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_synced_at": {
+          "name": "comment_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_carrier_name": {
+          "name": "shipping_carrier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_price_with_vat": {
+          "name": "total_price_with_vat",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_link_override": {
+      "name": "product_supplier_link_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_link_override_product_key_product_key_fk": {
+          "name": "product_supplier_link_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_link_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_override": {
+      "name": "product_supplier_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_override_product_key_product_key_fk": {
+          "name": "product_supplier_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing": {
+      "name": "pairing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_url": {
+          "name": "supplier_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "pairing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'navrhnute'"
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pairing_state_idx": {
+          "name": "pairing_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_confirmed_by_idx": {
+          "name": "pairing_confirmed_by_idx",
+          "columns": [
+            {
+              "expression": "confirmed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_variant_code_variant_code_fk": {
+          "name": "pairing_variant_code_variant_code_fk",
+          "tableFrom": "pairing",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pairing_confirmed_by_users_id_fk": {
+          "name": "pairing_confirmed_by_users_id_fk",
+          "tableFrom": "pairing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pairing_variant_code_unique": {
+          "name": "pairing_variant_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pairing_confirmation_ck": {
+          "name": "pairing_confirmation_ck",
+          "value": "(\"pairing\".\"state\" = 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)\n        OR (\"pairing\".\"state\" != 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NULL AND \"pairing\".\"confirmed_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier": {
+      "name": "supplier",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wholesale_base_url": {
+          "name": "wholesale_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_key": {
+          "name": "adapter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_settings": {
+      "name": "posta_uncollected_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_state": {
+      "name": "posta_uncollected_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notify_count": {
+          "name": "notify_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_state": {
+          "name": "terminal_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_settings": {
+      "name": "order_reminder_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_state": {
+      "name": "order_reminder_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_replacement_link": {
+      "name": "nedostupne_replacement_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nedostupne_replacement_link_variant_idx": {
+          "name": "nedostupne_replacement_link_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_state": {
+      "name": "nedostupne_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "nedostupne_email_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nedostupne_state_order_variant_type_uq": {
+          "name": "nedostupne_state_order_variant_type_uq",
+          "columns": [
+            {
+              "expression": "order_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template_history": {
+      "name": "mail_template_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "mail_template_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_template_history_key_idx": {
+          "name": "mail_template_history_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_template_history_changed_by_user_id_users_id_fk": {
+          "name": "mail_template_history_changed_by_user_id_users_id_fk",
+          "tableFrom": "mail_template_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template": {
+      "name": "mail_template",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail_template_updated_by_user_id_users_id_fk": {
+          "name": "mail_template_updated_by_user_id_users_id_fk",
+          "tableFrom": "mail_template",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_log": {
+      "name": "mail_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "mail_log_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_log_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "mail_log_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_log_created_idx": {
+          "name": "mail_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_log_source_created_idx": {
+          "name": "mail_log_source_created_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_log_actor_user_id_users_id_fk": {
+          "name": "mail_log_actor_user_id_users_id_fk",
+          "tableFrom": "mail_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_stock": {
+      "name": "supplier_stock",
+      "schema": "",
+      "columns": {
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "supplier_availability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "supplier_stock_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "supplier_stock_host_idx": {
+          "name": "supplier_stock_host_idx",
+          "columns": [
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "supplier_stock_avail_idx": {
+          "name": "supplier_stock_avail_idx",
+          "columns": [
+            {
+              "expression": "availability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "supplier_stock_link_size_label_pk": {
+          "name": "supplier_stock_link_size_label_pk",
+          "columns": [
+            "link",
+            "size_label"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_event": {
+      "name": "restock_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_link": {
+          "name": "supplier_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_availability_text": {
+          "name": "supplier_availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "supplier_price": {
+          "name": "supplier_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "restock_event_at_idx": {
+          "name": "restock_event_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "restock_event_variant_idx": {
+          "name": "restock_event_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_settings": {
+      "name": "restock_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shop_product_url": {
+      "name": "shop_product_url",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.theme_color": {
+      "name": "theme_color",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "theme_color_updated_by_user_id_users_id_fk": {
+          "name": "theme_color_updated_by_user_id_users_id_fk",
+          "tableFrom": "theme_color",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne"
+      ]
+    },
+    "public.pairing_state": {
+      "name": "pairing_state",
+      "schema": "public",
+      "values": [
+        "navrhnute",
+        "potvrdene"
+      ]
+    },
+    "public.nedostupne_email_type": {
+      "name": "nedostupne_email_type",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "alternativa"
+      ]
+    },
+    "public.mail_template_action": {
+      "name": "mail_template_action",
+      "schema": "public",
+      "values": [
+        "save",
+        "reset"
+      ]
+    },
+    "public.mail_log_source": {
+      "name": "mail_log_source",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "posta_uncollected",
+        "order_reminder",
+        "supplier_order",
+        "order_merge"
+      ]
+    },
+    "public.mail_log_status": {
+      "name": "mail_log_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.mail_log_trigger": {
+      "name": "mail_log_trigger",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "manual"
+      ]
+    },
+    "public.supplier_availability": {
+      "name": "supplier_availability",
+      "schema": "public",
+      "values": [
+        "available",
+        "unavailable",
+        "unknown"
+      ]
+    },
+    "public.supplier_stock_source": {
+      "name": "supplier_stock_source",
+      "schema": "public",
+      "values": [
+        "json_ld",
+        "meta",
+        "text",
+        "size_list",
+        "none"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -246,6 +246,13 @@
       "when": 1785928327041,
       "tag": "0034_melodic_wild_child",
       "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
+      "when": 1785935677728,
+      "tag": "0035_sturdy_darkstar",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema-theme-colors.ts
+++ b/apps/api/src/db/schema-theme-colors.ts
@@ -1,0 +1,27 @@
+import { pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { users } from "./schema-users.js";
+
+// issue 264: farby bublinek dodávateľov (issue 263) upraviteľné majiteľom.
+// Rovnaký vzor ako `mail_template` (issue 192, `.claude/rules/mail-
+// templates.md`): riadok tu existuje LEN pre farbu, ktorú majiteľ NAOZAJ
+// zmenil — chýbajúci riadok znamená "použi predvolenú hodnotu z kódu"
+// (`modules/theme-colors/registry.ts`). "Obnoviť predvolené" je preto
+// obyčajné zmazanie riadkov, presne ako mail-template reset, a predvolené
+// hodnoty nemôžu zastarať oproti kódu (kopírovanie predvolených hodnôt do
+// databázy migráciou by presne to spôsobilo).
+//
+// Šesť SAMOSTATNÝCH riadkov (nie jeden JSON blob so všetkými farbami) — každá
+// farba má vlastný `updatedAt`/`updatedByUserId`, takže pridanie ďalšej
+// upraviteľnej farby v budúcnosti nepotrebuje schémovú zmenu, len nový kľúč
+// v registri.
+export const themeColors = pgTable("theme_color", {
+  // Kľúč CSS premennej BEZ `--` prefixu (napr. "chip-done-bg") —
+  // `registry.ts`'s `THEME_COLOR_KEYS`. Text, nie enum: pribudnutie ďalšej
+  // upraviteľnej farby je zmena v kóde, nie migrácia.
+  key: text("key").primaryKey(),
+  // Hex farba vo tvare "#rrggbb" — validované v `registry.ts` PRED zápisom,
+  // nikdy sa nespolieha na DB constraint.
+  value: text("value").notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull(),
+  updatedByUserId: uuid("updated_by_user_id").references(() => users.id, { onDelete: "set null" }),
+});

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -11,3 +11,4 @@ export * from "./schema-mail-log.js";
 export * from "./schema-supplier-stock.js";
 export * from "./schema-restock.js";
 export * from "./schema-shop-feed.js";
+export * from "./schema-theme-colors.js";

--- a/apps/api/src/http/app.ts
+++ b/apps/api/src/http/app.ts
@@ -30,6 +30,7 @@ import { registerRestockRoutes, type RestockRunDeps } from "./restock-routes.js"
 import { shoptetImportConfigFromBaseUrl } from "../modules/shoptet-writeback/config.js";
 import { registerSchedulerRoutes } from "./scheduler-routes.js";
 import { registerSupplierRoutes } from "./supplier-routes.js";
+import { registerThemeColorRoutes } from "./theme-color-routes.js";
 
 const loginSchema = z.object({
   email: z.string().email(),
@@ -253,6 +254,8 @@ export function createApp(
 
   // issue 192: upraviteľné znenia e-mailov (obrazovka "Texty e-mailov").
   registerMailTemplateRoutes(app, db);
+  // issue 264: upraviteľné farby bublinek dodávateľov (koliesko v Topbar).
+  registerThemeColorRoutes(app, db);
   // issue 193: kniha odoslaných e-mailov (len čítanie) — zapisujú do nej samy
   // odosielacie cesty cez `mail-log/service.ts`.
   registerMailLogRoutes(app, db, options.adminBaseUrl ?? "https://www.forestshop.sk");

--- a/apps/api/src/http/theme-color-routes.ts
+++ b/apps/api/src/http/theme-color-routes.ts
@@ -1,0 +1,62 @@
+import { zValidator } from "@hono/zod-validator";
+import type { Hono } from "hono";
+import { z } from "zod";
+import type { Database } from "../db/client.js";
+import { record } from "../modules/audit/service.js";
+import { listThemeColors, resetThemeColors, saveThemeColors } from "../modules/theme-colors/store.js";
+import { requireRole, requireUser, type AppBindings } from "./middleware.js";
+import { requireSameOrigin } from "./origin-check.js";
+
+// issue 264: obrazovka "Farby aplikácie" (koliesko vpravo hore v Topbar).
+// Neplatný kód farby vracia 200 s `{ok:false, error}`, NIKDY 4xx — rovnaký
+// dôvod ako `mail-template-routes.ts` (Chromium loguje konzolovú chybu pre
+// KAŽDÚ ne-2xx odpoveď, `.claude/rules/testing.md`).
+
+// Zámerne voľná (nie hex-validovaná priamo tu) — presná hex kontrola beží v
+// `registry.ts`'s `validateThemeColorValues` a vracia doménovú chybu v tele
+// (200 {ok:false}), nie zValidator-ovú 400.
+const saveBody = z.object({ values: z.record(z.string(), z.string()) });
+
+export function registerThemeColorRoutes(app: Hono<AppBindings>, db: Database): void {
+  // Čítanie — každý prihlásený zamestnanec (rovnaká úroveň ako iné obrazovky):
+  // farby čipov vidí každý, kto vidí "Na objednanie", nielen kto ich smie meniť.
+  app.get("/api/theme-colors", requireUser(db), async (c) => {
+    const colors = await listThemeColors(db);
+    return c.json({
+      colors: colors.map((col) => ({
+        key: col.key,
+        label: col.label,
+        value: col.value,
+        defaultValue: col.defaultValue,
+        isCustomized: col.isCustomized,
+        updatedAt: col.updatedAt?.toISOString() ?? null,
+        updatedByName: col.updatedByName,
+      })),
+    });
+  });
+
+  app.put(
+    "/api/theme-colors",
+    requireSameOrigin(),
+    requireUser(db),
+    requireRole("admin", "manazer"),
+    zValidator("json", saveBody),
+    async (c) => {
+      const { values } = c.req.valid("json");
+      const user = c.get("user");
+      const now = new Date();
+      const result = await saveThemeColors(db, { values, userId: user.userId, now });
+      if (!result.ok) return c.json({ ok: false as const, error: result.errors.join(" ") });
+      await record(db, { at: now, actorUserId: user.userId, action: "theme_colors.save", entity: "theme_colors", data: { keys: Object.keys(values) } });
+      return c.json({ ok: true as const });
+    },
+  );
+
+  app.post("/api/theme-colors/reset", requireSameOrigin(), requireUser(db), requireRole("admin", "manazer"), async (c) => {
+    const user = c.get("user");
+    const now = new Date();
+    await resetThemeColors(db);
+    await record(db, { at: now, actorUserId: user.userId, action: "theme_colors.reset", entity: "theme_colors" });
+    return c.json({ ok: true as const });
+  });
+}

--- a/apps/api/src/modules/theme-colors/registry.ts
+++ b/apps/api/src/modules/theme-colors/registry.ts
@@ -1,0 +1,67 @@
+// issue 264: register šiestich upraviteľných farieb bublinek dodávateľov
+// (issue 263). Predvolené hodnoty sú PRESNÝMI hex kódmi, čo dnes žijú
+// natvrdo v `apps/web/src/styles/app.css`'s `:root` — pri "Obnoviť
+// predvolené" sa musia zhodovať bajt na bajt s tým, čo appka ukazovala PRED
+// týmto ticketom.
+
+export const THEME_COLOR_KEYS = [
+  "chip-done-bg",
+  "chip-done-text",
+  "chip-todo-bg",
+  "chip-todo-text",
+  "chip-active-bg",
+  "chip-active-text",
+] as const;
+
+export type ThemeColorKey = (typeof THEME_COLOR_KEYS)[number];
+
+export function isThemeColorKey(value: string): value is ThemeColorKey {
+  return (THEME_COLOR_KEYS as readonly string[]).includes(value);
+}
+
+export interface ThemeColorKind {
+  readonly label: string;
+  readonly defaultValue: string;
+}
+
+export const THEME_COLOR_KINDS: Readonly<Record<ThemeColorKey, ThemeColorKind>> = {
+  "chip-done-bg": { label: "Vybavený dodávateľ — pozadie", defaultValue: "#d14d3b" },
+  "chip-done-text": { label: "Vybavený dodávateľ — text", defaultValue: "#ffffff" },
+  "chip-todo-bg": { label: "Nespracovaný dodávateľ — pozadie", defaultValue: "#6cab68" },
+  "chip-todo-text": { label: "Nespracovaný dodávateľ — text", defaultValue: "#173617" },
+  "chip-active-bg": { label: "Práve zvolená bublinka — pozadie", defaultValue: "#dda43c" },
+  "chip-active-text": { label: "Práve zvolená bublinka — text", defaultValue: "#3b1d00" },
+};
+
+const HEX_COLOR_RE = /^#[0-9a-fA-F]{6}$/;
+
+export function isValidHexColor(value: string): boolean {
+  return HEX_COLOR_RE.test(value);
+}
+
+/** Overí presne túto množinu kľúčov (žiadny chýbajúci, žiadny navyše) a že
+ * KAŽDÁ hodnota je platný hex kód "#rrggbb" — vracia zoznam zrozumiteľných
+ * slovenských chýb, prázdny zoznam = v poriadku. Volá sa PRED zápisom, aby
+ * sa neplatný kód farby nikdy nedostal do databázy (rovnaký "over pred
+ * zápisom" vzor ako `mail-templates/render.ts`'s `validateTemplateText`). */
+export function validateThemeColorValues(values: Readonly<Record<string, string>>): readonly string[] {
+  const errors: string[] = [];
+  const givenKeys = new Set(Object.keys(values));
+
+  for (const key of THEME_COLOR_KEYS) {
+    if (!givenKeys.has(key)) {
+      errors.push(`Chýba farba „${THEME_COLOR_KINDS[key].label}“.`);
+      continue;
+    }
+    const value = values[key] ?? "";
+    if (!isValidHexColor(value)) {
+      errors.push(`Neplatný kód farby pre „${THEME_COLOR_KINDS[key].label}“ — očakávaný tvar #rrggbb.`);
+    }
+  }
+
+  for (const key of givenKeys) {
+    if (!isThemeColorKey(key)) errors.push(`Neznámy kľúč farby „${key}“.`);
+  }
+
+  return errors;
+}

--- a/apps/api/src/modules/theme-colors/store.ts
+++ b/apps/api/src/modules/theme-colors/store.ts
@@ -1,0 +1,88 @@
+import { eq } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { themeColors, users } from "../../db/schema.js";
+import { THEME_COLOR_KEYS, THEME_COLOR_KINDS, type ThemeColorKey, validateThemeColorValues } from "./registry.js";
+
+// issue 264: čítanie/zápis/reset upravených farieb bublinek dodávateľov.
+// Rovnaká štruktúra ako `modules/mail-templates/store.ts` (issue 192).
+
+export interface ResolvedThemeColor {
+  readonly key: ThemeColorKey;
+  readonly label: string;
+  readonly value: string;
+  readonly defaultValue: string;
+  /** `false` = platí predvolená hodnota z kódu (v databáze nie je žiadny riadok). */
+  readonly isCustomized: boolean;
+  readonly updatedAt: Date | null;
+  readonly updatedByName: string | null;
+}
+
+export async function listThemeColors(db: Database): Promise<readonly ResolvedThemeColor[]> {
+  const rows = await db
+    .select({
+      key: themeColors.key,
+      value: themeColors.value,
+      updatedAt: themeColors.updatedAt,
+      updatedByName: users.displayName,
+    })
+    .from(themeColors)
+    .leftJoin(users, eq(users.id, themeColors.updatedByUserId));
+  const byKey = new Map(rows.map((r) => [r.key, r]));
+
+  return THEME_COLOR_KEYS.map((key) => {
+    const kind = THEME_COLOR_KINDS[key];
+    const row = byKey.get(key);
+    if (row === undefined) {
+      return {
+        key,
+        label: kind.label,
+        value: kind.defaultValue,
+        defaultValue: kind.defaultValue,
+        isCustomized: false,
+        updatedAt: null,
+        updatedByName: null,
+      };
+    }
+    return {
+      key,
+      label: kind.label,
+      value: row.value,
+      defaultValue: kind.defaultValue,
+      isCustomized: true,
+      updatedAt: row.updatedAt,
+      updatedByName: row.updatedByName,
+    };
+  });
+}
+
+export type SaveThemeColorsResult = { readonly ok: true } | { readonly ok: false; readonly errors: readonly string[] };
+
+/** Uloží všetkých šesť farieb naraz (all-or-nothing) — kontrola beží PRED
+ * zápisom, takže čo i len jeden neplatný kód farby neuloží ANI JEDNU zmenu. */
+export async function saveThemeColors(
+  db: Database,
+  input: { readonly values: Readonly<Record<string, string>>; readonly userId: string; readonly now: Date },
+): Promise<SaveThemeColorsResult> {
+  const errors = validateThemeColorValues(input.values);
+  if (errors.length > 0) return { ok: false, errors };
+
+  await db.transaction(async (tx) => {
+    for (const key of THEME_COLOR_KEYS) {
+      const value = input.values[key];
+      if (value === undefined) continue; // unreachable — validateThemeColorValues already required every key
+      await tx
+        .insert(themeColors)
+        .values({ key, value, updatedAt: input.now, updatedByUserId: input.userId })
+        .onConflictDoUpdate({
+          target: themeColors.key,
+          set: { value, updatedAt: input.now, updatedByUserId: input.userId },
+        });
+    }
+  });
+  return { ok: true };
+}
+
+/** Vráti predvolené farby = zmaže všetky riadky. */
+export async function resetThemeColors(db: Database): Promise<void> {
+  await db.delete(themeColors);
+}

--- a/apps/api/tests/helpers/db.ts
+++ b/apps/api/tests/helpers/db.ts
@@ -60,7 +60,7 @@ export async function withCleanDb(): Promise<{ db: Database; close: () => Promis
     // predošlého behu potom vyzerá ako platné potvrdenie a beh preskočí
     // VŠETKY odkazy (presne to sa tu stalo pri druhom spustení).
     await db.execute(
-      sql`TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, nedostupne_replacement_link, mail_template, mail_template_history, supplier_stock, restock_settings, restock_event, shop_product_url RESTART IDENTITY CASCADE`,
+      sql`TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, nedostupne_replacement_link, mail_template, mail_template_history, supplier_stock, restock_settings, restock_event, shop_product_url, theme_color RESTART IDENTITY CASCADE`,
     );
     // issue 59: `order_open_status` is a NEW table with real production
     // content (the migration seeds it) — TRUNCATE alone would leave every

--- a/apps/api/tests/theme-colors.integration.test.ts
+++ b/apps/api/tests/theme-colors.integration.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, expect, it } from "vitest";
+import { themeColors, users } from "../src/db/schema.js";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import type { UserRole } from "../src/modules/auth/service.js";
+import { THEME_COLOR_KINDS } from "../src/modules/theme-colors/registry.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 264: obrazovka "Farby aplikácie" (koliesko v Topbar) cez HTTP.
+const HESLO = "test-heslo-abc";
+
+const DEFAULT_VALUES = {
+  "chip-done-bg": THEME_COLOR_KINDS["chip-done-bg"].defaultValue,
+  "chip-done-text": THEME_COLOR_KINDS["chip-done-text"].defaultValue,
+  "chip-todo-bg": THEME_COLOR_KINDS["chip-todo-bg"].defaultValue,
+  "chip-todo-text": THEME_COLOR_KINDS["chip-todo-text"].defaultValue,
+  "chip-active-bg": THEME_COLOR_KINDS["chip-active-bg"].defaultValue,
+  "chip-active-text": THEME_COLOR_KINDS["chip-active-text"].defaultValue,
+};
+
+let close: (() => Promise<void>) | undefined;
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  resetLoginRateLimit();
+});
+
+async function boot(role: UserRole) {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await ctx.db.insert(users).values({
+    email: "pouzivatel@forestshop.sk",
+    passwordHash: await hashPassword(HESLO),
+    displayName: "Test Používateľ",
+    role,
+  });
+  const app = createApp(ctx.db, { cookieSecure: false });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "pouzivatel@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie, db: ctx.db };
+}
+
+function jsonRequest(cookie: string, method: string, body?: unknown): RequestInit {
+  return {
+    method,
+    headers: { cookie, "content-type": "application/json" },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  };
+}
+
+it("zoznam vráti šesť predvolených farieb, kým sa nič neuložilo", async () => {
+  const { app, cookie } = await boot("manazer");
+  const res = await app.request("/api/theme-colors", { headers: { cookie } });
+  expect(res.status).toBe(200);
+  const payload = (await res.json()) as { colors: { key: string; value: string; defaultValue: string; isCustomized: boolean }[] };
+  expect(payload.colors).toHaveLength(6);
+  const done = payload.colors.find((c) => c.key === "chip-done-bg");
+  expect(done?.isCustomized).toBe(false);
+  expect(done?.value).toBe(THEME_COLOR_KINDS["chip-done-bg"].defaultValue);
+  expect(done?.defaultValue).toBe(THEME_COLOR_KINDS["chip-done-bg"].defaultValue);
+});
+
+it("čítanie je dostupné bez prihlásenia — 401", async () => {
+  const { app } = await boot("manazer");
+  const res = await app.request("/api/theme-colors");
+  expect(res.status).toBe(401);
+});
+
+it("uloženie zmení farby; vrátenie predvolených ich vráti späť", async () => {
+  const { app, cookie, db } = await boot("manazer");
+
+  const values = { ...DEFAULT_VALUES, "chip-done-bg": "#123456" };
+  const save = await app.request("/api/theme-colors", jsonRequest(cookie, "PUT", { values }));
+  expect(await save.json()).toEqual({ ok: true });
+
+  const afterSave = (await (await app.request("/api/theme-colors", { headers: { cookie } })).json()) as {
+    colors: { key: string; value: string; isCustomized: boolean }[];
+  };
+  const doneAfterSave = afterSave.colors.find((c) => c.key === "chip-done-bg");
+  expect(doneAfterSave?.value).toBe("#123456");
+  expect(doneAfterSave?.isCustomized).toBe(true);
+
+  const reset = await app.request("/api/theme-colors/reset", jsonRequest(cookie, "POST"));
+  expect(await reset.json()).toEqual({ ok: true });
+  expect(await db.select().from(themeColors)).toHaveLength(0);
+
+  const afterReset = (await (await app.request("/api/theme-colors", { headers: { cookie } })).json()) as {
+    colors: { key: string; value: string; isCustomized: boolean }[];
+  };
+  const doneAfterReset = afterReset.colors.find((c) => c.key === "chip-done-bg");
+  expect(doneAfterReset?.value).toBe(THEME_COLOR_KINDS["chip-done-bg"].defaultValue);
+  expect(doneAfterReset?.isCustomized).toBe(false);
+});
+
+it("neplatný kód farby sa NEULOŽÍ (200 s ok:false, žiadny riadok navyše)", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  const values = { ...DEFAULT_VALUES, "chip-done-bg": "not-a-color" };
+  const res = await app.request("/api/theme-colors", jsonRequest(cookie, "PUT", { values }));
+  expect(res.status).toBe(200);
+  const payload = (await res.json()) as { ok: boolean; error: string };
+  expect(payload.ok).toBe(false);
+  expect(payload.error).toContain("Vybavený dodávateľ — pozadie");
+  expect(await db.select().from(themeColors)).toHaveLength(0);
+});
+
+it("chýbajúci kľúč sa NEULOŽÍ ani čiastočne (all-or-nothing)", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  const partial = Object.fromEntries(Object.entries(DEFAULT_VALUES).filter(([key]) => key !== "chip-active-text"));
+  const res = await app.request("/api/theme-colors", jsonRequest(cookie, "PUT", { values: partial }));
+  const payload = (await res.json()) as { ok: boolean; error: string };
+  expect(payload.ok).toBe(false);
+  expect(await db.select().from(themeColors)).toHaveLength(0);
+});
+
+it("rola „citanie“ farby upraviť nesmie", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const res = await app.request("/api/theme-colors", jsonRequest(cookie, "PUT", { values: DEFAULT_VALUES }));
+  expect(res.status).toBe(403);
+  expect(await db.select().from(themeColors)).toHaveLength(0);
+});
+
+it("rola „citanie“ nesmie ani resetovať, ale SMIE čítať", async () => {
+  const { app, cookie } = await boot("citanie");
+  const resetRes = await app.request("/api/theme-colors/reset", jsonRequest(cookie, "POST"));
+  expect(resetRes.status).toBe(403);
+  const readRes = await app.request("/api/theme-colors", { headers: { cookie } });
+  expect(readRes.status).toBe(200);
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState, type JSX } from "react";
 import { fetchMe, postLogout, type Me } from "./api.js";
+import { applyThemeColors } from "./applyThemeColors.js";
 import { ChangePasswordForm } from "./components/ChangePasswordForm.js";
 import { Footer } from "./components/Footer.js";
 import { LoginForm } from "./components/LoginForm.js";
@@ -9,6 +10,7 @@ import { DEFAULT_TAB_ID, NAV, findTab, isVisibleTabId } from "./nav.js";
 import { fetchOrderReminderStatus } from "./orderReminderApi.js";
 import { OrdersRemainingCountContext } from "./ordersRemainingCountContext.js";
 import { fetchPostaUncollectedStatus } from "./postaUncollectedApi.js";
+import { fetchThemeColors } from "./themeColorsApi.js";
 
 // Prvá záložka z URL-u (`?tab=<id>`), keď existuje a je platná — inak
 // predvolená ("Sync zo Shoptetu"). Umožňuje priamy odkaz aj na SKRYTÉ
@@ -73,6 +75,24 @@ export function App(): JSX.Element {
       cancelled = true;
     };
   }, [me, activeTabId]);
+
+  // issue 264: farby bublinek dodávateľov sa premietnu ako CSS premenné na
+  // `document.documentElement` HNEĎ po prihlásení — pre KAŽDÉHO používateľa
+  // (nielen toho, kto má popup "Farby aplikácie" otvorený), keďže čipy vidia
+  // všetci. Beží raz pri prihlásení, nie pri každom prepnutí záložky —
+  // farby sa počas relácie menia len cez ten istý popup, ktorý si aplikuje
+  // živý náhľad sám.
+  useEffect(() => {
+    if (me === null) return;
+    fetchThemeColors()
+      .then((colors) => {
+        applyThemeColors(Object.fromEntries(colors.map((c) => [c.key, c.value])));
+      })
+      .catch(() => {
+        // Sieťový výpadok — appka zostane pri predvolených farbách z
+        // `app.css`, nič kritické.
+      });
+  }, [me]);
 
   const reload = useCallback(() => {
     setMeUnreachable(false);
@@ -155,6 +175,8 @@ export function App(): JSX.Element {
           <Topbar
             title={isVisibleTabId(activeTabId) ? (tab?.label ?? null) : null}
             greeting={`Prihlásený: ${me.displayName} (${me.role})`}
+            role={me.role}
+            onSessionExpired={reload}
             onLogout={logout}
             passwordPanelOpen={passwordPanelOpen}
             onTogglePasswordPanel={() => {

--- a/apps/web/src/applyThemeColors.test.ts
+++ b/apps/web/src/applyThemeColors.test.ts
@@ -11,8 +11,9 @@ it("zapíše každý kľúč ako CSS premennú s `--` prefixom na document.docum
   expect(document.documentElement.style.getPropertyValue("--chip-done-text")).toBe("#ffffff");
 });
 
-it("prázdny objekt nezapíše nič a nespadne", () => {
+it("prázdny objekt nezapíše žiadnu CSS premennú a nespadne", () => {
   expect(() => {
     applyThemeColors({});
   }).not.toThrow();
+  expect(document.documentElement.getAttribute("style")).toBeFalsy();
 });

--- a/apps/web/src/applyThemeColors.test.ts
+++ b/apps/web/src/applyThemeColors.test.ts
@@ -1,0 +1,18 @@
+import { afterEach, expect, it } from "vitest";
+import { applyThemeColors } from "./applyThemeColors.js";
+
+afterEach(() => {
+  document.documentElement.removeAttribute("style");
+});
+
+it("zapíše každý kľúč ako CSS premennú s `--` prefixom na document.documentElement", () => {
+  applyThemeColors({ "chip-done-bg": "#123456", "chip-done-text": "#ffffff" });
+  expect(document.documentElement.style.getPropertyValue("--chip-done-bg")).toBe("#123456");
+  expect(document.documentElement.style.getPropertyValue("--chip-done-text")).toBe("#ffffff");
+});
+
+it("prázdny objekt nezapíše nič a nespadne", () => {
+  expect(() => {
+    applyThemeColors({});
+  }).not.toThrow();
+});

--- a/apps/web/src/applyThemeColors.ts
+++ b/apps/web/src/applyThemeColors.ts
@@ -1,0 +1,12 @@
+// issue 264: JEDNA zdieľaná funkcia, čo premietne farby do CSS premenných na
+// `document.documentElement` — používa ju AJ štart appky (App.tsx, po
+// prihlásení, pre KAŽDÉHO používateľa) AJ živý náhľad v popupe (Theme
+// ColorPicker, pri každej zmene/ťahaní paletou). Inline štýl na root prvku má
+// vyššiu prioritu než `:root` pravidlo v `app.css`, takže sa prejaví
+// OKAMŽITE na celej stránke bez akéhokoľvek React re-renderu — presne to,
+// čo ticket žiada ("naživo... sa mu to bude meniť na stránke").
+export function applyThemeColors(values: Readonly<Record<string, string>>): void {
+  for (const [key, value] of Object.entries(values)) {
+    document.documentElement.style.setProperty(`--${key}`, value);
+  }
+}

--- a/apps/web/src/components/ThemeColorPicker.test.tsx
+++ b/apps/web/src/components/ThemeColorPicker.test.tsx
@@ -1,0 +1,141 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { ThemeColorPicker } from "./ThemeColorPicker.js";
+
+const { fetchThemeColors, saveThemeColors, resetThemeColors } = vi.hoisted(() => ({
+  fetchThemeColors: vi.fn(),
+  saveThemeColors: vi.fn(),
+  resetThemeColors: vi.fn(),
+}));
+
+vi.mock("../themeColorsApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../themeColorsApi.js")>();
+  return { ...actual, fetchThemeColors, saveThemeColors, resetThemeColors };
+});
+
+const COLORS = [
+  { key: "chip-done-bg", label: "Vybavený dodávateľ — pozadie", value: "#d14d3b", defaultValue: "#d14d3b", isCustomized: false, updatedAt: null, updatedByName: null },
+  { key: "chip-done-text", label: "Vybavený dodávateľ — text", value: "#ffffff", defaultValue: "#ffffff", isCustomized: false, updatedAt: null, updatedByName: null },
+  { key: "chip-todo-bg", label: "Nespracovaný dodávateľ — pozadie", value: "#6cab68", defaultValue: "#6cab68", isCustomized: false, updatedAt: null, updatedByName: null },
+  { key: "chip-todo-text", label: "Nespracovaný dodávateľ — text", value: "#173617", defaultValue: "#173617", isCustomized: false, updatedAt: null, updatedByName: null },
+  { key: "chip-active-bg", label: "Práve zvolená bublinka — pozadie", value: "#dda43c", defaultValue: "#dda43c", isCustomized: false, updatedAt: null, updatedByName: null },
+  { key: "chip-active-text", label: "Práve zvolená bublinka — text", value: "#3b1d00", defaultValue: "#3b1d00", isCustomized: false, updatedAt: null, updatedByName: null },
+];
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+  document.documentElement.removeAttribute("style");
+});
+
+function cssVar(key: string): string {
+  return document.documentElement.style.getPropertyValue(`--${key}`);
+}
+
+it("pre rolu „citanie“ sa tlačidlo vôbec nevykreslí", () => {
+  render(<ThemeColorPicker role="citanie" onSessionExpired={vi.fn()} />);
+  expect(screen.queryByTestId("themecolor-btn")).toBeNull();
+});
+
+it("pre rolu „sef“ sa tlačidlo vôbec nevykreslí", () => {
+  render(<ThemeColorPicker role="sef" onSessionExpired={vi.fn()} />);
+  expect(screen.queryByTestId("themecolor-btn")).toBeNull();
+});
+
+it("pre manažéra sa tlačidlo vykreslí a klik naň otvorí popup s načítanými farbami", async () => {
+  fetchThemeColors.mockResolvedValue(COLORS);
+  render(<ThemeColorPicker role="manazer" onSessionExpired={vi.fn()} />);
+  fireEvent.click(screen.getByTestId("themecolor-btn"));
+  await screen.findByTestId("themecolor-dialog");
+  expect(screen.getByTestId<HTMLInputElement>("themecolor-hex-chip-done-bg").value).toBe("#d14d3b");
+});
+
+it("zmena hex poľa naživo premietne farbu do CSS premennej na document.documentElement", async () => {
+  fetchThemeColors.mockResolvedValue(COLORS);
+  render(<ThemeColorPicker role="admin" onSessionExpired={vi.fn()} />);
+  fireEvent.click(screen.getByTestId("themecolor-btn"));
+  await screen.findByTestId("themecolor-dialog");
+
+  fireEvent.change(screen.getByTestId("themecolor-hex-chip-done-bg"), { target: { value: "#123456" } });
+  expect(cssVar("chip-done-bg")).toBe("#123456");
+});
+
+it("neplatný kód farby sa premietne do poľa, ale NEZAPÍŠE do CSS premennej, a Uložiť ostáva nedostupné", async () => {
+  fetchThemeColors.mockResolvedValue(COLORS);
+  render(<ThemeColorPicker role="admin" onSessionExpired={vi.fn()} />);
+  fireEvent.click(screen.getByTestId("themecolor-btn"));
+  await screen.findByTestId("themecolor-dialog");
+
+  const save = screen.getByTestId<HTMLButtonElement>("themecolor-save");
+  expect(save.disabled).toBe(true); // nič sa nezmenilo
+
+  fireEvent.change(screen.getByTestId("themecolor-hex-chip-done-bg"), { target: { value: "nieco-zle" } });
+  expect(cssVar("chip-done-bg")).toBe("#d14d3b"); // pôvodná hodnota, nie garbage
+  expect(save.disabled).toBe(true); // draft je síce "dirty", ale neplatný
+});
+
+it("Uložiť odošle celý draft a po úspechu popup zavrie", async () => {
+  fetchThemeColors.mockResolvedValue(COLORS);
+  saveThemeColors.mockResolvedValue({ ok: true });
+  render(<ThemeColorPicker role="admin" onSessionExpired={vi.fn()} />);
+  fireEvent.click(screen.getByTestId("themecolor-btn"));
+  await screen.findByTestId("themecolor-dialog");
+
+  fireEvent.change(screen.getByTestId("themecolor-hex-chip-done-bg"), { target: { value: "#123456" } });
+  fireEvent.click(screen.getByTestId("themecolor-save"));
+
+  await waitFor(() => {
+    expect(saveThemeColors).toHaveBeenCalledWith(expect.objectContaining({ "chip-done-bg": "#123456" }));
+  });
+  await waitFor(() => {
+    expect(screen.queryByTestId("themecolor-dialog")).toBeNull();
+  });
+});
+
+it("zamietnuté uloženie zobrazí hlášku servera a popup neZAVRIE", async () => {
+  fetchThemeColors.mockResolvedValue(COLORS);
+  saveThemeColors.mockResolvedValue({ ok: false, error: "Neplatný kód farby." });
+  render(<ThemeColorPicker role="admin" onSessionExpired={vi.fn()} />);
+  fireEvent.click(screen.getByTestId("themecolor-btn"));
+  await screen.findByTestId("themecolor-dialog");
+
+  fireEvent.change(screen.getByTestId("themecolor-hex-chip-done-bg"), { target: { value: "#123456" } });
+  fireEvent.click(screen.getByTestId("themecolor-save"));
+
+  await screen.findByText("Neplatný kód farby.");
+  expect(screen.getByTestId("themecolor-dialog")).not.toBeNull();
+});
+
+it("Zrušiť vráti CSS premenné na hodnotu pri otvorení a zavrie popup", async () => {
+  fetchThemeColors.mockResolvedValue(COLORS);
+  render(<ThemeColorPicker role="admin" onSessionExpired={vi.fn()} />);
+  fireEvent.click(screen.getByTestId("themecolor-btn"));
+  await screen.findByTestId("themecolor-dialog");
+
+  fireEvent.change(screen.getByTestId("themecolor-hex-chip-done-bg"), { target: { value: "#123456" } });
+  expect(cssVar("chip-done-bg")).toBe("#123456");
+
+  fireEvent.click(screen.getByTestId("themecolor-cancel"));
+  expect(cssVar("chip-done-bg")).toBe("#d14d3b");
+  expect(screen.queryByTestId("themecolor-dialog")).toBeNull();
+});
+
+it("Obnoviť predvolené zapíše predvolené hodnoty a nechá popup otvorený", async () => {
+  fetchThemeColors.mockResolvedValue(COLORS.map((c) => (c.key === "chip-done-bg" ? { ...c, value: "#111111", isCustomized: true } : c)));
+  resetThemeColors.mockResolvedValue({ ok: true });
+  render(<ThemeColorPicker role="admin" onSessionExpired={vi.fn()} />);
+  fireEvent.click(screen.getByTestId("themecolor-btn"));
+  await screen.findByTestId("themecolor-dialog");
+  expect(screen.getByTestId<HTMLInputElement>("themecolor-hex-chip-done-bg").value).toBe("#111111");
+
+  fireEvent.click(screen.getByTestId("themecolor-reset"));
+
+  await waitFor(() => {
+    expect(resetThemeColors).toHaveBeenCalled();
+  });
+  await waitFor(() => {
+    expect(screen.getByTestId<HTMLInputElement>("themecolor-hex-chip-done-bg").value).toBe("#d14d3b");
+  });
+  expect(cssVar("chip-done-bg")).toBe("#d14d3b");
+  expect(screen.getByTestId("themecolor-dialog")).not.toBeNull();
+});

--- a/apps/web/src/components/ThemeColorPicker.test.tsx
+++ b/apps/web/src/components/ThemeColorPicker.test.tsx
@@ -92,6 +92,34 @@ it("Uložiť odošle celý draft a po úspechu popup zavrie", async () => {
   });
 });
 
+it("kým Uložiť čaká na server, Zrušiť/Esc nič nerobí — žiadny reverted náhľad prežívajúci úspešné uloženie", async () => {
+  fetchThemeColors.mockResolvedValue(COLORS);
+  let resolveSave: (result: { ok: true }) => void = () => {};
+  saveThemeColors.mockImplementation(() => new Promise((resolve) => { resolveSave = resolve; }));
+  render(<ThemeColorPicker role="admin" onSessionExpired={vi.fn()} />);
+  fireEvent.click(screen.getByTestId("themecolor-btn"));
+  await screen.findByTestId("themecolor-dialog");
+
+  fireEvent.change(screen.getByTestId("themecolor-hex-chip-done-bg"), { target: { value: "#123456" } });
+  fireEvent.click(screen.getByTestId("themecolor-save"));
+
+  // Save request is in flight — Cancel must be a no-op (button disabled AND
+  // the click itself must not close/revert), otherwise the live CSS var
+  // would revert to baseline and never get re-applied once the save
+  // actually succeeds (code-review finding — the popup must stay open, not
+  // just the button disabled, since Escape bypasses the button entirely).
+  expect(screen.getByTestId<HTMLButtonElement>("themecolor-cancel").disabled).toBe(true);
+  fireEvent.click(screen.getByTestId("themecolor-cancel"));
+  expect(screen.getByTestId("themecolor-dialog")).not.toBeNull();
+  expect(cssVar("chip-done-bg")).toBe("#123456");
+
+  resolveSave({ ok: true });
+  await waitFor(() => {
+    expect(screen.queryByTestId("themecolor-dialog")).toBeNull();
+  });
+  expect(cssVar("chip-done-bg")).toBe("#123456");
+});
+
 it("zamietnuté uloženie zobrazí hlášku servera a popup neZAVRIE", async () => {
   fetchThemeColors.mockResolvedValue(COLORS);
   saveThemeColors.mockResolvedValue({ ok: false, error: "Neplatný kód farby." });

--- a/apps/web/src/components/ThemeColorPicker.tsx
+++ b/apps/web/src/components/ThemeColorPicker.tsx
@@ -76,11 +76,26 @@ export function ThemeColorPicker({ role, onSessionExpired }: { readonly role: Me
   const [busy, setBusy] = useState(false);
   const panelRef = useRef<HTMLDivElement | null>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
+  // Code review finding: close→reopen before the FIRST fetch resolves could
+  // let the STALE response's `.then()` land after a newer one and overwrite
+  // state with old values (same "latest wins" class of race as issue 151/251,
+  // `.claude/rules/frontend-design.md`) — each `openPicker()` bumps this and
+  // the `.then()` only applies if it is still the most recent request.
+  const fetchSeqRef = useRef(0);
 
+  // Code review finding: closing (Escape/backdrop/Cancel) WHILE a save/reset
+  // request is in flight reverted the live CSS preview to `baseline`
+  // immediately, but the in-flight request's OWN success handler (below)
+  // never re-applied its result — the page could keep showing the OLD
+  // colours even though the server (and this component's `baseline`) already
+  // has the NEW ones. Making `close()` a no-op while `busy` removes the race
+  // entirely: the dialog can only close once the request has settled, and
+  // both the save/reset success handlers close it themselves at that point.
   const close = useCallback(() => {
+    if (busy) return;
     applyThemeColors(baseline);
     setOpen(false);
-  }, [baseline]);
+  }, [busy, baseline]);
 
   // Esc zavrie dialóg rovnako ako "Zrušiť" (vráti pôvodné farby) — rovnaký
   // vzor ako `MailPreviewDialog.tsx` (issue 191).
@@ -110,9 +125,18 @@ export function ThemeColorPicker({ role, onSessionExpired }: { readonly role: Me
   function openPicker(e: MouseEvent<HTMLButtonElement>): void {
     previousFocusRef.current = e.currentTarget;
     setError("");
+    // Code review finding: without resetting these, a reopen whose refetch
+    // fails (network hiccup) would silently keep rendering the PREVIOUS
+    // session's draft/baseline as if fresh — `colors !== null` would skip the
+    // "Načítavam…" state and Save could re-persist a stale draft unnoticed.
+    setColors(null);
+    setDraft({});
+    setBaseline({});
     setOpen(true);
+    const seq = ++fetchSeqRef.current;
     fetchThemeColors()
       .then((list) => {
+        if (fetchSeqRef.current !== seq) return; // closed+reopened while this was in flight — a newer fetch already applied its own state
         setColors(list);
         const values = Object.fromEntries(list.map((c) => [c.key, c.value]));
         setDraft(values);
@@ -120,6 +144,7 @@ export function ThemeColorPicker({ role, onSessionExpired }: { readonly role: Me
         applyThemeColors(values);
       })
       .catch((err: unknown) => {
+        if (fetchSeqRef.current !== seq) return;
         if (err instanceof ThemeColorsUnauthorizedError) {
           onSessionExpired();
           return;
@@ -146,8 +171,12 @@ export function ThemeColorPicker({ role, onSessionExpired }: { readonly role: Me
         setBaseline(draft);
         setOpen(false);
       })
-      .catch(() => {
+      .catch((err: unknown) => {
         setBusy(false);
+        if (err instanceof ThemeColorsUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
         setError("Uloženie farieb zlyhalo.");
       });
   }
@@ -220,7 +249,7 @@ export function ThemeColorPicker({ role, onSessionExpired }: { readonly role: Me
               <button type="button" className="btn lg good" disabled={busy || !dirty || !allValid} onClick={save} data-testid="themecolor-save">
                 Uložiť
               </button>
-              <button type="button" className="btn lg ghost" onClick={close} data-testid="themecolor-cancel">
+              <button type="button" className="btn lg ghost" disabled={busy} onClick={close} data-testid="themecolor-cancel">
                 Zrušiť
               </button>
               <button type="button" className="btn lg ghost" disabled={busy || colors === null} onClick={resetToDefaults} data-testid="themecolor-reset">

--- a/apps/web/src/components/ThemeColorPicker.tsx
+++ b/apps/web/src/components/ThemeColorPicker.tsx
@@ -1,0 +1,235 @@
+import { useCallback, useEffect, useRef, useState, type JSX, type MouseEvent } from "react";
+import type { Me } from "../api.js";
+import { applyThemeColors } from "../applyThemeColors.js";
+import { fetchThemeColors, resetThemeColors, saveThemeColors, ThemeColorsUnauthorizedError, type ThemeColor } from "../themeColorsApi.js";
+
+// issue 264, majiteľ: "koliesko vpravo hore, vyskakovacie okno, naživo ako
+// bude ťahať farbu po palete tak sa mu to bude meniť na stránke". Viditeľné
+// len pre role, čo smú aj uložiť (`requireRole("admin","manazer")` na
+// serveri) — rovnaký `CONTROL_ROLES`-štýl gate ako `MailTemplatesSection.tsx`
+// (issue 192), len tu rovno skryje CELÉ tlačidlo namiesto len uzamknutia
+// polí, keďže čítať tieto farby na tomto mieste netreba (App.tsx ich už
+// premietne pri prihlásení pre KAŽDÉHO používateľa).
+const EDIT_ROLES: ReadonlySet<Me["role"]> = new Set(["admin", "manazer"]);
+
+const HEX_RE = /^#[0-9a-fA-F]{6}$/;
+
+interface ThemeColorGroup {
+  readonly title: string;
+  readonly sampleLabel: string;
+  readonly bgKey: string;
+  readonly textKey: string;
+}
+
+const GROUPS: readonly ThemeColorGroup[] = [
+  { title: "Vybavený dodávateľ", sampleLabel: "Vybavené", bgKey: "chip-done-bg", textKey: "chip-done-text" },
+  { title: "Nespracovaný dodávateľ", sampleLabel: "Nespracované", bgKey: "chip-todo-bg", textKey: "chip-todo-text" },
+  { title: "Práve zvolená bublinka", sampleLabel: "Zvolené", bgKey: "chip-active-bg", textKey: "chip-active-text" },
+];
+
+function ThemeColorField({
+  id,
+  label,
+  value,
+  onChange,
+}: {
+  readonly id: string;
+  readonly label: string;
+  readonly value: string;
+  readonly onChange: (value: string) => void;
+}): JSX.Element {
+  return (
+    <label className="themecolor-field">
+      <span className="themecolor-field-label">{label}</span>
+      <span className="themecolor-field-inputs">
+        <input
+          type="color"
+          value={HEX_RE.test(value) ? value : "#000000"}
+          onChange={(e) => {
+            onChange(e.target.value);
+          }}
+          data-testid={`themecolor-swatch-${id}`}
+          aria-label={`${label} — paleta`}
+        />
+        <input
+          type="text"
+          value={value}
+          onChange={(e) => {
+            onChange(e.target.value);
+          }}
+          data-testid={`themecolor-hex-${id}`}
+          aria-label={`${label} — kód farby`}
+          maxLength={7}
+          className="themecolor-hex-input"
+        />
+      </span>
+    </label>
+  );
+}
+
+export function ThemeColorPicker({ role, onSessionExpired }: { readonly role: Me["role"]; readonly onSessionExpired: () => void }): JSX.Element | null {
+  const [open, setOpen] = useState(false);
+  const [colors, setColors] = useState<readonly ThemeColor[] | null>(null);
+  const [draft, setDraft] = useState<Readonly<Record<string, string>>>({});
+  const [baseline, setBaseline] = useState<Readonly<Record<string, string>>>({});
+  const [error, setError] = useState("");
+  const [busy, setBusy] = useState(false);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  const close = useCallback(() => {
+    applyThemeColors(baseline);
+    setOpen(false);
+  }, [baseline]);
+
+  // Esc zavrie dialóg rovnako ako "Zrušiť" (vráti pôvodné farby) — rovnaký
+  // vzor ako `MailPreviewDialog.tsx` (issue 191).
+  useEffect(() => {
+    if (!open) return undefined;
+    function onKeyDown(e: KeyboardEvent): void {
+      if (e.key === "Escape") close();
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open, close]);
+
+  // Fokus do dialógu pri otvorení, späť na spúšťacie tlačidlo pri zavretí.
+  useEffect(() => {
+    if (!open) return undefined;
+    panelRef.current?.focus();
+    return () => {
+      const target = previousFocusRef.current;
+      if (target !== null && target.isConnected) target.focus();
+    };
+  }, [open]);
+
+  if (!EDIT_ROLES.has(role)) return null;
+
+  function openPicker(e: MouseEvent<HTMLButtonElement>): void {
+    previousFocusRef.current = e.currentTarget;
+    setError("");
+    setOpen(true);
+    fetchThemeColors()
+      .then((list) => {
+        setColors(list);
+        const values = Object.fromEntries(list.map((c) => [c.key, c.value]));
+        setDraft(values);
+        setBaseline(values);
+        applyThemeColors(values);
+      })
+      .catch((err: unknown) => {
+        if (err instanceof ThemeColorsUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setError("Farby aplikácie sa nepodarilo načítať.");
+      });
+  }
+
+  function setValue(key: string, value: string): void {
+    setDraft((prev) => ({ ...prev, [key]: value }));
+    if (HEX_RE.test(value)) applyThemeColors({ [key]: value });
+  }
+
+  function save(): void {
+    setBusy(true);
+    setError("");
+    saveThemeColors(draft)
+      .then((result) => {
+        setBusy(false);
+        if (!result.ok) {
+          setError(result.error);
+          return;
+        }
+        setBaseline(draft);
+        setOpen(false);
+      })
+      .catch(() => {
+        setBusy(false);
+        setError("Uloženie farieb zlyhalo.");
+      });
+  }
+
+  function resetToDefaults(): void {
+    setBusy(true);
+    setError("");
+    resetThemeColors()
+      .then((result) => {
+        setBusy(false);
+        if (!result.ok) {
+          setError(result.error);
+          return;
+        }
+        if (colors === null) return;
+        const defaults = Object.fromEntries(colors.map((c) => [c.key, c.defaultValue]));
+        setDraft(defaults);
+        setBaseline(defaults);
+        applyThemeColors(defaults);
+      })
+      .catch(() => {
+        setBusy(false);
+        setError("Vrátenie predvolených farieb zlyhalo.");
+      });
+  }
+
+  const allValid = Object.keys(draft).length > 0 && Object.values(draft).every((v) => HEX_RE.test(v));
+  const dirty = Object.keys(baseline).some((key) => baseline[key] !== draft[key]);
+
+  return (
+    <>
+      <button type="button" className="themecolor-btn" aria-label="Farby aplikácie" title="Farby aplikácie" data-testid="themecolor-btn" onClick={openPicker}>
+        🎨
+      </button>
+      {open && (
+        <div
+          className="modal-backdrop"
+          data-testid="themecolor-dialog-backdrop"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) close();
+          }}
+        >
+          <div className="modal" role="dialog" aria-modal="true" aria-labelledby="themecolor-dialog-title" tabIndex={-1} ref={panelRef} data-testid="themecolor-dialog">
+            <h3 id="themecolor-dialog-title" className="modal-title">
+              Farby aplikácie
+            </h3>
+            <p className="modal-meta">Farby bublinek dodávateľov v „Na objednanie“ — zmena sa prejaví na stránke okamžite, aj počas ťahania paletou.</p>
+            {error !== "" && (
+              <p role="alert" data-testid="themecolor-error">
+                {error}
+              </p>
+            )}
+            {colors === null ? (
+              <p>Načítavam…</p>
+            ) : (
+              <div className="themecolor-groups">
+                {GROUPS.map((group) => (
+                  <fieldset key={group.title} className="themecolor-group">
+                    <legend>{group.title}</legend>
+                    <span className="themecolor-sample" style={{ background: draft[group.bgKey], color: draft[group.textKey] }} data-testid={`themecolor-sample-${group.bgKey}`}>
+                      {group.sampleLabel}
+                    </span>
+                    <ThemeColorField id={group.bgKey} label="Pozadie" value={draft[group.bgKey] ?? ""} onChange={(v) => { setValue(group.bgKey, v); }} />
+                    <ThemeColorField id={group.textKey} label="Text" value={draft[group.textKey] ?? ""} onChange={(v) => { setValue(group.textKey, v); }} />
+                  </fieldset>
+                ))}
+              </div>
+            )}
+            <div className="modal-actions">
+              <button type="button" className="btn lg good" disabled={busy || !dirty || !allValid} onClick={save} data-testid="themecolor-save">
+                Uložiť
+              </button>
+              <button type="button" className="btn lg ghost" onClick={close} data-testid="themecolor-cancel">
+                Zrušiť
+              </button>
+              <button type="button" className="btn lg ghost" disabled={busy || colors === null} onClick={resetToDefaults} data-testid="themecolor-reset">
+                Obnoviť predvolené
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/components/Topbar.test.tsx
+++ b/apps/web/src/components/Topbar.test.tsx
@@ -8,6 +8,7 @@ afterEach(() => {
 
 function renderTopbar(overrides: {
   readonly title?: string | null;
+  readonly role?: "admin" | "manazer" | "sef" | "citanie";
   readonly onLogout?: () => void;
   readonly passwordPanelOpen?: boolean;
   readonly onTogglePasswordPanel?: () => void;
@@ -16,6 +17,8 @@ function renderTopbar(overrides: {
     <Topbar
       title={overrides.title === undefined ? "Sync zo Shoptetu" : overrides.title}
       greeting="Prihlásený: E2E Manažér (manazer)"
+      role={overrides.role ?? "manazer"}
+      onSessionExpired={() => {}}
       onLogout={overrides.onLogout ?? (() => {})}
       passwordPanelOpen={overrides.passwordPanelOpen ?? false}
       onTogglePasswordPanel={overrides.onTogglePasswordPanel ?? (() => {})}

--- a/apps/web/src/components/Topbar.tsx
+++ b/apps/web/src/components/Topbar.tsx
@@ -1,4 +1,6 @@
 import { useState, type JSX, type ReactNode } from "react";
+import type { Me } from "../api.js";
+import { ThemeColorPicker } from "./ThemeColorPicker.js";
 
 // Horná lišta — vlastný titulok obrazovky (vľavo) + používateľské menu
 // (vpravo). `title === null` pre SKRYTÉ obrazovky (katalóg/párovanie/
@@ -15,6 +17,8 @@ import { useState, type JSX, type ReactNode } from "react";
 export function Topbar({
   title,
   greeting,
+  role,
+  onSessionExpired,
   onLogout,
   passwordPanelOpen,
   onTogglePasswordPanel,
@@ -23,6 +27,11 @@ export function Topbar({
   readonly title: string | null;
   // "Prihlásený: <meno> (<rola>)" — `data-testid="greeting"`, overované e2e testami.
   readonly greeting: string;
+  // issue 264: koliesko "Farby aplikácie" — `ThemeColorPicker` sám rozhoduje,
+  // či sa vôbec vykreslí (len admin/manazer), Topbar mu len odovzdá rolu,
+  // rovnaký vzor ako `MailTemplatesSection`'s `role` prop.
+  readonly role: Me["role"];
+  readonly onSessionExpired: () => void;
   readonly onLogout: () => void;
   readonly passwordPanelOpen: boolean;
   readonly onTogglePasswordPanel: () => void;
@@ -34,6 +43,7 @@ export function Topbar({
     <header className="topbar">
       <div className="topbar-head">{title !== null && <h1>{title}</h1>}</div>
       <div className="topbar-user">
+        <ThemeColorPicker role={role} onSessionExpired={onSessionExpired} />
         <button
           type="button"
           className="usermenu-btn"

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -495,6 +495,12 @@ tr:last-child td {
 .topbar-user {
   position: relative;
   flex: 0 0 auto;
+  /* issue 264: koliesko "Farby aplikácie" sedí VEDĽA mena používateľa, nie
+     nad/pod ním — `.usermenu-panel` nižšie ostáva absolútne pozicovaný
+     voči tomuto (position:relative) rodičovi bez ohľadu na flex. */
+  display: flex;
+  align-items: center;
+  gap: var(--fs-space-2);
 }
 .usermenu-btn {
   display: flex;
@@ -2268,4 +2274,86 @@ tr:last-child td {
 }
 .ml-status-skipped {
   color: var(--fs-ink-muted);
+}
+
+/* ── Farby aplikácie (issue 264) ──────────────────────────────────────────
+   Koliesko vpravo hore (`.topbar-user`) otvorí popup so živým náhľadom
+   (znovupoužité `.modal`/`.modal-backdrop`/`.modal-actions`, issue 191). */
+.themecolor-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  border: 1px solid var(--fs-border);
+  background: var(--fs-surface);
+  font-size: var(--fs-text-md);
+  line-height: 1;
+  cursor: pointer;
+}
+.themecolor-btn:hover {
+  border-color: var(--fs-ink-faint);
+}
+.themecolor-groups {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+  gap: var(--fs-space-4);
+  margin-bottom: var(--fs-space-2);
+}
+.themecolor-group {
+  border: 1px solid var(--fs-border);
+  border-radius: var(--fs-radius-md);
+  padding: var(--fs-space-3) var(--fs-space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--fs-space-2);
+}
+.themecolor-group legend {
+  font-weight: var(--fs-weight-semibold);
+  padding: 0 var(--fs-space-1);
+}
+/* Živá ukážka priamo v POPUPE — viazaná na draft hodnoty (inline `style`,
+   nie CSS premennú), takže reaguje na KAŽDÝ stlačený kláves/ťah paletou aj
+   keď užívateľ práve nepozerá na inú obrazovku appky s viditeľnými čipmi. */
+.themecolor-sample {
+  align-self: flex-start;
+  display: inline-block;
+  width: max-content;
+  max-width: 100%;
+  padding: var(--fs-space-1) var(--fs-space-3);
+  border-radius: 999px;
+  font-size: var(--fs-text-sm);
+  font-weight: var(--fs-weight-semibold);
+}
+.themecolor-field {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--fs-space-3);
+}
+.themecolor-field-label {
+  color: var(--fs-ink-muted);
+  font-size: var(--fs-text-sm);
+}
+.themecolor-field-inputs {
+  display: flex;
+  align-items: center;
+  gap: var(--fs-space-2);
+}
+/* Natívny prehliadačový color picker — veľký dosah prsta/myši (issue 176's
+   "veľké ovládacie prvky" princíp platí aj tu). */
+.themecolor-field-inputs input[type="color"] {
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0;
+  border: 1px solid var(--fs-border);
+  border-radius: var(--fs-radius-sm);
+  cursor: pointer;
+}
+.themecolor-hex-input {
+  width: 6.5rem;
+  font-family: monospace;
+  text-transform: lowercase;
 }

--- a/apps/web/src/themeColorsApi.ts
+++ b/apps/web/src/themeColorsApi.ts
@@ -1,0 +1,60 @@
+import { z } from "zod";
+
+// issue 264: obrazovka "Farby aplikácie" (koliesko v Topbar) — zrkadlí
+// `http/theme-color-routes.ts`.
+
+const themeColorSchema = z.object({
+  key: z.string(),
+  label: z.string(),
+  value: z.string(),
+  defaultValue: z.string(),
+  isCustomized: z.boolean(),
+  updatedAt: z.string().nullable(),
+  updatedByName: z.string().nullable(),
+});
+export type ThemeColor = z.infer<typeof themeColorSchema>;
+
+const listSchema = z.object({ colors: z.array(themeColorSchema) });
+
+const writeSchema = z.union([z.object({ ok: z.literal(true) }), z.object({ ok: z.literal(false), error: z.string() })]);
+export type ThemeColorWriteResult = z.infer<typeof writeSchema>;
+
+export class ThemeColorsUnauthorizedError extends Error {
+  constructor() {
+    super("Neprihlásený");
+  }
+}
+
+async function readJson(response: Response, fallback: string): Promise<unknown> {
+  if (response.status === 401) throw new ThemeColorsUnauthorizedError();
+  if (!response.ok) {
+    try {
+      const body: unknown = await response.json();
+      const parsed = z.object({ error: z.string() }).safeParse(body);
+      if (parsed.success) throw new Error(parsed.data.error);
+    } catch (error) {
+      if (error instanceof Error && error.message !== "") throw error;
+    }
+    throw new Error(fallback);
+  }
+  return await response.json();
+}
+
+export async function fetchThemeColors(): Promise<readonly ThemeColor[]> {
+  const response = await fetch("/api/theme-colors");
+  return listSchema.parse(await readJson(response, "Farby aplikácie sa nepodarilo načítať")).colors;
+}
+
+export async function saveThemeColors(values: Readonly<Record<string, string>>): Promise<ThemeColorWriteResult> {
+  const response = await fetch("/api/theme-colors", {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ values }),
+  });
+  return writeSchema.parse(await readJson(response, "Uloženie farieb zlyhalo"));
+}
+
+export async function resetThemeColors(): Promise<ThemeColorWriteResult> {
+  const response = await fetch("/api/theme-colors/reset", { method: "POST" });
+  return writeSchema.parse(await readJson(response, "Vrátenie predvolených farieb zlyhalo"));
+}

--- a/apps/web/tests/e2e/theme-colors.spec.ts
+++ b/apps/web/tests/e2e/theme-colors.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "@playwright/test";
+
+const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
+const E2E_FARBY_EMAIL = "e2e-farby@forestshop.sk"; // musí sa zhodovať s hodnotou v scripts/e2e-setup.ts
+
+// issue 264: koliesko "Farby aplikácie" vpravo hore — živý náhľad počas
+// ťahania/písania, uloženie, vrátenie predvolených, zrušenie bez zápisu.
+test("koliesko farieb: živý náhľad, uloženie prežije reload, vrátenie predvolených, Zrušiť nič neuloží; konzola je čistá", async ({ page }) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/");
+  await page.getByLabel("E-mail").fill(E2E_FARBY_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+
+  // "Na objednanie" je predvolená obrazovka pre citanie/manazer? Nie —
+  // predvolená je "Sync zo Shoptetu" (nav.ts). Koliesko je v Topbar na
+  // KAŽDEJ obrazovke, takže sa netreba prepínať nikam.
+  const btn = page.getByTestId("themecolor-btn");
+  await expect(btn).toBeVisible();
+  await btn.click();
+  await expect(page.getByTestId("themecolor-dialog")).toBeVisible();
+
+  const hexDone = page.getByTestId("themecolor-hex-chip-done-bg");
+  await expect(hexDone).toHaveValue("#d14d3b");
+
+  // Živý náhľad: písanie do hex poľa premietne CSS premennú na
+  // document.documentElement OKAMŽITE, ešte pred uložením.
+  await hexDone.fill("#123456");
+  await expect
+    .poll(() => page.evaluate(() => document.documentElement.style.getPropertyValue("--chip-done-bg")))
+    .toBe("#123456");
+
+  await page.getByTestId("themecolor-save").click();
+  await expect(page.getByTestId("themecolor-dialog")).toBeHidden();
+
+  // Uložená hodnota prežije obnovenie stránky — App.tsx ju premietne pri
+  // prihlásení pre KAŽDÉHO používateľa, nielen v popupe.
+  await page.reload();
+  await expect
+    .poll(() => page.evaluate(() => document.documentElement.style.getPropertyValue("--chip-done-bg")))
+    .toBe("#123456");
+
+  await btn.click();
+  await expect(page.getByTestId("themecolor-dialog")).toBeVisible();
+  await expect(page.getByTestId("themecolor-hex-chip-done-bg")).toHaveValue("#123456");
+
+  // Zrušiť (bez uloženia zmeny) vráti live-náhľad na hodnotu PRI OTVORENÍ,
+  // nikdy na predvolenú — a nič nezapíše na server.
+  await page.getByTestId("themecolor-hex-chip-done-bg").fill("#abcdef");
+  await expect
+    .poll(() => page.evaluate(() => document.documentElement.style.getPropertyValue("--chip-done-bg")))
+    .toBe("#abcdef");
+  await page.getByTestId("themecolor-cancel").click();
+  await expect(page.getByTestId("themecolor-dialog")).toBeHidden();
+  await expect
+    .poll(() => page.evaluate(() => document.documentElement.style.getPropertyValue("--chip-done-bg")))
+    .toBe("#123456");
+
+  // Obnoviť predvolené — persistentné hneď (rovnaký vzor ako "Texty
+  // e-mailov"'s vrátenie pôvodného znenia), fixtúra tak ostáva rovnaká pre
+  // ďalšie behy.
+  await btn.click();
+  await page.getByTestId("themecolor-reset").click();
+  await expect(page.getByTestId("themecolor-hex-chip-done-bg")).toHaveValue("#d14d3b");
+  await page.getByTestId("themecolor-cancel").click();
+
+  expect(chyby).toEqual([]);
+});

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -2919,3 +2919,42 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   (66 súborov, po `db:migrate`), e2e 44/44.
 - No PR/merge/deploy in this dispatch — supervisor owns CI/PR/merge/deploy
   for this ticket per the dispatch's HARD CONSTRAINT.
+
+## Issue 264 — Nastavenie farieb: koliesko vpravo hore, popup s paletou a živým náhľadom
+
+- Commit `5c776bb` — chore: version bump 0.3.0-dev.153.
+- Commit `38b20d8` — `[red]`: `theme-colors.integration.test.ts`,
+  `applyThemeColors.test.ts`, `ThemeColorPicker.test.tsx`, `Topbar.test.tsx`
+  (new `role`/`onSessionExpired` props), `theme-colors.spec.ts` (e2e).
+- Commit `f36dbf1` — `[green]`: new `theme_color` table (key/value/
+  updatedAt/updatedByUserId, same "row = customized, missing = code
+  default" shape as `mail_template`/issue 192); `modules/theme-colors/
+  {registry,store}.ts` + `http/theme-color-routes.ts` (GET any logged-in
+  user, PUT/reset admin+manazer, all-or-nothing hex validation, 200
+  {ok:false} never 4xx); `applyThemeColors.ts` shared CSS-var helper used
+  by both `App.tsx` (apply-on-login, every role) and `ThemeColorPicker.tsx`
+  (live preview on every keystroke/drag); circle button in `Topbar.tsx`
+  (admin/manazer only); e2e-setup.ts isolated `e2e-farby@forestshop.sk`
+  fixture + `theme_color` added to both TRUNCATE lists.
+- Commit `a77472e` — code-review fixes (two independent passes): 🔴
+  Cancel/Escape/backdrop-click during an in-flight Save/Reset reverted the
+  live CSS preview to baseline while the server had already persisted the
+  NEW colours — `close()` now no-ops while `busy` (+ `disabled={busy}` on
+  Cancel), with a regression test proving it; 🟡 missing
+  `ThemeColorsUnauthorizedError` handling on save/reset catches; 🟡 reopen
+  without resetting stale `colors`/`draft`/`baseline`; 🟡 stale-fetch guard
+  (`fetchSeqRef`) for rapid close+reopen; 🔵 strengthened a tautological
+  empty-input test in `applyThemeColors.test.ts`.
+- Design comment + STEP 0 validation comment + review comment all posted
+  to issue 264 before/after the respective steps.
+- Playbook entry added to `.claude/rules/frontend-design.md` — the
+  "async popup: `close()` must no-op while `busy`" gotcha + the
+  "reopen must reset stale state" gotcha, for any future editable-settings
+  popup with Save+Cancel in this codebase.
+- Lokálne gates (po review fixoch): `pnpm typecheck`, `pnpm lint` čisté;
+  web unit 433/433 (54 súborov), API unit 579/579 (36 súborov), API
+  integration 491/491 (67 súborov, po `db:migrate` — nová migrácia
+  `0035_sturdy_darkstar.sql`), e2e 45/45 (nový `theme-colors.spec.ts`
+  overený aj samostatne po fix commite).
+- No PR/merge/deploy in this dispatch — supervisor owns CI/PR/merge/deploy
+  for this ticket per the dispatch's HARD CONSTRAINT.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.152",
+  "version": "0.3.0-dev.153",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -187,6 +187,12 @@ const E2E_RACE_EMAIL = "e2e-race@forestshop.sk"; // musí sa zhodovať s hodnoto
 // `admin`/`manazer` na odoslanie, rovnaká úroveň ako "Nedostupné tovary".
 const E2E_ZLUCENIE_EMAIL = "e2e-zlucenie@forestshop.sk"; // musí sa zhodovať s hodnotou v order-merge.spec.ts
 
+// issue 264: rovnaký mechanizmus a dôvod ako `E2E_ZLUCENIE_EMAIL` vyššie —
+// nový spec súbor (`theme-colors.spec.ts` — koliesko "Farby aplikácie")
+// dostáva VLASTNÝ izolovaný účet. Rola "manazer" — zápis vyžaduje
+// `admin`/`manazer`.
+const E2E_FARBY_EMAIL = "e2e-farby@forestshop.sk"; // musí sa zhodovať s hodnotou v theme-colors.spec.ts
+
 const { db, pool } = createDb();
 // Konštantný literál bez interpolácie — obyčajný reťazec je tu rovnako bezpečný
 // ako `sql` tagovaná šablóna (tú používa ekvivalentný apps/api/tests/helpers/db.ts),
@@ -217,7 +223,7 @@ await db.execute(
   // takže CASCADE ich nikdy nestrhne. Bez nich by potvrdenia dodávateľa z
   // PREDOŠLÉHO e2e behu prežili do ďalšieho (presne past popísaná v
   // `.claude/rules/supplier-stock.md`, tam pre `tests/helpers/db.ts`).
-  'TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, nedostupne_replacement_link, mail_template, mail_template_history, supplier_stock, restock_settings, restock_event, shop_product_url RESTART IDENTITY CASCADE',
+  'TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, nedostupne_replacement_link, mail_template, mail_template_history, supplier_stock, restock_settings, restock_event, shop_product_url, theme_color RESTART IDENTITY CASCADE',
 );
 // Rovnaký dôvod ako `tests/helpers/db.ts`: bez tohto by "Na objednanie" bolo
 // v CELOM e2e behu prázdne pre KAŽDÚ objednávku (žiadny nastavený otvorený
@@ -346,6 +352,7 @@ await db.insert(users).values({
 });
 await db.insert(users).values({ email: E2E_RACE_EMAIL, passwordHash: await hashPassword(E2E_HESLO), displayName: "E2E Manažér", role: "manazer" });
 await db.insert(users).values({ email: E2E_ZLUCENIE_EMAIL, passwordHash: await hashPassword(E2E_HESLO), displayName: "E2E Manažér", role: "manazer" });
+await db.insert(users).values({ email: E2E_FARBY_EMAIL, passwordHash: await hashPassword(E2E_HESLO), displayName: "E2E Manažér", role: "manazer" });
 
 // Katalóg pre E2E: tá istá commitnutá fixtúra ako v jednotkových testoch, cez tú istú
 // službu importu — E2E tak overuje skutočnú cestu dát, nie ručne nasypané riadky.


### PR DESCRIPTION
## Čo to robí

Majiteľ si vie farby v appke prestaviť sám — a **naživo vidí, ako to vyzerá, kým ťahá po palete**.

- Vpravo hore v hlavičke je **malé koliesko**, klik naň otvorí okno s farbami.
- Ťahanie po palete mení farbu na stránke **okamžite**, nie až po uložení.
- Pri každej farbe je aj **kód** (napr. `#D14D3B`) — zmena v jednom sa hneď prejaví v druhom.
- **Uložiť** zapíše natrvalo, **Zrušiť** vráti stav pred otvorením okna, **Obnoviť predvolené** vráti pôvodné farby.

Nastavuje šesť hodnôt zavedených v issue 263 — pozadie a farbu textu pre tri stavy bubliniek dodávateľov (všetko odkliknuté / sú nespracované položky / práve zvolená).

## Ako to funguje

- Hodnoty sú uložené **na serveri** (nová tabuľka + migrácia), takže platia všade a prežijú odhlásenie. Čítať ich smie ktokoľvek prihlásený, meniť len admin a manažér.
- Uplatňujú sa cez premenné v CSS na `:root` — preto vie živý náhľad prekresliť stránku okamžite, bez prekresľovania Reactu.
- Neplatný kód farby sa neuloží (zrozumiteľná slovenská hláška, uloženie je všetko-alebo-nič).

## Overenie

- `pnpm typecheck`, `pnpm lint` — čisté
- web unit 433/433, api unit 579/579, api integračné 491/491, e2e 45/45

issue 264
