### PR TITLE
Nastavenie farieb: zrozumiteľná hláška pri neplatnom kóde (issue 264)

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -847,3 +847,20 @@ paths:
   opačným prípadom — STARŠIA odpoveď z PRED zavretého+znovu otvoreného
   popupu prepisujúca NOVŠÍ stav (rovnaká trieda race ako issue 151/251,
   pozri "latest ref" záznamy vyššie v tomto súbore).
+- **"Uložiť je disabled pri neplatnom vstupe" NESTAČÍ ako celá odozva —
+  majiteľ sa musí dozvedieť PREČO a KTORÉ pole je zlé, a to sa dá odvodiť
+  priamo z existujúceho `draft`/validačného stavu bez nového `useState`.**
+  Issue 264 (živé overenie 0.3.0-dev.153, hex kód farby): `ThemeColorPicker
+  .tsx` už mal `allValid`/`dirty` ako ODVODENÉ hodnoty z `draft` — chýbajúca
+  hláška sa doplnila rovnakým princípom (`invalidKeys = new Set(Object
+  .entries(draft).filter(([,v]) => !HEX_RE.test(v)).map(([k]) => k))`
+  priamo v render tele), nie ďalším `useState` synchronizovaným v
+  `setValue()`. Spoločná hláška znovupoužila EXISTUJÚCI globálny
+  `[role="alert"]` CSS blok (`app.css`) pod VLASTNÝM `data-testid` (odlišným
+  od serverového `themecolor-error`u v tom istom komponente, aby oba mohli
+  koexistovať). Per-pole označenie ide cez `aria-invalid` prop + CSS
+  selektor `[aria-invalid="true"]` (existujúci `--fs-danger`/`--fs-danger-
+  bg` token, žiadny nový raw hex). Test na KAŽDÉ ĎALŠIE "tlačidlo je len
+  disabled" miesto v appke: dá sa dôvod odvodiť z toho, čo už komponent
+  počíta? Ak áno, pridaj hlášku + `aria-invalid` ako odvodenú hodnotu, nie
+  nový stav.

--- a/apps/web/src/components/ThemeColorPicker.test.tsx
+++ b/apps/web/src/components/ThemeColorPicker.test.tsx
@@ -60,7 +60,7 @@ it("zmena hex poľa naživo premietne farbu do CSS premennej na document.documen
   expect(cssVar("chip-done-bg")).toBe("#123456");
 });
 
-it("neplatný kód farby sa premietne do poľa, ale NEZAPÍŠE do CSS premennej, a Uložiť ostáva nedostupné", async () => {
+it("neplatný kód farby sa premietne do poľa, ale NEZAPÍŠE do CSS premennej, Uložiť ostáva nedostupné, a zobrazí sa zrozumiteľná hláška s aria-invalid — ktorá zmizne po oprave", async () => {
   fetchThemeColors.mockResolvedValue(COLORS);
   render(<ThemeColorPicker role="admin" onSessionExpired={vi.fn()} />);
   fireEvent.click(screen.getByTestId("themecolor-btn"));
@@ -68,10 +68,28 @@ it("neplatný kód farby sa premietne do poľa, ale NEZAPÍŠE do CSS premennej,
 
   const save = screen.getByTestId<HTMLButtonElement>("themecolor-save");
   expect(save.disabled).toBe(true); // nič sa nezmenilo
+  expect(screen.queryByTestId("themecolor-hex-invalid")).toBeNull();
 
-  fireEvent.change(screen.getByTestId("themecolor-hex-chip-done-bg"), { target: { value: "nieco-zle" } });
+  const hexInput = screen.getByTestId<HTMLInputElement>("themecolor-hex-chip-done-bg");
+  fireEvent.change(hexInput, { target: { value: "nieco-zle" } });
   expect(cssVar("chip-done-bg")).toBe("#d14d3b"); // pôvodná hodnota, nie garbage
   expect(save.disabled).toBe(true); // draft je síce "dirty", ale neplatný
+
+  // Majiteľ sa dozvie PREČO (issue 264, živé overenie 0.3.0-dev.153): zrozumiteľná
+  // hláška po slovensky v live regióne + označenie chybného poľa.
+  const alert = screen.getByTestId("themecolor-hex-invalid");
+  expect(alert.getAttribute("role")).toBe("alert");
+  expect(alert.textContent).toMatch(/#RRGGBB/);
+  expect(hexInput.getAttribute("aria-invalid")).toBe("true");
+
+  // Iné, stále platné pole nesmie byť označené ako neplatné.
+  const otherHexInput = screen.getByTestId<HTMLInputElement>("themecolor-hex-chip-done-text");
+  expect(otherHexInput.getAttribute("aria-invalid")).toBe("false");
+
+  // Hláška zmizne, len čo sa hodnota stane opäť platnou.
+  fireEvent.change(hexInput, { target: { value: "#123456" } });
+  expect(screen.queryByTestId("themecolor-hex-invalid")).toBeNull();
+  expect(hexInput.getAttribute("aria-invalid")).toBe("false");
 });
 
 it("Uložiť odošle celý draft a po úspechu popup zavrie", async () => {

--- a/apps/web/src/components/ThemeColorPicker.tsx
+++ b/apps/web/src/components/ThemeColorPicker.tsx
@@ -31,11 +31,13 @@ function ThemeColorField({
   id,
   label,
   value,
+  invalid,
   onChange,
 }: {
   readonly id: string;
   readonly label: string;
   readonly value: string;
+  readonly invalid: boolean;
   readonly onChange: (value: string) => void;
 }): JSX.Element {
   return (
@@ -59,6 +61,7 @@ function ThemeColorField({
           }}
           data-testid={`themecolor-hex-${id}`}
           aria-label={`${label} — kód farby`}
+          aria-invalid={invalid}
           maxLength={7}
           className="themecolor-hex-input"
         />
@@ -205,6 +208,11 @@ export function ThemeColorPicker({ role, onSessionExpired }: { readonly role: Me
 
   const allValid = Object.keys(draft).length > 0 && Object.values(draft).every((v) => HEX_RE.test(v));
   const dirty = Object.keys(baseline).some((key) => baseline[key] !== draft[key]);
+  // issue 264 živé overenie (0.3.0-dev.153): neplatný kód farby len ticho
+  // blokoval Uložiť, majiteľ sa nedozvedel prečo ani ktoré pole je zlé.
+  // Odvodené priamo z `draft` (rovnaký princíp ako `allValid`/`dirty` vyššie)
+  // — žiadny extra `useState`, zmizne samo, len čo sa hodnota opraví.
+  const invalidKeys = new Set(Object.entries(draft).filter(([, v]) => !HEX_RE.test(v)).map(([key]) => key));
 
   return (
     <>
@@ -229,6 +237,11 @@ export function ThemeColorPicker({ role, onSessionExpired }: { readonly role: Me
                 {error}
               </p>
             )}
+            {invalidKeys.size > 0 && (
+              <p role="alert" data-testid="themecolor-hex-invalid">
+                Kód farby musí byť v tvare #RRGGBB (napr. #D14D3B).
+              </p>
+            )}
             {colors === null ? (
               <p>Načítavam…</p>
             ) : (
@@ -239,8 +252,8 @@ export function ThemeColorPicker({ role, onSessionExpired }: { readonly role: Me
                     <span className="themecolor-sample" style={{ background: draft[group.bgKey], color: draft[group.textKey] }} data-testid={`themecolor-sample-${group.bgKey}`}>
                       {group.sampleLabel}
                     </span>
-                    <ThemeColorField id={group.bgKey} label="Pozadie" value={draft[group.bgKey] ?? ""} onChange={(v) => { setValue(group.bgKey, v); }} />
-                    <ThemeColorField id={group.textKey} label="Text" value={draft[group.textKey] ?? ""} onChange={(v) => { setValue(group.textKey, v); }} />
+                    <ThemeColorField id={group.bgKey} label="Pozadie" value={draft[group.bgKey] ?? ""} invalid={invalidKeys.has(group.bgKey)} onChange={(v) => { setValue(group.bgKey, v); }} />
+                    <ThemeColorField id={group.textKey} label="Text" value={draft[group.textKey] ?? ""} invalid={invalidKeys.has(group.textKey)} onChange={(v) => { setValue(group.textKey, v); }} />
                   </fieldset>
                 ))}
               </div>

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2357,3 +2357,10 @@ tr:last-child td {
   font-family: monospace;
   text-transform: lowercase;
 }
+/* issue 264 živé overenie: neplatný kód farby musí byť VIDIEĽNÝ na samotnom
+   poli, nielen v spoločnej hláške vyššie — s 6 otvorenými poľami inak nie je
+   jasné, KTORÉ z nich je zlé. */
+.themecolor-hex-input[aria-invalid="true"] {
+  border-color: var(--fs-danger);
+  background: var(--fs-danger-bg);
+}

--- a/apps/web/tests/e2e/theme-colors.spec.ts
+++ b/apps/web/tests/e2e/theme-colors.spec.ts
@@ -63,6 +63,22 @@ test("koliesko farieb: živý náhľad, uloženie prežije reload, vrátenie pre
     .poll(() => page.evaluate(() => document.documentElement.style.getPropertyValue("--chip-done-bg")))
     .toBe("#123456");
 
+  // issue 264 živé overenie (0.3.0-dev.153): neplatný kód farby musí
+  // majiteľovi ZROZUMITEĽNE povedať prečo — nielen ticho zablokovať Uložiť.
+  await btn.click();
+  await expect(page.getByTestId("themecolor-dialog")).toBeVisible();
+  const hexDoneAgain = page.getByTestId("themecolor-hex-chip-done-bg");
+  await hexDoneAgain.fill("nezmysel");
+  await expect(page.getByTestId("themecolor-hex-invalid")).toBeVisible();
+  await expect(page.getByTestId("themecolor-hex-invalid")).toContainText("#RRGGBB");
+  await expect(hexDoneAgain).toHaveAttribute("aria-invalid", "true");
+  await expect(page.getByTestId("themecolor-save")).toBeDisabled();
+  await hexDoneAgain.fill("#654321");
+  await expect(page.getByTestId("themecolor-hex-invalid")).toBeHidden();
+  await expect(hexDoneAgain).toHaveAttribute("aria-invalid", "false");
+  await page.getByTestId("themecolor-cancel").click();
+  await expect(page.getByTestId("themecolor-dialog")).toBeHidden();
+
   // Obnoviť predvolené — persistentné hneď (rovnaký vzor ako "Texty
   // e-mailov"'s vrátenie pôvodného znenia), fixtúra tak ostáva rovnaká pre
   // ďalšie behy.

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -2958,3 +2958,27 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   overený aj samostatne po fix commite).
 - No PR/merge/deploy in this dispatch — supervisor owns CI/PR/merge/deploy
   for this ticket per the dispatch's HARD CONSTRAINT.
+
+## Issue 264 follow-up — hláška pri neplatnom kóde farby
+
+- `d006f47` chore: bump version to 0.3.0-dev.154 (issue 264 follow-up)
+- `d30a942` [red] test: neplatný kód farby zobrazí hlášku + aria-invalid
+  (`ThemeColorPicker.test.tsx`) — confirmed failing before the fix.
+- `732f6f6` [green] fix: zrozumiteľná hláška + aria-invalid pri neplatnom
+  kóde farby (`ThemeColorPicker.tsx`, `app.css`) — odvodená množina
+  `invalidKeys` (rovnaký princíp ako existujúce `allValid`/`dirty`), nový
+  `role="alert"` blok (`themecolor-hex-invalid`), `aria-invalid` na
+  hex `<input>` + `[aria-invalid="true"]` CSS s `--fs-danger` tokenmi.
+- Extended `theme-colors.spec.ts` (existing e2e) with the same proof:
+  message text/visibility, `aria-invalid` set then cleared.
+- Design comment posted to issue 264 before the first code commit.
+- Playbook entry added to `.claude/rules/frontend-design.md` — "derive
+  the invalid-field message/marker from existing validation state,
+  don't add a new useState" gotcha.
+- Local gates: `pnpm typecheck`, `pnpm lint` clean; web unit 433/433 (54
+  files); API unit 579/579 (36 files); API integration 491/491 (67
+  files, after `db:migrate` — no new migration this time); e2e 45/45
+  (54.6s→55.7s, `theme-colors.spec.ts` now includes the invalid-hex
+  check).
+- No PR/merge/deploy in this dispatch — supervisor owns CI/PR/merge/deploy
+  for this follow-up per the dispatch's HARD CONSTRAINT.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.153",
+  "version": "0.3.0-dev.154",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Čo to robí

Dopĺňa poslednú chýbajúcu vec z nastavovania farieb: keď do políčka s kódom farby napíšeš nezmysel, appka to **povie po slovensky**.

Doteraz sa len ticho zablokovalo tlačidlo **Uložiť** — nič sa nepokazilo, ale nedalo sa zistiť prečo a ktoré z tých šiestich políčok je zle vyplnené.

Odteraz:

- v okne sa objaví hláška **„Kód farby musí byť v tvare #RRGGBB (napr. #D14D3B).“**
- **chybné políčko sa označí** červeným rámikom a podfarbením, takže hneď vidieť, ktoré to je
- hláška aj označenie zmiznú samé, len čo je hodnota v poriadku
- **Uložiť** ostáva zablokované, kým je čokoľvek zle — uloženie je aj naďalej všetko-alebo-nič

## Ako to funguje

Stav „ktoré políčka sú neplatné“ sa odvodzuje z rozpísaných hodnôt pri každom prekreslení — rovnako ako doterajšie „dá sa uložiť“ a „je zmenené“. Žiadny nový stav navyše, takže sa to nemá ako rozísť s realitou.

## Overenie

- `pnpm typecheck`, `pnpm lint` — čisté
- web unit 433/433, api unit 579/579, api integračné 491/491, e2e 45/45 (test na hlášku aj na jej zmiznutie)

issue 264
