### PR TITLE
Eshop → Upozornenia: nástenka vecí na vybavenie (issue 267)

### DIFF
--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -228,3 +228,10 @@ paths:
   vždy `pnpm --filter @forestshop/api db:migrate` proti tej istej
   `DATABASE_URL` — a ak sa nejaký zápis "úspešne" prejde, ale zodpovedajúci
   SELECT ukáže menej riadkov, než očakávaš, over NAJPRV toto, nie logiku.
+- **Čiastočný unique index (`uniqueIndex(...).on(...).where(sql\`...\`)`,
+  drizzle-orm `^0.38.x`) je vzor pre "dedup KÝM je riadok v danom stave,
+  ale ďalší výskyt PO tom stave je legitímny nový riadok"** — plný
+  (nepodmienený) unique index by druhý výskyt po prvom vyriešení odmietol
+  ako duplicitu. Prvý reálny prípad + plné odôvodnenie: issue 267's
+  `upozornenie_dedup_key_uq` (`.claude/rules/upozornenia.md`), nájdené
+  integračným testom PRED mergom, nie odhadom.

--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -864,3 +864,21 @@ paths:
   disabled" miesto v appke: dá sa dôvod odvodiť z toho, čo už komponent
   počíta? Ak áno, pridaj hlášku + `aria-invalid` ako odvodenú hodnotu, nie
   nový stav.
+- **Tento projekt NEMÁ `eslint-plugin-react-hooks` nakonfigurovaný** — písanie
+  `// eslint-disable-next-line react-hooks/exhaustive-deps` (bežný vzor v
+  iných React projektoch) tu NEZTLMÍ nič, naopak SPADNE s "Definition for
+  rule 'react-hooks/exhaustive-deps' was not found" (issue 267, nájdené
+  `pnpm lint`om pred pushom). Dôsledok je vážnejší než len chybný komentár:
+  **bez tohto pluginu ESLint nikdy neupozorní na neúplné dependency pole
+  `useCallback`/`useEffect`**, takže stale-closure bug (funkcia zachytí
+  STARÚ hodnotu premennej z prvého renderu, lebo chýba v `[]` poli) treba
+  nájsť RUČNÝM code review, nie spoľahnutím sa na lint. Presne toto sa stalo
+  v `UpozorneniaSection.tsx`'s `withBusy` — `useCallback((key, action) =>
+  {...action().then(load)...}, [])` s PRÁZDNYM poľom navždy zamrazil `load`
+  z PRVÉHO renderu, takže po prepnutí filtra "aj vybavené" (ktoré mení
+  `load`'s identitu cez jeho vlastný `useCallback([includeResolved, ...])`)
+  by `withBusy` po akcii refetchol so STARÝM filtrom. Fix: `load` patrí do
+  `withBusy`'s dependency poľa (`[load]`), presne ako susedný `saveDraft`
+  už mal správne. Test na KAŽDÝ ĎALŠÍ `useCallback`/`useEffect` v tomto
+  repe: manuálne prejsť, či telo číta niečo, čo NIE JE v dependency poli —
+  lint to tu NIKDY nezachytí.

--- a/.claude/rules/upozornenia.md
+++ b/.claude/rules/upozornenia.md
@@ -1,0 +1,56 @@
+---
+paths:
+  - "apps/api/src/modules/upozornenia/**"
+  - "apps/api/src/http/upozornenia-routes.ts"
+  - "apps/api/src/db/schema-upozornenia.ts"
+  - "apps/web/src/upozorneniaApi.ts"
+  - "apps/web/src/components/Upozornenia*.tsx"
+  - "apps/web/tests/e2e/upozornenia.spec.ts"
+---
+
+# Upozornenia (issue 267)
+
+- **`upsertUpozornenie()` (`modules/upozornenia/service.ts`) je JEDINÁ
+  zapisovacia cesta pre NOVÉ upozornenie** — presne rovnaký princíp ako
+  `.claude/rules/mail-log.md`'s "jediná odosielacia cesta". Budúci
+  automatický zdroj (#268 nevyzdvihnutá zásielka, #269 vrátenie) volá TÚTO
+  funkciu s vlastným `dedupKey`, nikdy vlastný `db.insert(upozornenie)`.
+- **`upozornenie_dedup_key_uq` je ČIASTOČNÝ unique index
+  (`WHERE resolved_at IS NULL`), nie plný.** Nájdené integračným testom PRED
+  mergom (nie odhadom): bez `.where()` druhý výskyt toho istého `dedupKey`
+  PO vyriešení prvého (napr. zásielka sa znova vyzdvihne a znova zastaví o
+  mesiac neskôr) narazí na unique-violation namiesto vloženia nového riadku
+  — `upsertUpozornenie`'s zámerné správanie je totiž "vyriešený riadok sa
+  NIKDY neobnovuje, ďalší výskyt dostane VLASTNÝ nový riadok". Drizzle-orm
+  (`^0.38.x`) podporuje toto cez `uniqueIndex(...).on(...).where(sql\`...\`)`
+  — každý ĎALŠÍ dedup stĺpec s "kým je nevyriešené" semantikou potrebuje ten
+  istý čiastočný index, nie obyčajný `uniqueIndex`.
+- **Stav (nové/otvorené/odložené/vybavené) sa NEUKLADÁ — počíta sa vždy z
+  troch nullable timestampov** (`seenAt`/`postponedUntil`/`resolvedAt`,
+  `modules/upozornenia/status.ts`'s `computeStatus`). Zámerné: odložená
+  karta sa má "v ten deň vrátiť späť" bez akejkoľvek novej naplánovanej
+  úlohy (ticket to explicitne zakazuje) — počítaný stav je vždy správny pri
+  čítaní, žiadny cron, čo ho má o polnoci preklopiť.
+- **Odznak v ľavom menu (`countActionableUpozornenia`) MUSÍ použiť rovnaký
+  predikát ako predvolený filter zoznamu** (`isActionableNow` — nevyriešené
+  A práve NEODLOŽENÉ) — inak číslo v menu a to, čo appka ukáže pri otvorení
+  záložky, nesedia. Pri ĎALŠOM filtri/odznaku v tomto module over, že obe
+  strany čítajú z TEJ ISTEJ funkcie, nikdy dve nezávislé JS podmienky.
+- **Odznak počtu (na rozdiel od "Na objednanie"'s `OrdersRemainingCountContext`,
+  issue 147) sa číta PRIAMO v `App.tsx`** (`fetchUpozorneniaCount`, rovnaký
+  vzor ako `automationStatus`/`fetchPostaUncollectedStatus`) — číslo musí
+  byť známe HNEĎ po prihlásení, nie až po prvom otvorení záložky (na rozdiel
+  od "Na objednanie", kde ho publikuje samotná obrazovka cez context).
+- **Otvorenie záložky = "prečítané" (hromadné `POST
+  /api/upozornenia/mark-seen`), nie per-kartové tlačidlo.**
+  `UpozorneniaSection.tsx` volá mark-seen a AŽ POTOM `load()` — cez
+  `mountedRef` guard (rovnaký vzor ako issue 251's StrictMode-bezpečný
+  "mountedRef nastavený v tele efektu", `.claude/rules/frontend-design.md`),
+  aby sa mark-seen spustil PRESNE RAZ za mount, nikdy znova pri zmene
+  filtra "aj vybavené" (ten len refetchne `load()` bez mark-seen).
+- **`updateOwnNote`/`deleteOwnNote` server-side vynucujú `source ===
+  "vlastne"`** — karta zo zdroja "appka" nemá tlačidlá Upraviť/Zmazať vôbec
+  vo frontende, ale to nestačí (rovnaká past ako `.claude/rules/
+  nedostupne.md`'s povinný náhľad — front-end skrytie nie je vynútenie).
+  Server vráti `updated`/`removed: false` namiesto chyby pri pokuse o cudziu
+  kartu.

--- a/.claude/rules/upozornenia.md
+++ b/.claude/rules/upozornenia.md
@@ -32,10 +32,15 @@ paths:
   úlohy (ticket to explicitne zakazuje) — počítaný stav je vždy správny pri
   čítaní, žiadny cron, čo ho má o polnoci preklopiť.
 - **Odznak v ľavom menu (`countActionableUpozornenia`) MUSÍ použiť rovnaký
-  predikát ako predvolený filter zoznamu** (`isActionableNow` — nevyriešené
-  A práve NEODLOŽENÉ) — inak číslo v menu a to, čo appka ukáže pri otvorení
-  záložky, nesedia. Pri ĎALŠOM filtri/odznaku v tomto module over, že obe
-  strany čítajú z TEJ ISTEJ funkcie, nikdy dve nezávislé JS podmienky.
+  predikát ako predvolený filter zoznamu** (nevyriešené A práve
+  NEODLOŽENÉ) — inak číslo v menu a to, čo appka ukáže pri otvorení
+  záložky, nesedia. Code review pred mergom (pôvodná verzia natiahla VŠETKY
+  riadky do JS a filtrovala cez samostatnú `isActionableNow` funkciu — druhá,
+  nezávisle udržiavaná implementácia tej istej podmienky, navyše zbytočný
+  celý-tabuľkový sken): oprava je zdieľaná `notPostponedCondition(now)`
+  (`queries.ts`), ktorú POUŽÍVA AJ `listUpozornenia`'s `WHERE`, AJ
+  `countActionableUpozornenia`'s `COUNT(*) WHERE` — nikdy dve nezávislé
+  implementácie tej istej podmienky (JS aj SQL), vždy JEDNA zdieľaná.
 - **Odznak počtu (na rozdiel od "Na objednanie"'s `OrdersRemainingCountContext`,
   issue 147) sa číta PRIAMO v `App.tsx`** (`fetchUpozorneniaCount`, rovnaký
   vzor ako `automationStatus`/`fetchPostaUncollectedStatus`) — číslo musí

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,3 +103,4 @@ Per-area rules live in `.claude/rules/<area>.md` with `paths:` frontmatter.
 - Kniha odoslaných e-mailov (F193 — jediná odosielacia cesta, dedup okno preskočení) → `.claude/rules/mail-log.md`
 - Párovanie produktov (#239 — samostatná od `pairing`, zdieľaný upsert s #121, live-overenie bez AI-dohady) → `.claude/rules/product-links.md`
 - Eshop → Vyhľadať (#240 — dve oddelené polia produkty/objednávky, detail produktu, zdieľaná zapisovacia cesta s #239) → `.claude/rules/search.md`
+- Eshop → Upozornenia (#267 — nástenka, čiastočný unique dedup index, počítaný stav bez cron-u, zdieľaná zapisovacia cesta pre budúce #268/#269) → `.claude/rules/upozornenia.md`

--- a/apps/api/drizzle/0036_brief_miss_america.sql
+++ b/apps/api/drizzle/0036_brief_miss_america.sql
@@ -1,0 +1,23 @@
+CREATE TYPE "public"."upozornenie_source" AS ENUM('vlastne', 'appka');--> statement-breakpoint
+CREATE TYPE "public"."upozornenie_type" AS ENUM('vlastna_poznamka');--> statement-breakpoint
+CREATE TABLE "upozornenie" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"type" "upozornenie_type" NOT NULL,
+	"source" "upozornenie_source" NOT NULL,
+	"title" text NOT NULL,
+	"details" text DEFAULT '' NOT NULL,
+	"link" text,
+	"dedup_key" text,
+	"due_at" timestamp with time zone,
+	"postponed_until" timestamp with time zone,
+	"seen_at" timestamp with time zone,
+	"resolved_at" timestamp with time zone,
+	"resolved_by_user_id" uuid,
+	"created_by_user_id" uuid,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "upozornenie" ADD CONSTRAINT "upozornenie_resolved_by_user_id_users_id_fk" FOREIGN KEY ("resolved_by_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "upozornenie" ADD CONSTRAINT "upozornenie_created_by_user_id_users_id_fk" FOREIGN KEY ("created_by_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "upozornenie_dedup_key_uq" ON "upozornenie" USING btree ("dedup_key") WHERE resolved_at IS NULL;--> statement-breakpoint
+CREATE INDEX "upozornenie_resolved_at_idx" ON "upozornenie" USING btree ("resolved_at");

--- a/apps/api/drizzle/meta/0036_snapshot.json
+++ b/apps/api/drizzle/meta/0036_snapshot.json
@@ -1,0 +1,2779 @@
+{
+  "id": "05ef0045-7a82-4c64-8a18-2229d805d222",
+  "prevId": "20565cd7-e053-4206-853a-6ed9224925bc",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_code": {
+          "name": "external_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_open_status": {
+      "name": "order_open_status",
+      "schema": "",
+      "columns": {
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Vybavuje sa'"
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop_remark": {
+          "name": "shop_remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shoptet_order_id": {
+          "name": "shoptet_order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_updated_at": {
+          "name": "comment_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_synced_at": {
+          "name": "comment_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_carrier_name": {
+          "name": "shipping_carrier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_price_with_vat": {
+          "name": "total_price_with_vat",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_link_override": {
+      "name": "product_supplier_link_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_link_override_product_key_product_key_fk": {
+          "name": "product_supplier_link_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_link_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_override": {
+      "name": "product_supplier_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_override_product_key_product_key_fk": {
+          "name": "product_supplier_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing": {
+      "name": "pairing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_url": {
+          "name": "supplier_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "pairing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'navrhnute'"
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pairing_state_idx": {
+          "name": "pairing_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_confirmed_by_idx": {
+          "name": "pairing_confirmed_by_idx",
+          "columns": [
+            {
+              "expression": "confirmed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_variant_code_variant_code_fk": {
+          "name": "pairing_variant_code_variant_code_fk",
+          "tableFrom": "pairing",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pairing_confirmed_by_users_id_fk": {
+          "name": "pairing_confirmed_by_users_id_fk",
+          "tableFrom": "pairing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pairing_variant_code_unique": {
+          "name": "pairing_variant_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pairing_confirmation_ck": {
+          "name": "pairing_confirmation_ck",
+          "value": "(\"pairing\".\"state\" = 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)\n        OR (\"pairing\".\"state\" != 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NULL AND \"pairing\".\"confirmed_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier": {
+      "name": "supplier",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wholesale_base_url": {
+          "name": "wholesale_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_key": {
+          "name": "adapter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_settings": {
+      "name": "posta_uncollected_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_state": {
+      "name": "posta_uncollected_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notify_count": {
+          "name": "notify_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_state": {
+          "name": "terminal_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_settings": {
+      "name": "order_reminder_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_state": {
+      "name": "order_reminder_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_replacement_link": {
+      "name": "nedostupne_replacement_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nedostupne_replacement_link_variant_idx": {
+          "name": "nedostupne_replacement_link_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_state": {
+      "name": "nedostupne_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "nedostupne_email_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nedostupne_state_order_variant_type_uq": {
+          "name": "nedostupne_state_order_variant_type_uq",
+          "columns": [
+            {
+              "expression": "order_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template_history": {
+      "name": "mail_template_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "mail_template_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_template_history_key_idx": {
+          "name": "mail_template_history_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_template_history_changed_by_user_id_users_id_fk": {
+          "name": "mail_template_history_changed_by_user_id_users_id_fk",
+          "tableFrom": "mail_template_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template": {
+      "name": "mail_template",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail_template_updated_by_user_id_users_id_fk": {
+          "name": "mail_template_updated_by_user_id_users_id_fk",
+          "tableFrom": "mail_template",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_log": {
+      "name": "mail_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "mail_log_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_log_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "mail_log_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_log_created_idx": {
+          "name": "mail_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_log_source_created_idx": {
+          "name": "mail_log_source_created_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_log_actor_user_id_users_id_fk": {
+          "name": "mail_log_actor_user_id_users_id_fk",
+          "tableFrom": "mail_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_stock": {
+      "name": "supplier_stock",
+      "schema": "",
+      "columns": {
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "supplier_availability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "supplier_stock_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "supplier_stock_host_idx": {
+          "name": "supplier_stock_host_idx",
+          "columns": [
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "supplier_stock_avail_idx": {
+          "name": "supplier_stock_avail_idx",
+          "columns": [
+            {
+              "expression": "availability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "supplier_stock_link_size_label_pk": {
+          "name": "supplier_stock_link_size_label_pk",
+          "columns": [
+            "link",
+            "size_label"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_event": {
+      "name": "restock_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_link": {
+          "name": "supplier_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_availability_text": {
+          "name": "supplier_availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "supplier_price": {
+          "name": "supplier_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "restock_event_at_idx": {
+          "name": "restock_event_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "restock_event_variant_idx": {
+          "name": "restock_event_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_settings": {
+      "name": "restock_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shop_product_url": {
+      "name": "shop_product_url",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.theme_color": {
+      "name": "theme_color",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "theme_color_updated_by_user_id_users_id_fk": {
+          "name": "theme_color_updated_by_user_id_users_id_fk",
+          "tableFrom": "theme_color",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upozornenie": {
+      "name": "upozornenie",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "upozornenie_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "upozornenie_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedup_key": {
+          "name": "dedup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postponed_until": {
+          "name": "postponed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seen_at": {
+          "name": "seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "upozornenie_dedup_key_uq": {
+          "name": "upozornenie_dedup_key_uq",
+          "columns": [
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "resolved_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upozornenie_resolved_at_idx": {
+          "name": "upozornenie_resolved_at_idx",
+          "columns": [
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upozornenie_resolved_by_user_id_users_id_fk": {
+          "name": "upozornenie_resolved_by_user_id_users_id_fk",
+          "tableFrom": "upozornenie",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "upozornenie_created_by_user_id_users_id_fk": {
+          "name": "upozornenie_created_by_user_id_users_id_fk",
+          "tableFrom": "upozornenie",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne"
+      ]
+    },
+    "public.pairing_state": {
+      "name": "pairing_state",
+      "schema": "public",
+      "values": [
+        "navrhnute",
+        "potvrdene"
+      ]
+    },
+    "public.nedostupne_email_type": {
+      "name": "nedostupne_email_type",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "alternativa"
+      ]
+    },
+    "public.mail_template_action": {
+      "name": "mail_template_action",
+      "schema": "public",
+      "values": [
+        "save",
+        "reset"
+      ]
+    },
+    "public.mail_log_source": {
+      "name": "mail_log_source",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "posta_uncollected",
+        "order_reminder",
+        "supplier_order",
+        "order_merge"
+      ]
+    },
+    "public.mail_log_status": {
+      "name": "mail_log_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.mail_log_trigger": {
+      "name": "mail_log_trigger",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "manual"
+      ]
+    },
+    "public.supplier_availability": {
+      "name": "supplier_availability",
+      "schema": "public",
+      "values": [
+        "available",
+        "unavailable",
+        "unknown"
+      ]
+    },
+    "public.supplier_stock_source": {
+      "name": "supplier_stock_source",
+      "schema": "public",
+      "values": [
+        "json_ld",
+        "meta",
+        "text",
+        "size_list",
+        "none"
+      ]
+    },
+    "public.upozornenie_source": {
+      "name": "upozornenie_source",
+      "schema": "public",
+      "values": [
+        "vlastne",
+        "appka"
+      ]
+    },
+    "public.upozornenie_type": {
+      "name": "upozornenie_type",
+      "schema": "public",
+      "values": [
+        "vlastna_poznamka"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1785935677728,
       "tag": "0035_sturdy_darkstar",
       "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "7",
+      "when": 1785941945412,
+      "tag": "0036_brief_miss_america",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema-upozornenia.ts
+++ b/apps/api/src/db/schema-upozornenia.ts
@@ -1,0 +1,59 @@
+import { sql } from "drizzle-orm";
+import { index, pgEnum, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { users } from "./schema-users.js";
+
+// issue 267: "Upozornenia" — jedna nástenka vecí, ktoré majiteľ musí vybaviť.
+// `type` je OTVORENÝ zoznam — dnes len `vlastna_poznamka` (majiteľove vlastné
+// poznámky, súčasť TOHTO ticketu); budúce automatické zdroje (#268
+// nevyzdvihnutá zásielka, #269 vrátenie) pridajú SVOJU hodnotu vlastnou
+// migráciou (`ALTER TYPE ... ADD VALUE`, rovnaký vzor ako
+// `nedostupneEmailType`/`.claude/rules/testing.md`'s "Nová pgEnum hodnota"
+// past). `source` je NEZÁVISLÝ, navždy 2-hodnotový enum — určuje UI schopnosť
+// (len `vlastne` karty majú Upraviť/Zmazať), `type` je len farebný štítok.
+export const upozornenieType = pgEnum("upozornenie_type", ["vlastna_poznamka"]);
+export const upozornenieSource = pgEnum("upozornenie_source", ["vlastne", "appka"]);
+
+export const upozornenie = pgTable(
+  "upozornenie",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    type: upozornenieType("type").notNull(),
+    source: upozornenieSource("source").notNull(),
+    title: text("title").notNull(),
+    details: text("details").notNull().default(""),
+    // Odkaz priamo na miesto v appke, ktorého sa karta týka (napr.
+    // "?tab=orders") — `null` pre vlastné poznámky, ktoré na nič neodkazujú.
+    link: text("link"),
+    // Dedup kľúč pre AUTOMATICKÉ zdroje (napr. "posta:EF123456789SK") —
+    // VLASTNÉ poznámky ho nikdy nenesú (ostáva null). Postgres unique index
+    // dovoľuje ľubovoľne veľa NULL hodnôt bez kolízie (rovnaká disciplína ako
+    // `nedostupne_state`'s plain-text dedup stĺpce), takže vlastné poznámky
+    // si navzájom nekolidujú.
+    dedupKey: text("dedup_key"),
+    // "Vybaviť do" — nepovinný dátum, ktorý majiteľ zadá pri vlastnej
+    // poznámke (alebo ho prinesie automatický zdroj).
+    dueAt: timestamp("due_at", { withTimezone: true }),
+    // Kým je v budúcnosti, karta zmizne zo zoznamu aj z odznaku (`status.ts`).
+    postponedUntil: timestamp("postponed_until", { withTimezone: true }),
+    // `null` = ešte nevidené ("Nové"). Nastavuje sa hromadne pri OTVORENÍ
+    // záložky (`POST /api/upozornenia/mark-seen`), nie per-karta kliknutím.
+    seenAt: timestamp("seen_at", { withTimezone: true }),
+    resolvedAt: timestamp("resolved_at", { withTimezone: true }),
+    // `null` pri vyplnenom `resolvedAt` bude neskôr znamenať "vybavené
+    // systémom" (budúci auto-close #268/#269) — dnes ho vypĺňa vždy človek.
+    resolvedByUserId: uuid("resolved_by_user_id").references(() => users.id, { onDelete: "set null" }),
+    createdByUserId: uuid("created_by_user_id").references(() => users.id, { onDelete: "set null" }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    // ČIASTOČNÝ unique index — platí len KÝM je riadok nevyriešený
+    // (`resolved_at IS NULL`). Bez `.where()` by druhý výskyt toho istého
+    // `dedupKey` PO vyriešení prvého (napr. zásielka sa znova vyzdvihne a
+    // znova zastaví o mesiac neskôr) narazil na unique-violation namiesto
+    // vloženia nového riadku (`upsertUpozornenie`'s zámerné správanie —
+    // vyriešený riadok sa NIKDY neobnovuje, dostane VLASTNÝ nový). Nájdené
+    // integračným testom PRED mergom, nie odhadom.
+    uniqueIndex("upozornenie_dedup_key_uq").on(t.dedupKey).where(sql`resolved_at IS NULL`),
+    index("upozornenie_resolved_at_idx").on(t.resolvedAt),
+  ],
+);

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -12,3 +12,4 @@ export * from "./schema-supplier-stock.js";
 export * from "./schema-restock.js";
 export * from "./schema-shop-feed.js";
 export * from "./schema-theme-colors.js";
+export * from "./schema-upozornenia.js";

--- a/apps/api/src/http/app.ts
+++ b/apps/api/src/http/app.ts
@@ -31,6 +31,7 @@ import { shoptetImportConfigFromBaseUrl } from "../modules/shoptet-writeback/con
 import { registerSchedulerRoutes } from "./scheduler-routes.js";
 import { registerSupplierRoutes } from "./supplier-routes.js";
 import { registerThemeColorRoutes } from "./theme-color-routes.js";
+import { registerUpozorneniaRoutes } from "./upozornenia-routes.js";
 
 const loginSchema = z.object({
   email: z.string().email(),
@@ -285,6 +286,12 @@ export function createApp(
       config: shoptetImportConfigFromBaseUrl(options.adminBaseUrl ?? "https://www.forestshop.sk", "", ""),
     },
   );
+
+  // issue 267: "Eshop → Upozornenia" — nástenka + vlastné poznámky + zdieľaná
+  // zapisovacia cesta, ktorú neskôr zavolajú #268/#269. Žiadny voliteľný
+  // dependency (na rozdiel od nedostupne/orderReminder vyššie) — táto
+  // obrazovka neposiela mail ani nekontaktuje tretiu stranu.
+  registerUpozorneniaRoutes(app, db);
 
   // Musí byť registrovaný AŽ PO všetkých skutočných /api/* trasách vyššie — Hono
   // vyberá presnejšiu zhodu, takže tie majú prednosť a sem sa dostane len to, čo

--- a/apps/api/src/http/upozornenia-routes.ts
+++ b/apps/api/src/http/upozornenia-routes.ts
@@ -1,0 +1,145 @@
+import { zValidator } from "@hono/zod-validator";
+import type { Hono } from "hono";
+import { z } from "zod";
+import type { Database } from "../db/client.js";
+import { record } from "../modules/audit/service.js";
+import { countActionableUpozornenia, listUpozornenia, type UpozornenieTypeValue } from "../modules/upozornenia/queries.js";
+import {
+  createOwnNote,
+  deleteOwnNote,
+  markAllSeen,
+  postponeUpozornenie,
+  resolveUpozornenie,
+  updateOwnNote,
+} from "../modules/upozornenia/service.js";
+import { requireRole, requireUser, type AppBindings } from "./middleware.js";
+import { requireSameOrigin } from "./origin-check.js";
+
+// issue 267: dnes existuje jediná hodnota (`upozornenie_type` pgEnum má LEN
+// `vlastna_poznamka`) — `.claude/rules/testing.md`'s "Nová pgEnum hodnota"
+// past platí aj tu, preto validácia typu ide cez `z.enum` s POLOM hodnôt,
+// nie natvrdo jedným literálom, aby budúci #268/#269 pridali svoju hodnotu
+// LEN sem + do enumu, nikde inde.
+const KNOWN_TYPES: readonly [UpozornenieTypeValue, ...UpozornenieTypeValue[]] = ["vlastna_poznamka"];
+
+const listQuery = z.object({
+  type: z.enum(KNOWN_TYPES).optional(),
+  includeResolved: z.enum(["true", "false"]).optional(),
+});
+
+const createBody = z.object({
+  title: z.string().trim().min(1).max(200),
+  details: z.string().trim().max(2000).optional(),
+  dueAt: z.coerce.date().nullable().optional(),
+});
+
+const updateBody = createBody;
+
+const idParam = z.object({ id: z.string().uuid() });
+
+const postponeBody = z.object({ until: z.coerce.date() });
+
+export function registerUpozorneniaRoutes(app: Hono<AppBindings>, db: Database): void {
+  // Čítanie — každý prihlásený zamestnanec (rovnaká úroveň ako
+  // #172/#173/#176 — `.claude/rules/nedostupne.md`).
+  app.get("/api/upozornenia", requireUser(db), zValidator("query", listQuery), async (c) => {
+    const { type, includeResolved } = c.req.valid("query");
+    const rows = await listUpozornenia(db, { ...(type === undefined ? {} : { type }), includeResolved: includeResolved === "true" }, new Date());
+    return c.json({ rows });
+  });
+
+  // Literal-path súrodenec MUSÍ byť pred akoukoľvek budúcou `/api/upozornenia/:id`
+  // trasou rovnakej metódy (`.claude/rules/http-routes.md`) — dnes žiadna GET
+  // `:id` trasa neexistuje, ale poradie sa drží ako zvyk, nie náhodou.
+  app.get("/api/upozornenia/count", requireUser(db), async (c) => {
+    const count = await countActionableUpozornenia(db, new Date());
+    return c.json({ count });
+  });
+
+  // Vytvorenie vlastnej poznámky — rovnaká rola ako zvyšok appky pre zápis.
+  app.post("/api/upozornenia", requireSameOrigin(), requireUser(db), requireRole("admin", "manazer"), zValidator("json", createBody), async (c) => {
+    const body = c.req.valid("json");
+    const user = c.get("user");
+    const now = new Date();
+    const created = await createOwnNote(db, {
+      title: body.title,
+      details: body.details ?? "",
+      dueAt: body.dueAt ?? null,
+      createdByUserId: user.userId,
+      now,
+    });
+    await record(db, { at: now, actorUserId: user.userId, action: "upozornenie.created", entity: "upozornenie", entityId: created.id, data: { title: body.title } });
+    return c.json({ ok: true as const, id: created.id });
+  });
+
+  // Hromadné označenie "videné" — volané pri OTVORENÍ záložky, nie per-karta
+  // kliknutím (`.claude/rules/…` návrhový komentár na tickete). Čítacia
+  // úroveň oprávnenia — nie je to zápis obsahu ani vyriešenie, len sledovanie
+  // toho, čo obsluha už videla.
+  app.post("/api/upozornenia/mark-seen", requireSameOrigin(), requireUser(db), async (c) => {
+    const count = await markAllSeen(db, new Date());
+    return c.json({ ok: true as const, marked: count });
+  });
+
+  app.patch(
+    "/api/upozornenia/:id",
+    requireSameOrigin(),
+    requireUser(db),
+    requireRole("admin", "manazer"),
+    zValidator("param", idParam),
+    zValidator("json", updateBody),
+    async (c) => {
+      const { id } = c.req.valid("param");
+      const body = c.req.valid("json");
+      const user = c.get("user");
+      const updated = await updateOwnNote(db, { id, title: body.title, details: body.details ?? "", dueAt: body.dueAt ?? null });
+      if (updated) {
+        await record(db, { at: new Date(), actorUserId: user.userId, action: "upozornenie.updated", entity: "upozornenie", entityId: id, data: { title: body.title } });
+      }
+      return c.json({ ok: true as const, updated });
+    },
+  );
+
+  // Zmazanie — rovnaká disciplína ako `nedostupne-routes.ts`'s odkazy: neznáme/
+  // už zmazané id (dvojklik) je NEŠKODNÉ, vždy 200, nikdy 4xx.
+  app.delete("/api/upozornenia/:id", requireSameOrigin(), requireUser(db), requireRole("admin", "manazer"), zValidator("param", idParam), async (c) => {
+    const { id } = c.req.valid("param");
+    const user = c.get("user");
+    const removed = await deleteOwnNote(db, id);
+    if (removed) {
+      await record(db, { at: new Date(), actorUserId: user.userId, action: "upozornenie.deleted", entity: "upozornenie", entityId: id, data: { id } });
+    }
+    return c.json({ ok: true as const, removed });
+  });
+
+  app.post("/api/upozornenia/:id/resolve", requireSameOrigin(), requireUser(db), requireRole("admin", "manazer"), zValidator("param", idParam), async (c) => {
+    const { id } = c.req.valid("param");
+    const user = c.get("user");
+    const now = new Date();
+    const resolved = await resolveUpozornenie(db, { id, resolvedByUserId: user.userId, now });
+    if (resolved) {
+      await record(db, { at: now, actorUserId: user.userId, action: "upozornenie.resolved", entity: "upozornenie", entityId: id, data: { id } });
+    }
+    return c.json({ ok: true as const, resolved });
+  });
+
+  app.post(
+    "/api/upozornenia/:id/postpone",
+    requireSameOrigin(),
+    requireUser(db),
+    requireRole("admin", "manazer"),
+    zValidator("param", idParam),
+    zValidator("json", postponeBody),
+    async (c) => {
+      const { id } = c.req.valid("param");
+      const { until } = c.req.valid("json");
+      const user = c.get("user");
+      const now = new Date();
+      const postponed = await postponeUpozornenie(db, { id, postponedUntil: until, now });
+      if (postponed) {
+        await record(db, { at: now, actorUserId: user.userId, action: "upozornenie.postponed", entity: "upozornenie", entityId: id, data: { until: until.toISOString() } });
+      }
+      return c.json({ ok: true as const, postponed });
+    },
+  );
+}

--- a/apps/api/src/modules/upozornenia/queries.ts
+++ b/apps/api/src/modules/upozornenia/queries.ts
@@ -1,0 +1,60 @@
+import { and, asc, desc, eq, isNull, lte, or } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { upozornenie, type upozornenieType } from "../../db/schema.js";
+import { computeStatus, isActionableNow, type UpozornenieStatus } from "./status.js";
+
+export type UpozornenieTypeValue = (typeof upozornenieType.enumValues)[number];
+export type UpozornenieSourceValue = "vlastne" | "appka";
+
+export interface UpozornenieRow {
+  readonly id: string;
+  readonly type: UpozornenieTypeValue;
+  readonly source: UpozornenieSourceValue;
+  readonly title: string;
+  readonly details: string;
+  readonly link: string | null;
+  readonly dueAt: Date | null;
+  readonly postponedUntil: Date | null;
+  readonly seenAt: Date | null;
+  readonly resolvedAt: Date | null;
+  readonly createdAt: Date;
+  readonly status: UpozornenieStatus;
+}
+
+export interface UpozornenieFilter {
+  readonly type?: UpozornenieTypeValue;
+  readonly includeResolved: boolean;
+}
+
+// Odložené karty ZOSTÁVAJÚ skryté, kým sa nevrátia — bez ohľadu na filter
+// "aj vybavené" (ticket: "zmizne zo zoznamu a v ten deň sa vráti späť", žiadny
+// spôsob si ich pozrieť skôr). Zoradenie: najbližší termín ("vybaviť do")
+// prvý, karty bez termínu naposledy, v rámci toho najnovšie vytvorené prvé.
+// Filter beží PRIAMO v SQL (nie JS `.filter()` po natiahnutí všetkého) —
+// `type` má dnes jedinú možnú hodnotu, takže porovnanie v JS by eslintu
+// vyzeralo ako vždy-pravdivé (`@typescript-eslint/no-unnecessary-condition`);
+// SQL porovnanie tento problém nemá a je to aj správne miesto na filter.
+export async function listUpozornenia(db: Database, filter: UpozornenieFilter, now: Date): Promise<readonly UpozornenieRow[]> {
+  const notPostponed = or(isNull(upozornenie.postponedUntil), lte(upozornenie.postponedUntil, now));
+  const conditions = [
+    notPostponed,
+    ...(filter.type === undefined ? [] : [eq(upozornenie.type, filter.type)]),
+    ...(filter.includeResolved ? [] : [isNull(upozornenie.resolvedAt)]),
+  ];
+
+  const rows = await db
+    .select()
+    .from(upozornenie)
+    .where(and(...conditions))
+    .orderBy(asc(upozornenie.dueAt), desc(upozornenie.createdAt));
+
+  return rows.map((r) => ({ ...r, status: computeStatus(r, now) }));
+}
+
+// Odznak v ľavom menu — rovnaký predikát, aký rozhoduje predvolený filter
+// "len nevybavené" (návrhový komentár na tickete: číslo v menu MUSÍ
+// zodpovedať tomu, čo appka ukáže pri otvorení záložky).
+export async function countActionableUpozornenia(db: Database, now: Date): Promise<number> {
+  const rows = await db.select({ seenAt: upozornenie.seenAt, postponedUntil: upozornenie.postponedUntil, resolvedAt: upozornenie.resolvedAt }).from(upozornenie);
+  return rows.filter((r) => isActionableNow(r, now)).length;
+}

--- a/apps/api/src/modules/upozornenia/queries.ts
+++ b/apps/api/src/modules/upozornenia/queries.ts
@@ -1,7 +1,7 @@
-import { and, asc, desc, eq, isNull, lte, or } from "drizzle-orm";
+import { and, asc, count, desc, eq, isNull, lte, or, type SQL } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
 import { upozornenie, type upozornenieType } from "../../db/schema.js";
-import { computeStatus, isActionableNow, type UpozornenieStatus } from "./status.js";
+import { computeStatus, type UpozornenieStatus } from "./status.js";
 
 export type UpozornenieTypeValue = (typeof upozornenieType.enumValues)[number];
 export type UpozornenieSourceValue = "vlastne" | "appka";
@@ -28,16 +28,23 @@ export interface UpozornenieFilter {
 
 // Odložené karty ZOSTÁVAJÚ skryté, kým sa nevrátia — bez ohľadu na filter
 // "aj vybavené" (ticket: "zmizne zo zoznamu a v ten deň sa vráti späť", žiadny
-// spôsob si ich pozrieť skôr). Zoradenie: najbližší termín ("vybaviť do")
-// prvý, karty bez termínu naposledy, v rámci toho najnovšie vytvorené prvé.
+// spôsob si ich pozrieť skôr). Zdieľané so `countActionableUpozornenia`
+// nižšie (code review na PR pred mergom: dve nezávislé implementácie tej
+// istej podmienky driftujú) — JEDNA funkcia rozhoduje "nie je práve
+// odložené" pre OBOCH volajúcich.
+function notPostponedCondition(now: Date): SQL {
+  return or(isNull(upozornenie.postponedUntil), lte(upozornenie.postponedUntil, now)) as SQL;
+}
+
 // Filter beží PRIAMO v SQL (nie JS `.filter()` po natiahnutí všetkého) —
 // `type` má dnes jedinú možnú hodnotu, takže porovnanie v JS by eslintu
 // vyzeralo ako vždy-pravdivé (`@typescript-eslint/no-unnecessary-condition`);
 // SQL porovnanie tento problém nemá a je to aj správne miesto na filter.
+// Zoradenie: najbližší termín ("vybaviť do") prvý, karty bez termínu
+// naposledy, v rámci toho najnovšie vytvorené prvé.
 export async function listUpozornenia(db: Database, filter: UpozornenieFilter, now: Date): Promise<readonly UpozornenieRow[]> {
-  const notPostponed = or(isNull(upozornenie.postponedUntil), lte(upozornenie.postponedUntil, now));
   const conditions = [
-    notPostponed,
+    notPostponedCondition(now),
     ...(filter.type === undefined ? [] : [eq(upozornenie.type, filter.type)]),
     ...(filter.includeResolved ? [] : [isNull(upozornenie.resolvedAt)]),
   ];
@@ -53,8 +60,16 @@ export async function listUpozornenia(db: Database, filter: UpozornenieFilter, n
 
 // Odznak v ľavom menu — rovnaký predikát, aký rozhoduje predvolený filter
 // "len nevybavené" (návrhový komentár na tickete: číslo v menu MUSÍ
-// zodpovedať tomu, čo appka ukáže pri otvorení záložky).
+// zodpovedať tomu, čo appka ukáže pri otvorení záložky). Code review pred
+// mergom: pôvodná verzia natiahla VŠETKY riadky do JS a filtrovala cez
+// `isActionableNow` — funkčne zhodné, ale druhá, nezávisle udržiavaná
+// implementácia TEJ ISTEJ podmienky (driftové riziko) a zbytočný celý-
+// tabuľkový sken. `COUNT(*) WHERE resolved_at IS NULL AND <notPostponed>`
+// zdieľa `notPostponedCondition` s `listUpozornenia` vyššie.
 export async function countActionableUpozornenia(db: Database, now: Date): Promise<number> {
-  const rows = await db.select({ seenAt: upozornenie.seenAt, postponedUntil: upozornenie.postponedUntil, resolvedAt: upozornenie.resolvedAt }).from(upozornenie);
-  return rows.filter((r) => isActionableNow(r, now)).length;
+  const [row] = await db
+    .select({ total: count() })
+    .from(upozornenie)
+    .where(and(isNull(upozornenie.resolvedAt), notPostponedCondition(now)));
+  return row?.total ?? 0;
 }

--- a/apps/api/src/modules/upozornenia/service.ts
+++ b/apps/api/src/modules/upozornenia/service.ts
@@ -1,0 +1,176 @@
+import { and, eq, isNull } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { upozornenie } from "../../db/schema.js";
+import type { UpozornenieSourceValue, UpozornenieTypeValue } from "./queries.js";
+
+// `Pick<Database, ...>` (rovnaký dôvod ako `audit/service.ts`'s
+// `AuditExecutor`) — budúci automatický zdroj (#268/#269) môže chcieť volať
+// `upsertUpozornenie` VNÚTRI vlastnej transakcie (napr. spolu so zápisom
+// stavu sledovania zásielky), takže táto funkcia musí prijať aj `tx`, nie
+// len top-level `db`.
+export type UpozornenieExecutor = Pick<Database, "insert" | "select" | "update">;
+
+export interface UpsertUpozornenieInput {
+  readonly type: UpozornenieTypeValue;
+  readonly source: UpozornenieSourceValue;
+  readonly title: string;
+  readonly details?: string;
+  readonly link?: string | null;
+  // Dedup kľúč pre automatické zdroje — VLASTNÉ poznámky ho NIKDY nenesú
+  // (musí ostať `undefined`/`null`, inak by dva vlastné záznamy s tým istým
+  // kľúčom kolidovali na unique indexe, čo pre `source: "vlastne"` nemá
+  // zmysel).
+  readonly dedupKey?: string | null;
+  readonly dueAt?: Date | null;
+  readonly createdByUserId?: string | null;
+  readonly now: Date;
+}
+
+export interface UpozornenieWriteResult {
+  readonly id: string;
+}
+
+// JEDINÁ zapisovacia cesta pre NOVÉ upozornenie — každý budúci automatický
+// zdroj (#268/#269) volá TÚTO funkciu, nikdy vlastný insert (rovnaký princíp
+// ako `.claude/rules/mail-log.md`'s "jediná odosielacia cesta"). Keď
+// `dedupKey` je zadaný a existuje preň ešte NEVYRIEŠENÝ riadok, ten sa len
+// OBNOVÍ (nadpis/podrobnosti/odkaz/termín) — riadok ostáva JEDEN, presne ako
+// ticket žiada ("keď nočná úloha zbehne desiatykrát, upozornenie ostane
+// JEDNO, len sa obnoví"). `postponedUntil`/`seenAt` sa pri obnove NEDOTÝKAJÚ
+// — majiteľovo rozhodnutie odložiť kartu prežije obnovu z toho istého zdroja.
+export async function upsertUpozornenie(db: UpozornenieExecutor, input: UpsertUpozornenieInput): Promise<UpozornenieWriteResult> {
+  const dedupKey = input.dedupKey ?? null;
+  if (dedupKey !== null) {
+    const [existing] = await db
+      .select({ id: upozornenie.id, resolvedAt: upozornenie.resolvedAt })
+      .from(upozornenie)
+      .where(eq(upozornenie.dedupKey, dedupKey))
+      .limit(1);
+    if (existing !== undefined && existing.resolvedAt === null) {
+      await db
+        .update(upozornenie)
+        .set({
+          title: input.title,
+          details: input.details ?? "",
+          link: input.link ?? null,
+          dueAt: input.dueAt ?? null,
+        })
+        .where(eq(upozornenie.id, existing.id));
+      return { id: existing.id };
+    }
+  }
+  const [inserted] = await db
+    .insert(upozornenie)
+    .values({
+      type: input.type,
+      source: input.source,
+      title: input.title,
+      details: input.details ?? "",
+      link: input.link ?? null,
+      dedupKey,
+      dueAt: input.dueAt ?? null,
+      createdByUserId: input.createdByUserId ?? null,
+      createdAt: input.now,
+    })
+    .returning({ id: upozornenie.id });
+  // `.insert().returning()` always yields exactly one row for a single
+  // `.values()` object — non-null assertion would be the alternative, but an
+  // explicit throw documents the invariant instead of silently trusting it.
+  if (inserted === undefined) throw new Error("Vloženie upozornenia zlyhalo bez chyby");
+  return { id: inserted.id };
+}
+
+export interface CreateOwnNoteInput {
+  readonly title: string;
+  readonly details?: string;
+  readonly dueAt?: Date | null;
+  readonly createdByUserId: string;
+  readonly now: Date;
+}
+
+export async function createOwnNote(db: UpozornenieExecutor, input: CreateOwnNoteInput): Promise<UpozornenieWriteResult> {
+  return upsertUpozornenie(db, {
+    type: "vlastna_poznamka",
+    source: "vlastne",
+    title: input.title,
+    details: input.details ?? "",
+    dueAt: input.dueAt ?? null,
+    createdByUserId: input.createdByUserId,
+    now: input.now,
+  });
+}
+
+export interface UpdateOwnNoteInput {
+  readonly id: string;
+  readonly title: string;
+  readonly details?: string;
+  readonly dueAt?: Date | null;
+}
+
+// Vlastnú poznámku smie upraviť/zmazať len ak `source === "vlastne"` — karta
+// zo zdroja "appka" nemá tlačidlá Upraviť/Zmazať vôbec (server to vynucuje
+// nezávisle od frontendu, presne rovnaká disciplína ako `requireRole` pri
+// iných zápisoch v tejto appke).
+export async function updateOwnNote(db: UpozornenieExecutor, input: UpdateOwnNoteInput): Promise<boolean> {
+  const result = await db
+    .update(upozornenie)
+    .set({ title: input.title, details: input.details ?? "", dueAt: input.dueAt ?? null })
+    .where(and(eq(upozornenie.id, input.id), eq(upozornenie.source, "vlastne")))
+    .returning({ id: upozornenie.id });
+  return result.length > 0;
+}
+
+export async function deleteOwnNote(db: Database, id: string): Promise<boolean> {
+  const result = await db
+    .delete(upozornenie)
+    .where(and(eq(upozornenie.id, id), eq(upozornenie.source, "vlastne")))
+    .returning({ id: upozornenie.id });
+  return result.length > 0;
+}
+
+export interface ResolveInput {
+  readonly id: string;
+  readonly resolvedByUserId: string;
+  readonly now: Date;
+}
+
+// Vyriešenie si "vidí" kartu zároveň (`seenAt`, ak ešte nebola) — obsluha,
+// ktorá klikla "Vybavené", kartu tým pádom videla, aj keby predtým bola ešte
+// "Nové" (COALESCE zachová PÔVODNÝ čas videnia, ak už existoval).
+export async function resolveUpozornenie(db: Database, input: ResolveInput): Promise<boolean> {
+  const [row] = await db.select({ seenAt: upozornenie.seenAt }).from(upozornenie).where(eq(upozornenie.id, input.id)).limit(1);
+  if (row === undefined) return false;
+  const result = await db
+    .update(upozornenie)
+    .set({ resolvedAt: input.now, resolvedByUserId: input.resolvedByUserId, seenAt: row.seenAt ?? input.now })
+    .where(eq(upozornenie.id, input.id))
+    .returning({ id: upozornenie.id });
+  return result.length > 0;
+}
+
+export interface PostponeInput {
+  readonly id: string;
+  readonly postponedUntil: Date;
+  readonly now: Date;
+}
+
+export async function postponeUpozornenie(db: Database, input: PostponeInput): Promise<boolean> {
+  const [row] = await db.select({ seenAt: upozornenie.seenAt }).from(upozornenie).where(eq(upozornenie.id, input.id)).limit(1);
+  if (row === undefined) return false;
+  const result = await db
+    .update(upozornenie)
+    .set({ postponedUntil: input.postponedUntil, seenAt: row.seenAt ?? input.now })
+    .where(eq(upozornenie.id, input.id))
+    .returning({ id: upozornenie.id });
+  return result.length > 0;
+}
+
+// Volané pri OTVORENÍ záložky — hromadne označí VŠETKY práve "Nové" karty
+// ako videné naraz (inbox vzor "otvoriť = prečítané"), žiadne per-kartové
+// tlačidlo "videné" navyše. Zámerne LEN `seenAt IS NULL` (nikdy nerieši
+// odložené/vyriešené karty — tie svoj `seenAt` už majú z okamihu prvej akcie
+// nad nimi, viď `resolveUpozornenie`/`postponeUpozornenie` vyššie).
+export async function markAllSeen(db: Database, now: Date): Promise<number> {
+  const result = await db.update(upozornenie).set({ seenAt: now }).where(isNull(upozornenie.seenAt)).returning({ id: upozornenie.id });
+  return result.length;
+}

--- a/apps/api/src/modules/upozornenia/status.test.ts
+++ b/apps/api/src/modules/upozornenia/status.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { computeStatus, isActionableNow } from "./status.js";
+import { computeStatus } from "./status.js";
 
 const NOW = new Date("2026-08-05T08:00:00Z");
 
@@ -32,22 +32,5 @@ describe("computeStatus", () => {
 
   it("presne v momente návratu (postponedUntil === now) sa už vracia — hranica patrí NÁVRATU, nie odloženiu", () => {
     expect(computeStatus({ seenAt: NOW, postponedUntil: NOW, resolvedAt: null }, NOW)).toBe("otvorene");
-  });
-});
-
-describe("isActionableNow", () => {
-  it("nové aj otvorené sú akčné", () => {
-    expect(isActionableNow({ seenAt: null, postponedUntil: null, resolvedAt: null }, NOW)).toBe(true);
-    expect(isActionableNow({ seenAt: NOW, postponedUntil: null, resolvedAt: null }, NOW)).toBe(true);
-  });
-
-  it("odložené (do budúcnosti) NIE JE akčné — zmizne z odznaku, kým sa nevráti", () => {
-    expect(
-      isActionableNow({ seenAt: NOW, postponedUntil: new Date("2099-01-01T00:00:00Z"), resolvedAt: null }, NOW),
-    ).toBe(false);
-  });
-
-  it("vybavené NIE JE akčné", () => {
-    expect(isActionableNow({ seenAt: NOW, postponedUntil: null, resolvedAt: NOW }, NOW)).toBe(false);
   });
 });

--- a/apps/api/src/modules/upozornenia/status.test.ts
+++ b/apps/api/src/modules/upozornenia/status.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { computeStatus, isActionableNow } from "./status.js";
+
+const NOW = new Date("2026-08-05T08:00:00Z");
+
+describe("computeStatus", () => {
+  it("vybavené má prednosť pred všetkým ostatným", () => {
+    expect(
+      computeStatus({ seenAt: null, postponedUntil: new Date("2099-01-01T00:00:00Z"), resolvedAt: NOW }, NOW),
+    ).toBe("vybavene");
+  });
+
+  it("odložené do BUDÚCNOSTI je 'odlozene', aj keď je nevidené", () => {
+    expect(
+      computeStatus({ seenAt: null, postponedUntil: new Date("2026-08-10T00:00:00Z"), resolvedAt: null }, NOW),
+    ).toBe("odlozene");
+  });
+
+  it("odložené do MINULOSTI (dátum návratu prešiel) sa už NEPOČÍTA ako odložené", () => {
+    expect(
+      computeStatus({ seenAt: NOW, postponedUntil: new Date("2026-08-01T00:00:00Z"), resolvedAt: null }, NOW),
+    ).toBe("otvorene");
+  });
+
+  it("nevidené bez odloženia je 'nove'", () => {
+    expect(computeStatus({ seenAt: null, postponedUntil: null, resolvedAt: null }, NOW)).toBe("nove");
+  });
+
+  it("videné, nevyriešené, neodložené je 'otvorene'", () => {
+    expect(computeStatus({ seenAt: NOW, postponedUntil: null, resolvedAt: null }, NOW)).toBe("otvorene");
+  });
+
+  it("presne v momente návratu (postponedUntil === now) sa už vracia — hranica patrí NÁVRATU, nie odloženiu", () => {
+    expect(computeStatus({ seenAt: NOW, postponedUntil: NOW, resolvedAt: null }, NOW)).toBe("otvorene");
+  });
+});
+
+describe("isActionableNow", () => {
+  it("nové aj otvorené sú akčné", () => {
+    expect(isActionableNow({ seenAt: null, postponedUntil: null, resolvedAt: null }, NOW)).toBe(true);
+    expect(isActionableNow({ seenAt: NOW, postponedUntil: null, resolvedAt: null }, NOW)).toBe(true);
+  });
+
+  it("odložené (do budúcnosti) NIE JE akčné — zmizne z odznaku, kým sa nevráti", () => {
+    expect(
+      isActionableNow({ seenAt: NOW, postponedUntil: new Date("2099-01-01T00:00:00Z"), resolvedAt: null }, NOW),
+    ).toBe(false);
+  });
+
+  it("vybavené NIE JE akčné", () => {
+    expect(isActionableNow({ seenAt: NOW, postponedUntil: null, resolvedAt: NOW }, NOW)).toBe(false);
+  });
+});

--- a/apps/api/src/modules/upozornenia/status.ts
+++ b/apps/api/src/modules/upozornenia/status.ts
@@ -14,13 +14,18 @@ export interface UpozornenieStatusInput {
   readonly resolvedAt: Date | null;
 }
 
-// [red] issue 267: zámerne nehotový stub — implementácia prichádza v
-// nasledujúcom [green] commite, tento len dokazuje, že `status.test.ts`
-// naozaj zlyhá bez skutočnej logiky.
-export function computeStatus(_row: UpozornenieStatusInput, _now: Date): UpozornenieStatus {
-  return "nove";
+export function computeStatus(row: UpozornenieStatusInput, now: Date): UpozornenieStatus {
+  if (row.resolvedAt !== null) return "vybavene";
+  if (row.postponedUntil !== null && row.postponedUntil.getTime() > now.getTime()) return "odlozene";
+  if (row.seenAt === null) return "nove";
+  return "otvorene";
 }
 
-export function isActionableNow(_row: UpozornenieStatusInput, _now: Date): boolean {
-  return false;
+// Odznak v ľavom menu aj predvolený filter "len nevybavené" ukazujú TO ISTÉ
+// číslo (návrhové rozhodnutie na tickete): nevyriešené A práve NEODLOŽENÉ.
+// Odložená karta sa do tohto počtu vráti sama v deň návratu (computeStatus
+// vyššie), bez zásahu.
+export function isActionableNow(row: UpozornenieStatusInput, now: Date): boolean {
+  const status = computeStatus(row, now);
+  return status === "nove" || status === "otvorene";
 }

--- a/apps/api/src/modules/upozornenia/status.ts
+++ b/apps/api/src/modules/upozornenia/status.ts
@@ -20,12 +20,3 @@ export function computeStatus(row: UpozornenieStatusInput, now: Date): Upozornen
   if (row.seenAt === null) return "nove";
   return "otvorene";
 }
-
-// Odznak v ľavom menu aj predvolený filter "len nevybavené" ukazujú TO ISTÉ
-// číslo (návrhové rozhodnutie na tickete): nevyriešené A práve NEODLOŽENÉ.
-// Odložená karta sa do tohto počtu vráti sama v deň návratu (computeStatus
-// vyššie), bez zásahu.
-export function isActionableNow(row: UpozornenieStatusInput, now: Date): boolean {
-  const status = computeStatus(row, now);
-  return status === "nove" || status === "otvorene";
-}

--- a/apps/api/src/modules/upozornenia/status.ts
+++ b/apps/api/src/modules/upozornenia/status.ts
@@ -1,0 +1,26 @@
+// issue 267: "Upozornenia" — stav karty (Nové/Otvorené/Odložené/Vybavené)
+// sa NEUKLADÁ ako vlastný stĺpec, počíta sa vždy nanovo z troch nullable
+// timestampov. Dôvod (viď návrhový komentár na tickete): odložená karta sa
+// má "v ten deň vrátiť späť" bez akejkoľvek novej naplánovanej úlohy — ticket
+// to explicitne zakazuje ("Žiadna nová naplánovaná úloha"). Uložený stavový
+// stĺpec by potreboval cron, čo ho o polnoci preklopí; počítaný stav je
+// vždy správny pri čítaní, bez bežiaceho procesu.
+
+export type UpozornenieStatus = "nove" | "otvorene" | "odlozene" | "vybavene";
+
+export interface UpozornenieStatusInput {
+  readonly seenAt: Date | null;
+  readonly postponedUntil: Date | null;
+  readonly resolvedAt: Date | null;
+}
+
+// [red] issue 267: zámerne nehotový stub — implementácia prichádza v
+// nasledujúcom [green] commite, tento len dokazuje, že `status.test.ts`
+// naozaj zlyhá bez skutočnej logiky.
+export function computeStatus(_row: UpozornenieStatusInput, _now: Date): UpozornenieStatus {
+  return "nove";
+}
+
+export function isActionableNow(_row: UpozornenieStatusInput, _now: Date): boolean {
+  return false;
+}

--- a/apps/api/tests/upozornenia-http.integration.test.ts
+++ b/apps/api/tests/upozornenia-http.integration.test.ts
@@ -79,6 +79,21 @@ describe("GET /api/upozornenia/count", () => {
     const body = (await res.json()) as { count: number };
     expect(body.count).toBe(1);
   });
+
+  // Code review: len postponed-vylúčenie bolo overené vyššie — pridané aj
+  // pre resolved (rovnaká zdieľaná SQL podmienka `notPostponedCondition` +
+  // `isNull(resolvedAt)` v `queries.ts`, obe strany testu patria k sebe).
+  it("vyriešená karta sa do počtu nezapočítava", async () => {
+    const { app, cookie, db } = await boot("manazer");
+    const now = new Date("2026-08-05T08:00:00Z");
+    await upsertUpozornenie(db, { type: "vlastna_poznamka", source: "vlastne", title: "Aktívna", now });
+    const resolvedCreate = await upsertUpozornenie(db, { type: "vlastna_poznamka", source: "vlastne", title: "Vyriešená", now });
+    await app.request(`/api/upozornenia/${resolvedCreate.id}/resolve`, { method: "POST", headers: { cookie } });
+
+    const res = await app.request("/api/upozornenia/count", { headers: { cookie } });
+    const body = (await res.json()) as { count: number };
+    expect(body.count).toBe(1);
+  });
 });
 
 describe("POST /api/upozornenia (vlastná poznámka)", () => {

--- a/apps/api/tests/upozornenia-http.integration.test.ts
+++ b/apps/api/tests/upozornenia-http.integration.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { users } from "../src/db/schema.js";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import type { UserRole } from "../src/modules/auth/service.js";
+import { upsertUpozornenie } from "../src/modules/upozornenia/service.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 267: HTTP vrstva pre "Eshop → Upozornenia".
+const HESLO = "test-heslo-abc";
+
+let close: (() => Promise<void>) | undefined;
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  resetLoginRateLimit();
+});
+
+async function boot(role: UserRole) {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await ctx.db.insert(users).values({ email: "pouzivatel@forestshop.sk", passwordHash: await hashPassword(HESLO), displayName: "Test", role });
+  const app = createApp(ctx.db, { cookieSecure: false });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "pouzivatel@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie, db: ctx.db };
+}
+
+describe("GET /api/upozornenia", () => {
+  it("čítanie funguje pre KAŽDÚ prihlásenú rolu (aj len-na-čítanie)", async () => {
+    const { app, cookie } = await boot("citanie");
+    const res = await app.request("/api/upozornenia", { headers: { cookie } });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { rows: readonly unknown[] };
+    expect(body.rows).toEqual([]);
+  });
+
+  it("bez prihlásenia vráti 401", async () => {
+    const { app } = await boot("manazer");
+    const res = await app.request("/api/upozornenia");
+    expect(res.status).toBe(401);
+  });
+
+  it("predvolený filter vynechá vyriešené a odložené karty, 'aj vybavené' ich vráti", async () => {
+    const { app, cookie, db } = await boot("manazer");
+    const now = new Date("2026-08-05T08:00:00Z");
+    await upsertUpozornenie(db, { type: "vlastna_poznamka", source: "vlastne", title: "Aktívna", now });
+    const resolvedCreate = await upsertUpozornenie(db, { type: "vlastna_poznamka", source: "vlastne", title: "Vyriešená", now });
+    await app.request(`/api/upozornenia/${resolvedCreate.id}/resolve`, { method: "POST", headers: { cookie } });
+
+    const defaultRes = await app.request("/api/upozornenia", { headers: { cookie } });
+    const defaultBody = (await defaultRes.json()) as { rows: readonly { title: string }[] };
+    expect(defaultBody.rows.map((r) => r.title)).toEqual(["Aktívna"]);
+
+    const allRes = await app.request("/api/upozornenia?includeResolved=true", { headers: { cookie } });
+    const allBody = (await allRes.json()) as { rows: readonly { title: string }[] };
+    expect(allBody.rows.map((r) => r.title).sort()).toEqual(["Aktívna", "Vyriešená"]);
+  });
+});
+
+describe("GET /api/upozornenia/count", () => {
+  it("počíta len akčné (nevybavené a neodložené) karty", async () => {
+    const { app, cookie, db } = await boot("manazer");
+    const now = new Date("2026-08-05T08:00:00Z");
+    await upsertUpozornenie(db, { type: "vlastna_poznamka", source: "vlastne", title: "Aktívna", now });
+    const postponedCreate = await upsertUpozornenie(db, { type: "vlastna_poznamka", source: "vlastne", title: "Odložená", now });
+    await app.request(`/api/upozornenia/${postponedCreate.id}/postpone`, {
+      method: "POST",
+      headers: { cookie, "content-type": "application/json" },
+      body: JSON.stringify({ until: "2099-01-01T00:00:00.000Z" }),
+    });
+
+    const res = await app.request("/api/upozornenia/count", { headers: { cookie } });
+    const body = (await res.json()) as { count: number };
+    expect(body.count).toBe(1);
+  });
+});
+
+describe("POST /api/upozornenia (vlastná poznámka)", () => {
+  it("rola 'citanie' NEMÔŽE vytvoriť poznámku (403)", async () => {
+    const { app, cookie } = await boot("citanie");
+    const res = await app.request("/api/upozornenia", {
+      method: "POST",
+      headers: { cookie, "content-type": "application/json" },
+      body: JSON.stringify({ title: "Pokus" }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("rola 'manazer' vytvorí poznámku a vidí ju v zozname", async () => {
+    const { app, cookie } = await boot("manazer");
+    const create = await app.request("/api/upozornenia", {
+      method: "POST",
+      headers: { cookie, "content-type": "application/json" },
+      body: JSON.stringify({ title: "Schôdzka v stredu", details: "o 10:00" }),
+    });
+    expect(create.status).toBe(200);
+    const created = (await create.json()) as { ok: boolean; id: string };
+    expect(created.ok).toBe(true);
+
+    const list = await app.request("/api/upozornenia", { headers: { cookie } });
+    const body = (await list.json()) as { rows: readonly { id: string; title: string; details: string; status: string }[] };
+    expect(body.rows).toHaveLength(1);
+    expect(body.rows[0]?.id).toBe(created.id);
+    expect(body.rows[0]?.details).toBe("o 10:00");
+    // Ešte nebola videná (žiadne otvorenie záložky/`mark-seen`).
+    expect(body.rows[0]?.status).toBe("nove");
+  });
+
+  it("prázdny nadpis je odmietnutý (400)", async () => {
+    const { app, cookie } = await boot("manazer");
+    const res = await app.request("/api/upozornenia", {
+      method: "POST",
+      headers: { cookie, "content-type": "application/json" },
+      body: JSON.stringify({ title: "" }),
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /api/upozornenia/mark-seen", () => {
+  it("po zavolaní sa nevidená karta stane 'otvorene'", async () => {
+    const { app, cookie, db } = await boot("manazer");
+    const now = new Date("2026-08-05T08:00:00Z");
+    await upsertUpozornenie(db, { type: "vlastna_poznamka", source: "vlastne", title: "Nová", now });
+
+    const seenRes = await app.request("/api/upozornenia/mark-seen", { method: "POST", headers: { cookie } });
+    const seenBody = (await seenRes.json()) as { ok: boolean; marked: number };
+    expect(seenBody.marked).toBe(1);
+
+    const list = await app.request("/api/upozornenia", { headers: { cookie } });
+    const body = (await list.json()) as { rows: readonly { status: string }[] };
+    expect(body.rows[0]?.status).toBe("otvorene");
+  });
+});
+
+describe("PATCH/DELETE /api/upozornenia/:id", () => {
+  it("upraví vlastnú poznámku", async () => {
+    const { app, cookie } = await boot("manazer");
+    const create = await app.request("/api/upozornenia", {
+      method: "POST",
+      headers: { cookie, "content-type": "application/json" },
+      body: JSON.stringify({ title: "Pôvodná" }),
+    });
+    const { id } = (await create.json()) as { id: string };
+    const patch = await app.request(`/api/upozornenia/${id}`, {
+      method: "PATCH",
+      headers: { cookie, "content-type": "application/json" },
+      body: JSON.stringify({ title: "Upravená" }),
+    });
+    expect((await patch.json()) as { ok: boolean; updated: boolean }).toEqual({ ok: true, updated: true });
+
+    const list = await app.request("/api/upozornenia", { headers: { cookie } });
+    const body = (await list.json()) as { rows: readonly { title: string }[] };
+    expect(body.rows[0]?.title).toBe("Upravená");
+  });
+
+  it("zmazanie neznámeho id vráti 200 {removed:false}, nikdy chybu", async () => {
+    const { app, cookie } = await boot("manazer");
+    const res = await app.request("/api/upozornenia/00000000-0000-0000-0000-000000000000", { method: "DELETE", headers: { cookie } });
+    expect(res.status).toBe(200);
+    expect((await res.json()) as { ok: boolean; removed: boolean }).toEqual({ ok: true, removed: false });
+  });
+});

--- a/apps/api/tests/upozornenia-service.integration.test.ts
+++ b/apps/api/tests/upozornenia-service.integration.test.ts
@@ -1,0 +1,175 @@
+import { eq } from "drizzle-orm";
+import { afterEach, describe, expect, it } from "vitest";
+import { upozornenie, users } from "../src/db/schema.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import {
+  createOwnNote,
+  deleteOwnNote,
+  markAllSeen,
+  postponeUpozornenie,
+  resolveUpozornenie,
+  updateOwnNote,
+  upsertUpozornenie,
+} from "../src/modules/upozornenia/service.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 267: "Upozornenia" — service-level testy (bez HTTP vrstvy) pre
+// zdieľanú zapisovaciu cestu (`upsertUpozornenie`) a per-kartové akcie.
+
+let close: (() => Promise<void>) | undefined;
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+});
+
+async function bootDb() {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const [user] = await ctx.db
+    .insert(users)
+    .values({ email: "majitel@forestshop.sk", passwordHash: await hashPassword("test-heslo-abc"), displayName: "Majiteľ", role: "manazer" })
+    .returning({ id: users.id });
+  if (user === undefined) throw new Error("test používateľ sa nepodarilo vložiť");
+  return { db: ctx.db, userId: user.id };
+}
+
+describe("upsertUpozornenie", () => {
+  it("bez dedupKey vždy VLOŽÍ nový riadok (vlastné poznámky nikdy nekolidujú)", async () => {
+    const { db, userId } = await bootDb();
+    const now = new Date("2026-08-05T08:00:00Z");
+    const a = await createOwnNote(db, { title: "Schôdzka v stredu", createdByUserId: userId, now });
+    const b = await createOwnNote(db, { title: "Vybaviť poistku", createdByUserId: userId, now });
+    expect(a.id).not.toBe(b.id);
+    const rows = await db.select().from(upozornenie);
+    expect(rows).toHaveLength(2);
+  });
+
+  it("s rovnakým dedupKey OBNOVÍ existujúci nevyriešený riadok namiesto duplicity", async () => {
+    const { db } = await bootDb();
+    const now = new Date("2026-08-05T08:00:00Z");
+    const first = await upsertUpozornenie(db, {
+      type: "vlastna_poznamka",
+      source: "appka",
+      title: "Zásielka čaká na pošte — 3 dni",
+      dedupKey: "posta:EF123456789SK",
+      now,
+    });
+    const later = new Date("2026-08-06T08:00:00Z");
+    const second = await upsertUpozornenie(db, {
+      type: "vlastna_poznamka",
+      source: "appka",
+      title: "Zásielka čaká na pošte — 4 dni",
+      dedupKey: "posta:EF123456789SK",
+      now: later,
+    });
+    expect(second.id).toBe(first.id);
+    const rows = await db.select().from(upozornenie);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.title).toBe("Zásielka čaká na pošte — 4 dni");
+    // Pôvodný `createdAt` sa NEMENÍ pri obnove (len UPDATE polí, nie nový insert).
+    expect(rows[0]?.createdAt.toISOString()).toBe(now.toISOString());
+  });
+
+  it("s rovnakým dedupKey, ale existujúci riadok je UŽ VYRIEŠENÝ, vloží NOVÝ riadok (nezruší vyriešenie starého)", async () => {
+    const { db, userId } = await bootDb();
+    const now = new Date("2026-08-05T08:00:00Z");
+    const first = await upsertUpozornenie(db, { type: "vlastna_poznamka", source: "appka", title: "Prvá vlna", dedupKey: "posta:X", now });
+    await resolveUpozornenie(db, { id: first.id, resolvedByUserId: userId, now });
+    const second = await upsertUpozornenie(db, { type: "vlastna_poznamka", source: "appka", title: "Nová vlna", dedupKey: "posta:X", now });
+    expect(second.id).not.toBe(first.id);
+    const rows = await db.select().from(upozornenie);
+    expect(rows).toHaveLength(2);
+  });
+
+  it("obnova NEPRESUNIE odloženie ani stav videnia nastavené majiteľom", async () => {
+    const { db } = await bootDb();
+    const now = new Date("2026-08-05T08:00:00Z");
+    const created = await upsertUpozornenie(db, { type: "vlastna_poznamka", source: "appka", title: "Pôvodný text", dedupKey: "posta:Y", now });
+    await postponeUpozornenie(db, { id: created.id, postponedUntil: new Date("2026-08-20T00:00:00Z"), now });
+    await upsertUpozornenie(db, { type: "vlastna_poznamka", source: "appka", title: "Obnovený text", dedupKey: "posta:Y", now });
+    const [row] = await db.select().from(upozornenie);
+    expect(row?.title).toBe("Obnovený text");
+    expect(row?.postponedUntil?.toISOString()).toBe("2026-08-20T00:00:00.000Z");
+  });
+});
+
+describe("updateOwnNote / deleteOwnNote — len zdroj 'vlastne'", () => {
+  it("upraví vlastnú poznámku", async () => {
+    const { db, userId } = await bootDb();
+    const now = new Date("2026-08-05T08:00:00Z");
+    const created = await createOwnNote(db, { title: "Pôvodný nadpis", createdByUserId: userId, now });
+    const updated = await updateOwnNote(db, { id: created.id, title: "Nový nadpis", details: "detaily" });
+    expect(updated).toBe(true);
+    const [row] = await db.select().from(upozornenie);
+    expect(row?.title).toBe("Nový nadpis");
+    expect(row?.details).toBe("detaily");
+  });
+
+  it("NEUPRAVÍ kartu zo zdroja 'appka' (server-side vynútenie, nie len UI)", async () => {
+    const { db } = await bootDb();
+    const now = new Date("2026-08-05T08:00:00Z");
+    const created = await upsertUpozornenie(db, { type: "vlastna_poznamka", source: "appka", title: "Automatická karta", dedupKey: "posta:Z", now });
+    const updated = await updateOwnNote(db, { id: created.id, title: "Pokus o úpravu" });
+    expect(updated).toBe(false);
+    const [row] = await db.select().from(upozornenie);
+    expect(row?.title).toBe("Automatická karta");
+  });
+
+  it("zmaže vlastnú poznámku, ale NIE kartu zo zdroja 'appka'", async () => {
+    const { db, userId } = await bootDb();
+    const now = new Date("2026-08-05T08:00:00Z");
+    const own = await createOwnNote(db, { title: "Zmazať ma", createdByUserId: userId, now });
+    const appka = await upsertUpozornenie(db, { type: "vlastna_poznamka", source: "appka", title: "Nezmazať", dedupKey: "posta:W", now });
+    expect(await deleteOwnNote(db, own.id)).toBe(true);
+    expect(await deleteOwnNote(db, appka.id)).toBe(false);
+    const rows = await db.select().from(upozornenie);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.title).toBe("Nezmazať");
+  });
+
+  it("zmazanie neznámeho/už zmazaného id je neškodné (vracia false, nikdy nevyhodí)", async () => {
+    const { db } = await bootDb();
+    expect(await deleteOwnNote(db, "00000000-0000-0000-0000-000000000000")).toBe(false);
+  });
+});
+
+describe("resolveUpozornenie / postponeUpozornenie", () => {
+  it("vyriešenie NIKDY predtým nevidenej karty ju zároveň označí ako videnú", async () => {
+    const { db, userId } = await bootDb();
+    const now = new Date("2026-08-05T08:00:00Z");
+    const created = await createOwnNote(db, { title: "Nikdy nevidená", createdByUserId: userId, now });
+    await resolveUpozornenie(db, { id: created.id, resolvedByUserId: userId, now });
+    const [row] = await db.select().from(upozornenie);
+    expect(row?.resolvedAt?.toISOString()).toBe(now.toISOString());
+    expect(row?.seenAt?.toISOString()).toBe(now.toISOString());
+  });
+
+  it("odloženie posunie 'vybaviť do' návratu a tiež kartu označí ako videnú", async () => {
+    const { db, userId } = await bootDb();
+    const now = new Date("2026-08-05T08:00:00Z");
+    const created = await createOwnNote(db, { title: "Odložiť ma", createdByUserId: userId, now });
+    const until = new Date("2026-08-12T00:00:00Z");
+    expect(await postponeUpozornenie(db, { id: created.id, postponedUntil: until, now })).toBe(true);
+    const [row] = await db.select().from(upozornenie);
+    expect(row?.postponedUntil?.toISOString()).toBe(until.toISOString());
+    expect(row?.seenAt).not.toBeNull();
+  });
+});
+
+describe("markAllSeen", () => {
+  it("označí VŠETKY nevidené karty naraz, nedotkne sa už videných", async () => {
+    const { db, userId } = await bootDb();
+    const now = new Date("2026-08-05T08:00:00Z");
+    const a = await createOwnNote(db, { title: "A", createdByUserId: userId, now });
+    const b = await createOwnNote(db, { title: "B", createdByUserId: userId, now });
+    // "B" je už videná skôr (napr. z predošlého otvorenia záložky).
+    await db.update(upozornenie).set({ seenAt: new Date("2026-08-04T00:00:00Z") }).where(eq(upozornenie.id, b.id));
+    const marked = await markAllSeen(db, now);
+    expect(marked).toBe(1);
+    const rows = await db.select().from(upozornenie).orderBy(upozornenie.title);
+    const aRow = rows.find((r) => r.id === a.id);
+    const bRow = rows.find((r) => r.id === b.id);
+    expect(aRow?.seenAt?.toISOString()).toBe(now.toISOString());
+    expect(bRow?.seenAt?.toISOString()).toBe("2026-08-04T00:00:00.000Z");
+  });
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -11,6 +11,7 @@ import { fetchOrderReminderStatus } from "./orderReminderApi.js";
 import { OrdersRemainingCountContext } from "./ordersRemainingCountContext.js";
 import { fetchPostaUncollectedStatus } from "./postaUncollectedApi.js";
 import { fetchThemeColors } from "./themeColorsApi.js";
+import { fetchUpozorneniaCount } from "./upozorneniaApi.js";
 
 // Prvá záložka z URL-u (`?tab=<id>`), keď existuje a je platná — inak
 // predvolená ("Sync zo Shoptetu"). Umožňuje priamy odkaz aj na SKRYTÉ
@@ -40,10 +41,34 @@ export function App(): JSX.Element {
     () => ({ count: ordersRemainingCount, setCount: setOrdersRemainingCount }),
     [ordersRemainingCount],
   );
-  const badgeCounts = useMemo<Readonly<Record<string, number>>>(
-    () => (ordersRemainingCount !== null ? { orders: ordersRemainingCount } : {}),
-    [ordersRemainingCount],
-  );
+  // issue 267: odznak "Upozornenia" — na rozdiel od `ordersRemainingCount`
+  // vyššie (publikované OBRAZOVKOU cez context, teda známe až po jej prvom
+  // zmountovaní) musí byť toto číslo známe HNEĎ po prihlásení, ešte pred
+  // prvým otvorením záložky — preto ide rovnakým priamym vzorom ako
+  // `automationStatus` nižšie (App.tsx si volá `fetch*` sám), nie cez
+  // context.
+  const [upozorneniaCount, setUpozorneniaCount] = useState<number | null>(null);
+  useEffect(() => {
+    if (me === null) return;
+    let cancelled = false;
+    fetchUpozorneniaCount()
+      .then((count) => {
+        if (!cancelled) setUpozorneniaCount(count);
+      })
+      .catch(() => {
+        // Sieťový výpadok — odznak zostane na poslednej známej hodnote.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [me, activeTabId]);
+
+  const badgeCounts = useMemo<Readonly<Record<string, number>>>(() => {
+    const counts: Record<string, number> = {};
+    if (ordersRemainingCount !== null) counts["orders"] = ordersRemainingCount;
+    if (upozorneniaCount !== null) counts["upozornenia"] = upozorneniaCount;
+    return counts;
+  }, [ordersRemainingCount, upozorneniaCount]);
 
   // issue 185: stav zapnuté/vypnuté pre "Automatizácie" priečinok v menu.
   // Na rozdiel od `ordersRemainingCount` vyššie (publikované OBRAZOVKOU

--- a/apps/web/src/components/UpozorneniaSection.test.tsx
+++ b/apps/web/src/components/UpozorneniaSection.test.tsx
@@ -1,0 +1,136 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { UpozorneniaSection } from "./UpozorneniaSection.js";
+
+const { fetchUpozornenia, markUpozorneniaSeen, createOwnNote, updateOwnNote, deleteOwnNote, resolveUpozornenie, postponeUpozornenie } = vi.hoisted(() => ({
+  fetchUpozornenia: vi.fn(),
+  markUpozorneniaSeen: vi.fn(),
+  createOwnNote: vi.fn(),
+  updateOwnNote: vi.fn(),
+  deleteOwnNote: vi.fn(),
+  resolveUpozornenie: vi.fn(),
+  postponeUpozornenie: vi.fn(),
+}));
+
+// `UpozorneniaUnauthorizedError` ostáva SKUTOČNÁ trieda (rovnaký dôvod ako
+// `NedostupneSection.test.tsx` — `instanceof` v komponente musí fungovať).
+vi.mock("../upozorneniaApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../upozorneniaApi.js")>();
+  return { ...actual, fetchUpozornenia, markUpozorneniaSeen, createOwnNote, updateOwnNote, deleteOwnNote, resolveUpozornenie, postponeUpozornenie };
+});
+
+const VLASTNA_KARTA = {
+  id: "own-1",
+  type: "vlastna_poznamka" as const,
+  source: "vlastne" as const,
+  title: "Schôdzka v stredu",
+  details: "o 10:00",
+  link: null,
+  dueAt: null,
+  postponedUntil: null,
+  seenAt: null,
+  resolvedAt: null,
+  createdAt: "2026-08-05T08:00:00.000Z",
+  status: "nove" as const,
+};
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+it("prázdny zoznam zobrazí informačnú vetu (po označení videných)", async () => {
+  markUpozorneniaSeen.mockResolvedValue(undefined);
+  fetchUpozornenia.mockResolvedValue([]);
+  render(<UpozorneniaSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("upozornenia-empty");
+  await waitFor(() => {
+    expect(markUpozorneniaSeen).toHaveBeenCalledTimes(1);
+  });
+});
+
+it("zobrazí kartu s 'Nové' štítkom pre nevidenú kartu", async () => {
+  markUpozorneniaSeen.mockResolvedValue(undefined);
+  fetchUpozornenia.mockResolvedValue([VLASTNA_KARTA]);
+  render(<UpozorneniaSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("upozornenie-own-1");
+  expect(screen.getByTestId("upozornenie-nove-own-1").textContent).toBe("Nové");
+  expect(screen.getByText("Schôdzka v stredu")).toBeTruthy();
+  expect(screen.getByText("o 10:00")).toBeTruthy();
+});
+
+it("rola 'citanie' vidí zoznam, ale NEVIDÍ žiadne akčné tlačidlá ani formulár", async () => {
+  markUpozorneniaSeen.mockResolvedValue(undefined);
+  fetchUpozornenia.mockResolvedValue([VLASTNA_KARTA]);
+  render(<UpozorneniaSection role="citanie" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("upozornenie-own-1");
+  expect(screen.queryByTestId("upozornenie-new")).toBeNull();
+  expect(screen.queryByTestId("upozornenie-resolve-own-1")).toBeNull();
+  expect(screen.queryByTestId("upozornenie-edit-own-1")).toBeNull();
+});
+
+it("karta zo zdroja 'appka' nemá Upraviť/Zmazať, len Vybavené/Odložiť", async () => {
+  markUpozorneniaSeen.mockResolvedValue(undefined);
+  fetchUpozornenia.mockResolvedValue([{ ...VLASTNA_KARTA, id: "appka-1", source: "appka" as const }]);
+  render(<UpozorneniaSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("upozornenie-appka-1");
+  expect(screen.getByTestId("upozornenie-resolve-appka-1")).toBeTruthy();
+  expect(screen.queryByTestId("upozornenie-edit-appka-1")).toBeNull();
+  expect(screen.queryByTestId("upozornenie-delete-appka-1")).toBeNull();
+});
+
+it("'+ Nové upozornenie' otvorí formulár, uloženie zavolá createOwnNote a znova načíta zoznam", async () => {
+  markUpozorneniaSeen.mockResolvedValue(undefined);
+  fetchUpozornenia.mockResolvedValueOnce([]).mockResolvedValueOnce([VLASTNA_KARTA]);
+  createOwnNote.mockResolvedValue(undefined);
+  render(<UpozorneniaSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("upozornenia-empty");
+
+  fireEvent.click(screen.getByTestId("upozornenie-new"));
+  fireEvent.change(screen.getByTestId("upozornenie-form-title"), { target: { value: "Schôdzka v stredu" } });
+  fireEvent.change(screen.getByTestId("upozornenie-form-details"), { target: { value: "o 10:00" } });
+  fireEvent.click(screen.getByTestId("upozornenie-form-save"));
+
+  await waitFor(() => {
+    expect(createOwnNote).toHaveBeenCalledWith({ title: "Schôdzka v stredu", details: "o 10:00", dueAt: null });
+  });
+  await screen.findByTestId("upozornenie-own-1");
+});
+
+it("klik na 'Vybavené' zavolá resolveUpozornenie a znova načíta zoznam", async () => {
+  markUpozorneniaSeen.mockResolvedValue(undefined);
+  fetchUpozornenia.mockResolvedValueOnce([VLASTNA_KARTA]).mockResolvedValueOnce([{ ...VLASTNA_KARTA, status: "vybavene" as const }]);
+  resolveUpozornenie.mockResolvedValue(undefined);
+  render(<UpozorneniaSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("upozornenie-own-1");
+
+  fireEvent.click(screen.getByTestId("upozornenie-resolve-own-1"));
+  await waitFor(() => {
+    expect(resolveUpozornenie).toHaveBeenCalledWith("own-1");
+  });
+});
+
+it("Upraviť predvyplní formulár existujúcimi hodnotami vlastnej poznámky", async () => {
+  markUpozorneniaSeen.mockResolvedValue(undefined);
+  fetchUpozornenia.mockResolvedValue([VLASTNA_KARTA]);
+  render(<UpozorneniaSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("upozornenie-own-1");
+
+  fireEvent.click(screen.getByTestId("upozornenie-edit-own-1"));
+  expect(screen.getByTestId<HTMLInputElement>("upozornenie-form-title").value).toBe("Schôdzka v stredu");
+  expect(screen.getByTestId<HTMLTextAreaElement>("upozornenie-form-details").value).toBe("o 10:00");
+});
+
+it("Zmazať zavolá deleteOwnNote a znova načíta zoznam", async () => {
+  markUpozorneniaSeen.mockResolvedValue(undefined);
+  fetchUpozornenia.mockResolvedValueOnce([VLASTNA_KARTA]).mockResolvedValueOnce([]);
+  deleteOwnNote.mockResolvedValue(undefined);
+  render(<UpozorneniaSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("upozornenie-own-1");
+
+  fireEvent.click(screen.getByTestId("upozornenie-delete-own-1"));
+  await waitFor(() => {
+    expect(deleteOwnNote).toHaveBeenCalledWith("own-1");
+  });
+  await screen.findByTestId("upozornenia-empty");
+});

--- a/apps/web/src/components/UpozorneniaSection.tsx
+++ b/apps/web/src/components/UpozorneniaSection.tsx
@@ -27,6 +27,19 @@ function formatDate(iso: string): string {
   return new Date(iso).toLocaleDateString("sk-SK", { day: "numeric", month: "numeric", year: "numeric" });
 }
 
+// Code review: "Odložiť do" nemalo `min` — dalo sa vybrať dátum v minulosti
+// (neškodné, `computeStatus` by ho vzalo ako "už sa vrátilo", ale mätúce
+// no-op). `<input type="date">`'s `min` očakáva `YYYY-MM-DD` v LOKÁLNOM
+// čase prehliadača, nie `toISOString()` (tá by okolo polnoci mohla ukázať
+// VČEREJŠÍ dátum v časových pásmach východne od UTC).
+function todayDateInputValue(): string {
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, "0");
+  const d = String(now.getDate()).padStart(2, "0");
+  return `${String(y)}-${m}-${d}`;
+}
+
 interface EditDraft {
   readonly id: string | null; // null = nový záznam
   readonly title: string;
@@ -255,6 +268,7 @@ export function UpozorneniaSection({ role, onSessionExpired }: { readonly role: 
                     </button>
                     <input
                       type="date"
+                      min={todayDateInputValue()}
                       value={postponeDraft[row.id] ?? ""}
                       onChange={(e) => {
                         const value = e.target.value;

--- a/apps/web/src/components/UpozorneniaSection.tsx
+++ b/apps/web/src/components/UpozorneniaSection.tsx
@@ -1,0 +1,305 @@
+import { useCallback, useEffect, useRef, useState, type JSX } from "react";
+import type { Me } from "../api.js";
+import {
+  createOwnNote,
+  deleteOwnNote,
+  fetchUpozornenia,
+  markUpozorneniaSeen,
+  postponeUpozornenie,
+  resolveUpozornenie,
+  updateOwnNote,
+  UpozorneniaUnauthorizedError,
+  type UpozornenieRow,
+} from "../upozorneniaApi.js";
+
+// issue 267: rovnaké dve role, ktoré appka všade inde vyžaduje na zápis
+// (`requireRole("admin", "manazer")`, `upozornenia-routes.ts`) — čítanie
+// (zoznam) smie vidieť KAŽDÝ prihlásený zamestnanec.
+const CONTROL_ROLES: ReadonlySet<Me["role"]> = new Set(["admin", "manazer"]);
+
+// Otvorený zoznam typov (dnes jediný) — budúci automatický zdroj (#268/#269)
+// pridá svoj štítok sem, keď pridá svoju `pgEnum` hodnotu.
+const TYPE_LABELS: Readonly<Record<UpozornenieRow["type"], string>> = {
+  vlastna_poznamka: "Moja poznámka",
+};
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("sk-SK", { day: "numeric", month: "numeric", year: "numeric" });
+}
+
+interface EditDraft {
+  readonly id: string | null; // null = nový záznam
+  readonly title: string;
+  readonly details: string;
+  readonly dueAt: string;
+}
+
+const EMPTY_DRAFT: EditDraft = { id: null, title: "", details: "", dueAt: "" };
+
+export function UpozorneniaSection({ role, onSessionExpired }: { readonly role: Me["role"]; readonly onSessionExpired: () => void }): JSX.Element {
+  const [rows, setRows] = useState<readonly UpozornenieRow[] | null>(null);
+  const [error, setError] = useState("");
+  const [includeResolved, setIncludeResolved] = useState(false);
+  const [busyId, setBusyId] = useState("");
+  const [draft, setDraft] = useState<EditDraft | null>(null);
+  const [postponeDraft, setPostponeDraft] = useState<Record<string, string>>({});
+  const canControl = CONTROL_ROLES.has(role);
+
+  const load = useCallback(() => {
+    fetchUpozornenia({ includeResolved })
+      .then(setRows)
+      .catch((err: unknown) => {
+        if (err instanceof UpozorneniaUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setError("Upozornenia sa nepodarilo načítať.");
+      });
+  }, [includeResolved, onSessionExpired]);
+
+  // Otvorenie záložky = "prečítané" (inbox vzor) — PRVÉ spustenie tohto
+  // efektu (mountedRef ešte `false`) hromadne označí všetky práve "Nové"
+  // karty ako videné a AŽ POTOM načíta zoznam (žiadny dvojitý fetch na
+  // mount) — žiadne per-kartové tlačidlo "videné" navyše. Každé ĎALŠIE
+  // spustenie (zmena `includeResolved`, teda nová identita `load`) už len
+  // refetchne, mark-seen sa nezopakuje. `mountedRef` sa nastavuje SYNCHRÓNNE
+  // v tele efektu (nie len v `useRef`'s počiatočnej hodnote) — `<StrictMode>`
+  // (`main.tsx`) efekt vo vývoji spustí, zruší a znova spustí, presne vzor z
+  // `.claude/rules/frontend-design.md`'s "mountedRef POTREBUJE nastaviť true
+  // AJ v tele efektu" (issue 251).
+  const mountedRef = useRef(false);
+  useEffect(() => {
+    if (!mountedRef.current) {
+      mountedRef.current = true;
+      markUpozorneniaSeen()
+        .then(load)
+        .catch(() => {
+          // Sieťový výpadok pri mark-seen — aspoň bežné načítanie zoznamu.
+          load();
+        });
+      return;
+    }
+    load();
+  }, [load]);
+
+  const withBusy = useCallback((key: string, action: () => Promise<void>) => {
+    setBusyId(key);
+    setError("");
+    action()
+      .then(load)
+      .catch(() => {
+        setError("Akcia zlyhala — skúste to znova.");
+      })
+      .finally(() => {
+        setBusyId("");
+      });
+  }, [load]);
+
+  const saveDraft = useCallback(() => {
+    if (draft === null || draft.title.trim() === "") return;
+    const input = { title: draft.title.trim(), details: draft.details.trim(), dueAt: draft.dueAt === "" ? null : draft.dueAt };
+    const action = draft.id === null ? () => createOwnNote(input) : () => updateOwnNote(draft.id ?? "", input).then(() => undefined);
+    setBusyId(draft.id ?? "new");
+    setError("");
+    action()
+      .then(() => {
+        setDraft(null);
+        load();
+      })
+      .catch(() => {
+        setError("Uloženie zlyhalo — skúste to znova.");
+      })
+      .finally(() => {
+        setBusyId("");
+      });
+  }, [draft, load]);
+
+  if (error !== "" && rows === null) return <p role="alert">{error}</p>;
+  if (rows === null) return <p>Načítavam…</p>;
+
+  return (
+    <section>
+      <p>Veci, ktoré treba vybaviť — nech ich zistila appka sama, alebo si ich zapísal majiteľ. Nič odtiaľto sa neposiela e-mailom ani na Discord.</p>
+
+      {error !== "" && <p role="alert">{error}</p>}
+
+      <div className="upozornenia-toolbar">
+        <label>
+          <input
+            type="checkbox"
+            checked={includeResolved}
+            onChange={(e) => {
+              setIncludeResolved(e.target.checked);
+            }}
+          />{" "}
+          aj vybavené
+        </label>
+        {canControl && (
+          <button
+            type="button"
+            className="btn good"
+            onClick={() => {
+              setDraft(EMPTY_DRAFT);
+            }}
+            data-testid="upozornenie-new"
+          >
+            + Nové upozornenie
+          </button>
+        )}
+      </div>
+
+      {draft !== null && (
+        <div className="card upozornenie-form" data-testid="upozornenie-form">
+          <label>
+            Nadpis
+            <input
+              value={draft.title}
+              onChange={(e) => {
+                const value = e.target.value;
+                setDraft((d) => (d === null ? d : { ...d, title: value }));
+              }}
+              aria-label="Nadpis upozornenia"
+              data-testid="upozornenie-form-title"
+            />
+          </label>
+          <label>
+            Podrobnosti
+            <textarea
+              value={draft.details}
+              onChange={(e) => {
+                const value = e.target.value;
+                setDraft((d) => (d === null ? d : { ...d, details: value }));
+              }}
+              aria-label="Podrobnosti upozornenia"
+              data-testid="upozornenie-form-details"
+            />
+          </label>
+          <label>
+            Vybaviť do (nepovinné)
+            <input
+              type="date"
+              value={draft.dueAt}
+              onChange={(e) => {
+                const value = e.target.value;
+                setDraft((d) => (d === null ? d : { ...d, dueAt: value }));
+              }}
+              aria-label="Vybaviť do"
+              data-testid="upozornenie-form-due"
+            />
+          </label>
+          <div className="upozornenie-form-actions">
+            <button type="button" className="btn good" disabled={draft.title.trim() === "" || busyId !== ""} onClick={saveDraft} data-testid="upozornenie-form-save">
+              💾 Uložiť
+            </button>
+            <button
+              type="button"
+              className="btn ghost"
+              onClick={() => {
+                setDraft(null);
+              }}
+            >
+              Zrušiť
+            </button>
+          </div>
+        </div>
+      )}
+
+      {rows.length === 0 ? (
+        <p data-testid="upozornenia-empty">Žiadne upozornenia — všetko je vybavené.</p>
+      ) : (
+        <div className="upozornenia-list" data-testid="upozornenia-list">
+          {rows.map((row) => {
+            const rowBusy = busyId === row.id;
+            const isOwn = row.source === "vlastne";
+            return (
+              <div className={"card upozornenie-card" + (row.status === "nove" ? " upozornenie-nove" : "")} key={row.id} data-testid={`upozornenie-${row.id}`}>
+                <div className="upozornenie-head">
+                  <span className="pill" data-testid={`upozornenie-type-${row.id}`}>
+                    {TYPE_LABELS[row.type]}
+                  </span>
+                  {row.status === "nove" && <strong data-testid={`upozornenie-nove-${row.id}`}>Nové</strong>}
+                  {row.status === "vybavene" && <span className="pill off">Vybavené</span>}
+                </div>
+                <p className="upozornenie-title">{row.title}</p>
+                {row.details !== "" && <p className="upozornenie-details">{row.details}</p>}
+                <p className="upozornenie-meta">
+                  Vzniklo {formatDate(row.createdAt)}
+                  {row.dueAt !== null && <> · vybaviť do {formatDate(row.dueAt)}</>}
+                </p>
+                {row.link !== null && (
+                  <a href={row.link} data-testid={`upozornenie-link-${row.id}`}>
+                    Otvoriť v appke
+                  </a>
+                )}
+                {canControl && row.status !== "vybavene" && (
+                  <div className="upozornenie-actions">
+                    <button
+                      type="button"
+                      className="btn sm good"
+                      disabled={rowBusy}
+                      onClick={() => {
+                        withBusy(row.id, () => resolveUpozornenie(row.id));
+                      }}
+                      data-testid={`upozornenie-resolve-${row.id}`}
+                    >
+                      ✓ Vybavené
+                    </button>
+                    <input
+                      type="date"
+                      value={postponeDraft[row.id] ?? ""}
+                      onChange={(e) => {
+                        const value = e.target.value;
+                        setPostponeDraft((d) => ({ ...d, [row.id]: value }));
+                      }}
+                      aria-label={`Odložiť do — ${row.title}`}
+                      data-testid={`upozornenie-postpone-date-${row.id}`}
+                    />
+                    <button
+                      type="button"
+                      className="btn sm ghost"
+                      disabled={rowBusy || (postponeDraft[row.id] ?? "") === ""}
+                      onClick={() => {
+                        const until = postponeDraft[row.id];
+                        if (until === undefined || until === "") return;
+                        withBusy(row.id, () => postponeUpozornenie(row.id, new Date(until).toISOString()));
+                      }}
+                      data-testid={`upozornenie-postpone-${row.id}`}
+                    >
+                      Odložiť
+                    </button>
+                    {isOwn && (
+                      <>
+                        <button
+                          type="button"
+                          className="btn sm ghost"
+                          disabled={rowBusy}
+                          onClick={() => {
+                            setDraft({ id: row.id, title: row.title, details: row.details, dueAt: row.dueAt === null ? "" : row.dueAt.slice(0, 10) });
+                          }}
+                          data-testid={`upozornenie-edit-${row.id}`}
+                        >
+                          Upraviť
+                        </button>
+                        <button
+                          type="button"
+                          className="btn sm ghost"
+                          disabled={rowBusy}
+                          onClick={() => {
+                            withBusy(row.id, () => deleteOwnNote(row.id));
+                          }}
+                          data-testid={`upozornenie-delete-${row.id}`}
+                        >
+                          ✕ Zmazať
+                        </button>
+                      </>
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/UpozorneniaSection.tsx
+++ b/apps/web/src/components/UpozorneniaSection.tsx
@@ -97,12 +97,21 @@ export function UpozorneniaSection({ role, onSessionExpired }: { readonly role: 
 
   const saveDraft = useCallback(() => {
     if (draft === null || draft.title.trim() === "") return;
+    const editId = draft.id;
     const input = { title: draft.title.trim(), details: draft.details.trim(), dueAt: draft.dueAt === "" ? null : draft.dueAt };
-    const action = draft.id === null ? () => createOwnNote(input) : () => updateOwnNote(draft.id ?? "", input).then(() => undefined);
-    setBusyId(draft.id ?? "new");
+    setBusyId(editId ?? "new");
     setError("");
-    action()
-      .then(() => {
+    // `updateOwnNote` vracia `false`, keď karta medzitým zmizla (zmazaná
+    // iným prihlásením) alebo prestala byť vlastnou poznámkou — obe sú
+    // legitímne (nechybové) situácie, nikdy sa NEZAVRIE formulár tak, akoby
+    // sa uloženie podarilo.
+    const action = editId === null ? createOwnNote(input).then(() => true) : updateOwnNote(editId, input);
+    action
+      .then((ok) => {
+        if (!ok) {
+          setError("Upozornenie medzitým zmizlo — obnovte zoznam a skúste to znova.");
+          return;
+        }
         setDraft(null);
         load();
       })

--- a/apps/web/src/nav.test.ts
+++ b/apps/web/src/nav.test.ts
@@ -10,13 +10,15 @@ import { DEFAULT_TAB_ID, HIDDEN_TABS, NAV, findTab, isVisibleTabId } from "./nav
 // (rovnaký dôvod ako "Nedostupné tovary" — pracovná obrazovka bez plánu).
 // Issue 240 pridalo "Vyhľadať" pod "Eshop" z rovnakého dôvodu. Issue 257
 // pridalo "Zlúčenie objednávok" pod "Eshop" z rovnakého dôvodu (majiteľ:
-// vlastná záložka, nie tlačidlo pri objednávke).
+// vlastná záložka, nie tlačidlo pri objednávke). Issue 267 pridalo
+// "Upozornenia" pod "Eshop" z rovnakého dôvodu (pracovná obrazovka bez
+// plánu/zapnuté-vypnuté konceptu).
 // Tento test je najbližšie k tomu, čo strojovo overiť dá (registrácia, nie DOM).
-it("NAV má tri priečinky (Systém/Eshop/Automatizácie), s 3/5/4 záložkami v poradí podľa dôležitosti", () => {
+it("NAV má tri priečinky (Systém/Eshop/Automatizácie), s 3/6/4 záložkami v poradí podľa dôležitosti", () => {
   expect(NAV).toHaveLength(3);
   expect(NAV.map((f) => f.label)).toEqual(["Systém", "Eshop", "Automatizácie"]);
   expect(NAV[0]?.tabs).toHaveLength(3);
-  expect(NAV[1]?.tabs).toHaveLength(5);
+  expect(NAV[1]?.tabs).toHaveLength(6);
   expect(NAV[2]?.tabs).toHaveLength(4);
   // issue 212: "Dodávateľský sklad" — scraper dostupnosti u dodávateľa;
   // patrí do Systému (zadanie majiteľa), nie medzi Automatizácie.
@@ -27,6 +29,7 @@ it("NAV má tri priečinky (Systém/Eshop/Automatizácie), s 3/5/4 záložkami v
     "Párovanie produktov",
     "Vyhľadať",
     "Zlúčenie objednávok",
+    "Upozornenia",
   ]);
   // issue 193: "Odoslané e-maily" — prehľad toho, čo automatizácie poslali.
   expect(NAV[2]?.tabs.map((t) => t.label)).toEqual([

--- a/apps/web/src/nav.ts
+++ b/apps/web/src/nav.ts
@@ -15,6 +15,7 @@ import { SearchSection } from "./components/SearchSection.js";
 import { SupplierLinksSection } from "./components/SupplierLinksSection.js";
 import { SupplierStockSection } from "./components/SupplierStockSection.js";
 import { SyncSection } from "./components/SyncSection.js";
+import { UpozorneniaSection } from "./components/UpozorneniaSection.js";
 
 // Spoločný tvar props pre KAŽDÚ obrazovku registrovanú tu — presne to, čo dnes
 // prijíma CatalogPage/OrdersSection/PairingSection/SchedulerSection/SyncSection.
@@ -98,6 +99,11 @@ export const NAV: readonly NavFolder[] = [
       // z rovnakého dôvodu ako "Párovanie produktov"/"Vyhľadať" vyššie
       // (obsluha na nej pracuje, žiadny plán/zapnuté-vypnuté koncept).
       { id: "order-merge", label: "Zlúčenie objednávok", icon: "🔀", Component: OrderMergeSection, wide: true },
+      // issue 267: "Upozornenia" — nástenka vecí, ktoré majiteľ musí vybaviť
+      // (vlastné poznámky + budúce automatické zdroje #268/#269). Patrí sem
+      // (nie do Automatizácie) z rovnakého dôvodu ako "Na objednanie" —
+      // obsluha na nej pracuje, žiadny plán/zapnuté-vypnuté koncept.
+      { id: "upozornenia", label: "Upozornenia", icon: "🔔", Component: UpozorneniaSection, wide: true },
     ],
   },
   {

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -1954,6 +1954,76 @@ tr:last-child td {
   color: var(--fs-ink-muted);
 }
 
+/* ---------------- 17. UPOZORNENIA (issue 267) ---------------- */
+.upozornenia-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--fs-space-4);
+  margin: var(--fs-space-2) 0 var(--fs-space-4);
+}
+.upozornenia-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--fs-space-4);
+}
+.upozornenie-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--fs-space-2);
+}
+/* issue 267: nevidená karta má výraznejší okraj — rovnaký princíp ako
+   issue 259's binárne farbenie riadkov "Na objednanie" (jeden jasný signál,
+   nikdy jediný — text "Nové" vedľa neho ostáva). */
+.upozornenie-nove {
+  border-left: 4px solid var(--fs-brand);
+}
+.upozornenie-head {
+  display: flex;
+  align-items: center;
+  gap: var(--fs-space-3);
+  flex-wrap: wrap;
+}
+.upozornenie-title {
+  font-size: var(--fs-text-md);
+  font-weight: var(--fs-weight-semibold);
+  margin: 0;
+}
+.upozornenie-details {
+  margin: 0;
+  color: var(--fs-ink-muted);
+  white-space: pre-wrap;
+}
+.upozornenie-meta {
+  margin: 0;
+  font-size: var(--fs-text-sm);
+  color: var(--fs-ink-faint);
+}
+.upozornenie-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--fs-space-2);
+  flex-wrap: wrap;
+  margin-top: var(--fs-space-2);
+}
+.upozornenie-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--fs-space-3);
+  margin-bottom: var(--fs-space-4);
+}
+.upozornenie-form label {
+  display: flex;
+  flex-direction: column;
+  gap: var(--fs-space-1);
+  font-size: var(--fs-text-sm);
+  color: var(--fs-ink-muted);
+}
+.upozornenie-form-actions {
+  display: flex;
+  gap: var(--fs-space-2);
+}
+
 /* ---------------- MODÁLNY DIALÓG (issue 191) ----------------
    Náhľad e-mailu pred odoslaním sa už nerozbaľuje na spodku stránky —
    otvorí sa cez obrazovku, takže je okamžite v zornom poli. `z-index`
@@ -2357,7 +2427,7 @@ tr:last-child td {
   font-family: monospace;
   text-transform: lowercase;
 }
-/* issue 264 živé overenie: neplatný kód farby musí byť VIDIEĽNÝ na samotnom
+/* issue 264 živé overenie: neplatný kód farby musí byť VIDITEĽNÝ na samotnom
    poli, nielen v spoločnej hláške vyššie — s 6 otvorenými poľami inak nie je
    jasné, KTORÉ z nich je zlé. */
 .themecolor-hex-input[aria-invalid="true"] {

--- a/apps/web/src/upozorneniaApi.ts
+++ b/apps/web/src/upozorneniaApi.ts
@@ -1,0 +1,113 @@
+import { z } from "zod";
+
+// issue 267: "Eshop → Upozornenia" — zrkadlí `UpozornenieRow`
+// (`apps/api/src/modules/upozornenia/queries.ts`).
+
+const rowSchema = z.object({
+  id: z.string(),
+  type: z.enum(["vlastna_poznamka"]),
+  source: z.enum(["vlastne", "appka"]),
+  title: z.string(),
+  details: z.string(),
+  link: z.string().nullable(),
+  dueAt: z.string().nullable(),
+  postponedUntil: z.string().nullable(),
+  seenAt: z.string().nullable(),
+  resolvedAt: z.string().nullable(),
+  createdAt: z.string(),
+  status: z.enum(["nove", "otvorene", "odlozene", "vybavene"]),
+});
+export type UpozornenieRow = z.infer<typeof rowSchema>;
+export type UpozornenieStatus = UpozornenieRow["status"];
+
+const listSchema = z.object({ rows: z.array(rowSchema) });
+const countSchema = z.object({ count: z.number() });
+
+export class UpozorneniaUnauthorizedError extends Error {
+  constructor() {
+    super("Neprihlásený");
+  }
+}
+
+const errorBodySchema = z.object({ error: z.string() });
+
+async function serverErrorMessage(response: Response, fallback: string): Promise<string> {
+  try {
+    const parsed = errorBodySchema.safeParse(await response.json());
+    if (parsed.success) return parsed.data.error;
+  } catch {
+    // telo nie je platný JSON — použi všeobecnú hlášku
+  }
+  return fallback;
+}
+
+async function readJson(response: Response, fallback: string): Promise<unknown> {
+  if (response.status === 401) throw new UpozorneniaUnauthorizedError();
+  if (!response.ok) throw new Error(await serverErrorMessage(response, fallback));
+  return await response.json();
+}
+
+export async function fetchUpozornenia(filter: { readonly includeResolved: boolean }): Promise<readonly UpozornenieRow[]> {
+  const params = new URLSearchParams();
+  if (filter.includeResolved) params.set("includeResolved", "true");
+  const qs = params.toString();
+  const response = await fetch(`/api/upozornenia${qs === "" ? "" : `?${qs}`}`);
+  return listSchema.parse(await readJson(response, "Upozornenia sa nepodarilo načítať")).rows;
+}
+
+export async function fetchUpozorneniaCount(): Promise<number> {
+  const response = await fetch("/api/upozornenia/count");
+  if (response.status === 401) return 0;
+  if (!response.ok) return 0;
+  return countSchema.parse(await response.json()).count;
+}
+
+export async function markUpozorneniaSeen(): Promise<void> {
+  const response = await fetch("/api/upozornenia/mark-seen", { method: "POST" });
+  if (response.status === 401) throw new UpozorneniaUnauthorizedError();
+  await readJson(response, "Označenie ako videné zlyhalo");
+}
+
+export interface OwnNoteInput {
+  readonly title: string;
+  readonly details?: string;
+  readonly dueAt?: string | null;
+}
+
+export async function createOwnNote(input: OwnNoteInput): Promise<void> {
+  const response = await fetch("/api/upozornenia", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  await readJson(response, "Upozornenie sa nepodarilo vytvoriť");
+}
+
+export async function updateOwnNote(id: string, input: OwnNoteInput): Promise<boolean> {
+  const response = await fetch(`/api/upozornenia/${encodeURIComponent(id)}`, {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  const body = (await readJson(response, "Upozornenie sa nepodarilo upraviť")) as { readonly updated: boolean };
+  return body.updated;
+}
+
+export async function deleteOwnNote(id: string): Promise<void> {
+  const response = await fetch(`/api/upozornenia/${encodeURIComponent(id)}`, { method: "DELETE" });
+  await readJson(response, "Upozornenie sa nepodarilo zmazať");
+}
+
+export async function resolveUpozornenie(id: string): Promise<void> {
+  const response = await fetch(`/api/upozornenia/${encodeURIComponent(id)}/resolve`, { method: "POST" });
+  await readJson(response, "Označenie ako vybavené zlyhalo");
+}
+
+export async function postponeUpozornenie(id: string, until: string): Promise<void> {
+  const response = await fetch(`/api/upozornenia/${encodeURIComponent(id)}/postpone`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ until }),
+  });
+  await readJson(response, "Odloženie zlyhalo");
+}

--- a/apps/web/tests/e2e/nav.spec.ts
+++ b/apps/web/tests/e2e/nav.spec.ts
@@ -18,8 +18,10 @@ const E2E_NAV_EMAIL = "e2e-nav@forestshop.sk";
 // "Vyhľadať" pod "Eshop" — jedenásta záložka. Issue 257 (2026-08-05) pridáva
 // "Zlúčenie objednávok" pod "Eshop" — dvanásta záložka (funkčný test v
 // samostatnom `order-merge.spec.ts`, rovnaký vzor ako "Vyhľadať"/
-// `search.spec.ts`).
-test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s dvanástimi záložkami, klik prepne obrazovku, panel sa zbalí do lišty a stav si pamätá, konzola je čistá", async ({
+// `search.spec.ts`). Issue 267 (2026-08-05) pridáva "Upozornenia" pod
+// "Eshop" — trinásta záložka (funkčný test v samostatnom
+// `upozornenia.spec.ts`, rovnaký vzor).
+test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s trinástimi záložkami, klik prepne obrazovku, panel sa zbalí do lišty a stav si pamätá, konzola je čistá", async ({
   page,
 }) => {
   const chyby: string[] = [];
@@ -40,8 +42,8 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s dvanástim
   await expect(page.getByRole("button", { name: "Eshop" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Automatizácie" })).toBeVisible();
 
-  // Presne dvanásť záložiek v CELOM menu.
-  await expect(page.locator(".side-nav .tab")).toHaveCount(12);
+  // Presne trinásť záložiek v CELOM menu.
+  await expect(page.locator(".side-nav .tab")).toHaveCount(13);
   await expect(page.getByRole("button", { name: "Sync zo Shoptetu" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Texty e-mailov" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Na objednanie" })).toBeVisible();
@@ -51,6 +53,7 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s dvanástim
   await expect(page.getByRole("button", { name: "Párovanie produktov" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Vyhľadať" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Zlúčenie objednávok" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Upozornenia" })).toBeVisible();
 
   // Predvolená obrazovka (bez kliknutia) je "Sync zo Shoptetu".
   await expect(page.getByRole("heading", { name: "Sync zo Shoptetu" })).toBeVisible();
@@ -74,6 +77,15 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s dvanástim
   const odznak = page.getByTestId("nav-badge-orders");
   await expect(odznak).toBeVisible();
   await expect(odznak).toHaveText(/^\d+$/);
+
+  // issue 267: rovnaký odznak vzor pre "Upozornenia" — na rozdiel od
+  // "Na objednanie" je toto číslo známe HNEĎ po prihlásení (`App.tsx` si ho
+  // fetchuje priamo, nie cez mount-only context), takže je viditeľné aj bez
+  // toho, aby test tú záložku vôbec otvoril. Presné číslo sa opäť
+  // zámerne neoveruje (zdieľaná globálna DB).
+  const upozornOdznak = page.getByTestId("nav-badge-upozornenia");
+  await expect(upozornOdznak).toBeVisible();
+  await expect(upozornOdznak).toHaveText(/^\d+$/);
 
   // issue 185: tri obrazovky, ktoré dovtedy sedeli len v `HIDDEN_TABS` — klik
   // na každú otvorí svoju obrazovku (samostatný `<h1>` titulok v Topbar-e,
@@ -119,6 +131,13 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s dvanástim
   await expect(page.getByRole("heading", { name: "Zlúčenie objednávok" })).toBeVisible();
   await expect(page.getByTestId("nav-status-order-merge")).toHaveCount(0);
 
+  // issue 267: rovnaký dôvod ako "Zlúčenie objednávok" vyššie — žiadny
+  // plán/zapnuté-vypnuté koncept, teda žiadny stavový odznak v menu (má
+  // však odznak POČTU, overený vyššie pri "Sync zo Shoptetu").
+  await page.getByRole("button", { name: "Upozornenia" }).click();
+  await expect(page.getByRole("heading", { name: "Upozornenia" })).toBeVisible();
+  await expect(page.getByTestId("nav-status-upozornenia")).toHaveCount(0);
+
   // issue 190: zbalenie panela do úzkej lišty. Zámerne je to SÚČASŤ tohto
   // testu, nie samostatný test — každý ďalší test v tomto súbore by znamenal
   // ďalšie prihlásenie na zdieľanom `MAX_ATTEMPTS=10` rozpočte
@@ -141,7 +160,7 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s dvanástim
 
   // Hlavičky priečinkov zmiznú, ikony všetkých modulov ostanú.
   await expect(page.getByRole("button", { name: "Systém" })).toHaveCount(0);
-  await expect(page.locator(".side-nav .tab")).toHaveCount(12);
+  await expect(page.locator(".side-nav .tab")).toHaveCount(13);
   // Názov sa v lište ukáže bublinou pri prejdení myšou.
   await expect(page.getByRole("button", { name: "Na objednanie" })).toHaveAttribute(
     "title",

--- a/apps/web/tests/e2e/upozornenia.spec.ts
+++ b/apps/web/tests/e2e/upozornenia.spec.ts
@@ -1,0 +1,96 @@
+import { expect, test } from "@playwright/test";
+
+const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
+const E2E_UPOZORNENIA_EMAIL = "e2e-upozornenia@forestshop.sk"; // musí sa zhodovať s hodnotou v scripts/e2e-setup.ts
+
+// issue 267: "Eshop → Upozornenia" — nástenka + vlastné poznámky. Reálny
+// prehliadač cez celý cyklus: vytvoriť, vidieť "Nové" zmiznúť po
+// znovunačítaní (mark-seen pri otvorení záložky), upraviť, odložiť, vybaviť,
+// zmazať. Konzola musí zostať čistá (`.claude/rules/testing.md`).
+//
+// Karty majú SERVEROM vygenerované id v testid-e (`upozornenie-<uuid>`), a
+// viacero VNORENÝCH prvkov na karte zdieľa rovnaký `upozornenie-` prefix
+// (`upozornenie-nove-<id>`, `upozornenie-resolve-<id>`, …) — namiesto
+// nejednoznačného testid-prefixového selektora sa preto karty vyhľadávajú
+// cez ich CSS TRIEDU `.upozornenie-card` (majú ju LEN karty samotné, žiadny
+// vnorený prvok), filtrovanú textom nadpisu.
+function kartaSNadpisom(page: import("@playwright/test").Page, nadpis: string) {
+  return page.locator(".upozornenie-card").filter({ hasText: nadpis });
+}
+
+test("vlastná poznámka — vytvorenie, 'Nové' zmizne po znovuotvorení, úprava, odloženie, vybavenie, zmazanie, konzola je čistá", async ({ page }) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/?tab=upozornenia");
+  await page.getByLabel("E-mail").fill(E2E_UPOZORNENIA_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await expect(page.getByRole("heading", { name: "Upozornenia" })).toBeVisible();
+  await expect(page.getByTestId("upozornenia-empty")).toBeVisible();
+
+  // Vytvorenie vlastnej poznámky.
+  await page.getByTestId("upozornenie-new").click();
+  await page.getByTestId("upozornenie-form-title").fill("Schôdzka v stredu");
+  await page.getByTestId("upozornenie-form-details").fill("O 10:00 s dodávateľom");
+  await page.getByTestId("upozornenie-form-save").click();
+  await expect(page.getByTestId("upozornenie-form")).toBeHidden();
+
+  const card = kartaSNadpisom(page, "Schôdzka v stredu");
+  await expect(card).toBeVisible();
+  await expect(card).toContainText("O 10:00 s dodávateľom");
+  await expect(card).toContainText("Nové");
+
+  // Znovuotvorenie záložky (reload) je "prečítané" — "Nové" zmizne, karta
+  // sa stane "Otvorené" (žiadny text "Nové" na nej).
+  await page.reload();
+  await expect(page.getByRole("heading", { name: "Upozornenia" })).toBeVisible();
+  const cardAfterReload = kartaSNadpisom(page, "Schôdzka v stredu");
+  await expect(cardAfterReload).toBeVisible();
+  await expect(cardAfterReload).not.toContainText("Nové");
+
+  // Úprava vlastnej poznámky.
+  await cardAfterReload.getByRole("button", { name: "Upraviť" }).click();
+  await page.getByTestId("upozornenie-form-title").fill("Schôdzka v stredu — presunutá");
+  await page.getByTestId("upozornenie-form-save").click();
+  const upravenaKarta = kartaSNadpisom(page, "Schôdzka v stredu — presunutá");
+  await expect(upravenaKarta).toBeVisible();
+
+  // Odloženie na budúci dátum — karta zmizne z predvoleného zoznamu.
+  const budúciDátum = new Date();
+  budúciDátum.setDate(budúciDátum.getDate() + 30);
+  const isoDen = budúciDátum.toISOString().slice(0, 10);
+  await upravenaKarta.locator('input[type="date"]').fill(isoDen);
+  await upravenaKarta.getByRole("button", { name: "Odložiť", exact: true }).click();
+  await expect(kartaSNadpisom(page, "Schôdzka v stredu — presunutá")).toHaveCount(0);
+
+  // "aj vybavené" NEVRÁTI odloženú kartu (ostáva skrytá, kým sa nevráti sama).
+  await page.getByText("aj vybavené").click();
+  await expect(kartaSNadpisom(page, "Schôdzka v stredu — presunutá")).toHaveCount(0);
+  await page.getByText("aj vybavené").click();
+
+  // Vlastná druhá poznámka, ktorú rovno vybavíme a zmažeme.
+  await page.getByTestId("upozornenie-new").click();
+  await page.getByTestId("upozornenie-form-title").fill("Vybaviť poistku");
+  await page.getByTestId("upozornenie-form-save").click();
+  const poistkaKarta = kartaSNadpisom(page, "Vybaviť poistku");
+  await expect(poistkaKarta).toBeVisible();
+  await poistkaKarta.getByRole("button", { name: "Vybavené" }).click();
+  await expect(kartaSNadpisom(page, "Vybaviť poistku")).toHaveCount(0);
+
+  // "aj vybavené" ju teraz ukáže (na rozdiel od odloženej vyššie).
+  await page.getByText("aj vybavené").click();
+  const vybavenaKarta = kartaSNadpisom(page, "Vybaviť poistku");
+  await expect(vybavenaKarta).toBeVisible();
+  await expect(vybavenaKarta).toContainText("Vybavené");
+  // Vybavená karta nemá žiadne akčné tlačidlá (Upraviť/Zmazať/Vybavené/Odložiť).
+  await expect(vybavenaKarta.getByRole("button", { name: "Zmazať" })).toHaveCount(0);
+  await expect(vybavenaKarta.getByRole("button", { name: "Vybavené" })).toHaveCount(0);
+
+  expect(chyby).toEqual([]);
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.154",
+  "version": "0.3.0-dev.155",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -193,6 +193,12 @@ const E2E_ZLUCENIE_EMAIL = "e2e-zlucenie@forestshop.sk"; // musí sa zhodovať s
 // `admin`/`manazer`.
 const E2E_FARBY_EMAIL = "e2e-farby@forestshop.sk"; // musí sa zhodovať s hodnotou v theme-colors.spec.ts
 
+// issue 267: rovnaký mechanizmus a dôvod ako `E2E_FARBY_EMAIL` vyššie — nový
+// spec súbor (`upozornenia.spec.ts` — nástenka "Upozornenia") dostáva
+// VLASTNÝ izolovaný účet. Rola "manazer" — zápis/vybavenie vyžaduje
+// `admin`/`manazer`.
+const E2E_UPOZORNENIA_EMAIL = "e2e-upozornenia@forestshop.sk"; // musí sa zhodovať s hodnotou v upozornenia.spec.ts
+
 const { db, pool } = createDb();
 // Konštantný literál bez interpolácie — obyčajný reťazec je tu rovnako bezpečný
 // ako `sql` tagovaná šablóna (tú používa ekvivalentný apps/api/tests/helpers/db.ts),
@@ -353,6 +359,7 @@ await db.insert(users).values({
 await db.insert(users).values({ email: E2E_RACE_EMAIL, passwordHash: await hashPassword(E2E_HESLO), displayName: "E2E Manažér", role: "manazer" });
 await db.insert(users).values({ email: E2E_ZLUCENIE_EMAIL, passwordHash: await hashPassword(E2E_HESLO), displayName: "E2E Manažér", role: "manazer" });
 await db.insert(users).values({ email: E2E_FARBY_EMAIL, passwordHash: await hashPassword(E2E_HESLO), displayName: "E2E Manažér", role: "manazer" });
+await db.insert(users).values({ email: E2E_UPOZORNENIA_EMAIL, passwordHash: await hashPassword(E2E_HESLO), displayName: "E2E Manažér", role: "manazer" });
 
 // Katalóg pre E2E: tá istá commitnutá fixtúra ako v jednotkových testoch, cez tú istú
 // službu importu — E2E tak overuje skutočnú cestu dát, nie ručne nasypané riadky.


### PR DESCRIPTION
## Čo to robí

Nová záložka **Eshop → Upozornenia** — jedno miesto, kde vidíš veci, ktoré treba vybaviť. Ráno otvoríš jednu záložku a vieš, čo dnes riešiť.

- Zoznam **kariet**: typ, nadpis jednou vetou, podrobnosti, dátumy a odkaz priamo na to miesto v appke.
- Pri každej karte **Vybavené** a **Odložiť**; pri vlastných poznámkach aj **Upraviť** a **Zmazať**.
- **+ Nové upozornenie** — vlastná poznámka (schôdzka, niečo vybaviť), s nepovinným dátumom „vybaviť do".
- **Počítadlo v ľavom menu** pri Upozorneniach — koľko je nevybavených.
- Filtre nad zoznamom: len nevybavené (predvolené), podľa typu, aj vybavené.

Nič sa neposiela e-mailom ani na Discord — je to nástenka v appke, nie ďalší kanál, ktorý pípa.

## Ako to funguje

- Stav karty (**nové / otvorené / odložené / vybavené**) sa **počíta z troch dátumov**, nikde sa neukladá. Preto sa odložená karta v daný deň vráti sama a nepotrebuje na to žiadnu novú naplánovanú úlohu.
- Zapisuje sa **jedinou spoločnou funkciou** `upsertUpozornenie()`. Tú budú volať aj budúce automatické zdroje (nevyzdvihnutá zásielka, vrátenie) — nikdy si nebude každý zdroj písať do tabuľky po svojom.
- Proti duplicitám slúži **stabilný kľúč** (čiastočný unikátny index), aby opakovaný beh nočnej úlohy nevyrobil desať rovnakých kariet.
- Upravovať a mazať sa dá len vlastná poznámka — kontroluje to server, nielen tlačidlá.

Tento krok robí **samotnú nástenku**. Automatické zdroje sú vlastné úlohy (#268 nevyzdvihnutá zásielka, #269 vrátenie / výmena / dobropis).

## Overenie

- `pnpm typecheck`, `pnpm lint` — čisté
- web unit 441/441, api unit 585/585, api integračné 513/513, e2e 46/46
- Nezávislá kontrola kódu: 0 kritických; jedna vec odložená ako #272 (súbeh pri zápise — dnes ju nemá čo spustiť, kým neexistuje automatický zdroj)

issue 267
