### PR TITLE
fix: nástenka Upozornenia — živé počítadlo, odložené karty sa dajú vrátiť, pravdivý prázdny zoznam (issue 267)

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -553,3 +553,21 @@ paths:
   — potrebné je NIEKOĽKO NEZÁVISLÝCH behov, každý s čerstvým DB reseedom
   (`scripts/e2e-setup.ts`) a reštartom API servera, nie opakovanie v tom
   istom procese/stave.
+- **Súbežne bežiace/zabudnuté `pnpm --filter @forestshop/api test:integration`
+  procesy (napr. z predošlého overovania, ktoré agent zabudol počkať/
+  zabiť) spôsobia SKUTOČNÉ zlyhania v INÝCH testoch — nie len pomalší
+  beh.** Issue 267 follow-up: paralelný beh nechal 19 testov v
+  `restock-run.integration.test.ts` padnúť na `Error: Hook timed out in
+  10000ms` (v `beforeEach`'s `withCleanDb()`) a `db-isolation-lock
+  .integration.test.ts` na `TypeError: close is not a function` — vyzeralo
+  to ako regresia z aktuálnej zmeny, no príčinou bol vyčerpaný Postgres
+  connection pool/súperenie o zdieľanú lokálnu DB medzi DVOMA súčasne
+  bežiacimi `vitest run tests` procesmi (`.claude/rules/testing.md`'s
+  vlastný advisory-zámok popis rieši len TRUNCATE-kolíziu, nie všeobecné
+  vyčerpanie zdrojov pri plnom paralelnom behu celej sady). Fresh beh PO
+  `ps aux | grep vitest` (a `kill -9` akéhokoľvek nájdeného osirelého
+  procesu z predošlého overovania) prešiel 69/69 súborov, 518/518 testov
+  čisto. Pred DÔVEROVANÍM červenému `test:integration` výsledku vždy over
+  `ps aux | grep vitest`, či nebeží iný súbežný beh — najmä po tom, čo
+  agent spustil viac `run_in_background` testovacích príkazov v tej istej
+  relácii bez čakania na ich skutočné dokončenie.

--- a/.claude/rules/upozornenia.md
+++ b/.claude/rules/upozornenia.md
@@ -59,3 +59,45 @@ paths:
   nedostupne.md`'s povinný náhľad — front-end skrytie nie je vynútenie).
   Server vráti `updated`/`removed: false` namiesto chyby pri pokuse o cudziu
   kartu.
+- **Odložená karta bola živo nájdená ako NEVIDITEĽNÁ ÚPLNE VŽDY — žiadna
+  hodnota žiadneho filtra ju neodkryla, a neexistovala akcia na jej
+  vrátenie skôr, než sa vráti sama** (issue 267 follow-up, gap 2, nájdené
+  post-deploy Playwright overením na produkcii `0.3.0-dev.155`:
+  `GET /api/upozornenia?includeResolved=true` vrátil `{"rows":[]}`, hoci
+  riadok existoval s `postponed_until` v budúcnosti). Fix je NEZÁVISLÝ
+  druhý filter `includePostponed` (mirror `includeResolved` — `queries.ts`'s
+  `listUpozornenia` vynechá `notPostponedCondition` len keď je `true`) PLUS
+  nová akcia `cancelPostpone`/`POST /api/upozornenia/:id/cancel-postpone`
+  (nastaví `postponedUntil: null`, seenAt sa NEDOTÝKA — karta bola už
+  videná v momente odloženia). **`countActionableUpozornenia` (odznak)
+  túto výnimku NIKDY nedostáva** — je to len UI zobrazenie na požiadanie,
+  nikdy zmena toho, čo je "akčné". Pri KAŽDOM ĎALŠOM boolean UI filtri v
+  tejto appke, ktorý pridáva DRUHÚ os k existujúcemu (`includeResolved`):
+  over, či osi sú naozaj ORTOGONÁLNE (karta môže byť A bez B) — ak áno,
+  nezlučuj ich do jedného checkboxu, daj druhý nezávislý.
+- **Prázdny zoznam tvrdil natvrdo "všetko je vybavené" bez ohľadu na
+  SKUTOČNÚ príčinu — živo nájdené s jedinou odloženou (nie vybavenou)
+  kartou** (issue 267 follow-up, gap 3). Fix: `classifyEmptyMessage()`
+  (`UpozorneniaSection.tsx`) rozhodne podľa JEDNÉHO doplnkového najširšieho
+  dopytu (`{includeResolved:true, includePostponed:true}`), spusteného LEN
+  keď je aktuálny (možno užší) zoznam prázdny — nikdy pri každom `load()`.
+  **Code review našiel, že tento doplnkový dopyt (presne ako HLAVNÝ
+  `fetchUpozornenia` dopyt) potrebuje "latest ref" poistku proti
+  zastaranej odpovedi** (`loadSeqRef`, inkrementovaný na začiatku KAŽDÉHO
+  `load()` volania) — ĎALŠÍ sibling výskyt tej istej triedy race, ktorú
+  `.claude/rules/frontend-design.md` dokumentuje pri issue 151/251/264.
+  Akýkoľvek BUDÚCI reťazený/doplnkový fetch v tomto súbore potrebuje ten
+  istý guard, nie len ten prvý v reťazci.
+- **Pridanie doplnkového `fetchUpozornenia` volania, ktoré sa spúšťa
+  PODMIENEČNE (len keď je zoznam prázdny), rozbije EXISTUJÚCE testy s
+  pevnou `mockResolvedValueOnce().mockResolvedValueOnce()` sekvenciou** —
+  ak prvé volanie vráti prázdne pole, vloží sa medzi ne NEČAKANÉ ĎALŠIE
+  volanie, ktoré spotrebuje `Once` hodnotu určenú pre NESKORŠÍ (napr.
+  po-mutácii) reload, a ten potom dostane `undefined` z vyčerpanej fronty
+  (`TypeError` na `.then` alebo test timeout). Fix (viď `UpozorneniaSection
+  .test.tsx`/`.badgeRefresh.test.tsx`): vlož TRETIE `mockResolvedValueOnce
+  ([])` presne na miesto, kde sa doplnkový dopyt spustí. Test, ktorý
+  namiesto sekvenčných `Once` hodnôt používa `mockImplementation` podľa
+  argumentu filtra (`UpozorneniaSection.emptyMessage.test.tsx`), tomuto
+  problému nepodlieha vôbec — uprednostni ten vzor, keď test musí
+  rozlišovať MEDZI viacerými súbežne možnými volaniami tej istej funkcie.

--- a/apps/api/src/http/upozornenia-routes.ts
+++ b/apps/api/src/http/upozornenia-routes.ts
@@ -5,6 +5,7 @@ import type { Database } from "../db/client.js";
 import { record } from "../modules/audit/service.js";
 import { countActionableUpozornenia, listUpozornenia, type UpozornenieTypeValue } from "../modules/upozornenia/queries.js";
 import {
+  cancelPostpone,
   createOwnNote,
   deleteOwnNote,
   markAllSeen,
@@ -25,6 +26,10 @@ const KNOWN_TYPES: readonly [UpozornenieTypeValue, ...UpozornenieTypeValue[]] = 
 const listQuery = z.object({
   type: z.enum(KNOWN_TYPES).optional(),
   includeResolved: z.enum(["true", "false"]).optional(),
+  // issue 267 (živé overenie, gap 2): nezávislá os od `includeResolved` —
+  // jediný spôsob, ako odkryť odloženú kartu (`queries.ts`'s
+  // `notPostponedCondition`).
+  includePostponed: z.enum(["true", "false"]).optional(),
 });
 
 const createBody = z.object({
@@ -43,8 +48,12 @@ export function registerUpozorneniaRoutes(app: Hono<AppBindings>, db: Database):
   // Čítanie — každý prihlásený zamestnanec (rovnaká úroveň ako
   // #172/#173/#176 — `.claude/rules/nedostupne.md`).
   app.get("/api/upozornenia", requireUser(db), zValidator("query", listQuery), async (c) => {
-    const { type, includeResolved } = c.req.valid("query");
-    const rows = await listUpozornenia(db, { ...(type === undefined ? {} : { type }), includeResolved: includeResolved === "true" }, new Date());
+    const { type, includeResolved, includePostponed } = c.req.valid("query");
+    const rows = await listUpozornenia(
+      db,
+      { ...(type === undefined ? {} : { type }), includeResolved: includeResolved === "true", includePostponed: includePostponed === "true" },
+      new Date(),
+    );
     return c.json({ rows });
   });
 
@@ -142,4 +151,18 @@ export function registerUpozorneniaRoutes(app: Hono<AppBindings>, db: Database):
       return c.json({ ok: true as const, postponed });
     },
   );
+
+  // issue 267 (živé overenie, gap 2): "vrátiť" odloženú kartu SKÔR, než sa
+  // vráti sama — rovnaká disciplína ako `/resolve`/`/postpone` (neznáme/už
+  // nedoloženo id je 200 {cancelled:false}, nikdy chyba).
+  app.post("/api/upozornenia/:id/cancel-postpone", requireSameOrigin(), requireUser(db), requireRole("admin", "manazer"), zValidator("param", idParam), async (c) => {
+    const { id } = c.req.valid("param");
+    const user = c.get("user");
+    const now = new Date();
+    const cancelled = await cancelPostpone(db, { id });
+    if (cancelled) {
+      await record(db, { at: now, actorUserId: user.userId, action: "upozornenie.postpone_cancelled", entity: "upozornenie", entityId: id, data: { id } });
+    }
+    return c.json({ ok: true as const, cancelled });
+  });
 }

--- a/apps/api/src/modules/upozornenia/queries.ts
+++ b/apps/api/src/modules/upozornenia/queries.ts
@@ -24,14 +24,23 @@ export interface UpozornenieRow {
 export interface UpozornenieFilter {
   readonly type?: UpozornenieTypeValue;
   readonly includeResolved: boolean;
+  // issue 267 (živé overenie, gap 2): NEZÁVISLÁ os od `includeResolved` —
+  // karta môže byť odložená bez toho, aby bola vybavená. Bez tohto
+  // parametra neexistovala ŽIADNA hodnota `includeResolved`, ktorá by
+  // odloženú kartu odkryla (`notPostponedCondition` sa aplikovala VŽDY).
+  readonly includePostponed?: boolean;
 }
 
-// Odložené karty ZOSTÁVAJÚ skryté, kým sa nevrátia — bez ohľadu na filter
-// "aj vybavené" (ticket: "zmizne zo zoznamu a v ten deň sa vráti späť", žiadny
-// spôsob si ich pozrieť skôr). Zdieľané so `countActionableUpozornenia`
-// nižšie (code review na PR pred mergom: dve nezávislé implementácie tej
-// istej podmienky driftujú) — JEDNA funkcia rozhoduje "nie je práve
-// odložené" pre OBOCH volajúcich.
+// Odložené karty ZOSTÁVAJÚ skryté, kým sa nevrátia SAMÉ (ticket: "zmizne zo
+// zoznamu a v ten deň sa vráti späť") — s JEDINOU výnimkou:
+// `filter.includePostponed === true` (issue 267 follow-up, gap 2: živé
+// overenie zistilo, že bez tejto výnimky sa odložená karta nedala pozrieť
+// ANI opraviť, keby sa majiteľ pomýlil v dátume). Zdieľané so
+// `countActionableUpozornenia` nižšie (code review na PR pred mergom: dve
+// nezávislé implementácie tej istej podmienky driftujú) — JEDNA funkcia
+// rozhoduje "nie je práve odložené" pre OBOCH volajúcich; odznak v menu
+// (nižšie) túto výnimku NIKDY nedostáva — je to len UI zobrazenie na
+// požiadanie, nie zmena toho, čo je "akčné".
 function notPostponedCondition(now: Date): SQL {
   return or(isNull(upozornenie.postponedUntil), lte(upozornenie.postponedUntil, now)) as SQL;
 }
@@ -44,7 +53,7 @@ function notPostponedCondition(now: Date): SQL {
 // naposledy, v rámci toho najnovšie vytvorené prvé.
 export async function listUpozornenia(db: Database, filter: UpozornenieFilter, now: Date): Promise<readonly UpozornenieRow[]> {
   const conditions = [
-    notPostponedCondition(now),
+    ...(filter.includePostponed === true ? [] : [notPostponedCondition(now)]),
     ...(filter.type === undefined ? [] : [eq(upozornenie.type, filter.type)]),
     ...(filter.includeResolved ? [] : [isNull(upozornenie.resolvedAt)]),
   ];

--- a/apps/api/src/modules/upozornenia/service.ts
+++ b/apps/api/src/modules/upozornenia/service.ts
@@ -165,6 +165,19 @@ export async function postponeUpozornenie(db: Database, input: PostponeInput): P
   return result.length > 0;
 }
 
+export interface CancelPostponeInput {
+  readonly id: string;
+}
+
+// issue 267 (živé overenie, gap 2): jediný spôsob, ako "vrátiť" odloženú
+// kartu SKÔR, než sa vráti sama (napr. majiteľ sa pomýlil v dátume) — na
+// rozdiel od `postponeUpozornenie` sa `seenAt` NEDOTÝKA (karta bola už
+// videná v momente odloženia, viď `postponeUpozornenie` vyššie).
+export async function cancelPostpone(db: Database, input: CancelPostponeInput): Promise<boolean> {
+  const result = await db.update(upozornenie).set({ postponedUntil: null }).where(eq(upozornenie.id, input.id)).returning({ id: upozornenie.id });
+  return result.length > 0;
+}
+
 // Volané pri OTVORENÍ záložky — hromadne označí VŠETKY práve "Nové" karty
 // ako videné naraz (inbox vzor "otvoriť = prečítané"), žiadne per-kartové
 // tlačidlo "videné" navyše. Zámerne LEN `seenAt IS NULL` (nikdy nerieši

--- a/apps/api/tests/upozornenia-http.integration.test.ts
+++ b/apps/api/tests/upozornenia-http.integration.test.ts
@@ -61,6 +61,58 @@ describe("GET /api/upozornenia", () => {
     const allBody = (await allRes.json()) as { rows: readonly { title: string }[] };
     expect(allBody.rows.map((r) => r.title).sort()).toEqual(["Aktívna", "Vyriešená"]);
   });
+
+  // Živé overenie po nasadení (issue 267 follow-up, gap 2): odložená karta
+  // bola neviditeľná ÚPLNE VŽDY, aj s `includeResolved=true` — nová nezávislá
+  // os `includePostponed` ju odkryje bez toho, aby menila význam
+  // "aj vybavené".
+  it("predvolený filter vynechá odloženú kartu, 'aj odložené' ju vráti", async () => {
+    const { app, cookie, db } = await boot("manazer");
+    const now = new Date("2026-08-05T08:00:00Z");
+    await upsertUpozornenie(db, { type: "vlastna_poznamka", source: "vlastne", title: "Aktívna", now });
+    const postponedCreate = await upsertUpozornenie(db, { type: "vlastna_poznamka", source: "vlastne", title: "Odložená", now });
+    await app.request(`/api/upozornenia/${postponedCreate.id}/postpone`, {
+      method: "POST",
+      headers: { cookie, "content-type": "application/json" },
+      body: JSON.stringify({ until: "2099-01-01T00:00:00.000Z" }),
+    });
+
+    const defaultRes = await app.request("/api/upozornenia", { headers: { cookie } });
+    const defaultBody = (await defaultRes.json()) as { rows: readonly { title: string }[] };
+    expect(defaultBody.rows.map((r) => r.title)).toEqual(["Aktívna"]);
+
+    const postponedRes = await app.request("/api/upozornenia?includePostponed=true", { headers: { cookie } });
+    const postponedBody = (await postponedRes.json()) as { rows: readonly { title: string }[] };
+    expect(postponedBody.rows.map((r) => r.title).sort()).toEqual(["Aktívna", "Odložená"]);
+  });
+});
+
+describe("POST /api/upozornenia/:id/cancel-postpone", () => {
+  it("zruší odloženie a karta sa vráti aj do PREDVOLENÉHO (bez includePostponed) zoznamu", async () => {
+    const { app, cookie, db } = await boot("manazer");
+    const now = new Date("2026-08-05T08:00:00Z");
+    const created = await upsertUpozornenie(db, { type: "vlastna_poznamka", source: "vlastne", title: "Odložená omylom", now });
+    await app.request(`/api/upozornenia/${created.id}/postpone`, {
+      method: "POST",
+      headers: { cookie, "content-type": "application/json" },
+      body: JSON.stringify({ until: "2099-01-01T00:00:00.000Z" }),
+    });
+
+    const cancelRes = await app.request(`/api/upozornenia/${created.id}/cancel-postpone`, { method: "POST", headers: { cookie } });
+    expect((await cancelRes.json()) as { ok: boolean; cancelled: boolean }).toEqual({ ok: true, cancelled: true });
+
+    const list = await app.request("/api/upozornenia", { headers: { cookie } });
+    const body = (await list.json()) as { rows: readonly { title: string; status: string }[] };
+    expect(body.rows.map((r) => r.title)).toEqual(["Odložená omylom"]);
+    expect(body.rows[0]?.status).toBe("otvorene");
+  });
+
+  it("neznáme id vráti 200 {cancelled:false}, nikdy chybu", async () => {
+    const { app, cookie } = await boot("manazer");
+    const res = await app.request("/api/upozornenia/00000000-0000-0000-0000-000000000000/cancel-postpone", { method: "POST", headers: { cookie } });
+    expect(res.status).toBe(200);
+    expect((await res.json()) as { ok: boolean; cancelled: boolean }).toEqual({ ok: true, cancelled: false });
+  });
 });
 
 describe("GET /api/upozornenia/count", () => {

--- a/apps/api/tests/upozornenia-service.integration.test.ts
+++ b/apps/api/tests/upozornenia-service.integration.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { upozornenie, users } from "../src/db/schema.js";
 import { hashPassword } from "../src/modules/auth/passwords.js";
 import {
+  cancelPostpone,
   createOwnNote,
   deleteOwnNote,
   markAllSeen,
@@ -153,6 +154,25 @@ describe("resolveUpozornenie / postponeUpozornenie", () => {
     const [row] = await db.select().from(upozornenie);
     expect(row?.postponedUntil?.toISOString()).toBe(until.toISOString());
     expect(row?.seenAt).not.toBeNull();
+  });
+});
+
+describe("cancelPostpone", () => {
+  it("vynuluje 'postponedUntil' — karta prestane byť odložená (bez zásahu do seenAt)", async () => {
+    const { db, userId } = await bootDb();
+    const now = new Date("2026-08-05T08:00:00Z");
+    const created = await createOwnNote(db, { title: "Odložiť ma", createdByUserId: userId, now });
+    await postponeUpozornenie(db, { id: created.id, postponedUntil: new Date("2026-08-20T00:00:00Z"), now });
+
+    expect(await cancelPostpone(db, { id: created.id })).toBe(true);
+    const [row] = await db.select().from(upozornenie).where(eq(upozornenie.id, created.id));
+    expect(row?.postponedUntil).toBeNull();
+    expect(row?.seenAt).not.toBeNull();
+  });
+
+  it("neznáme id je neškodné (vracia false, nikdy nevyhodí)", async () => {
+    const { db } = await bootDb();
+    expect(await cancelPostpone(db, { id: "00000000-0000-0000-0000-000000000000" })).toBe(false);
   });
 });
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -12,6 +12,7 @@ import { OrdersRemainingCountContext } from "./ordersRemainingCountContext.js";
 import { fetchPostaUncollectedStatus } from "./postaUncollectedApi.js";
 import { fetchThemeColors } from "./themeColorsApi.js";
 import { fetchUpozorneniaCount } from "./upozorneniaApi.js";
+import { UpozorneniaBadgeRefreshContext } from "./upozorneniaBadgeContext.js";
 
 // Prvá záložka z URL-u (`?tab=<id>`), keď existuje a je platná — inak
 // predvolená ("Sync zo Shoptetu"). Umožňuje priamy odkaz aj na SKRYTÉ
@@ -48,6 +49,18 @@ export function App(): JSX.Element {
   // `automationStatus` nižšie (App.tsx si volá `fetch*` sám), nie cez
   // context.
   const [upozorneniaCount, setUpozorneniaCount] = useState<number | null>(null);
+  // issue 267 (živé overenie, gap 1): mutácia spravená na PRÁVE otvorenej
+  // "Upozornenia" obrazovke (vytvorenie/odloženie/vybavenie/...) nemení
+  // `activeTabId`, takže bez tohto by odznak refetchol len pri zmene
+  // záložky. `UpozorneniaSection` zavolá `refresh()` (cez
+  // `UpozorneniaBadgeRefreshContext`) po každej úspešnej mutácii, čo
+  // bumpne tento nonce a zaradí sa do dependency poľa nižšie — count
+  // pritom naďalej vlastní/fetchuje TENTO efekt, nie obrazovka.
+  const [upozorneniaRefreshNonce, setUpozorneniaRefreshNonce] = useState(0);
+  const upozorneniaBadgeRefresh = useCallback(() => {
+    setUpozorneniaRefreshNonce((n) => n + 1);
+  }, []);
+  const upozorneniaBadgeContextValue = useMemo(() => ({ refresh: upozorneniaBadgeRefresh }), [upozorneniaBadgeRefresh]);
   useEffect(() => {
     if (me === null) return;
     let cancelled = false;
@@ -61,7 +74,7 @@ export function App(): JSX.Element {
     return () => {
       cancelled = true;
     };
-  }, [me, activeTabId]);
+  }, [me, activeTabId, upozorneniaRefreshNonce]);
 
   const badgeCounts = useMemo<Readonly<Record<string, number>>>(() => {
     const counts: Record<string, number> = {};
@@ -188,34 +201,36 @@ export function App(): JSX.Element {
 
   return (
     <OrdersRemainingCountContext.Provider value={ordersRemainingCountContextValue}>
-      <div className="app-shell">
-        <Sidebar
-          folders={NAV}
-          activeTabId={activeTabId}
-          onSelectTab={selectTab}
-          badgeCounts={badgeCounts}
-          badgeStatus={automationStatus}
-        />
-        <div className="main">
-          <Topbar
-            title={isVisibleTabId(activeTabId) ? (tab?.label ?? null) : null}
-            greeting={`Prihlásený: ${me.displayName} (${me.role})`}
-            role={me.role}
-            onSessionExpired={reload}
-            onLogout={logout}
-            passwordPanelOpen={passwordPanelOpen}
-            onTogglePasswordPanel={() => {
-              setPasswordPanelOpen((open) => !open);
-            }}
-          >
-            <ChangePasswordForm email={me.email} onSessionExpired={reload} />
-          </Topbar>
-          <main className={tab?.wide === true ? "main-wide" : undefined}>
-            {logoutError !== "" && <p role="alert">{logoutError}</p>}
-            {ActiveComponent !== null && <ActiveComponent role={me.role} onSessionExpired={reload} />}
-          </main>
+      <UpozorneniaBadgeRefreshContext.Provider value={upozorneniaBadgeContextValue}>
+        <div className="app-shell">
+          <Sidebar
+            folders={NAV}
+            activeTabId={activeTabId}
+            onSelectTab={selectTab}
+            badgeCounts={badgeCounts}
+            badgeStatus={automationStatus}
+          />
+          <div className="main">
+            <Topbar
+              title={isVisibleTabId(activeTabId) ? (tab?.label ?? null) : null}
+              greeting={`Prihlásený: ${me.displayName} (${me.role})`}
+              role={me.role}
+              onSessionExpired={reload}
+              onLogout={logout}
+              passwordPanelOpen={passwordPanelOpen}
+              onTogglePasswordPanel={() => {
+                setPasswordPanelOpen((open) => !open);
+              }}
+            >
+              <ChangePasswordForm email={me.email} onSessionExpired={reload} />
+            </Topbar>
+            <main className={tab?.wide === true ? "main-wide" : undefined}>
+              {logoutError !== "" && <p role="alert">{logoutError}</p>}
+              {ActiveComponent !== null && <ActiveComponent role={me.role} onSessionExpired={reload} />}
+            </main>
+          </div>
         </div>
-      </div>
+      </UpozorneniaBadgeRefreshContext.Provider>
     </OrdersRemainingCountContext.Provider>
   );
 }

--- a/apps/web/src/components/UpozorneniaSection.badgeRefresh.test.tsx
+++ b/apps/web/src/components/UpozorneniaSection.badgeRefresh.test.tsx
@@ -1,0 +1,86 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { UpozorneniaBadgeRefreshContext } from "../upozorneniaBadgeContext.js";
+import { UpozorneniaSection } from "./UpozorneniaSection.js";
+
+// issue 267 (živé overenie, gap 1): odznak v ľavom menu klamal, kým sa
+// stránka neobnovila — mutácia (vytvorenie/odloženie/vybavenie) na PRÁVE
+// otvorenej obrazovke nemala žiadny spúšťač refetchu. Tento test overuje, že
+// `UpozorneniaSection` po KAŽDEJ úspešnej mutácii zavolá `refresh()` z
+// `UpozorneniaBadgeRefreshContext` — spotrebiteľ v produkčnom kóde
+// (`App.tsx`) ho nahrádza spy funkciou, rovnaký vzor ako
+// `OrdersSection.remainingCount.test.tsx`.
+
+const { fetchUpozornenia, markUpozorneniaSeen, createOwnNote, resolveUpozornenie } = vi.hoisted(() => ({
+  fetchUpozornenia: vi.fn(),
+  markUpozorneniaSeen: vi.fn(),
+  createOwnNote: vi.fn(),
+  resolveUpozornenie: vi.fn(),
+}));
+
+vi.mock("../upozorneniaApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../upozorneniaApi.js")>();
+  return { ...actual, fetchUpozornenia, markUpozorneniaSeen, createOwnNote, resolveUpozornenie };
+});
+
+const KARTA = {
+  id: "own-1",
+  type: "vlastna_poznamka" as const,
+  source: "vlastne" as const,
+  title: "Schôdzka v stredu",
+  details: "",
+  link: null,
+  dueAt: null,
+  postponedUntil: null,
+  seenAt: null,
+  resolvedAt: null,
+  createdAt: "2026-08-05T08:00:00.000Z",
+  status: "nove" as const,
+};
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+it("klik na 'Vybavené' zavolá refresh() z UpozorneniaBadgeRefreshContext (odznak sa refetchne bez zmeny záložky)", async () => {
+  markUpozorneniaSeen.mockResolvedValue(undefined);
+  fetchUpozornenia.mockResolvedValueOnce([KARTA]).mockResolvedValueOnce([{ ...KARTA, status: "vybavene" as const }]);
+  resolveUpozornenie.mockResolvedValue(undefined);
+  const refresh = vi.fn();
+
+  render(
+    <UpozorneniaBadgeRefreshContext.Provider value={{ refresh }}>
+      <UpozorneniaSection role="manazer" onSessionExpired={vi.fn()} />
+    </UpozorneniaBadgeRefreshContext.Provider>,
+  );
+  await screen.findByTestId("upozornenie-own-1");
+  expect(refresh).not.toHaveBeenCalled();
+
+  fireEvent.click(screen.getByTestId("upozornenie-resolve-own-1"));
+  await waitFor(() => {
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+});
+
+it("uloženie novej vlastnej poznámky ('+ Nové upozornenie') tiež zavolá refresh()", async () => {
+  markUpozorneniaSeen.mockResolvedValue(undefined);
+  fetchUpozornenia.mockResolvedValueOnce([]).mockResolvedValueOnce([KARTA]);
+  createOwnNote.mockResolvedValue(undefined);
+  const refresh = vi.fn();
+
+  render(
+    <UpozorneniaBadgeRefreshContext.Provider value={{ refresh }}>
+      <UpozorneniaSection role="manazer" onSessionExpired={vi.fn()} />
+    </UpozorneniaBadgeRefreshContext.Provider>,
+  );
+  await screen.findByTestId("upozornenia-empty");
+
+  fireEvent.click(screen.getByTestId("upozornenie-new"));
+  fireEvent.change(screen.getByTestId("upozornenie-form-title"), { target: { value: "Schôdzka v stredu" } });
+  fireEvent.click(screen.getByTestId("upozornenie-form-save"));
+
+  await waitFor(() => {
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/UpozorneniaSection.badgeRefresh.test.tsx
+++ b/apps/web/src/components/UpozorneniaSection.badgeRefresh.test.tsx
@@ -65,7 +65,9 @@ it("klik na 'Vybavené' zavolá refresh() z UpozorneniaBadgeRefreshContext (odzn
 
 it("uloženie novej vlastnej poznámky ('+ Nové upozornenie') tiež zavolá refresh()", async () => {
   markUpozorneniaSeen.mockResolvedValue(undefined);
-  fetchUpozornenia.mockResolvedValueOnce([]).mockResolvedValueOnce([KARTA]);
+  // Tretie `[]` je issue 267 follow-up gap 3's doplnkový najširší dopyt,
+  // ktorý `load()` spraví, keď je zoznam prázdny (tu: hneď po mounte).
+  fetchUpozornenia.mockResolvedValueOnce([]).mockResolvedValueOnce([]).mockResolvedValueOnce([KARTA]);
   createOwnNote.mockResolvedValue(undefined);
   const refresh = vi.fn();
 

--- a/apps/web/src/components/UpozorneniaSection.emptyMessage.test.tsx
+++ b/apps/web/src/components/UpozorneniaSection.emptyMessage.test.tsx
@@ -1,0 +1,84 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import type { UpozornenieRow } from "../upozorneniaApi.js";
+import { UpozorneniaSection } from "./UpozorneniaSection.js";
+
+// issue 267 (živé overenie, gap 3): prázdny zoznam tvrdil natvrdo "všetko je
+// vybavené" bez ohľadu na to, PREČO je prázdny — aj keď jediná existujúca
+// karta bola len ODLOŽENÁ. Tieto testy overujú, že hláška zodpovedá
+// SKUTOČNEJ príčine (nič vôbec / všetko vybavené / všetko odložené /
+// kombinácia), zisťovanej doplnkovým najširším dopytom LEN keď je zoznam
+// prázdny.
+
+const { fetchUpozornenia, markUpozorneniaSeen } = vi.hoisted(() => ({
+  fetchUpozornenia: vi.fn(),
+  markUpozorneniaSeen: vi.fn(),
+}));
+
+vi.mock("../upozorneniaApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../upozorneniaApi.js")>();
+  return { ...actual, fetchUpozornenia, markUpozorneniaSeen };
+});
+
+function karta(id: string, status: UpozornenieRow["status"]): UpozornenieRow {
+  return {
+    id,
+    type: "vlastna_poznamka",
+    source: "vlastne",
+    title: `Karta ${id}`,
+    details: "",
+    link: null,
+    dueAt: null,
+    postponedUntil: status === "odlozene" ? "2099-01-01T00:00:00.000Z" : null,
+    seenAt: "2026-08-05T08:00:00.000Z",
+    resolvedAt: status === "vybavene" ? "2026-08-05T08:00:00.000Z" : null,
+    createdAt: "2026-08-05T08:00:00.000Z",
+    status,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+it("skutočne nič nie je zapísané — hláška to hovorí pravdivo", async () => {
+  markUpozorneniaSeen.mockResolvedValue(undefined);
+  fetchUpozornenia.mockResolvedValue([]);
+  render(<UpozorneniaSection role="manazer" onSessionExpired={vi.fn()} />);
+  const empty = await screen.findByTestId("upozornenia-empty");
+  expect(empty.textContent).toBe("Žiadne upozornenia — nič nie je zapísané.");
+});
+
+it("existuje len VYBAVENÁ karta — hláška to hovorí pravdivo (nie 'nič nie je zapísané')", async () => {
+  markUpozorneniaSeen.mockResolvedValue(undefined);
+  fetchUpozornenia.mockImplementation((filter: { readonly includeResolved: boolean; readonly includePostponed?: boolean }) => {
+    if (filter.includeResolved && filter.includePostponed === true) return Promise.resolve([karta("a", "vybavene")]);
+    return Promise.resolve([]);
+  });
+  render(<UpozorneniaSection role="manazer" onSessionExpired={vi.fn()} />);
+  const empty = await screen.findByTestId("upozornenia-empty");
+  expect(empty.textContent).toBe("Žiadne upozornenia — všetko je vybavené.");
+});
+
+it("existuje len ODLOŽENÁ karta — hláška hovorí 'odložené', NIKDY 'vybavené' (živý nález)", async () => {
+  markUpozorneniaSeen.mockResolvedValue(undefined);
+  fetchUpozornenia.mockImplementation((filter: { readonly includeResolved: boolean; readonly includePostponed?: boolean }) => {
+    if (filter.includeResolved && filter.includePostponed === true) return Promise.resolve([karta("b", "odlozene")]);
+    return Promise.resolve([]);
+  });
+  render(<UpozorneniaSection role="manazer" onSessionExpired={vi.fn()} />);
+  const empty = await screen.findByTestId("upozornenia-empty");
+  expect(empty.textContent).toBe("Žiadne upozornenia — všetko je odložené.");
+});
+
+it("existujú OBE (vybavená aj odložená) — hláška nehádže žiadnu konkrétnu nepravdivú príčinu", async () => {
+  markUpozorneniaSeen.mockResolvedValue(undefined);
+  fetchUpozornenia.mockImplementation((filter: { readonly includeResolved: boolean; readonly includePostponed?: boolean }) => {
+    if (filter.includeResolved && filter.includePostponed === true) return Promise.resolve([karta("c", "vybavene"), karta("d", "odlozene")]);
+    return Promise.resolve([]);
+  });
+  render(<UpozorneniaSection role="manazer" onSessionExpired={vi.fn()} />);
+  const empty = await screen.findByTestId("upozornenia-empty");
+  expect(empty.textContent).toBe("Žiadne upozornenia v tomto zobrazení — zvyšné sú vybavené alebo odložené.");
+});

--- a/apps/web/src/components/UpozorneniaSection.postponeVisibility.test.tsx
+++ b/apps/web/src/components/UpozorneniaSection.postponeVisibility.test.tsx
@@ -1,0 +1,74 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { UpozorneniaSection } from "./UpozorneniaSection.js";
+
+// issue 267 (živé overenie, gap 2): odložená karta bola neviditeľná ÚPLNE
+// VŽDY a nedala sa vrátiť — nový checkbox "aj odložené" (nezávislý od "aj
+// vybavené") odkryje ju, nové tlačidlo "Zrušiť odloženie" ju vráti naspäť.
+
+const { fetchUpozornenia, markUpozorneniaSeen, cancelPostponeUpozornenie } = vi.hoisted(() => ({
+  fetchUpozornenia: vi.fn(),
+  markUpozorneniaSeen: vi.fn(),
+  cancelPostponeUpozornenie: vi.fn(),
+}));
+
+vi.mock("../upozorneniaApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../upozorneniaApi.js")>();
+  return { ...actual, fetchUpozornenia, markUpozorneniaSeen, cancelPostponeUpozornenie };
+});
+
+const ODLOZENA_KARTA = {
+  id: "postponed-1",
+  type: "vlastna_poznamka" as const,
+  source: "vlastne" as const,
+  title: "Odložená karta",
+  details: "",
+  link: null,
+  dueAt: null,
+  postponedUntil: "2026-08-20T00:00:00.000Z",
+  seenAt: "2026-08-05T08:00:00.000Z",
+  resolvedAt: null,
+  createdAt: "2026-08-05T08:00:00.000Z",
+  status: "odlozene" as const,
+};
+
+const OTVORENA_KARTA = { ...ODLOZENA_KARTA, id: "open-1", title: "Otvorená karta", postponedUntil: null, status: "otvorene" as const };
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+it("zaškrtnutie 'aj odložené' znova načíta zoznam s includePostponed: true", async () => {
+  markUpozorneniaSeen.mockResolvedValue(undefined);
+  fetchUpozornenia.mockResolvedValue([]);
+  render(<UpozorneniaSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("upozornenia-empty");
+
+  fireEvent.click(screen.getByLabelText("aj odložené"));
+
+  await waitFor(() => {
+    expect(fetchUpozornenia).toHaveBeenLastCalledWith({ includeResolved: false, includePostponed: true });
+  });
+});
+
+it("otvorená (nie odložená) karta NEMÁ tlačidlo 'Zrušiť odloženie'", async () => {
+  markUpozorneniaSeen.mockResolvedValue(undefined);
+  fetchUpozornenia.mockResolvedValue([OTVORENA_KARTA]);
+  render(<UpozorneniaSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("upozornenie-open-1");
+  expect(screen.queryByTestId("upozornenie-cancel-postpone-open-1")).toBeNull();
+});
+
+it("odložená karta má tlačidlo 'Zrušiť odloženie', klik zavolá cancelPostponeUpozornenie a znova načíta zoznam", async () => {
+  markUpozorneniaSeen.mockResolvedValue(undefined);
+  fetchUpozornenia.mockResolvedValueOnce([ODLOZENA_KARTA]).mockResolvedValueOnce([{ ...ODLOZENA_KARTA, status: "otvorene" as const, postponedUntil: null }]);
+  cancelPostponeUpozornenie.mockResolvedValue(undefined);
+  render(<UpozorneniaSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("upozornenie-postponed-1");
+
+  fireEvent.click(screen.getByTestId("upozornenie-cancel-postpone-postponed-1"));
+  await waitFor(() => {
+    expect(cancelPostponeUpozornenie).toHaveBeenCalledWith("postponed-1");
+  });
+});

--- a/apps/web/src/components/UpozorneniaSection.postponeVisibility.test.tsx
+++ b/apps/web/src/components/UpozorneniaSection.postponeVisibility.test.tsx
@@ -47,8 +47,12 @@ it("zaškrtnutie 'aj odložené' znova načíta zoznam s includePostponed: true"
 
   fireEvent.click(screen.getByLabelText("aj odložené"));
 
+  // `toHaveBeenCalledWith` (nie `toHaveBeenLastCalledWith`) — issue 267
+  // follow-up gap 3's doplnkový najširší klasifikačný dopyt (spustený, lebo
+  // zoznam je prázdny) môže dobehnúť AŽ PO tomto volaní, takže "posledné"
+  // volanie nie je deterministicky toto.
   await waitFor(() => {
-    expect(fetchUpozornenia).toHaveBeenLastCalledWith({ includeResolved: false, includePostponed: true });
+    expect(fetchUpozornenia).toHaveBeenCalledWith({ includeResolved: false, includePostponed: true });
   });
 });
 

--- a/apps/web/src/components/UpozorneniaSection.test.tsx
+++ b/apps/web/src/components/UpozorneniaSection.test.tsx
@@ -81,7 +81,9 @@ it("karta zo zdroja 'appka' nemá Upraviť/Zmazať, len Vybavené/Odložiť", as
 
 it("'+ Nové upozornenie' otvorí formulár, uloženie zavolá createOwnNote a znova načíta zoznam", async () => {
   markUpozorneniaSeen.mockResolvedValue(undefined);
-  fetchUpozornenia.mockResolvedValueOnce([]).mockResolvedValueOnce([VLASTNA_KARTA]);
+  // Tretie `[]` je issue 267 follow-up gap 3's doplnkový najširší dopyt,
+  // ktorý `load()` spraví, keď je zoznam prázdny (tu: hneď po mounte).
+  fetchUpozornenia.mockResolvedValueOnce([]).mockResolvedValueOnce([]).mockResolvedValueOnce([VLASTNA_KARTA]);
   createOwnNote.mockResolvedValue(undefined);
   render(<UpozorneniaSection role="manazer" onSessionExpired={vi.fn()} />);
   await screen.findByTestId("upozornenia-empty");
@@ -123,7 +125,9 @@ it("Upraviť predvyplní formulár existujúcimi hodnotami vlastnej poznámky", 
 
 it("Zmazať zavolá deleteOwnNote a znova načíta zoznam", async () => {
   markUpozorneniaSeen.mockResolvedValue(undefined);
-  fetchUpozornenia.mockResolvedValueOnce([VLASTNA_KARTA]).mockResolvedValueOnce([]);
+  // Tretie `[]` je issue 267 follow-up gap 3's doplnkový najširší dopyt,
+  // ktorý `load()` spraví, keď je zoznam prázdny (tu: po zmazaní).
+  fetchUpozornenia.mockResolvedValueOnce([VLASTNA_KARTA]).mockResolvedValueOnce([]).mockResolvedValueOnce([]);
   deleteOwnNote.mockResolvedValue(undefined);
   render(<UpozorneniaSection role="manazer" onSessionExpired={vi.fn()} />);
   await screen.findByTestId("upozornenie-own-1");

--- a/apps/web/src/components/UpozorneniaSection.tsx
+++ b/apps/web/src/components/UpozorneniaSection.tsx
@@ -29,6 +29,18 @@ function formatDate(iso: string): string {
   return new Date(iso).toLocaleDateString("sk-SK", { day: "numeric", month: "numeric", year: "numeric" });
 }
 
+// issue 267 (živé overenie, gap 3): prázdny zoznam tvrdil natvrdo "všetko je
+// vybavené" bez ohľadu na SKUTOČNÚ príčinu — čistá funkcia rozhodne podľa
+// NAJŠIRŠIEHO dopytu (volaného len keď je aktuálny, možno UŽŠIE filtrovaný
+// zoznam prázdny — pozri `load()`), aby hláška nikdy netvrdila niečo, čo
+// nie je pravda.
+function classifyEmptyMessage(all: readonly UpozornenieRow[]): string {
+  if (all.length === 0) return "Žiadne upozornenia — nič nie je zapísané.";
+  if (all.every((r) => r.status === "vybavene")) return "Žiadne upozornenia — všetko je vybavené.";
+  if (all.every((r) => r.status === "odlozene")) return "Žiadne upozornenia — všetko je odložené.";
+  return "Žiadne upozornenia v tomto zobrazení — zvyšné sú vybavené alebo odložené.";
+}
+
 // Code review: "Odložiť do" nemalo `min` — dalo sa vybrať dátum v minulosti
 // (neškodné, `computeStatus` by ho vzalo ako "už sa vrátilo", ale mätúce
 // no-op). `<input type="date">`'s `min` očakáva `YYYY-MM-DD` v LOKÁLNOM
@@ -61,6 +73,9 @@ export function UpozorneniaSection({ role, onSessionExpired }: { readonly role: 
   const [busyId, setBusyId] = useState("");
   const [draft, setDraft] = useState<EditDraft | null>(null);
   const [postponeDraft, setPostponeDraft] = useState<Record<string, string>>({});
+  // issue 267 (živé overenie, gap 3): pravdivá príčina prázdneho zoznamu —
+  // počíta sa v `load()` nižšie, len keď je zoznam skutočne prázdny.
+  const [emptyMessage, setEmptyMessage] = useState("Žiadne upozornenia.");
   const canControl = CONTROL_ROLES.has(role);
   // issue 267 (živé overenie, gap 1): odznak v ľavom menu (`App.tsx`) sa bez
   // tohto refetchoval len pri zmene záložky — refresh() sa zavolá po KAŽDEJ
@@ -70,7 +85,24 @@ export function UpozorneniaSection({ role, onSessionExpired }: { readonly role: 
 
   const load = useCallback(() => {
     fetchUpozornenia({ includeResolved, includePostponed })
-      .then(setRows)
+      .then((data) => {
+        setRows(data);
+        if (data.length > 0) return;
+        // Zoznam je prázdny pod AKTUÁLNYMI (možno užšími) filtrami — ak sú
+        // už najširšie, `data` JE tá pravda; inak treba doplnkový najširší
+        // dopyt, aby hláška nikdy nehádala/netvrdila nesprávnu príčinu.
+        if (includeResolved && includePostponed) {
+          setEmptyMessage(classifyEmptyMessage(data));
+          return;
+        }
+        fetchUpozornenia({ includeResolved: true, includePostponed: true })
+          .then((all) => {
+            setEmptyMessage(classifyEmptyMessage(all));
+          })
+          .catch(() => {
+            setEmptyMessage("Žiadne upozornenia v tomto zobrazení.");
+          });
+      })
       .catch((err: unknown) => {
         if (err instanceof UpozorneniaUnauthorizedError) {
           onSessionExpired();
@@ -251,7 +283,7 @@ export function UpozorneniaSection({ role, onSessionExpired }: { readonly role: 
       )}
 
       {rows.length === 0 ? (
-        <p data-testid="upozornenia-empty">Žiadne upozornenia — všetko je vybavené.</p>
+        <p data-testid="upozornenia-empty">{emptyMessage}</p>
       ) : (
         <div className="upozornenia-list" data-testid="upozornenia-list">
           {rows.map((row) => {

--- a/apps/web/src/components/UpozorneniaSection.tsx
+++ b/apps/web/src/components/UpozorneniaSection.tsx
@@ -82,10 +82,20 @@ export function UpozorneniaSection({ role, onSessionExpired }: { readonly role: 
   // úspešnej mutácii (`withBusy`/`saveDraft`), aby ostal pravdivý aj keď
   // obsluha zostane na tejto obrazovke.
   const { refresh: refreshBadge } = useContext(UpozorneniaBadgeRefreshContext);
+  // Code review: `load()`'s doplnkový klasifikačný dopyt (nižšie) nemal
+  // žiadnu poistku proti ZASTARANEJ odpovedi — presne tá istá trieda race,
+  // akú `.claude/rules/frontend-design.md` rieši "latest ref" vzorom (issue
+  // 151/251/264: mikrotaska z PREDCHÁDZAJÚCEHO `load()` volania môže
+  // doraziť AŽ PO novšom a prepísať jeho výsledok zastaraným). `loadSeqRef`
+  // sa inkrementuje na ZAČIATKU každého `load()` volania; oba `.then()` nižšie
+  // sa uplatnia len ak je stále najnovšie.
+  const loadSeqRef = useRef(0);
 
   const load = useCallback(() => {
+    const seq = ++loadSeqRef.current;
     fetchUpozornenia({ includeResolved, includePostponed })
       .then((data) => {
+        if (loadSeqRef.current !== seq) return;
         setRows(data);
         if (data.length > 0) return;
         // Zoznam je prázdny pod AKTUÁLNYMI (možno užšími) filtrami — ak sú
@@ -97,13 +107,14 @@ export function UpozorneniaSection({ role, onSessionExpired }: { readonly role: 
         }
         fetchUpozornenia({ includeResolved: true, includePostponed: true })
           .then((all) => {
-            setEmptyMessage(classifyEmptyMessage(all));
+            if (loadSeqRef.current === seq) setEmptyMessage(classifyEmptyMessage(all));
           })
           .catch(() => {
-            setEmptyMessage("Žiadne upozornenia v tomto zobrazení.");
+            if (loadSeqRef.current === seq) setEmptyMessage("Žiadne upozornenia v tomto zobrazení.");
           });
       })
       .catch((err: unknown) => {
+        if (loadSeqRef.current !== seq) return;
         if (err instanceof UpozorneniaUnauthorizedError) {
           onSessionExpired();
           return;

--- a/apps/web/src/components/UpozorneniaSection.tsx
+++ b/apps/web/src/components/UpozorneniaSection.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useRef, useState, type JSX } from "react";
+import { useCallback, useContext, useEffect, useRef, useState, type JSX } from "react";
 import type { Me } from "../api.js";
+import { UpozorneniaBadgeRefreshContext } from "../upozorneniaBadgeContext.js";
 import {
   createOwnNote,
   deleteOwnNote,
@@ -57,6 +58,11 @@ export function UpozorneniaSection({ role, onSessionExpired }: { readonly role: 
   const [draft, setDraft] = useState<EditDraft | null>(null);
   const [postponeDraft, setPostponeDraft] = useState<Record<string, string>>({});
   const canControl = CONTROL_ROLES.has(role);
+  // issue 267 (živé overenie, gap 1): odznak v ľavom menu (`App.tsx`) sa bez
+  // tohto refetchoval len pri zmene záložky — refresh() sa zavolá po KAŽDEJ
+  // úspešnej mutácii (`withBusy`/`saveDraft`), aby ostal pravdivý aj keď
+  // obsluha zostane na tejto obrazovke.
+  const { refresh: refreshBadge } = useContext(UpozorneniaBadgeRefreshContext);
 
   const load = useCallback(() => {
     fetchUpozornenia({ includeResolved })
@@ -99,14 +105,17 @@ export function UpozorneniaSection({ role, onSessionExpired }: { readonly role: 
     setBusyId(key);
     setError("");
     action()
-      .then(load)
+      .then(() => {
+        load();
+        refreshBadge();
+      })
       .catch(() => {
         setError("Akcia zlyhala — skúste to znova.");
       })
       .finally(() => {
         setBusyId("");
       });
-  }, [load]);
+  }, [load, refreshBadge]);
 
   const saveDraft = useCallback(() => {
     if (draft === null || draft.title.trim() === "") return;
@@ -127,6 +136,7 @@ export function UpozorneniaSection({ role, onSessionExpired }: { readonly role: 
         }
         setDraft(null);
         load();
+        refreshBadge();
       })
       .catch(() => {
         setError("Uloženie zlyhalo — skúste to znova.");
@@ -134,7 +144,7 @@ export function UpozorneniaSection({ role, onSessionExpired }: { readonly role: 
       .finally(() => {
         setBusyId("");
       });
-  }, [draft, load]);
+  }, [draft, load, refreshBadge]);
 
   if (error !== "" && rows === null) return <p role="alert">{error}</p>;
   if (rows === null) return <p>Načítavam…</p>;

--- a/apps/web/src/components/UpozorneniaSection.tsx
+++ b/apps/web/src/components/UpozorneniaSection.tsx
@@ -2,6 +2,7 @@ import { useCallback, useContext, useEffect, useRef, useState, type JSX } from "
 import type { Me } from "../api.js";
 import { UpozorneniaBadgeRefreshContext } from "../upozorneniaBadgeContext.js";
 import {
+  cancelPostponeUpozornenie,
   createOwnNote,
   deleteOwnNote,
   fetchUpozornenia,
@@ -54,6 +55,9 @@ export function UpozorneniaSection({ role, onSessionExpired }: { readonly role: 
   const [rows, setRows] = useState<readonly UpozornenieRow[] | null>(null);
   const [error, setError] = useState("");
   const [includeResolved, setIncludeResolved] = useState(false);
+  // issue 267 (živé overenie, gap 2): nezávislý filter od `includeResolved`
+  // — odložená karta bola bez tohto NAVŽDY skrytá, aj s "aj vybavené".
+  const [includePostponed, setIncludePostponed] = useState(false);
   const [busyId, setBusyId] = useState("");
   const [draft, setDraft] = useState<EditDraft | null>(null);
   const [postponeDraft, setPostponeDraft] = useState<Record<string, string>>({});
@@ -65,7 +69,7 @@ export function UpozorneniaSection({ role, onSessionExpired }: { readonly role: 
   const { refresh: refreshBadge } = useContext(UpozorneniaBadgeRefreshContext);
 
   const load = useCallback(() => {
-    fetchUpozornenia({ includeResolved })
+    fetchUpozornenia({ includeResolved, includePostponed })
       .then(setRows)
       .catch((err: unknown) => {
         if (err instanceof UpozorneniaUnauthorizedError) {
@@ -74,7 +78,7 @@ export function UpozorneniaSection({ role, onSessionExpired }: { readonly role: 
         }
         setError("Upozornenia sa nepodarilo načítať.");
       });
-  }, [includeResolved, onSessionExpired]);
+  }, [includeResolved, includePostponed, onSessionExpired]);
 
   // Otvorenie záložky = "prečítané" (inbox vzor) — PRVÉ spustenie tohto
   // efektu (mountedRef ešte `false`) hromadne označí všetky práve "Nové"
@@ -166,6 +170,16 @@ export function UpozorneniaSection({ role, onSessionExpired }: { readonly role: 
           />{" "}
           aj vybavené
         </label>
+        <label>
+          <input
+            type="checkbox"
+            checked={includePostponed}
+            onChange={(e) => {
+              setIncludePostponed(e.target.checked);
+            }}
+          />{" "}
+          aj odložené
+        </label>
         {canControl && (
           <button
             type="button"
@@ -251,6 +265,11 @@ export function UpozorneniaSection({ role, onSessionExpired }: { readonly role: 
                   </span>
                   {row.status === "nove" && <strong data-testid={`upozornenie-nove-${row.id}`}>Nové</strong>}
                   {row.status === "vybavene" && <span className="pill off">Vybavené</span>}
+                  {row.status === "odlozene" && (
+                    <span className="pill" data-testid={`upozornenie-odlozene-${row.id}`}>
+                      Odložené{row.postponedUntil !== null && <> do {formatDate(row.postponedUntil)}</>}
+                    </span>
+                  )}
                 </div>
                 <p className="upozornenie-title">{row.title}</p>
                 {row.details !== "" && <p className="upozornenie-details">{row.details}</p>}
@@ -300,6 +319,22 @@ export function UpozorneniaSection({ role, onSessionExpired }: { readonly role: 
                     >
                       Odložiť
                     </button>
+                    {row.status === "odlozene" && (
+                      // issue 267 (živé overenie, gap 2): jediný spôsob, ako
+                      // vrátiť odloženú kartu SKÔR, než sa vráti sama (napr.
+                      // majiteľ sa pomýlil v dátume).
+                      <button
+                        type="button"
+                        className="btn sm ghost"
+                        disabled={rowBusy}
+                        onClick={() => {
+                          withBusy(row.id, () => cancelPostponeUpozornenie(row.id));
+                        }}
+                        data-testid={`upozornenie-cancel-postpone-${row.id}`}
+                      >
+                        Zrušiť odloženie
+                      </button>
+                    )}
                     {isOwn && (
                       <>
                         <button

--- a/apps/web/src/upozorneniaApi.ts
+++ b/apps/web/src/upozorneniaApi.ts
@@ -47,9 +47,10 @@ async function readJson(response: Response, fallback: string): Promise<unknown> 
   return await response.json();
 }
 
-export async function fetchUpozornenia(filter: { readonly includeResolved: boolean }): Promise<readonly UpozornenieRow[]> {
+export async function fetchUpozornenia(filter: { readonly includeResolved: boolean; readonly includePostponed?: boolean }): Promise<readonly UpozornenieRow[]> {
   const params = new URLSearchParams();
   if (filter.includeResolved) params.set("includeResolved", "true");
+  if (filter.includePostponed === true) params.set("includePostponed", "true");
   const qs = params.toString();
   const response = await fetch(`/api/upozornenia${qs === "" ? "" : `?${qs}`}`);
   return listSchema.parse(await readJson(response, "Upozornenia sa nepodarilo načítať")).rows;
@@ -110,4 +111,9 @@ export async function postponeUpozornenie(id: string, until: string): Promise<vo
     body: JSON.stringify({ until }),
   });
   await readJson(response, "Odloženie zlyhalo");
+}
+
+export async function cancelPostponeUpozornenie(id: string): Promise<void> {
+  const response = await fetch(`/api/upozornenia/${encodeURIComponent(id)}/cancel-postpone`, { method: "POST" });
+  await readJson(response, "Zrušenie odloženia zlyhalo");
 }

--- a/apps/web/src/upozorneniaBadgeContext.ts
+++ b/apps/web/src/upozorneniaBadgeContext.ts
@@ -1,0 +1,20 @@
+import { createContext } from "react";
+
+// issue 267 (živé overenie, gap 1): most medzi `UpozorneniaSection`
+// (mutuje dáta) a `App.tsx` (vlastní odznak v ľavom menu, `badgeCounts`).
+// Na rozdiel od `OrdersRemainingCountContext` (ten nesie SAMOTNÚ hodnotu,
+// lebo ju publikuje priamo obrazovka) tento context nesie LEN účinok
+// "niečo sa zmenilo" — `App.tsx` si count naďalej načítava a vlastní SÁM
+// (musí byť známy hneď po prihlásení, nie až po prvom otvorení záložky,
+// pôvodné návrhové rozhodnutie na tickete), len teraz dostáva aj DRUHÝ
+// spúšťač refetchu okrem zmeny záložky.
+export interface UpozorneniaBadgeRefreshContextValue {
+  readonly refresh: () => void;
+}
+
+export const UpozorneniaBadgeRefreshContext = createContext<UpozorneniaBadgeRefreshContextValue>({
+  refresh: () => {
+    // Predvolená hodnota mimo Provider-a (napr. test, čo rendruje
+    // UpozorneniaSection samostatne bez App.tsx) — bezpečné no-op.
+  },
+});

--- a/apps/web/tests/e2e/upozornenia.spec.ts
+++ b/apps/web/tests/e2e/upozornenia.spec.ts
@@ -32,7 +32,9 @@ test("vlastná poznámka — vytvorenie, 'Nové' zmizne po znovuotvorení, úpra
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
   await expect(page.getByRole("heading", { name: "Upozornenia" })).toBeVisible();
-  await expect(page.getByTestId("upozornenia-empty")).toBeVisible();
+  // issue 267 follow-up gap 3: skutočne nič nie je zapísané — hláška to
+  // musí povedať pravdivo, nie natvrdo "všetko je vybavené".
+  await expect(page.getByTestId("upozornenia-empty")).toHaveText("Žiadne upozornenia — nič nie je zapísané.");
 
   // Vytvorenie vlastnej poznámky.
   await page.getByTestId("upozornenie-new").click();
@@ -73,6 +75,17 @@ test("vlastná poznámka — vytvorenie, 'Nové' zmizne po znovuotvorení, úpra
   await page.getByText("aj vybavené").click();
   await expect(kartaSNadpisom(page, "Schôdzka v stredu — presunutá")).toHaveCount(0);
   await page.getByText("aj vybavené").click();
+
+  // issue 267 follow-up gap 2: "aj odložené" (NEZÁVISLÝ filter od "aj
+  // vybavené" vyššie) JU odkryje, a "Zrušiť odloženie" ju vráti naspäť skôr,
+  // než sa vráti sama.
+  await page.getByText("aj odložené").click();
+  const odlozenaKarta = kartaSNadpisom(page, "Schôdzka v stredu — presunutá");
+  await expect(odlozenaKarta).toBeVisible();
+  await expect(odlozenaKarta).toContainText("Odložené");
+  await odlozenaKarta.getByRole("button", { name: "Zrušiť odloženie" }).click();
+  await page.getByText("aj odložené").click(); // vypnúť filter — karta musí byť viditeľná AJ bez neho
+  await expect(kartaSNadpisom(page, "Schôdzka v stredu — presunutá")).toBeVisible();
 
   // Vlastná druhá poznámka, ktorú rovno vybavíme a zmažeme.
   await page.getByTestId("upozornenie-new").click();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.155",
+  "version": "0.3.0-dev.156",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Čo to robí

Dorobenie troch vecí, ktoré neprešli živým overením nástenky **Eshop → Upozornenia** po nasadení `0.3.0-dev.155`.

**1. Počítadlo v ľavom menu klamalo, kým sa stránka neobnovila.** Zapísal si poznámku a v menu ostala nula; správne číslo prišlo až po `F5`. Teraz sa počítadlo obnoví po každej zmene — pridanie, úprava, zmazanie, vybavenie aj odloženie.

**2. Odložená karta zmizla úplne — nedala sa nikde pozrieť ani vrátiť späť.** Keď si sa v dátume pomýlil, vec sa vrátila až o dva týždne a dovtedy sa s ňou nedalo nič robiť. Pribudol samostatný prepínač **„aj odložené"** (nezávislý od „aj vybavené") a pri odloženej karte tlačidlo **Zrušiť odloženie**.

**3. Prázdny zoznam tvrdil nepravdu.** Písalo sa „všetko je vybavené" aj vtedy, keď bola jediná karta len odložená. Text sa teraz rozlišuje: nič tu nie je / všetko vybavené / všetko odložené / kombinácia.

## Ako to funguje

- Počítadlo si vyžiada nové číslo cez spoločný kontext, ktorý zavolá každá zmena — nie je to nový mechanizmus, len sa doň zapojili aj tlačidlá na kartách.
- „aj odložené" a „aj vybavené" sú dve **nezávislé osi filtra**, nie jeden spoločný prepínač — dá sa pozrieť len odložené bez toho, aby sa vysypali aj vybavené.
- Zrušenie odloženia je vlastná operácia na serveri, nie prepis dátumu z prehliadača.
- Text prázdneho zoznamu sa počíta z toho, čo v databáze naozaj je, nie z toho, čo je práve vidieť.

## Overenie

- `pnpm typecheck`, `pnpm lint` — čisté
- web unit 450/450, api unit 585/585, api integračné 518/518, e2e 46/46
- Každá z troch vecí má vlastný test, ktorý bez opravy padá (RED) a s opravou prejde (GREEN)
- Nezávislá kontrola kódu: našla súbeh pri dvojfázovom načítaní textu prázdneho zoznamu — opravené v `504b045`

issue 267
