### PR TITLE
feat: nevyzdvihnutá zásielka vyrobí kartu na nástenke + atomický zápis upozornení (issue 268, issue 272)

### DIFF
--- a/.claude/rules/posta-uncollected.md
+++ b/.claude/rules/posta-uncollected.md
@@ -67,3 +67,18 @@ paths:
   Shoptet exportu. Toto NIE JE bug, len prechodný stav prvej hodiny po
   nasadení — neriešiť ako regresiu, ak sa znova objaví po podobnej
   migrácii pridávajúcej nové Shoptetove polia.
+- **Issue 268 zapojilo TENTO existujúci denný beh do nástenky Upozornenia
+  (#267) — `runPostaUncollectedLocked` volá `upsertUpozornenie`/
+  `autoResolveByDedupKey` (`.claude/rules/upozornenia.md`) PRIAMO, žiadny
+  nový poller/job.** Karta sa píše presne tam, kde `cls.uncollected` už
+  napĺňa `uncollected` pole výsledku; zatvára sa presne tam, kde
+  `terminalState(trackingJson) !== ""` (pred `continue`). `dedupKey` je
+  `posta:<packageNumber>` (`logic.ts`'s `postaUpozornenieDedupKey`) — JEDEN
+  zdieľaný helper pre OBE volania, aby zápis a zatvorenie nikdy nedostali
+  rôzny formát kľúča. **Známa medzera (code review, issue 275):** vetva
+  `cls.status === "invalid_format"` nerobí ani jedno z toho — karta
+  vytvorená pri predošlom "notified" behu ostane navždy otvorená, keď
+  tracking neskôr začne vracať neparsovateľný formát. Zriedkavé (formát sa
+  po platnom stave zvyčajne nemení), ale pri KAŽDOM ĎALŠOM novom stavu/
+  vetve pridanom do tejto funkcie over, či nepotrebuje TIEŽ napojenie na
+  write/auto-resolve cestu.

--- a/.claude/rules/upozornenia.md
+++ b/.claude/rules/upozornenia.md
@@ -101,3 +101,37 @@ paths:
   argumentu filtra (`UpozorneniaSection.emptyMessage.test.tsx`), tomuto
   problému nepodlieha vôbec — uprednostni ten vzor, keď test musí
   rozlišovať MEDZI viacerými súbežne možnými volaniami tej istej funkcie.
+- **`upsertUpozornenie()` mal TOCTOU medzeru (issue 272, objavené code
+  review-om pri #267, opravené pri #268 — prvom reálnom automatickom
+  volajúcom): samostatný `SELECT` a podľa jeho výsledku podmienený
+  `UPDATE`/`INSERT`, bez transakcie.** Fix je JEDEN atomický príkaz —
+  drizzle's `.insert(...).onConflictDoUpdate({ target: upozornenie.dedupKey,
+  targetWhere: sql\`resolved_at IS NULL\`, set: {...} })`. **`targetWhere`
+  MUSÍ textovo zrkadliť presne ten istý predikát, aký má samotný ČIASTOČNÝ
+  unique index** (`upozornenie_dedup_key_uq ... WHERE resolved_at IS NULL`,
+  vyššie v tomto súbore) — Postgres-ova ON CONFLICT inferencia potrebuje
+  zhodu cieľových stĺpcov AJ predikátu, inak arbiter index nerozpozná a
+  konflikt sa nevyrieši. `dedupKey: null` (vlastné poznámky) sa tohto NIKDY
+  netýka — Postgres nikdy nepovažuje dve `NULL` hodnoty v unique indexe za
+  zhodné, takže vlastné poznámky ostávajú vždy nový riadok. Prvé použitie
+  `targetWhere` v tomto repe — vzor pre KAŽDÝ ĎALŠÍ atomický upsert na
+  ČIASTOČNOM unique indexe.
+- **Test dokazujúci opravu TOCTOU race-u potrebuje PREDHRIATY connection
+  pool, inak sa "závod" v praxi nikdy nestretne.** Na studenom pripojení
+  (0 idle spojení v poole) dominuje latencia TCP handshaku (~15-20ms na
+  tomto Dockeri) nad latenciou samotného SQL dopytu (~3ms) — prvé volanie,
+  ktoré náhodou dostane pripojenie skôr, stihne CELÝ SELECT+INSERT cyklus
+  skôr, než ostatné vôbec stihnú odoslať svoj SELECT, takže test by ticho
+  prešiel AJ na chybnom (select-then-branch) kóde. Overené priamym
+  `pg.Pool` pokusom mimo vitestu (issue 272): bez predhriatia 5/5 "OK", s
+  predhriatím 2/5 "duplicate key" na starom kóde. Fix: `N` súbežných
+  `db.execute(sql\`select 1\`)` (cez `Promise.all`) PRED samotným závodom —
+  zabezpečí `N` HOTOVÝCH (idle) fyzických pripojení v poole, takže samotný
+  test už pretekáva len o rýchlosť SQL, nie o pripojenie
+  (`upozornenia-service.integration.test.ts`'s "súbežnosť" blok). Ani
+  predhriaty pool negarantuje 100 % zásah pri KAŽDOM behu — vyššia
+  `CONCURRENCY` (10, nie 2) zvyšuje šancu zásahu v jednom behu, ale
+  nezaručuje ju absolútne; to je vlastnosť testovania závodu na reálnej
+  DB, nie chyba tejto techniky. Rovnaký postup (predhriaty pool + vyšší
+  počet súbežných volaní) použi pri KAŽDOM ĎALŠOM teste, čo dokazuje opravu
+  TOCTOU/race-u cez skutočný Postgres, nie mock.

--- a/apps/api/drizzle/0037_graceful_skin.sql
+++ b/apps/api/drizzle/0037_graceful_skin.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."upozornenie_type" ADD VALUE 'nevyzdvihnuta_zasielka';

--- a/apps/api/drizzle/meta/0037_snapshot.json
+++ b/apps/api/drizzle/meta/0037_snapshot.json
@@ -1,0 +1,2780 @@
+{
+  "id": "b20f8cb9-ba0b-4791-99bf-047f3e73d354",
+  "prevId": "05ef0045-7a82-4c64-8a18-2229d805d222",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_code": {
+          "name": "external_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_open_status": {
+      "name": "order_open_status",
+      "schema": "",
+      "columns": {
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Vybavuje sa'"
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop_remark": {
+          "name": "shop_remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shoptet_order_id": {
+          "name": "shoptet_order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_updated_at": {
+          "name": "comment_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_synced_at": {
+          "name": "comment_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_carrier_name": {
+          "name": "shipping_carrier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_price_with_vat": {
+          "name": "total_price_with_vat",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_link_override": {
+      "name": "product_supplier_link_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_link_override_product_key_product_key_fk": {
+          "name": "product_supplier_link_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_link_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_override": {
+      "name": "product_supplier_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_override_product_key_product_key_fk": {
+          "name": "product_supplier_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing": {
+      "name": "pairing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_url": {
+          "name": "supplier_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "pairing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'navrhnute'"
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pairing_state_idx": {
+          "name": "pairing_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_confirmed_by_idx": {
+          "name": "pairing_confirmed_by_idx",
+          "columns": [
+            {
+              "expression": "confirmed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_variant_code_variant_code_fk": {
+          "name": "pairing_variant_code_variant_code_fk",
+          "tableFrom": "pairing",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pairing_confirmed_by_users_id_fk": {
+          "name": "pairing_confirmed_by_users_id_fk",
+          "tableFrom": "pairing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pairing_variant_code_unique": {
+          "name": "pairing_variant_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pairing_confirmation_ck": {
+          "name": "pairing_confirmation_ck",
+          "value": "(\"pairing\".\"state\" = 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)\n        OR (\"pairing\".\"state\" != 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NULL AND \"pairing\".\"confirmed_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier": {
+      "name": "supplier",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wholesale_base_url": {
+          "name": "wholesale_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_key": {
+          "name": "adapter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_settings": {
+      "name": "posta_uncollected_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_state": {
+      "name": "posta_uncollected_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notify_count": {
+          "name": "notify_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_state": {
+          "name": "terminal_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_settings": {
+      "name": "order_reminder_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_state": {
+      "name": "order_reminder_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_replacement_link": {
+      "name": "nedostupne_replacement_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nedostupne_replacement_link_variant_idx": {
+          "name": "nedostupne_replacement_link_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_state": {
+      "name": "nedostupne_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "nedostupne_email_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nedostupne_state_order_variant_type_uq": {
+          "name": "nedostupne_state_order_variant_type_uq",
+          "columns": [
+            {
+              "expression": "order_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template_history": {
+      "name": "mail_template_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "mail_template_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_template_history_key_idx": {
+          "name": "mail_template_history_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_template_history_changed_by_user_id_users_id_fk": {
+          "name": "mail_template_history_changed_by_user_id_users_id_fk",
+          "tableFrom": "mail_template_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template": {
+      "name": "mail_template",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail_template_updated_by_user_id_users_id_fk": {
+          "name": "mail_template_updated_by_user_id_users_id_fk",
+          "tableFrom": "mail_template",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_log": {
+      "name": "mail_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "mail_log_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_log_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "mail_log_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_log_created_idx": {
+          "name": "mail_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_log_source_created_idx": {
+          "name": "mail_log_source_created_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_log_actor_user_id_users_id_fk": {
+          "name": "mail_log_actor_user_id_users_id_fk",
+          "tableFrom": "mail_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_stock": {
+      "name": "supplier_stock",
+      "schema": "",
+      "columns": {
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "supplier_availability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "supplier_stock_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "supplier_stock_host_idx": {
+          "name": "supplier_stock_host_idx",
+          "columns": [
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "supplier_stock_avail_idx": {
+          "name": "supplier_stock_avail_idx",
+          "columns": [
+            {
+              "expression": "availability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "supplier_stock_link_size_label_pk": {
+          "name": "supplier_stock_link_size_label_pk",
+          "columns": [
+            "link",
+            "size_label"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_event": {
+      "name": "restock_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_link": {
+          "name": "supplier_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_availability_text": {
+          "name": "supplier_availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "supplier_price": {
+          "name": "supplier_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "restock_event_at_idx": {
+          "name": "restock_event_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "restock_event_variant_idx": {
+          "name": "restock_event_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_settings": {
+      "name": "restock_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shop_product_url": {
+      "name": "shop_product_url",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.theme_color": {
+      "name": "theme_color",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "theme_color_updated_by_user_id_users_id_fk": {
+          "name": "theme_color_updated_by_user_id_users_id_fk",
+          "tableFrom": "theme_color",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upozornenie": {
+      "name": "upozornenie",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "upozornenie_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "upozornenie_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedup_key": {
+          "name": "dedup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postponed_until": {
+          "name": "postponed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seen_at": {
+          "name": "seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "upozornenie_dedup_key_uq": {
+          "name": "upozornenie_dedup_key_uq",
+          "columns": [
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "resolved_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upozornenie_resolved_at_idx": {
+          "name": "upozornenie_resolved_at_idx",
+          "columns": [
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upozornenie_resolved_by_user_id_users_id_fk": {
+          "name": "upozornenie_resolved_by_user_id_users_id_fk",
+          "tableFrom": "upozornenie",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "upozornenie_created_by_user_id_users_id_fk": {
+          "name": "upozornenie_created_by_user_id_users_id_fk",
+          "tableFrom": "upozornenie",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne"
+      ]
+    },
+    "public.pairing_state": {
+      "name": "pairing_state",
+      "schema": "public",
+      "values": [
+        "navrhnute",
+        "potvrdene"
+      ]
+    },
+    "public.nedostupne_email_type": {
+      "name": "nedostupne_email_type",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "alternativa"
+      ]
+    },
+    "public.mail_template_action": {
+      "name": "mail_template_action",
+      "schema": "public",
+      "values": [
+        "save",
+        "reset"
+      ]
+    },
+    "public.mail_log_source": {
+      "name": "mail_log_source",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "posta_uncollected",
+        "order_reminder",
+        "supplier_order",
+        "order_merge"
+      ]
+    },
+    "public.mail_log_status": {
+      "name": "mail_log_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.mail_log_trigger": {
+      "name": "mail_log_trigger",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "manual"
+      ]
+    },
+    "public.supplier_availability": {
+      "name": "supplier_availability",
+      "schema": "public",
+      "values": [
+        "available",
+        "unavailable",
+        "unknown"
+      ]
+    },
+    "public.supplier_stock_source": {
+      "name": "supplier_stock_source",
+      "schema": "public",
+      "values": [
+        "json_ld",
+        "meta",
+        "text",
+        "size_list",
+        "none"
+      ]
+    },
+    "public.upozornenie_source": {
+      "name": "upozornenie_source",
+      "schema": "public",
+      "values": [
+        "vlastne",
+        "appka"
+      ]
+    },
+    "public.upozornenie_type": {
+      "name": "upozornenie_type",
+      "schema": "public",
+      "values": [
+        "vlastna_poznamka",
+        "nevyzdvihnuta_zasielka"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -260,6 +260,13 @@
       "when": 1785941945412,
       "tag": "0036_brief_miss_america",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1785953614763,
+      "tag": "0037_graceful_skin",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema-upozornenia.ts
+++ b/apps/api/src/db/schema-upozornenia.ts
@@ -3,14 +3,16 @@ import { index, pgEnum, pgTable, text, timestamp, uniqueIndex, uuid } from "driz
 import { users } from "./schema-users.js";
 
 // issue 267: "Upozornenia" — jedna nástenka vecí, ktoré majiteľ musí vybaviť.
-// `type` je OTVORENÝ zoznam — dnes len `vlastna_poznamka` (majiteľove vlastné
-// poznámky, súčasť TOHTO ticketu); budúce automatické zdroje (#268
-// nevyzdvihnutá zásielka, #269 vrátenie) pridajú SVOJU hodnotu vlastnou
-// migráciou (`ALTER TYPE ... ADD VALUE`, rovnaký vzor ako
-// `nedostupneEmailType`/`.claude/rules/testing.md`'s "Nová pgEnum hodnota"
-// past). `source` je NEZÁVISLÝ, navždy 2-hodnotový enum — určuje UI schopnosť
-// (len `vlastne` karty majú Upraviť/Zmazať), `type` je len farebný štítok.
-export const upozornenieType = pgEnum("upozornenie_type", ["vlastna_poznamka"]);
+// `type` je OTVORENÝ zoznam — `vlastna_poznamka` (majiteľove vlastné
+// poznámky, #267) a `nevyzdvihnuta_zasielka` (prvý automatický zdroj, #268:
+// `posta-uncollected/run.ts` volá `upsertUpozornenie` priamo zo svojho
+// existujúceho denného behu). Ďalší budúci automatický zdroj (#269
+// vrátenie) pridá SVOJU hodnotu vlastnou migráciou (`ALTER TYPE ... ADD
+// VALUE`, rovnaký vzor ako `nedostupneEmailType`/`.claude/rules/testing.md`'s
+// "Nová pgEnum hodnota" past). `source` je NEZÁVISLÝ, navždy 2-hodnotový enum
+// — určuje UI schopnosť (len `vlastne` karty majú Upraviť/Zmazať), `type` je
+// len farebný štítok.
+export const upozornenieType = pgEnum("upozornenie_type", ["vlastna_poznamka", "nevyzdvihnuta_zasielka"]);
 export const upozornenieSource = pgEnum("upozornenie_source", ["vlastne", "appka"]);
 
 export const upozornenie = pgTable(
@@ -39,8 +41,10 @@ export const upozornenie = pgTable(
     // záložky (`POST /api/upozornenia/mark-seen`), nie per-karta kliknutím.
     seenAt: timestamp("seen_at", { withTimezone: true }),
     resolvedAt: timestamp("resolved_at", { withTimezone: true }),
-    // `null` pri vyplnenom `resolvedAt` bude neskôr znamenať "vybavené
-    // systémom" (budúci auto-close #268/#269) — dnes ho vypĺňa vždy človek.
+    // `null` pri vyplnenom `resolvedAt` znamená "vybavené systémom" — #268's
+    // `autoResolveByDedupKey` (`upozornenia/service.ts`) ho zámerne
+    // NEVYPĹŇA; človek ho vyplní len cez `resolveUpozornenie` (ručné
+    // "Vybavené").
     resolvedByUserId: uuid("resolved_by_user_id").references(() => users.id, { onDelete: "set null" }),
     createdByUserId: uuid("created_by_user_id").references(() => users.id, { onDelete: "set null" }),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),

--- a/apps/api/src/http/upozornenia-routes.ts
+++ b/apps/api/src/http/upozornenia-routes.ts
@@ -16,12 +16,11 @@ import {
 import { requireRole, requireUser, type AppBindings } from "./middleware.js";
 import { requireSameOrigin } from "./origin-check.js";
 
-// issue 267: dnes existuje jediná hodnota (`upozornenie_type` pgEnum má LEN
-// `vlastna_poznamka`) — `.claude/rules/testing.md`'s "Nová pgEnum hodnota"
-// past platí aj tu, preto validácia typu ide cez `z.enum` s POLOM hodnôt,
-// nie natvrdo jedným literálom, aby budúci #268/#269 pridali svoju hodnotu
-// LEN sem + do enumu, nikde inde.
-const KNOWN_TYPES: readonly [UpozornenieTypeValue, ...UpozornenieTypeValue[]] = ["vlastna_poznamka"];
+// issue 267/268: `.claude/rules/testing.md`'s "Nová pgEnum hodnota" past
+// platí aj tu, preto validácia typu ide cez `z.enum` s POLOM hodnôt, nie
+// natvrdo jedným literálom, aby budúci #269 pridalo svoju hodnotu LEN sem +
+// do enumu, nikde inde.
+const KNOWN_TYPES: readonly [UpozornenieTypeValue, ...UpozornenieTypeValue[]] = ["vlastna_poznamka", "nevyzdvihnuta_zasielka"];
 
 const listQuery = z.object({
   type: z.enum(KNOWN_TYPES).optional(),

--- a/apps/api/src/modules/posta-uncollected/logic.ts
+++ b/apps/api/src/modules/posta-uncollected/logic.ts
@@ -222,6 +222,16 @@ export function terminalState(apiJson: unknown): string {
   return TERMINAL_STATE_CODES.has(state) ? state : "";
 }
 
+// issue 268: stabilný dedup kľúč pre nástenku Upozornenia (`upozornenia
+// /service.ts`'s `upsertUpozornenie`/`autoResolveByDedupKey`) — číslo
+// zásielky sa v rámci jednej zásielky nemení, takže opakovaný denný beh
+// vždy trafí TEN istý riadok. Presne tvar, aký schéma (`schema-upozornenia
+// .ts`) aj existujúce testy (`upozornenia-service.integration.test.ts`)
+// dokumentujú ako príklad ("posta:EF123456789SK").
+export function postaUpozornenieDedupKey(packageNumber: string): string {
+  return `posta:${packageNumber}`;
+}
+
 export function shouldSend(count: number, lastSent: Date | null, today: Date): boolean {
   if (count >= MAX_EMAILS) return false;
   if (count === 0) return true;

--- a/apps/api/src/modules/posta-uncollected/run.ts
+++ b/apps/api/src/modules/posta-uncollected/run.ts
@@ -3,8 +3,19 @@ import { log } from "../../logger.js";
 import type { MailTransport } from "../mail/transport.js";
 import { recordSkippedMail, sendLoggedMail, type MailLogContext } from "../mail-log/service.js";
 import { buildShoptetAdminOrderUrl } from "../orders/queries.js";
+import { pluralWord } from "../orders/pluralize.js";
 import { resolveTemplate } from "../mail-templates/store.js";
-import { buildEmail, classifyTracking, postaTemplateKey, shouldSend, sourceCoverage, terminalState, type SourceCoverage } from "./logic.js";
+import { autoResolveByDedupKey, upsertUpozornenie } from "../upozornenia/service.js";
+import {
+  buildEmail,
+  classifyTracking,
+  postaTemplateKey,
+  postaUpozornenieDedupKey,
+  shouldSend,
+  sourceCoverage,
+  terminalState,
+  type SourceCoverage,
+} from "./logic.js";
 import { loadEligibleOrders } from "./orders-source.js";
 import { loadPostaUncollectedState, prunePostaUncollectedState, upsertPostaUncollectedState } from "./state.js";
 import { TERMINAL_CACHE_DAYS, trackingLink } from "./constants.js";
@@ -175,6 +186,10 @@ async function runPostaUncollectedLocked(options: RunPostaUncollectedOptions): P
         },
         now,
       );
+      // issue 268: zásielka je doručená/vrátená — karta na Upozorneniach (ak
+      // vôbec vznikla) sa ZATVÁRA SAMA, bez zásahu majiteľa. Bezpečný no-op,
+      // keď žiadna nevyriešená karta pre tento dedupKey neexistuje.
+      await autoResolveByDedupKey(db, postaUpozornenieDedupKey(packageNumber), now);
       continue;
     }
 
@@ -286,6 +301,24 @@ async function runPostaUncollectedLocked(options: RunPostaUncollectedOptions): P
     }
 
     if (cls.uncollected) {
+      // issue 268: JEDINÁ zapisovacia cesta (#267/#272) — opakovaný denný
+      // beh na TÚ ISTÚ zásielku len OBNOVÍ existujúcu kartu (rovnaký
+      // `dedupKey`), nikdy nevyrobí druhú.
+      const daysWord = pluralWord(cls.daysAtPost, "deň", "dni", "dní");
+      await upsertUpozornenie(db, {
+        type: "nevyzdvihnuta_zasielka",
+        source: "appka",
+        title: `Zásielka pre objednávku ${shipment.externalOrderId} sa nevyzdvihla — ${String(cls.daysAtPost)} ${daysWord} na pošte`,
+        details: [
+          `Zákazník: ${shipment.customerName}`,
+          `Číslo zásielky: ${packageNumber}`,
+          `Dopravca: ${shipment.shippingCarrierName ?? ""}`,
+          `Čaká: ${String(cls.daysAtPost)} ${daysWord} na pošte`,
+        ].join("\n"),
+        link: adminOrderUrl(shipment),
+        dedupKey: postaUpozornenieDedupKey(packageNumber),
+        now,
+      });
       uncollected.push({
         orderCode: shipment.externalOrderId,
         packageNumber,

--- a/apps/api/src/modules/upozornenia/service.ts
+++ b/apps/api/src/modules/upozornenia/service.ts
@@ -183,6 +183,22 @@ export async function cancelPostpone(db: Database, input: CancelPostponeInput): 
   return result.length > 0;
 }
 
+// issue 268: automatický zdroj (napr. `posta-uncollected/run.ts`) volá TOTO
+// namiesto `resolveUpozornenie`, keď zásielka prestane byť problémom SAMA od
+// seba (doručená/vrátená) — na rozdiel od ručného vyriešenia
+// `resolvedByUserId` ostáva `null` (schéma to explicitne predpovedá: "null
+// pri vyplnenom resolvedAt znamená vybavené systémom"). Bezpečný no-op, keď
+// pre daný `dedupKey` žiadny NEVYRIEŠENÝ riadok neexistuje (karta ešte
+// nevznikla, alebo bola vyriešená/nahradená novou vlnou už skôr).
+export async function autoResolveByDedupKey(db: UpozornenieExecutor, dedupKey: string, now: Date): Promise<boolean> {
+  const result = await db
+    .update(upozornenie)
+    .set({ resolvedAt: now })
+    .where(and(eq(upozornenie.dedupKey, dedupKey), isNull(upozornenie.resolvedAt)))
+    .returning({ id: upozornenie.id });
+  return result.length > 0;
+}
+
 // Volané pri OTVORENÍ záložky — hromadne označí VŠETKY práve "Nové" karty
 // ako videné naraz (inbox vzor "otvoriť = prečítané"), žiadne per-kartové
 // tlačidlo "videné" navyše. Zámerne LEN `seenAt IS NULL` (nikdy nerieši

--- a/apps/api/src/modules/upozornenia/service.ts
+++ b/apps/api/src/modules/upozornenia/service.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull } from "drizzle-orm";
+import { and, eq, isNull, sql } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
 import { upozornenie } from "../../db/schema.js";
 import type { UpozornenieSourceValue, UpozornenieTypeValue } from "./queries.js";
@@ -38,28 +38,22 @@ export interface UpozornenieWriteResult {
 // ticket žiada ("keď nočná úloha zbehne desiatykrát, upozornenie ostane
 // JEDNO, len sa obnoví"). `postponedUntil`/`seenAt` sa pri obnove NEDOTÝKAJÚ
 // — majiteľovo rozhodnutie odložiť kartu prežije obnovu z toho istého zdroja.
+//
+// issue 272: JEDEN atomický SQL príkaz (`INSERT ... ON CONFLICT (dedup_key)
+// WHERE resolved_at IS NULL DO UPDATE ...`), nie samostatný SELECT + podľa
+// jeho výsledku podmienený UPDATE/INSERT — ten mal TOCTOU medzeru (dve
+// súbežné volania s tým istým, dosiaľ nepoužitým `dedupKey` mohli OBE vidieť
+// "žiadny riadok" a obe skončiť INSERT-om, druhé s vyhodenou chybou namiesto
+// obnovy). `targetWhere` zrkadlí PRESNE predikát `upozornenie_dedup_key_uq`
+// (`schema-upozornenia.ts`) — Postgres tak vie rozpoznať konflikt len s
+// NEVYRIEŠENÝM riadkom, presne ako predtým robil samostatný SELECT. Keď
+// `dedupKey` je `null` (vlastné poznámky), unique index sa naň NIKDY
+// nevzťahuje (Postgres nikdy nepovažuje dve NULL hodnoty za rovnaké), takže
+// ON CONFLICT sa preň jednoducho nikdy neuplatní — vlastné poznámky ostávajú
+// vždy nový riadok, presne ako predtým.
 export async function upsertUpozornenie(db: UpozornenieExecutor, input: UpsertUpozornenieInput): Promise<UpozornenieWriteResult> {
   const dedupKey = input.dedupKey ?? null;
-  if (dedupKey !== null) {
-    const [existing] = await db
-      .select({ id: upozornenie.id, resolvedAt: upozornenie.resolvedAt })
-      .from(upozornenie)
-      .where(eq(upozornenie.dedupKey, dedupKey))
-      .limit(1);
-    if (existing !== undefined && existing.resolvedAt === null) {
-      await db
-        .update(upozornenie)
-        .set({
-          title: input.title,
-          details: input.details ?? "",
-          link: input.link ?? null,
-          dueAt: input.dueAt ?? null,
-        })
-        .where(eq(upozornenie.id, existing.id));
-      return { id: existing.id };
-    }
-  }
-  const [inserted] = await db
+  const [row] = await db
     .insert(upozornenie)
     .values({
       type: input.type,
@@ -72,12 +66,23 @@ export async function upsertUpozornenie(db: UpozornenieExecutor, input: UpsertUp
       createdByUserId: input.createdByUserId ?? null,
       createdAt: input.now,
     })
+    .onConflictDoUpdate({
+      target: upozornenie.dedupKey,
+      targetWhere: sql`resolved_at IS NULL`,
+      set: {
+        title: input.title,
+        details: input.details ?? "",
+        link: input.link ?? null,
+        dueAt: input.dueAt ?? null,
+      },
+    })
     .returning({ id: upozornenie.id });
-  // `.insert().returning()` always yields exactly one row for a single
-  // `.values()` object — non-null assertion would be the alternative, but an
-  // explicit throw documents the invariant instead of silently trusting it.
-  if (inserted === undefined) throw new Error("Vloženie upozornenia zlyhalo bez chyby");
-  return { id: inserted.id };
+  // `.insert().returning()` always yields exactly one row (either the newly
+  // inserted row, or the conflicting row after the atomic update) — non-null
+  // assertion would be the alternative, but an explicit throw documents the
+  // invariant instead of silently trusting it.
+  if (row === undefined) throw new Error("Vloženie/aktualizácia upozornenia zlyhala bez chyby");
+  return { id: row.id };
 }
 
 export interface CreateOwnNoteInput {

--- a/apps/api/tests/posta-uncollected-run.integration.test.ts
+++ b/apps/api/tests/posta-uncollected-run.integration.test.ts
@@ -1,7 +1,7 @@
 import { eq } from "drizzle-orm";
 import pg from "pg";
 import { afterEach, expect, it } from "vitest";
-import { orders, postaUncollectedState } from "../src/db/schema.js";
+import { orders, postaUncollectedState, upozornenie } from "../src/db/schema.js";
 import type { MailMessage } from "../src/modules/mail/transport.js";
 import { POSTA_UNCOLLECTED_RUN_LOCK_KEY, runPostaUncollected } from "../src/modules/posta-uncollected/run.js";
 import type { TrackingClient } from "../src/modules/posta-uncollected/tracking-client.js";
@@ -258,4 +258,77 @@ it("dva súbežné behy sa serializujú (advisory zámok), nikdy neprebehnú nar
   const afterRun = await checker.query<{ pg_try_advisory_lock: boolean }>("select pg_try_advisory_lock($1)", [POSTA_UNCOLLECTED_RUN_LOCK_KEY]);
   expect(afterRun.rows[0]?.pg_try_advisory_lock).toBe(true);
   await checker.query("select pg_advisory_unlock($1)", [POSTA_UNCOLLECTED_RUN_LOCK_KEY]);
+});
+
+// issue 268: nevyzdvihnutá zásielka vyrobí kartu na nástenke Upozornenia
+// (#267's zdieľaná zapisovacia cesta), opakovaný beh ju len OBNOVÍ (nikdy
+// druhú), a keď sa zásielka doručí/vráti, karta sa ZAVRIE SAMA (bez zásahu
+// majiteľa) — presne "hotovo, keď" ticketu.
+it("nevyzdvihnutá zásielka vyrobí kartu na Upozorneniach s odkazom na objednávku", async () => {
+  const db = await boot();
+  await insertOrder(db, { externalOrderId: "20500010" });
+
+  await runPostaUncollected({
+    db,
+    now: TODAY,
+    trackingClient: notifiedTrackingClient(),
+    mailTransport: undefined,
+    bccEmail: "majitel@forestshop.sk",
+    adminBaseUrl: "https://www.forestshop.sk",
+  });
+
+  const rows = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "posta:EF123456789SK"));
+  expect(rows).toHaveLength(1);
+  expect(rows[0]?.type).toBe("nevyzdvihnuta_zasielka");
+  expect(rows[0]?.source).toBe("appka");
+  expect(rows[0]?.title).toContain("20500010");
+  expect(rows[0]?.link).toContain("20500010");
+  expect(rows[0]?.resolvedAt).toBeNull();
+});
+
+it("opakovaný beh na tú istú zásielku NEVYROBÍ druhú kartu, len ju obnoví", async () => {
+  const db = await boot();
+  await insertOrder(db, { externalOrderId: "20500011" });
+  const deps = {
+    trackingClient: notifiedTrackingClient(),
+    mailTransport: undefined,
+    bccEmail: "majitel@forestshop.sk",
+    adminBaseUrl: "https://www.forestshop.sk",
+  };
+
+  await runPostaUncollected({ db, now: TODAY, ...deps });
+  await runPostaUncollected({ db, now: new Date("2026-08-03T10:00:00Z"), ...deps });
+
+  const rows = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "posta:EF123456789SK"));
+  expect(rows).toHaveLength(1);
+});
+
+it("doručená zásielka zavrie svoju kartu SAMA, bez zásahu majiteľa (resolvedByUserId zostáva null)", async () => {
+  const db = await boot();
+  await insertOrder(db, { externalOrderId: "20500012" });
+
+  await runPostaUncollected({
+    db,
+    now: TODAY,
+    trackingClient: notifiedTrackingClient(),
+    mailTransport: undefined,
+    bccEmail: "majitel@forestshop.sk",
+    adminBaseUrl: "https://www.forestshop.sk",
+  });
+  const midway = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "posta:EF123456789SK"));
+  expect(midway[0]?.resolvedAt).toBeNull();
+
+  await runPostaUncollected({
+    db,
+    now: new Date("2026-08-03T10:00:00Z"),
+    trackingClient: () => Promise.resolve({ results: [{ status: "ok", events: [{ stateCode: "delivered" }] }] }),
+    mailTransport: undefined,
+    bccEmail: "majitel@forestshop.sk",
+    adminBaseUrl: "https://www.forestshop.sk",
+  });
+
+  const after = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "posta:EF123456789SK"));
+  expect(after).toHaveLength(1);
+  expect(after[0]?.resolvedAt).not.toBeNull();
+  expect(after[0]?.resolvedByUserId).toBeNull();
 });

--- a/apps/api/tests/upozornenia-service.integration.test.ts
+++ b/apps/api/tests/upozornenia-service.integration.test.ts
@@ -113,12 +113,21 @@ describe("upsertUpozornenie", () => {
 // súbežných pripojeniach vopred zabezpečí `N` HOTOVÝCH (idle) pripojení v
 // poole, takže samotný závod už pretekáva len o rýchlosť SQL, nie o
 // pripojenie.
+//
+// Code review (issue 272/268): ANI predhriaty pool nezaručuje 100 % zásah pri
+// KAŽDOM behu (namerané 2/5 na jednom behu starého kódu) — je to inherentná
+// vlastnosť testovania závodu na reálnej DB, nie chyba opravy. `CONCURRENCY`
+// je zámerne vyššie než najmenšie číslo, čo raz zafungovalo (5 → 10) — viac
+// súčasných pokusov na TEN istý dedupKey zvyšuje šancu, že sa aspoň dva
+// SELECTy naozaj prekryjú v jednom behu, takže prípadný BUDÚCI návrat k
+// select-then-branch kódu má vyššiu šancu, že ho tento test chytí hneď pri
+// prvom CI behu, nie až pri druhom/treťom.
 describe("upsertUpozornenie — súbežnosť (issue 272)", () => {
   it("dve súbežné volania s rovnakým NOVÝM dedupKey nikdy nezlyhajú a vyrobia PRESNE jeden riadok", async () => {
     const { db } = await bootDb();
     const now = new Date("2026-08-05T08:00:00Z");
     const dedupKey = "posta:EF999999999SK";
-    const CONCURRENCY = 5;
+    const CONCURRENCY = 10;
 
     await Promise.all(Array.from({ length: CONCURRENCY }, () => db.execute(sql`select 1`)));
 

--- a/apps/api/tests/upozornenia-service.integration.test.ts
+++ b/apps/api/tests/upozornenia-service.integration.test.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { afterEach, describe, expect, it } from "vitest";
 import { upozornenie, users } from "../src/db/schema.js";
 import { hashPassword } from "../src/modules/auth/passwords.js";
@@ -91,6 +91,47 @@ describe("upsertUpozornenie", () => {
     const [row] = await db.select().from(upozornenie);
     expect(row?.title).toBe("Obnovený text");
     expect(row?.postponedUntil?.toISOString()).toBe("2026-08-20T00:00:00.000Z");
+  });
+});
+
+// issue 272: TOCTOU race na `dedupKey` — dve súbežné volania s tým istým,
+// dosiaľ nepoužitým `dedupKey` (žiadny existujúci riadok) nesmú nikdy
+// vyhodiť unique-violation ani vyrobiť dva riadky. Na starom kóde (SELECT,
+// potom podmienený UPDATE/INSERT) obe volania uvidia "žiadny riadok" pri
+// svojom SELECTe skôr, než ktorékoľvek stihne INSERT — druhé INSERT-ne
+// narazí na `upozornenie_dedup_key_uq` a `Promise.all` zamietne s chybou
+// databázy.
+//
+// **Pool sa musí PREDHRIAŤ pred štartom závodu** — inak sa "závod" v praxi
+// nikdy nestretne: na studenom pripojení dominuje latencia TCP handshaku
+// (~15-20ms na tomto Dockeri) nad latenciou samotného SQL dopytu (~3ms), takže
+// prvé volanie, ktoré náhodou dostane pripojenie skôr, stihne CELÝ
+// SELECT+INSERT cyklus skôr, než ostatné vôbec stihnú odoslať svoj SELECT —
+// žiadny skutočný závod, test by ticho prešiel aj na chybnom kóde (overené
+// priamym `pg.Pool` pokusom mimo vitestu: bez predhriatia 5/5 "OK", s
+// predhriatím 2/5 "duplicate key" na starom kóde). `select 1` na `N`
+// súbežných pripojeniach vopred zabezpečí `N` HOTOVÝCH (idle) pripojení v
+// poole, takže samotný závod už pretekáva len o rýchlosť SQL, nie o
+// pripojenie.
+describe("upsertUpozornenie — súbežnosť (issue 272)", () => {
+  it("dve súbežné volania s rovnakým NOVÝM dedupKey nikdy nezlyhajú a vyrobia PRESNE jeden riadok", async () => {
+    const { db } = await bootDb();
+    const now = new Date("2026-08-05T08:00:00Z");
+    const dedupKey = "posta:EF999999999SK";
+    const CONCURRENCY = 5;
+
+    await Promise.all(Array.from({ length: CONCURRENCY }, () => db.execute(sql`select 1`)));
+
+    const results = await Promise.all(
+      Array.from({ length: CONCURRENCY }, (_, i) =>
+        upsertUpozornenie(db, { type: "vlastna_poznamka", source: "appka", title: `Pokus ${String(i)}`, dedupKey, now }),
+      ),
+    );
+
+    const rows = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, dedupKey));
+    expect(rows).toHaveLength(1);
+    // Všetkých 5 volaní muselo skončiť na TOM ISTOM riadku (atomický upsert).
+    for (const r of results) expect(r.id).toBe(rows[0]?.id);
   });
 });
 

--- a/apps/web/src/components/UpozorneniaSection.tsx
+++ b/apps/web/src/components/UpozorneniaSection.tsx
@@ -19,10 +19,11 @@ import {
 // (zoznam) smie vidieť KAŽDÝ prihlásený zamestnanec.
 const CONTROL_ROLES: ReadonlySet<Me["role"]> = new Set(["admin", "manazer"]);
 
-// Otvorený zoznam typov (dnes jediný) — budúci automatický zdroj (#268/#269)
-// pridá svoj štítok sem, keď pridá svoju `pgEnum` hodnotu.
+// Otvorený zoznam typov — budúci automatický zdroj (#269) pridá svoj štítok
+// sem, keď pridá svoju `pgEnum` hodnotu.
 const TYPE_LABELS: Readonly<Record<UpozornenieRow["type"], string>> = {
   vlastna_poznamka: "Moja poznámka",
+  nevyzdvihnuta_zasielka: "Nevyzdvihnutá zásielka",
 };
 
 function formatDate(iso: string): string {

--- a/apps/web/src/upozorneniaApi.ts
+++ b/apps/web/src/upozorneniaApi.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 
 const rowSchema = z.object({
   id: z.string(),
-  type: z.enum(["vlastna_poznamka"]),
+  type: z.enum(["vlastna_poznamka", "nevyzdvihnuta_zasielka"]),
   source: z.enum(["vlastne", "appka"]),
   title: z.string(),
   details: z.string(),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.156",
+  "version": "0.3.0-dev.157",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Čo to robí

**Nevyzdvihnutá zásielka sa teraz sama objaví ako karta na nástenke Upozornenia** — netreba nikam chodiť pozerať, či niekomu neleží balík na pošte. Karta nesie číslo balíka, zákazníka a odkaz na miesto v appke.

**Karta sa sama zavrie**, keď sa zásielka vyzdvihne alebo vráti — nezostane visieť ako vybavená vec, ktorú treba ručne odklikať.

Toto je prvý automatický zdroj kariet na nástenke (issue 267). Vrátenia / výmeny / dobropisy sú vlastná úloha (#269).

## Ako to funguje

- Zapája sa do **existujúcej nočnej úlohy Nevyzdvihnuté zásielky** — nevzniká druhý zbytočný poller.
- Zapisuje sa **jedinou spoločnou funkciou** `upsertUpozornenie()`, presne ako nástenka predpisuje.
- Proti duplicitám slúži **číslo balíka ako stabilný kľúč** — opakovaný beh úlohy nevyrobí desať rovnakých kariet.

## Poistka proti dvom naraz (issue 272)

Zápis upozornenia bol predtým dvojkrokový (najprv pozri, či existuje, potom zapíš) — dva behy v tej istej sekunde mohli naraziť. Kým neexistoval automatický zdroj, nemalo to čo spustiť; **týmto PR taký zdroj vzniká, tak sa to rieši rovno tu.**

Oprava je **jeden atomický zápis** cez čiastočný unikátny index — nie opakovanie po chybe a nie širší zámok. Dôkaz: test, ktorý púšťa desať súčasných zápisov toho istého kľúča naraz.

## Overenie

- `pnpm typecheck`, `pnpm lint` — čisté
- web unit 450/450, api unit + integračné 522/522 (dva plné behy), e2e 46/46
- Obe veci majú vlastný test, ktorý bez opravy padá a s opravou prejde
- Nezávislá kontrola kódu: 0 kritických, 0 vážnych; tri drobnosti vybavené, jedna hraničná vec (pokazené číslo balíka) založená ako samostatná úloha

issue 268
issue 272
