### PR TITLE
feat: text e-mailu sa dá upraviť priamo v okne pred odoslaním + kniha ukladá skutočne odoslané znenie (issue 277)

### DIFF
--- a/.claude/rules/mail-log.md
+++ b/.claude/rules/mail-log.md
@@ -52,3 +52,14 @@ paths:
 - **História pošty prežije zmazanie zamestnanca aj šablóny** — `actor_user_id`
   je `on delete set null`, `template_key` je obyčajný text bez FK. Zmazanie
   účtu nesmie zmazať dôkaz o tom, čo odišlo zákazníkovi.
+- **issue 277: `mail_log.body` (aditívna migrácia `0038_sad_kinsey_walden.sql`)
+  ukladá `message.text` pre KAŽDÉ odoslanie, nie len pre editovateľné cesty**
+  — `sendLoggedMail`'s obe vetvy (`sent`/`failed`) teraz posielajú `body:
+  message.text` do `insertEntry`. `recordSkippedMail` (preskočené) zámerne
+  NEDOSTÁVA `body` — appka pri preskočení žiadny text nikdy nevygenerovala,
+  takže `body` ostáva `null` (rovnaká disciplína ako `reason`/`subject`
+  vyššie: pole existuje len tam, kde má appka čo zapísať). Toto je súčasť
+  editovateľného náhľadu (`.claude/rules/nedostupne.md`'s `editedBody`) —
+  kniha teraz vie dokázať, ČO presne odišlo, nielen komu/kedy. `MailLogSection
+  .tsx` zobrazuje telo cez per-riadkové "👁 zobraziť text" tlačidlo (`row.body
+  !== null`), nie vždy — dlhý text by rozbil hustú tabuľku.

--- a/.claude/rules/mail-templates.md
+++ b/.claude/rules/mail-templates.md
@@ -74,6 +74,14 @@ paths:
   testoch, takže vlastný izolovaný účet pre nový spec súbor je stále povinný.
   **Nový e2e test aj tak nepridávaj s vlastným prihlásením zbytočne** — dva
   scenáre v jednom teste sú lacnejšie než dve prihlásenia.
+- **issue 277: `renderEditedBody` (`render.ts`) je zámerne SAMOSTATNÁ od
+  `renderTemplate` — jednorazová ručná úprava (okno náhľadu pred
+  odoslaním, `.claude/rules/nedostupne.md`) edituje UŽ HOTOVÝ text
+  (placeholdery dosadené), takže sa nepúšťa cez `parse`/`{{pole}}`/
+  `**tučné**` engine znova (obsluha nepozná/nepotrebuje šablónovú
+  syntax). Zdieľa len `htmlEscape` (exportovaná z `render.ts` kvôli
+  tomu) — prázdny riadok = odstavec, rovnaká konvencia ako šablóny,
+  jednoduchý riadok = `<br>`.
 - **issue 238: `samples.ts`'s "náhľad na skutočných dátach" pre
   `nedostupne_alternativa`'s `zoznam_nahrad` teraz vychádza z
   `nedostupne_replacement_link` (majiteľove ručné odkazy), nie z pôvodného

--- a/.claude/rules/nedostupne.md
+++ b/.claude/rules/nedostupne.md
@@ -72,3 +72,28 @@ paths:
 - **`insertTestVariantForProduct` (`tests/helpers/orders.ts`) NEMÁ od issue 245
   `relatedCodes` voľbu — odstránená spolu s celým `product.related_codes`
   stĺpcom (žiadny existujúci test ju reálne používal).**
+- **issue 277: `MailPreviewDialog.tsx` (zdieľaná s "Zlúčenie objednávok",
+  `.claude/rules/orders.md`) prestala byť READ-ONLY — telo je editovateľná
+  `<textarea>` (`bodyText`/`onBodyTextChange`), predvyplnená
+  `RenderedEmail.text` (appka ju už počítala od issue 192, len ju
+  nikam neposielala). Predmet/príjemca zostávajú needitovateľné.**
+  `sendNedostupneEmail`'s nový voliteľný `editedBody` PREPÍŠE
+  `html`/`text` tesne pred odoslaním (`renderEditedBody`,
+  `mail-templates/render.ts` — plain text → escapovaný HTML, ŽIADEN
+  `{{pole}}`/`**tučné**` engine druhýkrát), predmet ostáva z
+  NEUPRAVENÉHO vyrenderovania. Šablóna v `mail_template` sa touto
+  editáciou nikdy nemení — číta sa len na zostavenie predmetu
+  (integračný test `mail-edited-body.integration.test.ts` to dokazuje
+  bajt-na-bajt porovnaním riadku pred/po odoslaní). Server-side sa
+  editovaný text VALIDUJE len minimálne (`z.string().trim().min(1)
+  .max(20000)`) — žiadna kontrola formátu, appka dôveruje obsluhe (nie
+  klientom mimo appky) na TEXT, nikdy nie na business polia (recipient/
+  orderCode/dedup token), tie appka vždy prepočíta sama.
+- **Playwright's `toContainText`/testing-library's `textContent` NEVIDIA
+  hodnotu kontrolovaného `<textarea>`** (React nastavuje `.value` ako
+  DOM vlastnosť, nie textový uzol) — e2e/unit testy tela náhľadu preto
+  musia čítať `toHaveValue()`/`screen.getByTestId<HTMLTextAreaElement>
+  (...).value`, nikdy `toContainText`/`textContent` na kontajneri, ktorý
+  textarea obsahuje (`nedostupne.spec.ts`/`order-merge.spec.ts`, issue
+  277 — pôvodné testy kontrolovali `dangerouslySetInnerHTML` div a
+  ticho by prestali overovať čokoľvek po prechode na textarea).

--- a/.claude/rules/orders.md
+++ b/.claude/rules/orders.md
@@ -516,3 +516,11 @@ paths:
   `externalOrderId` je stabilné a čitateľné aj v e2e teste napísanom PRED
   behom (UUID sa dozvieš až za behu). Rovnaký zámer ako
   `NedostupneSection.tsx`'s `variantCode`-kľúčované testid.
+- **issue 277: "Zlúčenie objednávok" zdieľa `MailPreviewDialog.tsx`'s
+  editovateľné telo (`bodyText`/`onBodyTextChange`, `editedBody` na
+  `/send`) s "Nedostupné tovary" — plné odôvodnenie (prečo textarea a
+  nie rich-text, `renderEditedBody`, `toHaveValue()` namiesto
+  `toContainText()` na kontajneri s textarea vo vnútri) je zdokumentované
+  v `.claude/rules/nedostupne.md`, aby sa nemuselo písať dvakrát. `sendOrderMergeMail`'s nový voliteľný `editedBody` má rovnaký tvar
+  (`{ ...built.content, ...renderEditedBody(editedBody) }`, predmet
+  ostáva pôvodný).

--- a/apps/api/drizzle/0038_sad_kinsey_walden.sql
+++ b/apps/api/drizzle/0038_sad_kinsey_walden.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "mail_log" ADD COLUMN "body" text;

--- a/apps/api/drizzle/meta/0038_snapshot.json
+++ b/apps/api/drizzle/meta/0038_snapshot.json
@@ -1,0 +1,2786 @@
+{
+  "id": "deea8c44-b256-4f7f-b44e-7a1fd6c28f33",
+  "prevId": "b20f8cb9-ba0b-4791-99bf-047f3e73d354",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_code": {
+          "name": "external_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_open_status": {
+      "name": "order_open_status",
+      "schema": "",
+      "columns": {
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Vybavuje sa'"
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop_remark": {
+          "name": "shop_remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shoptet_order_id": {
+          "name": "shoptet_order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_updated_at": {
+          "name": "comment_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_synced_at": {
+          "name": "comment_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_carrier_name": {
+          "name": "shipping_carrier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_price_with_vat": {
+          "name": "total_price_with_vat",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_link_override": {
+      "name": "product_supplier_link_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_link_override_product_key_product_key_fk": {
+          "name": "product_supplier_link_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_link_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_override": {
+      "name": "product_supplier_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_override_product_key_product_key_fk": {
+          "name": "product_supplier_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing": {
+      "name": "pairing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_url": {
+          "name": "supplier_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "pairing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'navrhnute'"
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pairing_state_idx": {
+          "name": "pairing_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_confirmed_by_idx": {
+          "name": "pairing_confirmed_by_idx",
+          "columns": [
+            {
+              "expression": "confirmed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_variant_code_variant_code_fk": {
+          "name": "pairing_variant_code_variant_code_fk",
+          "tableFrom": "pairing",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pairing_confirmed_by_users_id_fk": {
+          "name": "pairing_confirmed_by_users_id_fk",
+          "tableFrom": "pairing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pairing_variant_code_unique": {
+          "name": "pairing_variant_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pairing_confirmation_ck": {
+          "name": "pairing_confirmation_ck",
+          "value": "(\"pairing\".\"state\" = 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)\n        OR (\"pairing\".\"state\" != 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NULL AND \"pairing\".\"confirmed_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier": {
+      "name": "supplier",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wholesale_base_url": {
+          "name": "wholesale_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_key": {
+          "name": "adapter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_settings": {
+      "name": "posta_uncollected_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_state": {
+      "name": "posta_uncollected_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notify_count": {
+          "name": "notify_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_state": {
+          "name": "terminal_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_settings": {
+      "name": "order_reminder_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_state": {
+      "name": "order_reminder_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_replacement_link": {
+      "name": "nedostupne_replacement_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nedostupne_replacement_link_variant_idx": {
+          "name": "nedostupne_replacement_link_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_state": {
+      "name": "nedostupne_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "nedostupne_email_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nedostupne_state_order_variant_type_uq": {
+          "name": "nedostupne_state_order_variant_type_uq",
+          "columns": [
+            {
+              "expression": "order_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template_history": {
+      "name": "mail_template_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "mail_template_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_template_history_key_idx": {
+          "name": "mail_template_history_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_template_history_changed_by_user_id_users_id_fk": {
+          "name": "mail_template_history_changed_by_user_id_users_id_fk",
+          "tableFrom": "mail_template_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template": {
+      "name": "mail_template",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail_template_updated_by_user_id_users_id_fk": {
+          "name": "mail_template_updated_by_user_id_users_id_fk",
+          "tableFrom": "mail_template",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_log": {
+      "name": "mail_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "mail_log_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_log_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "mail_log_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_log_created_idx": {
+          "name": "mail_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_log_source_created_idx": {
+          "name": "mail_log_source_created_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_log_actor_user_id_users_id_fk": {
+          "name": "mail_log_actor_user_id_users_id_fk",
+          "tableFrom": "mail_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_stock": {
+      "name": "supplier_stock",
+      "schema": "",
+      "columns": {
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "supplier_availability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "supplier_stock_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "supplier_stock_host_idx": {
+          "name": "supplier_stock_host_idx",
+          "columns": [
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "supplier_stock_avail_idx": {
+          "name": "supplier_stock_avail_idx",
+          "columns": [
+            {
+              "expression": "availability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "supplier_stock_link_size_label_pk": {
+          "name": "supplier_stock_link_size_label_pk",
+          "columns": [
+            "link",
+            "size_label"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_event": {
+      "name": "restock_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_link": {
+          "name": "supplier_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_availability_text": {
+          "name": "supplier_availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "supplier_price": {
+          "name": "supplier_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "restock_event_at_idx": {
+          "name": "restock_event_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "restock_event_variant_idx": {
+          "name": "restock_event_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_settings": {
+      "name": "restock_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shop_product_url": {
+      "name": "shop_product_url",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.theme_color": {
+      "name": "theme_color",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "theme_color_updated_by_user_id_users_id_fk": {
+          "name": "theme_color_updated_by_user_id_users_id_fk",
+          "tableFrom": "theme_color",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upozornenie": {
+      "name": "upozornenie",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "upozornenie_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "upozornenie_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedup_key": {
+          "name": "dedup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postponed_until": {
+          "name": "postponed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seen_at": {
+          "name": "seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "upozornenie_dedup_key_uq": {
+          "name": "upozornenie_dedup_key_uq",
+          "columns": [
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "resolved_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upozornenie_resolved_at_idx": {
+          "name": "upozornenie_resolved_at_idx",
+          "columns": [
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upozornenie_resolved_by_user_id_users_id_fk": {
+          "name": "upozornenie_resolved_by_user_id_users_id_fk",
+          "tableFrom": "upozornenie",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "upozornenie_created_by_user_id_users_id_fk": {
+          "name": "upozornenie_created_by_user_id_users_id_fk",
+          "tableFrom": "upozornenie",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne"
+      ]
+    },
+    "public.pairing_state": {
+      "name": "pairing_state",
+      "schema": "public",
+      "values": [
+        "navrhnute",
+        "potvrdene"
+      ]
+    },
+    "public.nedostupne_email_type": {
+      "name": "nedostupne_email_type",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "alternativa"
+      ]
+    },
+    "public.mail_template_action": {
+      "name": "mail_template_action",
+      "schema": "public",
+      "values": [
+        "save",
+        "reset"
+      ]
+    },
+    "public.mail_log_source": {
+      "name": "mail_log_source",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "posta_uncollected",
+        "order_reminder",
+        "supplier_order",
+        "order_merge"
+      ]
+    },
+    "public.mail_log_status": {
+      "name": "mail_log_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.mail_log_trigger": {
+      "name": "mail_log_trigger",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "manual"
+      ]
+    },
+    "public.supplier_availability": {
+      "name": "supplier_availability",
+      "schema": "public",
+      "values": [
+        "available",
+        "unavailable",
+        "unknown"
+      ]
+    },
+    "public.supplier_stock_source": {
+      "name": "supplier_stock_source",
+      "schema": "public",
+      "values": [
+        "json_ld",
+        "meta",
+        "text",
+        "size_list",
+        "none"
+      ]
+    },
+    "public.upozornenie_source": {
+      "name": "upozornenie_source",
+      "schema": "public",
+      "values": [
+        "vlastne",
+        "appka"
+      ]
+    },
+    "public.upozornenie_type": {
+      "name": "upozornenie_type",
+      "schema": "public",
+      "values": [
+        "vlastna_poznamka",
+        "nevyzdvihnuta_zasielka"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -267,6 +267,13 @@
       "when": 1785953614763,
       "tag": "0037_graceful_skin",
       "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "7",
+      "when": 1785957032743,
+      "tag": "0038_sad_kinsey_walden",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema-mail-log.ts
+++ b/apps/api/src/db/schema-mail-log.ts
@@ -45,6 +45,11 @@ export const mailLog = pgTable(
     recipient: text("recipient").notNull().default(""),
     bcc: text("bcc"),
     subject: text("subject"),
+    // issue 277: skutočne ODOSLANÝ text e-mailu (`MailMessage.text`) — bez
+    // tohto stĺpca kniha nemala ako dokázať, ČO presne odišlo, len KOMU/KEDY.
+    // `null` pre `skipped` záznamy (appka vtedy nič neposlala, žiadny text
+    // neexistuje).
+    body: text("body"),
     orderCode: text("order_code"),
     variantCode: text("variant_code"),
     packageNumber: text("package_number"),

--- a/apps/api/src/http/nedostupne-routes.ts
+++ b/apps/api/src/http/nedostupne-routes.ts
@@ -25,7 +25,10 @@ const previewBody = z.object({ orderCode: z.string().min(1), variantCode: z.stri
 // server-side vynútenie "náhľad VŽDY predchádza odoslaniu", pozri
 // `preview-tokens.ts`. Bez tohto by priame volanie API (mimo React UI) mohlo
 // poslať e-mail bez toho, aby čokoľvek jeho obsah niekedy zobrazilo.
-const sendBody = previewBody.extend({ previewToken: z.string().min(1) });
+// issue 277: obsluha mohla text v okne náhľadu upraviť pred odoslaním —
+// voliteľné, aby priame API volanie bez úpravy (nič neposlalo v `editedBody`)
+// ostalo spätne kompatibilné a poslalo pôvodné vyrenderované znenie.
+const sendBody = previewBody.extend({ previewToken: z.string().min(1), editedBody: z.string().trim().min(1).max(20000).optional() });
 
 // issue 238: majiteľov RUČNE vložený odkaz náhrady — validovaný ako URL
 // (rovnaká disciplína ako `orders-routes.ts`'s `orderLineSupplierLinkBody`,
@@ -102,7 +105,9 @@ export function registerNedostupneRoutes(app: Hono<AppBindings>, db: Database, d
       }
       const built = await buildEmailForType(db, ctx, emailType);
       const previewToken = issuePreviewToken(orderCode, variantCode, emailType, new Date());
-      return c.json({ ok: true as const, subject: built.subject, html: built.html, recipient: ctx.email, customerName: ctx.customerName, previewToken });
+      // issue 277: `text` je plain-textová verzia (rovnaká, akú appka odošle
+      // ako fallback) — frontend ju predvyplní do editovateľného okna.
+      return c.json({ ok: true as const, subject: built.subject, html: built.html, text: built.text, recipient: ctx.email, customerName: ctx.customerName, previewToken });
     },
   );
 
@@ -114,7 +119,7 @@ export function registerNedostupneRoutes(app: Hono<AppBindings>, db: Database, d
     requireRole("admin", "manazer"),
     zValidator("json", sendBody),
     async (c) => {
-      const { orderCode, variantCode, emailType, previewToken } = c.req.valid("json");
+      const { orderCode, variantCode, emailType, previewToken, editedBody } = c.req.valid("json");
       const user = c.get("user");
       const now = new Date();
       // Server-side vynútenie povinného náhľadu (code review pred mergom,
@@ -133,6 +138,7 @@ export function registerNedostupneRoutes(app: Hono<AppBindings>, db: Database, d
         bccEmail: deps.bccEmail,
         // issue 193: kniha odoslaných e-mailov ukáže, KTO odoslanie spustil.
         actorUserId: user.userId,
+        ...(editedBody === undefined ? {} : { editedBody }),
       });
       if (!result.ok) {
         return c.json({ ok: false as const, error: sendErrorMessage(result) });

--- a/apps/api/src/http/order-merge-routes.ts
+++ b/apps/api/src/http/order-merge-routes.ts
@@ -20,7 +20,9 @@ export interface OrderMergeRunDeps {
 const previewBody = z.object({ baseOrderId: z.string().uuid(), otherOrderIds: z.array(z.string().uuid()).min(1) });
 // `/send` musí priniesť token vydaný `/preview` PRE PRESNE tento (baseOrderId,
 // zoradený výber) — rovnaká disciplína ako `nedostupne-routes.ts`.
-const sendBody = previewBody.extend({ previewToken: z.string().min(1) });
+// issue 277: rovnaký zámer ako `nedostupne-routes.ts` — voliteľná ručná
+// úprava textu z okna náhľadu.
+const sendBody = previewBody.extend({ previewToken: z.string().min(1), editedBody: z.string().trim().min(1).max(20000).optional() });
 
 function bccMissing(deps: OrderMergeRunDeps): boolean {
   return deps.bccEmail === undefined || deps.bccEmail.trim() === "";
@@ -80,6 +82,7 @@ export function registerOrderMergeRoutes(app: Hono<AppBindings>, db: Database, d
         ok: true as const,
         subject: built.content.subject,
         html: built.content.html,
+        text: built.content.text,
         recipient: built.content.to ?? "",
         customerName: built.content.customerName,
         orderNumbers: built.content.orderNumbers,
@@ -97,7 +100,7 @@ export function registerOrderMergeRoutes(app: Hono<AppBindings>, db: Database, d
     requireRole("admin", "manazer"),
     zValidator("json", sendBody),
     async (c) => {
-      const { baseOrderId, otherOrderIds, previewToken } = c.req.valid("json");
+      const { baseOrderId, otherOrderIds, previewToken, editedBody } = c.req.valid("json");
       const user = c.get("user");
       const now = new Date();
       // Server-side vynútenie povinného náhľadu — token sa KONZUMUJE
@@ -113,6 +116,7 @@ export function registerOrderMergeRoutes(app: Hono<AppBindings>, db: Database, d
         mailTransport: deps.mailTransport,
         bccEmail: deps.bccEmail,
         actorUserId: user.userId,
+        ...(editedBody === undefined ? {} : { editedBody }),
       });
       if (result.status !== "sent") {
         return c.json({ ok: false as const, error: sendErrorMessage(result) });

--- a/apps/api/src/modules/mail-log/queries.ts
+++ b/apps/api/src/modules/mail-log/queries.ts
@@ -21,6 +21,9 @@ export interface MailLogRow {
   readonly templateKey: string | null;
   readonly recipient: string;
   readonly subject: string | null;
+  // issue 277: skutočne odoslaný/pokúšaný text — `null` pre `skipped` (appka
+  // vtedy žiadny text nevygenerovala).
+  readonly body: string | null;
   readonly orderCode: string | null;
   readonly variantCode: string | null;
   readonly packageNumber: string | null;
@@ -64,6 +67,7 @@ export async function listMailLog(db: Database, filter: MailLogFilter, adminBase
       templateKey: mailLog.templateKey,
       recipient: mailLog.recipient,
       subject: mailLog.subject,
+      body: mailLog.body,
       orderCode: mailLog.orderCode,
       variantCode: mailLog.variantCode,
       packageNumber: mailLog.packageNumber,
@@ -90,6 +94,7 @@ export async function listMailLog(db: Database, filter: MailLogFilter, adminBase
     templateKey: r.templateKey,
     recipient: r.recipient,
     subject: r.subject,
+    body: r.body,
     orderCode: r.orderCode,
     variantCode: r.variantCode,
     packageNumber: r.packageNumber,

--- a/apps/api/src/modules/mail-log/service.ts
+++ b/apps/api/src/modules/mail-log/service.ts
@@ -27,6 +27,9 @@ interface MailLogEntry extends MailLogContext {
   readonly recipient: string;
   readonly bcc?: string | undefined;
   readonly subject?: string;
+  // issue 277: skutočne odoslaný/pokúšaný text — `undefined` pre `skipped`
+  // (appka vtedy žiadny text nevygenerovala).
+  readonly body?: string;
   readonly reason?: string;
 }
 
@@ -41,6 +44,7 @@ async function insertEntry(db: Pick<Database, "insert">, now: Date, entry: MailL
       recipient: entry.recipient,
       bcc: entry.bcc ?? null,
       subject: entry.subject ?? null,
+      body: entry.body ?? null,
       orderCode: entry.orderCode ?? null,
       variantCode: entry.variantCode ?? null,
       packageNumber: entry.packageNumber ?? null,
@@ -121,10 +125,11 @@ export async function sendLoggedMail(
       recipient: message.to,
       bcc: message.bcc,
       subject: message.subject,
+      body: message.text,
       reason: rawErrorMessage,
     });
     return { ok: false, rawErrorMessage };
   }
-  await insertEntry(db, now, { ...ctx, status: "sent", recipient: message.to, bcc: message.bcc, subject: message.subject });
+  await insertEntry(db, now, { ...ctx, status: "sent", recipient: message.to, bcc: message.bcc, subject: message.subject, body: message.text });
   return { ok: true };
 }

--- a/apps/api/src/modules/mail-templates/render.test.ts
+++ b/apps/api/src/modules/mail-templates/render.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { renderTemplate, validateTemplateText, type TemplateContext } from "./render.js";
+import { renderEditedBody, renderTemplate, validateTemplateText, type TemplateContext } from "./render.js";
 
 // issue 192. Čistá jednotka — žiadna databáza, žiadna sieť, nikdy sa nič
 // neodosiela.
@@ -131,5 +131,36 @@ describe("validateTemplateText", () => {
   it("prázdny predmet aj prázdne telo sa odmietnu", () => {
     const errors = validateTemplateText({ subject: "   ", body: "\n" }, ALLOWED);
     expect(errors).toHaveLength(2);
+  });
+});
+
+// issue 277: jednorazová RUČNÁ úprava textu tesne pred odoslaním — text je UŽ
+// HOTOVÝ (zástupné polia dosadené obsluhou v okne náhľadu), takže sa
+// NEPÚŠŤA cez `{{pole}}`/`**tučné**` šablónový engine znova. Prázdny riadok =
+// nový odstavec (rovnaká konvencia ako šablóny).
+describe("renderEditedBody — jednorazová ručná úprava (issue 277)", () => {
+  it("prázdny riadok oddeľuje odstavce, jednoduchý riadok zalomí VNÚTRI odstavca", () => {
+    const out = renderEditedBody("Dobrý deň,\nešte dopĺňam vetu.\n\nS pozdravom,\nobchod");
+    expect(out.html).toContain("<p>Dobrý deň,<br>\n      ešte dopĺňam vetu.</p>");
+    expect(out.html).toContain("<p>S pozdravom,<br>\n      obchod</p>");
+    expect(out.text).toBe("Dobrý deň,\nešte dopĺňam vetu.\n\nS pozdravom,\nobchod");
+  });
+
+  it("HTML napísané obsluhou sa ESCAPUJE, nikdy sa nestane surovou značkou", () => {
+    const out = renderEditedBody('Dopisujem <script>alert("x")</script> priamo.');
+    expect(out.html).toContain("&lt;script&gt;");
+    expect(out.html).not.toContain("<script>");
+    expect(out.text).toContain("<script>"); // čistý text sa neescapuje, ide len ako telo e-mailu
+  });
+
+  it("prázdne odstavce (viac za sebou idúcich prázdnych riadkov) sa zahodia, nezostanú prázdne <p>", () => {
+    const out = renderEditedBody("Prvý.\n\n\n\nDruhý.");
+    expect(out.html.match(/<p>/g)).toHaveLength(2);
+    expect(out.text).toBe("Prvý.\n\nDruhý.");
+  });
+
+  it("okolité biele znaky celého textu aj každého odseku sa orežú", () => {
+    const out = renderEditedBody("  \n  Ahoj.  \n\n  ");
+    expect(out.text).toBe("Ahoj.");
   });
 });

--- a/apps/api/src/modules/mail-templates/render.ts
+++ b/apps/api/src/modules/mail-templates/render.ts
@@ -91,7 +91,7 @@ function parse(source: string): readonly Node[] {
   return root;
 }
 
-function htmlEscape(value: string): string {
+export function htmlEscape(value: string): string {
   return value
     .replaceAll("&", "&amp;")
     .replaceAll("<", "&lt;")
@@ -262,6 +262,39 @@ export function renderTemplate(template: MailTemplateText, ctx: TemplateContext)
     html: assembleHtml(toPieces(bodyNodes, ctx, "html")),
     text: assembleText(toPieces(bodyNodes, ctx, "text")),
   };
+}
+
+export interface RenderedEditedBody {
+  readonly html: string;
+  readonly text: string;
+}
+
+/**
+ * issue 277: jednorazová RUČNÁ úprava textu tesne pred odoslaním (okno
+ * náhľadu, `MailPreviewDialog.tsx`) — obsluha edituje UŽ HOTOVÝ text (zástupné
+ * polia dosadené, žiadna `{{pole}}`/`**tučné**` šablónová syntax), preto sa
+ * NEPÚŠŤA cez `parse`/placeholder engine znova (`renderTemplate`). Prázdny
+ * riadok = nový odstavec (rovnaká konvencia ako šablóny), jednoduchý riadok v
+ * odstavci = zalomenie. Escapovanie je VÝHRADNE tu — obsluha smie napísať
+ * čokoľvek, nikdy sa to nezapíše ako surové HTML (rovnaká disciplína ako
+ * `assembleHtml` vyššie).
+ */
+export function renderEditedBody(text: string): RenderedEditedBody {
+  const paragraphs = text
+    .replaceAll("\r\n", "\n")
+    .split(/\n[ \t]*\n+/)
+    .map((p) => p.trim())
+    .filter((p) => p !== "");
+  const htmlParagraphs = paragraphs.map((p) => `    <p>${htmlEscape(p).replaceAll("\n", "<br>\n      ")}</p>`);
+  const html = [
+    "<!DOCTYPE html>",
+    "<html>",
+    '  <body style="font-family: Arial, sans-serif; font-size: 16px; color: #333;">',
+    ...htmlParagraphs,
+    "  </body>",
+    "</html>",
+  ].join("\n");
+  return { html, text: paragraphs.join("\n\n") };
 }
 
 /** Mená zástupných polí použitých v texte — vrátane tých v podmienkach. */

--- a/apps/api/src/modules/nedostupne/send.ts
+++ b/apps/api/src/modules/nedostupne/send.ts
@@ -8,6 +8,7 @@ import { recordSkippedMail, sendLoggedMail, type MailLogContext } from "../mail-
 import { resolveTemplate } from "../mail-templates/store.js";
 import { listOpenStatusNames } from "../orders/open-statuses.js";
 import { NEDOSTUPNE_SEND_LOCK_KEY, TYPE_ALTERNATIVE, type NedostupneEmailType } from "./constants.js";
+import { renderEditedBody } from "../mail-templates/render.js";
 import { buildAlternativeEmail, buildUnavailableEmail, type BuiltNedostupneEmail } from "./logic.js";
 import { listReplacementLinksForVariant } from "./replacement-links.js";
 import { hasSentNedostupne, markSentNedostupne } from "./state.js";
@@ -93,6 +94,11 @@ export interface SendNedostupneOptions {
   // zamestnanca (žiadny naplánovaný beh), takže sa zapisuje do knihy
   // odoslaných e-mailov ako `manual` s jeho menom.
   readonly actorUserId?: string;
+  // issue 277: obsluha upravila text priamo v okne náhľadu — keď je
+  // prítomný, PREPÍŠE vygenerované `html`/`text` (predmet ostáva pôvodný,
+  // ticket edituje len text e-mailu). Šablóna v DB sa touto úpravou nikdy
+  // nemení — číta sa len na zostavenie predmetu (`buildEmailForType`).
+  readonly editedBody?: string;
 }
 
 /**
@@ -123,7 +129,7 @@ export async function sendNedostupneEmail(options: SendNedostupneOptions): Promi
 }
 
 async function sendNedostupneEmailLocked(options: SendNedostupneOptions): Promise<SendNedostupneResult> {
-  const { db, now, orderCode, variantCode, emailType, mailTransport, bccEmail, actorUserId } = options;
+  const { db, now, orderCode, variantCode, emailType, mailTransport, bccEmail, actorUserId, editedBody } = options;
 
   // issue 193: každý pokus (aj neúspešný) sa zapisuje do spoločnej knihy
   // odoslaných e-mailov — `mail-log/service.ts`.
@@ -166,10 +172,14 @@ async function sendNedostupneEmailLocked(options: SendNedostupneOptions): Promis
   }
 
   const built = await buildEmailForType(db, ctx, emailType);
+  // issue 277: obsluha mohla text v okne náhľadu upraviť — odošle sa PRESNE
+  // to (predmet ostáva z pôvodného vyrenderovania), nikdy znova
+  // vygenerovaná šablóna.
+  const finalEmail: BuiltNedostupneEmail = editedBody === undefined ? built : { subject: built.subject, ...renderEditedBody(editedBody) };
   const sendResult = await sendLoggedMail(
     db,
     mailTransport,
-    { to: email, subject: built.subject, text: built.text, html: built.html, bcc: bccEmail },
+    { to: email, subject: finalEmail.subject, text: finalEmail.text, html: finalEmail.html, bcc: bccEmail },
     now,
     logCtx,
   );

--- a/apps/api/src/modules/orders/merge-mail.ts
+++ b/apps/api/src/modules/orders/merge-mail.ts
@@ -4,7 +4,7 @@ import { orders } from "../../db/schema.js";
 import { log } from "../../logger.js";
 import { recordSkippedMail, sendLoggedMail, type MailLogContext } from "../mail-log/service.js";
 import { globalContext, textValue } from "../mail-templates/context.js";
-import { renderTemplate } from "../mail-templates/render.js";
+import { renderEditedBody, renderTemplate } from "../mail-templates/render.js";
 import { resolveTemplate } from "../mail-templates/store.js";
 import type { MailTransport } from "../mail/transport.js";
 import { listOpenStatusNames } from "./open-statuses.js";
@@ -216,6 +216,9 @@ export interface SendOrderMergeMailOptions {
   // issue 193: kto tlačidlo stlačil — táto cesta je VŽDY ručná akcia
   // zamestnanca.
   readonly actorUserId?: string;
+  // issue 277: rovnaký zámer ako `nedostupne/send.ts`'s `editedBody` — obsluha
+  // upravila text priamo v okne náhľadu, predmet ostáva pôvodný.
+  readonly editedBody?: string;
 }
 
 /**
@@ -228,9 +231,12 @@ export interface SendOrderMergeMailOptions {
  * (`merge-mail-preview-tokens.ts`, vynútené v `http/order-merge-routes.ts`).
  */
 export async function sendOrderMergeMail(options: SendOrderMergeMailOptions): Promise<SendOrderMergeMailResult> {
-  const { db, now, baseOrderId, otherOrderIds, mailTransport, bccEmail, actorUserId } = options;
+  const { db, now, baseOrderId, otherOrderIds, mailTransport, bccEmail, actorUserId, editedBody } = options;
   const built = await buildOrderMergeMailContent(db, baseOrderId, otherOrderIds);
   if (!built.ok) return { status: built.error };
+  // issue 277: obsluha mohla text v okne náhľadu upraviť — odošle sa PRESNE
+  // to (predmet ostáva z pôvodného vyrenderovania).
+  const finalContent = editedBody === undefined ? built.content : { ...built.content, ...renderEditedBody(editedBody) };
 
   const logCtx: MailLogContext = {
     source: "order_merge",
@@ -261,7 +267,7 @@ export async function sendOrderMergeMail(options: SendOrderMergeMailOptions): Pr
   const sendResult = await sendLoggedMail(
     db,
     mailTransport,
-    { to, subject: built.content.subject, text: built.content.text, html: built.content.html, bcc: bccEmail },
+    { to, subject: built.content.subject, text: finalContent.text, html: finalContent.html, bcc: bccEmail },
     now,
     logCtx,
   );

--- a/apps/api/tests/mail-edited-body.integration.test.ts
+++ b/apps/api/tests/mail-edited-body.integration.test.ts
@@ -1,0 +1,136 @@
+import { eq } from "drizzle-orm";
+import { afterEach, expect, it } from "vitest";
+import { mailLog, mailTemplates, orderLines, orders } from "../src/db/schema.js";
+import type { MailMessage } from "../src/modules/mail/transport.js";
+import { sendOrderMergeMail } from "../src/modules/orders/merge-mail.js";
+import { DEFAULT_ORDER_OPEN_STATUS } from "../src/modules/orders/open-statuses.js";
+import { sendNedostupneEmail } from "../src/modules/nedostupne/send.js";
+import { saveTemplate } from "../src/modules/mail-templates/store.js";
+import { insertTestVariantForProduct } from "./helpers/orders.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 277: jednorazová RUČNÁ úprava textu tesne pred odoslaním (okno
+// náhľadu) — appka MUSÍ odoslať presne to, čo obsluha upravila (nie znova
+// vygenerovanú šablónu), zapísať TO ISTÉ do Knihy odoslaných e-mailov, a
+// šablóna v `mail_template` musí po odoslaní ostať bajt na bajt nezmenená.
+// Falošný mail transport — nikdy skutočný SMTP (majiteľova podmienka).
+
+let close: (() => Promise<void>) | undefined;
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+});
+
+async function boot() {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  return ctx.db;
+}
+
+function fakeMail(): { readonly transport: (m: MailMessage) => Promise<void>; readonly sent: MailMessage[] } {
+  const sent: MailMessage[] = [];
+  return {
+    transport: (m) => {
+      sent.push(m);
+      return Promise.resolve();
+    },
+    sent,
+  };
+}
+
+it("nedostupne: editedBody nahradí vygenerované znenie, šablóna ostáva nezmenená, Kniha uloží upravený text", async () => {
+  const db = await boot();
+  await insertTestVariantForProduct(db, "P277A", "P277A", { productName: "Nohavice Test" });
+  const [order] = await db
+    .insert(orders)
+    .values({ externalOrderId: "27700001", customerName: "Ján Novák", statusName: DEFAULT_ORDER_OPEN_STATUS, placedAt: new Date("2026-08-01T10:00:00Z"), email: "jan@example.sk" })
+    .returning({ id: orders.id });
+  if (order === undefined) throw new Error("test objednávka sa nepodarilo vložiť");
+  await db.insert(orderLines).values({ orderId: order.id, variantCode: "P277A", quantity: 1, state: "nedostupne" });
+
+  // Majiteľ si predtým prispôsobil šablónu — musí ostať PRESNE takáto po
+  // odoslaní s ručne upraveným textom (dôkaz, že editácia nikdy nezapisuje
+  // do `mail_template`).
+  const now = new Date("2026-08-01T11:00:00Z");
+  const actorId = await seedActor(db);
+  const saved = await saveTemplate(db, {
+    key: "nedostupne",
+    subject: "Vlastný predmet — {{meno_zakaznika}}",
+    body: "Vlastné znenie pre {{meno_zakaznika}}.",
+    userId: actorId,
+    now,
+  });
+  expect(saved.ok).toBe(true);
+  const beforeSend = (await db.select().from(mailTemplates).where(eq(mailTemplates.key, "nedostupne")))[0];
+  if (beforeSend === undefined) throw new Error("šablóna sa nepodarilo uložiť pred testom");
+
+  const { transport, sent } = fakeMail();
+  const editedText = "Dobrý deň, Ján,\n\nváš tovar bohužiaľ nemáme skladom — ospravedlňujeme sa a hľadáme náhradu.\n\nS pozdravom, obchod";
+  const result = await sendNedostupneEmail({
+    db,
+    now: new Date("2026-08-01T12:00:00Z"),
+    orderCode: "27700001",
+    variantCode: "P277A",
+    emailType: "nedostupne",
+    mailTransport: transport,
+    bccEmail: "majitel@forestshop.sk",
+    editedBody: editedText,
+  });
+  expect(result).toEqual({ ok: true });
+  expect(sent).toHaveLength(1);
+  expect(sent[0]?.text).toBe(editedText);
+  expect(sent[0]?.html).toContain("váš tovar bohužiaľ nemáme skladom");
+  expect(sent[0]?.html).not.toContain("Vlastné znenie pre");
+  // Predmet ostáva z NEUPRAVENÉHO vyrenderovania (ticket edituje len text).
+  expect(sent[0]?.subject).toBe("Vlastný predmet — Ján Novák");
+
+  const afterSend = (await db.select().from(mailTemplates).where(eq(mailTemplates.key, "nedostupne")))[0];
+  expect(afterSend).toEqual(beforeSend);
+
+  const logRow = (await db.select({ recipient: mailLog.recipient, body: mailLog.body }).from(mailLog))[0];
+  expect(logRow?.recipient).toBe("jan@example.sk");
+  expect(logRow?.body).toBe(editedText);
+});
+
+async function seedActor(db: Awaited<ReturnType<typeof boot>>): Promise<string> {
+  const { users } = await import("../src/db/schema.js");
+  const { hashPassword } = await import("../src/modules/auth/passwords.js");
+  const [row] = await db
+    .insert(users)
+    .values({ email: "sablona-autor@forestshop.sk", passwordHash: await hashPassword("heslo-testovacie"), displayName: "Autor šablóny", role: "manazer" })
+    .returning({ id: users.id });
+  if (row === undefined) throw new Error("test používateľ sa nepodarilo vložiť");
+  return row.id;
+}
+
+it("order-merge: editedBody nahradí vygenerované znenie, Kniha uloží upravený text", async () => {
+  const db = await boot();
+  const [base] = await db
+    .insert(orders)
+    .values({ externalOrderId: "27700101", customerName: "Eva Kováčová", statusName: DEFAULT_ORDER_OPEN_STATUS, placedAt: new Date("2026-08-01T09:00:00Z"), email: "eva@example.sk" })
+    .returning({ id: orders.id });
+  const [other] = await db
+    .insert(orders)
+    .values({ externalOrderId: "27700102", customerName: "Eva Kováčová", statusName: DEFAULT_ORDER_OPEN_STATUS, placedAt: new Date("2026-08-01T10:00:00Z"), email: "eva@example.sk" })
+    .returning({ id: orders.id });
+  if (base === undefined || other === undefined) throw new Error("test objednávky sa nepodarilo vložiť");
+
+  const { transport, sent } = fakeMail();
+  const editedText = "Ahoj Eva,\n\nobe tvoje objednávky posielame spolu v jednej zásielke.\n\nĎakujeme!";
+  const result = await sendOrderMergeMail({
+    db,
+    now: new Date("2026-08-01T12:00:00Z"),
+    baseOrderId: base.id,
+    otherOrderIds: [other.id],
+    mailTransport: transport,
+    bccEmail: "majitel@forestshop.sk",
+    editedBody: editedText,
+  });
+  expect(result.status).toBe("sent");
+  expect(sent).toHaveLength(1);
+  expect(sent[0]?.text).toBe(editedText);
+  expect(sent[0]?.html).toContain("obe tvoje objednávky posielame spolu");
+
+  const logRow = (await db.select({ body: mailLog.body }).from(mailLog))[0];
+  expect(logRow?.body).toBe(editedText);
+});

--- a/apps/api/tests/mail-edited-body.integration.test.ts
+++ b/apps/api/tests/mail-edited-body.integration.test.ts
@@ -1,6 +1,9 @@
 import { eq } from "drizzle-orm";
 import { afterEach, expect, it } from "vitest";
-import { mailLog, mailTemplates, orderLines, orders } from "../src/db/schema.js";
+import { mailLog, mailTemplates, orderLines, orders, users } from "../src/db/schema.js";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
 import type { MailMessage } from "../src/modules/mail/transport.js";
 import { sendOrderMergeMail } from "../src/modules/orders/merge-mail.js";
 import { DEFAULT_ORDER_OPEN_STATUS } from "../src/modules/orders/open-statuses.js";
@@ -133,4 +136,76 @@ it("order-merge: editedBody nahradí vygenerované znenie, Kniha uloží upraven
 
   const logRow = (await db.select({ body: mailLog.body }).from(mailLog))[0];
   expect(logRow?.body).toBe(editedText);
+});
+
+// HTTP-úrovňový dôkaz — náhľad vracia `text` (frontend ho predvyplní do
+// editovateľného okna), `/send` prijme `editedBody`, a `GET /api/mail-log`
+// vráti uložené telo (rovnaká cesta ako obsluha uvidí na obrazovke Kniha
+// odoslaných e-mailov).
+const HESLO = "test-heslo-abc";
+
+afterEach(() => {
+  resetLoginRateLimit();
+});
+
+async function bootHttp(nedostupneSent: MailMessage[], orderMergeSent: MailMessage[]) {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await ctx.db.insert(users).values({ email: "pouzivatel@forestshop.sk", passwordHash: await hashPassword(HESLO), displayName: "Test", role: "manazer" });
+  const app = createApp(ctx.db, {
+    cookieSecure: false,
+    nedostupne: {
+      mailTransport: (m: MailMessage) => {
+        nedostupneSent.push(m);
+        return Promise.resolve();
+      },
+      bccEmail: "majitel@forestshop.sk",
+      adminBaseUrl: "https://www.forestshop.sk",
+    },
+    orderMerge: {
+      mailTransport: (m: MailMessage) => {
+        orderMergeSent.push(m);
+        return Promise.resolve();
+      },
+      bccEmail: "majitel@forestshop.sk",
+    },
+  });
+  const login = await app.request("/api/login", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ email: "pouzivatel@forestshop.sk", password: HESLO }) });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie, db: ctx.db };
+}
+
+it("HTTP: nedostupne náhľad vráti 'text', /send prijme editedBody, mail-log ukáže uložené telo", async () => {
+  const nedostupneSent: MailMessage[] = [];
+  const { app, cookie, db } = await bootHttp(nedostupneSent, []);
+  await insertTestVariantForProduct(db, "P277B", "P277B", { productName: "Čiapka Test" });
+  const [order] = await db
+    .insert(orders)
+    .values({ externalOrderId: "27700201", customerName: "Marek Test", statusName: DEFAULT_ORDER_OPEN_STATUS, placedAt: new Date("2026-08-01T10:00:00Z"), email: "marek@example.sk" })
+    .returning({ id: orders.id });
+  if (order === undefined) throw new Error("test objednávka sa nepodarilo vložiť");
+  await db.insert(orderLines).values({ orderId: order.id, variantCode: "P277B", quantity: 1, state: "nedostupne" });
+
+  const previewRes = await app.request("/api/nedostupne/preview", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ orderCode: "27700201", variantCode: "P277B", emailType: "nedostupne" }),
+  });
+  const preview = (await previewRes.json()) as { ok: boolean; text: string; previewToken: string };
+  expect(preview.ok).toBe(true);
+  expect(typeof preview.text).toBe("string");
+  expect(preview.text.length).toBeGreaterThan(0);
+
+  const editedText = "Marek, tvoj tovar bohužiaľ nemáme — ozveme sa s náhradou.";
+  const sendRes = await app.request("/api/nedostupne/send", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ orderCode: "27700201", variantCode: "P277B", emailType: "nedostupne", previewToken: preview.previewToken, editedBody: editedText }),
+  });
+  expect((await sendRes.json() as { ok: boolean }).ok).toBe(true);
+  expect(nedostupneSent[0]?.text).toBe(editedText);
+
+  const logRes = await app.request("/api/mail-log", { headers: { cookie } });
+  const logBody = (await logRes.json()) as { rows: { body: string | null }[] };
+  expect(logBody.rows[0]?.body).toBe(editedText);
 });

--- a/apps/web/src/components/MailLogSection.test.tsx
+++ b/apps/web/src/components/MailLogSection.test.tsx
@@ -26,6 +26,8 @@ const RIADOK = {
   variantCode: null,
   packageNumber: "RR123456789SK",
   sequence: 1,
+  // issue 277: skutočne odoslaný text — `null` len pre "preskočené" (nižšie).
+  body: "Dobrý deň,\n\nvaša zásielka čaká na pošte.",
   reason: null,
   actorName: null,
   adminLink: "https://www.forestshop.sk/admin/objednavky-detail/?id=1",
@@ -39,6 +41,7 @@ const DUPLICITA = {
   actorName: "Zbyněk",
   source: "nedostupne" as const,
   sequence: null,
+  body: null,
   reason: "už bolo odoslané skôr — druhý e-mail sa neposiela",
 };
 
@@ -79,6 +82,19 @@ it("zablokovaná duplicita je vidno aj s menom zamestnanca, ktorý ju vyvolal", 
   expect(riadok.textContent).toContain("Preskočené");
   expect(riadok.textContent).toContain("už bolo odoslané skôr");
   expect(riadok.textContent).toContain("Zbyněk");
+});
+
+// issue 277: kniha musí vedieť ukázať SKUTOČNE odoslaný text — inak by
+// akceptačná podmienka "kniha nesmie klamať" nebola overiteľná na obrazovke.
+it("riadok s uloženým textom má tlačidlo na jeho zobrazenie; riadok bez textu (preskočené) ho nemá", async () => {
+  renderSection();
+  const riadokSoTextom = await screen.findByTestId("mail-log-row-r1");
+  expect(riadokSoTextom.textContent).not.toContain("vaša zásielka čaká na pošte");
+
+  fireEvent.click(screen.getByTestId("mail-log-body-toggle-r1"));
+  await screen.findByText(/vaša zásielka čaká na pošte/);
+
+  expect(screen.queryByTestId("mail-log-body-toggle-r2")).toBeNull();
 });
 
 it("zmena filtra automatizácie znovu načíta prehľad s tým filtrom", async () => {

--- a/apps/web/src/components/MailLogSection.tsx
+++ b/apps/web/src/components/MailLogSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, type JSX } from "react";
+import { Fragment, useCallback, useEffect, useState, type JSX } from "react";
 import {
   fetchMailLog,
   MailLogUnauthorizedError,
@@ -48,6 +48,10 @@ export function MailLogSection({ onSessionExpired }: { readonly onSessionExpired
   const [source, setSource] = useState<MailLogSource | "">("");
   const [status, setStatus] = useState<MailLogRow["status"] | "">("");
   const [period, setPeriod] = useState<MailLogPeriod>("30");
+  // issue 277: ktoré riadky majú práve rozbalené zobrazenie skutočne
+  // odoslaného textu — appka ho zámerne neukazuje vždy (dlhý text by
+  // rozbil hustú tabuľku), obsluha si ho vyžiada per riadok.
+  const [expandedBodyIds, setExpandedBodyIds] = useState<ReadonlySet<string>>(new Set());
 
   const load = useCallback(() => {
     fetchMailLog({ source, status, period })
@@ -160,36 +164,67 @@ export function MailLogSection({ onSessionExpired }: { readonly onSessionExpired
               </tr>
             </thead>
             <tbody>
-              {data.rows.map((row) => (
-                <tr key={row.id} data-testid={`mail-log-row-${row.id}`} className={`ml-row ml-row-${row.status}`}>
-                  <td className="ml-when">
-                    {formatWhen(row.createdAt)}
-                    <span className="ml-trigger">{row.trigger === "manual" ? (row.actorName ?? "ručne") : "plán"}</span>
-                  </td>
-                  <td>
-                    {MAIL_LOG_SOURCE_LABELS[row.source]}
-                    {row.sequence !== null && <span className="ml-seq">{row.sequence}. upozornenie</span>}
-                  </td>
-                  <td className="ml-recipient">{row.recipient === "" ? "—" : row.recipient}</td>
-                  <td>
-                    {row.adminLink === null ? (
-                      subjectOfRow(row) === "" ? (
-                        (row.subject ?? "—")
-                      ) : (
-                        subjectOfRow(row)
-                      )
-                    ) : (
-                      <a href={row.adminLink} target="_blank" rel="noreferrer noopener">
-                        {subjectOfRow(row)}
-                      </a>
+              {data.rows.map((row) => {
+                const expanded = expandedBodyIds.has(row.id);
+                return (
+                  <Fragment key={row.id}>
+                    <tr data-testid={`mail-log-row-${row.id}`} className={`ml-row ml-row-${row.status}`}>
+                      <td className="ml-when">
+                        {formatWhen(row.createdAt)}
+                        <span className="ml-trigger">{row.trigger === "manual" ? (row.actorName ?? "ručne") : "plán"}</span>
+                      </td>
+                      <td>
+                        {MAIL_LOG_SOURCE_LABELS[row.source]}
+                        {row.sequence !== null && <span className="ml-seq">{row.sequence}. upozornenie</span>}
+                      </td>
+                      <td className="ml-recipient">{row.recipient === "" ? "—" : row.recipient}</td>
+                      <td>
+                        {row.adminLink === null ? (
+                          subjectOfRow(row) === "" ? (
+                            (row.subject ?? "—")
+                          ) : (
+                            subjectOfRow(row)
+                          )
+                        ) : (
+                          <a href={row.adminLink} target="_blank" rel="noreferrer noopener">
+                            {subjectOfRow(row)}
+                          </a>
+                        )}
+                        {/* issue 277: `body` je `null` len pre "preskočené" —
+                            appka vtedy žiadny text nevygenerovala. */}
+                        {row.body !== null && (
+                          <button
+                            type="button"
+                            className="btn sm ghost ml-body-toggle"
+                            data-testid={`mail-log-body-toggle-${row.id}`}
+                            onClick={() => {
+                              setExpandedBodyIds((ids) => {
+                                const next = new Set(ids);
+                                if (next.has(row.id)) next.delete(row.id);
+                                else next.add(row.id);
+                                return next;
+                              });
+                            }}
+                          >
+                            {expanded ? "▲ skryť text" : "👁 zobraziť text"}
+                          </button>
+                        )}
+                      </td>
+                      <td>
+                        <span className={`ml-status ml-status-${row.status}`}>{STATUS_LABELS[row.status]}</span>
+                        {row.reason !== null && <span className="ml-reason">{row.reason}</span>}
+                      </td>
+                    </tr>
+                    {expanded && row.body !== null && (
+                      <tr className="ml-body-row" data-testid={`mail-log-body-${row.id}`}>
+                        <td colSpan={5}>
+                          <pre className="ml-body-text">{row.body}</pre>
+                        </td>
+                      </tr>
                     )}
-                  </td>
-                  <td>
-                    <span className={`ml-status ml-status-${row.status}`}>{STATUS_LABELS[row.status]}</span>
-                    {row.reason !== null && <span className="ml-reason">{row.reason}</span>}
-                  </td>
-                </tr>
-              ))}
+                  </Fragment>
+                );
+              })}
             </tbody>
           </table>
         </div>

--- a/apps/web/src/components/MailPreviewDialog.tsx
+++ b/apps/web/src/components/MailPreviewDialog.tsx
@@ -10,12 +10,22 @@ import { useEffect, useRef, type JSX, type ReactNode, type RefObject } from "rea
 // Komponenta je generická (žiadna zmienka o "nedostupných tovaroch") — ďalšie
 // automatizácie posielajú e-maily rovnakým spôsobom a majú ten istý kontrakt
 // "bez potvrdenia človekom e-mail neodíde".
+//
+// issue 277: telo e-mailu je odteraz EDITOVATEĽNÉ priamo v okne — `bodyText`/
+// `onBodyTextChange` nahrádzajú pôvodný read-only `dangerouslySetInnerHTML`
+// z `html`. Volajúci sedí na PLAIN-TEXTOVEJ verzii (`RenderedEmail.text`,
+// appka ju už počíta od issue 192) — HTML formátovanie (tučné písmo) sa pri
+// ručnej úprave zámerne nezachováva (obsluha edituje hotové vety, nie
+// šablónu); server escapuje a bezpečne prevedie späť na HTML
+// (`renderEditedBody`). Predmet/príjemca ostávajú needitovateľné — ticket
+// hovorí o úprave TEXTU e-mailu, nie predmetu.
 export function MailPreviewDialog({
   testId,
   title,
   recipient,
   subject,
-  html,
+  bodyText,
+  onBodyTextChange,
   confirmLabel,
   confirmDisabled,
   onConfirm,
@@ -27,7 +37,8 @@ export function MailPreviewDialog({
   readonly title: string;
   readonly recipient: string;
   readonly subject: string;
-  readonly html: string;
+  readonly bodyText: string;
+  readonly onBodyTextChange: (value: string) => void;
   readonly confirmLabel: string;
   readonly confirmDisabled: boolean;
   readonly onConfirm: () => void;
@@ -101,11 +112,22 @@ export function MailPreviewDialog({
         <p className="modal-meta">
           Komu: {recipient} — Predmet: {subject}
         </p>
-        {/* `html` je appkou GENEROVANÝ e-mail (napr. `buildEmailForType`,
-            `modules/nedostupne/logic.ts`) — meno zákazníka aj náhradné
-            produkty sú tam už HTML-escapované, nikdy surový užívateľský
-            vstup priamo tu. */}
-        <div className="modal-body" dangerouslySetInnerHTML={{ __html: html }} />
+        <label className="modal-body-label" htmlFor={`${testId}-body`}>
+          Text e-mailu (dá sa upraviť pred odoslaním)
+        </label>
+        {/* issue 277: obsluha edituje priamo tu — odošle sa PRESNE tento
+            text (server ho pri odoslaní escapuje a bezpečne prevedie na
+            HTML, `renderEditedBody`), nikdy pôvodná šablóna. */}
+        <textarea
+          id={`${testId}-body`}
+          className="modal-body modal-body-edit"
+          data-testid={`${testId}-body`}
+          value={bodyText}
+          onChange={(e) => {
+            onBodyTextChange(e.target.value);
+          }}
+          rows={10}
+        />
         {children}
         <div className="modal-actions">
           <button

--- a/apps/web/src/components/NedostupneSection.test.tsx
+++ b/apps/web/src/components/NedostupneSection.test.tsx
@@ -159,7 +159,7 @@ it("rola citanie NEVIDÍ žiadne akčné tlačidlá (len admin/manazer smie odos
 
 it("klik na 'náhľad' otvorí povinný náhľad PRED odoslaním — Odoslať sa ešte nevolá", async () => {
   fetchNedostupneList.mockResolvedValue(LIST_WITH_GROUP);
-  fetchNedostupnePreview.mockResolvedValue({ ok: true, subject: "Informácia o dostupnosti vašej objednávky — Forestshop.sk", html: "<p>Ahoj</p>", recipient: "jan@example.sk", customerName: "Ján Novák", previewToken: "tok-1" });
+  fetchNedostupnePreview.mockResolvedValue({ ok: true, subject: "Informácia o dostupnosti vašej objednávky — Forestshop.sk", html: "<p>Ahoj</p>", text: "Ahoj", recipient: "jan@example.sk", customerName: "Ján Novák", previewToken: "tok-1" });
   render(<NedostupneSection role="manazer" onSessionExpired={vi.fn()} />);
   await screen.findByTestId("nedostupne-group-40237/L");
 
@@ -176,7 +176,7 @@ it("potvrdenie náhľadu odošle presne s parametrami náhľadu a znovu načíta
     bccMissing: false,
     mailNotConfigured: false,
   });
-  fetchNedostupnePreview.mockResolvedValue({ ok: true, subject: "Predmet", html: "<p>Ahoj</p>", recipient: "jan@example.sk", customerName: "Ján Novák", previewToken: "tok-1" });
+  fetchNedostupnePreview.mockResolvedValue({ ok: true, subject: "Predmet", html: "<p>Ahoj</p>", text: "Ahoj", recipient: "jan@example.sk", customerName: "Ján Novák", previewToken: "tok-1" });
   sendNedostupneEmail.mockResolvedValue({ ok: true });
   render(<NedostupneSection role="manazer" onSessionExpired={vi.fn()} />);
   await screen.findByTestId("nedostupne-group-40237/L");
@@ -186,16 +186,49 @@ it("potvrdenie náhľadu odošle presne s parametrami náhľadu a znovu načíta
   fireEvent.click(screen.getByTestId("nedostupne-preview-confirm"));
 
   await waitFor(() => {
-    expect(sendNedostupneEmail).toHaveBeenCalledWith("17600001", "40237/L", "nedostupne", "tok-1");
+    expect(sendNedostupneEmail).toHaveBeenCalledWith("17600001", "40237/L", "nedostupne", "tok-1", "Ahoj");
   });
   await waitFor(() => {
     expect(screen.queryByTestId("nedostupne-preview")).toBeNull();
   });
 });
 
+// issue 277: obsluha vie priamo v okne prepísať text — odošle sa PRESNE to,
+// čo je v textovom poli v momente kliknutia na Odoslať, nikdy pôvodný náhľad.
+it("obsluha upraví text v náhľade — odošle sa upravený text, nie pôvodný", async () => {
+  fetchNedostupneList.mockResolvedValue(LIST_WITH_GROUP);
+  fetchNedostupnePreview.mockResolvedValue({ ok: true, subject: "Predmet", html: "<p>Ahoj</p>", text: "Ahoj", recipient: "jan@example.sk", customerName: "Ján Novák", previewToken: "tok-1" });
+  sendNedostupneEmail.mockResolvedValue({ ok: true });
+  render(<NedostupneSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("nedostupne-group-40237/L");
+
+  fireEvent.click(screen.getByTestId("nedostupne-send-17600001-40237/L"));
+  await screen.findByTestId("nedostupne-preview");
+  const textarea = screen.getByTestId("nedostupne-preview-body");
+  fireEvent.change(textarea, { target: { value: "Ešte dopisujem vlastnú vetu." } });
+  fireEvent.click(screen.getByTestId("nedostupne-preview-confirm"));
+
+  await waitFor(() => {
+    expect(sendNedostupneEmail).toHaveBeenCalledWith("17600001", "40237/L", "nedostupne", "tok-1", "Ešte dopisujem vlastnú vetu.");
+  });
+});
+
+it("prázdny text v náhľade zablokuje tlačidlo Odoslať", async () => {
+  fetchNedostupneList.mockResolvedValue(LIST_WITH_GROUP);
+  fetchNedostupnePreview.mockResolvedValue({ ok: true, subject: "Predmet", html: "<p>Ahoj</p>", text: "Ahoj", recipient: "jan@example.sk", customerName: "Ján Novák", previewToken: "tok-1" });
+  render(<NedostupneSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("nedostupne-group-40237/L");
+
+  fireEvent.click(screen.getByTestId("nedostupne-send-17600001-40237/L"));
+  await screen.findByTestId("nedostupne-preview");
+  fireEvent.change(screen.getByTestId("nedostupne-preview-body"), { target: { value: "   " } });
+
+  expect(screen.getByTestId("nedostupne-preview-confirm").hasAttribute("disabled")).toBe(true);
+});
+
 it("zrušenie náhľadu NEPOŠLE nič", async () => {
   fetchNedostupneList.mockResolvedValue(LIST_WITH_GROUP);
-  fetchNedostupnePreview.mockResolvedValue({ ok: true, subject: "Predmet", html: "<p>Ahoj</p>", recipient: "jan@example.sk", customerName: "Ján Novák", previewToken: "tok-1" });
+  fetchNedostupnePreview.mockResolvedValue({ ok: true, subject: "Predmet", html: "<p>Ahoj</p>", text: "Ahoj", recipient: "jan@example.sk", customerName: "Ján Novák", previewToken: "tok-1" });
   render(<NedostupneSection role="manazer" onSessionExpired={vi.fn()} />);
   await screen.findByTestId("nedostupne-group-40237/L");
 
@@ -210,7 +243,7 @@ it("zrušenie náhľadu NEPOŠLE nič", async () => {
 
 it("zlyhané odoslanie (ok:false) zobrazí server hlášku a nezavrie náhľad", async () => {
   fetchNedostupneList.mockResolvedValue(LIST_WITH_GROUP);
-  fetchNedostupnePreview.mockResolvedValue({ ok: true, subject: "Predmet", html: "<p>Ahoj</p>", recipient: "jan@example.sk", customerName: "Ján Novák", previewToken: "tok-1" });
+  fetchNedostupnePreview.mockResolvedValue({ ok: true, subject: "Predmet", html: "<p>Ahoj</p>", text: "Ahoj", recipient: "jan@example.sk", customerName: "Ján Novák", previewToken: "tok-1" });
   sendNedostupneEmail.mockResolvedValue({ ok: false, error: "Tento e-mail už bol tejto objednávke odoslaný." });
   render(<NedostupneSection role="manazer" onSessionExpired={vi.fn()} />);
   await screen.findByTestId("nedostupne-group-40237/L");
@@ -236,7 +269,7 @@ it("401 pri načítaní zavolá onSessionExpired", async () => {
 // aj klikom mimo neho, a ani jedna z týchto ciest NESMIE nič odoslať.
 async function otvorNahlad(): Promise<void> {
   fetchNedostupneList.mockResolvedValue(LIST_WITH_GROUP);
-  fetchNedostupnePreview.mockResolvedValue({ ok: true, subject: "Predmet", html: "<p>Ahoj</p>", recipient: "jan@example.sk", customerName: "Ján Novák", previewToken: "tok-1" });
+  fetchNedostupnePreview.mockResolvedValue({ ok: true, subject: "Predmet", html: "<p>Ahoj</p>", text: "Ahoj", recipient: "jan@example.sk", customerName: "Ján Novák", previewToken: "tok-1" });
   render(<NedostupneSection role="manazer" onSessionExpired={vi.fn()} />);
   await screen.findByTestId("nedostupne-group-40237/L");
   fireEvent.click(screen.getByTestId("nedostupne-send-17600001-40237/L"));

--- a/apps/web/src/components/NedostupneSection.tsx
+++ b/apps/web/src/components/NedostupneSection.tsx
@@ -37,6 +37,9 @@ export function NedostupneSection({ role, onSessionExpired }: { readonly role: M
   const [busyKey, setBusyKey] = useState("");
   const [actionError, setActionError] = useState("");
   const [pending, setPending] = useState<PendingSend | null>(null);
+  // issue 277: obsluhou upravený text okna náhľadu — predvyplnený z
+  // `preview.text` pri otvorení, needovateľný pri zatvorení/novom otvorení.
+  const [editedBody, setEditedBody] = useState("");
   // issue 191: spúšťacie tlačidlo si pamätáme už pri kliknutí — kým sa náhľad
   // načítava, je `disabled` a prehliadač z neho fokus zhodí, takže po zavretí
   // dialógu by sa nemal kam vrátiť (naživo overené na produkcii).
@@ -76,6 +79,7 @@ export function NedostupneSection({ role, onSessionExpired }: { readonly role: M
       fetchNedostupnePreview(orderCode, variantCode, emailType)
         .then((preview) => {
           setPending({ orderCode, variantCode, emailType, preview });
+          setEditedBody(preview.text);
         })
         .catch((err: unknown) => {
           if (err instanceof NedostupneUnauthorizedError) {
@@ -95,7 +99,7 @@ export function NedostupneSection({ role, onSessionExpired }: { readonly role: M
     if (pending === null) return;
     const key = `${pending.orderCode}|${pending.variantCode}|${pending.emailType}`;
     setBusyKey(key);
-    sendNedostupneEmail(pending.orderCode, pending.variantCode, pending.emailType, pending.preview.previewToken)
+    sendNedostupneEmail(pending.orderCode, pending.variantCode, pending.emailType, pending.preview.previewToken, editedBody)
       .then((result) => {
         if (!result.ok) {
           setActionError(result.error);
@@ -114,7 +118,7 @@ export function NedostupneSection({ role, onSessionExpired }: { readonly role: M
       .finally(() => {
         setBusyKey("");
       });
-  }, [pending, load, onSessionExpired]);
+  }, [pending, editedBody, load, onSessionExpired]);
 
   // issue 238: pridanie majiteľovho ručného odkazu náhrady — po úspechu sa
   // draft vyprázdni a zoznam sa znova načíta (server je zdroj pravdy, žiadny
@@ -326,9 +330,10 @@ export function NedostupneSection({ role, onSessionExpired }: { readonly role: M
           title="Náhľad e-mailu — povinné pred odoslaním"
           recipient={pending.preview.recipient}
           subject={pending.preview.subject}
-          html={pending.preview.html}
+          bodyText={editedBody}
+          onBodyTextChange={setEditedBody}
           confirmLabel="📧 Odoslať zákazníkovi"
-          confirmDisabled={busyKey !== ""}
+          confirmDisabled={busyKey !== "" || editedBody.trim() === ""}
           onConfirm={confirmSend}
           returnFocusRef={triggerRef}
           onClose={() => {

--- a/apps/web/src/components/OrderMergeSection.test.tsx
+++ b/apps/web/src/components/OrderMergeSection.test.tsx
@@ -48,7 +48,7 @@ it("klik na 'náhľad' otvorí povinný náhľad — Odoslať sa ešte nevolá, 
   fireEvent.click(screen.getByTestId("order-merge-send-27700101"));
   await screen.findByTestId("order-merge-preview");
   expect(sendOrderMergeMail).not.toHaveBeenCalled();
-  expect((screen.getByTestId("order-merge-preview-body") as HTMLTextAreaElement).value).toBe("Ahoj");
+  expect(screen.getByTestId<HTMLTextAreaElement>("order-merge-preview-body").value).toBe("Ahoj");
 });
 
 it("potvrdenie BEZ úpravy odošle pôvodný predvyplnený text", async () => {

--- a/apps/web/src/components/OrderMergeSection.test.tsx
+++ b/apps/web/src/components/OrderMergeSection.test.tsx
@@ -1,0 +1,108 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { OrderMergeSection } from "./OrderMergeSection.js";
+
+const { fetchOrderMergeCandidates, fetchOrderMergePreview, sendOrderMergeMail } = vi.hoisted(() => ({
+  fetchOrderMergeCandidates: vi.fn(),
+  fetchOrderMergePreview: vi.fn(),
+  sendOrderMergeMail: vi.fn(),
+}));
+
+vi.mock("../orderMergeApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../orderMergeApi.js")>();
+  return { ...actual, fetchOrderMergeCandidates, fetchOrderMergePreview, sendOrderMergeMail };
+});
+
+// issue 277: rovnaký "editovateľný náhľad" mechanizmus ako
+// `NedostupneSection.test.tsx` — obe cesty zdieľajú `MailPreviewDialog`.
+
+const GROUP = {
+  customerName: "Eva Kováčová",
+  email: "eva@example.sk",
+  orders: [
+    { orderId: "order-a", externalOrderId: "27700101", placedAt: "2026-08-01T10:00:00.000Z" },
+    { orderId: "order-b", externalOrderId: "27700100", placedAt: "2026-07-31T10:00:00.000Z" },
+  ],
+};
+
+const LIST_WITH_GROUP = { groups: [GROUP], bccMissing: false, mailNotConfigured: false };
+const PREVIEW = { ok: true, subject: "Predmet", html: "<p>Ahoj</p>", text: "Ahoj", recipient: "eva@example.sk", customerName: "Eva Kováčová", orderNumbers: ["27700100", "27700101"], previewToken: "tok-1" };
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+it("prázdny zoznam zobrazí informačnú vetu", async () => {
+  fetchOrderMergeCandidates.mockResolvedValue({ groups: [], bccMissing: false, mailNotConfigured: false });
+  render(<OrderMergeSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("order-merge-empty");
+});
+
+it("klik na 'náhľad' otvorí povinný náhľad — Odoslať sa ešte nevolá, textové pole je predvyplnené z náhľadu", async () => {
+  fetchOrderMergeCandidates.mockResolvedValue(LIST_WITH_GROUP);
+  fetchOrderMergePreview.mockResolvedValue(PREVIEW);
+  render(<OrderMergeSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("order-merge-group-27700101");
+
+  fireEvent.click(screen.getByTestId("order-merge-send-27700101"));
+  await screen.findByTestId("order-merge-preview");
+  expect(sendOrderMergeMail).not.toHaveBeenCalled();
+  expect((screen.getByTestId("order-merge-preview-body") as HTMLTextAreaElement).value).toBe("Ahoj");
+});
+
+it("potvrdenie BEZ úpravy odošle pôvodný predvyplnený text", async () => {
+  fetchOrderMergeCandidates.mockResolvedValue(LIST_WITH_GROUP);
+  fetchOrderMergePreview.mockResolvedValue(PREVIEW);
+  sendOrderMergeMail.mockResolvedValue({ ok: true });
+  render(<OrderMergeSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("order-merge-group-27700101");
+
+  fireEvent.click(screen.getByTestId("order-merge-send-27700101"));
+  await screen.findByTestId("order-merge-preview");
+  fireEvent.click(screen.getByTestId("order-merge-preview-confirm"));
+
+  await waitFor(() => {
+    expect(sendOrderMergeMail).toHaveBeenCalledWith("order-a", ["order-b"], "tok-1", "Ahoj");
+  });
+});
+
+it("obsluha upraví text v náhľade — odošle sa upravený text, nie pôvodný", async () => {
+  fetchOrderMergeCandidates.mockResolvedValue(LIST_WITH_GROUP);
+  fetchOrderMergePreview.mockResolvedValue(PREVIEW);
+  sendOrderMergeMail.mockResolvedValue({ ok: true });
+  render(<OrderMergeSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("order-merge-group-27700101");
+
+  fireEvent.click(screen.getByTestId("order-merge-send-27700101"));
+  await screen.findByTestId("order-merge-preview");
+  fireEvent.change(screen.getByTestId("order-merge-preview-body"), { target: { value: "Ahoj Eva, obe objednávky pošleme spolu." } });
+  fireEvent.click(screen.getByTestId("order-merge-preview-confirm"));
+
+  await waitFor(() => {
+    expect(sendOrderMergeMail).toHaveBeenCalledWith("order-a", ["order-b"], "tok-1", "Ahoj Eva, obe objednávky pošleme spolu.");
+  });
+});
+
+it("zrušenie náhľadu NEPOŠLE nič", async () => {
+  fetchOrderMergeCandidates.mockResolvedValue(LIST_WITH_GROUP);
+  fetchOrderMergePreview.mockResolvedValue(PREVIEW);
+  render(<OrderMergeSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("order-merge-group-27700101");
+
+  fireEvent.click(screen.getByTestId("order-merge-send-27700101"));
+  await screen.findByTestId("order-merge-preview");
+  fireEvent.click(screen.getByTestId("order-merge-preview-cancel"));
+
+  await waitFor(() => {
+    expect(screen.queryByTestId("order-merge-preview")).toBeNull();
+  });
+  expect(sendOrderMergeMail).not.toHaveBeenCalled();
+});
+
+it("rola citanie NEVIDÍ tlačidlo odoslania", async () => {
+  fetchOrderMergeCandidates.mockResolvedValue(LIST_WITH_GROUP);
+  render(<OrderMergeSection role="citanie" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("order-merge-group-27700101");
+  expect(screen.queryByTestId("order-merge-send-27700101")).toBeNull();
+});

--- a/apps/web/src/components/OrderMergeSection.tsx
+++ b/apps/web/src/components/OrderMergeSection.tsx
@@ -34,6 +34,9 @@ export function OrderMergeSection({ role, onSessionExpired }: { readonly role: M
   const [busyKey, setBusyKey] = useState("");
   const [actionError, setActionError] = useState("");
   const [pending, setPending] = useState<PendingSend | null>(null);
+  // issue 277: obsluhou upravený text okna náhľadu — rovnaký vzor ako
+  // `NedostupneSection.tsx`.
+  const [editedBody, setEditedBody] = useState("");
   // issue 191's vzor (`NedostupneSection.tsx`) — spúšťacie tlačidlo sa počas
   // načítania náhľadu stáva `disabled`, prehliadač z neho fokus zhodí.
   const triggerRef = useRef<HTMLElement | null>(null);
@@ -71,6 +74,7 @@ export function OrderMergeSection({ role, onSessionExpired }: { readonly role: M
       )
         .then((preview) => {
           setPending({ group, preview });
+          setEditedBody(preview.text);
         })
         .catch((err: unknown) => {
           if (err instanceof OrderMergeUnauthorizedError) {
@@ -96,6 +100,7 @@ export function OrderMergeSection({ role, onSessionExpired }: { readonly role: M
       base.orderId,
       rest.map((o) => o.orderId),
       pending.preview.previewToken,
+      editedBody,
     )
       .then((result) => {
         if (!result.ok) {
@@ -115,7 +120,7 @@ export function OrderMergeSection({ role, onSessionExpired }: { readonly role: M
       .finally(() => {
         setBusyKey("");
       });
-  }, [pending, load, onSessionExpired]);
+  }, [pending, editedBody, load, onSessionExpired]);
 
   if (!loaded) return <p>Načítavam…</p>;
   if (error !== "") return <p role="alert">{error}</p>;
@@ -185,9 +190,10 @@ export function OrderMergeSection({ role, onSessionExpired }: { readonly role: M
           title="Náhľad e-mailu — povinné pred odoslaním"
           recipient={pending.preview.recipient}
           subject={pending.preview.subject}
-          html={pending.preview.html}
+          bodyText={editedBody}
+          onBodyTextChange={setEditedBody}
           confirmLabel="📧 Odoslať zákazníkovi"
-          confirmDisabled={busyKey !== ""}
+          confirmDisabled={busyKey !== "" || editedBody.trim() === ""}
           onConfirm={confirmSend}
           returnFocusRef={triggerRef}
           onClose={() => {

--- a/apps/web/src/mailLogApi.ts
+++ b/apps/web/src/mailLogApi.ts
@@ -25,6 +25,9 @@ const rowSchema = z.object({
   templateKey: z.string().nullable(),
   recipient: z.string(),
   subject: z.string().nullable(),
+  // issue 277: skutočne odoslaný/pokúšaný text — `null` pre "preskočené"
+  // (appka vtedy žiadny text nevygenerovala).
+  body: z.string().nullable(),
   orderCode: z.string().nullable(),
   variantCode: z.string().nullable(),
   packageNumber: z.string().nullable(),

--- a/apps/web/src/nedostupneApi.ts
+++ b/apps/web/src/nedostupneApi.ts
@@ -39,7 +39,9 @@ export type NedostupneList = z.infer<typeof listSchema>;
 export type NedostupneEmailType = "nedostupne" | "alternativa";
 
 const previewResultSchema = z.union([
-  z.object({ ok: z.literal(true), subject: z.string(), html: z.string(), recipient: z.string(), customerName: z.string(), previewToken: z.string() }),
+  // issue 277: `text` je plain-textová verzia (rovnaká, akú appka odošle ako
+  // fallback) — frontend ju predvyplní do editovateľného okna náhľadu.
+  z.object({ ok: z.literal(true), subject: z.string(), html: z.string(), text: z.string(), recipient: z.string(), customerName: z.string(), previewToken: z.string() }),
   z.object({ ok: z.literal(false), error: z.string() }),
 ]);
 export type NedostupnePreview = Extract<z.infer<typeof previewResultSchema>, { readonly ok: true }>;
@@ -97,11 +99,14 @@ export async function sendNedostupneEmail(
   variantCode: string,
   emailType: NedostupneEmailType,
   previewToken: string,
+  // issue 277: text, ktorý obsluha (prípadne) upravila v okne náhľadu —
+  // appka ho pošle PRESNE takto, nikdy znova vygenerovanú šablónu.
+  editedBody: string,
 ): Promise<NedostupneSendResult> {
   const response = await fetch("/api/nedostupne/send", {
     method: "POST",
     headers: { "content-type": "application/json" },
-    body: JSON.stringify({ orderCode, variantCode, emailType, previewToken }),
+    body: JSON.stringify({ orderCode, variantCode, emailType, previewToken, editedBody }),
   });
   if (response.status === 401) throw new NedostupneUnauthorizedError();
   return sendResultSchema.parse(await response.json());

--- a/apps/web/src/orderMergeApi.ts
+++ b/apps/web/src/orderMergeApi.ts
@@ -21,6 +21,9 @@ const previewResultSchema = z.union([
     ok: z.literal(true),
     subject: z.string(),
     html: z.string(),
+    // issue 277: plain-textová verzia — frontend ju predvyplní do
+    // editovateľného okna náhľadu.
+    text: z.string(),
     recipient: z.string(),
     customerName: z.string(),
     orderNumbers: z.array(z.string()),
@@ -81,11 +84,13 @@ export async function sendOrderMergeMail(
   baseOrderId: string,
   otherOrderIds: readonly string[],
   previewToken: string,
+  // issue 277: text, ktorý obsluha (prípadne) upravila v okne náhľadu.
+  editedBody: string,
 ): Promise<OrderMergeSendResult> {
   const response = await fetch("/api/order-merge/send", {
     method: "POST",
     headers: { "content-type": "application/json" },
-    body: JSON.stringify({ baseOrderId, otherOrderIds, previewToken }),
+    body: JSON.stringify({ baseOrderId, otherOrderIds, previewToken, editedBody }),
   });
   if (response.status === 401) throw new OrderMergeUnauthorizedError();
   return sendResultSchema.parse(await response.json());

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2354,6 +2354,23 @@ tr:last-child td {
   font-weight: var(--fs-weight-medium);
   white-space: nowrap;
 }
+/* issue 277: skutočne odoslaný text — tlačidlo je vlastný riadok pod
+   predmetom (rovnaký "doplnkový údaj pod hlavným" vzor ako `.ml-trigger`/
+   `.ml-reason` vyššie), rozbalené telo je samostatný riadok tabuľky cez
+   celú šírku. */
+.ml-body-toggle {
+  display: block;
+  margin-top: var(--fs-space-1);
+}
+.ml-body-row td {
+  background: var(--fs-surface-alt);
+}
+.ml-body-text {
+  margin: 0;
+  white-space: pre-wrap;
+  font-family: inherit;
+  font-size: var(--fs-text-sm);
+}
 .ml-status-sent {
   color: var(--fs-brand);
 }

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2073,6 +2073,24 @@ tr:last-child td {
   border-radius: var(--fs-radius-md);
   padding: var(--fs-space-3) var(--fs-space-4);
 }
+.modal-body-label {
+  display: block;
+  margin-bottom: var(--fs-space-1);
+  font-size: var(--fs-text-sm);
+  color: var(--fs-ink-muted);
+}
+/* issue 277: editovateľné telo náhľadu — rovnaký vizuálny rámec ako
+   pôvodný read-only `.modal-body`, len ako skutočný ovládací prvok
+   (`width: 100%`/`resize: vertical`/font zdedený z appky). */
+.modal-body-edit {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  resize: vertical;
+  font-family: inherit;
+  font-size: var(--fs-text-base);
+  color: var(--fs-ink);
+}
 .modal-actions {
   display: flex;
   flex-wrap: wrap;

--- a/apps/web/tests/e2e/nedostupne.spec.ts
+++ b/apps/web/tests/e2e/nedostupne.spec.ts
@@ -80,9 +80,12 @@ test("ručné odkazy náhrad, prekliky na e-shop/dodávateľa, povinný náhľad
   // (issue 192), táto zmena mení len zdroj `zoznam_nahrad`.
   await groupAfterReload.getByTestId("nedostupne-alt-send-9008-40287").click();
   const preview = page.getByTestId("nedostupne-preview");
+  const previewBody = page.getByTestId("nedostupne-preview-body");
   await expect(preview).toBeVisible();
-  await expect(preview).toContainText("https://www.forestshop.sk/e2e-nahrada-1/");
-  await expect(preview).toContainText("https://www.forestshop.sk/e2e-nahrada-2/");
+  // issue 277: text e-mailu je odteraz EDITOVATEĽNÝ (textarea, nie read-only
+  // náhľad) — predvyplnený plain-textovou verziou appky.
+  await expect(previewBody).toHaveValue(/https:\/\/www\.forestshop\.sk\/e2e-nahrada-1\//);
+  await expect(previewBody).toHaveValue(/https:\/\/www\.forestshop\.sk\/e2e-nahrada-2\//);
   await page.getByTestId("nedostupne-preview-cancel").click();
   await expect(preview).toBeHidden();
 
@@ -124,6 +127,13 @@ test("ručné odkazy náhrad, prekliky na e-shop/dodávateľa, povinný náhľad
   // Znovu otvoriť a pokračovať v pôvodnom overení odoslania.
   await page.getByTestId("nedostupne-send-9008-40287").click();
   await expect(preview).toBeVisible();
+
+  // issue 277: obsluha text v okne priamo prepíše — appka to prijme (žiadna
+  // validácia formátu, len nesmie zostať prázdne) a pokúsi sa poslať
+  // upravenú verziu (fail-closed BCC kontrola nižšie to aj tak zastaví, no
+  // úprava samotná appku nezablokuje).
+  await previewBody.fill("Dobrý deň, e2e zákazník — dopĺňam vlastnú vetu priamo v náhľade.");
+  await expect(previewBody).toHaveValue("Dobrý deň, e2e zákazník — dopĺňam vlastnú vetu priamo v náhľade.");
 
   // Potvrdenie odoslania bez nakonfigurovaného mailu vráti graceful chybu
   // (fail-closed, žiadny skutočný pokus o SMTP spojenie) — BCC kontrola beží

--- a/apps/web/tests/e2e/order-merge.spec.ts
+++ b/apps/web/tests/e2e/order-merge.spec.ts
@@ -43,10 +43,14 @@ test("záložka vypíše zákazníkov s ≥2 otvorenými objednávkami, povinný
   // ako "Nedostupné tovary" — server-side vynútený token).
   await group.getByTestId("order-merge-send-9011").click();
   const preview = page.getByTestId("order-merge-preview");
+  const previewBody = page.getByTestId("order-merge-preview-body");
   await expect(preview).toBeVisible();
   await expect(preview).toContainText("e2e-zakaznik-zlucenie@example.sk");
-  await expect(preview).toContainText("9010");
-  await expect(preview).toContainText("9011");
+  // issue 277: text e-mailu je odteraz EDITOVATEĽNÝ (textarea, nie read-only
+  // náhľad) — čísla objednávok sú v TELE (predmet ich nenesie), preto sa
+  // overujú cez hodnotu poľa, nie cez textContent dialógu.
+  await expect(previewBody).toHaveValue(/9010/);
+  await expect(previewBody).toHaveValue(/9011/);
 
   // Zavrieť klávesom Esc bez odoslania — nič sa nezmení.
   await page.keyboard.press("Escape");
@@ -58,6 +62,12 @@ test("záložka vypíše zákazníkov s ≥2 otvorenými objednávkami, povinný
   // sa zobrazí.
   await group.getByTestId("order-merge-send-9011").click();
   await expect(preview).toBeVisible();
+
+  // issue 277: obsluha text priamo prepíše — appka to prijme (žiadna zmena
+  // formátu, len nesmie zostať prázdne).
+  await previewBody.fill("Dobrý deň, e2e zákazník — obe objednávky posielame spolu, vlastná veta z e2e testu.");
+  await expect(previewBody).toHaveValue("Dobrý deň, e2e zákazník — obe objednávky posielame spolu, vlastná veta z e2e testu.");
+
   await page.getByTestId("order-merge-preview-confirm").click();
   await expect(page.getByText("chýba adresa pre skrytú kópiu majiteľovi (ORDER_MERGE_BCC_EMAIL)", { exact: true })).toBeVisible();
 

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -2982,3 +2982,51 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   check).
 - No PR/merge/deploy in this dispatch — supervisor owns CI/PR/merge/deploy
   for this follow-up per the dispatch's HARD CONSTRAINT.
+
+## issue 277 — Náhľad e-mailu: text sa dá upraviť priamo v okne pred odoslaním
+- `5be33ca` chore: bump version to 0.3.0-dev.158.
+- `2c38151`/`e7cc0ab` [red]/[green]: `renderEditedBody` (`mail-templates/
+  render.ts`) — plain-text-edit → safe escaped HTML/text, exported
+  `htmlEscape`. Pure unit tests (`render.test.ts`).
+- `89febb3`/`0e297bb`: [red]/[green] `editedBody` flows through
+  `sendNedostupneEmail`/`sendOrderMergeMail` (subject stays from the
+  rendered template, only html/text get overridden) + new `mail_log.body`
+  column (migration `0038_sad_kinsey_walden.sql`) — `sendLoggedMail` now
+  persists `message.text` for every sender, not just the two editable
+  ones. New integration file `mail-edited-body.integration.test.ts`
+  proves: edited text is what's actually sent, the `mail_template` row
+  the owner customized stays byte-identical after sending, and `mail_log`
+  stores the edited text (HTTP round trip too — preview returns `text`,
+  `/send` accepts `editedBody`, `GET /api/mail-log` shows it).
+- `44ccc5f`: routes wiring (`nedostupne-routes.ts`/`order-merge-routes.ts`
+  zod schemas + preview response `text` field), `mail-log/queries.ts`
+  exposes `body`.
+- `9d12ba5`: `MailPreviewDialog.tsx` — the read-only `dangerouslySetInnerHTML`
+  div became a `<textarea>` bound to `bodyText`/`onBodyTextChange` (subject/
+  recipient stay non-editable). Wired into `NedostupneSection.tsx`.
+- `8b21cc0`: same wiring into `OrderMergeSection.tsx` + new unit test file
+  (none existed before).
+- `e559a8d`/`26b1c04`: [red]/[green] `MailLogSection.tsx` gets a per-row
+  "👁 zobraziť text" toggle (only when `body !== null`) — the actually-sent
+  text is now visible on the "Odoslané e-maily" screen, not just stored.
+- `e61e6a4`: e2e specs (`nedostupne.spec.ts`/`order-merge.spec.ts`) updated
+  to `toHaveValue()` on the textarea instead of `toContainText()` on the
+  dialog (a `<textarea>`'s live value isn't part of DOM `textContent`) +
+  added an actual edit-and-verify-value step in both.
+- **Scope decision (documented on the ticket + in the PR):** only the TWO
+  flows where Send is TODAY gated by Preview (server-enforced
+  `previewToken`) got the editable dialog — Nedostupné tovary, Zlúčenie
+  objednávok. "Pripomienky objednávok"/"Nevyzdvihnuté zásielky" show a
+  preview that is informational only (Send doesn't require it, no
+  previewToken) and "Objednávka dodávateľovi" is a HIDDEN feature
+  (`SHOW_ORDER_MAIL_ACTIONS = false`, issue 118) — none of the three were
+  converted; each documented with its reason rather than silently
+  skipped.
+- Design comment + STEP-0 validation comment posted to issue 277 before
+  the first code commit.
+- Local gates: `pnpm typecheck`, `pnpm lint` clean; web unit 459/459 (59
+  files, incl. new `OrderMergeSection.test.tsx`); API unit 589/589 (37
+  files); API integration 525/525 (70 files, after `db:migrate`); e2e
+  46/46, zero console errors.
+- No PR/merge/deploy in this dispatch — supervisor owns CI/PR/merge/deploy
+  per the dispatch's HARD CONSTRAINT.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.157",
+  "version": "0.3.0-dev.158",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Čo to robí

**Text e-mailu sa dá upraviť priamo v okne pred odoslaním.** Doteraz bol náhľad len na pozretie — buď odišlo presne to, čo appka vygenerovala, alebo sa musela prepisovať šablóna. Teraz sa dá do okna dopísať veta, niečo zmazať, upraviť oslovenie — a odošle sa presne to, čo je v okne.

- **Šablóna sa nemení.** Záložka Texty e-mailov ďalej drží predvolené znenia; úprava v okne je jednorazová, ďalší e-mail vyjde zase zo šablóny.
- **Odoslanie je stále jeden klik** — žiadny krok navyše.
- **Zrušiť** zahodí úpravu bez odoslania.
- Predmet a adresát sa v okne meniť nedajú — mení sa telo e-mailu.

## Kniha odoslaných e-mailov teraz ukazuje skutočný text

Bez tohto by kniha klamala: zobrazovala by šablónu, hoci zákazníkovi odišlo niečo iné. Preto sa ku každému odoslanému e-mailu ukladá **skutočne odoslané znenie** a v Knihe odoslaných e-mailov sa dá rozkliknúť („👁 zobraziť text"). Platí to pre **všetky** odosielacie cesty, nie len pre tie dve upraviteľné.

## Kde okno na úpravu je a kde nie (a prečo)

**Je** na dvoch miestach, kde e-mail odosiela človek klikom a appka náhľad vynucuje: **Nedostupné tovary** a **Zlúčenie objednávok**.

**Nie je** tam, kde e-mail odchádza sám v noci bez človeka pri obrazovke — **Pripomienky objednávok** a **Nevyzdvihnuté zásielky**. Tam nie je moment, v ktorom by sa dalo okno ukázať; ich náhľad je len informatívny. **Objednávka dodávateľovi** má odosielanie v appke zatiaľ skryté (issue 118).

## Bezpečnosť

Upravený text sa nikdy nevkladá do e-mailu tak, ako prišiel z prehliadača — na serveri sa zaobchádza ako s obyčajným textom (znaky sa escapujú, riadky a odstavce sa formátujú), takže sa cez úpravu nedá prepašovať cudzí kód do odosielaného e-mailu. Zástupné polia sa v upravenom texte už znovu nevyhodnocujú.

## Overenie

- `pnpm typecheck`, `pnpm lint` — čisté
- web unit 459/459, api unit 589/589, api integračné 525/525, e2e 46/46 bez chýb v konzole
- Testy dokazujú, že sa odosiela a zapisuje upravený text a že riadok šablóny ostáva nezmenený

issue 277
