### PR TITLE
Na objednanie: pod číslom objednávky aj kód produktu s odkazom na náš eshop

### DIFF
--- a/.claude/rules/orders.md
+++ b/.claude/rules/orders.md
@@ -524,3 +524,46 @@ paths:
   v `.claude/rules/nedostupne.md`, aby sa nemuselo písať dvakrát. `sendOrderMergeMail`'s nový voliteľný `editedBody` má rovnaký tvar
   (`{ ...built.content, ...renderEditedBody(editedBody) }`, predmet
   ostáva pôvodný).
+- **issue 276: kód produktu POD číslom objednávky, prelinkovaný na náš eshop
+  (`OpenOrderLine.ourUrl`), je TRETÍ spotrebiteľ toho istého vzoru, aký
+  založilo issue 238 na "Nedostupné tovary" (`nedostupne/queries.ts`'s
+  `ourProductUrl`) — LEFT JOIN `shop_product_url` podľa kódu variantu
+  (nikdy INNER — chýbajúci feed riadok nesmie vyradiť riadok zo zoznamu),
+  `<a>` len keď adresu poznáme, inak plain text. **Zámerne NEPOUŽÍVA
+  `shopLinks.ts`'s `ourProductLink()`** (vyhľadávací fallback, ktorý
+  používa `RestockSection.tsx`) — majiteľova podmienka pre TENTO obrazovka
+  je opačná: neznáma adresa = neaktívny text, nikdy odkaz na vyhľadávanie.
+  Keďže `shop_product_url` je kľúčovaná LEN kódom variantu (nie
+  objednávkou), VŠETKY riadky zdieľajúce ten istý `variantCode` naprieč
+  RÔZNYMI objednávkami dostanú TÚ ISTÚ `ourUrl` hodnotu — to sa využilo aj
+  v teste (`orders.spec.ts`): fixtúrový variant "40287" má (kvôli inému,
+  staršiemu "Nedostupné tovary" testu, issue 238) už seedovaný
+  `shop_product_url` riadok, takže objednávka 9002 nad tým istým variantom
+  dostala kód-odkaz "zadarmo", bez potreby novej fixtúry.
+- **Ceiling test PASSING (`orders-layout.spec.ts`'s 105px) after adding an
+  ALWAYS-rendered second line to a cell is NOT the same proof as "row height
+  didn't change" — code review on issue 276 caught this distinction.**
+  `.ord-code-cell` (kód produktu POD číslom objednávky) renderuje sa na
+  KAŽDOM riadku (variant kód je vždy prítomný), na rozdiel od `.ord-remark-
+  cell`'s voliteľného `remark` — takže "strop 105px prešiel" samo osebe
+  dokazuje len HORNÚ hranicu, nie že sa PRIEMERNÁ výška riadku nezvýšila (ten
+  istý strop by prešiel aj pri systematickom náraste, napr. 55px→78px).
+  **Skutočný dôkaz "nula zmena" bol PÁROVÉ meranie** (rovnaká myšlienka ako
+  živé `page.addStyleTag` kandidáty z issue 105/107/111/127/164, len BEZ
+  potreby produkcie): `page.evaluate` najprv zmeria `getBoundingClientRect
+  ().height` VŠETKÝCH `.order-row`, potom vloží `<style>.ord-code-cell{
+  display:none!important}</style>` (simuluje "pred zmenou" stav BEZ
+  akéhokoľvek redeploy/revert) a zmeria ZNOVA — obe sady čísel boli PRE
+  KAŽDÝ RIADOK bajt-na-bajt zhodné, na VŠETKÝCH 4 šírkach, na OBOCH
+  fixtúrových sadách (izolovaný `E2E_ROZLOZENIE_EMAIL` účet aj globálny
+  `E2E_FILTRE_EMAIL` s 8 riadkami DODAVATEL-TEST-1/"(bez dodávateľa)").
+  Príčina: `.ord-order-cell`'s pridaná výška (jeden `--fs-text-xs` riadok +
+  `--fs-space-1` margin, ~16-20px) ostáva pod výškou, ktorú riadku už aj tak
+  vynucujú iné bunky (stavové tlačidlá `.ord-state-btn-group`, `.ord-qty-
+  stack`) — najnižšia nameraná výška riadku dnes (85px pri 1920px) má
+  bezpečnú rezervu nad `.ord-order-cell`'s samostatnou výškou. **Test na
+  KAŽDÝ ĎALŠÍ vždy-viditeľný (nie podmienene renderovaný) druhý riadok v
+  tejto tabuľke:** nestačí, že existujúci ceiling test prešiel — spusti
+  párové pred/po meranie (dočasná inštrumentácia spec súboru, revert pred
+  commitom, presne tento vzor) a over, že žiadny riadok skutočne NEROSTIE,
+  nielen že žiadny neprekročil strop.

--- a/apps/api/src/modules/orders/queries.ts
+++ b/apps/api/src/modules/orders/queries.ts
@@ -6,6 +6,7 @@ import {
   productSupplierLinkOverrides,
   productSupplierOverrides,
   products,
+  shopProductUrl,
   supplierContacts,
   variants,
   type OrderLineState,
@@ -66,6 +67,15 @@ export interface OpenOrderLine {
   readonly variantCode: string;
   readonly variantName: string;
   readonly sizeLabel: string | null;
+  /**
+   * issue 276: priama adresa NÁŠHO produktu z feedu pre porovnávače (issue
+   * 220, `shop_product_url`), `null` keď kód vo feede nie je. Rovnaký zámer
+   * ako `nedostupne/queries.ts`'s `ourProductUrl` (issue 238) — majiteľova
+   * podmienka je identická: KEĎ adresu nemáme, kód sa ukáže ako neaktívny
+   * text, NIKDY vyhľadávací fallback (`shopLinks.ts`'s `ourProductLink`
+   * používa `restock`/e2e obrazovka, tu zámerne nie).
+   */
+  readonly ourUrl: string | null;
   readonly quantity: number;
   readonly state: OrderLineState;
   // issue 60: nezávislý príznak "objednané u dodávateľa" (viď komentár k
@@ -155,6 +165,7 @@ export async function listOpenOrderLinesBySupplier(
       internalNote: products.internalNote,
       supplierLinkOverride: productSupplierLinkOverrides.url,
       externalCode: variants.externalCode,
+      ourUrl: shopProductUrl.url,
     })
     .from(orderLines)
     .innerJoin(orders, eq(orders.id, orderLines.orderId))
@@ -162,6 +173,10 @@ export async function listOpenOrderLinesBySupplier(
     .innerJoin(products, eq(products.key, variants.productKey))
     .leftJoin(productSupplierOverrides, eq(productSupplierOverrides.productKey, products.key))
     .leftJoin(productSupplierLinkOverrides, eq(productSupplierLinkOverrides.productKey, products.key))
+    // issue 276: LEFT zámerne — variant bez záznamu vo feede NESMIE zo
+    // zoznamu vypadnúť (rovnaký dôvod ako `restock/queries.ts`/
+    // `nedostupne/queries.ts`), len jeho kód sa vykreslí ako neaktívny text.
+    .leftJoin(shopProductUrl, eq(shopProductUrl.code, orderLines.variantCode))
     .where(inArray(orders.statusName, [...openStatuses]))
     // Sekundárne triedenie podľa najnovšej objednávky ako prvej v rámci
     // dodávateľa — rovnaký zámer ako katalógov `desc(fetchedAt), desc(id)`
@@ -199,6 +214,7 @@ export async function listOpenOrderLinesBySupplier(
       variantCode: row.variantCode,
       variantName: row.variantName,
       sizeLabel: row.sizeLabel,
+      ourUrl: row.ourUrl,
       quantity: row.quantity,
       state: row.state,
       ordered: row.ordered,

--- a/apps/api/tests/orders-our-url.integration.test.ts
+++ b/apps/api/tests/orders-our-url.integration.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, expect, it } from "vitest";
+import { orderLines, orders, shopProductUrl } from "../src/db/schema.js";
+import { listOpenOrderLinesBySupplier } from "../src/modules/orders/queries.js";
+import { insertTestVariant } from "./helpers/orders.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 276: majiteľ chce pod číslom objednávky aj kód produktu prelinkovaný
+// na náš eshop. Adresa ide z `shop_product_url` (feed pre porovnávače, issue
+// 220) — rovnaký zámer ako `nedostupne/queries.ts`'s `ourProductUrl` (issue
+// 238): keď kód vo feede JE, `listOpenOrderLinesBySupplier` vráti jeho
+// priamu adresu; keď NIE JE, vráti `null` (frontend to vykreslí ako
+// neaktívny text, nikdy vyhľadávací fallback).
+
+let close: (() => Promise<void>) | undefined;
+
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+});
+
+it("riadok, ktorého kód JE vo feede pre porovnávače, nesie priamu adresu produktu (ourUrl)", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const db = ctx.db;
+
+  await insertTestVariant(db, "A-1", "Dodávateľ Alfa");
+  await db.insert(shopProductUrl).values({
+    code: "A-1",
+    url: "https://www.forestshop.sk/a-1/",
+    fetchedAt: new Date("2026-08-05T09:00:00Z"),
+  });
+
+  const [objednavka] = await db
+    .insert(orders)
+    .values({ externalOrderId: "9101", customerName: "Zákazník", statusName: "Vybavuje sa", placedAt: new Date("2026-08-01T00:00:00Z") })
+    .returning();
+  if (objednavka === undefined) throw new Error("insert zlyhal");
+  await db.insert(orderLines).values({ orderId: objednavka.id, variantCode: "A-1", quantity: 1 });
+
+  const suppliers = await listOpenOrderLinesBySupplier(db, "https://test.example");
+  const alfa = suppliers.find((s) => s.supplier === "Dodávateľ Alfa");
+  expect(alfa?.lines.map((l) => l.ourUrl)).toEqual(["https://www.forestshop.sk/a-1/"]);
+});
+
+it("riadok, ktorého kód NIE JE vo feede pre porovnávače, dostane ourUrl: null (nikdy vyhľadávací fallback)", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const db = ctx.db;
+
+  await insertTestVariant(db, "B-1", "Dodávateľ Bravo");
+
+  const [objednavka] = await db
+    .insert(orders)
+    .values({ externalOrderId: "9102", customerName: "Zákazník", statusName: "Vybavuje sa", placedAt: new Date("2026-08-01T00:00:00Z") })
+    .returning();
+  if (objednavka === undefined) throw new Error("insert zlyhal");
+  await db.insert(orderLines).values({ orderId: objednavka.id, variantCode: "B-1", quantity: 1 });
+
+  const suppliers = await listOpenOrderLinesBySupplier(db, "https://test.example");
+  const bravo = suppliers.find((s) => s.supplier === "Dodávateľ Bravo");
+  expect(bravo?.lines.map((l) => l.ourUrl)).toEqual([null]);
+});

--- a/apps/web/src/components/OrderLineRow.adminLink.test.tsx
+++ b/apps/web/src/components/OrderLineRow.adminLink.test.tsx
@@ -36,6 +36,7 @@ const LINE = {
   externalCode: null,
   supplierAssignable: false,
   manualSupplierOverride: null,
+  ourUrl: null,
 };
 
 beforeEach(() => {

--- a/apps/web/src/components/OrderLineRow.productCodeLink.test.tsx
+++ b/apps/web/src/components/OrderLineRow.productCodeLink.test.tsx
@@ -1,0 +1,78 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { OrdersSection } from "./OrdersSection.js";
+
+// issue 276: majiteľ, "pod číslom objednávky nech je aj kód produktu,
+// prelinkovaný na náš eshop — niekedy sa musím pozrieť, ako ten produkt
+// vyzerá". Vlastný súbor — `OrderLineRow.adminLink.test.tsx` je tematicky
+// najbližší (rovnaká bunka `.ord-order-cell`), ale založenie NOVÉHO súboru
+// drží `.claude/rules/frontend-design.md`'s zavedený vzor pre samostatnú
+// funkciu namiesto pridávania do existujúceho.
+const { fetchOpenOrders, fetchOrdersOverview } = vi.hoisted(() => ({ fetchOpenOrders: vi.fn(), fetchOrdersOverview: vi.fn() }));
+
+vi.mock("../ordersApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../ordersApi.js")>();
+  return { ...actual, fetchOpenOrders,
+    fetchOrdersOverview };
+});
+
+const LINE_ZNAMY = {
+  lineId: "66666666-6666-6666-6666-666666666666",
+  orderId: "cccccccc-6666-6666-6666-666666666666",
+  externalOrderId: "20261300",
+  customerName: "Zákazník Delta",
+  comment: null,
+  remark: null,
+  shopRemark: null,
+  adminUrl: "https://www.forestshop.sk/admin/vyhladavanie/?string=20261300&src=orders",
+  placedAt: "2026-08-01T00:00:00.000Z",
+  variantCode: "60542",
+  variantName: "Nohavice Hart Wild-T",
+  sizeLabel: null,
+  quantity: 1,
+  state: "objednane" as const,
+  ordered: false,
+  supplierUrl: null,
+  supplierNote: null,
+  externalCode: null,
+  supplierAssignable: false,
+  manualSupplierOverride: null,
+  ourUrl: "https://www.forestshop.sk/nohavice-hart-wild-t/?variantId=60542",
+};
+
+const LINE_NEZNAMY = { ...LINE_ZNAMY, lineId: "77777777-7777-7777-7777-777777777777", variantCode: "99999/ZZ", ourUrl: null };
+
+beforeEach(() => {
+  fetchOrdersOverview.mockResolvedValue({ today: { orderCount: 0, revenue: "0.00" }, week: { orderCount: 0, revenue: "0.00" }, month: { orderCount: 0, revenue: "0.00" } });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+it("kód produktu, ktorý poznáme z feedu, je kliknuteľný odkaz na náš eshop v novej karte", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Delta", lines: [LINE_ZNAMY], email: null }]);
+
+  render(<OrdersSection role="citanie" onSessionExpired={() => {}} />);
+
+  const riadok = await screen.findByTestId(`order-line-${LINE_ZNAMY.lineId}`);
+  const odkaz = within(riadok).getByRole<HTMLAnchorElement>("link", {
+    name: `Otvoriť produkt ${LINE_ZNAMY.variantCode} na našom eshope`,
+  });
+  expect(odkaz.href).toBe(LINE_ZNAMY.ourUrl);
+  expect(odkaz.target).toBe("_blank");
+  expect(odkaz.rel).toBe("noreferrer noopener");
+  expect(odkaz.textContent).toBe(LINE_ZNAMY.variantCode);
+});
+
+it("kód produktu, ktorý vo feede nepoznáme, sa zobrazí ako obyčajný text (nedá sa kliknúť)", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Delta", lines: [LINE_NEZNAMY], email: null }]);
+
+  render(<OrdersSection role="citanie" onSessionExpired={() => {}} />);
+
+  const riadok = await screen.findByTestId(`order-line-${LINE_NEZNAMY.lineId}`);
+  const text = within(riadok).getByTestId(`code-text-${LINE_NEZNAMY.lineId}`);
+  expect(text.textContent).toBe(LINE_NEZNAMY.variantCode);
+  expect(within(riadok).queryByRole("link", { name: `Otvoriť produkt ${LINE_NEZNAMY.variantCode} na našom eshope` })).toBeNull();
+});

--- a/apps/web/src/components/OrderLineRow.productCodeLink.test.tsx
+++ b/apps/web/src/components/OrderLineRow.productCodeLink.test.tsx
@@ -57,7 +57,10 @@ it("kód produktu, ktorý poznáme z feedu, je kliknuteľný odkaz na náš esho
   render(<OrdersSection role="citanie" onSessionExpired={() => {}} />);
 
   const riadok = await screen.findByTestId(`order-line-${LINE_ZNAMY.lineId}`);
-  const odkaz = within(riadok).getByRole<HTMLAnchorElement>("link", {
+  // Rovnaký obalový vzor ako `.ord-remark-cell`/`.ord-shop-remark-cell` — aj
+  // ich testid sa overuje priamo, nielen odkaz/text vo vnútri.
+  const bunka = within(riadok).getByTestId(`code-cell-${LINE_ZNAMY.lineId}`);
+  const odkaz = within(bunka).getByRole<HTMLAnchorElement>("link", {
     name: `Otvoriť produkt ${LINE_ZNAMY.variantCode} na našom eshope`,
   });
   expect(odkaz.href).toBe(LINE_ZNAMY.ourUrl);
@@ -72,7 +75,8 @@ it("kód produktu, ktorý vo feede nepoznáme, sa zobrazí ako obyčajný text (
   render(<OrdersSection role="citanie" onSessionExpired={() => {}} />);
 
   const riadok = await screen.findByTestId(`order-line-${LINE_NEZNAMY.lineId}`);
-  const text = within(riadok).getByTestId(`code-text-${LINE_NEZNAMY.lineId}`);
+  const bunka = within(riadok).getByTestId(`code-cell-${LINE_NEZNAMY.lineId}`);
+  const text = within(bunka).getByTestId(`code-text-${LINE_NEZNAMY.lineId}`);
   expect(text.textContent).toBe(LINE_NEZNAMY.variantCode);
-  expect(within(riadok).queryByRole("link", { name: `Otvoriť produkt ${LINE_NEZNAMY.variantCode} na našom eshope` })).toBeNull();
+  expect(within(bunka).queryByRole("link", { name: `Otvoriť produkt ${LINE_NEZNAMY.variantCode} na našom eshope` })).toBeNull();
 });

--- a/apps/web/src/components/OrderLineRow.remarkCell.test.tsx
+++ b/apps/web/src/components/OrderLineRow.remarkCell.test.tsx
@@ -34,6 +34,7 @@ const ZAKLAD = {
   externalCode: null,
   supplierAssignable: false,
   manualSupplierOverride: null,
+  ourUrl: null,
 };
 
 const RIADOK_BEZ_POZNAMKY = {

--- a/apps/web/src/components/OrderLineRow.shopRemarkCell.test.tsx
+++ b/apps/web/src/components/OrderLineRow.shopRemarkCell.test.tsx
@@ -32,6 +32,7 @@ const ZAKLAD = {
   externalCode: null,
   supplierAssignable: false,
   manualSupplierOverride: null,
+  ourUrl: null,
 };
 
 const RIADOK_BEZ_POZNAMKY = {

--- a/apps/web/src/components/OrderLineRow.supplierAssignCell.test.tsx
+++ b/apps/web/src/components/OrderLineRow.supplierAssignCell.test.tsx
@@ -37,6 +37,7 @@ const ZAKLAD = {
   supplierNote: null,
   externalCode: null,
   manualSupplierOverride: null,
+  ourUrl: null,
 };
 
 const RIADOK_NERADITELNY = {

--- a/apps/web/src/components/OrderLineRow.supplierLinkEditCell.test.tsx
+++ b/apps/web/src/components/OrderLineRow.supplierLinkEditCell.test.tsx
@@ -36,6 +36,7 @@ const ZAKLAD = {
   externalCode: null,
   supplierAssignable: false,
   manualSupplierOverride: null,
+  ourUrl: null,
 };
 
 const RIADOK_BEZ_ODKAZU = { ...ZAKLAD, lineId: "11111111-0000-0000-0000-000000000010", supplierUrl: null };

--- a/apps/web/src/components/OrderLineRow.tsx
+++ b/apps/web/src/components/OrderLineRow.tsx
@@ -244,6 +244,32 @@ export function OrderLineRow({
           >
             {line.externalOrderId}
           </a>
+          {/* issue 276: majiteľ, "pod číslom objednávky aj kód produktu,
+              prelinkovaný na náš eshop — niekedy sa musím pozrieť, ako ten
+              produkt vyzerá". Adresa ide z rovnakého feedu pre porovnávače
+              ako `nedostupne`/`restock` (issue 220) — keď kód vo feede nie
+              je, `line.ourUrl` je `null` a kód sa vykreslí ako neaktívny
+              text, NIKDY vyhľadávací fallback (majiteľova výslovná
+              podmienka). */}
+          <div className="ord-code-cell" data-testid={`code-cell-${line.lineId}`}>
+            {line.ourUrl !== null ? (
+              <a
+                href={line.ourUrl}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="ord-code-link"
+                data-testid={`code-link-${line.lineId}`}
+                aria-label={`Otvoriť produkt ${line.variantCode} na našom eshope`}
+                title="Otvoriť produkt na našom eshope"
+              >
+                {line.variantCode}
+              </a>
+            ) : (
+              <span className="ord-code-text" data-testid={`code-text-${line.lineId}`}>
+                {line.variantCode}
+              </span>
+            )}
+          </div>
         </td>
         <td>{line.customerName}</td>
         {/* issue 171: majiteľ, doslovne "poznamka zakaznika daj pod text

--- a/apps/web/src/components/OrdersOverviewTiles.test.tsx
+++ b/apps/web/src/components/OrdersOverviewTiles.test.tsx
@@ -41,6 +41,7 @@ const makeLine = (overrides: Partial<OrderLine> = {}): OrderLine => ({
   externalCode: null,
   supplierAssignable: false,
   manualSupplierOverride: null,
+  ourUrl: null,
   ...overrides,
 });
 

--- a/apps/web/src/components/OrdersSection.assignSupplier.test.tsx
+++ b/apps/web/src/components/OrdersSection.assignSupplier.test.tsx
@@ -47,6 +47,7 @@ const LINE_BEZ_DODAVATELA = {
   externalCode: null,
   supplierAssignable: true,
   manualSupplierOverride: null,
+  ourUrl: null,
 };
 
 beforeEach(() => {

--- a/apps/web/src/components/OrdersSection.comment.test.tsx
+++ b/apps/web/src/components/OrdersSection.comment.test.tsx
@@ -48,6 +48,7 @@ const RIADOK_1 = {
   externalCode: null,
   supplierAssignable: false,
   manualSupplierOverride: null,
+  ourUrl: null,
 };
 
 const RIADOK_2 = { ...RIADOK_1, lineId: "22222222-4444-4444-4444-444444444444", variantCode: "D-2" };

--- a/apps/web/src/components/OrdersSection.hideResolvedEditorGuard.test.tsx
+++ b/apps/web/src/components/OrdersSection.hideResolvedEditorGuard.test.tsx
@@ -43,6 +43,7 @@ const LINE = {
   externalCode: null,
   supplierAssignable: false,
   manualSupplierOverride: null,
+  ourUrl: null,
 };
 
 beforeEach(() => {

--- a/apps/web/src/components/OrdersSection.mailActions.test.tsx
+++ b/apps/web/src/components/OrdersSection.mailActions.test.tsx
@@ -53,6 +53,7 @@ const LINE_STARA = {
   externalCode: null,
   supplierAssignable: false,
   manualSupplierOverride: null,
+  ourUrl: null,
 };
 
 // Rovnaký riadok, ale vo stave "caka_sa" (vybavený, nie "objednane") —

--- a/apps/web/src/components/OrdersSection.ordered.test.tsx
+++ b/apps/web/src/components/OrdersSection.ordered.test.tsx
@@ -47,6 +47,7 @@ const LINE_STARA = {
   externalCode: null,
   supplierAssignable: false,
   manualSupplierOverride: null,
+  ourUrl: null,
 };
 
 const LINE_NOVA = {
@@ -70,6 +71,7 @@ const LINE_NOVA = {
   externalCode: null,
   supplierAssignable: false,
   manualSupplierOverride: null,
+  ourUrl: null,
 };
 
 beforeEach(() => {

--- a/apps/web/src/components/OrdersSection.remainingCount.test.tsx
+++ b/apps/web/src/components/OrdersSection.remainingCount.test.tsx
@@ -58,6 +58,7 @@ const LINE_NEVYBAVENY = {
   externalCode: null,
   supplierAssignable: false,
   manualSupplierOverride: null,
+  ourUrl: null,
 };
 
 const LINE_VYBAVENY = { ...LINE_NEVYBAVENY, lineId: "22222222-2222-2222-2222-222222222147", ordered: true };

--- a/apps/web/src/components/OrdersSection.selectedSupplierPersistence.test.tsx
+++ b/apps/web/src/components/OrdersSection.selectedSupplierPersistence.test.tsx
@@ -42,6 +42,7 @@ const LINE_ALFA = {
   externalCode: null,
   supplierAssignable: false,
   manualSupplierOverride: null,
+  ourUrl: null,
 };
 
 const LINE_BETA = { ...LINE_ALFA, lineId: "22222222-2222-2222-2222-222222222148", variantCode: "P-2" };

--- a/apps/web/src/components/OrdersSection.supplierLinkValidation.test.tsx
+++ b/apps/web/src/components/OrdersSection.supplierLinkValidation.test.tsx
@@ -39,6 +39,7 @@ const LINE_ALFA = {
   externalCode: null,
   supplierAssignable: false,
   manualSupplierOverride: null,
+  ourUrl: null,
 };
 
 beforeEach(() => {

--- a/apps/web/src/components/OrdersSection.test.tsx
+++ b/apps/web/src/components/OrdersSection.test.tsx
@@ -52,6 +52,7 @@ const LINE_STARA = {
   externalCode: null,
   supplierAssignable: false,
   manualSupplierOverride: null,
+  ourUrl: null,
 };
 
 const LINE_NOVA = {
@@ -75,6 +76,7 @@ const LINE_NOVA = {
   externalCode: null,
   supplierAssignable: false,
   manualSupplierOverride: null,
+  ourUrl: null,
 };
 
 beforeEach(() => {

--- a/apps/web/src/components/OrdersSection.writeFailures.test.tsx
+++ b/apps/web/src/components/OrdersSection.writeFailures.test.tsx
@@ -42,6 +42,7 @@ const LINE_ALFA = {
   externalCode: null,
   supplierAssignable: false,
   manualSupplierOverride: null,
+  ourUrl: null,
 };
 
 const LINE_BETA = {

--- a/apps/web/src/components/OrdersToolbar.test.tsx
+++ b/apps/web/src/components/OrdersToolbar.test.tsx
@@ -28,6 +28,7 @@ const makeLine = (overrides: Partial<OrderLine> = {}): OrderLine => ({
   externalCode: null,
   supplierAssignable: false,
   manualSupplierOverride: null,
+  ourUrl: null,
   ...overrides,
 });
 

--- a/apps/web/src/components/SupplierActionsPanel.groupColor.test.tsx
+++ b/apps/web/src/components/SupplierActionsPanel.groupColor.test.tsx
@@ -28,6 +28,7 @@ const makeLine = (overrides: Partial<OrderLine> = {}): OrderLine => ({
   externalCode: null,
   supplierAssignable: false,
   manualSupplierOverride: null,
+  ourUrl: null,
   ...overrides,
 });
 

--- a/apps/web/src/ordersApi.test.ts
+++ b/apps/web/src/ordersApi.test.ts
@@ -36,6 +36,7 @@ const LINE = {
   externalCode: null,
   supplierAssignable: false,
   manualSupplierOverride: null,
+  ourUrl: null,
 };
 
 it("prečíta otvorené objednávky zoskupené podľa dodávateľa, vrátane e-mailu dodávateľa", async () => {

--- a/apps/web/src/ordersApi.ts
+++ b/apps/web/src/ordersApi.ts
@@ -28,6 +28,12 @@ const orderLineSchema = z.object({
   variantCode: z.string(),
   variantName: z.string(),
   sizeLabel: z.string().nullable(),
+  // issue 276: priama adresa NÁŠHO produktu z feedu pre porovnávače (issue
+  // 220), `null` keď kód vo feede nie je — appka vtedy ukáže kód ako
+  // neaktívny text, nikdy vyhľadávací fallback (rovnaký zámer ako
+  // `nedostupne/queries.ts`'s `ourProductUrl`, issue 238). `.regex` je druhá
+  // vrstva overenia, rovnaký vzor ako `adminUrl`/`supplierUrl` vyššie.
+  ourUrl: z.string().regex(/^https?:\/\//).nullable(),
   quantity: z.number(),
   state: z.enum(["objednane", "caka_sa", "skladom", "nedostupne"]),
   // issue 60: nezávislý príznak "objednané u dodávateľa" (viď `state.ts`'s

--- a/apps/web/src/ordersWriteFailures.test.ts
+++ b/apps/web/src/ordersWriteFailures.test.ts
@@ -30,6 +30,7 @@ const LINE: OrderLine = {
   externalCode: null,
   supplierAssignable: false,
   manualSupplierOverride: null,
+  ourUrl: null,
 };
 
 const SUPPLIERS: readonly SupplierOpenOrders[] = [{ supplier: "Dodávateľ Alfa", lines: [LINE], email: null }];

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -1427,6 +1427,34 @@ tr:last-child td {
   white-space: nowrap;
   text-overflow: ellipsis;
 }
+/* issue 276: majiteľ, "pod číslom objednávky nech je aj kód produktu,
+   prelinkovaný na náš eshop" — druhý (block-level) riadok POD číslom
+   objednávky, v TEJ ISTEJ bunke (žiadny nový stĺpec) — rovnaký "žiadny
+   display:flex priamo na `<td>`" princíp ako `.ord-remark-cell`/
+   `.ord-product-name` (issue 163/171/95). Kód sa vykreslí ako odkaz LEN keď
+   poznáme jeho adresu z feedu pre porovnávače (`line.ourUrl`), inak ako
+   neaktívny text — nikdy vyhľadávací fallback (majiteľova výslovná
+   podmienka, rovnaký zámer ako `nedostupne/queries.ts`'s `ourProductUrl`,
+   issue 238 — na rozdiel od `shopLinks.ts`'s `ourProductLink`, ktorý
+   fallback POUŽÍVA na `restock` obrazovke). Druhoradý údaj → tlmená farba +
+   menšie písmo, rovnaký vzor ako `.ord-remark`. */
+.ord-code-cell {
+  max-width: 100%;
+  margin-top: var(--fs-space-1);
+}
+.ord-code-link,
+.ord-code-text {
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--fs-text-xs);
+  color: var(--fs-ink-muted);
+}
+.ord-code-link {
+  text-decoration: underline;
+}
 /* issue 65: upozornenie na starú nevybavenú objednávku (>14 dní) — výrazná
    farba (`--fs-warning`), rovnaká sémantika ako `.orders-table tr.state-
    caka_sa` vyššie, ale nezávislá od stavu riadku (môže sa zobraziť pri

--- a/apps/web/tests/e2e/orders.spec.ts
+++ b/apps/web/tests/e2e/orders.spec.ts
@@ -305,6 +305,14 @@ test("manažér vidí otvorené objednávky zoskupené podľa dodávateľa, konz
   // Objednávka 9001 je UŽ vybavená (stav "caka_sa") — upozornenie na staré
   // objednávky sa NIKDY nezobrazí pre vybavený riadok, aj keby bol starý.
   await expect(riadokAlfa.locator("[data-testid^='stale-badge-']")).toHaveCount(0);
+  // issue 276: "4859/46" NEMÁ riadok v `shop_product_url` (feed pre
+  // porovnávače, `scripts/e2e-setup.ts` ho seeduje LEN pre "40287"/
+  // "PREP-2") — kód sa preto zobrazí ako obyčajný, nekliknuteľný text
+  // (akceptačná podmienka 2), nikdy vyhľadávací fallback.
+  const kodAlfa = riadokAlfa.getByText("4859/46", { exact: true });
+  await expect(kodAlfa).toBeVisible();
+  expect(await kodAlfa.evaluate((el) => el.tagName)).toBe("SPAN");
+  await expect(riadokAlfa.getByRole("link", { name: "Otvoriť produkt 4859/46 na našom eshope" })).toHaveCount(0);
 
   // Objednávka 9002 je nad variantom "40287", ktorý nemá dodávateľa
   // (`product.supplier` je `null`) — zoskupí sa pod zástupný kľúč, nie pod
@@ -320,10 +328,16 @@ test("manažér vidí otvorené objednávky zoskupené podľa dodávateľa, konz
   await expect(riadokBez).toContainText("9002");
   await expect(riadokBez).toContainText("E2E Zákazník Bez dodávateľa");
   await expect(riadokBez).toContainText("Čiapka Polar FOREST");
-  // issue 117: variant kód ("40287") sa už NIKDE nezobrazuje viditeľne —
-  // stále však nesie zmysel (a je overiteľný) cez aria-label na obale
-  // stavových tlačidiel tohto riadku (issue 161: predtým `<select>`, ten
-  // istý `aria-label` ostal zachovaný na `role="radiogroup"` obale).
+  // issue 117: variant kód sa PREDTÝM nikde nezobrazoval viditeľne (zostal
+  // len v aria-label na obale stavových tlačidiel, issue 161) — issue 276
+  // ho vrátilo naspäť, pod číslo objednávky, ako odkaz na náš eshop.
+  // `scripts/e2e-setup.ts` seeduje `shop_product_url` riadok pre "40287"
+  // (preklik na eshop pre "Nedostupné tovary", issue 238) — TEN ISTÝ riadok
+  // (kľúčovaný len kódom variantu, nie objednávkou) sa preto použije aj tu.
+  const kodBez = riadokBez.getByRole("link", { name: "Otvoriť produkt 40287 na našom eshope" });
+  await expect(kodBez).toHaveAttribute("href", "https://www.forestshop.sk/e2e-nedostupne-40287/");
+  await expect(kodBez).toHaveAttribute("target", "_blank");
+  await expect(kodBez).toHaveText("40287");
   await expect(riadokBez.getByLabel("Zmeniť stav riadku objednávky 9002 / 40287")).toBeVisible();
   // Predvolený stav riadku (schema default "objednane") a chýbajúca veľkosť —
   // issue 60: premenované na "Nevybavené" (slovo "Objednané" teraz patrí

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -3030,3 +3030,51 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   46/46, zero console errors.
 - No PR/merge/deploy in this dispatch — supervisor owns CI/PR/merge/deploy
   per the dispatch's HARD CONSTRAINT.
+
+## Issue 276 — product code under order number, linked to our shop (2026-08-05)
+
+- Version bumped to 0.3.0-dev.159 (dev==main after issue 277 merge) —
+  own commit `d68908c` before the feature commit.
+- Backend: `apps/api/src/modules/orders/queries.ts`'s
+  `listOpenOrderLinesBySupplier` gained a LEFT JOIN on `shop_product_url`
+  by variant code, new `OpenOrderLine.ourUrl: string | null` — same
+  pattern as `nedostupne/queries.ts`'s `ourProductUrl` (issue 238), never
+  `shopLinks.ts`'s search-fallback `ourProductLink` (used by `restock`
+  only).
+- Frontend: `ordersApi.ts`'s zod schema gained `ourUrl`
+  (`.regex(/^https?:\/\//).nullable()`); `OrderLineRow.tsx` renders a new
+  `.ord-code-cell` block under the order-number link — `<a>` when
+  `ourUrl !== null`, plain `<span>` otherwise, never a dead/guessed link.
+- Feature commit `272aee2` — new integration test
+  (`orders-our-url.integration.test.ts`, 2 tests: known + unknown feed
+  code), new unit test (`OrderLineRow.productCodeLink.test.tsx`, 2 tests),
+  `orders.spec.ts` updated (stale issue-117 "code never shows" comment
+  replaced + new link/plain-text e2e assertions on existing fixture rows
+  "40287"/"4859/46" — no new e2e fixture data needed), ~19 existing
+  `OrderLine`-shaped test fixtures given an explicit `ourUrl: null` field
+  (this repo's "every field explicit" convention).
+- Design comment + STEP-0 validation comment posted to issue 276 before
+  the first code commit.
+- Row-height ceiling (`orders-layout.spec.ts`, 105px) passed on the first
+  local e2e run — but a dispatched code-review subagent correctly flagged
+  that "ceiling passed" alone doesn't prove no systematic increase (the
+  new `.ord-code-cell` line, unlike `.ord-remark-cell`, is ALWAYS
+  rendered). Follow-up: temporary paired before/after instrumentation
+  (`page.evaluate` measuring all `.order-row` heights, then toggling
+  `.ord-code-cell{display:none}` and re-measuring) on both the isolated
+  layout fixture and the global `E2E_FILTRE_EMAIL` 8-row fixture, across
+  all 4 widths — every row's height was byte-identical before/after.
+  Instrumentation reverted before commit; see `.claude/rules/orders.md`
+  for the full finding + the "ceiling alone isn't proof" lesson.
+- Review: dispatched `general-purpose` code-reviewer subagent
+  (`superpowers:requesting-code-review`), diff `cb51a7a..272aee2`. Result:
+  0 Critical, 1 Important (row-height proof, addressed above with the
+  paired measurement), 2 Minor (unused `code-cell-` testid — now asserted
+  in `OrderLineRow.productCodeLink.test.tsx`; playbook entry — added).
+- Local gates (re-run after the review fixes): `pnpm typecheck`,
+  `pnpm lint` clean; web unit 461/461 (60 files, incl. updated
+  `OrderLineRow.productCodeLink.test.tsx`); API unit 589/589 (37 files);
+  API integration 527/527 (71 files, after `db:migrate`); e2e 46/46 (full
+  suite, before the review-triggered debug run), zero console errors.
+- No PR/merge/deploy in this dispatch — supervisor owns CI/PR/merge/deploy
+  per the dispatch's HARD CONSTRAINT.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.158",
+  "version": "0.3.0-dev.159",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Čo to robí

**V Na objednanie je pod číslom objednávky aj kód produktu — a ak adresu toho produktu na našom eshope poznáme, dá sa na ňu kliknúť.** Šéf nepozná všetky produkty podľa názvu; teraz si vie priamo z tabuľky otvoriť produkt na `www.forestshop.sk` a pozrieť sa, ako vyzerá. Odkaz sa otvorí v novej karte, takže rozrobená práca v tabuľke ostáva.

- **Keď adresu nepoznáme, kód sa zobrazí len ako obyčajný text** — nikdy nie mŕtvy odkaz ani odkaz do vyhľadávania. Radšej nič, ako poslať šéfa na stránku, ktorá neexistuje.
- **Adresa sa berie z už existujúceho zdroja** — z odkazov na naše produkty stiahnutých z feedu (issue 220). Nevzniká druhý zdroj adries.
- **Riadok tabuľky sa nezvýšil.** Tabuľka je hustá a robí sa v nej rýchlo, tak to bolo odmerané: rovnaká výška riadku pred zmenou aj po nej, na dvoch sadách dát a štyroch šírkach okna.

## Overenie

- `pnpm typecheck`, `pnpm lint` — čisté
- web unit, api unit, api integračné a e2e testy prešli, bez chýb v konzole prehliadača
- Testy pokrývajú obe vetvy: známa adresa (klikateľný odkaz do novej karty) aj neznáma adresa (obyčajný text)
- Kód prešiel dvoma revíziami; nájdené pripomienky sú opravené v commite `9eba383`

issue 276
