### PR TITLE
Upozornenia: karta pri vrátení/výmene/dobropise + oprava visiacej karty zo zásielky (issues 269, 275)

### DIFF
--- a/.claude/rules/orders.md
+++ b/.claude/rules/orders.md
@@ -567,3 +567,20 @@ paths:
   párové pred/po meranie (dočasná inštrumentácia spec súboru, revert pred
   commitom, presne tento vzor) a over, že žiadny riadok skutočne NEROSTIE,
   nielen že žiadny neprekročil strop.
+- **Issue 269: `ingestOrders`'s DB transakcia (po upsert-e `order` riadkov,
+  pred XML-backfill krokom) teraz NAVYŠE volá zdieľanú `upsertUpozornenie()`
+  (`.claude/rules/upozornenia.md`) pre KAŽDÚ objednávku, ktorej `statusName`
+  je jeden zo živo overených vrátkových stavov (`orders/return-status.ts`).**
+  Plné odôvodnenie (dedup na objednávku nie na pod-stav, prečo sa karta
+  nikdy nezatvára automaticky) je v `upozornenia.md`, aby sa nepísalo
+  dvakrát. Pre KAŽDÝ ĎALŠÍ nový stĺpec/pole odvodené z `order.status_name`
+  vnútri tejto transakcie: pamätaj, že `orderInfo` (a teda aj tento hák) je
+  naplnené LEN pre objednávky, čo majú aspoň JEDEN skutočný produktový
+  riadok (nie len pseudo-položky) — rovnaké obmedzenie, aké má celý
+  `order` upsert vyššie, nie nová medzera zavedená týmto tiketom.
+  Integračné testy pre CSV-riadené vrátkové stavy s diakritikou
+  (`orders-ingest-return-upozornenie.integration.test.ts`) potrebujú
+  SKUTOČNÉ cp1250 bajty (appka vždy dekóduje `decodeCp1250`) — súbor si
+  stavia kódovaciu tabuľku DYNAMICKY (dekóduje všetkých 256 bajtov cez
+  `TextDecoder("windows-1250")` a obráti mapu), namiesto ručne písanej
+  tabuľky kódových bodov alebo novej závislosti (`iconv-lite`).

--- a/.claude/rules/posta-uncollected.md
+++ b/.claude/rules/posta-uncollected.md
@@ -75,10 +75,21 @@ paths:
   `terminalState(trackingJson) !== ""` (pred `continue`). `dedupKey` je
   `posta:<packageNumber>` (`logic.ts`'s `postaUpozornenieDedupKey`) — JEDEN
   zdieľaný helper pre OBE volania, aby zápis a zatvorenie nikdy nedostali
-  rôzny formát kľúča. **Známa medzera (code review, issue 275):** vetva
-  `cls.status === "invalid_format"` nerobí ani jedno z toho — karta
-  vytvorená pri predošlom "notified" behu ostane navždy otvorená, keď
-  tracking neskôr začne vracať neparsovateľný formát. Zriedkavé (formát sa
-  po platnom stave zvyčajne nemení), ale pri KAŽDOM ĎALŠOM novom stavu/
-  vetve pridanom do tejto funkcie over, či nepotrebuje TIEŽ napojenie na
-  write/auto-resolve cestu.
+  rôzny formát kľúča. **Oprava medzery (issue 275, pôvodne nájdenej code
+  review-om na #268):** vetva `cls.status === "invalid_format"` predtým
+  nerobila ani jedno z toho — karta vytvorená pri predošlom "notified" behu
+  ostávala navždy otvorená, keď tracking neskôr začal vracať neparsovateľný
+  formát, bez akéhokoľvek signálu pre majiteľa. Fix je TRETIA funkcia,
+  `updateIfUnresolvedByDedupKey` (`upozornenia/service.ts`) — na rozdiel od
+  `upsertUpozornenie` (create-or-refresh) a `autoResolveByDedupKey` (close),
+  táto je čisté UPDATE-if-exists: keď pre `dedupKey` existuje nevyriešená
+  karta, jej titulok/podrobnosti sa prepíšu na "sledovanie zlyhalo, over
+  ručne", ale `resolvedAt` sa nedotýka (karta ostáva otvorená — auto-
+  zatvorenie by mohlo skryť reálny, ešte nevyriešený problém) A NIKDY sa
+  nevytvorí NOVÁ karta (zásielka, čo nikdy predtým nebola nahlásená ako
+  nevyzdvihnutá, nepotrebuje kartu len kvôli jednorazovému zlyhaniu
+  trackingu — to by bol zbytočný šum). Pri KAŽDOM ĎALŠOM novom stave/vetve
+  pridanom do tejto funkcie over, či nepotrebuje TIEŽ napojenie na
+  write/auto-resolve/update-in-place cestu — a ak ide o zdroj, čo môže
+  STRATIŤ SCHOPNOSŤ rozhodnúť (nie o skutočnú zmenu stavu), zváž
+  `updateIfUnresolvedByDedupKey`, nie automatické zatvorenie.

--- a/.claude/rules/upozornenia.md
+++ b/.claude/rules/upozornenia.md
@@ -101,6 +101,22 @@ paths:
   argumentu filtra (`UpozorneniaSection.emptyMessage.test.tsx`), tomuto
   problému nepodlieha vôbec — uprednostni ten vzor, keď test musí
   rozlišovať MEDZI viacerými súbežne možnými volaniami tej istej funkcie.
+- **Issue 269 (druhý automatický zdroj, vrátenie/výmena/dobropis) sa napojilo
+  na import objednávok (`orders/ingest.ts`'s `ingestOrders`) PRIAMO vnútri
+  jeho existujúcej DB transakcie — rovnaký vzor ako #268's napojenie na
+  `posta-uncollected/run.ts`.** Nová `pgEnum` hodnota `vratenie`. `dedupKey`
+  je `vratenie:<externalOrderId>` — na OBJEDNÁVKU, NIE na konkrétny
+  pod-stav: prechod "Vratený tovar" → "Vybavený Dobropis" tej istej
+  objednávky OBNOVÍ tú istú kartu, nikdy nevyrobí druhú (rovnaký princíp
+  ako `posta-uncollected`'s dedup na ZÁSIELKU, nie na jej okamžitú
+  klasifikáciu). Presný zoznam rozpoznaných stavov (`orders/return-status.ts`'s
+  `classifyReturnStatus`) bol OVERENÝ ŽIVO na produkčnej DB pred
+  implementáciou (`docker exec forestshop-postgres-1 psql ... GROUP BY
+  status_name`) — presne tri stavy z tela ticketu, žiadny ďalší. Karta sa
+  NIKDY nezatvára automaticky (na rozdiel od #268) — ticket to explicitne
+  žiada, majiteľ ju zavrie ručne cez "Vybavené". `shoptetOrderId` pre odkaz
+  do administrácie sa berie PRIAMO z `orderIdsByCode` (best-effort XML
+  fetch, už načítaná mapa vnútri tej istej funkcie) — žiadny extra dopyt.
 - **`upsertUpozornenie()` mal TOCTOU medzeru (issue 272, objavené code
   review-om pri #267, opravené pri #268 — prvom reálnom automatickom
   volajúcom): samostatný `SELECT` a podľa jeho výsledku podmienený

--- a/apps/api/drizzle/0039_demonic_wallop.sql
+++ b/apps/api/drizzle/0039_demonic_wallop.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."upozornenie_type" ADD VALUE 'vratenie';

--- a/apps/api/drizzle/meta/0039_snapshot.json
+++ b/apps/api/drizzle/meta/0039_snapshot.json
@@ -1,0 +1,2787 @@
+{
+  "id": "56c5b61d-4dbe-46ab-9b8e-6f7ca1f9fcec",
+  "prevId": "deea8c44-b256-4f7f-b44e-7a1fd6c28f33",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_code": {
+          "name": "external_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_open_status": {
+      "name": "order_open_status",
+      "schema": "",
+      "columns": {
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Vybavuje sa'"
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop_remark": {
+          "name": "shop_remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shoptet_order_id": {
+          "name": "shoptet_order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_updated_at": {
+          "name": "comment_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_synced_at": {
+          "name": "comment_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_carrier_name": {
+          "name": "shipping_carrier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_price_with_vat": {
+          "name": "total_price_with_vat",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_link_override": {
+      "name": "product_supplier_link_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_link_override_product_key_product_key_fk": {
+          "name": "product_supplier_link_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_link_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_override": {
+      "name": "product_supplier_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_override_product_key_product_key_fk": {
+          "name": "product_supplier_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing": {
+      "name": "pairing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_url": {
+          "name": "supplier_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "pairing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'navrhnute'"
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pairing_state_idx": {
+          "name": "pairing_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_confirmed_by_idx": {
+          "name": "pairing_confirmed_by_idx",
+          "columns": [
+            {
+              "expression": "confirmed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_variant_code_variant_code_fk": {
+          "name": "pairing_variant_code_variant_code_fk",
+          "tableFrom": "pairing",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pairing_confirmed_by_users_id_fk": {
+          "name": "pairing_confirmed_by_users_id_fk",
+          "tableFrom": "pairing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pairing_variant_code_unique": {
+          "name": "pairing_variant_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pairing_confirmation_ck": {
+          "name": "pairing_confirmation_ck",
+          "value": "(\"pairing\".\"state\" = 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)\n        OR (\"pairing\".\"state\" != 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NULL AND \"pairing\".\"confirmed_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier": {
+      "name": "supplier",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wholesale_base_url": {
+          "name": "wholesale_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_key": {
+          "name": "adapter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_settings": {
+      "name": "posta_uncollected_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_state": {
+      "name": "posta_uncollected_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notify_count": {
+          "name": "notify_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_state": {
+          "name": "terminal_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_settings": {
+      "name": "order_reminder_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_state": {
+      "name": "order_reminder_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_replacement_link": {
+      "name": "nedostupne_replacement_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nedostupne_replacement_link_variant_idx": {
+          "name": "nedostupne_replacement_link_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_state": {
+      "name": "nedostupne_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "nedostupne_email_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nedostupne_state_order_variant_type_uq": {
+          "name": "nedostupne_state_order_variant_type_uq",
+          "columns": [
+            {
+              "expression": "order_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template_history": {
+      "name": "mail_template_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "mail_template_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_template_history_key_idx": {
+          "name": "mail_template_history_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_template_history_changed_by_user_id_users_id_fk": {
+          "name": "mail_template_history_changed_by_user_id_users_id_fk",
+          "tableFrom": "mail_template_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template": {
+      "name": "mail_template",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail_template_updated_by_user_id_users_id_fk": {
+          "name": "mail_template_updated_by_user_id_users_id_fk",
+          "tableFrom": "mail_template",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_log": {
+      "name": "mail_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "mail_log_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_log_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "mail_log_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_log_created_idx": {
+          "name": "mail_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_log_source_created_idx": {
+          "name": "mail_log_source_created_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_log_actor_user_id_users_id_fk": {
+          "name": "mail_log_actor_user_id_users_id_fk",
+          "tableFrom": "mail_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_stock": {
+      "name": "supplier_stock",
+      "schema": "",
+      "columns": {
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "supplier_availability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "supplier_stock_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "supplier_stock_host_idx": {
+          "name": "supplier_stock_host_idx",
+          "columns": [
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "supplier_stock_avail_idx": {
+          "name": "supplier_stock_avail_idx",
+          "columns": [
+            {
+              "expression": "availability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "supplier_stock_link_size_label_pk": {
+          "name": "supplier_stock_link_size_label_pk",
+          "columns": [
+            "link",
+            "size_label"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_event": {
+      "name": "restock_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_link": {
+          "name": "supplier_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_availability_text": {
+          "name": "supplier_availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "supplier_price": {
+          "name": "supplier_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "restock_event_at_idx": {
+          "name": "restock_event_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "restock_event_variant_idx": {
+          "name": "restock_event_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_settings": {
+      "name": "restock_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shop_product_url": {
+      "name": "shop_product_url",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.theme_color": {
+      "name": "theme_color",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "theme_color_updated_by_user_id_users_id_fk": {
+          "name": "theme_color_updated_by_user_id_users_id_fk",
+          "tableFrom": "theme_color",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upozornenie": {
+      "name": "upozornenie",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "upozornenie_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "upozornenie_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedup_key": {
+          "name": "dedup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postponed_until": {
+          "name": "postponed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seen_at": {
+          "name": "seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "upozornenie_dedup_key_uq": {
+          "name": "upozornenie_dedup_key_uq",
+          "columns": [
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "resolved_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upozornenie_resolved_at_idx": {
+          "name": "upozornenie_resolved_at_idx",
+          "columns": [
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upozornenie_resolved_by_user_id_users_id_fk": {
+          "name": "upozornenie_resolved_by_user_id_users_id_fk",
+          "tableFrom": "upozornenie",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "upozornenie_created_by_user_id_users_id_fk": {
+          "name": "upozornenie_created_by_user_id_users_id_fk",
+          "tableFrom": "upozornenie",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne"
+      ]
+    },
+    "public.pairing_state": {
+      "name": "pairing_state",
+      "schema": "public",
+      "values": [
+        "navrhnute",
+        "potvrdene"
+      ]
+    },
+    "public.nedostupne_email_type": {
+      "name": "nedostupne_email_type",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "alternativa"
+      ]
+    },
+    "public.mail_template_action": {
+      "name": "mail_template_action",
+      "schema": "public",
+      "values": [
+        "save",
+        "reset"
+      ]
+    },
+    "public.mail_log_source": {
+      "name": "mail_log_source",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "posta_uncollected",
+        "order_reminder",
+        "supplier_order",
+        "order_merge"
+      ]
+    },
+    "public.mail_log_status": {
+      "name": "mail_log_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.mail_log_trigger": {
+      "name": "mail_log_trigger",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "manual"
+      ]
+    },
+    "public.supplier_availability": {
+      "name": "supplier_availability",
+      "schema": "public",
+      "values": [
+        "available",
+        "unavailable",
+        "unknown"
+      ]
+    },
+    "public.supplier_stock_source": {
+      "name": "supplier_stock_source",
+      "schema": "public",
+      "values": [
+        "json_ld",
+        "meta",
+        "text",
+        "size_list",
+        "none"
+      ]
+    },
+    "public.upozornenie_source": {
+      "name": "upozornenie_source",
+      "schema": "public",
+      "values": [
+        "vlastne",
+        "appka"
+      ]
+    },
+    "public.upozornenie_type": {
+      "name": "upozornenie_type",
+      "schema": "public",
+      "values": [
+        "vlastna_poznamka",
+        "nevyzdvihnuta_zasielka",
+        "vratenie"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -274,6 +274,13 @@
       "when": 1785957032743,
       "tag": "0038_sad_kinsey_walden",
       "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "7",
+      "when": 1785965276820,
+      "tag": "0039_demonic_wallop",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/cli/orders-ingest.ts
+++ b/apps/api/src/cli/orders-ingest.ts
@@ -61,6 +61,8 @@ try {
     rawDir: env.ORDERS_RAW_DIR,
     windowStart: dateFrom,
     windowEnd: dateUntil,
+    // issue 269: odkaz priamo na objednávku vo vrátkovej karte na Upozorneniach.
+    adminBaseUrl: env.SHOPTET_ADMIN_BASE_URL,
     ...(ordersXmlUrl === undefined
       ? {}
       : { fetchOrderIds: createHttpOrderIdsFetcher({ url: ordersXmlUrl, dateFrom: idsDateFrom, dateUntil }) }),

--- a/apps/api/src/db/schema-upozornenia.ts
+++ b/apps/api/src/db/schema-upozornenia.ts
@@ -4,15 +4,18 @@ import { users } from "./schema-users.js";
 
 // issue 267: "Upozornenia" — jedna nástenka vecí, ktoré majiteľ musí vybaviť.
 // `type` je OTVORENÝ zoznam — `vlastna_poznamka` (majiteľove vlastné
-// poznámky, #267) a `nevyzdvihnuta_zasielka` (prvý automatický zdroj, #268:
+// poznámky, #267), `nevyzdvihnuta_zasielka` (prvý automatický zdroj, #268:
 // `posta-uncollected/run.ts` volá `upsertUpozornenie` priamo zo svojho
-// existujúceho denného behu). Ďalší budúci automatický zdroj (#269
-// vrátenie) pridá SVOJU hodnotu vlastnou migráciou (`ALTER TYPE ... ADD
-// VALUE`, rovnaký vzor ako `nedostupneEmailType`/`.claude/rules/testing.md`'s
-// "Nová pgEnum hodnota" past). `source` je NEZÁVISLÝ, navždy 2-hodnotový enum
-// — určuje UI schopnosť (len `vlastne` karty majú Upraviť/Zmazať), `type` je
-// len farebný štítok.
-export const upozornenieType = pgEnum("upozornenie_type", ["vlastna_poznamka", "nevyzdvihnuta_zasielka"]);
+// existujúceho denného behu) a `vratenie` (druhý automatický zdroj, #269:
+// import objednávok, `orders/ingest.ts`, volá `upsertUpozornenie` priamo zo
+// svojej existujúcej DB transakcie, keď objednávka prejde do vrátkového
+// stavu). Ďalší budúci automatický zdroj pridá SVOJU hodnotu vlastnou
+// migráciou (`ALTER TYPE ... ADD VALUE`, rovnaký vzor ako
+// `nedostupneEmailType`/`.claude/rules/testing.md`'s "Nová pgEnum hodnota"
+// past). `source` je NEZÁVISLÝ, navždy 2-hodnotový enum — určuje UI
+// schopnosť (len `vlastne` karty majú Upraviť/Zmazať), `type` je len
+// farebný štítok.
+export const upozornenieType = pgEnum("upozornenie_type", ["vlastna_poznamka", "nevyzdvihnuta_zasielka", "vratenie"]);
 export const upozornenieSource = pgEnum("upozornenie_source", ["vlastne", "appka"]);
 
 export const upozornenie = pgTable(

--- a/apps/api/src/http/upozornenia-routes.ts
+++ b/apps/api/src/http/upozornenia-routes.ts
@@ -16,11 +16,11 @@ import {
 import { requireRole, requireUser, type AppBindings } from "./middleware.js";
 import { requireSameOrigin } from "./origin-check.js";
 
-// issue 267/268: `.claude/rules/testing.md`'s "Nová pgEnum hodnota" past
+// issue 267/268/269: `.claude/rules/testing.md`'s "Nová pgEnum hodnota" past
 // platí aj tu, preto validácia typu ide cez `z.enum` s POLOM hodnôt, nie
-// natvrdo jedným literálom, aby budúci #269 pridalo svoju hodnotu LEN sem +
-// do enumu, nikde inde.
-const KNOWN_TYPES: readonly [UpozornenieTypeValue, ...UpozornenieTypeValue[]] = ["vlastna_poznamka", "nevyzdvihnuta_zasielka"];
+// natvrdo jedným literálom, aby budúci ďalší automatický zdroj pridal svoju
+// hodnotu LEN sem + do enumu, nikde inde.
+const KNOWN_TYPES: readonly [UpozornenieTypeValue, ...UpozornenieTypeValue[]] = ["vlastna_poznamka", "nevyzdvihnuta_zasielka", "vratenie"];
 
 const listQuery = z.object({
   type: z.enum(KNOWN_TYPES).optional(),

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -101,6 +101,10 @@ const runOrdersIngest: RunOrdersIngest | undefined =
           rawDir: env.ORDERS_RAW_DIR,
           windowStart: dateFrom,
           windowEnd: dateUntil,
+          // issue 269: odkaz priamo na objednávku vo vrátkovej karte na
+          // Upozorneniach — rovnaká premenná ako `postaUncollectedDeps`/
+          // `orderReminderDeps`/`nedostupneDeps` nižšie.
+          adminBaseUrl: env.SHOPTET_ADMIN_BASE_URL,
           ...(ordersXmlUrl === undefined
             ? {}
             : { fetchOrderIds: createHttpOrderIdsFetcher({ url: ordersXmlUrl, dateFrom: idsDateFrom, dateUntil }) }),

--- a/apps/api/src/modules/orders/ingest.ts
+++ b/apps/api/src/modules/orders/ingest.ts
@@ -4,6 +4,7 @@ import type { Database } from "../../db/client.js";
 import { orderLines, orders, variants } from "../../db/schema.js";
 import { log } from "../../logger.js";
 import { storeRawSnapshot } from "../catalog/raw-store.js";
+import { upsertUpozornenie } from "../upozornenia/service.js";
 import { redactSourceLabel, type OrderIdsFetcher } from "./fetcher.js";
 import {
   decodeCp1250,
@@ -17,6 +18,8 @@ import {
   type OrderLineCandidate,
   type OrderRowIssue,
 } from "./parser.js";
+import { buildShoptetAdminOrderUrl } from "./queries.js";
+import { classifyReturnStatus, returnUpozornenieDedupKey } from "./return-status.js";
 
 // Zámok je JEDEN pevný kľúč, NIE odvodený z obsahu — rovnaký dôvod ako
 // katalógov `INGEST_ADVISORY_LOCK_KEY` (`catalog/ingest.ts`): serializuje
@@ -91,6 +94,13 @@ export interface OrdersIngestOptions {
   // prijatia dát). Pri zlyhaní sa jednoducho zaloguje varovanie a použije
   // sa prázdna mapa — `COALESCE` v zápise nižšie ochráni predtým zistené id.
   readonly fetchOrderIds?: OrderIdsFetcher;
+  // issue 269: základ odkazu do Shoptet administrácie pre kartu na
+  // Upozorneniach (`buildShoptetAdminOrderUrl`) — nepovinné, rovnaký vzor
+  // ako `http/app.ts`'s `options.adminBaseUrl ?? "https://www.forestshop.sk"`
+  // (nikdy natvrdo importovaný `env.ts` priamo do tohto modulu). Chýbajúci
+  // v testoch, čo tento zdroj netestujú, je bezpečný — použije sa
+  // predvolená verejná adresa appky.
+  readonly adminBaseUrl?: string;
 }
 
 export type OrdersIngestResult =
@@ -395,6 +405,34 @@ export async function ingestOrders(db: Database, options: OrdersIngestOptions): 
           })
           .returning({ id: orders.id, externalOrderId: orders.externalOrderId });
         for (const row of inserted) orderIdByExternalId.set(row.externalOrderId, row.id);
+      }
+
+      // issue 269: druhý automatický zdroj pre nástenku Upozornenia (#267) —
+      // objednávka, ktorej `statusName` je jeden zo živo overených vrátkových
+      // stavov (`return-status.ts`), dostane/obnoví kartu cez ZDIEĽANÚ
+      // zapisovaciu cestu (`upsertUpozornenie`, #267/#272), volanú PRIAMO
+      // vnútri TEJTO transakcie (rovnaký vzor, akým sa #268 napojilo na
+      // `posta-uncollected/run.ts`). `dedupKey` je na OBJEDNÁVKU (nie na
+      // pod-stav) — opakovaný import tej istej objednávky v tom istom
+      // vrátkovom stave, alebo jej prechod medzi dvomi vrátkovými stavmi,
+      // len OBNOVÍ tú istú kartu. Karta sa NIKDY nezatvára automaticky
+      // (ticket to explicitne žiada — majiteľ ju zavrie ručne cez
+      // "Vybavené"), preto tu na rozdiel od #268 niet `autoResolveByDedupKey`
+      // volania. `shoptetOrderId` je to isté, čo sa práve zapísalo vyššie
+      // (`orderIdsByCode`, best-effort XML fetch) — žiadny extra dopyt.
+      const adminBaseUrl = options.adminBaseUrl ?? "https://www.forestshop.sk";
+      for (const [externalOrderId, info] of orderInfo) {
+        const returnLabel = classifyReturnStatus(info.statusName);
+        if (returnLabel === null) continue;
+        await upsertUpozornenie(tx, {
+          type: "vratenie",
+          source: "appka",
+          title: `Objednávka ${externalOrderId} — ${returnLabel}`,
+          details: [`Zákazník: ${info.customerName}`, `Stav objednávky: ${info.statusName}`].join("\n"),
+          link: buildShoptetAdminOrderUrl(adminBaseUrl, externalOrderId, orderIdsByCode.get(externalOrderId) ?? null),
+          dedupKey: returnUpozornenieDedupKey(externalOrderId),
+          now: options.now,
+        });
       }
 
       // issue 132: `orderIdsByCode` (best-effort XML fetch, prípadne

--- a/apps/api/src/modules/orders/return-status.test.ts
+++ b/apps/api/src/modules/orders/return-status.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { classifyReturnStatus, returnUpozornenieDedupKey } from "./return-status.js";
+
+describe("classifyReturnStatus", () => {
+  it("rozpozná presne tri živo overené vrátkové stavy", () => {
+    expect(classifyReturnStatus("Vratený tovar")).toBe("vrátený tovar");
+    expect(classifyReturnStatus("Vybavená výmena")).toBe("vybavená výmena");
+    expect(classifyReturnStatus("Vybavený Dobropis")).toBe("vybavený dobropis");
+  });
+
+  it("bežné (nevrátkové) stavy vrátia null", () => {
+    expect(classifyReturnStatus("Vybavuje sa")).toBeNull();
+    expect(classifyReturnStatus("Vybavená")).toBeNull();
+    expect(classifyReturnStatus("Stornovaná")).toBeNull();
+    expect(classifyReturnStatus("")).toBeNull();
+  });
+
+  it("normalizuje (NFC + orez) rovnako ako `order.status_name`, nikdy bajtovo presnú zhodu", () => {
+    expect(classifyReturnStatus("  Vratený tovar  ")).toBe("vrátený tovar");
+    // NFD (rozložená diakritika) — rovnaký zámer ako `parser.test.ts`'s
+    // existujúca `normalizeStatusName` kontrola.
+    expect(classifyReturnStatus("Vratený tovar".normalize("NFD"))).toBe("vrátený tovar");
+  });
+});
+
+describe("returnUpozornenieDedupKey", () => {
+  it("je stabilný na objednávku, nezávislý od konkrétneho pod-stavu", () => {
+    expect(returnUpozornenieDedupKey("20260805")).toBe("vratenie:20260805");
+  });
+});

--- a/apps/api/src/modules/orders/return-status.ts
+++ b/apps/api/src/modules/orders/return-status.ts
@@ -1,0 +1,31 @@
+import { normalizeStatusName } from "./parser.js";
+
+// issue 269: druhý automatický zdroj pre nástenku Upozornenia (#267) —
+// objednávka, ktorá prešla do vrátkového/výmenného/dobropisového stavu.
+// Presný zoznam OVERENÝ ŽIVO na produkčnej DB (2026-08-05, `.claude/rules/
+// upozornenia.md`'s validačný komentár na tickete), nie odhadnutý zo starej
+// appky — zoznam sa NESMIE rozšíriť "od oka", nový vrátkový stav treba znova
+// overiť proti reálnym dátam predtým, než sa sem pridá. Kľúč mapy je
+// NORMALIZOVANÝ (`normalizeStatusName`, rovnaká funkcia, akú `ingest.ts`
+// používa na uloženie `order.status_name`) — porovnanie beží v rovnakej
+// forme na oboch stranách, presne ako `open-statuses.ts`.
+const RETURN_STATUS_LABELS: ReadonlyMap<string, string> = new Map([
+  [normalizeStatusName("Vratený tovar"), "vrátený tovar"],
+  [normalizeStatusName("Vybavená výmena"), "vybavená výmena"],
+  [normalizeStatusName("Vybavený Dobropis"), "vybavený dobropis"],
+]);
+
+/** `null`, keď stav objednávky nie je žiadny zo živo overených vrátkových
+ * stavov — inak ľudský štítok použiteľný priamo v titulku karty. */
+export function classifyReturnStatus(statusName: string): string | null {
+  return RETURN_STATUS_LABELS.get(normalizeStatusName(statusName)) ?? null;
+}
+
+/** Stabilný kľúč proti duplicitám — JEDNA karta NA OBJEDNÁVKU (nie na
+ * konkrétny pod-stav): prechod "Vratený tovar" → "Vybavený Dobropis" je
+ * koncepčne TÁ ISTÁ udalosť pre TÚ istú objednávku, rovnaký princíp ako
+ * `posta-uncollected/logic.ts`'s `postaUpozornenieDedupKey` (kľúč na
+ * zásielku, nie na jej okamžitú klasifikáciu). */
+export function returnUpozornenieDedupKey(externalOrderId: string): string {
+  return `vratenie:${externalOrderId}`;
+}

--- a/apps/api/src/modules/posta-uncollected/run.ts
+++ b/apps/api/src/modules/posta-uncollected/run.ts
@@ -5,7 +5,7 @@ import { recordSkippedMail, sendLoggedMail, type MailLogContext } from "../mail-
 import { buildShoptetAdminOrderUrl } from "../orders/queries.js";
 import { pluralWord } from "../orders/pluralize.js";
 import { resolveTemplate } from "../mail-templates/store.js";
-import { autoResolveByDedupKey, upsertUpozornenie } from "../upozornenia/service.js";
+import { autoResolveByDedupKey, updateIfUnresolvedByDedupKey, upsertUpozornenie } from "../upozornenia/service.js";
 import {
   buildEmail,
   classifyTracking,
@@ -195,6 +195,24 @@ async function runPostaUncollectedLocked(options: RunPostaUncollectedOptions): P
 
     const cls = classifyTracking(trackingJson, now);
     if (cls.status === "invalid_format") {
+      // issue 275 (medzera nájdená code review-om na #268): zásielka, ktorá
+      // UŽ MÁ nevyriešenú kartu na Upozorneniach (vznikla skôr, kým bola v
+      // stave notified/ZNP), a ktorej tracking neskôr začne vracať
+      // nečitateľný formát — karta sa OZNAČÍ inak (aby majiteľ vedel, PREČO
+      // sa sama nezavrie), ale NIKDY sa automaticky nezavrie (to by skrylo
+      // reálny, ešte nevyriešený problém) a NIKDY sa nevyrobí NOVÁ (zásielka,
+      // čo nikdy predtým nebola nahlásená, nepotrebuje kartu len kvôli
+      // jednorazovému/prechodnému zlyhaniu sledovania) —
+      // `updateIfUnresolvedByDedupKey` je čisto UPDATE-if-exists.
+      await updateIfUnresolvedByDedupKey(db, postaUpozornenieDedupKey(packageNumber), {
+        title: `Zásielka pre objednávku ${shipment.externalOrderId} — sledovanie zlyhalo (over ručne)`,
+        details: [
+          `Zákazník: ${shipment.customerName}`,
+          `Číslo zásielky: ${packageNumber}`,
+          "Sledovanie na Pošte SK vrátilo nečitateľný formát — appka už nevie automaticky rozoznať, či je zásielka vyzdvihnutá.",
+          "Over stav ručne (posta.sk alebo Shoptet) a kartu vybav manuálne.",
+        ].join("\n"),
+      });
       invalid.push({
         orderCode: shipment.externalOrderId,
         packageNumber,

--- a/apps/api/src/modules/upozornenia/service.ts
+++ b/apps/api/src/modules/upozornenia/service.ts
@@ -199,6 +199,30 @@ export async function autoResolveByDedupKey(db: UpozornenieExecutor, dedupKey: s
   return result.length > 0;
 }
 
+export interface UpdateIfUnresolvedInput {
+  readonly title: string;
+  readonly details: string;
+}
+
+// issue 275: keď automatický zdroj zistí, že jeho vlastné sledovanie (napr.
+// tracking na Pošte SK) prestalo fungovať, a pre `dedupKey` UŽ existuje
+// nevyriešená karta (vznikla skôr, kým sledovanie ešte fungovalo) — táto
+// karta sa má OZNAČIŤ inak (aby majiteľ vedel, PREČO sa sama nezavrie), ale
+// NIKDY automaticky zavrieť (to by skrylo reálny, ešte nevyriešený problém)
+// ani NIKDY vytvoriť ako novú (zdroj, čo nikdy predtým problém nehlásil,
+// nepotrebuje novú kartu len kvôli jednorazovému/prechodnému zlyhaniu
+// sledovania). Na rozdiel od `upsertUpozornenie` preto NIKDY nevkladá nový
+// riadok — čisto UPDATE-if-exists. Bezpečný no-op, keď pre `dedupKey` žiadna
+// nevyriešená karta neexistuje.
+export async function updateIfUnresolvedByDedupKey(db: UpozornenieExecutor, dedupKey: string, input: UpdateIfUnresolvedInput): Promise<boolean> {
+  const result = await db
+    .update(upozornenie)
+    .set({ title: input.title, details: input.details })
+    .where(and(eq(upozornenie.dedupKey, dedupKey), isNull(upozornenie.resolvedAt)))
+    .returning({ id: upozornenie.id });
+  return result.length > 0;
+}
+
 // Volané pri OTVORENÍ záložky — hromadne označí VŠETKY práve "Nové" karty
 // ako videné naraz (inbox vzor "otvoriť = prečítané"), žiadne per-kartové
 // tlačidlo "videné" navyše. Zámerne LEN `seenAt IS NULL` (nikdy nerieši

--- a/apps/api/tests/orders-ingest-return-upozornenie.integration.test.ts
+++ b/apps/api/tests/orders-ingest-return-upozornenie.integration.test.ts
@@ -56,7 +56,7 @@ const CP1250_ENCODE: ReadonlyMap<string, number> = (() => {
 })();
 
 function encodeCp1250(text: string): Buffer {
-  return Buffer.from(Uint8Array.from([...text].map((ch) => CP1250_ENCODE.get(ch) ?? 0x3f)));
+  return Buffer.from(Uint8Array.from(Array.from(text, (ch) => CP1250_ENCODE.get(ch) ?? 0x3f)));
 }
 
 function buildCsv(header: readonly string[], rows: readonly Record<string, string>[]): Buffer {

--- a/apps/api/tests/orders-ingest-return-upozornenie.integration.test.ts
+++ b/apps/api/tests/orders-ingest-return-upozornenie.integration.test.ts
@@ -1,0 +1,174 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { eq } from "drizzle-orm";
+import { afterEach, expect, it } from "vitest";
+import { upozornenie } from "../src/db/schema.js";
+import { ingestOrders, type OrdersExportFetcher } from "../src/modules/orders/ingest.js";
+import { insertTestVariant } from "./helpers/orders.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 269: import objednávok vyrobí/obnoví kartu na Upozorneniach (#267),
+// keď objednávka prejde do vrátkového stavu — vydelené do VLASTNÉHO súboru
+// (rovnaký dôvod ako `orders-ingest-posta-fields.integration.test.ts`,
+// `.claude/rules/testing.md`'s eslint `max-lines: 400`).
+const WINDOW_START = new Date("2020-01-01T00:00:00Z");
+const WINDOW_END = new Date("2030-01-01T00:00:00Z");
+const NOW = new Date("2026-07-30T10:00:00Z");
+
+let close: (() => Promise<void>) | undefined;
+let rawDir: string | undefined;
+
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  if (rawDir !== undefined) await rm(rawDir, { recursive: true, force: true });
+  rawDir = undefined;
+});
+
+async function boot(): Promise<{ db: Awaited<ReturnType<typeof withCleanDb>>["db"]; dir: string }> {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  rawDir = await mkdtemp(join(tmpdir(), "forestshop-orders-return-raw-"));
+  return { db: ctx.db, dir: rawDir };
+}
+
+function fetcherOf(body: Buffer): OrdersExportFetcher {
+  return () => Promise.resolve({ body, sourceLabel: "fixtúra" });
+}
+
+// `ingestOrders` VŽDY dekóduje ako windows-1250 (`decodeCp1250`) — na rozdiel
+// od `orders-ingest.integration.test.ts`'s ASCII-only `buildCsv` (ktorá by
+// diakritiku pri UTF-8 zápise na druhej strane pokazila, `.claude/rules/
+// orders.md`), tento súbor POTREBUJE reálne vrátkové stavy s diakritikou
+// ("Vratený tovar" a pod.) — preto sa CSV zapisuje priamo ako cp1250 BYTES,
+// nie ako UTF-8 text. Kódovaciu tabuľku (znak → byte) staviame DYNAMICKY
+// dekódovaním všetkých 256 bajtov cez `TextDecoder("windows-1250")` a
+// obrátením mapy — žiadna nová závislosť (`iconv-lite`), žiadna ručne
+// prepisovaná tabuľka kódových bodov.
+const CP1250_ENCODE: ReadonlyMap<string, number> = (() => {
+  const map = new Map<string, number>();
+  for (let byte = 0; byte < 256; byte += 1) {
+    const ch = new TextDecoder("windows-1250").decode(Buffer.from([byte]));
+    if (!map.has(ch)) map.set(ch, byte);
+  }
+  return map;
+})();
+
+function encodeCp1250(text: string): Buffer {
+  return Buffer.from(Uint8Array.from([...text].map((ch) => CP1250_ENCODE.get(ch) ?? 0x3f)));
+}
+
+function buildCsv(header: readonly string[], rows: readonly Record<string, string>[]): Buffer {
+  const esc = (v: string): string => `"${v.replaceAll('"', '""')}"`;
+  const lines = [header.map(esc).join(";") + ";"];
+  for (const row of rows) {
+    lines.push(header.map((c) => esc(row[c] ?? "")).join(";") + ";");
+  }
+  return encodeCp1250(lines.join("\r\n") + "\r\n");
+}
+
+const HEADER = ["code", "date", "statusName", "billFullName", "itemName", "itemAmount", "itemCode"] as const;
+
+function rowOf(code: string, statusName: string): Record<string, string> {
+  return {
+    code,
+    date: "2026-06-15 10:30:00",
+    statusName,
+    billFullName: "Ján Novák",
+    itemName: "Nohavice",
+    itemAmount: "1",
+    itemCode: "40237/XL",
+  };
+}
+
+it("encodeCp1250 je verný inverzný krok voči appkinmu decodeCp1250 (sebakontrola fixtúry)", () => {
+  const original = "Vratený tovar — Vybavená výmena — Vybavený Dobropis";
+  expect(new TextDecoder("windows-1250").decode(encodeCp1250(original))).toBe(original);
+});
+
+it("objednávka v nevrátkovom stave NEVYROBÍ kartu na Upozorneniach", async () => {
+  const { db, dir } = await boot();
+  await insertTestVariant(db, "40237/XL");
+
+  await ingestOrders(db, {
+    fetchExport: fetcherOf(buildCsv(HEADER, [rowOf("20600001", "Stornovaná")])),
+    now: NOW,
+    rawDir: dir,
+    windowStart: WINDOW_START,
+    windowEnd: WINDOW_END,
+  });
+
+  const rows = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "vratenie:20600001"));
+  expect(rows).toHaveLength(0);
+});
+
+it("objednávka vo vrátkovom stave vyrobí kartu s odkazom na objednávku, nikdy sa nezatvorí sama", async () => {
+  const { db, dir } = await boot();
+  await insertTestVariant(db, "40237/XL");
+
+  const result = await ingestOrders(db, {
+    fetchExport: fetcherOf(buildCsv(HEADER, [rowOf("20600002", "Vratený tovar")])),
+    now: NOW,
+    rawDir: dir,
+    windowStart: WINDOW_START,
+    windowEnd: WINDOW_END,
+    adminBaseUrl: "https://www.forestshop.sk",
+  });
+  expect(result.status).toBe("accepted");
+
+  const rows = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "vratenie:20600002"));
+  expect(rows).toHaveLength(1);
+  expect(rows[0]?.type).toBe("vratenie");
+  expect(rows[0]?.source).toBe("appka");
+  expect(rows[0]?.title).toContain("20600002");
+  expect(rows[0]?.title).toContain("vrátený tovar");
+  expect(rows[0]?.link).toContain("20600002");
+  expect(rows[0]?.resolvedAt).toBeNull();
+});
+
+it("opakovaný import tej istej objednávky v tom istom vrátkovom stave NEVYROBÍ druhú kartu, len ju obnoví", async () => {
+  const { db, dir } = await boot();
+  await insertTestVariant(db, "40237/XL");
+  const csv = buildCsv(HEADER, [rowOf("20600003", "Vybavená výmena")]);
+
+  await ingestOrders(db, { fetchExport: fetcherOf(csv), now: NOW, rawDir: dir, windowStart: WINDOW_START, windowEnd: WINDOW_END });
+  await ingestOrders(db, {
+    fetchExport: fetcherOf(csv),
+    now: new Date("2026-07-31T10:00:00Z"),
+    rawDir: dir,
+    windowStart: WINDOW_START,
+    windowEnd: WINDOW_END,
+  });
+
+  const rows = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "vratenie:20600003"));
+  expect(rows).toHaveLength(1);
+});
+
+it("prechod z jedného vrátkového stavu do druhého (Vratený tovar -> Vybavený Dobropis) OBNOVÍ tú istú kartu, nikdy druhú", async () => {
+  const { db, dir } = await boot();
+  await insertTestVariant(db, "40237/XL");
+
+  await ingestOrders(db, {
+    fetchExport: fetcherOf(buildCsv(HEADER, [rowOf("20600004", "Vratený tovar")])),
+    now: NOW,
+    rawDir: dir,
+    windowStart: WINDOW_START,
+    windowEnd: WINDOW_END,
+  });
+  const before = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "vratenie:20600004"));
+  expect(before).toHaveLength(1);
+  expect(before[0]?.title).toContain("vrátený tovar");
+
+  await ingestOrders(db, {
+    fetchExport: fetcherOf(buildCsv(HEADER, [rowOf("20600004", "Vybavený Dobropis")])),
+    now: new Date("2026-07-31T10:00:00Z"),
+    rawDir: dir,
+    windowStart: WINDOW_START,
+    windowEnd: WINDOW_END,
+  });
+  const after = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "vratenie:20600004"));
+  expect(after).toHaveLength(1); // stále JEDNA karta na objednávku, nikdy druhá pre nový pod-stav
+  expect(after[0]?.id).toBe(before[0]?.id);
+  expect(after[0]?.title).toContain("vybavený dobropis");
+});

--- a/apps/api/tests/posta-uncollected-run.integration.test.ts
+++ b/apps/api/tests/posta-uncollected-run.integration.test.ts
@@ -332,3 +332,58 @@ it("doručená zásielka zavrie svoju kartu SAMA, bez zásahu majiteľa (resolve
   expect(after[0]?.resolvedAt).not.toBeNull();
   expect(after[0]?.resolvedByUserId).toBeNull();
 });
+
+// issue 275: code review na #268 našlo medzeru — vetva `invalid_format`
+// nerobila ani vytvorenie/obnovu, ani zatvorenie karty. Zásielka, ktorá UŽ
+// MALA nevyriešenú kartu (z predošlého "notified"/ZNP behu), a ktorej
+// tracking neskôr začne vracať nečitateľný formát, ostávala navždy otvorená
+// bez akéhokoľvek signálu pre majiteľa. Fix: karta sa OZNAČÍ inak (titulok
+// vysvetlí, že sledovanie zlyhalo), ale NIKDY sa nezatvorí sama — majiteľ ju
+// musí vybaviť ručne, presne ako inú kartu tohto typu.
+it("zásielka s existujúcou kartou, ktorej sledovanie prestane fungovať (invalid_format), dostane OZNAČENIE — karta ostáva otvorená", async () => {
+  const db = await boot();
+  await insertOrder(db, { externalOrderId: "20500013" });
+
+  await runPostaUncollected({
+    db,
+    now: TODAY,
+    trackingClient: notifiedTrackingClient(),
+    mailTransport: undefined,
+    bccEmail: "majitel@forestshop.sk",
+    adminBaseUrl: "https://www.forestshop.sk",
+  });
+  const midway = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "posta:EF123456789SK"));
+  expect(midway).toHaveLength(1);
+  expect(midway[0]?.resolvedAt).toBeNull();
+
+  await runPostaUncollected({
+    db,
+    now: new Date("2026-08-03T10:00:00Z"),
+    trackingClient: () => Promise.resolve({ results: [{ status: "invalid_format" }] }),
+    mailTransport: undefined,
+    bccEmail: "majitel@forestshop.sk",
+    adminBaseUrl: "https://www.forestshop.sk",
+  });
+
+  const after = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "posta:EF123456789SK"));
+  expect(after).toHaveLength(1); // stále len JEDNA karta, nikdy druhá
+  expect(after[0]?.resolvedAt).toBeNull(); // NIKDY sa nezavrie sama (skrylo by reálny problém)
+  expect(after[0]?.title).toContain("sledovanie zlyhalo");
+});
+
+it("zásielka BEZ existujúcej karty, ktorej prvá klasifikácia je invalid_format, NEVYROBÍ novú kartu (žiadny šum)", async () => {
+  const db = await boot();
+  await insertOrder(db, { externalOrderId: "20500014", packageNumber: "12345678901234" });
+
+  await runPostaUncollected({
+    db,
+    now: TODAY,
+    trackingClient: () => Promise.resolve({ results: [{ status: "invalid_format" }] }),
+    mailTransport: undefined,
+    bccEmail: "majitel@forestshop.sk",
+    adminBaseUrl: "https://www.forestshop.sk",
+  });
+
+  const rows = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "posta:12345678901234"));
+  expect(rows).toHaveLength(0);
+});

--- a/apps/web/src/components/UpozorneniaSection.tsx
+++ b/apps/web/src/components/UpozorneniaSection.tsx
@@ -19,11 +19,12 @@ import {
 // (zoznam) smie vidieť KAŽDÝ prihlásený zamestnanec.
 const CONTROL_ROLES: ReadonlySet<Me["role"]> = new Set(["admin", "manazer"]);
 
-// Otvorený zoznam typov — budúci automatický zdroj (#269) pridá svoj štítok
+// Otvorený zoznam typov — budúci ďalší automatický zdroj pridá svoj štítok
 // sem, keď pridá svoju `pgEnum` hodnotu.
 const TYPE_LABELS: Readonly<Record<UpozornenieRow["type"], string>> = {
   vlastna_poznamka: "Moja poznámka",
   nevyzdvihnuta_zasielka: "Nevyzdvihnutá zásielka",
+  vratenie: "Vrátenie",
 };
 
 function formatDate(iso: string): string {

--- a/apps/web/src/upozorneniaApi.ts
+++ b/apps/web/src/upozorneniaApi.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 
 const rowSchema = z.object({
   id: z.string(),
-  type: z.enum(["vlastna_poznamka", "nevyzdvihnuta_zasielka"]),
+  type: z.enum(["vlastna_poznamka", "nevyzdvihnuta_zasielka", "vratenie"]),
   source: z.enum(["vlastne", "appka"]),
   title: z.string(),
   details: z.string(),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.159",
+  "version": "0.3.0-dev.160",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Čo to robí

Dve veci okolo nástenky **Upozornenia** — obe malé, obe v tom istom mieste, preto idú v jednom nasadení.

### 1. Vrátenie / výmena / dobropis vyrobí kartu (issue 269)

Keď objednávka prejde do stavu, ktorý znamená vrátený tovar, vybavenú výmenu alebo dobropis, objaví sa na nástenke Upozornenia karta — je to vec, ktorú treba fyzicky vybaviť (prevziať tovar, vrátiť peniaze, poslať náhradu).

- Karta nesie ľudský nadpis s číslom objednávky a tým, o aký stav ide, meno zákazníka, dátum a **odkaz priamo na tú objednávku** v appke.
- Zapisuje sa **spoločnou zapisovacou cestou z issue 267** — žiadny druhý zapisovač, žiadny nový nočný job. Píše sa rovno z importu objednávok, ktorý aj tak beží.
- **Opakovaný import nevyrobí druhú kartu** na tú istú objednávku — kľúč proti duplicitám je objednávka + typ udalosti.
- Kartu **appka sama nezatvára**. Či je vec naozaj vybavená, vie iba majiteľ — zavrie ju kliknutím na **Vybavené**.
- Nič sa neposiela e-mailom ani na Discord.

### 2. Karta zo zásielky už neostane visieť naveky (issue 275)

Nález z revízie kódu pri issue 268: keď zásielke, ktorá už mala otvorenú kartu „nevyzdvihnutá zásielka", prestal ísť tracking rozobrať (`invalid_format`), karta ostala otvorená navždy a appka o tom nedala vedieť.

Rozhodnutie (zapísané na ticket pred prvým commitom): karta sa v takom prípade **na mieste prepíše** tak, aby vysvetlila, že sledovanie zásielky zlyhalo — ale **nezatvorí sa automaticky** (zavretím by sa skryl možno stále reálny problém) a **nevyrobí sa nová karta** zásielke, ktorá nikdy označená nebola (zbytočný šum).

## Overenie

- `pnpm typecheck`, `pnpm lint` — čisté
- api unit 593, web unit 461, api integračné 534 (19 nových), e2e 46/46 — všetko prešlo
- Na issue 275 je najprv commit s padajúcim testom (`[red]`), až potom oprava (`[green]`) — test teda naozaj chytá tú chybu
- Kód prešiel dvoma revíziami — 0 kritických, 0 varovaní, 0 námetov

issue 269
issue 275
