### PR TITLE
Upozornenia: vybavené vrátenie sa už nikdy neohlási znova + pravdivý popis odkazu (issue 269, 267)

### DIFF
--- a/.claude/rules/upozornenia.md
+++ b/.claude/rules/upozornenia.md
@@ -151,3 +151,62 @@ paths:
   DB, nie chyba tejto techniky. Rovnaký postup (predhriaty pool + vyšší
   počet súbežných volaní) použi pri KAŽDOM ĎALŠOM teste, čo dokazuje opravu
   TOCTOU/race-u cez skutočný Postgres, nie mock.
+- **Issue 269 (živé overenie na 0.3.0-dev.160): vybavené vrátenie sa PO
+  ĎALŠOM importe znova vyrobilo ako DRUHÁ karta — DRUHÝ krát, čo tento istý
+  ČIASTOČNÝ index (`WHERE resolved_at IS NULL`) prekvapil (prvý bol #272's
+  TOCTOU vyššie).** Príčina: index dovoľuje ĎALŠÍ výskyt PO vyriešení prvého
+  — zámerné pre #268 (zásielka sa smie o mesiac znova zaseknúť), ale pre
+  `vratenie` je vybavený riadok KONEČNÝ, nikdy sa nemá zopakovať. **Poučenie
+  pre KAŽDÝ ĎALŠÍ budúci automatický zdroj, čo bude volať `upsertUpozornenie`
+  s vlastným `dedupKey`:** rozhodni sa VOPRED a EXPLICITNE, do ktorej z dvoch
+  kategórií patrí — "znova sa smie ohlásiť po vybavení" (#268, žiadna extra
+  práca, `upsertUpozornenie` samo osebe stačí) VERZUS "vybavené je KONEČNÉ,
+  nikdy sa nemá zopakovať" (#269) — ten druhý prípad si musí sám dopísať
+  vlastný existence pre-check (nikdy zmenu `upsertUpozornenie`/schémy/indexu
+  samotného, ktoré ostávajú zdieľané a nezmenené pre PRVÚ kategóriu).
+- **Existence pre-check pre "KONEČNÉ" kategóriu (`orders/ingest.ts`'s
+  `resolvedReturnDedupKeys`) je JEDEN batchovaný `SELECT ... WHERE dedup_key
+  IN (...) ... .for("update")` nad VŠETKÝMI kandidátmi TOHO ISTÉHO behu
+  naraz, NIE dopyt v cykle** — `.for("update")` je POVINNÉ, nie voliteľné
+  vylepšenie: bez neho je to obyčajné READ COMMITTED čítanie, ktoré sa
+  NIKDY nezablokuje na súbežnom ručnom "Vybavené" (`resolveUpozornenie`, mimo
+  tejto transakcie) — ten by mohol commitnúť PRESNE medzi pre-checkom a
+  neskorším `upsertUpozornenie` volaním PRE TEN ISTÝ kandidát, čím by sa ten
+  istý bug zopakoval, len naživo zriedkavejšie (code review nález, nie
+  pôvodný test). `.for("update")` zamkne KAŽDÝ existujúci kandidátny riadok
+  na zvyšok transakcie (rovnaký vzor ako `orders/state.ts`/`.claude/rules/
+  database.md`) — súbežné `resolveUpozornenie` naň POČKÁ, takže rozhodnutie
+  je vždy postavené na ČERSTVOM, nie zastaranom stave. Bez JOINu (jedna
+  tabuľka) nepotrebuje `of` zoznam.
+- **Set-based dávkový skip (`resolvedReturnDedupKeys.has(dedupKey)`)
+  POTREBUJE explicitný test s ≥2 kandidátmi v JEDNOM behu, kde je vybavený
+  LEN JEDEN — jednotlivé (1-kandidátové) testy nedokážu odhaliť regresiu na
+  "všetko alebo nič za celú dávku" namiesto správneho rozlíšenia PO
+  KĽÚČOCH.** (`orders-ingest-return-upozornenie.integration.test.ts`'s
+  "v jednom importe s viacerými..." test — pridané až pri code review, nie
+  v pôvodnom RED/GREEN páre.) Test na KAŽDÝ ĎALŠÍ Set/Map-based dávkový
+  rozhodovací mechanizmus v tomto module: over samostatne, že jeden člen
+  dávky neovplyvní rozhodnutie o INOM členovi tej istej dávky.
+- **Deterministický dôkaz, že `.for("update")` fix naozaj UZAVIERA TOCTOU
+  okno (nie len "vyzerá správne"), potrebuje `pg_blocking_pids` SCOPOVANÝ na
+  KONKRÉTNY backend pid, nie holé `pg_stat_activity WHERE wait_event_type =
+  'Lock'`** (`.claude/rules/database.md`'s technika, spresnená) — tento box
+  beží súbežné testovacie/vývojové relácie na tej istej lokálnej Postgres
+  inštancii, takže holý "čaká NIEKTO na NEJAKÝ zámok" dopyt môže dať falošný
+  pozitív z úplne nesúvisiacej aktivity. Správny dopyt: `SELECT count(*)
+  FROM pg_stat_activity a WHERE a.wait_event_type = 'Lock' AND $1 = ANY
+  (pg_blocking_pids(a.pid))`, kde `$1` je PRIAMO `rawClient`'s vlastný
+  `pg_backend_pid()` (zistený ihneď po pripojení, pred `BEGIN`).
+  **Prekvapenie objavené priamym dočasným odstránením `.for("update")` a
+  behom testu proti starému kódu (nie len úvahou):** `INSERT ... ON CONFLICT`
+  sám osebe ČAKÁ na uvoľnenie riadkového zámku súbežnej transakcie na
+  kandidátnom riadku (Postgres to potrebuje na správne vyhodnotenie
+  arbitra) — takže "niekto sa zasekol na `rawClient`'s zámku" bolo PRAVDA
+  aj BEZ nášho `.for("update")`, len na INOM mieste (samotný `INSERT`, nie
+  náš pre-check). To znamená: samotný "zaseknutý?" medzikrok NEROZLIŠUJE
+  opravený/neopravený kód — dokazuje len že test vytvoril SKUTOČNÝ súbeh
+  (nie no-op). **Skutočný dôkaz opravy je AŽ finálna asercia počtu
+  riadkov** (bez opravy 2 riadky, s opravou 1) — over to VŽDY OBOMA smermi
+  (dočasne odstrániť opravu → test spadne presne na tomto mieste, vrátiť →
+  zelený), presne ako `.claude/rules/regression-test-first.md` vyžaduje pre
+  RED/GREEN, aj keď ide o code-review-dodaný test mimo pôvodného páru.

--- a/apps/api/src/modules/orders/ingest.ts
+++ b/apps/api/src/modules/orders/ingest.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
-import { between, eq, inArray, sql } from "drizzle-orm";
+import { and, between, eq, inArray, isNotNull, sql } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
-import { orderLines, orders, variants } from "../../db/schema.js";
+import { orderLines, orders, upozornenie, variants } from "../../db/schema.js";
 import { log } from "../../logger.js";
 import { storeRawSnapshot } from "../catalog/raw-store.js";
 import { upsertUpozornenie } from "../upozornenia/service.js";
@@ -421,16 +421,47 @@ export async function ingestOrders(db: Database, options: OrdersIngestOptions): 
       // volania. `shoptetOrderId` je to isté, čo sa práve zapísalo vyššie
       // (`orderIdsByCode`, best-effort XML fetch) — žiadny extra dopyt.
       const adminBaseUrl = options.adminBaseUrl ?? "https://www.forestshop.sk";
+      const returnCandidates: { externalOrderId: string; returnLabel: string; customerName: string; statusName: string; dedupKey: string }[] = [];
       for (const [externalOrderId, info] of orderInfo) {
         const returnLabel = classifyReturnStatus(info.statusName);
         if (returnLabel === null) continue;
+        returnCandidates.push({
+          externalOrderId,
+          returnLabel,
+          customerName: info.customerName,
+          statusName: info.statusName,
+          dedupKey: returnUpozornenieDedupKey(externalOrderId),
+        });
+      }
+      // Naživo overené na produkcii (0.3.0-dev.160): vybavené vrátenie je
+      // KONEČNÉ — na rozdiel od #268 (zásielka, čo sa smie znova zaseknúť o
+      // mesiac) sa už NIKDY nemá znova ohlásiť, hoci Shoptet-ov status
+      // objednávky ostáva v tom istom vrátkovom stave navždy. `upsertUpozornenie`'s
+      // ČIASTOČNÝ unique index (`WHERE resolved_at IS NULL`, `.claude/rules/
+      // upozornenia.md`) necháva VYRIEŠENÝ riadok mimo arbitra, takže bez tejto
+      // kontroly by ďalší import s tým istým `dedupKey` prešiel ako čistý
+      // INSERT — druhý riadok na tú istú objednávku. JEDEN batchovaný dopyt nad
+      // VŠETKÝMI kandidátnymi kľúčmi tohto behu naraz (nie dopyt v cykle)
+      // zistí, ktoré už majú VYRIEŠENÝ riadok — tie sa nižšie PRESKOČIA, ostatné
+      // (žiadna karta zatiaľ, alebo ešte nevyriešená) sa naďalej vyrobia/obnovia
+      // presne ako doteraz (prechod medzi pod-stavmi ostáva funkčný).
+      let resolvedReturnDedupKeys: ReadonlySet<string> = new Set();
+      if (returnCandidates.length > 0) {
+        const resolvedRows = await tx
+          .select({ dedupKey: upozornenie.dedupKey })
+          .from(upozornenie)
+          .where(and(inArray(upozornenie.dedupKey, returnCandidates.map((c) => c.dedupKey)), isNotNull(upozornenie.resolvedAt)));
+        resolvedReturnDedupKeys = new Set(resolvedRows.map((row) => row.dedupKey).filter((key): key is string => key !== null));
+      }
+      for (const candidate of returnCandidates) {
+        if (resolvedReturnDedupKeys.has(candidate.dedupKey)) continue;
         await upsertUpozornenie(tx, {
           type: "vratenie",
           source: "appka",
-          title: `Objednávka ${externalOrderId} — ${returnLabel}`,
-          details: [`Zákazník: ${info.customerName}`, `Stav objednávky: ${info.statusName}`].join("\n"),
-          link: buildShoptetAdminOrderUrl(adminBaseUrl, externalOrderId, orderIdsByCode.get(externalOrderId) ?? null),
-          dedupKey: returnUpozornenieDedupKey(externalOrderId),
+          title: `Objednávka ${candidate.externalOrderId} — ${candidate.returnLabel}`,
+          details: [`Zákazník: ${candidate.customerName}`, `Stav objednávky: ${candidate.statusName}`].join("\n"),
+          link: buildShoptetAdminOrderUrl(adminBaseUrl, candidate.externalOrderId, orderIdsByCode.get(candidate.externalOrderId) ?? null),
+          dedupKey: candidate.dedupKey,
           now: options.now,
         });
       }

--- a/apps/api/src/modules/orders/ingest.ts
+++ b/apps/api/src/modules/orders/ingest.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { and, between, eq, inArray, isNotNull, sql } from "drizzle-orm";
+import { between, eq, inArray, sql } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
 import { orderLines, orders, upozornenie, variants } from "../../db/schema.js";
 import { log } from "../../logger.js";
@@ -445,13 +445,33 @@ export async function ingestOrders(db: Database, options: OrdersIngestOptions): 
       // zistí, ktoré už majú VYRIEŠENÝ riadok — tie sa nižšie PRESKOČIA, ostatné
       // (žiadna karta zatiaľ, alebo ešte nevyriešená) sa naďalej vyrobia/obnovia
       // presne ako doteraz (prechod medzi pod-stavmi ostáva funkčný).
+      // Code review (issue 269): bez `.for("update")` by tento SELECT bol
+      // obyčajné READ COMMITTED čítanie — neblokoval by sa na súbežnom
+      // ručnom "Vybavené" (`resolveUpozornenie`, mimo tejto transakcie),
+      // ktorý by mohol commitnúť PRESNE medzi týmto dopytom a nižším
+      // `upsertUpozornenie` volaním pre TEN istý kandidát. V tom úzkom okne
+      // by kandidát vyzeral ešte nevyriešený, `upsertUpozornenie` by ho
+      // normálne obnovil/vytvoril, a hneď potom by sa stal vyriešeným —
+      // ten istý bug, len naživo zriedkavejšie. `.for("update")` zamkne
+      // KAŽDÝ existujúci riadok s niektorým z kandidátnych `dedupKey` na
+      // celý zvyšok tejto transakcie: súbežné `resolveUpozornenie` na
+      // ktoromkoľvek z nich POČKÁ, kým táto transakcia commitne (rovnaký
+      // vzor ako `orders/state.ts`/`.claude/rules/database.md`'s riadkové
+      // zámky), takže rozhodnutie "je/nie je už vyriešený" je vždy
+      // postavené na ČERSTVOM stave, nie na zastaranom snapshote spred
+      // začiatku cyklu. Bez JOINu (jedna tabuľka) nepotrebuje `of` zoznam.
       let resolvedReturnDedupKeys: ReadonlySet<string> = new Set();
       if (returnCandidates.length > 0) {
-        const resolvedRows = await tx
-          .select({ dedupKey: upozornenie.dedupKey })
+        const candidateRows = await tx
+          .select({ dedupKey: upozornenie.dedupKey, resolvedAt: upozornenie.resolvedAt })
           .from(upozornenie)
-          .where(and(inArray(upozornenie.dedupKey, returnCandidates.map((c) => c.dedupKey)), isNotNull(upozornenie.resolvedAt)));
-        resolvedReturnDedupKeys = new Set(resolvedRows.map((row) => row.dedupKey).filter((key): key is string => key !== null));
+          .where(inArray(upozornenie.dedupKey, returnCandidates.map((c) => c.dedupKey)))
+          .for("update");
+        resolvedReturnDedupKeys = new Set(
+          candidateRows
+            .filter((row): row is { dedupKey: string; resolvedAt: Date } => row.resolvedAt !== null && row.dedupKey !== null)
+            .map((row) => row.dedupKey),
+        );
       }
       for (const candidate of returnCandidates) {
         if (resolvedReturnDedupKeys.has(candidate.dedupKey)) continue;

--- a/apps/api/tests/helpers/orders-return-csv.ts
+++ b/apps/api/tests/helpers/orders-return-csv.ts
@@ -1,0 +1,44 @@
+// issue 269 (vydelené code review-om pri druhom spotrebiteľovi, TOCTOU
+// zámkový test `orders-ingest-return-upozornenie-lock.integration.test.ts`):
+// vrátkové stavy ("Vratený tovar" a pod.) nesú diakritiku, a `ingestOrders`
+// VŽDY dekóduje ako windows-1250 (`decodeCp1250`) — obyčajný UTF-8 zápis by
+// diakritiku na druhej strane pokazil (mojibake, `.claude/rules/orders.md`).
+// Táto tabuľka (znak → byte) sa stavia DYNAMICKY dekódovaním všetkých 256
+// bajtov cez `TextDecoder("windows-1250")` a obrátením mapy — žiadna nová
+// závislosť (`iconv-lite`), žiadna ručne prepisovaná tabuľka kódových bodov.
+// Zdieľané, aby ho oba súbory nemuseli stavať nezávisle dvakrát.
+const CP1250_ENCODE: ReadonlyMap<string, number> = (() => {
+  const map = new Map<string, number>();
+  for (let byte = 0; byte < 256; byte += 1) {
+    const ch = new TextDecoder("windows-1250").decode(Buffer.from([byte]));
+    if (!map.has(ch)) map.set(ch, byte);
+  }
+  return map;
+})();
+
+export function encodeCp1250(text: string): Buffer {
+  return Buffer.from(Uint8Array.from(Array.from(text, (ch) => CP1250_ENCODE.get(ch) ?? 0x3f)));
+}
+
+export function buildReturnStatusCsv(header: readonly string[], rows: readonly Record<string, string>[]): Buffer {
+  const esc = (v: string): string => `"${v.replaceAll('"', '""')}"`;
+  const lines = [header.map(esc).join(";") + ";"];
+  for (const row of rows) {
+    lines.push(header.map((c) => esc(row[c] ?? "")).join(";") + ";");
+  }
+  return encodeCp1250(lines.join("\r\n") + "\r\n");
+}
+
+export const RETURN_STATUS_CSV_HEADER = ["code", "date", "statusName", "billFullName", "itemName", "itemAmount", "itemCode"] as const;
+
+export function returnStatusRowOf(code: string, statusName: string): Record<string, string> {
+  return {
+    code,
+    date: "2026-06-15 10:30:00",
+    statusName,
+    billFullName: "Ján Novák",
+    itemName: "Nohavice",
+    itemAmount: "1",
+    itemCode: "40237/XL",
+  };
+}

--- a/apps/api/tests/orders-ingest-return-upozornenie-lock.integration.test.ts
+++ b/apps/api/tests/orders-ingest-return-upozornenie-lock.integration.test.ts
@@ -1,0 +1,120 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { eq } from "drizzle-orm";
+import pg from "pg";
+import { afterEach, expect, it } from "vitest";
+import { upozornenie } from "../src/db/schema.js";
+import { ingestOrders, type OrdersExportFetcher } from "../src/modules/orders/ingest.js";
+import { withCleanDb } from "./helpers/db.js";
+import { insertTestVariant } from "./helpers/orders.js";
+import { buildReturnStatusCsv, RETURN_STATUS_CSV_HEADER, returnStatusRowOf } from "./helpers/orders-return-csv.js";
+
+// Code review (issue 269): vydelené do VLASTNÉHO súboru (rovnaký dôvod ako
+// `orders-state-lock.integration.test.ts` je oddelený od
+// `orders-http-state.integration.test.ts` — `.claude/rules/testing.md`'s
+// eslint `max-lines: 400`). Dokazuje DETERMINISTICKY (rovnaká technika ako
+// `orders-state-lock.integration.test.ts`/`.claude/rules/database.md`'s
+// `pg_stat_activity` dôkaz), že `orders/ingest.ts`'s dávkový pre-check pred
+// vrátkovým cyklom naozaj berie `.for("update")` na kandidátnych riadkoch —
+// bez neho by bol obyčajným READ COMMITTED čítaním, ktoré by sa NIKDY
+// nezaseklo na súbežnom riadkovom zámku (Postgres nikdy nečaká na cudzí
+// zámok pri obyčajnom SELECTe), a rozhodnutie "je/nie je už vyriešený" by sa
+// mohlo oprieť o ZASTARANÝ stav spred súbežného "Vybavené".
+const WINDOW_START = new Date("2020-01-01T00:00:00Z");
+const WINDOW_END = new Date("2030-01-01T00:00:00Z");
+
+let close: (() => Promise<void>) | undefined;
+let rawDir: string | undefined;
+
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  if (rawDir !== undefined) await rm(rawDir, { recursive: true, force: true });
+  rawDir = undefined;
+});
+
+function fetcherOf(body: Buffer): OrdersExportFetcher {
+  return () => Promise.resolve({ body, sourceLabel: "fixtúra" });
+}
+
+it("dávkový pre-check čaká na súbežný riadkový zámok — vidí ČERSTVÝ (vyriešený) stav, nikdy zastaraný", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const db = ctx.db;
+  rawDir = await mkdtemp(join(tmpdir(), "forestshop-orders-return-lock-raw-"));
+  await insertTestVariant(db, "40237/XL");
+
+  const csv = buildReturnStatusCsv(RETURN_STATUS_CSV_HEADER, [returnStatusRowOf("20600100", "Vratený tovar")]);
+  await ingestOrders(db, { fetchExport: fetcherOf(csv), now: new Date("2026-07-30T10:00:00Z"), rawDir, windowStart: WINDOW_START, windowEnd: WINDOW_END });
+  const [card] = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "vratenie:20600100"));
+  if (card === undefined) throw new Error("karta sa nevyrobila");
+  expect(card.resolvedAt).toBeNull();
+
+  const databaseUrl = process.env["DATABASE_URL"];
+  if (databaseUrl === undefined || databaseUrl === "") throw new Error("Integračné testy potrebujú DATABASE_URL");
+  const rawClient = new pg.Client({ connectionString: databaseUrl });
+  const pollClient = new pg.Client({ connectionString: databaseUrl });
+  await rawClient.connect();
+  await pollClient.connect();
+  const rawClientPidResult = await rawClient.query<{ pid: number }>("SELECT pg_backend_pid() AS pid");
+  const rawClientPid = rawClientPidResult.rows[0]?.pid;
+  if (rawClientPid === undefined) throw new Error("nepodarilo sa zistiť backend pid rawClient");
+  await rawClient.query("BEGIN");
+  // Podrží riadkový zámok na TEJ istej karte, aký si `ingest.ts`'s dávkový
+  // pre-check žiada cez vlastné `.for("update")`.
+  await rawClient.query("SELECT id FROM upozornenie WHERE id = $1 FOR UPDATE", [card.id]);
+
+  try {
+    const concurrentImport = ingestOrders(db, {
+      fetchExport: fetcherOf(csv),
+      now: new Date("2026-08-01T10:00:00Z"),
+      rawDir,
+      windowStart: WINDOW_START,
+      windowEnd: WINDOW_END,
+    });
+
+    // Deterministický dôkaz SKUTOČNEJ súbežnosti (`.claude/rules/database.md`'s
+    // `pg_stat_activity` technika, SPRESNENÁ o `pg_blocking_pids` — tento box
+    // zdieľa Postgres s ďalšími súbežnými behmi, takže holé "čaká NIEKTO na
+    // NEJAKÝ zámok" by mohlo dať falošný pozitív z úplne nesúvisiacej
+    // aktivity; over PRIAMO, že blokujúci je PRÁVE `rawClient`) — bounded poll
+    // namiesto pevného `setTimeout`, aby test nezávisel od uhádnutého času.
+    // POZOR: toto dokazuje len že test SKUTOČNE vytvoril súbeh (nie že test
+    // je no-op) — NEROZLIŠUJE, či zaseknutie nastalo na pre-checku (s
+    // opravou) alebo až na `upsertUpozornenie`'s vlastnom `INSERT ... ON
+    // CONFLICT` (Postgres z rovnakého dôvodu čaká na uvoľnenie riadkového
+    // zámku aj BEZ nášho `.for("update")`, len potom uvidí ČERSTVÝ stav príliš
+    // neskoro — arbiter už nekonfliktuje s vyriešeným riadkom, takže vznikne
+    // DRUHÝ riadok). Skutočný dôkaz OPRAVY je AŽ finálna asercia nižšie.
+    const deadline = Date.now() + 5000;
+    let blockedByRawClient = false;
+    while (Date.now() < deadline) {
+      const { rows } = await pollClient.query<{ count: string }>(
+        "SELECT count(*)::text AS count FROM pg_stat_activity a WHERE a.wait_event_type = 'Lock' AND $1 = ANY (pg_blocking_pids(a.pid))",
+        [rawClientPid],
+      );
+      if (Number(rows[0]?.count ?? "0") > 0) {
+        blockedByRawClient = true;
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    expect(blockedByRawClient).toBe(true); // dôkaz, že `.for("update")` skutočne zaseklo druhý import PRÁVE na tomto zámku
+
+    // Simuluje súbežné ručné "Vybavené", ktoré stihlo commitnúť MEDZITÝM —
+    // presne v momente, keď je druhý import zaseknutý na zámku.
+    await rawClient.query("UPDATE upozornenie SET resolved_at = $1 WHERE id = $2", [new Date("2026-07-31T09:00:00Z"), card.id]);
+    await rawClient.query("COMMIT");
+
+    await concurrentImport;
+
+    const after = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "vratenie:20600100"));
+    expect(after).toHaveLength(1); // presne jedna karta — dôkaz, že pre-check videl ČERSTVÝ (commitnutý) vyriešený stav
+    expect(after[0]?.id).toBe(card.id);
+    expect(after[0]?.resolvedAt).not.toBeNull();
+  } finally {
+    await rawClient.end();
+    await pollClient.end();
+  }
+});

--- a/apps/api/tests/orders-ingest-return-upozornenie.integration.test.ts
+++ b/apps/api/tests/orders-ingest-return-upozornenie.integration.test.ts
@@ -3,8 +3,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { eq } from "drizzle-orm";
 import { afterEach, expect, it } from "vitest";
-import { upozornenie } from "../src/db/schema.js";
+import { upozornenie, users } from "../src/db/schema.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
 import { ingestOrders, type OrdersExportFetcher } from "../src/modules/orders/ingest.js";
+import { resolveUpozornenie } from "../src/modules/upozornenia/service.js";
 import { insertTestVariant } from "./helpers/orders.js";
 import { withCleanDb } from "./helpers/db.js";
 
@@ -171,4 +173,41 @@ it("prechod z jedného vrátkového stavu do druhého (Vratený tovar -> Vybaven
   expect(after).toHaveLength(1); // stále JEDNA karta na objednávku, nikdy druhá pre nový pod-stav
   expect(after[0]?.id).toBe(before[0]?.id);
   expect(after[0]?.title).toContain("vybavený dobropis");
+});
+
+// issue 269 (naživo overenie na 0.3.0-dev.160): vybavené vrátenie je
+// KONEČNÉ — na rozdiel od #268's nevyzdvihnutej zásielky sa nesmie NIKDY
+// znova ohlásiť, aj keď Shoptet-ov status objednávky ostáva v tom istom
+// vrátkovom stave navždy (žiadna budúca zmena ho nikdy nevráti späť).
+it("po vybavení karty (Vybavené) opakovaný import UŽ NEVYROBÍ druhú kartu na tú istú objednávku", async () => {
+  const { db, dir } = await boot();
+  await insertTestVariant(db, "40237/XL");
+  const csv = buildCsv(HEADER, [rowOf("20600005", "Vratený tovar")]);
+
+  await ingestOrders(db, { fetchExport: fetcherOf(csv), now: NOW, rawDir: dir, windowStart: WINDOW_START, windowEnd: WINDOW_END });
+  const before = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "vratenie:20600005"));
+  expect(before).toHaveLength(1);
+  const cardId = before[0]?.id;
+  if (cardId === undefined) throw new Error("karta sa nevyrobila");
+
+  const [user] = await db
+    .insert(users)
+    .values({ email: "majitel-269@forestshop.sk", passwordHash: await hashPassword("test-heslo-abc"), displayName: "Majiteľ", role: "manazer" })
+    .returning({ id: users.id });
+  if (user === undefined) throw new Error("test používateľ sa nepodarilo vložiť");
+  const resolved = await resolveUpozornenie(db, { id: cardId, resolvedByUserId: user.id, now: new Date("2026-07-31T09:00:00Z") });
+  expect(resolved).toBe(true);
+
+  await ingestOrders(db, {
+    fetchExport: fetcherOf(csv),
+    now: new Date("2026-08-01T10:00:00Z"),
+    rawDir: dir,
+    windowStart: WINDOW_START,
+    windowEnd: WINDOW_END,
+  });
+
+  const after = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "vratenie:20600005"));
+  expect(after).toHaveLength(1); // presne jedna karta — stále tá vybavená, žiadna nová
+  expect(after[0]?.id).toBe(cardId);
+  expect(after[0]?.resolvedAt).not.toBeNull();
 });

--- a/apps/api/tests/orders-ingest-return-upozornenie.integration.test.ts
+++ b/apps/api/tests/orders-ingest-return-upozornenie.integration.test.ts
@@ -7,8 +7,9 @@ import { upozornenie, users } from "../src/db/schema.js";
 import { hashPassword } from "../src/modules/auth/passwords.js";
 import { ingestOrders, type OrdersExportFetcher } from "../src/modules/orders/ingest.js";
 import { resolveUpozornenie } from "../src/modules/upozornenia/service.js";
-import { insertTestVariant } from "./helpers/orders.js";
 import { withCleanDb } from "./helpers/db.js";
+import { insertTestVariant } from "./helpers/orders.js";
+import { encodeCp1250, RETURN_STATUS_CSV_HEADER, buildReturnStatusCsv, returnStatusRowOf } from "./helpers/orders-return-csv.js";
 
 // issue 269: import objednávok vyrobí/obnoví kartu na Upozorneniach (#267),
 // keď objednávka prejde do vrátkového stavu — vydelené do VLASTNÉHO súboru
@@ -44,45 +45,13 @@ function fetcherOf(body: Buffer): OrdersExportFetcher {
 // diakritiku pri UTF-8 zápise na druhej strane pokazila, `.claude/rules/
 // orders.md`), tento súbor POTREBUJE reálne vrátkové stavy s diakritikou
 // ("Vratený tovar" a pod.) — preto sa CSV zapisuje priamo ako cp1250 BYTES,
-// nie ako UTF-8 text. Kódovaciu tabuľku (znak → byte) staviame DYNAMICKY
-// dekódovaním všetkých 256 bajtov cez `TextDecoder("windows-1250")` a
-// obrátením mapy — žiadna nová závislosť (`iconv-lite`), žiadna ručne
-// prepisovaná tabuľka kódových bodov.
-const CP1250_ENCODE: ReadonlyMap<string, number> = (() => {
-  const map = new Map<string, number>();
-  for (let byte = 0; byte < 256; byte += 1) {
-    const ch = new TextDecoder("windows-1250").decode(Buffer.from([byte]));
-    if (!map.has(ch)) map.set(ch, byte);
-  }
-  return map;
-})();
-
-function encodeCp1250(text: string): Buffer {
-  return Buffer.from(Uint8Array.from(Array.from(text, (ch) => CP1250_ENCODE.get(ch) ?? 0x3f)));
-}
-
-function buildCsv(header: readonly string[], rows: readonly Record<string, string>[]): Buffer {
-  const esc = (v: string): string => `"${v.replaceAll('"', '""')}"`;
-  const lines = [header.map(esc).join(";") + ";"];
-  for (const row of rows) {
-    lines.push(header.map((c) => esc(row[c] ?? "")).join(";") + ";");
-  }
-  return encodeCp1250(lines.join("\r\n") + "\r\n");
-}
-
-const HEADER = ["code", "date", "statusName", "billFullName", "itemName", "itemAmount", "itemCode"] as const;
-
-function rowOf(code: string, statusName: string): Record<string, string> {
-  return {
-    code,
-    date: "2026-06-15 10:30:00",
-    statusName,
-    billFullName: "Ján Novák",
-    itemName: "Nohavice",
-    itemAmount: "1",
-    itemCode: "40237/XL",
-  };
-}
+// nie ako UTF-8 text. Pomocníky sú od issue 269's TOCTOU zámkového testu
+// ZDIEĽANÉ (`./helpers/orders-return-csv.js`), aby ich nemal aj DRUHÝ súbor
+// (`orders-ingest-return-upozornenie-lock.integration.test.ts`) stavať
+// nezávisle znova.
+const HEADER = RETURN_STATUS_CSV_HEADER;
+const buildCsv = buildReturnStatusCsv;
+const rowOf = returnStatusRowOf;
 
 it("encodeCp1250 je verný inverzný krok voči appkinmu decodeCp1250 (sebakontrola fixtúry)", () => {
   const original = "Vratený tovar — Vybavená výmena — Vybavený Dobropis";
@@ -210,4 +179,51 @@ it("po vybavení karty (Vybavené) opakovaný import UŽ NEVYROBÍ druhú kartu 
   expect(after).toHaveLength(1); // presne jedna karta — stále tá vybavená, žiadna nová
   expect(after[0]?.id).toBe(cardId);
   expect(after[0]?.resolvedAt).not.toBeNull();
+});
+
+// Code review (issue 269): jediný predošlý test overoval vždy PRESNE JEDNU
+// vrátkovú objednávku za beh — ale skutočná nová logika je dávkový `Set`
+// (`resolvedReturnDedupKeys`), postavený nad VŠETKÝMI kandidátmi TOHO ISTÉHO
+// importu naraz. Tento test dokazuje, že vybavenie JEDNEJ objednávky v dávke
+// NEOVPLYVNÍ ostatné — objednávka, čo ešte nie je vybavená, sa naďalej
+// normálne obnoví, aj keď je v tom istom CSV/behu ako tá vybavená.
+it("v jednom importe s viacerými vrátkovými objednávkami ovplyvní vybavenie LEN tú svoju kartu", async () => {
+  const { db, dir } = await boot();
+  await insertTestVariant(db, "40237/XL");
+  const csv = buildCsv(HEADER, [rowOf("20600008", "Vratený tovar"), rowOf("20600009", "Vybavená výmena")]);
+
+  await ingestOrders(db, { fetchExport: fetcherOf(csv), now: NOW, rawDir: dir, windowStart: WINDOW_START, windowEnd: WINDOW_END });
+  const beforeResolved = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "vratenie:20600008"));
+  const beforeOpen = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "vratenie:20600009"));
+  expect(beforeResolved).toHaveLength(1);
+  expect(beforeOpen).toHaveLength(1);
+  const resolvedCardId = beforeResolved[0]?.id;
+  const openCardId = beforeOpen[0]?.id;
+  if (resolvedCardId === undefined || openCardId === undefined) throw new Error("karty sa nevyrobili");
+
+  const [user] = await db
+    .insert(users)
+    .values({ email: "majitel-269-dvojica@forestshop.sk", passwordHash: await hashPassword("test-heslo-abc"), displayName: "Majiteľ", role: "manazer" })
+    .returning({ id: users.id });
+  if (user === undefined) throw new Error("test používateľ sa nepodarilo vložiť");
+  expect(await resolveUpozornenie(db, { id: resolvedCardId, resolvedByUserId: user.id, now: new Date("2026-07-31T09:00:00Z") })).toBe(true);
+
+  // Druhý import — rovnaké CSV, obe objednávky ostávajú vo vrátkovom stave.
+  await ingestOrders(db, {
+    fetchExport: fetcherOf(csv),
+    now: new Date("2026-08-01T10:00:00Z"),
+    rawDir: dir,
+    windowStart: WINDOW_START,
+    windowEnd: WINDOW_END,
+  });
+
+  const afterResolved = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "vratenie:20600008"));
+  expect(afterResolved).toHaveLength(1); // vybavená ostáva vybavená, žiadna nová
+  expect(afterResolved[0]?.id).toBe(resolvedCardId);
+  expect(afterResolved[0]?.resolvedAt).not.toBeNull();
+
+  const afterOpen = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "vratenie:20600009"));
+  expect(afterOpen).toHaveLength(1); // stále JEDNA karta, ale STÁLE OBNOVENÁ — nikdy sa nedotkla druhého kandidáta
+  expect(afterOpen[0]?.id).toBe(openCardId);
+  expect(afterOpen[0]?.resolvedAt).toBeNull();
 });

--- a/apps/web/src/components/UpozorneniaSection.tsx
+++ b/apps/web/src/components/UpozorneniaSection.tsx
@@ -324,7 +324,7 @@ export function UpozorneniaSection({ role, onSessionExpired }: { readonly role: 
                 </p>
                 {row.link !== null && (
                   <a href={row.link} data-testid={`upozornenie-link-${row.id}`}>
-                    Otvoriť v appke
+                    Otvoriť objednávku v Shoptete
                   </a>
                 )}
                 {canControl && row.status !== "vybavene" && (

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.160",
+  "version": "0.3.0-dev.161",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Čo to robí

Oprava chyby, ktorú našlo živé overenie predchádzajúceho nasadenia (0.3.0-dev.160) priamo na produkcii.

### 1. Vybavené vrátenie sa už nikdy neohlási znova

Karta „Vrátenie / výmena / dobropis" sa dala kliknutím na **Vybavené** odstrániť, ale ďalší nočný import objednávok ju vyrobil znova — a keďže stav objednávky v Shoptete sa už nikdy nezmení, karta by sa majiteľovi vracala každú noc donekonečna.

Príčina: spoločná zapisovacia cesta má ochranu proti duplicitám zámerne obmedzenú na NEVYBAVENÉ karty (aby sa napr. zásielka, ktorá sa o mesiac znova zasekne, mohla ohlásiť nanovo). Pre vrátenie to ale neplatí — vybavené vrátenie je konečné.

Riešenie: import si vopred, jedným dopytom pre celú dávku, zistí, na ktoré objednávky už karta existuje (aj vybavená), a tie preskočí. Riadky sa pritom zamknú (`.for("update")`), takže druhá kartu nevyrobí ani súbežne bežiaci import. Správanie ostatných zdrojov (zásielky) sa nemení.

### 2. Karta hovorí pravdu o svojom odkaze

Odkaz na karte bol popísaný „Otvoriť v appke", ale vedie do administrácie Shoptetu. Popis opravený, aby text sedel so skutočnosťou.

## Overenie

- Najprv commit s padajúcim testom (`[red]`), až potom oprava (`[green]`) — test teda naozaj chytá tú chybu
- Pribudol aj samostatný test na súbežný beh (overené v oboch smeroch: bez opravy padá, s opravou prechádza) a test na zmiešanú dávku
- `pnpm typecheck`, `pnpm lint` — čisté
- api unit 593, web unit 461, api integračné 537, e2e 46/46 — všetko prešlo
- Nezávislá revízia kódu: 0 kritických; dve dôležité pripomienky opravené v commite `61d9e7d`

issue 269
issue 267
