### PR TITLE
Upozornenia: záložka Vybavené s históriou a vrátením karty späť (issue 283)

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -882,3 +882,29 @@ paths:
   už mal správne. Test na KAŽDÝ ĎALŠÍ `useCallback`/`useEffect` v tomto
   repe: manuálne prejsť, či telo číta niečo, čo NIE JE v dependency poli —
   lint to tu NIKDY nezachytí.
+- **Pridanie DRUHEJ nezávislej pod-obrazovky (záložka/tab) do existujúcej
+  sekcie NESMIE zdediť pôvodnej loading/error "gate" tej PRVEJ pod-
+  obrazovky na CELÝ návratový JSX.** Issue 283 (code review pred mergom,
+  nie test): `UpozorneniaSection.tsx` mal pôvodne `if (rows === null)
+  return <p>Načítavam…</p>;` PRED vykreslením čohokoľvek — keď pribudla
+  nezávislá záložka "Vybavené" (vlastný fetch, vlastný komponent
+  `UpozorneniaResolvedList`), táto stará gata (patriaca LEN "Otvorené"
+  zoznamu) blokovala aj samotný PREPÍNAČ záložiek, takže obsluha sa
+  nedostala k "Vybavené" kým "Otvorené" ešte len načítavalo (alebo
+  sieťovo zlyhalo — v tom prípade NAVŽDY, kým nezobrazí len chybu bez
+  akcie). Fix: `intro`/`tabBar` JSX sa počíta VŽDY (pred akýmkoľvek
+  early-return), samostatná vetva `if (activeTab === "druhá-záložka")
+  return (...)` sa vráti PRED gate patriacou prvej záložke, a gate samotná
+  sa vzťahuje LEN na zvyšný "prvá záložka" flow. TypeScript-ova
+  narrow-cez-ternár past: `activeTab === "X" ? A : B` NEVIE skombinovať
+  narrowing so SAMOSTATNÝM skorším `if (cond && rows === null) return`
+  (dva oddelené kontrolné toky) — preto to musí byť postupnosť
+  PLOCHÝCH `if (...) return (...)` vetiev v JEDNOM rovnom toku, nie
+  ternár za skorším podmieneným returnom. Regresný test (`UpozorneniaSection
+  .resolvedTab.test.tsx`): mockni prvej záložky fetch tak, aby sa NIKDY
+  nevyriešil (`new Promise(() => {})`) aj tak, aby zlyhal, a over v OBOCH
+  prípadoch, že prepínač záložiek (`data-testid="...-tab-druhá"`) je
+  napriek tomu v DOM-e. Test pre KAŽDÚ ĎALŠIU sekciu, čo dostane DRUHÚ
+  nezávislú záložku: patrí existujúca loading/error gate LEN jednej
+  záložke? Ak áno, presuň ju AŽ ZA vetvu tej druhej, nikdy ju nenechaj
+  gatovať spoločný prepínač.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -571,3 +571,21 @@ paths:
   `ps aux | grep vitest`, či nebeží iný súbežný beh — najmä po tom, čo
   agent spustil viac `run_in_background` testovacích príkazov v tej istej
   relácii bez čakania na ich skutočné dokončenie.
+- **Rovnaký symptóm (`Hook timed out in 10000ms` v `restock-run
+  .integration.test.ts`, aj Playwright e2e `Test timeout of 30000ms
+  exceeded` v ÚPLNE INÝCH, nesúvisiacich spec súboroch) sa dá vyrobiť AJ
+  BEZ druhého `vitest`/e2e procesu — stačí, že `dev1` je zaťažený INÝMI
+  súbežnými Claude reláciami/procesmi.** Issue 283: `ps aux | grep vitest`
+  bol čistý (žiadny osirelý test proces), ale `uptime` ukázal load average
+  ~14-17 (5+ súbežných `claude` relácií + `pytest` behy + GitHub Actions
+  runner na tom istom boxe) — 19/19 testov v `restock-run.integration
+  .test.ts` aj viacero NESÚVISIACICH e2e testov (`orders.spec.ts`,
+  `pairing.spec.ts`, `orders-supplier-link.spec.ts`) padlo na timeout v
+  JEDNOM behu, potom prešlo 100% pri izolovanom re-behu TOHO ISTÉHO
+  súboru bez zmeny kódu. Test pred DÔVEROVANÍM červenému výsledku:
+  `ps aux | grep vitest` NESTAČÍ samo osebe — over AJ `uptime` (vysoký
+  load average bez zjavného vlastného vitest/pytest procesu) a pri
+  podozrení preveruj IZOLOVANÝM re-behom PRESNE toho zlyhaného
+  súboru/testu (`vitest run tests/<súbor>` / `playwright test
+  tests/e2e/<súbor>`), nikdy nepredpokladaj regresiu len z jedného
+  červeného plného behu na zdieľanom, vyťaženom boxe.

--- a/.claude/rules/upozornenia.md
+++ b/.claude/rules/upozornenia.md
@@ -235,3 +235,34 @@ paths:
   všetko".** Upsert prepíše byte-identické hodnoty, takže asercie prejdú aj
   pri pokazenej logike. Dávkový test musí druhému (neovplyvnenému) kandidátovi
   ZMENIŤ pod-stav a overiť, že sa titulok SKUTOČNE zmenil.
+- **Issue 283 (majiteľ, komentár na tickete): "vrátenie vyriešenej karty späť
+  medzi otvorené" (záložka "Vybavené", `returnUpozornenieToOpen`,
+  `service.ts`) odchytáva kolíziu s `upozornenie_dedup_key_uq` PRIAMO z DB
+  chyby JEDNÉHO atomického `UPDATE`u (SQLSTATE 23505, `constraint ===
+  "upozornenie_dedup_key_uq"`), NIE cez samostatný SELECT-pred-UPDATE
+  pre-check.** Ten istý vzor ako `catalog/ingest.ts`'s (neexportovaná)
+  `isUniqueViolation` — duplikovaná v `upozornenia/service.ts` zámerne malá
+  (mvp-philosophy: žiadna zdieľaná abstrakcia pre dvoch konzumentov v
+  nesúvisiacich moduloch). Pre-check by znovu otvoril PRESNE tú TOCTOU triedu
+  chyby, akú tento modul už dvakrát riešil na tom istom čiastočnom indexe
+  (#272/#269, vyššie v tomto súbore) — atomický UPDATE + odchytenie chyby je
+  race-proof z podstaty. Test na KAŽDÚ ĎALŠIU akciu na tomto module, ktorá
+  môže naraziť na ČIASTOČNÝ unique index: over najprv, či existuje atomický
+  SQL príkaz + chybu-odchytávajúci vzor, predtým než siahneš po
+  SELECT-pred-zápisom pre-checku.
+- **`GET /api/upozornenia/resolved` (história vybavených) je NOVÁ trasa, nie
+  ďalší filter na existujúcej `GET /api/upozornenia`** — zámerne INÝ tvar
+  výstupu (`resolvedByName` cez `LEFT JOIN users`) aj INÉ triedenie
+  (`resolvedAt DESC`, nie `dueAt ASC`/`createdAt DESC`). Cap namiesto
+  stránkovania (`RESOLVED_LIST_LIMIT = 200`) je rovnaký vzor ako `mail-log/
+  queries.ts`'s pevný `limit: 200` — appka nikde inde nemá stránkovaciu UI.
+- **Kolízia vrátenia (dva riadky s ROVNAKÝM `dedupKey`, jeden vyriešený a
+  jeden otvorený) sa NEDÁ vyrobiť cez ŽIADNU appkinu UI akciu** — vlastné
+  poznámky nikdy nenesú `dedupKey` (nikdy nekolidujú), a kartu s ním vyrába
+  LEN automatický import (mimo dosahu bežného klikania). Preto ju overuje
+  LEN service+HTTP integračný test (`upozornenia-resolved.integration
+  .test.ts`/`upozornenia-resolved-http.integration.test.ts`), NIE Playwright
+  e2e — rovnaký princíp ako `e2e-real-user-testing.md`'s výnimka pre backend
+  scenáre, ktoré skutočný používateľ klikaním nikdy nevyrobí. E2E
+  (`upozornenia.spec.ts`) namiesto toho overuje LEN to, čo je reálne
+  dosiahnuteľné klikaním: záložka "Vybavené" + úspešné vrátenie karty späť.

--- a/apps/api/src/http/upozornenia-routes.ts
+++ b/apps/api/src/http/upozornenia-routes.ts
@@ -3,7 +3,7 @@ import type { Hono } from "hono";
 import { z } from "zod";
 import type { Database } from "../db/client.js";
 import { record } from "../modules/audit/service.js";
-import { countActionableUpozornenia, listUpozornenia, type UpozornenieTypeValue } from "../modules/upozornenia/queries.js";
+import { countActionableUpozornenia, listResolvedUpozornenia, listUpozornenia, type UpozornenieTypeValue } from "../modules/upozornenia/queries.js";
 import {
   cancelPostpone,
   createOwnNote,
@@ -11,6 +11,7 @@ import {
   markAllSeen,
   postponeUpozornenie,
   resolveUpozornenie,
+  returnUpozornenieToOpen,
   updateOwnNote,
 } from "../modules/upozornenia/service.js";
 import { requireRole, requireUser, type AppBindings } from "./middleware.js";
@@ -62,6 +63,15 @@ export function registerUpozorneniaRoutes(app: Hono<AppBindings>, db: Database):
   app.get("/api/upozornenia/count", requireUser(db), async (c) => {
     const count = await countActionableUpozornenia(db, new Date());
     return c.json({ count });
+  });
+
+  // issue 283: záložka "Vybavené" — história vybavených kariet, rovnaká
+  // čítacia úroveň oprávnenia ako hlavný zoznam vyššie. Literal-path
+  // súrodenec pred akoukoľvek budúcou `/api/upozornenia/:id` GET trasou
+  // (`.claude/rules/http-routes.md`).
+  app.get("/api/upozornenia/resolved", requireUser(db), async (c) => {
+    const rows = await listResolvedUpozornenia(db, new Date());
+    return c.json({ rows });
   });
 
   // Vytvorenie vlastnej poznámky — rovnaká rola ako zvyšok appky pre zápis.
@@ -163,5 +173,22 @@ export function registerUpozorneniaRoutes(app: Hono<AppBindings>, db: Database):
       await record(db, { at: now, actorUserId: user.userId, action: "upozornenie.postpone_cancelled", entity: "upozornenie", entityId: id, data: { id } });
     }
     return c.json({ ok: true as const, cancelled });
+  });
+
+  // issue 283 (majiteľ, komentár na tickete): vrátenie omylom vybavenej
+  // karty späť medzi otvorené, zo záložky "Vybavené". `result` je jedna z
+  // troch hodnôt (`returnUpozornenieToOpen`'s vlastný komentár) — 200 vo
+  // VŠETKÝCH prípadoch vrátane kolízie (rovnaká disciplína ako `/resolve`/
+  // `/cancel-postpone` — bežné, OČAKÁVANÉ zlyhanie nikdy nie je 4xx/5xx,
+  // `.claude/rules/testing.md`).
+  app.post("/api/upozornenia/:id/return-to-open", requireSameOrigin(), requireUser(db), requireRole("admin", "manazer"), zValidator("param", idParam), async (c) => {
+    const { id } = c.req.valid("param");
+    const user = c.get("user");
+    const now = new Date();
+    const result = await returnUpozornenieToOpen(db, { id });
+    if (result === "returned") {
+      await record(db, { at: now, actorUserId: user.userId, action: "upozornenie.returned_to_open", entity: "upozornenie", entityId: id, data: { id } });
+    }
+    return c.json({ ok: true as const, result });
   });
 }

--- a/apps/api/src/modules/upozornenia/queries.ts
+++ b/apps/api/src/modules/upozornenia/queries.ts
@@ -1,6 +1,6 @@
-import { and, asc, count, desc, eq, isNull, lte, or, type SQL } from "drizzle-orm";
+import { and, asc, count, desc, eq, isNotNull, isNull, lte, or, type SQL } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
-import { upozornenie, type upozornenieType } from "../../db/schema.js";
+import { upozornenie, users, type upozornenieType } from "../../db/schema.js";
 import { computeStatus, type UpozornenieStatus } from "./status.js";
 
 export type UpozornenieTypeValue = (typeof upozornenieType.enumValues)[number];
@@ -81,4 +81,51 @@ export async function countActionableUpozornenia(db: Database, now: Date): Promi
     .from(upozornenie)
     .where(and(isNull(upozornenie.resolvedAt), notPostponedCondition(now)));
   return row?.total ?? 0;
+}
+
+// issue 283: majiteľ rozhodol na tickete — záložka "Vybavené" na nástenke,
+// história vybavených kariet zoradená OD NAJNOVŠIE VYBAVENÝCH, s menom+časom
+// toho, kto vybavil. Rovnaký cap-namiesto-stránkovania vzor ako `mail-log/
+// queries.ts`'s pevný `limit: 200` — appka nikde inde nemá stránkovaciu UI, a
+// tabuľka rastie monotónne (vybavené vrátkové karty sa nikdy nemažú, viď
+// `.claude/rules/upozornenia.md`), takže cap je nutný.
+export const RESOLVED_LIST_LIMIT = 200;
+
+export interface ResolvedUpozornenieRow extends UpozornenieRow {
+  // `null` = vybavené AUTOMATICKY systémom (#268's `autoResolveByDedupKey`
+  // nikdy nevypĺňa `resolvedByUserId` — schéma to explicitne predpovedá,
+  // `schema-upozornenia.ts`). Frontend zobrazí zástupný text "automaticky".
+  // Code review: `resolvedByUserId` má `onDelete: "set null"` — ak sa neskôr
+  // zmaže účet zamestnanca, čo predtým RUČNE vybavil kartu, `resolvedByName`
+  // sa stane `null` a tá karta sa zobrazí nerozoznateľne od naozaj
+  // automaticky vybavenej. Prijaté zámerne (predpríprava opačnej výnimky by
+  // vyžadovala nový stĺpec/audit záznam mimo rozsahu tohto ticketu) — ak sa
+  // niekedy ukáže ako problém, riešenie je čítať `audit_events` (`entity:
+  // "upozornenie"`, `action: "upozornenie.resolved"`) namiesto tejto FK.
+  readonly resolvedByName: string | null;
+}
+
+export async function listResolvedUpozornenia(db: Database, now: Date): Promise<readonly ResolvedUpozornenieRow[]> {
+  const rows = await db
+    .select({
+      id: upozornenie.id,
+      type: upozornenie.type,
+      source: upozornenie.source,
+      title: upozornenie.title,
+      details: upozornenie.details,
+      link: upozornenie.link,
+      dueAt: upozornenie.dueAt,
+      postponedUntil: upozornenie.postponedUntil,
+      seenAt: upozornenie.seenAt,
+      resolvedAt: upozornenie.resolvedAt,
+      createdAt: upozornenie.createdAt,
+      resolvedByName: users.displayName,
+    })
+    .from(upozornenie)
+    .leftJoin(users, eq(upozornenie.resolvedByUserId, users.id))
+    .where(isNotNull(upozornenie.resolvedAt))
+    .orderBy(desc(upozornenie.resolvedAt))
+    .limit(RESOLVED_LIST_LIMIT);
+
+  return rows.map((r) => ({ ...r, status: computeStatus(r, now) }));
 }

--- a/apps/api/src/modules/upozornenia/service.ts
+++ b/apps/api/src/modules/upozornenia/service.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull, sql } from "drizzle-orm";
+import { and, eq, isNotNull, isNull, sql } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
 import { upozornenie } from "../../db/schema.js";
 import type { UpozornenieSourceValue, UpozornenieTypeValue } from "./queries.js";
@@ -231,4 +231,48 @@ export async function updateIfUnresolvedByDedupKey(db: UpozornenieExecutor, dedu
 export async function markAllSeen(db: Database, now: Date): Promise<number> {
   const result = await db.update(upozornenie).set({ seenAt: now }).where(isNull(upozornenie.seenAt)).returning({ id: upozornenie.id });
   return result.length;
+}
+
+// SQLSTATE 23505 = unique_violation. Rovnaký vzor ako `catalog/ingest.ts`'s
+// `isUniqueViolation` (tam neexportovaná, jediný dovtedy konzument) —
+// duplikovaná tu zámerne malá (10 riadkov), namiesto zdieľanej abstrakcie pre
+// dvoch konzumentov, ktorí navyše žijú v úplne nesúvisiacich moduloch
+// (`.claude/rules/mvp-philosophy.md`'s "žiadna abstrakcia pre jediného/pár
+// konzumentov, ak je priama implementácia rovnako čitateľná").
+function isUniqueViolation(error: unknown, constraint: string): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "23505" && "constraint" in error && error.constraint === constraint;
+}
+
+export type ReturnToOpenResult = "returned" | "no_op" | "collision";
+
+export interface ReturnToOpenInput {
+  readonly id: string;
+}
+
+// issue 283 (majiteľ, komentár na tickete): "Vybavené" záložka umožňuje
+// vrátiť omylom vybavenú kartu späť medzi otvorené. `upozornenie_dedup_key_uq`
+// je ČIASTOČNÝ unique index (`WHERE resolved_at IS NULL`,
+// `schema-upozornenia.ts`) — vyčistenie `resolvedAt` môže preto naraziť na
+// UŽ EXISTUJÚCU otvorenú kartu s rovnakým `dedupKey` (automatický zdroj,
+// napr. #269's vrátenie, ktoré je zámerne znovu-ohlásiteľné). Kolízia sa
+// ODCHYTÁVA z DB chyby jediného atomického UPDATE-u (rovnaký princíp ako
+// `upsertUpozornenie`'s `ON CONFLICT`), NIE cez samostatný SELECT-pred-UPDATE
+// pre-check — ten by znovu otvoril presne tú TOCTOU triedu chyby, akú tento
+// modul už dvakrát riešil na tom istom čiastočnom indexe (#272/#269,
+// `.claude/rules/upozornenia.md`). WHERE `resolved_at IS NOT NULL` zaručuje,
+// že karta, ktorá už NIE JE vybavená (dvojklik/medzičasom vrátená inak), sa
+// tíško no-opne — rovnaká disciplína ako `resolveUpozornenie`/`cancelPostpone`
+// vyššie (neznáme/nevhodné id nikdy nevyhodí, vždy 200).
+export async function returnUpozornenieToOpen(db: Database, input: ReturnToOpenInput): Promise<ReturnToOpenResult> {
+  try {
+    const result = await db
+      .update(upozornenie)
+      .set({ resolvedAt: null, resolvedByUserId: null })
+      .where(and(eq(upozornenie.id, input.id), isNotNull(upozornenie.resolvedAt)))
+      .returning({ id: upozornenie.id });
+    return result.length > 0 ? "returned" : "no_op";
+  } catch (error) {
+    if (isUniqueViolation(error, "upozornenie_dedup_key_uq")) return "collision";
+    throw error;
+  }
 }

--- a/apps/api/tests/orders-ingest-return-upozornenie-reopen.integration.test.ts
+++ b/apps/api/tests/orders-ingest-return-upozornenie-reopen.integration.test.ts
@@ -1,0 +1,94 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { eq } from "drizzle-orm";
+import { afterEach, expect, it } from "vitest";
+import { upozornenie, users } from "../src/db/schema.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import { ingestOrders, type OrdersExportFetcher } from "../src/modules/orders/ingest.js";
+import { resolveUpozornenie, returnUpozornenieToOpen } from "../src/modules/upozornenia/service.js";
+import { withCleanDb } from "./helpers/db.js";
+import { insertTestVariant } from "./helpers/orders.js";
+import { encodeCp1250, RETURN_STATUS_CSV_HEADER, buildReturnStatusCsv, returnStatusRowOf } from "./helpers/orders-return-csv.js";
+
+// issue 283 (majiteľova podmienka na tickete): keď sa vybavené vrátenie
+// vráti späť medzi otvorené (`returnUpozornenieToOpen`), `orders/ingest.ts`'s
+// pre-check (`hasUnresolvedByKey`) uvidí pre jej `dedupKey` NEVYRIEŠENÝ
+// súrodenec — ĎALŠÍ nočný import ju preto ZNOVA obnoví (rovnaká cesta, akou
+// by prešla akákoľvek iná otvorená vrátková karta). Ticket to explicitne
+// hovorí ako OČAKÁVANÉ/SPRÁVNE správanie ("that is correct and intended") —
+// tento test to DOKAZUJE, kód `ingest.ts` sa NEMENÍ. Vydelené do VLASTNÉHO
+// súboru rovnakým vzorom ako `-lock.integration.test.ts` (`.claude/rules/
+// testing.md`'s eslint `max-lines: 400`, existujúci `orders-ingest-return-
+// upozornenie.integration.test.ts` je už na 309 riadkoch).
+const WINDOW_START = new Date("2020-01-01T00:00:00Z");
+const WINDOW_END = new Date("2030-01-01T00:00:00Z");
+const NOW = new Date("2026-08-06T10:00:00Z");
+
+let close: (() => Promise<void>) | undefined;
+let rawDir: string | undefined;
+
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  if (rawDir !== undefined) await rm(rawDir, { recursive: true, force: true });
+  rawDir = undefined;
+});
+
+async function boot(): Promise<{ db: Awaited<ReturnType<typeof withCleanDb>>["db"]; dir: string }> {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  rawDir = await mkdtemp(join(tmpdir(), "forestshop-orders-return-reopen-raw-"));
+  return { db: ctx.db, dir: rawDir };
+}
+
+function fetcherOf(body: Buffer): OrdersExportFetcher {
+  return () => Promise.resolve({ body, sourceLabel: "fixtúra" });
+}
+
+it("encodeCp1250 je verný inverzný krok voči appkinmu decodeCp1250 (sebakontrola fixtúry)", () => {
+  expect(new TextDecoder("windows-1250").decode(encodeCp1250("Vratený tovar"))).toBe("Vratený tovar");
+});
+
+it("karta vrátená späť medzi otvorené sa ĎALŠÍM importom ZNOVA obnoví — nezostane navždy zamrznutá", async () => {
+  const { db, dir } = await boot();
+  await insertTestVariant(db, "40237/XL");
+  const csv = buildReturnStatusCsv(RETURN_STATUS_CSV_HEADER, [returnStatusRowOf("20700010", "Vratený tovar")]);
+
+  await ingestOrders(db, { fetchExport: fetcherOf(csv), now: NOW, rawDir: dir, windowStart: WINDOW_START, windowEnd: WINDOW_END });
+  const before = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "vratenie:20700010"));
+  expect(before).toHaveLength(1);
+  const cardId = before[0]?.id;
+  if (cardId === undefined) throw new Error("karta sa nevyrobila");
+
+  const [user] = await db
+    .insert(users)
+    .values({ email: "majitel-283-reopen@forestshop.sk", passwordHash: await hashPassword("test-heslo-abc"), displayName: "Majiteľ", role: "manazer" })
+    .returning({ id: users.id });
+  if (user === undefined) throw new Error("test používateľ sa nepodarilo vložiť");
+
+  // Majiteľ omylom klikol "Vybavené", potom si to rozmyslel a vrátil kartu
+  // späť medzi otvorené zo záložky "Vybavené".
+  expect(await resolveUpozornenie(db, { id: cardId, resolvedByUserId: user.id, now: new Date("2026-08-06T11:00:00Z") })).toBe(true);
+  expect(await returnUpozornenieToOpen(db, { id: cardId })).toBe("returned");
+  const afterReturn = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "vratenie:20700010"));
+  expect(afterReturn).toHaveLength(1); // stále JEDNA karta — vrátenie neduplikuje
+  expect(afterReturn[0]?.resolvedAt).toBeNull();
+
+  // Ďalší import (napr. nasledujúcu noc) — karta je teraz NEVYRIEŠENÁ, takže
+  // pre-check ju NEPRESKOČÍ; ten istý pod-stav sa upsertne (obnoví) ako
+  // ktorákoľvek iná otvorená vrátková karta.
+  await ingestOrders(db, {
+    fetchExport: fetcherOf(buildReturnStatusCsv(RETURN_STATUS_CSV_HEADER, [returnStatusRowOf("20700010", "Vybavená výmena")])),
+    now: new Date("2026-08-07T10:00:00Z"),
+    rawDir: dir,
+    windowStart: WINDOW_START,
+    windowEnd: WINDOW_END,
+  });
+
+  const after = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "vratenie:20700010"));
+  expect(after).toHaveLength(1); // stále presne jedna karta, žiadna duplicita
+  expect(after[0]?.id).toBe(cardId); // TÁ ISTÁ karta — obnovená, nie nová
+  expect(after[0]?.resolvedAt).toBeNull(); // ostáva otvorená
+  expect(after[0]?.title).toContain("vybavená výmena"); // OBNOVENÁ — dôkaz že import ju vôbec nepreskočil
+});

--- a/apps/api/tests/upozornenia-resolved-http.integration.test.ts
+++ b/apps/api/tests/upozornenia-resolved-http.integration.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { users } from "../src/db/schema.js";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import type { UserRole } from "../src/modules/auth/service.js";
+import { autoResolveByDedupKey, upsertUpozornenie } from "../src/modules/upozornenia/service.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 283 (majiteľ, komentár na tickete): "Vybavené" záložka — HTTP vrstva
+// pre `GET /api/upozornenia/resolved` a `POST /api/upozornenia/:id/return-to-
+// open`, vydelené do VLASTNÉHO súboru rovnakým vzorom ako `upozornenia-http
+// .integration.test.ts` (`.claude/rules/testing.md`'s eslint `max-lines: 400`).
+const HESLO = "test-heslo-abc";
+
+let close: (() => Promise<void>) | undefined;
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  resetLoginRateLimit();
+});
+
+async function boot(role: UserRole) {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await ctx.db.insert(users).values({ email: "pouzivatel-283@forestshop.sk", passwordHash: await hashPassword(HESLO), displayName: "Test", role });
+  const app = createApp(ctx.db, { cookieSecure: false });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "pouzivatel-283@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie, db: ctx.db };
+}
+
+describe("GET /api/upozornenia/resolved", () => {
+  // Rola 'citanie' nesmie `POST /resolve` (`requireRole("admin","manazer")`)
+  // — táto rola tu preto len ČÍTA, vyriešenie nastáva PRIAMO cez `db`
+  // (`autoResolveByDedupKey`, rovnaký vzor ako `upozornenia-http.integration
+  // .test.ts`'s `upsertUpozornenie(db, ...)` volania), nie cez HTTP trasu,
+  // ktorú by táto rola dostala 403.
+  it("čítanie funguje pre KAŽDÚ prihlásenú rolu (aj len-na-čítanie), vráti len vyriešené", async () => {
+    const { app, cookie, db } = await boot("citanie");
+    const now = new Date("2026-08-06T08:00:00Z");
+    await upsertUpozornenie(db, { type: "vlastna_poznamka", source: "vlastne", title: "Otvorená", now });
+    await upsertUpozornenie(db, { type: "nevyzdvihnuta_zasielka", source: "appka", title: "Vyriešená", dedupKey: "posta:283TEST", now });
+    await autoResolveByDedupKey(db, "posta:283TEST", now);
+
+    const res = await app.request("/api/upozornenia/resolved", { headers: { cookie } });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { rows: readonly { title: string }[] };
+    expect(body.rows.map((r) => r.title)).toEqual(["Vyriešená"]);
+  });
+
+  it("nesie meno toho, kto vyriešil (rola 'manazer' klikla 'Vybavené' cez HTTP)", async () => {
+    const { app, cookie, db } = await boot("manazer");
+    const now = new Date("2026-08-06T08:00:00Z");
+    const resolvedCreate = await upsertUpozornenie(db, { type: "vlastna_poznamka", source: "vlastne", title: "Vyriešená", now });
+    await app.request(`/api/upozornenia/${resolvedCreate.id}/resolve`, { method: "POST", headers: { cookie } });
+
+    const res = await app.request("/api/upozornenia/resolved", { headers: { cookie } });
+    const body = (await res.json()) as { rows: readonly { title: string; resolvedByName: string | null }[] };
+    expect(body.rows.map((r) => r.title)).toEqual(["Vyriešená"]);
+    expect(body.rows[0]?.resolvedByName).toBe("Test");
+  });
+
+  it("bez prihlásenia vráti 401", async () => {
+    const { app } = await boot("manazer");
+    const res = await app.request("/api/upozornenia/resolved");
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("POST /api/upozornenia/:id/return-to-open", () => {
+  it("rola 'citanie' NEMÔŽE vrátiť kartu späť (403)", async () => {
+    const { app, cookie, db } = await boot("citanie");
+    const now = new Date("2026-08-06T08:00:00Z");
+    const created = await upsertUpozornenie(db, { type: "vlastna_poznamka", source: "vlastne", title: "Vyriešená", now });
+    await app.request(`/api/upozornenia/${created.id}/resolve`, { method: "POST", headers: { cookie } });
+    const res = await app.request(`/api/upozornenia/${created.id}/return-to-open`, { method: "POST", headers: { cookie } });
+    expect(res.status).toBe(403);
+  });
+
+  it("rola 'manazer' vráti vyriešenú kartu späť medzi otvorené — objaví sa v predvolenom (bez includeResolved) zozname", async () => {
+    const { app, cookie, db } = await boot("manazer");
+    const now = new Date("2026-08-06T08:00:00Z");
+    const created = await upsertUpozornenie(db, { type: "vlastna_poznamka", source: "vlastne", title: "Omylom vybavená", now });
+    await app.request(`/api/upozornenia/${created.id}/resolve`, { method: "POST", headers: { cookie } });
+
+    const returnRes = await app.request(`/api/upozornenia/${created.id}/return-to-open`, { method: "POST", headers: { cookie } });
+    expect((await returnRes.json()) as { ok: boolean; result: string }).toEqual({ ok: true, result: "returned" });
+
+    const list = await app.request("/api/upozornenia", { headers: { cookie } });
+    const body = (await list.json()) as { rows: readonly { title: string; status: string }[] };
+    expect(body.rows.map((r) => r.title)).toEqual(["Omylom vybavená"]);
+    expect(body.rows[0]?.status).toBe("otvorene");
+
+    const resolvedList = await app.request("/api/upozornenia/resolved", { headers: { cookie } });
+    const resolvedBody = (await resolvedList.json()) as { rows: readonly unknown[] };
+    expect(resolvedBody.rows).toEqual([]);
+  });
+
+  it("neznáme id vráti 200 {result:'no_op'}, nikdy chybu", async () => {
+    const { app, cookie } = await boot("manazer");
+    const res = await app.request("/api/upozornenia/00000000-0000-0000-0000-000000000000/return-to-open", { method: "POST", headers: { cookie } });
+    expect(res.status).toBe(200);
+    expect((await res.json()) as { ok: boolean; result: string }).toEqual({ ok: true, result: "no_op" });
+  });
+
+  it("kolízia s existujúcou otvorenou kartou rovnakého dedupKey vráti 200 {result:'collision'}, nikdy 500", async () => {
+    const { app, cookie, db } = await boot("manazer");
+    const now = new Date("2026-08-06T08:00:00Z");
+    const dedupKey = "vratenie:20700099";
+    const resolved = await upsertUpozornenie(db, { type: "vratenie", source: "appka", title: "Staršia vlna", dedupKey, now });
+    await app.request(`/api/upozornenia/${resolved.id}/resolve`, { method: "POST", headers: { cookie } });
+    await upsertUpozornenie(db, { type: "vratenie", source: "appka", title: "Nová vlna", dedupKey, now: new Date("2026-08-06T12:00:00Z") });
+
+    const res = await app.request(`/api/upozornenia/${resolved.id}/return-to-open`, { method: "POST", headers: { cookie } });
+    expect(res.status).toBe(200);
+    expect((await res.json()) as { ok: boolean; result: string }).toEqual({ ok: true, result: "collision" });
+  });
+
+  it("bez prihlásenia vráti 401", async () => {
+    const { app } = await boot("manazer");
+    const res = await app.request("/api/upozornenia/00000000-0000-0000-0000-000000000000/return-to-open", { method: "POST" });
+    expect(res.status).toBe(401);
+  });
+});

--- a/apps/api/tests/upozornenia-resolved.integration.test.ts
+++ b/apps/api/tests/upozornenia-resolved.integration.test.ts
@@ -1,0 +1,159 @@
+import { eq } from "drizzle-orm";
+import { afterEach, describe, expect, it } from "vitest";
+import { upozornenie, users } from "../src/db/schema.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import { listResolvedUpozornenia, RESOLVED_LIST_LIMIT } from "../src/modules/upozornenia/queries.js";
+import { autoResolveByDedupKey, resolveUpozornenie, returnUpozornenieToOpen, upsertUpozornenie } from "../src/modules/upozornenia/service.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 283 (majiteľ, komentár na tickete): záložka "Vybavené" — service-level
+// testy pre `listResolvedUpozornenia` a `returnUpozornenieToOpen`, vydelené do
+// VLASTNÉHO súboru (rovnaký dôvod ako iné rozdelenia v tomto adresári,
+// `.claude/rules/testing.md`'s eslint `max-lines: 400`).
+
+let close: (() => Promise<void>) | undefined;
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+});
+
+async function bootDb() {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const [user] = await ctx.db
+    .insert(users)
+    .values({ email: "majitel-283@forestshop.sk", passwordHash: await hashPassword("test-heslo-abc"), displayName: "Majiteľ Testovací", role: "manazer" })
+    .returning({ id: users.id });
+  if (user === undefined) throw new Error("test používateľ sa nepodarilo vložiť");
+  return { db: ctx.db, userId: user.id };
+}
+
+describe("listResolvedUpozornenia", () => {
+  it("vráti LEN vyriešené karty, zoradené od NAJNOVŠIE vyriešených", async () => {
+    const { db, userId } = await bootDb();
+    const now = new Date("2026-08-06T08:00:00Z");
+    const open = await upsertUpozornenie(db, { type: "vlastna_poznamka", source: "vlastne", title: "Ešte otvorená", now });
+    const first = await upsertUpozornenie(db, { type: "vlastna_poznamka", source: "vlastne", title: "Vyriešená skôr", now });
+    const second = await upsertUpozornenie(db, { type: "vlastna_poznamka", source: "vlastne", title: "Vyriešená neskôr", now });
+    await resolveUpozornenie(db, { id: first.id, resolvedByUserId: userId, now: new Date("2026-08-06T09:00:00Z") });
+    await resolveUpozornenie(db, { id: second.id, resolvedByUserId: userId, now: new Date("2026-08-06T10:00:00Z") });
+    void open;
+
+    const rows = await listResolvedUpozornenia(db, now);
+    expect(rows.map((r) => r.title)).toEqual(["Vyriešená neskôr", "Vyriešená skôr"]);
+    expect(rows.every((r) => r.status === "vybavene")).toBe(true);
+  });
+
+  it("nesie meno toho, kto vybavil ručne, a 'null' pre AUTOMATICKY vybavenú kartu", async () => {
+    const { db, userId } = await bootDb();
+    const now = new Date("2026-08-06T08:00:00Z");
+    const manual = await upsertUpozornenie(db, { type: "vlastna_poznamka", source: "vlastne", title: "Ručne vybavená", now });
+    await resolveUpozornenie(db, { id: manual.id, resolvedByUserId: userId, now });
+    await upsertUpozornenie(db, { type: "nevyzdvihnuta_zasielka", source: "appka", title: "Automaticky vybavená", dedupKey: "posta:AUTO1", now });
+    await autoResolveByDedupKey(db, "posta:AUTO1", now);
+
+    const rows = await listResolvedUpozornenia(db, now);
+    const manualRow = rows.find((r) => r.title === "Ručne vybavená");
+    const autoRow = rows.find((r) => r.title === "Automaticky vybavená");
+    expect(manualRow?.resolvedByName).toBe("Majiteľ Testovací");
+    expect(autoRow?.resolvedByName).toBeNull();
+  });
+
+  // Code review: predchádzajúca verzia overovala len `RESOLVED_LIST_LIMIT ===
+  // 200` — prešla by aj keby samotné `.limit(...)` volanie v `queries.ts`
+  // niekto omylom zmazal. Skutočný regresný dôkaz musí SKUTOČNE nasadiť viac
+  // riadkov, než je cap, a overiť, že orezanie naozaj funguje aj SMEROVO
+  // (najnovšie vyriešené prežijú, najstaršie orezané odpadnú).
+  it("orezanie na RESOLVED_LIST_LIMIT (200) SKUTOČNE funguje — najstaršie vyriešené odpadnú, najnovšie ostanú", async () => {
+    const { db } = await bootDb();
+    const now = new Date("2026-08-06T08:00:00Z");
+    const TOTAL = RESOLVED_LIST_LIMIT + 5;
+    await db.insert(upozornenie).values(
+      Array.from({ length: TOTAL }, (_, i) => ({
+        type: "vlastna_poznamka" as const,
+        source: "vlastne" as const,
+        title: `Cap ${String(i)}`,
+        resolvedAt: new Date(now.getTime() + i * 1000),
+        createdAt: now,
+      })),
+    );
+
+    const rows = await listResolvedUpozornenia(db, now);
+    expect(rows).toHaveLength(RESOLVED_LIST_LIMIT);
+    // Zoradené `resolvedAt DESC` — najnovšie (najvyššie i) prvé, najstaršie
+    // (i < 5, orezané cap-om) medzi výsledkami VÔBEC nie sú.
+    expect(rows[0]?.title).toBe(`Cap ${String(TOTAL - 1)}`);
+    expect(rows[RESOLVED_LIST_LIMIT - 1]?.title).toBe(`Cap ${String(TOTAL - RESOLVED_LIST_LIMIT)}`);
+    expect(rows.some((r) => r.title === "Cap 0")).toBe(false);
+  });
+});
+
+describe("returnUpozornenieToOpen", () => {
+  it("vráti vyriešenú kartu späť medzi otvorené — vyčistí resolvedAt aj resolvedByUserId", async () => {
+    const { db, userId } = await bootDb();
+    const now = new Date("2026-08-06T08:00:00Z");
+    const created = await upsertUpozornenie(db, { type: "vlastna_poznamka", source: "vlastne", title: "Omylom vybavená", now });
+    await resolveUpozornenie(db, { id: created.id, resolvedByUserId: userId, now });
+
+    const result = await returnUpozornenieToOpen(db, { id: created.id });
+    expect(result).toBe("returned");
+
+    const [row] = await db.select().from(upozornenie).where(eq(upozornenie.id, created.id));
+    expect(row?.resolvedAt).toBeNull();
+    expect(row?.resolvedByUserId).toBeNull();
+  });
+
+  it("neznáme id je neškodné (vracia 'no_op', nikdy nevyhodí)", async () => {
+    const { db } = await bootDb();
+    const result = await returnUpozornenieToOpen(db, { id: "00000000-0000-0000-0000-000000000000" });
+    expect(result).toBe("no_op");
+  });
+
+  it("karta, ktorá NIE JE vyriešená, je neškodné no-op (dvojklik)", async () => {
+    const { db } = await bootDb();
+    const now = new Date("2026-08-06T08:00:00Z");
+    const created = await upsertUpozornenie(db, { type: "vlastna_poznamka", source: "vlastne", title: "Stále otvorená", now });
+    const result = await returnUpozornenieToOpen(db, { id: created.id });
+    expect(result).toBe("no_op");
+    const [row] = await db.select().from(upozornenie).where(eq(upozornenie.id, created.id));
+    expect(row?.resolvedAt).toBeNull();
+  });
+
+  // issue 283 (majiteľova podmienka): index proti duplicitám je ČIASTOČNÝ
+  // (platí len na nevybavené karty) — vrátenie karty späť sa MUSÍ zrozumiteľne
+  // odmietnuť, keď na ten istý `dedupKey` medzitým vznikla NOVÁ otvorená karta
+  // (napr. #269's `vratenie` — objednávka prešla znova do vrátkového stavu a
+  // ďalší import obnovil/vytvoril otvorenú kartu skôr, než sa tá stará vrátila).
+  it("kolízia s existujúcou OTVORENOU kartou rovnakého dedupKey sa odmietne ako 'collision', nikdy nespadne", async () => {
+    const { db, userId } = await bootDb();
+    const now = new Date("2026-08-06T08:00:00Z");
+    const dedupKey = "vratenie:20700001";
+    const resolved = await upsertUpozornenie(db, { type: "vratenie", source: "appka", title: "Staršia vlna", dedupKey, now });
+    await resolveUpozornenie(db, { id: resolved.id, resolvedByUserId: userId, now });
+    // Nová otvorená karta pre ROVNAKÝ dedupKey (partial index ju dovolí, lebo
+    // predchádzajúca je už vyriešená — presne #269's zámerné správanie).
+    const open = await upsertUpozornenie(db, { type: "vratenie", source: "appka", title: "Nová vlna", dedupKey, now: new Date("2026-08-06T12:00:00Z") });
+    expect(open.id).not.toBe(resolved.id);
+
+    const result = await returnUpozornenieToOpen(db, { id: resolved.id });
+    expect(result).toBe("collision");
+
+    // Staršia karta ostáva vyriešená — pokus o vrátenie NEZANECHAL rozbitý stav.
+    const [resolvedRow] = await db.select().from(upozornenie).where(eq(upozornenie.id, resolved.id));
+    expect(resolvedRow?.resolvedAt).not.toBeNull();
+    const [openRow] = await db.select().from(upozornenie).where(eq(upozornenie.id, open.id));
+    expect(openRow?.resolvedAt).toBeNull();
+  });
+
+  it("vrátenie VLASTNEJ poznámky (dedupKey null) nikdy nekoliduje — NULL sa nikdy nepovažuje za zhodu", async () => {
+    const { db, userId } = await bootDb();
+    const now = new Date("2026-08-06T08:00:00Z");
+    const a = await upsertUpozornenie(db, { type: "vlastna_poznamka", source: "vlastne", title: "Poznámka A", now });
+    const b = await upsertUpozornenie(db, { type: "vlastna_poznamka", source: "vlastne", title: "Poznámka B", now });
+    await resolveUpozornenie(db, { id: a.id, resolvedByUserId: userId, now });
+    await resolveUpozornenie(db, { id: b.id, resolvedByUserId: userId, now });
+
+    expect(await returnUpozornenieToOpen(db, { id: a.id })).toBe("returned");
+    expect(await returnUpozornenieToOpen(db, { id: b.id })).toBe("returned");
+  });
+});

--- a/apps/web/src/components/UpozorneniaResolvedList.test.tsx
+++ b/apps/web/src/components/UpozorneniaResolvedList.test.tsx
@@ -1,0 +1,109 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { UpozorneniaResolvedList } from "./UpozorneniaResolvedList.js";
+
+// issue 283: záložka "Vybavené" — komponentové testy pre históriu vybavených
+// kariet + vrátenie späť medzi otvorené.
+
+const { fetchResolvedUpozornenia, returnUpozornenieToOpen } = vi.hoisted(() => ({
+  fetchResolvedUpozornenia: vi.fn(),
+  returnUpozornenieToOpen: vi.fn(),
+}));
+
+// `UpozorneniaUnauthorizedError` ostáva SKUTOČNÁ trieda (rovnaký dôvod ako
+// `UpozorneniaSection.test.tsx` — `instanceof` v komponente musí fungovať).
+vi.mock("../upozorneniaApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../upozorneniaApi.js")>();
+  return { ...actual, fetchResolvedUpozornenia, returnUpozornenieToOpen };
+});
+
+const RESOLVED_MANUAL = {
+  id: "resolved-1",
+  type: "vlastna_poznamka" as const,
+  source: "vlastne" as const,
+  title: "Omylom vybavená",
+  details: "",
+  link: null,
+  dueAt: null,
+  postponedUntil: null,
+  seenAt: "2026-08-05T08:00:00.000Z",
+  resolvedAt: "2026-08-06T09:00:00.000Z",
+  createdAt: "2026-08-05T08:00:00.000Z",
+  status: "vybavene" as const,
+  resolvedByName: "Majiteľ",
+};
+
+const RESOLVED_AUTO = {
+  id: "resolved-2",
+  type: "nevyzdvihnuta_zasielka" as const,
+  source: "appka" as const,
+  title: "Zásielka vyzdvihnutá",
+  details: "",
+  link: null,
+  dueAt: null,
+  postponedUntil: null,
+  seenAt: "2026-08-05T08:00:00.000Z",
+  resolvedAt: "2026-08-06T09:00:00.000Z",
+  createdAt: "2026-08-05T08:00:00.000Z",
+  status: "vybavene" as const,
+  resolvedByName: null,
+};
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+it("prázdny zoznam zobrazí informačnú vetu", async () => {
+  fetchResolvedUpozornenia.mockResolvedValue([]);
+  render(<UpozorneniaResolvedList canControl={true} onSessionExpired={vi.fn()} onReturnedToOpen={vi.fn()} />);
+  await screen.findByTestId("upozornenia-resolved-empty");
+});
+
+it("zobrazí meno toho, kto vybavil, a 'automaticky' pre kartu bez resolvedByName", async () => {
+  fetchResolvedUpozornenia.mockResolvedValue([RESOLVED_MANUAL, RESOLVED_AUTO]);
+  render(<UpozorneniaResolvedList canControl={true} onSessionExpired={vi.fn()} onReturnedToOpen={vi.fn()} />);
+  await screen.findByTestId("upozornenie-resolved-resolved-1");
+
+  expect(screen.getByTestId("upozornenie-resolved-meta-resolved-1").textContent).toContain("Majiteľ");
+  expect(screen.getByTestId("upozornenie-resolved-meta-resolved-2").textContent).toContain("automaticky");
+});
+
+it("rola 'citanie' vidí zoznam, ale NEVIDÍ tlačidlo 'Vrátiť medzi otvorené'", async () => {
+  fetchResolvedUpozornenia.mockResolvedValue([RESOLVED_MANUAL]);
+  render(<UpozorneniaResolvedList canControl={false} onSessionExpired={vi.fn()} onReturnedToOpen={vi.fn()} />);
+  await screen.findByTestId("upozornenie-resolved-resolved-1");
+  expect(screen.queryByTestId("upozornenie-return-resolved-1")).toBeNull();
+});
+
+it("klik na 'Vrátiť medzi otvorené' zavolá returnUpozornenieToOpen, znova načíta zoznam a upovedomí rodiča", async () => {
+  fetchResolvedUpozornenia.mockResolvedValueOnce([RESOLVED_MANUAL]).mockResolvedValueOnce([]);
+  returnUpozornenieToOpen.mockResolvedValue("returned");
+  const onReturnedToOpen = vi.fn();
+  render(<UpozorneniaResolvedList canControl={true} onSessionExpired={vi.fn()} onReturnedToOpen={onReturnedToOpen} />);
+  await screen.findByTestId("upozornenie-resolved-resolved-1");
+
+  fireEvent.click(screen.getByTestId("upozornenie-return-resolved-1"));
+  await waitFor(() => {
+    expect(returnUpozornenieToOpen).toHaveBeenCalledWith("resolved-1");
+  });
+  await waitFor(() => {
+    expect(onReturnedToOpen).toHaveBeenCalledTimes(1);
+  });
+  await screen.findByTestId("upozornenia-resolved-empty");
+});
+
+it("kolízia zobrazí zrozumiteľnú Slovak hlášku, karta OSTÁVA v zozname, rodič sa neupovedomí", async () => {
+  fetchResolvedUpozornenia.mockResolvedValue([RESOLVED_MANUAL]);
+  returnUpozornenieToOpen.mockResolvedValue("collision");
+  const onReturnedToOpen = vi.fn();
+  render(<UpozorneniaResolvedList canControl={true} onSessionExpired={vi.fn()} onReturnedToOpen={onReturnedToOpen} />);
+  await screen.findByTestId("upozornenie-resolved-resolved-1");
+
+  fireEvent.click(screen.getByTestId("upozornenie-return-resolved-1"));
+  await waitFor(() => {
+    expect(screen.getByRole("alert").textContent).toContain("už otvorená karta existuje");
+  });
+  expect(onReturnedToOpen).not.toHaveBeenCalled();
+  expect(screen.getByTestId("upozornenie-resolved-resolved-1")).toBeTruthy();
+});

--- a/apps/web/src/components/UpozorneniaResolvedList.tsx
+++ b/apps/web/src/components/UpozorneniaResolvedList.tsx
@@ -1,0 +1,141 @@
+import { useCallback, useEffect, useRef, useState, type JSX } from "react";
+import { fetchResolvedUpozornenia, returnUpozornenieToOpen, UpozorneniaUnauthorizedError, type ResolvedUpozornenieRow } from "../upozorneniaApi.js";
+
+// issue 283 (majiteľ, komentár na tickete): záložka "Vybavené" na nástenke
+// Upozornenia — história vyriešených kariet + tlačidlo na vrátenie späť medzi
+// otvorené. Vyčlenené do VLASTNÉHO komponentu, aby `UpozorneniaSection.tsx`
+// (už 432 riadkov) neprerástol cez eslint `max-lines: 400`
+// (`.claude/rules/frontend-design.md`'s zavedený vzor pre rastúce súbory).
+const RESOLVED_LIST_LIMIT = 200;
+
+const TYPE_LABELS: Readonly<Record<ResolvedUpozornenieRow["type"], string>> = {
+  vlastna_poznamka: "Moja poznámka",
+  nevyzdvihnuta_zasielka: "Nevyzdvihnutá zásielka",
+  vratenie: "Vrátenie",
+};
+
+function formatDateTime(iso: string): string {
+  return new Date(iso).toLocaleString("sk-SK", { dateStyle: "short", timeStyle: "short" });
+}
+
+export function UpozorneniaResolvedList({
+  canControl,
+  onSessionExpired,
+  onReturnedToOpen,
+}: {
+  readonly canControl: boolean;
+  readonly onSessionExpired: () => void;
+  readonly onReturnedToOpen: () => void;
+}): JSX.Element {
+  const [rows, setRows] = useState<readonly ResolvedUpozornenieRow[] | null>(null);
+  const [error, setError] = useState("");
+  const [busyId, setBusyId] = useState("");
+  // Rovnaký "latest ref" princíp ako `UpozorneniaSection.tsx`'s `loadSeqRef`
+  // (issue 254/251/151, `.claude/rules/frontend-design.md`) — chráni pred
+  // zastaranou odpoveďou z PREDCHÁDZAJÚCEho `load()` volania (mount + refetch
+  // po vrátení karty späť môžu bežať tesne po sebe).
+  const loadSeqRef = useRef(0);
+
+  const load = useCallback(() => {
+    const seq = ++loadSeqRef.current;
+    fetchResolvedUpozornenia()
+      .then((data) => {
+        if (loadSeqRef.current !== seq) return;
+        setRows(data);
+      })
+      .catch((err: unknown) => {
+        if (loadSeqRef.current !== seq) return;
+        if (err instanceof UpozorneniaUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setError("Vybavené upozornenia sa nepodarilo načítať.");
+      });
+  }, [onSessionExpired]);
+
+  useEffect(load, [load]);
+
+  const handleReturn = useCallback(
+    (row: ResolvedUpozornenieRow) => {
+      setBusyId(row.id);
+      setError("");
+      returnUpozornenieToOpen(row.id)
+        .then((result) => {
+          if (result === "collision") {
+            setError(`Kartu „${row.title}“ nejde vrátiť späť — na túto objednávku už otvorená karta existuje.`);
+            return;
+          }
+          // "returned" aj "no_op" (karta medzitým prestala byť vybavená
+          // odinakiaľ) obe znamenajú, že zoznam treba prekresliť.
+          load();
+          onReturnedToOpen();
+        })
+        .catch((err: unknown) => {
+          if (err instanceof UpozorneniaUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setError("Vrátenie karty zlyhalo — skúste to znova.");
+        })
+        .finally(() => {
+          setBusyId("");
+        });
+    },
+    [load, onReturnedToOpen, onSessionExpired],
+  );
+
+  if (error !== "" && rows === null) return <p role="alert">{error}</p>;
+  if (rows === null) return <p>Načítavam…</p>;
+
+  return (
+    <section data-testid="upozornenia-resolved-list">
+      {error !== "" && <p role="alert">{error}</p>}
+
+      {rows.length === RESOLVED_LIST_LIMIT && (
+        <p className="upozornenia-cap-note">Zobrazených posledných {RESOLVED_LIST_LIMIT} vybavených upozornení (od najnovšie vybavených).</p>
+      )}
+
+      {rows.length === 0 ? (
+        <p data-testid="upozornenia-resolved-empty">Zatiaľ nič nie je vybavené.</p>
+      ) : (
+        <div className="upozornenia-list">
+          {rows.map((row) => {
+            const rowBusy = busyId === row.id;
+            return (
+              <div className="card upozornenie-card" key={row.id} data-testid={`upozornenie-resolved-${row.id}`}>
+                <div className="upozornenie-head">
+                  <span className="pill" data-testid={`upozornenie-resolved-type-${row.id}`}>
+                    {TYPE_LABELS[row.type]}
+                  </span>
+                  <span className="pill off">Vybavené</span>
+                </div>
+                <p className="upozornenie-title">{row.title}</p>
+                {row.details !== "" && <p className="upozornenie-details">{row.details}</p>}
+                <p className="upozornenie-meta">Vzniklo {formatDateTime(row.createdAt)}</p>
+                <p className="upozornenie-resolved-meta" data-testid={`upozornenie-resolved-meta-${row.id}`}>
+                  Vybavil(a) {row.resolvedByName ?? "automaticky"}
+                  {row.resolvedAt !== null && <> · {formatDateTime(row.resolvedAt)}</>}
+                </p>
+                {canControl && (
+                  <div className="upozornenie-actions">
+                    <button
+                      type="button"
+                      className="btn sm ghost"
+                      disabled={rowBusy}
+                      onClick={() => {
+                        handleReturn(row);
+                      }}
+                      data-testid={`upozornenie-return-${row.id}`}
+                    >
+                      ↩ Vrátiť medzi otvorené
+                    </button>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/UpozorneniaSection.resolvedTab.test.tsx
+++ b/apps/web/src/components/UpozorneniaSection.resolvedTab.test.tsx
@@ -1,0 +1,92 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { UpozorneniaSection } from "./UpozorneniaSection.js";
+
+// issue 283 (majiteľ, komentár na tickete): záložka "Vybavené" — prepínanie
+// medzi "Otvorené" (predvolené) a "Vybavené", vydelené do VLASTNÉHO súboru
+// (`UpozorneniaSection.test.tsx` je už na hranici, rovnaký vzor ako
+// `.badgeRefresh`/`.emptyMessage`/`.postponeVisibility` súbory vedľa neho).
+
+const { fetchUpozornenia, markUpozorneniaSeen, fetchResolvedUpozornenia } = vi.hoisted(() => ({
+  fetchUpozornenia: vi.fn(),
+  markUpozorneniaSeen: vi.fn(),
+  fetchResolvedUpozornenia: vi.fn(),
+}));
+
+vi.mock("../upozorneniaApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../upozorneniaApi.js")>();
+  return { ...actual, fetchUpozornenia, markUpozorneniaSeen, fetchResolvedUpozornenia };
+});
+
+const VLASTNA_KARTA = {
+  id: "own-1",
+  type: "vlastna_poznamka" as const,
+  source: "vlastne" as const,
+  title: "Schôdzka v stredu",
+  details: "",
+  link: null,
+  dueAt: null,
+  postponedUntil: null,
+  seenAt: "2026-08-05T08:00:00.000Z",
+  resolvedAt: null,
+  createdAt: "2026-08-05T08:00:00.000Z",
+  status: "otvorene" as const,
+};
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+it("predvolená záložka je 'Otvorené' — zobrazí otvorený zoznam, nevolá fetchResolvedUpozornenia", async () => {
+  markUpozorneniaSeen.mockResolvedValue(undefined);
+  fetchUpozornenia.mockResolvedValue([VLASTNA_KARTA]);
+  render(<UpozorneniaSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("upozornenie-own-1");
+
+  expect(screen.getByTestId("upozornenia-tab-otvorene").getAttribute("aria-selected")).toBe("true");
+  expect(screen.getByTestId("upozornenia-tab-vybavene").getAttribute("aria-selected")).toBe("false");
+  expect(fetchResolvedUpozornenia).not.toHaveBeenCalled();
+});
+
+it("klik na záložku 'Vybavené' zobrazí históriu vybavených kariet, otvorený zoznam sa skryje", async () => {
+  markUpozorneniaSeen.mockResolvedValue(undefined);
+  fetchUpozornenia.mockResolvedValue([VLASTNA_KARTA]);
+  fetchResolvedUpozornenia.mockResolvedValue([]);
+  render(<UpozorneniaSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("upozornenie-own-1");
+
+  fireEvent.click(screen.getByTestId("upozornenia-tab-vybavene"));
+  await waitFor(() => {
+    expect(fetchResolvedUpozornenia).toHaveBeenCalledTimes(1);
+  });
+  await screen.findByTestId("upozornenia-resolved-empty");
+  expect(screen.queryByTestId("upozornenie-own-1")).toBeNull();
+
+  fireEvent.click(screen.getByTestId("upozornenia-tab-otvorene"));
+  await screen.findByTestId("upozornenie-own-1");
+});
+
+// Code review: pôvodná verzia gatovala CELÚ sekciu (vrátane prepínača
+// záložiek) na "Otvorené" zoznam ešte NAČÍTANÝM/BEZ CHYBY — kým "Otvorené"
+// ešte len načítavalo (alebo sieťovo zlyhalo), obsluha sa NEDOSTALA ani k
+// nezávislej záložke "Vybavené". Tento test dokazuje OBIDVA prípady priamo
+// (dočasné vrátenie starej gaty na oba prípady spadlo presne tu, návrat
+// opravy prešiel znova — `regression-test-first.md`'s obojsmerné overenie).
+it("prepínač záložiek je dostupný AJ kým sa 'Otvorené' ešte len načítava", async () => {
+  markUpozorneniaSeen.mockResolvedValue(undefined);
+  fetchUpozornenia.mockReturnValue(new Promise(() => {})); // nikdy sa nevyrieši — simuluje "ešte načítava"
+  render(<UpozorneniaSection role="manazer" onSessionExpired={vi.fn()} />);
+
+  await screen.findByTestId("upozornenia-tab-vybavene");
+  expect(screen.getByText("Načítavam…")).toBeTruthy();
+});
+
+it("prepínač záložiek je dostupný AJ keď 'Otvorené' zlyhá sieťovou chybou", async () => {
+  markUpozorneniaSeen.mockResolvedValue(undefined);
+  fetchUpozornenia.mockRejectedValue(new Error("sieťový výpadok"));
+  render(<UpozorneniaSection role="manazer" onSessionExpired={vi.fn()} />);
+
+  await screen.findByTestId("upozornenia-tab-vybavene");
+  expect(screen.getByRole("alert").textContent).toBe("Upozornenia sa nepodarilo načítať.");
+});

--- a/apps/web/src/components/UpozorneniaSection.tsx
+++ b/apps/web/src/components/UpozorneniaSection.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useContext, useEffect, useRef, useState, type JSX } from "react";
 import type { Me } from "../api.js";
 import { UpozorneniaBadgeRefreshContext } from "../upozorneniaBadgeContext.js";
+import { UpozornenieCard } from "./UpozornenieCard.js";
+import { UpozorneniaResolvedList } from "./UpozorneniaResolvedList.js";
 import {
   cancelPostponeUpozornenie,
   createOwnNote,
@@ -19,32 +21,6 @@ import {
 // (zoznam) smie vidieť KAŽDÝ prihlásený zamestnanec.
 const CONTROL_ROLES: ReadonlySet<Me["role"]> = new Set(["admin", "manazer"]);
 
-// Otvorený zoznam typov — budúci ďalší automatický zdroj pridá svoj štítok
-// sem, keď pridá svoju `pgEnum` hodnotu.
-const TYPE_LABELS: Readonly<Record<UpozornenieRow["type"], string>> = {
-  vlastna_poznamka: "Moja poznámka",
-  nevyzdvihnuta_zasielka: "Nevyzdvihnutá zásielka",
-  vratenie: "Vrátenie",
-};
-
-// Code review (issue 269, druhé kolo, finding 10): štítok odkazu sa odvodzuje
-// od TYPU karty, nikdy ako natvrdo napísaný literál na mieste vykreslenia —
-// oba dnešné automatické zdroje (#268 nevyzdvihnutá zásielka, #269 vrátenie)
-// odkazujú na Shoptet administráciu objednávky (`buildShoptetAdminOrderUrl`),
-// takže majú rovnaký štítok. `vlastna_poznamka` nikdy nenesie `link` (server
-// ho nikdy nevyplní), takže sem nepotrebuje vlastný záznam — `??` fallback
-// nižšie pokrýva AJ ňu, AJ akýkoľvek budúci typ, čo by omylom dostal odkaz
-// bez vlastného štítku, namiesto tichého predpokladu "je to vždy Shoptet".
-const LINK_LABELS: Readonly<Partial<Record<UpozornenieRow["type"], string>>> = {
-  nevyzdvihnuta_zasielka: "Otvoriť objednávku v Shoptete",
-  vratenie: "Otvoriť objednávku v Shoptete",
-};
-const DEFAULT_LINK_LABEL = "Otvoriť odkaz";
-
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString("sk-SK", { day: "numeric", month: "numeric", year: "numeric" });
-}
-
 // issue 267 (živé overenie, gap 3): prázdny zoznam tvrdil natvrdo "všetko je
 // vybavené" bez ohľadu na SKUTOČNÚ príčinu — čistá funkcia rozhodne podľa
 // NAJŠIRŠIEHO dopytu (volaného len keď je aktuálny, možno UŽŠIE filtrovaný
@@ -57,19 +33,6 @@ function classifyEmptyMessage(all: readonly UpozornenieRow[]): string {
   return "Žiadne upozornenia v tomto zobrazení — zvyšné sú vybavené alebo odložené.";
 }
 
-// Code review: "Odložiť do" nemalo `min` — dalo sa vybrať dátum v minulosti
-// (neškodné, `computeStatus` by ho vzalo ako "už sa vrátilo", ale mätúce
-// no-op). `<input type="date">`'s `min` očakáva `YYYY-MM-DD` v LOKÁLNOM
-// čase prehliadača, nie `toISOString()` (tá by okolo polnoci mohla ukázať
-// VČEREJŠÍ dátum v časových pásmach východne od UTC).
-function todayDateInputValue(): string {
-  const now = new Date();
-  const y = now.getFullYear();
-  const m = String(now.getMonth() + 1).padStart(2, "0");
-  const d = String(now.getDate()).padStart(2, "0");
-  return `${String(y)}-${m}-${d}`;
-}
-
 interface EditDraft {
   readonly id: string | null; // null = nový záznam
   readonly title: string;
@@ -80,6 +43,10 @@ interface EditDraft {
 const EMPTY_DRAFT: EditDraft = { id: null, title: "", details: "", dueAt: "" };
 
 export function UpozorneniaSection({ role, onSessionExpired }: { readonly role: Me["role"]; readonly onSessionExpired: () => void }): JSX.Element {
+  // issue 283 (majiteľ, komentár na tickete): záložka "Vybavené" — predvolená
+  // ostáva "otvorene" presne ako ticket žiada ("Keep the existing view as
+  // the default").
+  const [activeTab, setActiveTab] = useState<"otvorene" | "vybavene">("otvorene");
   const [rows, setRows] = useState<readonly UpozornenieRow[] | null>(null);
   const [error, setError] = useState("");
   const [includeResolved, setIncludeResolved] = useState(false);
@@ -209,13 +176,84 @@ export function UpozorneniaSection({ role, onSessionExpired }: { readonly role: 
       });
   }, [draft, load, refreshBadge]);
 
-  if (error !== "" && rows === null) return <p role="alert">{error}</p>;
-  if (rows === null) return <p>Načítavam…</p>;
+  // Code review (issue 283): pôvodná verzia gatovala CELÚ sekciu (vrátane
+  // samotného prepínača záložiek) na `rows === null`/`error` — teda kým
+  // "Otvorené" ešte len načítavalo (alebo sieťovo zlyhalo), obsluha sa
+  // NEDOSTALA ani k záložke "Vybavené", hoci tá je nezávislá a mohla by sa
+  // pokojne otvoriť. `intro`/`tabBar` sa preto renderujú VŽDY, nezávisle od
+  // `rows`/`error` — tie patria LEN vetve `activeTab === "otvorene"`.
+  const intro = <p>Veci, ktoré treba vybaviť — nech ich zistila appka sama, alebo si ich zapísal majiteľ. Nič odtiaľto sa neposiela e-mailom ani na Discord.</p>;
+  const tabBar = (
+    <div className="upozornenia-tabs" role="tablist">
+      <button
+        type="button"
+        role="tab"
+        aria-selected={activeTab === "otvorene"}
+        className={"upozornenia-tab" + (activeTab === "otvorene" ? " active" : "")}
+        onClick={() => {
+          setActiveTab("otvorene");
+        }}
+        data-testid="upozornenia-tab-otvorene"
+      >
+        Otvorené
+      </button>
+      <button
+        type="button"
+        role="tab"
+        aria-selected={activeTab === "vybavene"}
+        className={"upozornenia-tab" + (activeTab === "vybavene" ? " active" : "")}
+        onClick={() => {
+          setActiveTab("vybavene");
+        }}
+        data-testid="upozornenia-tab-vybavene"
+      >
+        Vybavené
+      </button>
+    </div>
+  );
+
+  if (activeTab === "vybavene") {
+    return (
+      <section>
+        {intro}
+        {tabBar}
+        <UpozorneniaResolvedList
+          canControl={canControl}
+          onSessionExpired={onSessionExpired}
+          onReturnedToOpen={() => {
+            load();
+            refreshBadge();
+          }}
+        />
+      </section>
+    );
+  }
+
+  // Odtiaľto `activeTab === "otvorene"` — `rows`/`error` (patriace LEN
+  // tomuto zoznamu) sa smú vyhodnotiť.
+  if (error !== "" && rows === null) {
+    return (
+      <section>
+        {intro}
+        {tabBar}
+        <p role="alert">{error}</p>
+      </section>
+    );
+  }
+  if (rows === null) {
+    return (
+      <section>
+        {intro}
+        {tabBar}
+        <p>Načítavam…</p>
+      </section>
+    );
+  }
 
   return (
     <section>
-      <p>Veci, ktoré treba vybaviť — nech ich zistila appka sama, alebo si ich zapísal majiteľ. Nič odtiaľto sa neposiela e-mailom ani na Discord.</p>
-
+      {intro}
+      {tabBar}
       {error !== "" && <p role="alert">{error}</p>}
 
       <div className="upozornenia-toolbar">
@@ -313,118 +351,35 @@ export function UpozorneniaSection({ role, onSessionExpired }: { readonly role: 
         <p data-testid="upozornenia-empty">{emptyMessage}</p>
       ) : (
         <div className="upozornenia-list" data-testid="upozornenia-list">
-          {rows.map((row) => {
-            const rowBusy = busyId === row.id;
-            const isOwn = row.source === "vlastne";
-            return (
-              <div className={"card upozornenie-card" + (row.status === "nove" ? " upozornenie-nove" : "")} key={row.id} data-testid={`upozornenie-${row.id}`}>
-                <div className="upozornenie-head">
-                  <span className="pill" data-testid={`upozornenie-type-${row.id}`}>
-                    {TYPE_LABELS[row.type]}
-                  </span>
-                  {row.status === "nove" && <strong data-testid={`upozornenie-nove-${row.id}`}>Nové</strong>}
-                  {row.status === "vybavene" && <span className="pill off">Vybavené</span>}
-                  {row.status === "odlozene" && (
-                    <span className="pill" data-testid={`upozornenie-odlozene-${row.id}`}>
-                      Odložené{row.postponedUntil !== null && <> do {formatDate(row.postponedUntil)}</>}
-                    </span>
-                  )}
-                </div>
-                <p className="upozornenie-title">{row.title}</p>
-                {row.details !== "" && <p className="upozornenie-details">{row.details}</p>}
-                <p className="upozornenie-meta">
-                  Vzniklo {formatDate(row.createdAt)}
-                  {row.dueAt !== null && <> · vybaviť do {formatDate(row.dueAt)}</>}
-                </p>
-                {row.link !== null && (
-                  <a href={row.link} target="_blank" rel="noreferrer" data-testid={`upozornenie-link-${row.id}`}>
-                    {LINK_LABELS[row.type] ?? DEFAULT_LINK_LABEL}
-                  </a>
-                )}
-                {canControl && row.status !== "vybavene" && (
-                  <div className="upozornenie-actions">
-                    <button
-                      type="button"
-                      className="btn sm good"
-                      disabled={rowBusy}
-                      onClick={() => {
-                        withBusy(row.id, () => resolveUpozornenie(row.id));
-                      }}
-                      data-testid={`upozornenie-resolve-${row.id}`}
-                    >
-                      ✓ Vybavené
-                    </button>
-                    <input
-                      type="date"
-                      min={todayDateInputValue()}
-                      value={postponeDraft[row.id] ?? ""}
-                      onChange={(e) => {
-                        const value = e.target.value;
-                        setPostponeDraft((d) => ({ ...d, [row.id]: value }));
-                      }}
-                      aria-label={`Odložiť do — ${row.title}`}
-                      data-testid={`upozornenie-postpone-date-${row.id}`}
-                    />
-                    <button
-                      type="button"
-                      className="btn sm ghost"
-                      disabled={rowBusy || (postponeDraft[row.id] ?? "") === ""}
-                      onClick={() => {
-                        const until = postponeDraft[row.id];
-                        if (until === undefined || until === "") return;
-                        withBusy(row.id, () => postponeUpozornenie(row.id, new Date(until).toISOString()));
-                      }}
-                      data-testid={`upozornenie-postpone-${row.id}`}
-                    >
-                      Odložiť
-                    </button>
-                    {row.status === "odlozene" && (
-                      // issue 267 (živé overenie, gap 2): jediný spôsob, ako
-                      // vrátiť odloženú kartu SKÔR, než sa vráti sama (napr.
-                      // majiteľ sa pomýlil v dátume).
-                      <button
-                        type="button"
-                        className="btn sm ghost"
-                        disabled={rowBusy}
-                        onClick={() => {
-                          withBusy(row.id, () => cancelPostponeUpozornenie(row.id));
-                        }}
-                        data-testid={`upozornenie-cancel-postpone-${row.id}`}
-                      >
-                        Zrušiť odloženie
-                      </button>
-                    )}
-                    {isOwn && (
-                      <>
-                        <button
-                          type="button"
-                          className="btn sm ghost"
-                          disabled={rowBusy}
-                          onClick={() => {
-                            setDraft({ id: row.id, title: row.title, details: row.details, dueAt: row.dueAt === null ? "" : row.dueAt.slice(0, 10) });
-                          }}
-                          data-testid={`upozornenie-edit-${row.id}`}
-                        >
-                          Upraviť
-                        </button>
-                        <button
-                          type="button"
-                          className="btn sm ghost"
-                          disabled={rowBusy}
-                          onClick={() => {
-                            withBusy(row.id, () => deleteOwnNote(row.id));
-                          }}
-                          data-testid={`upozornenie-delete-${row.id}`}
-                        >
-                          ✕ Zmazať
-                        </button>
-                      </>
-                    )}
-                  </div>
-                )}
-              </div>
-            );
-          })}
+          {rows.map((row) => (
+            <UpozornenieCard
+              key={row.id}
+              row={row}
+              canControl={canControl}
+              busy={busyId === row.id}
+              postponeDraftValue={postponeDraft[row.id] ?? ""}
+              onPostponeDraftChange={(value) => {
+                setPostponeDraft((d) => ({ ...d, [row.id]: value }));
+              }}
+              onResolve={() => {
+                withBusy(row.id, () => resolveUpozornenie(row.id));
+              }}
+              onPostpone={() => {
+                const until = postponeDraft[row.id];
+                if (until === undefined || until === "") return;
+                withBusy(row.id, () => postponeUpozornenie(row.id, new Date(until).toISOString()));
+              }}
+              onCancelPostpone={() => {
+                withBusy(row.id, () => cancelPostponeUpozornenie(row.id));
+              }}
+              onEdit={() => {
+                setDraft({ id: row.id, title: row.title, details: row.details, dueAt: row.dueAt === null ? "" : row.dueAt.slice(0, 10) });
+              }}
+              onDelete={() => {
+                withBusy(row.id, () => deleteOwnNote(row.id));
+              }}
+            />
+          ))}
         </div>
       )}
     </section>

--- a/apps/web/src/components/UpozornenieCard.tsx
+++ b/apps/web/src/components/UpozornenieCard.tsx
@@ -1,0 +1,143 @@
+import type { JSX } from "react";
+import type { UpozornenieRow } from "../upozorneniaApi.js";
+
+// issue 283 (code review — súbor `UpozorneniaSection.tsx` prerástol eslint
+// `max-lines: 400` po pridaní záložky "Vybavené"): rovnaký zavedený vzor ako
+// `OrderLineRow.tsx`/`OrdersSection.tsx` (`.claude/rules/frontend-design.md`
+// — "TABLE ROW / list-item rendering sa extrahuje ako prvé, je takmer vždy
+// najväčší a najsamostatnejší kus"). Karta je čisto zobrazovacia + callbacky
+// z rodiča — vlastný stav (`busyId`/`postponeDraft`/`draft`) ostáva v
+// `UpozorneniaSection.tsx`, ktorý je jediný, čo ho potrebuje zdieľať naprieč
+// viacerými kartami naraz.
+
+// Otvorený zoznam typov — budúci ďalší automatický zdroj pridá svoj štítok
+// sem, keď pridá svoju `pgEnum` hodnotu.
+const TYPE_LABELS: Readonly<Record<UpozornenieRow["type"], string>> = {
+  vlastna_poznamka: "Moja poznámka",
+  nevyzdvihnuta_zasielka: "Nevyzdvihnutá zásielka",
+  vratenie: "Vrátenie",
+};
+
+// Code review (issue 269, druhé kolo, finding 10): štítok odkazu sa odvodzuje
+// od TYPU karty, nikdy ako natvrdo napísaný literál na mieste vykreslenia —
+// oba dnešné automatické zdroje (#268 nevyzdvihnutá zásielka, #269 vrátenie)
+// odkazujú na Shoptet administráciu objednávky (`buildShoptetAdminOrderUrl`),
+// takže majú rovnaký štítok. `vlastna_poznamka` nikdy nenesie `link` (server
+// ho nikdy nevyplní), takže sem nepotrebuje vlastný záznam — `??` fallback
+// nižšie pokrýva AJ ňu, AJ akýkoľvek budúci typ, čo by omylom dostal odkaz
+// bez vlastného štítku, namiesto tichého predpokladu "je to vždy Shoptet".
+const LINK_LABELS: Readonly<Partial<Record<UpozornenieRow["type"], string>>> = {
+  nevyzdvihnuta_zasielka: "Otvoriť objednávku v Shoptete",
+  vratenie: "Otvoriť objednávku v Shoptete",
+};
+const DEFAULT_LINK_LABEL = "Otvoriť odkaz";
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("sk-SK", { day: "numeric", month: "numeric", year: "numeric" });
+}
+
+// Code review: "Odložiť do" nemalo `min` — dalo sa vybrať dátum v minulosti
+// (neškodné, `computeStatus` by ho vzalo ako "už sa vrátilo", ale mätúce
+// no-op). `<input type="date">`'s `min` očakáva `YYYY-MM-DD` v LOKÁLNOM
+// čase prehliadača, nie `toISOString()` (tá by okolo polnoci mohla ukázať
+// VČEREJŠÍ dátum v časových pásmach východne od UTC).
+function todayDateInputValue(): string {
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, "0");
+  const d = String(now.getDate()).padStart(2, "0");
+  return `${String(y)}-${m}-${d}`;
+}
+
+export interface UpozornenieCardProps {
+  readonly row: UpozornenieRow;
+  readonly canControl: boolean;
+  readonly busy: boolean;
+  readonly postponeDraftValue: string;
+  readonly onPostponeDraftChange: (value: string) => void;
+  readonly onResolve: () => void;
+  readonly onPostpone: () => void;
+  readonly onCancelPostpone: () => void;
+  readonly onEdit: () => void;
+  readonly onDelete: () => void;
+}
+
+export function UpozornenieCard({
+  row,
+  canControl,
+  busy,
+  postponeDraftValue,
+  onPostponeDraftChange,
+  onResolve,
+  onPostpone,
+  onCancelPostpone,
+  onEdit,
+  onDelete,
+}: UpozornenieCardProps): JSX.Element {
+  const isOwn = row.source === "vlastne";
+  return (
+    <div className={"card upozornenie-card" + (row.status === "nove" ? " upozornenie-nove" : "")} data-testid={`upozornenie-${row.id}`}>
+      <div className="upozornenie-head">
+        <span className="pill" data-testid={`upozornenie-type-${row.id}`}>
+          {TYPE_LABELS[row.type]}
+        </span>
+        {row.status === "nove" && <strong data-testid={`upozornenie-nove-${row.id}`}>Nové</strong>}
+        {row.status === "vybavene" && <span className="pill off">Vybavené</span>}
+        {row.status === "odlozene" && (
+          <span className="pill" data-testid={`upozornenie-odlozene-${row.id}`}>
+            Odložené{row.postponedUntil !== null && <> do {formatDate(row.postponedUntil)}</>}
+          </span>
+        )}
+      </div>
+      <p className="upozornenie-title">{row.title}</p>
+      {row.details !== "" && <p className="upozornenie-details">{row.details}</p>}
+      <p className="upozornenie-meta">
+        Vzniklo {formatDate(row.createdAt)}
+        {row.dueAt !== null && <> · vybaviť do {formatDate(row.dueAt)}</>}
+      </p>
+      {row.link !== null && (
+        <a href={row.link} target="_blank" rel="noreferrer" data-testid={`upozornenie-link-${row.id}`}>
+          {LINK_LABELS[row.type] ?? DEFAULT_LINK_LABEL}
+        </a>
+      )}
+      {canControl && row.status !== "vybavene" && (
+        <div className="upozornenie-actions">
+          <button type="button" className="btn sm good" disabled={busy} onClick={onResolve} data-testid={`upozornenie-resolve-${row.id}`}>
+            ✓ Vybavené
+          </button>
+          <input
+            type="date"
+            min={todayDateInputValue()}
+            value={postponeDraftValue}
+            onChange={(e) => {
+              onPostponeDraftChange(e.target.value);
+            }}
+            aria-label={`Odložiť do — ${row.title}`}
+            data-testid={`upozornenie-postpone-date-${row.id}`}
+          />
+          <button type="button" className="btn sm ghost" disabled={busy || postponeDraftValue === ""} onClick={onPostpone} data-testid={`upozornenie-postpone-${row.id}`}>
+            Odložiť
+          </button>
+          {row.status === "odlozene" && (
+            // issue 267 (živé overenie, gap 2): jediný spôsob, ako vrátiť
+            // odloženú kartu SKÔR, než sa vráti sama (napr. majiteľ sa
+            // pomýlil v dátume).
+            <button type="button" className="btn sm ghost" disabled={busy} onClick={onCancelPostpone} data-testid={`upozornenie-cancel-postpone-${row.id}`}>
+              Zrušiť odloženie
+            </button>
+          )}
+          {isOwn && (
+            <>
+              <button type="button" className="btn sm ghost" disabled={busy} onClick={onEdit} data-testid={`upozornenie-edit-${row.id}`}>
+                Upraviť
+              </button>
+              <button type="button" className="btn sm ghost" disabled={busy} onClick={onDelete} data-testid={`upozornenie-delete-${row.id}`}>
+                ✕ Zmazať
+              </button>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2052,6 +2052,44 @@ tr:last-child td {
   gap: var(--fs-space-2);
 }
 
+/* issue 283: záložka "Vybavené" — prepínač + história vyriešených kariet. */
+.upozornenia-tabs {
+  display: flex;
+  gap: var(--fs-space-2);
+  margin-bottom: var(--fs-space-3);
+}
+.upozornenia-tab {
+  padding: var(--fs-space-2) var(--fs-space-4);
+  border: 1px solid var(--fs-border);
+  border-radius: var(--fs-radius-md);
+  background: var(--fs-surface);
+  color: var(--fs-ink-muted);
+  font-weight: var(--fs-weight-semibold);
+  cursor: pointer;
+}
+/* Rovnaký hover vzor ako sidebar `.tabs .tab:hover` (issue 190) — code
+   review: nový interaktívny prvok vedľa existujúceho vzoru by ho nemal
+   vynechať. `.active` (deklarované AŽ PO `:hover` nižšie v súbore) zostáva
+   vizuálne dominantné aj pri súčasnom hoveri vďaka poradiu pravidiel. */
+.upozornenia-tab:hover {
+  background: var(--fs-surface-alt);
+}
+.upozornenia-tab.active {
+  background: var(--fs-brand);
+  border-color: var(--fs-brand);
+  color: var(--fs-surface);
+}
+.upozornenie-resolved-meta {
+  margin: 0;
+  font-size: var(--fs-text-sm);
+  color: var(--fs-ink-faint);
+}
+.upozornenia-cap-note {
+  margin: 0 0 var(--fs-space-3);
+  font-size: var(--fs-text-sm);
+  color: var(--fs-ink-faint);
+}
+
 /* ---------------- MODÁLNY DIALÓG (issue 191) ----------------
    Náhľad e-mailu pred odoslaním sa už nerozbaľuje na spodku stránky —
    otvorí sa cez obrazovku, takže je okamžite v zornom poli. `z-index`

--- a/apps/web/src/upozorneniaApi.ts
+++ b/apps/web/src/upozorneniaApi.ts
@@ -23,6 +23,16 @@ export type UpozornenieStatus = UpozornenieRow["status"];
 const listSchema = z.object({ rows: z.array(rowSchema) });
 const countSchema = z.object({ count: z.number() });
 
+// issue 283: záložka "Vybavené" — zrkadlí `ResolvedUpozornenieRow`
+// (`apps/api/src/modules/upozornenia/queries.ts`).
+const resolvedRowSchema = rowSchema.extend({ resolvedByName: z.string().nullable() });
+export type ResolvedUpozornenieRow = z.infer<typeof resolvedRowSchema>;
+const resolvedListSchema = z.object({ rows: z.array(resolvedRowSchema) });
+
+const returnToOpenResultSchema = z.enum(["returned", "no_op", "collision"]);
+export type ReturnToOpenResult = z.infer<typeof returnToOpenResultSchema>;
+const returnToOpenSchema = z.object({ result: returnToOpenResultSchema });
+
 export class UpozorneniaUnauthorizedError extends Error {
   constructor() {
     super("Neprihlásený");
@@ -116,4 +126,14 @@ export async function postponeUpozornenie(id: string, until: string): Promise<vo
 export async function cancelPostponeUpozornenie(id: string): Promise<void> {
   const response = await fetch(`/api/upozornenia/${encodeURIComponent(id)}/cancel-postpone`, { method: "POST" });
   await readJson(response, "Zrušenie odloženia zlyhalo");
+}
+
+export async function fetchResolvedUpozornenia(): Promise<readonly ResolvedUpozornenieRow[]> {
+  const response = await fetch("/api/upozornenia/resolved");
+  return resolvedListSchema.parse(await readJson(response, "Vybavené upozornenia sa nepodarilo načítať")).rows;
+}
+
+export async function returnUpozornenieToOpen(id: string): Promise<ReturnToOpenResult> {
+  const response = await fetch(`/api/upozornenia/${encodeURIComponent(id)}/return-to-open`, { method: "POST" });
+  return returnToOpenSchema.parse(await readJson(response, "Vrátenie karty zlyhalo")).result;
 }

--- a/apps/web/tests/e2e/upozornenia.spec.ts
+++ b/apps/web/tests/e2e/upozornenia.spec.ts
@@ -104,6 +104,34 @@ test("vlastná poznámka — vytvorenie, 'Nové' zmizne po znovuotvorení, úpra
   // Vybavená karta nemá žiadne akčné tlačidlá (Upraviť/Zmazať/Vybavené/Odložiť).
   await expect(vybavenaKarta.getByRole("button", { name: "Zmazať" })).toHaveCount(0);
   await expect(vybavenaKarta.getByRole("button", { name: "Vybavené" })).toHaveCount(0);
+  await page.getByText("aj vybavené").click(); // vypnúť filter, aby predvolený zoznam neukazoval vybavené
+
+  // issue 283 (majiteľ, komentár na tickete): záložka "Vybavené" — história
+  // vybavených kariet + vrátenie omylom vybavenej karty späť medzi otvorené.
+  // Kolízia s ČIASTOČNÝM unique indexom (`upozornenie_dedup_key_uq`) NEJDE
+  // vyvolať cez ŽIADNU appkinu UI akciu (vlastné poznámky nikdy nenesú
+  // `dedupKey` — jedine automatický import ho vyrobí), preto ju overuje
+  // `upozornenia-resolved.integration.test.ts`/`upozornenia-resolved-http
+  // .integration.test.ts` priamo na DB úrovni (rovnaký princíp ako
+  // `e2e-real-user-testing.md`'s výnimka pre scenáre, čo skutočný používateľ
+  // klikaním nikdy nevyrobí).
+  await page.getByTestId("upozornenia-tab-vybavene").click();
+  await expect(page.getByTestId("upozornenia-tab-vybavene")).toHaveAttribute("aria-selected", "true");
+  await expect(kartaSNadpisom(page, "Schôdzka v stredu — presunutá")).toHaveCount(0); // len OTVORENÁ karta, tu nepatrí
+
+  const historickaKarta = kartaSNadpisom(page, "Vybaviť poistku");
+  await expect(historickaKarta).toBeVisible();
+  await expect(historickaKarta).toContainText("Vybavil(a) E2E Manažér");
+
+  // Vrátenie omylom vybavenej karty späť medzi otvorené.
+  await historickaKarta.getByRole("button", { name: "Vrátiť medzi otvorené" }).click();
+  await expect(kartaSNadpisom(page, "Vybaviť poistku")).toHaveCount(0);
+
+  await page.getByTestId("upozornenia-tab-otvorene").click();
+  const vratenaKarta = kartaSNadpisom(page, "Vybaviť poistku");
+  await expect(vratenaKarta).toBeVisible();
+  await expect(vratenaKarta).not.toContainText("Nové"); // bola už videná pri predchádzajúcom vybavení
+  await expect(vratenaKarta.getByRole("button", { name: "Vybavené" })).toBeVisible(); // znova akčná
 
   expect(chyby).toEqual([]);
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.162",
+  "version": "0.3.0-dev.163",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Čo to robí

Na nástenke **Upozornenia** pribudla záložka **Vybavené** (issue 283).

- Prepínač medzi **Otvorené** (doterajší pohľad, ostáva predvolený) a **Vybavené**.
- V zozname vybavených sú karty od naposledy vybavenej, s tým, kto ich vybavil a kedy. Zoznam je zastropovaný na 200 posledných, aby sa nafukoval donekonečna.
- Každá karta má tlačidlo **Vrátiť medzi otvorené** — omylom kliknuté Vybavené sa tým dá vziať späť.
- Odznak v menu naďalej počíta len otvorené karty.

Prečo to vzniklo: pri oprave vrátkových kariet (issue 269) sa vybavenie stalo konečným — dovtedy sa omylom zavretá karta sama vrátila pri ďalšom importe. Bez tejto záložky by jeden preklik úlohu skryl natrvalo. Majiteľ si z troch možností vybral práve túto.

**Jeden špeciálny prípad je ošetrený:** ochrana proti duplicitám platí len na otvorené karty, takže vrátiť sa dá naraziť na už existujúcu otvorenú kartu na tú istú objednávku (môže nastať pri zásielkach, ktoré sa smú ohlásiť znova). V takom prípade appka zrozumiteľne odmietne namiesto chyby.

## Overenie

- `pnpm typecheck`, `pnpm lint` — čisté
- api unit 593, web unit 471, api integračné 556, e2e 46/46 — všetko prešlo
- Nezávislá revízia diffu našla dve skutočné chyby (prepínač záložiek sa nedal kliknúť, kým sa načítaval zoznam otvorených; test na strop bol tautológia) — obe opravené vrátane nových regresných testov

issue 283
