### PR TITLE
Upozornenia: preč so zdvojeným prepínačom „aj vybavené" v Otvorených

### DIFF
--- a/.claude/rules/upozornenia.md
+++ b/.claude/rules/upozornenia.md
@@ -266,3 +266,17 @@ paths:
   scenáre, ktoré skutočný používateľ klikaním nikdy nevyrobí. E2E
   (`upozornenia.spec.ts`) namiesto toho overuje LEN to, čo je reálne
   dosiahnuteľné klikaním: záložka "Vybavené" + úspešné vrátenie karty späť.
+- **Vyriešené karty žijú VÝHRADNE v záložke "Vybavené" (`UpozorneniaResolvedList`,
+  `GET /api/upozornenia/resolved`) — záložka "Otvorené" ich NIKDY neukazuje.**
+  Checkbox "aj vybavené" (pôvodný inline náhľad vyriešených kariet priamo v
+  "Otvorené", predchodca záložky "Vybavené") bol issue 283-follow-up
+  odstránený ako duplicitná zobrazovacia cesta pre tie isté dáta —
+  `UpozorneniaSection.tsx`'s `load()` volá `fetchUpozornenia` s
+  `includeResolved` NAPEVNO `false` (nie ovládané žiadnym UI filtrom).
+  `includeResolved: true` na strane API OSTÁVA (`upozornenia-http
+  .integration.test.ts` ho stále overuje) — používa ho VÝHRADNE
+  `classifyEmptyMessage`'s doplnkový najširší dopyt (rozlíšenie "všetko je
+  vybavené" od "všetko je odložené" v prázdnom zozname), nikdy priame
+  zobrazenie karty. Nová "druhá" cesta na zobrazenie vyriešenej karty v
+  "Otvorené" (checkbox, filter, čokoľvek) by túto duplicitu vrátila späť —
+  nepridávaj ju.

--- a/apps/web/src/components/UpozorneniaSection.tsx
+++ b/apps/web/src/components/UpozorneniaSection.tsx
@@ -49,9 +49,8 @@ export function UpozorneniaSection({ role, onSessionExpired }: { readonly role: 
   const [activeTab, setActiveTab] = useState<"otvorene" | "vybavene">("otvorene");
   const [rows, setRows] = useState<readonly UpozornenieRow[] | null>(null);
   const [error, setError] = useState("");
-  const [includeResolved, setIncludeResolved] = useState(false);
-  // issue 267 (živé overenie, gap 2): nezávislý filter od `includeResolved`
-  // — odložená karta bola bez tohto NAVŽDY skrytá, aj s "aj vybavené".
+  // issue 267 (živé overenie, gap 2): nezávislý filter od vyriešených kariet
+  // — odložená karta bola bez tohto NAVŽDY skrytá.
   const [includePostponed, setIncludePostponed] = useState(false);
   const [busyId, setBusyId] = useState("");
   const [draft, setDraft] = useState<EditDraft | null>(null);
@@ -76,18 +75,18 @@ export function UpozorneniaSection({ role, onSessionExpired }: { readonly role: 
 
   const load = useCallback(() => {
     const seq = ++loadSeqRef.current;
-    fetchUpozornenia({ includeResolved, includePostponed })
+    // issue 283 (Vybavené záložka nahradila checkbox "aj vybavené"): tento
+    // zoznam už NIKDY nesmie ukázať vyriešenú kartu — `includeResolved` je
+    // preto vždy `false`, nie ovládané žiadnym filtrom.
+    fetchUpozornenia({ includeResolved: false, includePostponed })
       .then((data) => {
         if (loadSeqRef.current !== seq) return;
         setRows(data);
         if (data.length > 0) return;
-        // Zoznam je prázdny pod AKTUÁLNYMI (možno užšími) filtrami — ak sú
-        // už najširšie, `data` JE tá pravda; inak treba doplnkový najširší
-        // dopyt, aby hláška nikdy nehádala/netvrdila nesprávnu príčinu.
-        if (includeResolved && includePostponed) {
-          setEmptyMessage(classifyEmptyMessage(data));
-          return;
-        }
+        // Zoznam je prázdny pod AKTUÁLNYMI (možno užšími) filtrami — treba
+        // doplnkový najširší dopyt, aby hláška nikdy nehádala/netvrdila
+        // nesprávnu príčinu (napr. "všetko je vybavené", hoci je len
+        // odložené).
         fetchUpozornenia({ includeResolved: true, includePostponed: true })
           .then((all) => {
             if (loadSeqRef.current === seq) setEmptyMessage(classifyEmptyMessage(all));
@@ -104,13 +103,13 @@ export function UpozorneniaSection({ role, onSessionExpired }: { readonly role: 
         }
         setError("Upozornenia sa nepodarilo načítať.");
       });
-  }, [includeResolved, includePostponed, onSessionExpired]);
+  }, [includePostponed, onSessionExpired]);
 
   // Otvorenie záložky = "prečítané" (inbox vzor) — PRVÉ spustenie tohto
   // efektu (mountedRef ešte `false`) hromadne označí všetky práve "Nové"
   // karty ako videné a AŽ POTOM načíta zoznam (žiadny dvojitý fetch na
   // mount) — žiadne per-kartové tlačidlo "videné" navyše. Každé ĎALŠIE
-  // spustenie (zmena `includeResolved`, teda nová identita `load`) už len
+  // spustenie (zmena `includePostponed`, teda nová identita `load`) už len
   // refetchne, mark-seen sa nezopakuje. `mountedRef` sa nastavuje SYNCHRÓNNE
   // v tele efektu (nie len v `useRef`'s počiatočnej hodnote) — `<StrictMode>`
   // (`main.tsx`) efekt vo vývoji spustí, zruší a znova spustí, presne vzor z
@@ -257,16 +256,6 @@ export function UpozorneniaSection({ role, onSessionExpired }: { readonly role: 
       {error !== "" && <p role="alert">{error}</p>}
 
       <div className="upozornenia-toolbar">
-        <label>
-          <input
-            type="checkbox"
-            checked={includeResolved}
-            onChange={(e) => {
-              setIncludeResolved(e.target.checked);
-            }}
-          />{" "}
-          aj vybavené
-        </label>
         <label>
           <input
             type="checkbox"

--- a/apps/web/src/components/UpozornenieCard.tsx
+++ b/apps/web/src/components/UpozornenieCard.tsx
@@ -82,7 +82,6 @@ export function UpozornenieCard({
           {TYPE_LABELS[row.type]}
         </span>
         {row.status === "nove" && <strong data-testid={`upozornenie-nove-${row.id}`}>Nové</strong>}
-        {row.status === "vybavene" && <span className="pill off">Vybavené</span>}
         {row.status === "odlozene" && (
           <span className="pill" data-testid={`upozornenie-odlozene-${row.id}`}>
             Odložené{row.postponedUntil !== null && <> do {formatDate(row.postponedUntil)}</>}

--- a/apps/web/tests/e2e/upozornenia.spec.ts
+++ b/apps/web/tests/e2e/upozornenia.spec.ts
@@ -71,14 +71,8 @@ test("vlastná poznámka — vytvorenie, 'Nové' zmizne po znovuotvorení, úpra
   await upravenaKarta.getByRole("button", { name: "Odložiť", exact: true }).click();
   await expect(kartaSNadpisom(page, "Schôdzka v stredu — presunutá")).toHaveCount(0);
 
-  // "aj vybavené" NEVRÁTI odloženú kartu (ostáva skrytá, kým sa nevráti sama).
-  await page.getByText("aj vybavené").click();
-  await expect(kartaSNadpisom(page, "Schôdzka v stredu — presunutá")).toHaveCount(0);
-  await page.getByText("aj vybavené").click();
-
-  // issue 267 follow-up gap 2: "aj odložené" (NEZÁVISLÝ filter od "aj
-  // vybavené" vyššie) JU odkryje, a "Zrušiť odloženie" ju vráti naspäť skôr,
-  // než sa vráti sama.
+  // issue 267 follow-up gap 2: "aj odložené" JU odkryje, a "Zrušiť odloženie"
+  // ju vráti naspäť skôr, než sa vráti sama.
   await page.getByText("aj odložené").click();
   const odlozenaKarta = kartaSNadpisom(page, "Schôdzka v stredu — presunutá");
   await expect(odlozenaKarta).toBeVisible();
@@ -96,15 +90,12 @@ test("vlastná poznámka — vytvorenie, 'Nové' zmizne po znovuotvorení, úpra
   await poistkaKarta.getByRole("button", { name: "Vybavené" }).click();
   await expect(kartaSNadpisom(page, "Vybaviť poistku")).toHaveCount(0);
 
-  // "aj vybavené" ju teraz ukáže (na rozdiel od odloženej vyššie).
-  await page.getByText("aj vybavené").click();
-  const vybavenaKarta = kartaSNadpisom(page, "Vybaviť poistku");
-  await expect(vybavenaKarta).toBeVisible();
-  await expect(vybavenaKarta).toContainText("Vybavené");
-  // Vybavená karta nemá žiadne akčné tlačidlá (Upraviť/Zmazať/Vybavené/Odložiť).
-  await expect(vybavenaKarta.getByRole("button", { name: "Zmazať" })).toHaveCount(0);
-  await expect(vybavenaKarta.getByRole("button", { name: "Vybavené" })).toHaveCount(0);
-  await page.getByText("aj vybavené").click(); // vypnúť filter, aby predvolený zoznam neukazoval vybavené
+  // issue 283 follow-up: vybavené karty žijú LEN v záložke "Vybavené" —
+  // "Otvorené" ich už NIKDY neukáže (checkbox "aj vybavené" bol odstránený
+  // spolu s touto duplicitnou zobrazovacou cestou, `.claude/rules/
+  // upozornenia.md`), žiadnym prepínačom ju nejde znova odkryť tu.
+  await expect(page.getByText("aj vybavené")).toHaveCount(0);
+  await expect(kartaSNadpisom(page, "Vybaviť poistku")).toHaveCount(0);
 
   // issue 283 (majiteľ, komentár na tickete): záložka "Vybavené" — história
   // vybavených kariet + vrátenie omylom vybavenej karty späť medzi otvorené.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.163",
+  "version": "0.3.0-dev.164",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Čo to robí

Na nástenke **Upozornenia** zmizol z pohľadu **Otvorené** starý prepínač „aj vybavené".

Prečo: minulý ticket (283) tam pridal záložku **Vybavené**, ktorá to isté robí lepšie — ukazuje, kto kartu vybavil a kedy, a dá sa z nej karta vrátiť medzi otvorené. Inline zobrazené vybavené karty v Otvorených nemali ani jedno z toho. Dve miesta na tú istú vec, jedno horšie. Odteraz platí jednoducho: **Otvorené = nevybavené, Vybavené = vybavené.** Prepínač „aj odložené" ostáva, ten je o niečom inom.

Rozhranie appky sa nemení nijako inak — žiadna funkcia sa nestratila.

## Detaily

- Pohľad Otvorené si teraz vybavené karty nepýta vôbec, takže sa tam nemôžu objaviť ani omylom.
- Vypadla mŕtva vetva v karte, ktorá kreslila značku „Vybavené" — v Otvorených už nemá čo označiť.
- Na strane servera nič nepribudlo ani neubudlo: parameter na vybavené karty tam ostáva, lebo ho naďalej potrebuje hláška prázdneho zoznamu („všetko je vybavené" / „všetko je odložené").

## Overenie

- `pnpm typecheck`, `pnpm lint` — čisté
- api unit 593, web unit 471, api integračné 556, e2e 46/46 — všetko prešlo
- e2e test na Upozornenia prepísaný: overuje, že prepínač už neexistuje a že vybavená karta z Otvorených naozaj zmizne

Nadväzuje na issue 283.
