### PR TITLE
Ľavé menu: Eshop hore a menšie rozostupy (issues 287, 288)

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -908,3 +908,14 @@ paths:
   nezávislú záložku: patrí existujúca loading/error gate LEN jednej
   záložke? Ak áno, presuň ju AŽ ZA vetvu tej druhej, nikdy ju nenechaj
   gatovať spoločný prepínač.
+- **`DEFAULT_TAB_ID` (predvolená obrazovka PO PRIHLÁSENÍ, `nav.ts`) bolo
+  odvodené od `NAV[0]?.tabs[0]?.id` — akékoľvek PREUSPORIADANIE priečinkov
+  v `NAV` teda ticho zmení aj landing obrazovku, hoci o tom zadanie vôbec
+  nehovorí.** Issue 287 (majiteľ chcel "Eshop" ako prvý priečinok — čisto
+  vizuálne poradie v menu) by bez zásahu presunulo predvolenú obrazovku zo
+  "Sync zo Shoptetu" na "Na objednanie" — nezadaná vedľajšia zmena správania
+  ("scope creep" cez náhodnú väzbu v kóde, nie cez úmysel). Fix:
+  `DEFAULT_TAB_ID` je teraz PEVNÝ literál `"sync"`, nezávislý od poradia v
+  `NAV`. Pri KAŽDOM ĎALŠOM preusporiadaní `NAV` (pridanie/presun priečinka,
+  zmena poradia skupín) skontroluj, či sa `DEFAULT_TAB_ID` nezmenil ticho —
+  ak zadanie nežiada zmenu landing obrazovky, drž ju pevnú.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -589,3 +589,18 @@ paths:
   súboru/testu (`vitest run tests/<súbor>` / `playwright test
   tests/e2e/<súbor>`), nikdy nepredpokladaj regresiu len z jedného
   červeného plného behu na zdieľanom, vyťaženom boxe.
+- **Rovnaká trieda vyššie (preťažený zdieľaný box) má aj tichší tvar bez
+  akéhokoľvek testovacieho výstupu** — `pnpm --filter @forestshop/web e2e`
+  spadlo hneď na `Error: Timed out waiting 60000ms from config.webServer.`
+  (issues 287/288), teda PRED spustením čo i len jedného testu; oba
+  `webServer` procesy (`e2e-setup.ts` + `tsx src/index.ts`) sa nestihli
+  zdvihnúť do 60 s po ~9-minútovom integračnom behu na tom istom
+  vyťaženom boxe. Manuálne spustenie `pnpm exec tsx scripts/e2e-setup.ts`
+  z KOREŇA repa (nie z `apps/web` s relatívnou cestou `../../scripts/...`)
+  potvrdilo, že skript sám funguje (0 exit, reálne logy) — problém bol
+  čisto o čase na vyťaženom boxe, nie o rozbitom skripte/ceste. Fix: ŽIADNA
+  zmena kódu, len opakovanie `pnpm --filter @forestshop/web e2e` prešlo
+  načisto (46/46). Pri `Timed out waiting Nms from config.webServer` bez
+  akéhokoľvek ďalšieho výstupu skús izolovaný re-beh AKO PRVÉ, nie
+  predlžovanie timeoutu (`no-timeout-band-aids.md`) ani hľadanie bugu v
+  `e2e-setup.ts`/`playwright.config.ts`.

--- a/apps/web/src/nav.test.ts
+++ b/apps/web/src/nav.test.ts
@@ -12,18 +12,18 @@ import { DEFAULT_TAB_ID, HIDDEN_TABS, NAV, findTab, isVisibleTabId } from "./nav
 // pridalo "Zlúčenie objednávok" pod "Eshop" z rovnakého dôvodu (majiteľ:
 // vlastná záložka, nie tlačidlo pri objednávke). Issue 267 pridalo
 // "Upozornenia" pod "Eshop" z rovnakého dôvodu (pracovná obrazovka bez
-// plánu/zapnuté-vypnuté konceptu).
+// plánu/zapnuté-vypnuté konceptu). Issue 287 preusporiadalo poradie SAMOTNÝCH
+// priečinkov (majiteľ: "Eshop dať uplne ako prvý... šéf ho používa
+// najčastejšie") — Eshop je teraz prvý, Systém druhý, Automatizácie tretie;
+// položky vnútri každého priečinka ostali nezmenené.
 // Tento test je najbližšie k tomu, čo strojovo overiť dá (registrácia, nie DOM).
-it("NAV má tri priečinky (Systém/Eshop/Automatizácie), s 3/6/4 záložkami v poradí podľa dôležitosti", () => {
+it("NAV má tri priečinky (Eshop/Systém/Automatizácie), s 6/3/4 záložkami v poradí podľa dôležitosti", () => {
   expect(NAV).toHaveLength(3);
-  expect(NAV.map((f) => f.label)).toEqual(["Systém", "Eshop", "Automatizácie"]);
-  expect(NAV[0]?.tabs).toHaveLength(3);
-  expect(NAV[1]?.tabs).toHaveLength(6);
+  expect(NAV.map((f) => f.label)).toEqual(["Eshop", "Systém", "Automatizácie"]);
+  expect(NAV[0]?.tabs).toHaveLength(6);
+  expect(NAV[1]?.tabs).toHaveLength(3);
   expect(NAV[2]?.tabs).toHaveLength(4);
-  // issue 212: "Dodávateľský sklad" — scraper dostupnosti u dodávateľa;
-  // patrí do Systému (zadanie majiteľa), nie medzi Automatizácie.
-  expect(NAV[0]?.tabs.map((t) => t.label)).toEqual(["Sync zo Shoptetu", "Texty e-mailov", "Dodávateľský sklad"]);
-  expect(NAV[1]?.tabs.map((t) => t.label)).toEqual([
+  expect(NAV[0]?.tabs.map((t) => t.label)).toEqual([
     "Na objednanie",
     "Nedostupné tovary",
     "Párovanie produktov",
@@ -31,6 +31,9 @@ it("NAV má tri priečinky (Systém/Eshop/Automatizácie), s 3/6/4 záložkami v
     "Zlúčenie objednávok",
     "Upozornenia",
   ]);
+  // issue 212: "Dodávateľský sklad" — scraper dostupnosti u dodávateľa;
+  // patrí do Systému (zadanie majiteľa), nie medzi Automatizácie.
+  expect(NAV[1]?.tabs.map((t) => t.label)).toEqual(["Sync zo Shoptetu", "Texty e-mailov", "Dodávateľský sklad"]);
   // issue 193: "Odoslané e-maily" — prehľad toho, čo automatizácie poslali.
   expect(NAV[2]?.tabs.map((t) => t.label)).toEqual([
     // issue 213: prepínanie vypredaných produktov späť na skladom.
@@ -41,7 +44,10 @@ it("NAV má tri priečinky (Systém/Eshop/Automatizácie), s 3/6/4 záložkami v
   ]);
 });
 
-it("DEFAULT_TAB_ID je prvá viditeľná záložka ('sync')", () => {
+// issue 287: DEFAULT_TAB_ID sa už NEODVODZUJE od NAV[0] (to je teraz "eshop")
+// — zámerne pevne "sync", aby sa poradie priečinkov v menu nedotklo
+// predvolenej obrazovky po prihlásení (nezadané, mimo rozsahu ticketu).
+it("DEFAULT_TAB_ID je pevne 'sync' — nezávisí od poradia priečinkov v NAV", () => {
   expect(DEFAULT_TAB_ID).toBe("sync");
 });
 

--- a/apps/web/src/nav.ts
+++ b/apps/web/src/nav.ts
@@ -59,23 +59,13 @@ export interface NavFolder {
 // App.tsx/Sidebar.tsx.
 export const NAV: readonly NavFolder[] = [
   {
-    id: "system",
-    label: "Systém",
-    // issue 192: "Texty e-mailov" patrí sem — je to nastavenie appky, ktoré sa
-    // dotýka VŠETKÝCH automatizácií naraz, nie práca s konkrétnymi
-    // objednávkami (tá je v Eshope) ani jedna konkrétna automatizácia.
-    tabs: [
-      { id: "sync", label: "Sync zo Shoptetu", icon: "🔄", Component: SyncSection },
-      { id: "mail-templates", label: "Texty e-mailov", icon: "✉️", Component: MailTemplatesSection, wide: true },
-      // issue 212: scraper dostupnosti u dodávateľa — patrí do Systému
-      // (majiteľ: "scrapera ktoreho chcem v zalozke system"), nie medzi
-      // Automatizácie: nič neprepína, len zbiera údaje pre issue 213.
-      { id: "supplier-stock", label: "Dodávateľský sklad", icon: "🏭", Component: SupplierStockSection, wide: true },
-    ],
-  },
-  {
     id: "eshop",
     label: "Eshop",
+    // issue 287: majiteľ, "adresár Eshop dať uplne ako prvý... Eshop je to,
+    // čo šéf používa najčastejšie, tak nech je hore" — priečinok je preto
+    // PRVÝ v poli (poradie prvkov = poradie vykreslenia, `Sidebar.tsx`
+    // neprida žiadne vlastné triedenie). Položky vnútri ostávajú nezmenené.
+    //
     // issue 195: "Nedostupné tovary" patrí SEM, nie medzi Automatizácie —
     // nemá naplánovanú úlohu ani prepínač zapnuté/vypnuté, je to obrazovka,
     // na ktorej obsluha pracuje, presne ako "Na objednanie". `wide: true` pri
@@ -104,6 +94,21 @@ export const NAV: readonly NavFolder[] = [
       // (nie do Automatizácie) z rovnakého dôvodu ako "Na objednanie" —
       // obsluha na nej pracuje, žiadny plán/zapnuté-vypnuté koncept.
       { id: "upozornenia", label: "Upozornenia", icon: "🔔", Component: UpozorneniaSection, wide: true },
+    ],
+  },
+  {
+    id: "system",
+    label: "Systém",
+    // issue 192: "Texty e-mailov" patrí sem — je to nastavenie appky, ktoré sa
+    // dotýka VŠETKÝCH automatizácií naraz, nie práca s konkrétnymi
+    // objednávkami (tá je v Eshope) ani jedna konkrétna automatizácia.
+    tabs: [
+      { id: "sync", label: "Sync zo Shoptetu", icon: "🔄", Component: SyncSection },
+      { id: "mail-templates", label: "Texty e-mailov", icon: "✉️", Component: MailTemplatesSection, wide: true },
+      // issue 212: scraper dostupnosti u dodávateľa — patrí do Systému
+      // (majiteľ: "scrapera ktoreho chcem v zalozke system"), nie medzi
+      // Automatizácie: nič neprepína, len zbiera údaje pre issue 213.
+      { id: "supplier-stock", label: "Dodávateľský sklad", icon: "🏭", Component: SupplierStockSection, wide: true },
     ],
   },
   {
@@ -141,7 +146,13 @@ export const HIDDEN_TABS: Readonly<Record<string, NavTab>> = {
   scheduler: { id: "scheduler", label: "Plánovač", icon: "🗓️", Component: SchedulerSection },
 };
 
-export const DEFAULT_TAB_ID: string = NAV[0]?.tabs[0]?.id ?? "sync";
+// issue 287: priečinky v `NAV` sa preusporiadali (Eshop je teraz prvý), ale
+// predvolená obrazovka PO PRIHLÁSENÍ sa zámerne NEMENÍ — zadanie žiadalo len
+// vizuálne poradie priečinkov v menu, nie zmenu landing obrazovky. Preto sa
+// `DEFAULT_TAB_ID` už neodvodzuje od `NAV[0]` (to by ticho prepnutím
+// priečinkov zmenilo predvolenú obrazovku na "Na objednanie"), ale pevne
+// ukazuje na "sync" — presne rovnaké správanie ako pred touto zmenou.
+export const DEFAULT_TAB_ID: string = "sync";
 
 /** Nájde záložku podľa id — najprv medzi viditeľnými (NAV), potom v skrytých. */
 export function findTab(id: string): NavTab | undefined {

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -307,7 +307,11 @@ tr:last-child td {
   align-items: center;
   gap: var(--fs-space-3);
   width: 100%;
-  padding: var(--fs-space-2) var(--fs-space-3);
+  /* issue 288: rozostupy ľavého menu stiahnuté o jeden krok existujúcej
+     tokenovej škály (8px → 4px vertikálne) — s pribúdajúcimi záložkami
+     (dnes 13) sa pôvodné rozostupy sčítali na zbytočné rolovanie. Horizontálne
+     odsadenie (klikacia šírka) sa nemení. */
+  padding: var(--fs-space-1) var(--fs-space-3);
   border: 0;
   background: none;
   cursor: pointer;
@@ -336,8 +340,11 @@ tr:last-child td {
 .nav-folder.collapsed .folder-head .folder-chev {
   transform: rotate(-90deg);
 }
+/* issue 288: medzera PO skupine (pred ďalšou hlavičkou priečinka) stiahnutá
+   z --fs-space-3 (12px) na --fs-space-2 (8px), rovnaký dôvod ako
+   `.folder-head`/`.tabs .tab` vyššie. */
 .folder-body {
-  margin: var(--fs-space-1) 0 var(--fs-space-3);
+  margin: var(--fs-space-1) 0 var(--fs-space-2);
 }
 .nav-folder.collapsed .folder-body {
   display: none;
@@ -351,7 +358,9 @@ tr:last-child td {
   display: flex;
   align-items: center;
   gap: var(--fs-space-3);
-  padding: var(--fs-space-2) var(--fs-space-3);
+  /* issue 288: rovnaké stiahnutie ako `.folder-head` vyššie (8px → 4px
+     vertikálne) — pri 13 záložkách toto samo prináša najväčšiu úsporu. */
+  padding: var(--fs-space-1) var(--fs-space-3);
   border-radius: var(--fs-radius-sm);
   color: var(--fs-ink);
   font-size: var(--fs-text-base);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.164",
+  "version": "0.3.0-dev.165",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Čo to robí

Dve úpravy ľavého menu, obe zo zadania od šéfa.

**Eshop je hore (issue 287).** Poradie skupín je odteraz **Eshop → Systém → Automatizácie** namiesto doterajšieho Systém → Eshop → Automatizácie. Položky vnútri skupín ostávajú, ako boli. Eshop je to, čo sa používa najčastejšie, tak nech to netreba hľadať v strede.

**Menu je kratšie (issue 288).** Rozostupy medzi položkami sa stiahli o jeden krok — z 8 na 4 body medzi položkami a z 12 na 8 pod skupinou. Používajú sa existujúce hodnoty z dizajnu, žiadne nové čísla natvrdo. Vodorovné odsadenie a veľkosť klikacej plochy v zbalenom menu sa nemenili, takže sa klikne rovnako pohodlne — len sa toho na obrazovku zmestí viac a nebude sa musieť tak skoro rolovať.

## Jedna vec, ktorú si všimla vlastná revízia

Obrazovka, na ktorú appka skočí po prihlásení, sa brala ako „prvá položka prvej skupiny". Prehodenie poradia by ju teda ticho zmenilo zo **Sync zo Shoptetu** na **Na objednanie** — čo nikto nechcel. Odviazané: prihlásenie naďalej končí na Sync zo Shoptetu bez ohľadu na poradie v menu. Doplnený test.

## Overenie

- `pnpm typecheck`, `pnpm lint` — čisté
- api unit 593, web unit 471, api integračné 556, e2e 46/46 — všetko prešlo
- Test na poradie skupín v menu doplnený tak, aby vedel spadnúť, keby sa poradie znova prehodilo

Nadväzuje na issue 287 a issue 288.
