### PR TITLE
Správny slovenský čas a čitateľné dátumy (issue 293)

### DIFF
--- a/.claude/rules/deploy.md
+++ b/.claude/rules/deploy.md
@@ -10,6 +10,27 @@ paths:
 
 # Deployment (dev2)
 
+- **Kontajner beží v `TZ=Europe/Bratislava` (issue 293) — nastavené DVAKRÁT,
+  zámerne.** `Dockerfile`'s `ENV TZ=Europe/Bratislava` (runtime štádium) je
+  baked-in predvolená hodnota v samotnom obraze; `docker-compose.prod.yml`'s
+  `TZ: Europe/Bratislava` v `app`'s `environment:` bloku ju robí
+  explicitnou/prepísateľnou na úrovni nasadenia, rovnaká disciplína ako
+  každá iná premenná nižšie. Predtým appka aj kontajner bežali BEZ
+  nastaveného pásma (teda v UTC) — naplánované úlohy (`.claude/rules/
+  scheduler.md`) tak reálne behali o 1-2 hodiny neskôr, než majiteľ
+  nastavil. Node 24's plné ICU rozlíši `TZ` SPRÁVNE aj bez `tzdata`
+  balíka (overené priamo: `docker run --rm -e TZ=Europe/Bratislava
+  node:24-alpine node -e '...'` dal správny +1/+2 offset s nula
+  nainštalovanými balíkmi) — `tzdata` (v `Dockerfile`'s `apk add`) je tu
+  napriek tomu, lebo Alpine's `/usr/share/zoneinfo` inak vôbec neexistuje a
+  musl-linkované nástroje MIMO Node/V8 (napr. shellov vlastný `date`)
+  bez neho ticho spadnú späť do UTC — overené priamo (`date` v holom
+  obraze ukázal UTC aj s `TZ` nastaveným, správny CEST čas až po `apk add
+  tzdata`). Postgres-ova VLASTNÁ session `timezone` ostáva zámerne UTC
+  (`timestamptz` stĺpce sa VŽDY ukladajú v UTC bez ohľadu na session
+  pásmo — to je odporúčaná prax, nie chyba) — appka prevádza na slovenský
+  čas AŽ pri čítaní/plánovaní (`apps/api/src/timezone.ts`), nikdy sa
+  nespolieha na to, že DB samotná vráti lokálny čas.
 - **Nová premenná v `env.ts` MUSÍ dostať svoj riadok v `environment:` bloku
   `docker-compose.prod.yml` — inak sa do kontajnera NIKDY nedostane, aj keby
   bola korektne nastavená v `/srv/forestshop/.env`.** Compose neprenáša `.env`

--- a/.claude/rules/posta-uncollected.md
+++ b/.claude/rules/posta-uncollected.md
@@ -38,8 +38,10 @@ paths:
   (per zásielka), a xact-scoped zámok by znamenal držať jednu DB transakciu
   otvorenú počas nich (zbytočná záťaž na connection pool). Nájdené code
   review na PR 177 — bez zámku by dva prekrývajúce sa behy (dvaja manažéri
-  "Spustiť teraz" súčasne, alebo ručný klik prekrývajúci sa s 07:00 UTC
-  scheduled behom) mohli OBA prečítať ten istý `notifyCount` pred zápisom a
+  "Spustiť teraz" súčasne, alebo ručný klik prekrývajúci sa s 07:00
+  Europe/Bratislava scheduled behom — issue 293: predtým doslovné 07:00
+  UTC, appka reálne behala až o 09:00 slovenského času) mohli OBA prečítať
+  ten istý `notifyCount` pred zápisom a
   poslať duplicitný e-mail zákazníkovi. Regresný test (deterministický,
   `pg_try_advisory_lock` z druhého pripojenia — rovnaká technika ako
   `db-isolation-lock.integration.test.ts`):

--- a/.claude/rules/posta-uncollected.md
+++ b/.claude/rules/posta-uncollected.md
@@ -38,9 +38,12 @@ paths:
   (per zásielka), a xact-scoped zámok by znamenal držať jednu DB transakciu
   otvorenú počas nich (zbytočná záťaž na connection pool). Nájdené code
   review na PR 177 — bez zámku by dva prekrývajúce sa behy (dvaja manažéri
-  "Spustiť teraz" súčasne, alebo ručný klik prekrývajúci sa s 07:00
-  Europe/Bratislava scheduled behom — issue 293: predtým doslovné 07:00
-  UTC, appka reálne behala až o 09:00 slovenského času) mohli OBA prečítať
+  "Spustiť teraz" súčasne, alebo ručný klik prekrývajúci sa s 09:00
+  Europe/Bratislava scheduled behom — issue 293: predtým sa `hourLocal: 7`
+  interpretoval doslovne ako 7:00 UTC, čo bolo 09:00 slovenského letného
+  času a bol to zámer odjakživa; oprava časového pásma literál nechala
+  nedotknutý, takže nasledujúci tiket ho vrátil na 9, aby cieľový čas
+  09:00 Europe/Bratislava zostal zachovaný) mohli OBA prečítať
   ten istý `notifyCount` pred zápisom a
   poslať duplicitný e-mail zákazníkovi. Regresný test (deterministický,
   `pg_try_advisory_lock` z druhého pripojenia — rovnaká technika ako

--- a/.claude/rules/scheduler.md
+++ b/.claude/rules/scheduler.md
@@ -21,12 +21,23 @@ paths:
   `executeJob` ich odchytí a zapíše ako `job_run.status = "failure"`.
 - **Rozvrh je diskriminovaná únia `Schedule = DailySchedule | HourlySchedule`
   (`kind: "daily" | "hourly"`, `types.ts`), žiadny cron výraz.** `isDue()`
-  (`scheduler.ts`) je čistá funkcia — periodizuje podľa `kind` (`daily`: UTC
-  kalendárny deň, `hourly`: UTC deň+hodina, #115). Nová `daily` úloha dostáva
-  vlastný `{ kind: "daily", hourUtc, minuteUtc }`; zvoľ ho aspoň 15 min od
-  existujúcich `daily` úloh, aby sa neprekrývali zbytočne (nie je to tvrdá
-  závislosť, len aby operátor v logoch/`job_run` vedel odlíšiť poradie). Nová
-  `hourly` úloha dostáva `{ kind: "hourly", minuteUtc }` — nemá `hourUtc`,
+  (`scheduler.ts`) je čistá funkcia — periodizuje podľa `kind`. **`daily`:
+  MIESTNY (Europe/Bratislava) kalendárny deň + miestna hodina/minúta (issue
+  293 — predtým doslovné UTC, appka aj kontajner bežali bez nastaveného
+  pásma, takže úloha nastavená na 7:00 reálne behala až o 9:00/8:00
+  slovenského času; `hourUtc`/`minuteUtc` sú odvtedy premenované na
+  `hourLocal`/`minuteLocal`, aby meno sedelo s tým, ako sa hodnota
+  interpretuje).** `hourly`: ZOSTÁVA podľa UTC dňa+hodiny (#115), ZÁMERNE
+  nelokalizované — hodinový job nemá cieľovú hodinu (beží každú hodinu),
+  lokalizácia by v deň prechodu na zimný čas (opakovaná miestna hodina
+  02:00-03:00) spôsobila falošné preskočenie skutočného behu; minúta v
+  rámci hodiny je pre tento časový pás (vždy celohodinový offset) rovnaká v
+  UTC aj v miestnom čase, netreba ju prepočítavať. Nová `daily` úloha
+  dostáva vlastný `{ kind: "daily", hourLocal, minuteLocal }` (SLOVENSKÝ
+  čas, nie UTC); zvoľ ho aspoň 15 min od existujúcich `daily` úloh, aby sa
+  neprekrývali zbytočne (nie je to tvrdá závislosť, len aby operátor v
+  logoch/`job_run` vedel odlíšiť poradie). Nová `hourly` úloha dostáva
+  `{ kind: "hourly", minuteUtc }` — nemá `hourLocal`/`hourUtc`,
   beží v KAŽDEJ UTC hodine. Dnes zaregistrované: **:20 KAŽDÚ hodinu import
   katalógu** (`catalogImportJob`, `hourly` od issue 184, pôvodne `daily`
   01:00 — zmerané trvanie behu 19.5-22.9 s, zanedbateľné), 01:15 mazanie

--- a/.claude/rules/scheduler.md
+++ b/.claude/rules/scheduler.md
@@ -88,8 +88,8 @@ paths:
   sieťových volaní na posta.sk (per zásielka), a držať jednu DB transakciu
   otvorenú počas nich by zbytočne zaťažovalo connection pool. Bez tohto
   zámku by dva prekrývajúce sa behy (dvaja manažéri klikli "Spustiť teraz"
-  súčasne, alebo ručný klik sa prekryl s 07:00 UTC naplánovaným behom) mohli
-  OBA prečítať ten istý predošlý `notifyCount` pred zápisom a poslať
+  súčasne, alebo ručný klik sa prekryl s 09:00 Europe/Bratislava naplánovaným
+  behom) mohli OBA prečítať ten istý predošlý `notifyCount` pred zápisom a poslať
   DUPLICITNÝ eskalačný e-mail zákazníkovi (review na PR 177 — nájdené pred
   mergom, nie testom).
 - **`tick()`'s zámok chráni LEN kontrolu splatnosti + vloženie "running"

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,16 @@ ENV NODE_ENV=production
 # Same reasoning as the build stage above — never let Playwright's postinstall
 # try (and fail) to download its own bundled Chromium on Alpine.
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+# issue 293: appka (aj tento kontajner) predtým bežala bez nastaveného
+# časového pásma, teda v UTC — naplánované úlohy tak reálne behali o 1-2
+# hodiny neskôr, než majiteľ nastavil (`scheduler.ts` teraz počíta v
+# Europe/Bratislava, viď `apps/api/src/timezone.ts`, ale appka aj bez toho
+# musí BEŽAŤ v správnom pásme, aby žiadne ĎALŠIE počítanie dátumu — logy,
+# budúci kód mimo `timezone.ts` — ticho nespadlo do UTC). `docker-compose
+# .prod.yml` nastavuje TO ISTÉ `TZ` znova v `environment:` bloku (viditeľné
+# cez `docker exec ... env`, `.claude/rules/deploy.md`'s overovací vzor) —
+# tu je len baked-in predvolená hodnota v samotnom obraze.
+ENV TZ=Europe/Bratislava
 # issue 122: real, working Chromium for Alpine (musl libc) — Playwright's own
 # downloaded browser build targets glibc distros only and will not run here.
 # `playwright-import.ts`'s `resolveChromiumExecutablePath()` finds this
@@ -31,7 +41,15 @@ ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 # freetype packages are the standard set needed for headless Chromium to
 # actually render (a bare `chromium` package alone crashes on launch on
 # Alpine — documented Puppeteer/Playwright-on-Alpine requirement).
-RUN apk add --no-cache chromium nss freetype freetype-dev harfbuzz ca-certificates ttf-freefont
+# issue 293: `tzdata` added alongside — Node 24's bundled full ICU resolves
+# `TZ`/`Intl` correctly WITHOUT it (verified directly: `docker run --rm -e
+# TZ=Europe/Bratislava node:24-alpine node -e '...'` gave the right +1/+2
+# offset with zero packages installed), but Alpine's own `/usr/share/
+# zoneinfo` is otherwise ABSENT — musl-linked tools (the shell's own `date`,
+# and potentially Chromium's own non-V8 codepaths) silently fall back to UTC
+# without it (verified: `date` inside the bare image printed UTC despite TZ
+# being set, and printed the correct CEST time only after `apk add tzdata`).
+RUN apk add --no-cache chromium nss freetype freetype-dev harfbuzz ca-certificates ttf-freefont tzdata
 # Produkčné závislosti sa inštalujú znova, nekopírujú sa z build fázy: pnpm robí
 # node_modules zo symlinkov do svojho store, a tie by po skopírovaní ukazovali do
 # prázdna. Natívny modul argon2 sa tak zároveň zostaví pre runtime obraz.

--- a/apps/api/src/modules/posta-uncollected/logic.ts
+++ b/apps/api/src/modules/posta-uncollected/logic.ts
@@ -1,6 +1,7 @@
 import { globalContext, textValue } from "../mail-templates/context.js";
 import type { MailTemplateKey } from "../mail-templates/registry.js";
 import { renderTemplate, type MailTemplateText, type RenderedEmail } from "../mail-templates/render.js";
+import { zonedDateKey } from "../../timezone.js";
 import {
   CANCELLED_STATUSES,
   daysNeededForNextEmail,
@@ -205,7 +206,13 @@ export function classifyTracking(apiJson: unknown, today: Date): TrackingClassif
     const rawTill = p.retainedTill ?? events.find((e) => e.retainedTill !== undefined)?.retainedTill;
     if (rawTill !== undefined && rawTill !== null && rawTill !== "") {
       const d = parseIsoDatePrefix(rawTill);
-      out.retainedTill = d !== null ? d.toISOString().slice(0, 10) : "";
+      // issue 293: `zonedDateKey` namiesto `toISOString().slice(0, 10)` —
+      // konzistentné s `state.ts`/`run.ts`. `d` je tu vždy UTC polnoc
+      // (`parseIsoDatePrefix` posta.sk-ovho ČISTO kalendárneho dátumu bez
+      // časovej zložky), takže prevod na Europe/Bratislava NIKDY neposunie
+      // deň (miestna polnoc + 1-2h offset ostáva v TEN istý kalendárny
+      // deň) — ide o zjednotenie ciest, nie o opravu pozorovateľného chýbania.
+      out.retainedTill = d !== null ? zonedDateKey(d) : "";
     }
   }
   return out;

--- a/apps/api/src/modules/posta-uncollected/run.ts
+++ b/apps/api/src/modules/posta-uncollected/run.ts
@@ -1,5 +1,6 @@
 import type { Database } from "../../db/client.js";
 import { log } from "../../logger.js";
+import { zonedDateKey } from "../../timezone.js";
 import type { MailTransport } from "../mail/transport.js";
 import { recordSkippedMail, sendLoggedMail, type MailLogContext } from "../mail-log/service.js";
 import { buildShoptetAdminOrderUrl } from "../orders/queries.js";
@@ -349,7 +350,9 @@ async function runPostaUncollectedLocked(options: RunPostaUncollectedOptions): P
         notifiedSince: cls.notifiedSince,
         daysAtPost: cls.daysAtPost,
         count: effectiveCount,
-        lastSentAt: effectiveLastSent === null ? "" : effectiveLastSent.toISOString().slice(0, 10),
+        // issue 293: SLOVENSKÝ deň behu, nie UTC — rovnaký dôvod ako
+        // `state.ts`'s `upsertPostaUncollectedState`.
+        lastSentAt: effectiveLastSent === null ? "" : zonedDateKey(effectiveLastSent),
         callNeeded: effectiveCount >= 4,
         trackingLink: trackingLink(packageNumber),
         adminLink: adminOrderUrl(shipment),

--- a/apps/api/src/modules/posta-uncollected/state.ts
+++ b/apps/api/src/modules/posta-uncollected/state.ts
@@ -1,6 +1,7 @@
 import { inArray, notInArray, sql } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
 import { postaUncollectedState } from "../../db/schema.js";
+import { zonedDateKey } from "../../timezone.js";
 
 export interface PostaUncollectedStateRow {
   readonly orderCode: string;
@@ -52,8 +53,12 @@ export async function upsertPostaUncollectedState(
   update: PostaUncollectedStateUpdate,
   now: Date,
 ): Promise<void> {
-  const lastSentAt = update.lastSentAt === null ? null : update.lastSentAt.toISOString().slice(0, 10);
-  const terminalAt = update.terminalAt === null ? null : update.terminalAt.toISOString().slice(0, 10);
+  // issue 293: SLOVENSKÝ kalendárny deň, nie UTC — `toISOString().slice(0, 10)`
+  // by pre beh tesne po miestnej polnoci (ale ešte pred UTC polnocou) uložilo
+  // VČEREJŠÍ deň, čo posunulo eskalačnú kadenciu (`shouldSend`'s "dní od
+  // posledného poslania") o deň.
+  const lastSentAt = update.lastSentAt === null ? null : zonedDateKey(update.lastSentAt);
+  const terminalAt = update.terminalAt === null ? null : zonedDateKey(update.terminalAt);
   await db
     .insert(postaUncollectedState)
     .values({

--- a/apps/api/src/modules/scheduler/jobs.ts
+++ b/apps/api/src/modules/scheduler/jobs.ts
@@ -222,11 +222,15 @@ export const POSTA_UNCOLLECTED_JOB_NAME = "posta-uncollected";
 export type RunPostaUncollected = (db: Database, now: Date) => Promise<PostaUncollectedRunResult>;
 
 /**
- * "Nevyzdvihnuté zásielky" (issue 172) — denne o 07:00 Europe/Bratislava
+ * "Nevyzdvihnuté zásielky" (issue 172) — denne o 09:00 Europe/Bratislava
  * (issue 293: `hourLocal`/`minuteLocal` sú teraz SKUTOČNE miestny čas —
- * appka aj kontajner predtým bežali v UTC, takže táto úloha reálne behala
- * až o 09:00 slovenského času, v zime o 08:00; komentár tu predtým TENTO
- * posun mylne opisoval ako zámer namiesto ho pomenovať ako chybu). Na rozdiel od
+ * appka aj kontajner predtým bežali v UTC bez nastaveného pásma, takže
+ * literál `hourLocal: 7` sa PRED opravou interpretoval ako 7:00 UTC =
+ * 09:00 slovenského letného času (08:00 v zime) — to bol zámer odjakživa.
+ * Samotná oprava časového pásma (issue 293) tento literál nechala
+ * nedotknutý, čo by ho zmenilo na 07:00 SKUTOČNE miestneho — o dve hodiny
+ * skôr, než malo — preto ho tento následný tiket vrátil na 9, aby zostal
+ * skutočný cieľový čas 09:00 Europe/Bratislava). Na rozdiel od
  * `catalogImportJob`/`ordersImportJob` NIE JE `run` nikdy `undefined` — táto
  * automatizácia číta priamo z už importovaných objednávok (žiadna
  * samostatná URL na nakonfigurovanie), a chýbajúce SMTP/BCC rieši
@@ -239,7 +243,7 @@ export type RunPostaUncollected = (db: Database, now: Date) => Promise<PostaUnco
 export function postaUncollectedJob(run: RunPostaUncollected): ScheduledJob {
   return {
     name: POSTA_UNCOLLECTED_JOB_NAME,
-    schedule: { kind: "daily", hourLocal: 7, minuteLocal: 0 },
+    schedule: { kind: "daily", hourLocal: 9, minuteLocal: 0 },
     async run(db, now) {
       const enabled = await isPostaUncollectedEnabled(db);
       if (!enabled) {
@@ -256,10 +260,13 @@ export const ORDER_REMINDER_JOB_NAME = "order-reminder";
 export type RunOrderReminder = (db: Database, now: Date) => Promise<OrderReminderRunResult>;
 
 /**
- * "Pripomienky objednávok" (issue 173) — denne o 06:00 Europe/Bratislava
+ * "Pripomienky objednávok" (issue 173) — denne o 08:00 Europe/Bratislava
  * (issue 293: `hourLocal`/`minuteLocal` sú teraz SKUTOČNE miestny čas —
- * predtým reálne behala až o 08:00 slovenského času, v zime o 07:00, rovnaký
- * dôvod ako `postaUncollectedJob` vyššie). Rovnaký
+ * rovnaký dôvod ako `postaUncollectedJob` vyššie: literál `hourLocal: 6` sa
+ * PRED opravou interpretoval ako 6:00 UTC = 08:00 slovenského letného času
+ * (07:00 v zime), čo bol zámer odjakživa. Samotná oprava časového pásma ho
+ * nechala nedotknutý, čo by ho zmenilo na 06:00 SKUTOČNE miestneho — o dve
+ * hodiny skôr — preto ho tento následný tiket vrátil na 8). Rovnaký
  * vzor ako `postaUncollectedJob`: `run` nie je nikdy `undefined` (číta priamo
  * z už importovaných objednávok), chýbajúce OPENAI_API_KEY/MAIL_HOST/BCC rieši
  * `runOrderReminder` SAMA (per-objednávka, viditeľne v `job_run.detail`),
@@ -271,7 +278,7 @@ export type RunOrderReminder = (db: Database, now: Date) => Promise<OrderReminde
 export function orderReminderJob(run: RunOrderReminder): ScheduledJob {
   return {
     name: ORDER_REMINDER_JOB_NAME,
-    schedule: { kind: "daily", hourLocal: 6, minuteLocal: 0 },
+    schedule: { kind: "daily", hourLocal: 8, minuteLocal: 0 },
     async run(db, now) {
       const enabled = await isOrderReminderEnabled(db);
       if (!enabled) {

--- a/apps/api/src/modules/scheduler/jobs.ts
+++ b/apps/api/src/modules/scheduler/jobs.ts
@@ -86,7 +86,7 @@ export function catalogImportJob(runIngest: RunIngest | undefined): ScheduledJob
 export function pruneRawExportsJob(keepDays = 14): ScheduledJob {
   return {
     name: PRUNE_RAW_EXPORTS_JOB_NAME,
-    schedule: { kind: "daily", hourUtc: 1, minuteUtc: 15 },
+    schedule: { kind: "daily", hourLocal: 1, minuteLocal: 15 },
     async run(db, now) {
       const result = await pruneRawSnapshots(db, { keepDays, now });
       return { detail: result };
@@ -98,7 +98,7 @@ export function pruneRawExportsJob(keepDays = 14): ScheduledJob {
 export function sessionCleanupJob(): ScheduledJob {
   return {
     name: SESSION_CLEANUP_JOB_NAME,
-    schedule: { kind: "daily", hourUtc: 1, minuteUtc: 30 },
+    schedule: { kind: "daily", hourLocal: 1, minuteLocal: 30 },
     async run(db, now) {
       const result = await cleanupExpiredSessions(db, now);
       return { detail: result };
@@ -147,7 +147,7 @@ export function pruneRawOrdersJob(rawDir: string, keepDays = 30): ScheduledJob {
     // prekrývať KAŽDÝ deň (nie len raz), nie iba pri tomto jednom sedení —
     // neprekáža, `pruneRawOrders` nemá žiadny DB advisory zámok (viď komentár
     // vyššie), takže si nekonkuruje.
-    schedule: { kind: "daily", hourUtc: 2, minuteUtc: 0 },
+    schedule: { kind: "daily", hourLocal: 2, minuteLocal: 0 },
     async run(_db, now) {
       const result = await pruneRawOrders(rawDir, { keepDays, now });
       return { detail: result };
@@ -222,10 +222,11 @@ export const POSTA_UNCOLLECTED_JOB_NAME = "posta-uncollected";
 export type RunPostaUncollected = (db: Database, now: Date) => Promise<PostaUncollectedRunResult>;
 
 /**
- * "Nevyzdvihnuté zásielky" (issue 172) — denne o 09:00 Europe/Bratislava
- * (07:00 UTC — CEST v lete/CET v zime posunie skutočný čas behu o hodinu,
- * rovnaká DST-nevedomá disciplína ako ostatné `daily` joby v tomto súbore;
- * presnosť na hodinu nie je pre túto úlohu kritická). Na rozdiel od
+ * "Nevyzdvihnuté zásielky" (issue 172) — denne o 07:00 Europe/Bratislava
+ * (issue 293: `hourLocal`/`minuteLocal` sú teraz SKUTOČNE miestny čas —
+ * appka aj kontajner predtým bežali v UTC, takže táto úloha reálne behala
+ * až o 09:00 slovenského času, v zime o 08:00; komentár tu predtým TENTO
+ * posun mylne opisoval ako zámer namiesto ho pomenovať ako chybu). Na rozdiel od
  * `catalogImportJob`/`ordersImportJob` NIE JE `run` nikdy `undefined` — táto
  * automatizácia číta priamo z už importovaných objednávok (žiadna
  * samostatná URL na nakonfigurovanie), a chýbajúce SMTP/BCC rieši
@@ -238,7 +239,7 @@ export type RunPostaUncollected = (db: Database, now: Date) => Promise<PostaUnco
 export function postaUncollectedJob(run: RunPostaUncollected): ScheduledJob {
   return {
     name: POSTA_UNCOLLECTED_JOB_NAME,
-    schedule: { kind: "daily", hourUtc: 7, minuteUtc: 0 },
+    schedule: { kind: "daily", hourLocal: 7, minuteLocal: 0 },
     async run(db, now) {
       const enabled = await isPostaUncollectedEnabled(db);
       if (!enabled) {
@@ -255,10 +256,10 @@ export const ORDER_REMINDER_JOB_NAME = "order-reminder";
 export type RunOrderReminder = (db: Database, now: Date) => Promise<OrderReminderRunResult>;
 
 /**
- * "Pripomienky objednávok" (issue 173) — denne o 08:00 Europe/Bratislava
- * (06:00 UTC — CEST v lete/CET v zime posunie skutočný čas behu o hodinu,
- * rovnaká DST-nevedomá disciplína ako `postaUncollectedJob`/ostatné `daily`
- * joby vyššie; presnosť na hodinu nie je pre túto úlohu kritická). Rovnaký
+ * "Pripomienky objednávok" (issue 173) — denne o 06:00 Europe/Bratislava
+ * (issue 293: `hourLocal`/`minuteLocal` sú teraz SKUTOČNE miestny čas —
+ * predtým reálne behala až o 08:00 slovenského času, v zime o 07:00, rovnaký
+ * dôvod ako `postaUncollectedJob` vyššie). Rovnaký
  * vzor ako `postaUncollectedJob`: `run` nie je nikdy `undefined` (číta priamo
  * z už importovaných objednávok), chýbajúce OPENAI_API_KEY/MAIL_HOST/BCC rieši
  * `runOrderReminder` SAMA (per-objednávka, viditeľne v `job_run.detail`),
@@ -270,7 +271,7 @@ export type RunOrderReminder = (db: Database, now: Date) => Promise<OrderReminde
 export function orderReminderJob(run: RunOrderReminder): ScheduledJob {
   return {
     name: ORDER_REMINDER_JOB_NAME,
-    schedule: { kind: "daily", hourUtc: 6, minuteUtc: 0 },
+    schedule: { kind: "daily", hourLocal: 6, minuteLocal: 0 },
     async run(db, now) {
       const enabled = await isOrderReminderEnabled(db);
       if (!enabled) {
@@ -285,7 +286,10 @@ export function orderReminderJob(run: RunOrderReminder): ScheduledJob {
 export type RunSupplierStock = (db: Database, now: Date) => Promise<SupplierStockRunResult>;
 
 /**
- * "Dodávateľský sklad" (issue 212) — denne o 04:20 UTC, teda dostatočne PRED
+ * "Dodávateľský sklad" (issue 212) — denne o 04:20 Europe/Bratislava (issue
+ * 293: predtým sa `hourLocal`/`minuteLocal` reálne interpretovali ako UTC,
+ * appka teraz behá o 1-2 hodiny SKÔR, než predtým — poradie a rozostup
+ * medzi nočnými jobmi nižšie ostávajú NEZMENENÉ), teda dostatočne PRED
  * automatizáciou prepínania (issue 213), aby tá pracovala s čerstvými dátami
  * z tejto noci, a zároveň mimo `pruneRawExportsJob` (01:15) /
  * `sessionCleanupJob` (01:30) / `pruneRawOrdersJob` (02:00).
@@ -297,7 +301,7 @@ export type RunSupplierStock = (db: Database, now: Date) => Promise<SupplierStoc
 export function supplierStockJob(run: RunSupplierStock): ScheduledJob {
   return {
     name: SUPPLIER_STOCK_JOB_NAME,
-    schedule: { kind: "daily", hourUtc: 4, minuteUtc: 20 },
+    schedule: { kind: "daily", hourLocal: 4, minuteLocal: 20 },
     async run(db, now) {
       return { detail: await run(db, now) };
     },
@@ -307,7 +311,8 @@ export function supplierStockJob(run: RunSupplierStock): ScheduledJob {
 export type RunRestock = (db: Database, now: Date) => Promise<RestockRunResult>;
 
 /**
- * "Vypredané → Skladom" (issue 213) — denne o 04:50 UTC, teda 30 minút PO
+ * "Vypredané → Skladom" (issue 213) — denne o 04:50 Europe/Bratislava (issue
+ * 293 — pozri poznámku na `supplierStockJob` vyššie), teda 30 minút PO
  * `supplierStockJob` (04:20), aby pracovalo s potvrdeniami z tejto noci.
  *
  * Na rozdiel od scrapera MÁ `enabled` prepínač: toto je jediná automatizácia,
@@ -318,7 +323,7 @@ export type RunRestock = (db: Database, now: Date) => Promise<RestockRunResult>;
 export function restockJob(run: RunRestock | undefined): ScheduledJob {
   return {
     name: RESTOCK_JOB_NAME,
-    schedule: { kind: "daily", hourUtc: 4, minuteUtc: 50 },
+    schedule: { kind: "daily", hourLocal: 4, minuteLocal: 50 },
     async run(db, now) {
       const enabled = await isRestockEnabled(db);
       if (!enabled) {
@@ -336,7 +341,8 @@ export type RunShopFeed = (db: Database, now: Date) => Promise<ShopFeedRunResult
 
 /**
  * Obnovenie mapy „kód variantu → adresa detailu" z feedu pre porovnávače
- * (issue 220) — denne o 03:50 UTC, teda PRED `supplierStockJob` (04:20) aj
+ * (issue 220) — denne o 03:50 Europe/Bratislava (issue 293 — pozri poznámku
+ * na `supplierStockJob` vyššie), teda PRED `supplierStockJob` (04:20) aj
  * `restockJob` (04:50), aby overovací zoznam ráno ukazoval čerstvé adresy.
  *
  * Vlastný advisory zámok NEMÁ: na rozdiel od `postaUncollectedJob` či
@@ -349,7 +355,7 @@ export type RunShopFeed = (db: Database, now: Date) => Promise<ShopFeedRunResult
 export function shopFeedJob(run: RunShopFeed): ScheduledJob {
   return {
     name: SHOP_FEED_JOB_NAME,
-    schedule: { kind: "daily", hourUtc: 3, minuteUtc: 50 },
+    schedule: { kind: "daily", hourLocal: 3, minuteLocal: 50 },
     async run(db, now) {
       return { detail: await run(db, now) };
     },

--- a/apps/api/src/modules/scheduler/scheduler.test.ts
+++ b/apps/api/src/modules/scheduler/scheduler.test.ts
@@ -1,34 +1,38 @@
 import { expect, it } from "vitest";
 import { isDue } from "./scheduler.js";
 
-const DAILY = { kind: "daily" as const, hourUtc: 1, minuteUtc: 0 };
+// issue 293: `hourLocal`/`minuteLocal` sú Europe/Bratislava miestny čas
+// (predtým `hourUtc`/`minuteUtc`, doslova UTC) — dátumové literály nižšie sú
+// preto UTC okamihy zodpovedajúce miestnemu "01:00" na dátume 2026-07-29
+// (letný čas, offset +2, teda "01:00 miestne" = "23:00 predošlý deň UTC").
+const DAILY = { kind: "daily" as const, hourLocal: 1, minuteLocal: 0 };
 
 it("daily: nie je splatná pred naplánovanou hodinou, keď ešte dnes nebežala", () => {
-  expect(isDue(DAILY, new Date("2026-07-29T00:59:00Z"), null)).toBe(false);
+  expect(isDue(DAILY, new Date("2026-07-28T22:59:00Z"), null)).toBe(false);
 });
 
 it("daily: je splatná presne v naplánovanú minútu, keď ešte dnes nebežala", () => {
-  expect(isDue(DAILY, new Date("2026-07-29T01:00:00Z"), null)).toBe(true);
+  expect(isDue(DAILY, new Date("2026-07-28T23:00:00Z"), null)).toBe(true);
 });
 
 it("daily: je splatná aj neskôr v ten istý deň, keď ešte nebežala", () => {
-  expect(isDue(DAILY, new Date("2026-07-29T14:00:00Z"), null)).toBe(true);
+  expect(isDue(DAILY, new Date("2026-07-29T12:00:00Z"), null)).toBe(true);
 });
 
 it("daily: nie je splatná, keď už dnes bežala (bez ohľadu na hodinu posledného behu)", () => {
-  expect(isDue(DAILY, new Date("2026-07-29T14:00:00Z"), { startedAt: new Date("2026-07-29T01:00:00Z") })).toBe(
+  expect(isDue(DAILY, new Date("2026-07-29T12:00:00Z"), { startedAt: new Date("2026-07-28T23:00:00Z") })).toBe(
     false,
   );
 });
 
-it("daily: je znova splatná ĎALŠÍ UTC kalendárny deň, aj keď posledný beh bol len pár hodín predtým", () => {
-  expect(isDue(DAILY, new Date("2026-07-30T01:00:00Z"), { startedAt: new Date("2026-07-29T23:00:00Z") })).toBe(
+it("daily: je znova splatná ĎALŠÍ SLOVENSKÝ kalendárny deň, aj keď posledný beh bol len pár hodín predtým", () => {
+  expect(isDue(DAILY, new Date("2026-07-29T23:00:00Z"), { startedAt: new Date("2026-07-29T21:00:00Z") })).toBe(
     true,
   );
 });
 
-it("daily: nie je splatná v ten istý UTC kalendárny deň, aj keď posledný beh bol tesne pred naplánovanou minútou", () => {
-  expect(isDue(DAILY, new Date("2026-07-29T01:05:00Z"), { startedAt: new Date("2026-07-29T00:59:59Z") })).toBe(
+it("daily: nie je splatná v ten istý SLOVENSKÝ kalendárny deň, aj keď posledný beh bol tesne pred naplánovanou minútou", () => {
+  expect(isDue(DAILY, new Date("2026-07-28T23:05:00Z"), { startedAt: new Date("2026-07-28T22:59:59Z") })).toBe(
     false,
   );
 });
@@ -74,7 +78,7 @@ it("hourly: je znova splatná pri prechode cez polnoc (nová UTC hodina 00 nasle
 // v UTC — inak úloha nastavená na 7:00 skutočne bežala až o 9:00 (v zime
 // 8:00) slovenského času. `DAILY_LOCAL` používa presne tie isté číselné
 // hodnoty (7:00) ako `postaUncollectedJob` v `jobs.ts`.
-const DAILY_LOCAL = { kind: "daily" as const, hourUtc: 7, minuteUtc: 0 };
+const DAILY_LOCAL = { kind: "daily" as const, hourLocal: 7, minuteLocal: 0 };
 
 it("issue 293: denná úloha na 7:00 je splatná o 7:00 SLOVENSKÉHO času v LETE (UTC+2)", () => {
   // 2026-08-06 07:00 Europe/Bratislava (letný čas, offset +2) = 05:00 UTC.
@@ -96,7 +100,7 @@ it("issue 293: denná úloha sa NEOPAKUJE dvakrát v ten istý SLOVENSKÝ deň, 
   // byť odvodený zo slovenského dňa, inak by tento druhý tick (UTC deň sa
   // medzitým zmenil) vyhodnotil úlohu ako znova splatnú a spustil ju
   // DRUHÝKRÁT v ten istý slovenský deň.
-  const dailyEarly = { kind: "daily" as const, hourUtc: 0, minuteUtc: 5 };
+  const dailyEarly = { kind: "daily" as const, hourLocal: 0, minuteLocal: 5 };
   expect(
     isDue(dailyEarly, new Date("2026-08-06T12:00:00Z"), { startedAt: new Date("2026-08-05T22:10:00Z") }),
   ).toBe(false);

--- a/apps/api/src/modules/scheduler/scheduler.test.ts
+++ b/apps/api/src/modules/scheduler/scheduler.test.ts
@@ -76,8 +76,10 @@ it("hourly: je znova splatná pri prechode cez polnoc (nová UTC hodina 00 nasle
 
 // issue 293: rozvrh musí počítať naplánovanú hodinu v Europe/Bratislava, nie
 // v UTC — inak úloha nastavená na 7:00 skutočne bežala až o 9:00 (v zime
-// 8:00) slovenského času. `DAILY_LOCAL` používa presne tie isté číselné
-// hodnoty (7:00) ako `postaUncollectedJob` v `jobs.ts`.
+// 8:00) slovenského času. `DAILY_LOCAL`'s hodnota (7:00) je len ilustračná
+// pre tento generický test `isDue()` — NEZODPOVEDÁ už aktuálnej hodnote
+// `postaUncollectedJob` v `jobs.ts` (tá je od nasledujúceho tiketu 9:00, aby
+// zostal zachovaný pôvodný zámer po oprave časového pásma).
 const DAILY_LOCAL = { kind: "daily" as const, hourLocal: 7, minuteLocal: 0 };
 
 it("issue 293: denná úloha na 7:00 je splatná o 7:00 SLOVENSKÉHO času v LETE (UTC+2)", () => {

--- a/apps/api/src/modules/scheduler/scheduler.test.ts
+++ b/apps/api/src/modules/scheduler/scheduler.test.ts
@@ -69,3 +69,68 @@ it("hourly: je znova splatná pri prechode cez polnoc (nová UTC hodina 00 nasle
     true,
   );
 });
+
+// issue 293: rozvrh musí počítať naplánovanú hodinu v Europe/Bratislava, nie
+// v UTC — inak úloha nastavená na 7:00 skutočne bežala až o 9:00 (v zime
+// 8:00) slovenského času. `DAILY_LOCAL` používa presne tie isté číselné
+// hodnoty (7:00) ako `postaUncollectedJob` v `jobs.ts`.
+const DAILY_LOCAL = { kind: "daily" as const, hourUtc: 7, minuteUtc: 0 };
+
+it("issue 293: denná úloha na 7:00 je splatná o 7:00 SLOVENSKÉHO času v LETE (UTC+2)", () => {
+  // 2026-08-06 07:00 Europe/Bratislava (letný čas, offset +2) = 05:00 UTC.
+  expect(isDue(DAILY_LOCAL, new Date("2026-08-06T05:00:00Z"), null)).toBe(true);
+  // O minútu skôr (04:59 slovenského času) ešte nie je splatná.
+  expect(isDue(DAILY_LOCAL, new Date("2026-08-06T04:59:00Z"), null)).toBe(false);
+});
+
+it("issue 293: denná úloha na 7:00 je splatná o 7:00 SLOVENSKÉHO času v ZIME (UTC+1)", () => {
+  // 2026-01-06 07:00 Europe/Bratislava (zimný čas, offset +1) = 06:00 UTC.
+  expect(isDue(DAILY_LOCAL, new Date("2026-01-06T06:00:00Z"), null)).toBe(true);
+  expect(isDue(DAILY_LOCAL, new Date("2026-01-06T05:59:00Z"), null)).toBe(false);
+});
+
+it("issue 293: denná úloha sa NEOPAKUJE dvakrát v ten istý SLOVENSKÝ deň, aj keď posledný beh bol tesne po miestnej polnoci (iný UTC kalendárny deň)", () => {
+  // Posledný beh: 2026-08-06 00:10 Europe/Bratislava = 2026-08-05T22:10:00Z
+  // (INÝ UTC kalendárny deň, ten istý slovenský deň). "Teraz": 2026-08-06
+  // 14:00 Europe/Bratislava = 2026-08-06T12:00:00Z. Periodizačný kľúč MUSÍ
+  // byť odvodený zo slovenského dňa, inak by tento druhý tick (UTC deň sa
+  // medzitým zmenil) vyhodnotil úlohu ako znova splatnú a spustil ju
+  // DRUHÝKRÁT v ten istý slovenský deň.
+  const dailyEarly = { kind: "daily" as const, hourUtc: 0, minuteUtc: 5 };
+  expect(
+    isDue(dailyEarly, new Date("2026-08-06T12:00:00Z"), { startedAt: new Date("2026-08-05T22:10:00Z") }),
+  ).toBe(false);
+});
+
+it("issue 293: denná úloha nie je PRESKOČENÁ v deň prechodu na LETNÝ čas (2026-03-29) oproti predošlému dňu", () => {
+  // Posledný beh: 2026-03-28 07:00 (deň PRED prechodom) = 2026-03-28T06:00:00Z.
+  // Teraz: 2026-03-29 07:00 (samotný deň prechodu, PO skoku 02:00→03:00) =
+  // 2026-03-29T05:00:00Z. Nový slovenský deň → má byť znova splatná.
+  expect(
+    isDue(DAILY_LOCAL, new Date("2026-03-29T05:00:00Z"), { startedAt: new Date("2026-03-28T06:00:00Z") }),
+  ).toBe(true);
+});
+
+it("issue 293: denná úloha sa NESPUSTÍ DVAKRÁT v samotný deň prechodu na letný čas, aj keď sa offset uprostred dňa zmenil", () => {
+  // Posledný beh aj "teraz" sú OBA 2026-03-29 (deň prechodu), len rôzna
+  // hodina — kľúč je čisto dátumový, offset zmena uprostred dňa nesmie
+  // spôsobiť falošné "iný deň".
+  expect(
+    isDue(DAILY_LOCAL, new Date("2026-03-29T18:00:00Z"), { startedAt: new Date("2026-03-29T05:00:00Z") }),
+  ).toBe(false);
+});
+
+it("issue 293: denná úloha nie je PRESKOČENÁ v deň prechodu na ZIMNÝ čas (2026-10-25) oproti predošlému dňu", () => {
+  // Posledný beh: 2026-10-24 07:00 (deň PRED prechodom) = 2026-10-24T05:00:00Z.
+  // Teraz: 2026-10-25 07:00 (samotný deň prechodu, PO skoku 03:00→02:00) =
+  // 2026-10-25T06:00:00Z. Nový slovenský deň → má byť znova splatná.
+  expect(
+    isDue(DAILY_LOCAL, new Date("2026-10-25T06:00:00Z"), { startedAt: new Date("2026-10-24T05:00:00Z") }),
+  ).toBe(true);
+});
+
+it("issue 293: denná úloha sa NESPUSTÍ DVAKRÁT v samotný deň prechodu na zimný čas, aj keď sa offset uprostred dňa zmenil", () => {
+  expect(
+    isDue(DAILY_LOCAL, new Date("2026-10-25T19:00:00Z"), { startedAt: new Date("2026-10-25T06:00:00Z") }),
+  ).toBe(false);
+});

--- a/apps/api/src/modules/scheduler/scheduler.ts
+++ b/apps/api/src/modules/scheduler/scheduler.ts
@@ -2,6 +2,7 @@ import { desc, eq, sql } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
 import { jobRuns } from "../../db/schema.js";
 import { log } from "../../logger.js";
+import { getZonedDateParts, zonedDateKey } from "../../timezone.js";
 import type { Schedule, ScheduledJob } from "./types.js";
 
 // Zámok naplánovaných úloh — VLASTNÝ, samostatný kľúč (advisory zámky zdieľajú
@@ -14,13 +15,21 @@ function utcDateKey(d: Date): string {
   return d.toISOString().slice(0, 10);
 }
 
-// Kľúč periódy podľa druhu rozvrhu — `daily` periodizuje podľa UTC
-// kalendárneho dňa (nezmenené), `hourly` (#115) podľa UTC dňa+hodiny, aby sa
-// tá istá hodina neopakovala dvakrát. Rovnaký beh v RÔZNYCH periódach (napr.
-// 23:00 včera vs. 01:00 dnes pri `daily`, alebo 10:xx vs. 11:xx pri `hourly`)
-// má rôzny kľúč → znova splatná.
+// Kľúč periódy podľa druhu rozvrhu — issue 293: `daily` periodizuje podľa
+// MIESTNEHO (Europe/Bratislava) kalendárneho dňa (predtým UTC deň — beh
+// tesne po slovenskej polnoci, ale ešte pred UTC polnocou, dostal VČEREJŠÍ
+// kľúč a úloha sa mohla spustiť DRUHÝKRÁT v ten istý slovenský deň).
+// `hourly` (#115) ZOSTÁVA podľa UTC dňa+hodiny, ZÁMERNE nelokalizované —
+// hodinový job nemá cieľovú hodinu (beží KAŽDÚ hodinu), lokalizácia kľúča by
+// v deň prechodu na ZIMNÝ čas (miestna hodina 02:00-03:00 sa v UTC termínoch
+// vyskytne DVAKRÁT) spôsobila, že druhý skutočný beh sa nesprávne považuje
+// za duplicitný tej istej periódy. UTC hodina je jednoznačná a monotónna,
+// presne to hodinový job potrebuje — `zonedDateKey` (nová, lokalizovaná
+// cesta) sa preto používa LEN pre `daily`.
+// Rovnaký beh v RÔZNYCH periódach (napr. 23:00 včera vs. 01:00 dnes pri
+// `daily`, alebo 10:xx vs. 11:xx pri `hourly`) má rôzny kľúč → znova splatná.
 function periodKey(schedule: Schedule, d: Date): string {
-  if (schedule.kind === "daily") return utcDateKey(d);
+  if (schedule.kind === "daily") return zonedDateKey(d);
   return `${utcDateKey(d)}T${String(d.getUTCHours()).padStart(2, "0")}`;
 }
 
@@ -38,10 +47,18 @@ export function isDue(
 ): boolean {
   if (lastRun !== null && periodKey(schedule, lastRun.startedAt) === periodKey(schedule, now)) return false;
   if (schedule.kind === "daily") {
-    const targetMinuteOfDay = schedule.hourUtc * 60 + schedule.minuteUtc;
-    const nowMinuteOfDay = now.getUTCHours() * 60 + now.getUTCMinutes();
+    // issue 293: cieľová aj aktuálna hodina/minúta sa porovnávajú v
+    // MIESTNOM (Europe/Bratislava) čase, nie v UTC — `hourLocal`/
+    // `minuteLocal` (types.ts) sú teraz slovenský čas, presne to, čo
+    // majiteľ v `jobs.ts` nastavuje.
+    const targetMinuteOfDay = schedule.hourLocal * 60 + schedule.minuteLocal;
+    const { hour, minute } = getZonedDateParts(now);
+    const nowMinuteOfDay = hour * 60 + minute;
     return nowMinuteOfDay >= targetMinuteOfDay;
   }
+  // Minúta v rámci hodiny je pre Europe/Bratislava (celohodinový offset)
+  // časovo-pásmovo NEZÁVISLÁ — UTC minúta == miestna minúta, netreba
+  // lokalizovať (viď komentár na `HourlySchedule.minuteUtc` v types.ts).
   return now.getUTCMinutes() >= schedule.minuteUtc;
 }
 

--- a/apps/api/src/modules/scheduler/types.ts
+++ b/apps/api/src/modules/scheduler/types.ts
@@ -1,14 +1,20 @@
 import type { Database } from "../../db/client.js";
 
-// Denná schéma vyjadrená ako presná hodina:minúta v UTC — najjednoduchšia vec,
-// ktorá pokrýva "spusti raz za noc" bez potreby cron-výrazového parsera. Úloha
-// je "splatná" v danom ticku, keď aktuálny UTC čas dosiahol/prekročil tento
-// bod a dnes (podľa UTC kalendárneho dňa) ešte nebežala — viď `isDue`
-// v scheduler.ts.
+// Denná schéma vyjadrená ako presná hodina:minúta v MIESTNOM (Europe/
+// Bratislava) čase — najjednoduchšia vec, ktorá pokrýva "spusti raz za noc"
+// bez potreby cron-výrazového parsera. Úloha je "splatná" v danom ticku,
+// keď aktuálny miestny čas dosiahol/prekročil tento bod a dnes (podľa
+// MIESTNEHO kalendárneho dňa) ešte nebežala — viď `isDue` v scheduler.ts.
+// Issue 293: predtým `hourUtc`/`minuteUtc` interpretované doslova ako UTC —
+// appka aj kontajner bežali v UTC, takže úloha nastavená na 7:00 sa v
+// skutočnosti spustila až o 9:00 (v zime 8:00) slovenského času. Polia sú
+// premenované na `hourLocal`/`minuteLocal`, aby meno zodpovedalo tomu, ako
+// sa hodnota SKUTOČNE číta — číselné hodnoty v `jobs.ts` ostali NEZMENENÉ,
+// zmenil sa len ich VÝZNAM.
 export interface DailySchedule {
   readonly kind: "daily";
-  readonly hourUtc: number;
-  readonly minuteUtc: number;
+  readonly hourLocal: number;
+  readonly minuteLocal: number;
 }
 
 // Hodinová schéma (#115) — rovnaký princíp ako `DailySchedule`, len s
@@ -16,9 +22,18 @@ export interface DailySchedule {
 // minúta dosiahla/prekročila `minuteUtc` A v tejto UTC hodine ešte nebežala.
 // Zámerne DISKRIMINOVANÁ ÚNIA s `DailySchedule` (spoločné pole `kind`),
 // nie jeden preťažený tvar s voliteľným flagom — vylučuje nezmyselné
-// kombinácie (napr. `everyHour` + nastavené `hourUtc` súčasne) a zodpovedá
+// kombinácie (napr. `everyHour` + nastavené `hourLocal` súčasne) a zodpovedá
 // existujúcemu štýlu repa (`CatalogIngestOutcome`/`OrdersIngestOutcome`
 // diskriminujú podľa `status`).
+//
+// `minuteUtc` (nie `minuteLocal`) je ZÁMERNÉ a ZOSTÁVA po issue 293 — na
+// rozdiel od `DailySchedule` hodinový job nemá cieľovú HODINU (beží v
+// KAŽDEJ hodine), len minútu v rámci hodiny. Minúta v rámci hodiny je v
+// Europe/Bratislava (celohodinový offset, vždy +1 alebo +2) rovnaká v UTC
+// aj v miestnom čase — preto sa netreba lokalizovať, a jej `periodKey`
+// (`scheduler.ts`) ZÁMERNE ostáva podľa UTC dňa+hodiny (jednoznačné,
+// monotónne, bez rizika opakovanej miestnej hodiny 02:00-03:00 v deň
+// prechodu na zimný čas — viď komentár pri `periodKey`).
 export interface HourlySchedule {
   readonly kind: "hourly";
   readonly minuteUtc: number;

--- a/apps/api/src/timezone.test.ts
+++ b/apps/api/src/timezone.test.ts
@@ -1,0 +1,51 @@
+import { expect, it } from "vitest";
+import { getZonedDateParts, zonedDateKey, BRATISLAVA_TIME_ZONE } from "./timezone.js";
+
+// issue 293: jediné spoločné miesto pre prácu s Europe/Bratislava pásmom —
+// `scheduler.ts` aj `posta-uncollected/{state,run,logic}.ts` predtým počítali
+// dátum/hodinu v UTC (`toISOString().slice(0,10)` / `getUTCHours()`), čo
+// posunulo naplánované úlohy o 1-2 hodiny a zobrazovalo dátumy tesne pred
+// polnocou slovenského času ako VČEREJŠOK.
+
+it("BRATISLAVA_TIME_ZONE je Europe/Bratislava", () => {
+  expect(BRATISLAVA_TIME_ZONE).toBe("Europe/Bratislava");
+});
+
+it("getZonedDateParts rozloží UTC okamih na miestne zložky v LETE (offset +2)", () => {
+  expect(getZonedDateParts(new Date("2026-08-06T05:00:00Z"))).toEqual({
+    year: 2026,
+    month: 8,
+    day: 6,
+    hour: 7,
+    minute: 0,
+    second: 0,
+  });
+});
+
+it("getZonedDateParts rozloží UTC okamih na miestne zložky v ZIME (offset +1)", () => {
+  expect(getZonedDateParts(new Date("2026-01-06T06:00:00Z"))).toEqual({
+    year: 2026,
+    month: 1,
+    day: 6,
+    hour: 7,
+    minute: 0,
+    second: 0,
+  });
+});
+
+it("zonedDateKey vráti DNEŠNÝ slovenský deň pre okamih tesne PO miestnej polnoci, aj keď je to ešte VČEREJŠÍ UTC kalendárny deň", () => {
+  // 2026-08-05T22:10:00Z = 2026-08-06 00:10 Europe/Bratislava (letný čas).
+  expect(zonedDateKey(new Date("2026-08-05T22:10:00Z"))).toBe("2026-08-06");
+  // `toISOString().slice(0, 10)` (stará, nesprávna cesta) by tu vrátilo
+  // "2026-08-05" — presne opačný, nesprávny deň.
+});
+
+it("zonedDateKey vráti VČEREJŠÍ slovenský deň pre okamih tesne PRED miestnou polnocou, aj keď je to už DNEŠNÝ UTC kalendárny deň", () => {
+  // 2026-08-06T21:50:00Z = 2026-08-06 23:50 Europe/Bratislava (ešte ten istý
+  // slovenský deň, UTC deň je zhodný — kontrolný prípad na hranicu).
+  expect(zonedDateKey(new Date("2026-08-06T21:50:00Z"))).toBe("2026-08-06");
+});
+
+it("zonedDateKey funguje aj mimo predvoleného pásma, keď sa zadá explicitne", () => {
+  expect(zonedDateKey(new Date("2026-08-06T05:00:00Z"), "UTC")).toBe("2026-08-06");
+});

--- a/apps/api/src/timezone.ts
+++ b/apps/api/src/timezone.ts
@@ -1,0 +1,59 @@
+// Zdieľané jadro pre prácu s Europe/Bratislava časovým pásmom — DST-vedomé,
+// založené na vstavanom `Intl.DateTimeFormat` (Node 24 má plné ICU aj IANA
+// databázu zón), žiadna závislosť navyše. Issue 293: appka (aj kontajner)
+// dovtedy počítala dátumy/čas v UTC, takže naplánované úlohy behali o 1-2
+// hodiny neskôr, než majiteľ nastavil, a pár obrazoviek ukazovalo dátum v
+// nečitateľnom UTC tvare namiesto slovenského. Predtým existovali DVE
+// samostatné implementácie toho istého triku (`modules/orders/parser.ts`'s
+// `parseShopLocalDateTime`, `modules/orders/overview.ts`'s
+// `computeBratislavaPeriodBoundaries`) — tento modul je JEDNO spoločné
+// miesto na koreňovej `src/` úrovni (rovnaká úroveň ako `logger.ts`/
+// `env.ts` — cross-cutting utilita, nepatrí žiadnemu konkrétnemu
+// `modules/*`), obe znovu použijú `getZonedDateParts` namiesto duplicitného
+// `Intl.DateTimeFormat` volania.
+
+export const BRATISLAVA_TIME_ZONE = "Europe/Bratislava";
+
+export interface ZonedDateParts {
+  readonly year: number;
+  readonly month: number; // 1-12
+  readonly day: number;
+  readonly hour: number;
+  readonly minute: number;
+  readonly second: number;
+}
+
+/** Rozloží UTC okamih na kalendárne/časové zložky v danom pásme (predvolene
+ * Europe/Bratislava). */
+export function getZonedDateParts(instant: Date, timeZone: string = BRATISLAVA_TIME_ZONE): ZonedDateParts {
+  const dtf = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    hourCycle: "h23",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+  const parts = dtf.formatToParts(instant);
+  const get = (type: string): number => Number(parts.find((p) => p.type === type)?.value ?? "0");
+  return {
+    year: get("year"),
+    month: get("month"),
+    day: get("day"),
+    hour: get("hour"),
+    minute: get("minute"),
+    second: get("second"),
+  };
+}
+
+/** "YYYY-MM-DD" kalendárny dátum v danom pásme — pre DB `date` stĺpce a pre
+ * "raz za deň" rozvrhové kľúče. NIKDY `toISOString().slice(0, 10)` (to je
+ * vždy UTC deň — presne issue 293's chyba: čokoľvek medzi 22:00 a polnocou
+ * slovenského času vyjde s dátumom VČEREJŠKA). */
+export function zonedDateKey(instant: Date, timeZone: string = BRATISLAVA_TIME_ZONE): string {
+  const { year, month, day } = getZonedDateParts(instant, timeZone);
+  const pad = (n: number): string => String(n).padStart(2, "0");
+  return `${String(year).padStart(4, "0")}-${pad(month)}-${pad(day)}`;
+}

--- a/apps/api/tests/posta-uncollected-run.integration.test.ts
+++ b/apps/api/tests/posta-uncollected-run.integration.test.ts
@@ -387,3 +387,31 @@ it("zásielka BEZ existujúcej karty, ktorej prvá klasifikácia je invalid_form
   const rows = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "posta:12345678901234"));
   expect(rows).toHaveLength(0);
 });
+
+// issue 293: `lastSentAt` sa predtým odvodzovalo cez `toISOString().slice(0, 10)`
+// (VŽDY UTC kalendárny deň) — beh tesne po SLOVENSKEJ polnoci (ale ešte pred
+// UTC polnocou) tak zapísal VČEREJŠÍ deň namiesto dnešného.
+it("issue 293: lastSentAt sa uloží podľa SLOVENSKÉHO dňa behu, nie UTC — aj tesne po miestnej polnoci", async () => {
+  const db = await boot();
+  await insertOrder(db, { externalOrderId: "20500015" });
+  const sent: MailMessage[] = [];
+
+  // 2026-08-05T22:10:00Z = 2026-08-06 00:10 Europe/Bratislava (letný čas) —
+  // slovenský deň je UŽ 6.8., UTC deň je ešte 5.8.
+  const justAfterLocalMidnight = new Date("2026-08-05T22:10:00Z");
+
+  const result = await runPostaUncollected({
+    db,
+    now: justAfterLocalMidnight,
+    trackingClient: notifiedTrackingClient(),
+    mailTransport: (m) => {
+      sent.push(m);
+      return Promise.resolve();
+    },
+    bccEmail: "majitel@forestshop.sk",
+    adminBaseUrl: "https://www.forestshop.sk",
+  });
+
+  expect(sent).toHaveLength(1);
+  expect(result.uncollected[0]?.lastSentAt).toBe("2026-08-06");
+});

--- a/apps/api/tests/scheduler-http.integration.test.ts
+++ b/apps/api/tests/scheduler-http.integration.test.ts
@@ -9,7 +9,9 @@ import type { ScheduledJob } from "../src/modules/scheduler/types.js";
 import { withCleanDb } from "./helpers/db.js";
 
 const HESLO = "test-heslo-abc"; // testovacie údaje, nie tajomstvo
-const NOW = new Date("2026-07-29T01:00:00Z");
+// issue 293: `hourLocal`/`minuteLocal` sú Europe/Bratislava miestny čas —
+// 2026-07-28T23:00:00Z = 2026-07-29 01:00 Europe/Bratislava (letný čas).
+const NOW = new Date("2026-07-28T23:00:00Z");
 
 let close: (() => Promise<void>) | undefined;
 afterEach(async () => {
@@ -66,7 +68,7 @@ it("manazer vidí posledný beh každej úlohy", async () => {
 
   const job: ScheduledJob = {
     name: "test-job",
-    schedule: { kind: "daily", hourUtc: 1, minuteUtc: 0 },
+    schedule: { kind: "daily", hourLocal: 1, minuteLocal: 0 },
     run: () => Promise.resolve({ detail: { removed: 3 } }),
   };
   await tick(db, [job], NOW);

--- a/apps/api/tests/scheduler.integration.test.ts
+++ b/apps/api/tests/scheduler.integration.test.ts
@@ -12,14 +12,18 @@ afterEach(async () => {
   close = undefined;
 });
 
-const NOW = new Date("2026-07-29T01:00:00Z");
-const PRED_HODINOU = new Date("2026-07-29T00:00:00Z");
-const NASLEDUJUCI_DEN = new Date("2026-07-30T01:00:00Z");
+// issue 293: `hourLocal`/`minuteLocal` sú Europe/Bratislava miestny čas
+// (predtým `hourUtc`/`minuteUtc`, doslova UTC) — literály nižšie sú UTC
+// okamihy zodpovedajúce miestnemu "01:00"/"00:00" na dátume 2026-07-29
+// (letný čas, offset +2).
+const NOW = new Date("2026-07-28T23:00:00Z"); // 2026-07-29 01:00 Europe/Bratislava
+const PRED_HODINOU = new Date("2026-07-28T22:00:00Z"); // 2026-07-29 00:00 Europe/Bratislava
+const NASLEDUJUCI_DEN = new Date("2026-07-29T23:00:00Z"); // 2026-07-30 01:00 Europe/Bratislava
 
 function fakeJob(overrides: Partial<ScheduledJob> = {}): ScheduledJob {
   return {
     name: "fake-job",
-    schedule: { kind: "daily", hourUtc: 1, minuteUtc: 0 },
+    schedule: { kind: "daily", hourLocal: 1, minuteLocal: 0 },
     run: () => Promise.resolve({ detail: { ok: true } }),
     ...overrides,
   };
@@ -75,7 +79,7 @@ it("druhý tick v ten istý deň úlohu nezopakuje", async () => {
   expect(all).toHaveLength(1);
 });
 
-it("ďalší UTC kalendárny deň úlohu znova spustí", async () => {
+it("ďalší SLOVENSKÝ kalendárny deň úlohu znova spustí", async () => {
   const ctx = await withCleanDb();
   close = ctx.close;
   const job = fakeJob();

--- a/apps/web/src/components/CatalogPage.tsx
+++ b/apps/web/src/components/CatalogPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState, type SyntheticEvent, type JSX } from "react";
 import type { Me } from "../api.js";
+import { formatSkDate, formatSkDateTime } from "../formatDate.js";
 import {
   CatalogUnauthorizedError,
   fetchCatalogStats,
@@ -33,7 +34,7 @@ function SnapshotLine({ stats }: { readonly stats: CatalogStats }): JSX.Element 
     return <p data-testid="snapshot">Katalóg zatiaľ nebol importovaný.</p>;
   }
 
-  const fetchedAtLabel = new Date(snapshot.fetchedAt).toLocaleString("sk-SK");
+  const fetchedAtLabel = formatSkDateTime(snapshot.fetchedAt);
   const anomaliesLabel = snapshot.issueCount === null ? "—" : String(snapshot.issueCount);
   const zdrojAAnomalie = `zdroj: ${snapshot.sourceLabel}, anomálií: ${anomaliesLabel}`;
 
@@ -307,7 +308,7 @@ export function CatalogPage({
                     <>
                       {" "}
                       <strong data-testid={`missing-${item.code}`}>
-                        (chýba od {new Date(item.missingSince).toLocaleDateString("sk-SK")})
+                        (chýba od {formatSkDate(item.missingSince)})
                       </strong>
                     </>
                   )}

--- a/apps/web/src/components/MailLogSection.tsx
+++ b/apps/web/src/components/MailLogSection.tsx
@@ -1,4 +1,5 @@
 import { Fragment, useCallback, useEffect, useState, type JSX } from "react";
+import { formatSkDateTime } from "../formatDate.js";
 import {
   fetchMailLog,
   MailLogUnauthorizedError,
@@ -26,10 +27,6 @@ const PERIOD_LABELS: readonly { readonly value: MailLogPeriod; readonly label: s
   { value: "90", label: "posledných 90 dní" },
   { value: "all", label: "celá história" },
 ];
-
-function formatWhen(iso: string): string {
-  return new Date(iso).toLocaleString("sk-SK", { dateStyle: "short", timeStyle: "short" });
-}
 
 /** Čoho sa e-mail týkal — objednávka, tovar, zásielka. Prázdny reťazec, keď
  * odosielateľ nič z toho nemá (objednávka dodávateľovi). */
@@ -170,7 +167,7 @@ export function MailLogSection({ onSessionExpired }: { readonly onSessionExpired
                   <Fragment key={row.id}>
                     <tr data-testid={`mail-log-row-${row.id}`} className={`ml-row ml-row-${row.status}`}>
                       <td className="ml-when">
-                        {formatWhen(row.createdAt)}
+                        {formatSkDateTime(row.createdAt)}
                         <span className="ml-trigger">{row.trigger === "manual" ? (row.actorName ?? "ručne") : "plán"}</span>
                       </td>
                       <td>

--- a/apps/web/src/components/OrderLineRow.tsx
+++ b/apps/web/src/components/OrderLineRow.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState, type JSX } from "react";
+import { formatSkDate } from "../formatDate.js";
 import type { OrderLine } from "../ordersApi.js";
 import { STATE_LABELS } from "../orderLineStateLabels.js";
 import { formatVariantTotalChip, isStaleOrderLine, orderLineAgeDays, type VariantTotal } from "../ordersSummary.js";
@@ -453,7 +454,7 @@ export function OrderLineRow({
           )}
         </td>
         <td className="ord-date-cell">
-          {new Date(line.placedAt).toLocaleDateString("sk-SK")}
+          {formatSkDate(line.placedAt)}
           {/* issue 65: upozornenie na starú nevybavenú objednávku — priamy
               náprotivok starej appky's ⚠️ badge (`ordersSummary.ts`'s
               `isStaleOrderLine`, hranica 14 dní). issue 127: viditeľný text

--- a/apps/web/src/components/OrderReminderRow.test.tsx
+++ b/apps/web/src/components/OrderReminderRow.test.tsx
@@ -1,0 +1,39 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, expect, it } from "vitest";
+import { OrderReminderEmailedRow } from "./OrderReminderRow.js";
+import type { OrderReminderResolvedRow } from "../orderReminderApi.js";
+
+// issue 293: dátum vyriešenia sa predtým robil odseknutím prvých desiatich
+// znakov z UTC ISO reťazca (`row.resolvedAt.slice(0, 10)`) — nečitateľný
+// tvar ("2026-08-05") a pre časy medzi 22:00 a polnocou SLOVENSKÉHO času
+// ukázal o deň SKORŠÍ dátum, než je náš kalendárny deň.
+
+const ROW: OrderReminderResolvedRow = {
+  orderCode: "20260900",
+  adminLink: "https://admin.example/order/1",
+  name: "Test Zákazník",
+  phone: "",
+  email: "zakaznik@example.com",
+  itemLabel: "",
+  days: 3,
+  // 2026-08-05T22:10:00Z = 2026-08-06 00:10 Europe/Bratislava (letný čas) —
+  // presne minútu po slovenskej polnoci, ešte v UTC deň PREDTÝM.
+  resolvedAt: "2026-08-05T22:10:00.000Z",
+  resolvedBy: "ai",
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+it("issue 293: dátum vyriešenia tesne po SLOVENSKEJ polnoci sa zobrazí ako DNEŠNÝ slovenský deň v čitateľnom tvare, nie včerajší UTC rez", () => {
+  render(
+    <table>
+      <tbody>
+        <OrderReminderEmailedRow row={ROW} />
+      </tbody>
+    </table>,
+  );
+  const cell = screen.getByRole("row").lastElementChild;
+  expect(cell?.textContent).toBe("6. 8. 2026");
+});

--- a/apps/web/src/components/OrderReminderRow.tsx
+++ b/apps/web/src/components/OrderReminderRow.tsx
@@ -1,4 +1,5 @@
 import type { JSX } from "react";
+import { formatSkDate } from "../formatDate.js";
 import type { OrderReminderPendingRow, OrderReminderResolvedRow, OrderReminderRow } from "../orderReminderApi.js";
 
 // Vydelené z `OrderReminderSection.tsx` (issue 173) — rovnaký vzor ako
@@ -87,7 +88,7 @@ export function OrderReminderEmailedRow({ row }: { readonly row: OrderReminderRe
       <td>{row.name}</td>
       <td>{row.email}</td>
       <td>{row.itemLabel !== "" ? row.itemLabel : "—"}</td>
-      <td>{row.resolvedAt.slice(0, 10)}</td>
+      <td>{formatSkDate(row.resolvedAt)}</td>
     </tr>
   );
 }

--- a/apps/web/src/components/OrderReminderSection.tsx
+++ b/apps/web/src/components/OrderReminderSection.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState, type JSX } from "react";
 import type { Me } from "../api.js";
+import { formatSkDateTime } from "../formatDate.js";
 import {
   fetchOrderReminderPreview,
   fetchOrderReminderStatus,
@@ -161,7 +162,7 @@ export function OrderReminderSection({
 
       {status.lastRun !== null && (
         <p className="order-reminder-last-run">
-          Posledný beh: {new Date(status.lastRun.startedAt).toLocaleString("sk-SK")} —{" "}
+          Posledný beh: {formatSkDateTime(status.lastRun.startedAt)} —{" "}
           {status.lastRun.status === "failure" ? "❌ chyba" : status.lastRun.skippedReason !== null ? `⏸ ${status.lastRun.skippedReason}` : "✅ OK"}
         </p>
       )}

--- a/apps/web/src/components/OrdersOverviewTiles.tsx
+++ b/apps/web/src/components/OrdersOverviewTiles.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, type JSX } from "react";
+import { formatSkDate } from "../formatDate.js";
 import { fetchOrdersOverview, OrdersUnauthorizedError, type OrdersOverview, type SupplierOpenOrders } from "../ordersApi.js";
 import { countAffectedOrders, formatOrderCount, oldestWaitingPlacedAt, summarizeOrderLines } from "../ordersSummary.js";
 
@@ -69,7 +70,7 @@ export function OrdersOverviewTiles({
           <SimpleTile
             testId="overview-ordering-oldest"
             label="Najstaršia čakajúca"
-            value={oldestPlacedAt === null ? "—" : new Date(oldestPlacedAt).toLocaleDateString("sk-SK")}
+            value={formatSkDate(oldestPlacedAt)}
           />
         </div>
       </div>

--- a/apps/web/src/components/PairingGroupRow.tsx
+++ b/apps/web/src/components/PairingGroupRow.tsx
@@ -1,4 +1,5 @@
 import type { JSX } from "react";
+import { formatSkDate } from "../formatDate.js";
 import { groupConfirmation, isGroupFullyConfirmed, type ProductGroup } from "../pairingGroups.js";
 
 const STATE_LABELS = { navrhnute: "Navrhnuté", potvrdene: "Potvrdené" } as const;
@@ -86,7 +87,7 @@ export function PairingGroupRow({
       <td>
         {confirmed.confirmedByName === null
           ? "—"
-          : `${confirmed.confirmedByName} (${new Date(confirmed.confirmedAt ?? "").toLocaleDateString("sk-SK")})`}
+          : `${confirmed.confirmedByName} (${formatSkDate(confirmed.confirmedAt)})`}
       </td>
       {canConfirm && (
         <td>

--- a/apps/web/src/components/PairingVariantRow.tsx
+++ b/apps/web/src/components/PairingVariantRow.tsx
@@ -1,4 +1,5 @@
 import type { JSX } from "react";
+import { formatSkDate } from "../formatDate.js";
 import type { PairingItem } from "../pairingApi.js";
 
 const STATE_LABELS: Record<PairingItem["state"], string> = {
@@ -83,7 +84,7 @@ export function PairingVariantRow({
       <td>
         {item.confirmedByName === null
           ? "—"
-          : `${item.confirmedByName} (${new Date(item.confirmedAt ?? "").toLocaleDateString("sk-SK")})`}
+          : `${item.confirmedByName} (${formatSkDate(item.confirmedAt)})`}
       </td>
       {canConfirm && (
         <td>

--- a/apps/web/src/components/PostaUncollectedRow.test.tsx
+++ b/apps/web/src/components/PostaUncollectedRow.test.tsx
@@ -1,0 +1,45 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { PostaUncollectedRow } from "./PostaUncollectedRow.js";
+import type { PostaUncollectedShipment } from "../postaUncollectedApi.js";
+
+// issue 293: `retainedTill` (termín vyzdvihnutia) aj `lastSentAt` (naposledy
+// poslané) sa vykresľovali ako SUROVÝ tvar "YYYY-MM-DD" priamo zo servera
+// namiesto slovenského "12. 8. 2026" — nečitateľné pre bežného používateľa.
+
+const SHIPMENT: PostaUncollectedShipment = {
+  orderCode: "20260900",
+  packageNumber: "EF123456789SK",
+  name: "Test Zákazník",
+  email: "",
+  phone: "",
+  officeName: "Pošta 1",
+  officeAddr: "",
+  retainedTill: "2026-08-12",
+  notifiedSince: "2026-08-06",
+  daysAtPost: 2,
+  count: 1,
+  lastSentAt: "2026-08-06",
+  callNeeded: false,
+  trackingLink: "https://tracking.example/EF123456789SK",
+  adminLink: "https://admin.example/order/1",
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+it("issue 293: termín vyzdvihnutia a dátum posledného odoslania sa zobrazia v slovenskom tvare, nie ako surový YYYY-MM-DD zo servera", () => {
+  render(
+    <table>
+      <tbody>
+        <PostaUncollectedRow shipment={SHIPMENT} onPreview={vi.fn()} />
+      </tbody>
+    </table>,
+  );
+  const row = screen.getByTestId(`posta-row-${SHIPMENT.packageNumber}`);
+  expect(row.textContent).toContain("12. 8. 2026");
+  expect(row.textContent).not.toContain("2026-08-12");
+  expect(row.textContent).toContain("6. 8. 2026");
+  expect(row.textContent).not.toContain("2026-08-06");
+});

--- a/apps/web/src/components/PostaUncollectedRow.tsx
+++ b/apps/web/src/components/PostaUncollectedRow.tsx
@@ -1,4 +1,5 @@
 import type { JSX } from "react";
+import { formatSkDate } from "../formatDate.js";
 import type { PostaUncollectedShipment } from "../postaUncollectedApi.js";
 
 // Vydelené z `PostaUncollectedSection.tsx` (issue 172) — rovnaký vzor ako
@@ -30,7 +31,7 @@ export function PostaUncollectedRow({
         {shipment.phone !== "" && <div className="posta-phone">{shipment.phone}</div>}
       </td>
       <td>{shipment.daysAtPost}</td>
-      <td>{shipment.retainedTill !== "" ? shipment.retainedTill : "čo najskôr"}</td>
+      <td>{shipment.retainedTill !== "" ? formatSkDate(shipment.retainedTill) : "čo najskôr"}</td>
       <td>
         {shipment.count}/4{" "}
         {shipment.callNeeded && (
@@ -39,7 +40,7 @@ export function PostaUncollectedRow({
           </span>
         )}
       </td>
-      <td>{shipment.lastSentAt !== "" ? shipment.lastSentAt : "—"}</td>
+      <td>{formatSkDate(shipment.lastSentAt)}</td>
       <td>
         <button
           type="button"

--- a/apps/web/src/components/PostaUncollectedSection.tsx
+++ b/apps/web/src/components/PostaUncollectedSection.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState, type JSX } from "react";
 import type { Me } from "../api.js";
+import { formatSkDateTime } from "../formatDate.js";
 import {
   fetchPostaUncollectedPreview,
   fetchPostaUncollectedStatus,
@@ -134,7 +135,7 @@ export function PostaUncollectedSection({
 
       {status.lastRun !== null && (
         <p className="posta-last-run">
-          Posledný beh: {new Date(status.lastRun.startedAt).toLocaleString("sk-SK")} —{" "}
+          Posledný beh: {formatSkDateTime(status.lastRun.startedAt)} —{" "}
           {status.lastRun.status === "failure" ? "❌ chyba" : status.lastRun.skippedReason !== null ? `⏸ ${status.lastRun.skippedReason}` : "✅ OK"}
         </p>
       )}

--- a/apps/web/src/components/RestockSection.tsx
+++ b/apps/web/src/components/RestockSection.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState, type JSX } from "react";
 import type { Me } from "../api.js";
+import { formatSkDateTime } from "../formatDate.js";
 import {
   fetchRestockStatus,
   fetchRestockWaiting,
@@ -25,11 +26,6 @@ const STATE_LABEL: Readonly<Record<"sellable" | "out_of_stock" | "discontinued",
   out_of_stock: "vypredané",
   discontinued: "ukončený predaj",
 };
-
-function formatDateTime(iso: string): string {
-  const date = new Date(iso);
-  return Number.isNaN(date.getTime()) ? "—" : date.toLocaleString("sk-SK");
-}
 
 export function RestockSection({
   role,
@@ -178,7 +174,7 @@ export function RestockSection({
 
       {lastRun !== null && (
         <p data-testid="restock-last-run">
-          Posledný beh: {formatDateTime(lastRun.startedAt)} —{" "}
+          Posledný beh: {formatSkDateTime(lastRun.startedAt)} —{" "}
           {lastRun.status === "failure"
             ? "❌ chyba"
             : lastRun.skippedReason !== null
@@ -250,7 +246,7 @@ export function RestockSection({
             <tbody>
               {events.map((event) => (
                 <tr key={event.id} data-testid={`restock-event-${event.variantCode}`}>
-                  <td>{formatDateTime(event.at)}</td>
+                  <td>{formatSkDateTime(event.at)}</td>
                   <td>{event.variantCode}</td>
                   <td>{event.productName}</td>
                   <td>{event.supplier ?? "—"}</td>

--- a/apps/web/src/components/SchedulerSection.tsx
+++ b/apps/web/src/components/SchedulerSection.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState, type JSX } from "react";
 import type { Me } from "../api.js";
+import { formatSkDateTime } from "../formatDate.js";
 import { detailText, jobLabel, STATUS_LABELS } from "../schedulerLabels.js";
 import { fetchJobRuns, SchedulerUnauthorizedError, type JobRun } from "../schedulerApi.js";
 
@@ -67,10 +68,10 @@ export function SchedulerSection({
             {runs.map((run) => (
               <tr key={run.jobName} data-testid={`job-${run.jobName}`}>
                 <td>{jobLabel(run.jobName)}</td>
-                <td>{new Date(run.startedAt).toLocaleString("sk-SK")}</td>
+                <td>{formatSkDateTime(run.startedAt)}</td>
                 <td>{STATUS_LABELS[run.status]}</td>
                 <td>
-                  {run.finishedAt === null ? "—" : new Date(run.finishedAt).toLocaleString("sk-SK")}
+                  {formatSkDateTime(run.finishedAt)}
                 </td>
                 <td>{detailText(run)}</td>
               </tr>

--- a/apps/web/src/components/SearchSection.tsx
+++ b/apps/web/src/components/SearchSection.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useRef, useState, type SyntheticEvent, type JSX } from "react";
 import type { Me } from "../api.js";
+import { formatSkDateTime } from "../formatDate.js";
 import { validateSupplierLinkUrl } from "../ordersApi.js";
 import {
   fetchProductDetail,
@@ -32,12 +33,6 @@ const SUPPLIER_AVAILABILITY_LABELS: Record<"available" | "unavailable" | "unknow
   unknown: "Nezistené",
 };
 
-function formatDateTime(iso: string | null): string {
-  if (iso === null) return "—";
-  const date = new Date(iso);
-  return Number.isNaN(date.getTime()) ? "—" : date.toLocaleString("sk-SK");
-}
-
 /** Rovnaká "uložené vs. odoslané do Shoptetu" logika ako `SupplierLinksSection.tsx`'s
  * `statusLabel` — vyvodená len z `supplierLinkUpdatedAt`/`supplierLinkSyncedAt`. */
 function linkStatusLabel(detail: ProductDetail): string {
@@ -45,7 +40,7 @@ function linkStatusLabel(detail: ProductDetail): string {
   const pending = detail.supplierLinkSyncedAt === null || detail.supplierLinkSyncedAt < detail.supplierLinkUpdatedAt;
   return pending
     ? "⏳ Uložené, čaká na odoslanie"
-    : `✅ Odoslané do Shoptetu (${formatDateTime(detail.supplierLinkSyncedAt)})`;
+    : `✅ Odoslané do Shoptetu (${formatSkDateTime(detail.supplierLinkSyncedAt)})`;
 }
 
 function supplierAvailabilityLabel(variant: ProductDetailVariant): string {

--- a/apps/web/src/components/SupplierLinksSection.tsx
+++ b/apps/web/src/components/SupplierLinksSection.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState, type SyntheticEvent, type JSX } from "react";
 import type { Me } from "../api.js";
+import { formatSkDateTime } from "../formatDate.js";
 import { validateSupplierLinkUrl } from "../ordersApi.js";
 import {
   saveProductLink,
@@ -17,12 +18,6 @@ import {
 // odošle do Shoptetu — táto obrazovka doň nezapisuje žiadnou NOVOU cestou.
 const CAN_EDIT_ROLES: ReadonlySet<Me["role"]> = new Set(["admin", "manazer"]);
 
-function formatDateTime(iso: string | null): string {
-  if (iso === null) return "—";
-  const date = new Date(iso);
-  return Number.isNaN(date.getTime()) ? "—" : date.toLocaleString("sk-SK");
-}
-
 /**
  * Stav "uložené vs. odoslané do Shoptetu" (ticketova akceptačná podmienka) sa
  * dá vyvodiť LEN z `updatedAt`/`syncedAt` — `updatedAt === null` znamená
@@ -34,7 +29,7 @@ function formatDateTime(iso: string | null): string {
 function statusLabel(item: ProductLinkItem): string {
   if (item.updatedAt === null) return item.url === null ? "—" : "zo Shoptetu";
   const pending = item.syncedAt === null || item.syncedAt < item.updatedAt;
-  return pending ? "⏳ Uložené, čaká na odoslanie" : `✅ Odoslané do Shoptetu (${formatDateTime(item.syncedAt)})`;
+  return pending ? "⏳ Uložené, čaká na odoslanie" : `✅ Odoslané do Shoptetu (${formatSkDateTime(item.syncedAt)})`;
 }
 
 export function SupplierLinksSection({

--- a/apps/web/src/components/SupplierStockSection.tsx
+++ b/apps/web/src/components/SupplierStockSection.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState, type JSX } from "react";
 import type { Me } from "../api.js";
+import { formatSkDateTime } from "../formatDate.js";
 import {
   fetchSupplierStockStatus,
   runSupplierStockNow,
@@ -19,12 +20,6 @@ const AVAILABILITY_LABEL: Readonly<Record<SupplierAvailability, string>> = {
   unavailable: "Vypredané",
   unknown: "Neviem",
 };
-
-function formatDateTime(iso: string | null): string {
-  if (iso === null) return "—";
-  const date = new Date(iso);
-  return Number.isNaN(date.getTime()) ? "—" : date.toLocaleString("sk-SK");
-}
 
 export function SupplierStockSection({
   role,
@@ -136,10 +131,10 @@ export function SupplierStockSection({
         </p>
       )}
 
-      <p data-testid="ss-last-checked">Naposledy kontrolované: {formatDateTime(overview.lastCheckedAt)}</p>
+      <p data-testid="ss-last-checked">Naposledy kontrolované: {formatSkDateTime(overview.lastCheckedAt)}</p>
       {lastRun !== null && (
         <p data-testid="ss-last-run">
-          Posledný beh: {formatDateTime(lastRun.startedAt)} —{" "}
+          Posledný beh: {formatSkDateTime(lastRun.startedAt)} —{" "}
           {lastRun.status === "failure" ? "❌ chyba" : lastRun.status === "running" ? "⏳ beží" : "✅ OK"}
           {lastRun.errorMessage !== null && ` (${lastRun.errorMessage})`}
         </p>
@@ -211,7 +206,7 @@ export function SupplierStockSection({
                   <td>{host.readable}</td>
                   <td>{host.unknown}</td>
                   <td>{host.failed}</td>
-                  <td>{formatDateTime(host.lastConfirmedAt)}</td>
+                  <td>{formatSkDateTime(host.lastConfirmedAt)}</td>
                 </tr>
               ))}
             </tbody>
@@ -252,7 +247,7 @@ export function SupplierStockSection({
                     {row.availabilityText !== "" && ` (${row.availabilityText})`}
                   </td>
                   <td>{row.price === null ? "—" : `${row.price} €`}</td>
-                  <td>{formatDateTime(row.checkedAt)}</td>
+                  <td>{formatSkDateTime(row.checkedAt)}</td>
                 </tr>
               ))}
             </tbody>

--- a/apps/web/src/components/SyncSection.tsx
+++ b/apps/web/src/components/SyncSection.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState, type JSX } from "react";
 import type { Me } from "../api.js";
 import { CatalogUnauthorizedError, triggerCatalogIngest, type CatalogIngestOutcome } from "../catalogApi.js";
+import { formatSkDateTime } from "../formatDate.js";
 import { OrdersUnauthorizedError, triggerOrdersIngest, type OrdersIngestOutcome } from "../ordersApi.js";
 import { fetchJobRuns, SchedulerUnauthorizedError, type JobRun } from "../schedulerApi.js";
 import { detailText, jobLabel, STATUS_LABELS } from "../schedulerLabels.js";
@@ -53,7 +54,7 @@ function describeOrdersOutcome(result: OrdersIngestOutcome): Notice {
 
 function lastRunLine(run: JobRun | undefined): string {
   if (run === undefined) return "Posledný beh: zatiaľ nikdy";
-  const cas = new Date(run.startedAt).toLocaleString("sk-SK");
+  const cas = formatSkDateTime(run.startedAt);
   const verdikt = run.status === "running" ? "⏳ beží…" : run.status === "success" ? "✅ OK" : "❌ CHYBA";
   return `Posledný beh: ${cas} — ${verdikt}`;
 }
@@ -233,9 +234,9 @@ export function SyncSection({
                 {runs.map((run) => (
                   <tr key={run.jobName} data-testid={`sync-job-${run.jobName}`}>
                     <td>{jobLabel(run.jobName)}</td>
-                    <td>{new Date(run.startedAt).toLocaleString("sk-SK")}</td>
+                    <td>{formatSkDateTime(run.startedAt)}</td>
                     <td>{STATUS_LABELS[run.status]}</td>
-                    <td>{run.finishedAt === null ? "—" : new Date(run.finishedAt).toLocaleString("sk-SK")}</td>
+                    <td>{formatSkDateTime(run.finishedAt)}</td>
                     <td>{detailText(run)}</td>
                   </tr>
                 ))}

--- a/apps/web/src/components/UpozorneniaResolvedList.tsx
+++ b/apps/web/src/components/UpozorneniaResolvedList.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState, type JSX } from "react";
+import { formatSkDateTime } from "../formatDate.js";
 import { fetchResolvedUpozornenia, returnUpozornenieToOpen, UpozorneniaUnauthorizedError, type ResolvedUpozornenieRow } from "../upozorneniaApi.js";
 
 // issue 283 (majiteľ, komentár na tickete): záložka "Vybavené" na nástenke
@@ -13,10 +14,6 @@ const TYPE_LABELS: Readonly<Record<ResolvedUpozornenieRow["type"], string>> = {
   nevyzdvihnuta_zasielka: "Nevyzdvihnutá zásielka",
   vratenie: "Vrátenie",
 };
-
-function formatDateTime(iso: string): string {
-  return new Date(iso).toLocaleString("sk-SK", { dateStyle: "short", timeStyle: "short" });
-}
 
 export function UpozorneniaResolvedList({
   canControl,
@@ -111,10 +108,10 @@ export function UpozorneniaResolvedList({
                 </div>
                 <p className="upozornenie-title">{row.title}</p>
                 {row.details !== "" && <p className="upozornenie-details">{row.details}</p>}
-                <p className="upozornenie-meta">Vzniklo {formatDateTime(row.createdAt)}</p>
+                <p className="upozornenie-meta">Vzniklo {formatSkDateTime(row.createdAt)}</p>
                 <p className="upozornenie-resolved-meta" data-testid={`upozornenie-resolved-meta-${row.id}`}>
                   Vybavil(a) {row.resolvedByName ?? "automaticky"}
-                  {row.resolvedAt !== null && <> · {formatDateTime(row.resolvedAt)}</>}
+                  {row.resolvedAt !== null && <> · {formatSkDateTime(row.resolvedAt)}</>}
                 </p>
                 {canControl && (
                   <div className="upozornenie-actions">

--- a/apps/web/src/components/UpozornenieCard.tsx
+++ b/apps/web/src/components/UpozornenieCard.tsx
@@ -1,4 +1,5 @@
 import type { JSX } from "react";
+import { formatSkDate } from "../formatDate.js";
 import type { UpozornenieRow } from "../upozorneniaApi.js";
 
 // issue 283 (code review — súbor `UpozorneniaSection.tsx` prerástol eslint
@@ -31,10 +32,6 @@ const LINK_LABELS: Readonly<Partial<Record<UpozornenieRow["type"], string>>> = {
   vratenie: "Otvoriť objednávku v Shoptete",
 };
 const DEFAULT_LINK_LABEL = "Otvoriť odkaz";
-
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString("sk-SK", { day: "numeric", month: "numeric", year: "numeric" });
-}
 
 // Code review: "Odložiť do" nemalo `min` — dalo sa vybrať dátum v minulosti
 // (neškodné, `computeStatus` by ho vzalo ako "už sa vrátilo", ale mätúce
@@ -84,15 +81,15 @@ export function UpozornenieCard({
         {row.status === "nove" && <strong data-testid={`upozornenie-nove-${row.id}`}>Nové</strong>}
         {row.status === "odlozene" && (
           <span className="pill" data-testid={`upozornenie-odlozene-${row.id}`}>
-            Odložené{row.postponedUntil !== null && <> do {formatDate(row.postponedUntil)}</>}
+            Odložené{row.postponedUntil !== null && <> do {formatSkDate(row.postponedUntil)}</>}
           </span>
         )}
       </div>
       <p className="upozornenie-title">{row.title}</p>
       {row.details !== "" && <p className="upozornenie-details">{row.details}</p>}
       <p className="upozornenie-meta">
-        Vzniklo {formatDate(row.createdAt)}
-        {row.dueAt !== null && <> · vybaviť do {formatDate(row.dueAt)}</>}
+        Vzniklo {formatSkDate(row.createdAt)}
+        {row.dueAt !== null && <> · vybaviť do {formatSkDate(row.dueAt)}</>}
       </p>
       {row.link !== null && (
         <a href={row.link} target="_blank" rel="noreferrer" data-testid={`upozornenie-link-${row.id}`}>

--- a/apps/web/src/formatDate.test.ts
+++ b/apps/web/src/formatDate.test.ts
@@ -1,0 +1,35 @@
+import { expect, it } from "vitest";
+import { formatSkDate, formatSkDateTime } from "./formatDate.js";
+
+// issue 293: jediná spoločná funkcia na slovenský tvar dátumu/času —
+// `timeZone: "Europe/Bratislava"` je VÝSLOVNE nastavené, takže výsledok
+// nezávisí od pásma nastaveného na počítači toho, kto sa práve pozerá.
+
+it("formatSkDate: bežný okamih v slovenskom tvare", () => {
+  expect(formatSkDate("2026-08-06T12:00:00.000Z")).toBe("6. 8. 2026");
+});
+
+it("formatSkDate: okamih tesne PO slovenskej polnoci sa zobrazí ako DNEŠNÝ deň, nie UTC-VČEREJŠÍ", () => {
+  // 2026-08-05T22:10:00Z = 2026-08-06 00:10 Europe/Bratislava (letný čas).
+  expect(formatSkDate("2026-08-05T22:10:00.000Z")).toBe("6. 8. 2026");
+});
+
+it("formatSkDate: prijme aj Date objekt priamo", () => {
+  expect(formatSkDate(new Date("2026-08-06T12:00:00.000Z"))).toBe("6. 8. 2026");
+});
+
+it("formatSkDate: prázdny/neplatný/chýbajúci vstup → pomlčka", () => {
+  expect(formatSkDate("")).toBe("—");
+  expect(formatSkDate(null)).toBe("—");
+  expect(formatSkDate(undefined)).toBe("—");
+  expect(formatSkDate("nezmysel")).toBe("—");
+});
+
+it("formatSkDateTime: dátum + čas bez sekúnd", () => {
+  expect(formatSkDateTime("2026-08-06T12:40:11.000Z")).toBe("6. 8. 2026 14:40");
+});
+
+it("formatSkDateTime: prázdny/neplatný vstup → pomlčka", () => {
+  expect(formatSkDateTime("")).toBe("—");
+  expect(formatSkDateTime("nezmysel")).toBe("—");
+});

--- a/apps/web/src/formatDate.ts
+++ b/apps/web/src/formatDate.ts
@@ -1,0 +1,33 @@
+// Jediná spoločná funkcia na zobrazenie dátumu/času v appke — issue 293.
+// Predtým takmer každá sekcia mala VLASTNÉ `toLocaleString`/
+// `toLocaleDateString("sk-SK")` volanie (rôzne, jeden aj s desiatkami
+// sekúnd navyše) a tri miesta navyše krájali surový ISO reťazec
+// (`slice(0, 10)`) namiesto formátovania — to vždy vráti UTC kalendárny
+// deň, takže čokoľvek medzi 22:00 a polnocou slovenského času sa ukázalo s
+// dátumom VČEREJŠKA. `timeZone: "Europe/Bratislava"` je tu VÝSLOVNE
+// nastavené (nie ponechané na predvolené pásmo prehliadača) — obrazovka
+// tak ukazuje rovnaký slovenský dátum bez ohľadu na to, v akom pásme má
+// nastavený svoj počítač ten, kto sa práve pozerá.
+const TIME_ZONE = "Europe/Bratislava";
+
+function toValidDate(value: string | Date | null | undefined): Date | null {
+  if (value === null || value === undefined || value === "") return null;
+  const d = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+/** Slovenský tvar dátumu, napr. "6. 8. 2026". Prázdny/nerozpoznateľný
+ * vstup → "—". */
+export function formatSkDate(value: string | Date | null | undefined): string {
+  const d = toValidDate(value);
+  if (d === null) return "—";
+  return d.toLocaleDateString("sk-SK", { timeZone: TIME_ZONE });
+}
+
+/** Slovenský tvar dátumu + času (bez sekúnd), napr. "6. 8. 2026 14:40".
+ * Prázdny/nerozpoznateľný vstup → "—". */
+export function formatSkDateTime(value: string | Date | null | undefined): string {
+  const d = toValidDate(value);
+  if (d === null) return "—";
+  return d.toLocaleString("sk-SK", { timeZone: TIME_ZONE, dateStyle: "short", timeStyle: "short" });
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -49,6 +49,13 @@ services:
       DATABASE_URL: postgres://forestshop:${POSTGRES_PASSWORD}@postgres:5432/forestshop
       PORT: 3000
       SESSION_COOKIE_SECURE: "true"
+      # issue 293: kontajner predtým bežal bez nastaveného pásma (teda v
+      # UTC), takže naplánované úlohy behali o 1-2 hodiny neskôr, než
+      # majiteľ nastavil. `Dockerfile` má TÚ ISTÚ hodnotu ako baked-in
+      # predvolenú (`ENV TZ=Europe/Bratislava`) — tento riadok ju len robí
+      # explicitnou/prepísateľnou tu, rovnaká disciplína ako každá iná
+      # premenná v tomto bloku.
+      TZ: Europe/Bratislava
       # Zámerne BEZ `:?` (na rozdiel od POSTGRES_PASSWORD/CF_TUNNEL_TOKEN nižšie) —
       # `env.ts` (F0) má SHOPTET_EXPORT_URL ako `.optional()`, appka bez neho beží,
       # len ručný import vráti 503. Bare kľúč preberá hodnotu z `/srv/forestshop/.env`,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.165",
+  "version": "0.3.0-dev.166",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Čo to robí

Appka ukazovala časy o dve hodiny posunuté a dátumy v tvare, ktorý sa Slovákovi zle číta. Toto opravuje oboje.

**Automatizácie bežali o dve hodiny neskôr, než mali.** Plánovač počítal hodiny v svetovom čase (UTC), takže úloha nastavená na 7:00 sa reálne spustila o 9:00 nášho času (v zime o 8:00). Odteraz sa denné úlohy plánujú v čase Europe/Bratislava — vrátane poistky "raz za deň", aby v deň prechodu na letný/zimný čas úloha nezbehla dvakrát ani sa nevynechala. Hodinové úlohy (každú hodinu v danej minúte) ostávajú zámerne na UTC — tie nemajú "cieľovú hodinu" a lokalizácia ich kľúča by v deň prechodu na zimný čas zopakovanú hodinu 2:00–3:00 nesprávne vyhodnotila ako už zbehnutú.

**Dve automatizácie, čo posielajú maily zákazníkom, dostali späť svoj pôvodný čas.** Nevyzdvihnuté zásielky a Pripomienky objednávok reálne odjakživa bežali o 9:00 a 8:00 nášho času — samotná oprava pásma by ich potichu posunula na 7:00 a 6:00 ráno. Hodnoty sú vrátené na 9:00 a 8:00. Nočné údržbové úlohy (mazanie starých exportov, upratovanie prihlásení, sklad, feed) ostali nedotknuté.

**Kontajner appky vie, v akom sme pásme.** Doteraz bežal v UTC s prázdnym nastavením pásma; teraz má `TZ=Europe/Bratislava` a dáta časových pásiem nainštalované.

**Dátumy sa čítajú jednotne.** Na troch miestach sa surový strojový tvar `2026-08-05` ukazoval používateľovi tak, ako prišiel z databázy. Zároveň si každá obrazovka formátovala dátum po svojom. Odteraz to robí jedna spoločná funkcia (16 miest zjednotených) — všade rovnaký slovenský tvar.

## Overenie

- `pnpm typecheck`, `pnpm lint` — čisté
- api unit 606, web unit 479, api integračné 557, e2e 46/46 — všetko prešlo
- Nové testy overujú letný čas, zimný čas aj deň prechodu; napísané ako padajúce pred opravou

Nadväzuje na issue 293. Ticket zostáva otvorený, kým sa oprava neoverí naživo po nasadení.
