### PR TITLE
Vyhľadať dve polia, mobil, nástenka bez vybavených vecí, akčná karta zásielky

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -919,3 +919,71 @@ paths:
   `NAV`. Pri KAŽDOM ĎALŠOM preusporiadaní `NAV` (pridanie/presun priečinka,
   zmena poradia skupín) skontroluj, či sa `DEFAULT_TAB_ID` nezmenil ticho —
   ak zadanie nežiada zmenu landing obrazovky, drž ju pevnú.
+- **Zdieľaný obal na vodorovné rolovanie tabuľky (issue 291 — 19 obyčajných
+  tabuliek dostalo VLASTNÝ posuvný obal namiesto rolovania celej stránky):
+  nová trieda `.fs-table-wrap { overflow-x: auto; }` (`app.css`, hneď za
+  generickým `table` resetom) je pre KAŽDÚ jednoduchú tabuľku, ktorá
+  nepotrebuje vlastné rozloženie — `<table>` sa len obalí `<div
+  className="fs-table-wrap">`, žiadna zmena vnútri tabuľky.
+  `.orders-table-wrap`/`.ml-table-wrap` (existujúce PRED týmto tiketom)
+  ostávajú SAMOSTATNÉ triedy — majú svoj vlastný `min-width`/
+  `table-layout`, tie sa nezjednocovali. Test na KAŽDÚ ĎALŠIU novú
+  `<table>` v appke: obal ju rovno `.fs-table-wrap`-om, nikdy nenechávaj
+  tabuľku bez vlastného posuvného obalu (`.main > main` — bežná, nie
+  `wide: true`, obrazovka — nemá `overflow-x: hidden`, takže neobalená
+  tabuľka posunie celú STRÁNKU, presne akceptačný prípad tiketu — "Sync zo
+  Shoptetu" mala 4085px `scrollWidth` pri 375px okne).
+- **Sidebar (`Sidebar.tsx`, issue 190's rail mechanizmus) dostal PRVOTNÝ
+  (mount-time) predvolený stav podľa šírky okna (issue 291) — uložená
+  voľba v `localStorage` VŽDY vyhráva, šírka rozhoduje LEN keď žiadna
+  voľba ešte neexistuje.** `readStoredRail(): boolean | null` (`null` =
+  nič uložené, na rozdiel od pôvodného `readRail(): boolean`, ktoré
+  chýbajúci kľúč nerozlíšilo od výslovného "rozbaliť") + `isNarrowViewport()`
+  (`window.innerWidth <= 640`) → `initialRail()` = `stored ?? narrow`. Toto
+  je ČISTO mount-time predvoľba, ŽIADNY `resize` listener — appka sa na
+  zmenu šírky OKNA počas behu nereaguje (mimo dohodnutého minimálneho
+  rozsahu tiketu). Existujúci `useEffect` (zápis do `localStorage` pri
+  KAŽDEJ zmene `rail`) ostal nezmenený — aj auto-predvoľba sa teda hneď
+  "zapíše" ako keby ju užívateľ zvolil; to je zámerné (rovnaké zariadenie
+  nabudúce dostane rovnaký predvolený stav bez opätovného prepočtu
+  šírky), nie chyba. Test pre `window.innerWidth` v jsdom: `Object
+  .defineProperty(window, "innerWidth", {writable:true, configurable:true,
+  value: N})` PRED `render()` — priama `window.innerWidth = N` v jsdom
+  nesedí spoľahlivo na getter/setter, treba `defineProperty`; a treba ju
+  po teste VRÁTIŤ (`afterEach`) presne z rovnakého dôvodu ako existujúci
+  `localStorage.clear()` o pár riadkov vyššie v tom istom súbore.
+- **`flex: 0 0 auto` na flex položke, ktorá sa MÔŽE ocitnúť SAMA na
+  vlastnom zalomenom riadku (`flex-wrap: wrap` na rodičovi), zabráni jej
+  zmenšiť sa aj keď na ten riadok nemá dosť miesta — položka potom
+  jednoducho PRETRŠÍ mimo rodiča/viewport, nie je to vidno v CSS, len pri
+  reálnom vykreslení na úzkej šírke.** Issue 291 (topbar sa mal zalomiť,
+  aby meno prihláseného nezmizlo): `.topbar` dostalo `flex-wrap: wrap`, ale
+  `.topbar-user` (koliesko "Farby aplikácie" + meno prihláseného) malo
+  ZDEDENÉ `flex: 0 0 auto` (issue 264) — na 375px zalomilo na VLASTNÝ
+  riadok správne, ale `flex-shrink: 0` mu bránilo zmenšiť sa POD svoju
+  obsahovú šírku (298px) do dostupných 239px, takže blok ticho pretŕčal
+  27px mimo viditeľnú šírku (`document.documentElement.scrollWidth` 402px
+  namiesto 375px) — objavené AŽ živým Playwright meraním
+  `getBoundingClientRect()` pri 375px, nie čítaním CSS (jsdom by to vôbec
+  nezachytilo, žiadny reálny layout). Fix: `.topbar-user` → `flex: 0 1
+  auto; min-width: 0;` (dovolí zmenšenie CELÉHO bloku) + `.usermenu-btn`
+  (meno prihláseného, existujúce orezanie textu `overflow:hidden;
+  text-overflow:ellipsis`) → `flex: 1 1 auto; min-width: 0;` (zmenšenie
+  ide PRVOTNE na toto tlačidlo, nie na `.themecolor-btn`'s pevné 36px
+  koliesko vedľa neho, ktoré si drží svoje PÔVODNÉ `flex: 0 0 auto`).
+  Test na KAŽDÚ ĎALŠIU `flex-wrap: wrap` zmenu v appke: má NEJAKÁ položka,
+  čo môže skončiť SAMA na zalomenom riadku, `flex-shrink: 0` (explicitne
+  alebo cez `flex: 0 0 auto`)? Ak áno, over REÁLNYM Playwright meraním pri
+  najužšej cieľovej šírke (nie len vizuálne na širokom monitore), či sa
+  nezmenší namiesto zalomenia — over `element.getBoundingClientRect
+  ().right <= window.innerWidth`, nie len že "vyzerá to zalomené".
+- **Playwright's `Timed out waiting 60000ms from config.webServer` (žiadny
+  ďalší výstup) je ZNÁMY jav na tomto zdieľanom, vyťaženom boxe (issues
+  287/288, `.claude/rules/testing.md`) — potvrdené znova pri issue 291
+  (`uptime` ukázal load average 33 tesne po behu integračných testov).**
+  Žiadna zmena kódu, len počkanie na pokles záťaže (load average pod ~10)
+  a čistý opakovaný beh — 46/47 prešlo hneď, jediné zvyšné zlyhanie
+  (nesúvisiaci `upozornenia.spec.ts`) bol ĎALŠÍ prípad TEJ ISTEJ triedy
+  (izolovaný re-beh prešiel čisto). Pred hľadaním regresie v diffe: over
+  `uptime`/`ps aux | grep vitest` PRED panikou, over izolovaným re-behom
+  PRESNE zlyhaného súboru.

--- a/.claude/rules/posta-uncollected.md
+++ b/.claude/rules/posta-uncollected.md
@@ -98,3 +98,48 @@ paths:
   write/auto-resolve/update-in-place cestu — a ak ide o zdroj, čo môže
   STRATIŤ SCHOPNOSŤ rozhodnúť (nie o skutočnú zmenu stavu), zváž
   `updateIfUnresolvedByDedupKey`, nie automatické zatvorenie.
+- **Issue 298 (šéf, cez majiteľa): karta na Upozorneniach preklikáva PRIAMO
+  na sledovanie zásielky na Pošte SK (`trackingLink`, `constants.ts` — ten
+  istý helper, aký "Nevyzdvihnuté zásielky"'s výsledková tabuľka už používa,
+  `PostaUncollectedRow.tsx`), NIE na Shoptet admin objednávku (predošlé
+  správanie).** `run.ts`'s `upsertUpozornenie` volanie: `link:
+  trackingLink(packageNumber)` namiesto `adminOrderUrl(shipment)` — číslo
+  objednávky ostáva čitateľné v TITULKU karty, len prestalo byť samotným
+  klikateľným odkazom (appka nemá druhé pole na "druhý odkaz", `link` je
+  JEDEN stĺpec). `details` NAVYŠE pridáva `Vyzdvihnutie do: <dátum>` riadok
+  KEĎ `cls.retainedTill` nie je prázdne (rovnaká hodnota, akú `classifyTracking`
+  UŽ vypočítal pre e-mailovú šablónu — žiadne nové sieťové volanie); keď
+  Pošta SK termín nevráti, riadok sa VYNECHÁ celý (nie prázdny "Vyzdvihnutie
+  do: "). **Zisťovanie o "preklik do vyfiltrovaného zoznamu oznámených
+  zásielok" (šéfova druhá časť žiadosti):** Pošta SK nemá zdokumentovaný/
+  potvrdený verejný filtrovaný-zoznam URL formát — appka pozná len (a) tento
+  per-zásielkový `trackingLink` (`https://www.posta.sk/sledovanie-zasielok#parcel=<číslo>`)
+  a (b) samotné `TRACKING_API_URL_TEMPLATE` (JSON API, nie stránka pre
+  človeka). Kým sa nenájde/nepotvrdí live taký zoznamový odkaz, appka
+  odkazuje LEN na konkrétnu zásielku — nevymýšľaj URL vzor, ktorý nebol
+  overený naživo (`.claude/rules/investigate-existing-first.md`'s princíp).
+- **LINK_LABELS (`UpozornenieCard.tsx`) pre `nevyzdvihnuta_zasielka` je
+  odteraz "Sledovať zásielku na Pošte" (predtým "Otvoriť objednávku v
+  Shoptete", zdieľané s `vratenie` — tá si svoj pôvodný štítok zachováva).**
+  **Pokus o E2E fixtúru bol ZAMIETNUTÝ, poučenie pre budúce podobné
+  prípady:** predbežná verzia issue 298 pridala do `scripts/e2e-setup.ts`
+  jednu PEVNE seedovanú `upozornenie` kartu (UŽ odloženú, aby sa vyhla
+  predvolenej "Otvorené" záložke) — ale `upozornenie` je GLOBÁLNA, nie
+  per-užívateľská tabuľka, takže akýkoľvek trvalo seedovaný riadok mení
+  VÝSLEDOK `classifyEmptyMessage`'s doplnkového dopytu (`includeResolved:
+  true, includePostponed: true`) pre KAŽDÝ účet vrátane samotného
+  `upozornenia.spec.ts`'s — živo spadlo na jeho ÚPLNE PRVEJ asercii
+  ("Žiadne upozornenia — nič nie je zapísané." sa zmenilo na "…— všetko je
+  odložené.", presne to gap-3 regresné overenie z issue 267 follow-up).
+  Riešenie NIE je zmeniť tú asserciu (zmenilo by zmysel testu, čo overuje
+  "naozaj nič nie je zapísané") — namiesto toho karta zostáva pokrytá
+  VÝHRADNE (a) integračným testom obsahu/linky
+  (`posta-uncollected-run.integration.test.ts`) a (b) vitest komponentovým
+  testom rendrovania štítku (`UpozorneniaSection.test.tsx`'s
+  `NEVYZDVIHNUTA_KARTA` fixtúra — rovnaký vzor ako existujúci `VRATENIE_KARTA`
+  link test). **Test pre KAŽDÚ ĎALŠIU myšlienku "seedni fixnú kartu do
+  `upozornenie` v `e2e-setup.ts`":** táto tabuľka je zdieľaná GLOBÁLNE
+  naprieč VŠETKÝMI e2e účtami/spec súbormi — akýkoľvek trvalý riadok mení
+  `classifyEmptyMessage`'s výsledok pre každého; over najprv, či niektorý
+  INÝ spec súbor (najmä `upozornenia.spec.ts` samo) nespolieha na skutočne
+  prázdnu tabuľku, než pridáš seed.

--- a/.claude/rules/scheduler.md
+++ b/.claude/rules/scheduler.md
@@ -45,8 +45,9 @@ paths:
   issue 184 — hodinový import produkuje viac snapshotov, box je na 98 %
   disku), 01:30 mazanie relácií (`daily`), :45 KAŽDÚ hodinu import
   objednávok (`ordersImportJob`, `hourly` od #115, pôvodne `daily` #22),
-  02:00 mazanie surových exportov objednávok (`pruneRawOrdersJob`, `daily`,
-  #28), :50 KAŽDÚ hodinu spätný zápis odkazov na dodávateľa do Shoptetu
+  02:10 mazanie surových exportov objednávok (`pruneRawOrdersJob`, `daily`,
+  #28 — NIE 02:00, pozri poznámku o jarnom prechode nižšie), :50 KAŽDÚ
+  hodinu spätný zápis odkazov na dodávateľa do Shoptetu
   (`shoptetWritebackJob`, `hourly`, issue 122 — mimo kolízie s `:45`), :55
   KAŽDÚ hodinu spätný zápis poznámky objednávky do Shoptetu
   (`orderNoteWritebackJob`, `hourly`, issue 123 — mimo kolízie s `:45`/`:50`).
@@ -54,6 +55,18 @@ paths:
   `:45`/`:55` predošlej hodiny, 30 min k `:50`). Pridanie ďalšieho `kind` (napr.
   "weekly") by znamenalo rozšíriť `periodKey()` (`scheduler.ts`) o ďalšiu
   vetvu — rovnaký vzor ako `hourly`.
+- **Nová `daily` úloha sa NIKDY nesmie naplánovať PRESNE na jarný prechod na
+  letný čas v Europe/Bratislava — miestne `hourLocal: 2, minuteLocal: 0`
+  (posledná marcová nedeľa) je okamih, keď 02:00 v tú noc VÔBEC
+  NEEXISTUJE (hodiny skočia z 01:59 rovno na 03:00).** Nie je to bug — job
+  sa spustí korektne hneď, ako miestny čas dosiahne 03:00 (`isDue()`) — ale
+  ten JEDEN deň v roku beh ticho omešká asi o hodinu, bez akéhokoľvek
+  signálu operátorovi. Zistené code review na issue 293 (`pruneRawOrdersJob`
+  bolo pôvodne presne na `hourLocal: 2, minuteLocal: 0`) — fix bol posunúť
+  minútu mimo hranice (`minuteLocal: 10`), nie hodinu. Pri KAŽDEJ ďalšej
+  `daily` úlohe naplánovanej na 02:00-02:59 (alebo na hraničný čas v inom
+  pásme, ak appka niekedy pridá druhé pásmo): vyhni sa `minuteLocal: 0`
+  presne na tejto hodine, alebo zvoľ inú hodinu úplne.
 - **Job NEPOTREBUJE vlastný advisory zámok, keď buď (a) volaná business
   funkcia už berie svoj vlastný vnútri seba** (`catalogImportJob`/
   `ordersImportJob` → `ingestCatalog`/`ingestOrders`), **alebo (b) sa vôbec

--- a/.claude/rules/search.md
+++ b/.claude/rules/search.md
@@ -6,18 +6,57 @@ paths:
   - "apps/api/src/http/product-detail-routes.ts"
   - "apps/web/src/searchApi.ts"
   - "apps/web/src/components/SearchSection.tsx"
+  - "apps/web/src/components/OrderSearchPanel.tsx"
 ---
 
-# Eshop → Vyhľadať (issue 240)
+# Eshop → Vyhľadať (issue 240, issue 289)
 
-- **"Hľadať prednostne produkty, potom objednávky" sa rieši DVOMA
-  ODDELENÝMI poľami (`GlobalSearchResult.products`/`.orders`), NIE jedným
-  zoradeným zoznamom s relevance skóre.** Frontend ich vykreslí ako dva
-  vizuálne oddelené bloky v tomto poradí — produkty prirodzene skončia PRED
-  objednávkami bez toho, aby bolo treba počítať/porovnávať skóre naprieč
-  dvomi úplne odlišnými entitami (variant vs. objednávka). Rozšírenie o
-  ĎALŠIU prehľadávanú oblasť (napr. dodávateľov, e-maily) patrí ako TRETIE
-  samostatné pole, nie zamiešané do jedného z existujúcich dvoch.
+- **OPRAVA nedorozumenia z issue 240 (zapísané na ticket 289, overené
+  priamo v kóde pred zmenou): "dve oddelené polia" popisovalo len BACKENDOVÝ
+  dátový model (`GlobalSearchResult.products`/`.orders`, dve polia v JEDNEJ
+  JSON odpovedi), NIE dve oddelené VSTUPNÉ polia vo formulári — do issue 289
+  malo `SearchSection.tsx` JEDNO spoločné textové pole ("Hľadať"), ktoré
+  hľadalo naraz produkty aj objednávky cez `GET /api/search?q=...`, a
+  frontend výsledok len rozdeľoval do dvoch VIZUÁLNYCH blokov pod tým istým
+  poľom. Issue 289 (majiteľova požiadavka) toto zmenilo na SKUTOČNE dve
+  nezávislé vstupné polia — "Produkt" (`SearchSection.tsx`) a "Objednávka"
+  (`OrderSearchPanel.tsx`, vlastný súbor/stav) — každé s vlastným dopytom,
+  vlastným tlačidlom, vlastným výsledkom. Backend sa NEZMENIL: obe polia
+  volajú TÚ ISTÚ `GET /api/search?q=...` cestu (vždy vracia oba zoznamy
+  naraz), každé si z odpovede vezme len svoju polovicu — žiadna nová
+  backendová cesta nebola potrebná ani pridaná. Klik na nájdenú objednávku
+  vedie do Shoptet detailu objednávky (`o.adminUrl`, postavené
+  `buildShoptetAdminOrderUrl`-om — TEN ISTÝ helper ako
+  `OrderReminderRow.tsx`/`MailLogSection.tsx`/Upozornenia), rozhodnuté na
+  ticket-e; appka ho tu len znovupoužíva, nebolo treba nič meniť.
+- **`OrderSearchPanel` je namontovaný VŽDY, aj počas zobrazenia detailu
+  produktu — mimo `SearchSection.tsx`'s `if (selectedProductKey !== null)`
+  vetvy, nie vo vnútri nej.** Dôvod: pôvodné jedno spoločné pole (issue
+  240) malo svoj `result` stav v TOM ISTOM komponente ako detail produktu,
+  takže prechod do detailu a späť ho nikdy neodmountoval — objednávkový
+  výsledok prežil. Keby bol `OrderSearchPanel` vykreslený LEN vo vetve so
+  zoznamom (nie aj vo vetve s detailom), React by ho pri otvorení detailu
+  produktu odmountoval a jeho dopyt/výsledok by sa stratil — regresia oproti
+  pôvodnému správaniu. Obe vetvy `SearchSection.tsx`'s návratu preto končia
+  `<OrderSearchPanel onSessionExpired={onSessionExpired} />` ako posledným
+  súrodencom (Fragment), nikdy len jedna z nich.
+- **Tlačidlá polí sú POMENOVANÉ ODLIŠNE ("Hľadať produkt"/"Hľadať
+  objednávku"), nie obe len "Hľadať"** — dva rovnaké prístupné mená v
+  jednom formulári by si navzájom kolidovali (Playwright aj Testing
+  Library `getByRole("button", {name})` by vrátili 2 prvky) a `.claude/
+  rules/testing.md` už dokumentuje, že bare "Hľadať" koliduje aj s
+  `catalog.spec.ts`'s vlastným "Hľadať" tlačidlom substring-om cez
+  "Vyhľadať" nav záložku — odlišné mená obe riziká odstraňujú, nie len to
+  jedno. Rovnako `<label>`y sú "Produkt"/"Objednávka" (nie "Hľadať X") —
+  krátke, ľudské popisky nad/pri poli, presne ako ticket žiadal.
+- **"Hľadať prednostne produkty, potom objednávky" (pôvodná formulácia
+  240) je teraz len historický kontext** — s dvoma nezávislými poľami
+  (289) sa "poradie produktov pred objednávkami" netýka poradia
+  VYHĽADÁVANIA (obe polia sú si rovné, žiadne "prednostne"), len poradia,
+  v akom sú polia/výsledky vykreslené na obrazovke (Produkt hore,
+  Objednávka dole — ticket 289's doslovná požiadavka). Rozšírenie o ĎALŠIU
+  prehľadávanú oblasť (napr. dodávateľov) patrí ako TRETIE, rovnako
+  nezávislé pole, nie zamiešané do jedného z existujúcich dvoch.
 - **Editácia dodávateľskej linky na tejto obrazovke ide VÝHRADNE cez
   existujúcu `POST /api/product-links/:productKey` (issue 239) —
   `product-detail` trasa je LEN NA ČÍTANIE.** Nepridávaj sem druhú

--- a/.claude/rules/upozornenia.md
+++ b/.claude/rules/upozornenia.md
@@ -280,3 +280,35 @@ paths:
   zobrazenie karty. Nová "druhá" cesta na zobrazenie vyriešenej karty v
   "Otvorené" (checkbox, filter, čokoľvek) by túto duplicitu vrátila späť —
   nepridávaj ju.
+- **AKTUALIZÁCIA (issue 297, 2026-08-06): "Karta sa NIKDY nezatvára
+  automaticky" (bod vyššie o `vratenie`) UŽ NEPLATÍ pre CELÝ typ — platí len
+  pre `Vratený tovar`.** Šéf (cez majiteľa): nástenka nemá upozorňovať na už
+  HOTOVÉ veci. `orders/return-status.ts` sa preto rozdelilo na DVE nezávislé
+  mapy: `classifyReturnStatus` (AKTÍVNY stav, dnes len "Vratený tovar" —
+  zakladá/obnoví kartu, presne ako predtým) a `classifyFinishedReturnStatus`
+  (HOTOVÉ stavy "Vybavená výmena"/"Vybavený Dobropis" — NIKDY nezakladajú
+  kartu; namiesto toho AUTOMATICKY ZATVORIA existujúcu otvorenú kartu pre
+  ten istý `dedupKey`, `resolvedByUserId` ostáva `null` — rovnaký princíp ako
+  #268's doručená zásielka). **Objednávka, ktorá prešla z AKTÍVNEHO do
+  HOTOVÉHO stavu, teda UŽ NEOBNOVÍ titulok karty na nový pod-stav (predošlé
+  správanie) — namiesto toho kartu ZATVORÍ.** Celá logika (candidates loop +
+  `.for("update")` pre-check + upsert + auto-resolve) je vyčlenená z
+  `ingest.ts` do `apps/api/src/modules/orders/return-upozornenia.ts`
+  (`applyReturnUpozornenia`) — `ingest.ts` narazilo na eslint `max-lines: 400`
+  po pridaní finished-stavovej vetvy (`.claude/rules/testing.md`). Nový
+  súbor duplikuje `ingest.ts`'s malý `chunk()` helper LOKÁLNE (import odtiaľ
+  by vyrobil cyklickú závislosť — `ingest.ts` volá `applyReturnUpozornenia`),
+  rovnaký princíp ako `service.ts`'s `isUniqueViolation`. **Existujúce
+  otvorené karty pre HOTOVÉ stavy (12 na produkcii v čase ticketu) sa
+  zatvoria NAŽIVO cez ĎALŠÍ naplánovaný `ordersImportJob` beh (hodinový,
+  `:45`) — ŽIADNA jednorazová migrácia** (rovnaký mechanizmus, aký #269 už
+  používa na OBNOVU existujúcich kariet): keďže objednávkový export nesie
+  AKTUÁLNY Shoptet stav pri KAŽDOM importe, ďalší beh znova klasifikuje tú
+  istú objednávku a nájde ju HOTOVÚ. Podmienka: objednávka musí ešte
+  spadať do `DEFAULT_ORDERS_IMPORT_WINDOW_DAYS`-dňového posuvného okna
+  exportu (`orders.md`) — vrátkové objednávky vznikajú krátko po nákupe,
+  takže to v praxi vždy platí, ale je to PREDPOKLAD, nie záruka do
+  nekonečna. Test na KAŽDÝ ĎALŠÍ prípad "táto karta sa má prestať zakladať a
+  existujúce otvorené sa majú zatvoriť": over najprv, či nasledujúci
+  naplánovaný beh prirodzene dorieši existujúce riadky (žiadna migrácia
+  potrebná), predtým než sa píše jednorazový skript.

--- a/apps/api/src/modules/orders/ingest.ts
+++ b/apps/api/src/modules/orders/ingest.ts
@@ -1,10 +1,9 @@
 import { createHash } from "node:crypto";
-import { and, between, eq, inArray, sql } from "drizzle-orm";
+import { between, eq, inArray, sql } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
-import { orderLines, orders, upozornenie, variants } from "../../db/schema.js";
+import { orderLines, orders, variants } from "../../db/schema.js";
 import { log } from "../../logger.js";
 import { storeRawSnapshot } from "../catalog/raw-store.js";
-import { upsertUpozornenie } from "../upozornenia/service.js";
 import { redactSourceLabel, type OrderIdsFetcher } from "./fetcher.js";
 import {
   decodeCp1250,
@@ -18,8 +17,7 @@ import {
   type OrderLineCandidate,
   type OrderRowIssue,
 } from "./parser.js";
-import { buildShoptetAdminOrderUrl } from "./queries.js";
-import { classifyReturnStatus, returnUpozornenieDedupKey } from "./return-status.js";
+import { applyReturnUpozornenia } from "./return-upozornenia.js";
 
 // Zámok je JEDEN pevný kľúč, NIE odvodený z obsahu — rovnaký dôvod ako
 // katalógov `INGEST_ADVISORY_LOCK_KEY` (`catalog/ingest.ts`): serializuje
@@ -484,127 +482,21 @@ export async function ingestOrders(db: Database, options: OrdersIngestOptions): 
         insertedLineCount += batch.length;
       }
 
-      // issue 269: druhý automatický zdroj pre nástenku Upozornenia (#267) —
-      // objednávka, ktorej `statusName` je jeden zo živo overených vrátkových
-      // stavov (`return-status.ts`), dostane/obnoví kartu cez ZDIEĽANÚ
-      // zapisovaciu cestu (`upsertUpozornenie`, #267/#272). `dedupKey` je na
-      // OBJEDNÁVKU (nie na pod-stav) — opakovaný import tej istej objednávky
-      // v tom istom vrátkovom stave, alebo jej prechod medzi dvomi vrátkovými
-      // stavmi, len OBNOVÍ tú istú kartu. Karta sa NIKDY nezatvára automaticky
-      // (ticket to explicitne žiada — majiteľ ju zavrie ručne cez
-      // "Vybavené"), preto tu na rozdiel od #268 niet `autoResolveByDedupKey`
-      // volania. `shoptetOrderId` je to isté, čo sa práve zapísalo vyššie
-      // (`orderIdsByCode`, best-effort XML fetch) — žiadny extra dopyt.
-      //
-      // Code review (issue 269, ďalšie kolo): tento blok beží ZÁMERNE AŽ TU,
-      // tesne PRED commitom — nie hneď po upsert-e `order` riadkov, ako
-      // pôvodne. Jeho `.for("update")` pre-check (nižšie) drží riadkové
-      // zámky na EXISTUJÚCICH kartách po ZVYŠOK tejto transakcie, takže čím
-      // neskôr v transakcii beží, tým kratšie sú tie zámky držané — inak by
-      // majiteľ kliknúť "Vybavené" na karte čakal, kým dobehne CELÝ zvyšok
-      // (variantová validácia + dávkové vloženie `order_line`), nie len
-      // zvyšný pár SQL príkazov. Blok číta len `orderInfo`/`orderIdsByCode`
-      // (oboje pripravené MIMO transakcie) a nič PO ňom nezávisí od jeho
-      // výsledku — smie teda sedieť takto neskoro bez zmeny správania.
+      // issue 269/297: druhý automatický zdroj pre nástenku Upozornenia
+      // (#267) — plná logika (AKTÍVNY vrátkový stav zakladá/obnoví kartu,
+      // HOTOVÝ ju automaticky zatvorí) vyčlenená do `return-upozornenia.ts`
+      // (eslint `max-lines: 400`, `.claude/rules/testing.md`) — čítaj JEJ
+      // vlastné komentáre pre plné odôvodnenie (dedup na objednávku,
+      // `.for("update")` pre-check, prečo beží až TESNE PRED commitom).
       const adminBaseUrl = options.adminBaseUrl ?? "https://www.forestshop.sk";
-      const returnCandidates: { externalOrderId: string; returnLabel: string; customerName: string; statusName: string; dedupKey: string }[] = [];
-      for (const [externalOrderId, info] of orderInfo) {
-        const returnLabel = classifyReturnStatus(info.statusName);
-        if (returnLabel === null) continue;
-        returnCandidates.push({
-          externalOrderId,
-          returnLabel,
-          customerName: info.customerName,
-          statusName: info.statusName,
-          dedupKey: returnUpozornenieDedupKey(externalOrderId),
-        });
-      }
-      // Naživo overené na produkcii (0.3.0-dev.160): vybavené vrátenie je
-      // KONEČNÉ — na rozdiel od #268 (zásielka, čo sa smie znova zaseknúť o
-      // mesiac) sa už NIKDY nemá znova ohlásiť, hoci Shoptet-ov status
-      // objednávky ostáva v tom istom vrátkovom stave navždy. `upsertUpozornenie`'s
-      // ČIASTOČNÝ unique index (`WHERE resolved_at IS NULL`, `.claude/rules/
-      // upozornenia.md`) necháva VYRIEŠENÝ riadok mimo arbitra, takže bez tejto
-      // kontroly by ďalší import s tým istým `dedupKey` prešiel ako čistý
-      // INSERT — druhý riadok na tú istú objednávku.
-      //
-      // Code review (issue 269, druhé kolo — finding 1): skip sa smie
-      // uplatniť LEN keď pre `dedupKey` NEEXISTUJE žiadny NEVYRIEŠENÝ
-      // súrodenec. Kľúč, ktorý má SÚČASNE vyriešený AJ otvorený riadok
-      // (presne stav, aký pôvodný bug na 0.3.0-dev.160 vyrobil, kým sa
-      // ešte volalo druhýkrát) musí naďalej obnoviť/refreshnúť svoj
-      // OTVORENÝ riadok — inak by ten otvorený navždy zamrzol na starom
-      // titulku/pod-stave. Preto sa najprv PO KĽÚČI zisťuje, či existuje
-      // aspoň jeden NEVYRIEŠENÝ riadok (`hasUnresolvedByKey`), a do skip
-      // množiny idú len kľúče, kde je odpoveď "nie" — pozri regresný test
-      // "otvorený súrodenec vedľa vyriešeného...".
-      //
-      // Dávka kandidátov ide cez rovnaký `chunk(..., ORDERS_INGEST_BATCH_SIZE)`
-      // vzor ako každý iný `IN (...)` dopyt v tomto súbore (parametrový
-      // limit Postgresu, `ORDERS_INGEST_BATCH_SIZE`'s vlastný komentár
-      // vyššie). `type = 'vratenie'` vo WHERE (finding 2) robí zámer
-      // explicitný a zaručuje, že `.for("update")` nikdy nezamkne CUDZÍ
-      // riadok, ktorý by náhodou zdieľal rovnaký `dedupKey` s iným typom
-      // karty (dnes sa to stať nemôže — jediný ďalší automatický zdroj,
-      // #268, má odlišný `postaUpozornenieDedupKey` formát — ale WHERE tu
-      // dokumentuje zámer, nespolieha sa na to ticho).
-      //
-      // `.for("update")` je POVINNÉ, nie voliteľné vylepšenie — bez neho je
-      // to obyčajné READ COMMITTED čítanie, ktoré sa NIKDY nezablokuje na
-      // súbežnom ručnom "Vybavené" (`resolveUpozornenie`, mimo tejto
-      // transakcie), ten by mohol commitnúť PRESNE medzi pre-checkom a
-      // neskorším `upsertUpozornenie` volaním PRE TEN ISTÝ kandidát. V tom
-      // úzkom okne by kandidát vyzeral ešte nevyriešený, `upsertUpozornenie`
-      // by ho normálne obnovil, a hneď potom by sa stal vyriešeným — ten
-      // istý bug, len naživo zriedkavejšie. `.for("update")` zamkne KAŽDÝ
-      // existujúci kandidátny riadok na zvyšok tejto transakcie (rovnaký
-      // vzor ako `orders/state.ts`/`.claude/rules/database.md`'s riadkové
-      // zámky), takže rozhodnutie je vždy postavené na ČERSTVOM stave. Bez
-      // JOINu (jedna tabuľka) nepotrebuje `of` zoznam.
-      const resolvedReturnDedupKeys = new Set<string>();
-      if (returnCandidates.length > 0) {
-        for (const batch of chunk(returnCandidates.map((c) => c.dedupKey), ORDERS_INGEST_BATCH_SIZE)) {
-          const candidateRows = await tx
-            .select({ dedupKey: upozornenie.dedupKey, resolvedAt: upozornenie.resolvedAt })
-            .from(upozornenie)
-            .where(and(eq(upozornenie.type, "vratenie"), inArray(upozornenie.dedupKey, batch)))
-            .for("update");
-          // finding 12: `row.dedupKey` je nullable v type, ale `inArray`
-          // NIKDY nezhodí NULL (Postgres `IN` sémantika) — jediný praktický
-          // dôvod `continue` nižšie je TS-narrowing na `string`, nikdy
-          // skutočná runtime vetva. Predikát preto NEKOMBINUJE dve
-          // podmienky do jedného type-guardu ako predtým — `resolvedAt` je
-          // JEDINÁ skutočná obchodná podmienka.
-          const hasUnresolvedByKey = new Map<string, boolean>();
-          for (const row of candidateRows) {
-            const dedupKey = row.dedupKey;
-            if (dedupKey === null) continue;
-            const already = hasUnresolvedByKey.get(dedupKey) ?? false;
-            hasUnresolvedByKey.set(dedupKey, already || row.resolvedAt === null);
-          }
-          for (const [dedupKey, hasUnresolved] of hasUnresolvedByKey) {
-            if (!hasUnresolved) resolvedReturnDedupKeys.add(dedupKey);
-          }
-        }
-      }
-      // finding 11: počet KONEČNE vybavených vrátení preskočených v tomto
-      // behu — rovnaké pomenovanie ako susedný `skippedItemCount` vyššie.
-      let skippedResolvedReturnCount = 0;
-      for (const candidate of returnCandidates) {
-        if (resolvedReturnDedupKeys.has(candidate.dedupKey)) {
-          skippedResolvedReturnCount += 1;
-          continue;
-        }
-        await upsertUpozornenie(tx, {
-          type: "vratenie",
-          source: "appka",
-          title: `Objednávka ${candidate.externalOrderId} — ${candidate.returnLabel}`,
-          details: [`Zákazník: ${candidate.customerName}`, `Stav objednávky: ${candidate.statusName}`].join("\n"),
-          link: buildShoptetAdminOrderUrl(adminBaseUrl, candidate.externalOrderId, orderIdsByCode.get(candidate.externalOrderId) ?? null),
-          dedupKey: candidate.dedupKey,
-          now: options.now,
-        });
-      }
+      const { skippedResolvedReturnCount, autoResolvedFinishedReturnCount } = await applyReturnUpozornenia({
+        tx,
+        orderInfo,
+        orderIdsByCode,
+        adminBaseUrl,
+        now: options.now,
+        batchSize: ORDERS_INGEST_BATCH_SIZE,
+      });
 
       log.info(
         {
@@ -614,6 +506,7 @@ export async function ingestOrders(db: Database, options: OrdersIngestOptions): 
           pseudoItemCount,
           issueCount: issues.length,
           skippedResolvedReturnCount,
+          autoResolvedFinishedReturnCount,
         },
         "objednávky naimportované",
       );

--- a/apps/api/src/modules/orders/return-status.test.ts
+++ b/apps/api/src/modules/orders/return-status.test.ts
@@ -1,11 +1,19 @@
 import { describe, expect, it } from "vitest";
-import { classifyReturnStatus, returnUpozornenieDedupKey } from "./return-status.js";
+import { classifyFinishedReturnStatus, classifyReturnStatus, returnUpozornenieDedupKey } from "./return-status.js";
 
+// issue 297: "Vybavená výmena"/"Vybavený Dobropis" sú HOTOVÉ stavy — appka
+// pre ne NEZAKLADÁ kartu (`classifyReturnStatus` vracia `null`), namiesto
+// toho existujúcu otvorenú kartu AUTOMATICKY ZATVÁRA
+// (`classifyFinishedReturnStatus`, `.claude/rules/upozornenia.md`).
+// "Vratený tovar" ostáva jediný AKTÍVNY stav.
 describe("classifyReturnStatus", () => {
-  it("rozpozná presne tri živo overené vrátkové stavy", () => {
+  it("rozpozná jediný živo overený AKTÍVNY vrátkový stav", () => {
     expect(classifyReturnStatus("Vratený tovar")).toBe("vrátený tovar");
-    expect(classifyReturnStatus("Vybavená výmena")).toBe("vybavená výmena");
-    expect(classifyReturnStatus("Vybavený Dobropis")).toBe("vybavený dobropis");
+  });
+
+  it("HOTOVÉ stavy (Vybavená výmena, Vybavený Dobropis) NEZAKLADAJÚ kartu — vrátia null", () => {
+    expect(classifyReturnStatus("Vybavená výmena")).toBeNull();
+    expect(classifyReturnStatus("Vybavený Dobropis")).toBeNull();
   });
 
   it("bežné (nevrátkové) stavy vrátia null", () => {
@@ -20,6 +28,24 @@ describe("classifyReturnStatus", () => {
     // NFD (rozložená diakritika) — rovnaký zámer ako `parser.test.ts`'s
     // existujúca `normalizeStatusName` kontrola.
     expect(classifyReturnStatus("Vratený tovar".normalize("NFD"))).toBe("vrátený tovar");
+  });
+});
+
+describe("classifyFinishedReturnStatus", () => {
+  it("rozpozná presne dva živo overené HOTOVÉ vrátkové stavy", () => {
+    expect(classifyFinishedReturnStatus("Vybavená výmena")).toBe("vybavená výmena");
+    expect(classifyFinishedReturnStatus("Vybavený Dobropis")).toBe("vybavený dobropis");
+  });
+
+  it("AKTÍVNY stav (Vratený tovar) a bežné stavy NIE SÚ hotové — vrátia null", () => {
+    expect(classifyFinishedReturnStatus("Vratený tovar")).toBeNull();
+    expect(classifyFinishedReturnStatus("Vybavuje sa")).toBeNull();
+    expect(classifyFinishedReturnStatus("")).toBeNull();
+  });
+
+  it("normalizuje (NFC + orez) rovnako ako `classifyReturnStatus`", () => {
+    expect(classifyFinishedReturnStatus("  Vybavený Dobropis  ")).toBe("vybavený dobropis");
+    expect(classifyFinishedReturnStatus("Vybavená výmena".normalize("NFD"))).toBe("vybavená výmena");
   });
 });
 

--- a/apps/api/src/modules/orders/return-status.ts
+++ b/apps/api/src/modules/orders/return-status.ts
@@ -9,16 +9,34 @@ import { normalizeStatusName } from "./parser.js";
 // NORMALIZOVANÝ (`normalizeStatusName`, rovnaká funkcia, akú `ingest.ts`
 // používa na uloženie `order.status_name`) — porovnanie beží v rovnakej
 // forme na oboch stranách, presne ako `open-statuses.ts`.
-const RETURN_STATUS_LABELS: ReadonlyMap<string, string> = new Map([
-  [normalizeStatusName("Vratený tovar"), "vrátený tovar"],
+//
+// issue 297 (majiteľov šéf, cez Discord): "Vybavená výmena"/"Vybavený
+// Dobropis" sú HOTOVÉ stavy — majiteľ NEPOTREBUJE upozornenie na prácu, ktorú
+// niekto už spravil. Zoznam sa preto rozdeľuje na DVE nezávislé mapy:
+// AKTÍVNE (`classifyReturnStatus`, karta sa ZAKLADÁ/OBNOVUJE) a HOTOVÉ
+// (`classifyFinishedReturnStatus`, existujúca otvorená karta sa naopak
+// AUTOMATICKY ZATVÁRA — `ingest.ts`). "Vratený tovar" ostáva zatiaľ v
+// AKTÍVNYCH — majiteľ ešte nepovedal, ako presne chce upozornenie na vrátené
+// zásielky riešiť (jeho druhý bod v tom istom vlákne, mimo rozsahu #297).
+const ACTIVE_RETURN_STATUS_LABELS: ReadonlyMap<string, string> = new Map([[normalizeStatusName("Vratený tovar"), "vrátený tovar"]]);
+
+const FINISHED_RETURN_STATUS_LABELS: ReadonlyMap<string, string> = new Map([
   [normalizeStatusName("Vybavená výmena"), "vybavená výmena"],
   [normalizeStatusName("Vybavený Dobropis"), "vybavený dobropis"],
 ]);
 
-/** `null`, keď stav objednávky nie je žiadny zo živo overených vrátkových
- * stavov — inak ľudský štítok použiteľný priamo v titulku karty. */
+/** `null`, keď stav objednávky nie je AKTÍVNY vrátkový stav (karta sa
+ * zakladá/obnovuje) — inak ľudský štítok použiteľný priamo v titulku karty. */
 export function classifyReturnStatus(statusName: string): string | null {
-  return RETURN_STATUS_LABELS.get(normalizeStatusName(statusName)) ?? null;
+  return ACTIVE_RETURN_STATUS_LABELS.get(normalizeStatusName(statusName)) ?? null;
+}
+
+/** `null`, keď stav objednávky nie je HOTOVÝ vrátkový stav — inak ľudský
+ * štítok (dnes nepoužitý v titulku, len na symetriu s `classifyReturnStatus`
+ * pre budúcich volajúcich). Existujúca otvorená karta pre tento `dedupKey` sa
+ * pri tomto stave AUTOMATICKY ZATVÁRA (`ingest.ts`), nikdy nezakladá nová. */
+export function classifyFinishedReturnStatus(statusName: string): string | null {
+  return FINISHED_RETURN_STATUS_LABELS.get(normalizeStatusName(statusName)) ?? null;
 }
 
 /** Stabilný kľúč proti duplicitám — JEDNA karta NA OBJEDNÁVKU (nie na

--- a/apps/api/src/modules/orders/return-upozornenia.ts
+++ b/apps/api/src/modules/orders/return-upozornenia.ts
@@ -1,0 +1,133 @@
+import { and, eq, inArray } from "drizzle-orm";
+import { upozornenie } from "../../db/schema.js";
+import { buildShoptetAdminOrderUrl } from "./queries.js";
+import { classifyFinishedReturnStatus, classifyReturnStatus, returnUpozornenieDedupKey } from "./return-status.js";
+import { autoResolveByDedupKey, upsertUpozornenie, type UpozornenieExecutor } from "../upozornenia/service.js";
+
+// Malá, zámerne DUPLIKOVANÁ kópia `ingest.ts`'s `chunk()` — import odtiaľ by
+// vyrobil CYKLICKÚ závislosť (`ingest.ts` volá TENTO súbor). Rovnaká
+// disciplína ako `upozornenia/service.ts`'s `isUniqueViolation`
+// (`.claude/rules/mvp-philosophy.md`: žiadna zdieľaná abstrakcia pre dvoch
+// konzumentov v nesúvisiacich moduloch, keď je priama kópia rovnako čitateľná).
+function chunk<T>(items: readonly T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
+  return out;
+}
+
+// issue 269/297: druhý automatický zdroj pre nástenku Upozornenia (#267) —
+// objednávka, ktorej `statusName` je AKTÍVNY vrátkový stav (`return-status.ts`),
+// dostane/obnoví kartu cez ZDIEĽANÚ zapisovaciu cestu (`upsertUpozornenie`,
+// #267/#272); objednávka, ktorej `statusName` je HOTOVÝ vrátkový stav (#297,
+// "Vybavená výmena"/"Vybavený Dobropis"), namiesto toho AUTOMATICKY ZATVORÍ
+// svoju existujúcu otvorenú kartu (`autoResolveByDedupKey`, rovnaký princíp
+// ako #268's doručená zásielka). `dedupKey` je na OBJEDNÁVKU (nie na
+// pod-stav) — opakovaný import v tom istom AKTÍVNOM stave, alebo prechod
+// medzi dvomi objednávkami rovnakého kandidáta, len OBNOVÍ tú istú kartu.
+// Vyčlenené z `ingest.ts` do VLASTNÉHO súboru (issue 297 poslalo `ingest.ts`
+// cez eslint `max-lines: 400`, `.claude/rules/testing.md`) — volá sa ZÁMERNE
+// AŽ TESNE PRED COMMITOM tej istej transakcie (viď volajúce miesto), nie
+// hneď po upsert-e `order` riadkov: `.for("update")` pre-check nižšie drží
+// riadkové zámky na EXISTUJÚCICH kartách po ZVYŠOK transakcie, takže čím
+// neskôr beží, tým kratšie sú zámky držané — inak by majiteľov klik
+// "Vybavené" čakal, kým dobehne CELÝ zvyšok importu.
+export interface ApplyReturnUpozorneniaOptions {
+  readonly tx: UpozornenieExecutor;
+  readonly orderInfo: ReadonlyMap<string, { readonly customerName: string; readonly statusName: string }>;
+  readonly orderIdsByCode: ReadonlyMap<string, number>;
+  readonly adminBaseUrl: string;
+  readonly now: Date;
+  // `ingest.ts`'s `ORDERS_INGEST_BATCH_SIZE` — posielaný explicitne (nie
+  // importovaný priamo odtiaľ), aby sa predišlo cyklickej závislosti.
+  readonly batchSize: number;
+}
+
+export interface ApplyReturnUpozorneniaResult {
+  readonly skippedResolvedReturnCount: number;
+  readonly autoResolvedFinishedReturnCount: number;
+}
+
+export async function applyReturnUpozornenia(options: ApplyReturnUpozorneniaOptions): Promise<ApplyReturnUpozorneniaResult> {
+  const { tx, orderInfo, orderIdsByCode, adminBaseUrl, now, batchSize } = options;
+  const returnCandidates: { externalOrderId: string; returnLabel: string; customerName: string; statusName: string; dedupKey: string }[] = [];
+  // Objednávky, ktorých stav je HOTOVÝ, NIKDY nejdú do `returnCandidates`
+  // (žiadna nová/obnovená karta) — ich `dedupKey` ide do TEJTO množiny, ktorá
+  // po dávke ZATVORÍ existujúcu otvorenú kartu (ak vôbec vznikla).
+  const finishedReturnDedupKeys: string[] = [];
+  for (const [externalOrderId, info] of orderInfo) {
+    const returnLabel = classifyReturnStatus(info.statusName);
+    if (returnLabel !== null) {
+      returnCandidates.push({ externalOrderId, returnLabel, customerName: info.customerName, statusName: info.statusName, dedupKey: returnUpozornenieDedupKey(externalOrderId) });
+      continue;
+    }
+    if (classifyFinishedReturnStatus(info.statusName) !== null) finishedReturnDedupKeys.push(returnUpozornenieDedupKey(externalOrderId));
+  }
+
+  // Naživo overené na produkcii (0.3.0-dev.160): vybavené vrátenie je
+  // KONEČNÉ — na rozdiel od #268 (zásielka, čo sa smie znova zaseknúť o
+  // mesiac) sa už NIKDY nemá znova ohlásiť, hoci Shoptet-ov status objednávky
+  // ostáva v tom istom AKTÍVNOM stave navždy. `upsertUpozornenie`'s
+  // ČIASTOČNÝ unique index (`WHERE resolved_at IS NULL`, `.claude/rules/
+  // upozornenia.md`) necháva VYRIEŠENÝ riadok mimo arbitra, takže bez tejto
+  // kontroly by ďalší import s tým istým `dedupKey` prešiel ako čistý INSERT.
+  //
+  // Skip sa smie uplatniť LEN keď pre `dedupKey` NEEXISTUJE žiadny
+  // NEVYRIEŠENÝ súrodenec (kľúč môže mať SÚČASNE vyriešený aj otvorený riadok
+  // — historický bug na 0.3.0-dev.160) — inak by ten otvorený navždy zamrzol.
+  // `.for("update")` je POVINNÉ (nie voliteľné) — bez neho by súbežné ručné
+  // "Vybavené" (`resolveUpozornenie`, mimo tejto transakcie) mohlo commitnúť
+  // PRESNE medzi pre-checkom a neskorším `upsertUpozornenie` volaním pre TEN
+  // ISTÝ kandidát, a ten istý bug (len naživo zriedkavejší) by sa zopakoval.
+  const resolvedReturnDedupKeys = new Set<string>();
+  if (returnCandidates.length > 0) {
+    for (const batch of chunk(returnCandidates.map((c) => c.dedupKey), batchSize)) {
+      const candidateRows = await tx
+        .select({ dedupKey: upozornenie.dedupKey, resolvedAt: upozornenie.resolvedAt })
+        .from(upozornenie)
+        .where(and(eq(upozornenie.type, "vratenie"), inArray(upozornenie.dedupKey, batch)))
+        .for("update");
+      // `row.dedupKey` je nullable v type, ale `inArray` NIKDY nezhodí NULL
+      // (Postgres `IN` sémantika) — `continue` nižšie je len TS-narrowing.
+      const hasUnresolvedByKey = new Map<string, boolean>();
+      for (const row of candidateRows) {
+        const dedupKey = row.dedupKey;
+        if (dedupKey === null) continue;
+        const already = hasUnresolvedByKey.get(dedupKey) ?? false;
+        hasUnresolvedByKey.set(dedupKey, already || row.resolvedAt === null);
+      }
+      for (const [dedupKey, hasUnresolved] of hasUnresolvedByKey) {
+        if (!hasUnresolved) resolvedReturnDedupKeys.add(dedupKey);
+      }
+    }
+  }
+  let skippedResolvedReturnCount = 0;
+  for (const candidate of returnCandidates) {
+    if (resolvedReturnDedupKeys.has(candidate.dedupKey)) {
+      skippedResolvedReturnCount += 1;
+      continue;
+    }
+    await upsertUpozornenie(tx, {
+      type: "vratenie",
+      source: "appka",
+      title: `Objednávka ${candidate.externalOrderId} — ${candidate.returnLabel}`,
+      details: [`Zákazník: ${candidate.customerName}`, `Stav objednávky: ${candidate.statusName}`].join("\n"),
+      link: buildShoptetAdminOrderUrl(adminBaseUrl, candidate.externalOrderId, orderIdsByCode.get(candidate.externalOrderId) ?? null),
+      dedupKey: candidate.dedupKey,
+      now,
+    });
+  }
+
+  // issue 297: objednávka, ktorá prešla do HOTOVÉHO vrátkového stavu, ZATVÁRA
+  // svoju existujúcu otvorenú kartu SAMA (`resolvedByUserId` ostáva `null`,
+  // "vybavené systémom"). Jednoduchý UPDATE bez TOCTOU rizika (na rozdiel od
+  // `upsertUpozornenie`'s INSERT vyššie) — súbežné dvojité zatvorenie je
+  // idempotentné, druhé volanie jednoducho nenájde žiadny riadok na
+  // aktualizáciu. Bezpečný no-op, keď pre `dedupKey` žiadna nevyriešená karta
+  // neexistuje (objednávka bola HOTOVÁ už pri PRVOM importe).
+  let autoResolvedFinishedReturnCount = 0;
+  for (const dedupKey of finishedReturnDedupKeys) {
+    if (await autoResolveByDedupKey(tx, dedupKey, now)) autoResolvedFinishedReturnCount += 1;
+  }
+
+  return { skippedResolvedReturnCount, autoResolvedFinishedReturnCount };
+}

--- a/apps/api/src/modules/posta-uncollected/logic.test.ts
+++ b/apps/api/src/modules/posta-uncollected/logic.test.ts
@@ -1,5 +1,21 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { MAIL_TEMPLATE_KINDS } from "../mail-templates/registry.js";
+
+// issue 293 review finding: `buildEmail`'s `retainedTillDisplay` je jediné
+// miesto v tomto module, čo si dátum na Y/M/D rozoberá SAMO (`getUTCDate()`
+// atď.) namiesto zdieľaného `timezone.ts`'s `getZonedDateParts` — tento spy
+// dokazuje, že po oprave naň skutočne ide. Priamy `vi.spyOn` na natívny ESM
+// modul zlyhá ("Module namespace is not configurable in ESM") — `vi.mock` s
+// `importOriginal` je jediný spôsob, ako v ESM prostredí nahradiť JEDEN
+// export a ostatné (`zonedDateKey`) nechať skutočné (rovnaký vzor ako
+// `modules/orders/raw-prune.test.ts`).
+const { getZonedDateParts: spiedGetZonedDateParts } = vi.hoisted(() => ({ getZonedDateParts: vi.fn() }));
+vi.mock("../../timezone.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../timezone.js")>();
+  spiedGetZonedDateParts.mockImplementation(actual.getZonedDateParts);
+  return { ...actual, getZonedDateParts: spiedGetZonedDateParts };
+});
+
 import {
   buildEmail,
   postaTemplateKey,
@@ -183,6 +199,13 @@ describe("buildEmail", () => {
     expect(built.html).toContain("Ján Novák");
     expect(built.html).toContain("10. 8. 2026"); // 2026-08-10 vs today 2026-08-02 → future, teda zobrazí sa
     expect(built.html).not.toContain("<script>");
+  });
+
+  it("retainedTillDisplay ide cez zdieľaný getZonedDateParts (timezone.ts), nie cez vlastné getUTC* volania — a vykreslený deň ostáva rovnaký", () => {
+    spiedGetZonedDateParts.mockClear();
+    const built = buildEmail(MAIL_TEMPLATE_KINDS[postaTemplateKey(1)].defaultText, "Ján Novák", "EF123456789SK", "Pošta 1", "Hlavná 1, Žilina", "2026-08-10", TODAY);
+    expect(spiedGetZonedDateParts).toHaveBeenCalled();
+    expect(built.html).toContain("10. 8. 2026");
   });
 
   it("4. e-mail žiada priamy kontakt na eshop@forestshop.sk", () => {

--- a/apps/api/src/modules/posta-uncollected/logic.ts
+++ b/apps/api/src/modules/posta-uncollected/logic.ts
@@ -1,7 +1,7 @@
 import { globalContext, textValue } from "../mail-templates/context.js";
 import type { MailTemplateKey } from "../mail-templates/registry.js";
 import { renderTemplate, type MailTemplateText, type RenderedEmail } from "../mail-templates/render.js";
-import { zonedDateKey } from "../../timezone.js";
+import { getZonedDateParts, zonedDateKey } from "../../timezone.js";
 import {
   CANCELLED_STATUSES,
   daysNeededForNextEmail,
@@ -274,8 +274,18 @@ export function buildEmail(
   today: Date,
 ): BuiltEmail {
   const d = retainedTill !== "" ? parseIsoDatePrefix(retainedTill) : null;
+  // issue 293 review finding: `d` je VŽDY UTC-polnočný kalendárny dátum
+  // (`parseIsoDatePrefix` vyššie), takže "UTC" pásmo tu dá identický
+  // výsledok ako predošlé vlastné `getUTC*` volania — jediný rozdiel je, že
+  // teraz ide cez ROVNAKÝ zdieľaný helper ako zvyšok modulu (`zonedDateKey`
+  // nižšie), namiesto vlastnej duplicitnej Y/M/D extrakcie.
   const retainedTillDisplay =
-    d !== null && d >= today ? `${String(d.getUTCDate())}. ${String(d.getUTCMonth() + 1)}. ${String(d.getUTCFullYear())}` : "";
+    d !== null && d >= today
+      ? (() => {
+          const parts = getZonedDateParts(d, "UTC");
+          return `${String(parts.day)}. ${String(parts.month)}. ${String(parts.year)}`;
+        })()
+      : "";
   const link = trackingLink(trackNum);
   return renderTemplate(template, {
     ...globalContext(),

--- a/apps/api/src/modules/posta-uncollected/run.ts
+++ b/apps/api/src/modules/posta-uncollected/run.ts
@@ -324,17 +324,31 @@ async function runPostaUncollectedLocked(options: RunPostaUncollectedOptions): P
       // beh na TÚ ISTÚ zásielku len OBNOVÍ existujúcu kartu (rovnaký
       // `dedupKey`), nikdy nevyrobí druhú.
       const daysWord = pluralWord(cls.daysAtPost, "deň", "dni", "dní");
+      // issue 298 (šéf, cez majiteľa): karta má ukázať, čo treba riešiť
+      // ("dokedy leží na pošte") a preklikom viesť PRIAMO na Poštu SK — nie
+      // nová sieťová výzva, `cls.retainedTill` je HODNOTA, ktorú tento istý
+      // beh UŽ vypočítal z tej istej odpovede trackingu (`classifyTracking`,
+      // `logic.ts`), pridáva sa LEN keď ju Pošta SK pre danú zásielku vrátila
+      // (bežne chýba, keď zásielka ešte nemá stanovený termín vrátenia).
+      const detailLines = [
+        `Zákazník: ${shipment.customerName}`,
+        `Číslo zásielky: ${packageNumber}`,
+        `Dopravca: ${shipment.shippingCarrierName ?? ""}`,
+        `Čaká: ${String(cls.daysAtPost)} ${daysWord} na pošte`,
+      ];
+      if (cls.retainedTill !== "") detailLines.push(`Vyzdvihnutie do: ${cls.retainedTill}`);
       await upsertUpozornenie(db, {
         type: "nevyzdvihnuta_zasielka",
         source: "appka",
         title: `Zásielka pre objednávku ${shipment.externalOrderId} sa nevyzdvihla — ${String(cls.daysAtPost)} ${daysWord} na pošte`,
-        details: [
-          `Zákazník: ${shipment.customerName}`,
-          `Číslo zásielky: ${packageNumber}`,
-          `Dopravca: ${shipment.shippingCarrierName ?? ""}`,
-          `Čaká: ${String(cls.daysAtPost)} ${daysWord} na pošte`,
-        ].join("\n"),
-        link: adminOrderUrl(shipment),
+        details: detailLines.join("\n"),
+        // Preklik VEDIE PRIAMO na Poštu SK (šéfova žiadosť "možno s preklikom
+        // do pošty") — nahrádza predošlý odkaz na Shoptet admin objednávku
+        // (ten zostáva čitateľný v titulku/`Zákazník`/`Číslo zásielky` vyššie,
+        // len prestal byť KLIKATEĽNÝM odkazom karty). Rovnaký `trackingLink`
+        // helper, aký už používa "Nevyzdvihnuté zásielky"'s výsledková
+        // tabuľka (`PostaUncollectedRow.tsx`) — žiadna nová sieťová/URL logika.
+        link: trackingLink(packageNumber),
         dedupKey: postaUpozornenieDedupKey(packageNumber),
         now,
       });

--- a/apps/api/src/modules/scheduler/jobs.ts
+++ b/apps/api/src/modules/scheduler/jobs.ts
@@ -147,7 +147,15 @@ export function pruneRawOrdersJob(rawDir: string, keepDays = 30): ScheduledJob {
     // prekrývať KAŽDÝ deň (nie len raz), nie iba pri tomto jednom sedení —
     // neprekáža, `pruneRawOrders` nemá žiadny DB advisory zámok (viď komentár
     // vyššie), takže si nekonkuruje.
-    schedule: { kind: "daily", hourLocal: 2, minuteLocal: 0 },
+    // issue 293 review finding: `hourLocal: 2, minuteLocal: 0` je PRESNE
+    // okamih jarného prechodu na letný čas v Europe/Bratislava (miestne
+    // 02:00 v tú noc VÔBEC NEEXISTUJE — hodiny skočia z 01:59 rovno na
+    // 03:00). Nie je to bug — `isDue()` job spustí správne hneď, ako
+    // miestny čas dosiahne 03:00 — ale ten JEDEN deň v roku beh ticho
+    // omešká asi o hodinu. `minuteLocal: 10` (namiesto 0) je zámerne mimo
+    // presnej hranice prechodu, aby k tomuto miniatúrnemu ročnému
+    // omeškaniu vôbec nedochádzalo.
+    schedule: { kind: "daily", hourLocal: 2, minuteLocal: 10 },
     async run(_db, now) {
       const result = await pruneRawOrders(rawDir, { keepDays, now });
       return { detail: result };
@@ -299,7 +307,7 @@ export type RunSupplierStock = (db: Database, now: Date) => Promise<SupplierStoc
  * medzi nočnými jobmi nižšie ostávajú NEZMENENÉ), teda dostatočne PRED
  * automatizáciou prepínania (issue 213), aby tá pracovala s čerstvými dátami
  * z tejto noci, a zároveň mimo `pruneRawExportsJob` (01:15) /
- * `sessionCleanupJob` (01:30) / `pruneRawOrdersJob` (02:00).
+ * `sessionCleanupJob` (01:30) / `pruneRawOrdersJob` (02:10).
  *
  * Žiadny `enabled` prepínač (na rozdiel od `postaUncollectedJob`/
  * `orderReminderJob`): scraper nikam nezapisuje, len číta stránky

--- a/apps/api/tests/helpers/orders-return-csv.ts
+++ b/apps/api/tests/helpers/orders-return-csv.ts
@@ -31,12 +31,17 @@ export function buildReturnStatusCsv(header: readonly string[], rows: readonly R
 
 export const RETURN_STATUS_CSV_HEADER = ["code", "date", "statusName", "billFullName", "itemName", "itemAmount", "itemCode"] as const;
 
-export function returnStatusRowOf(code: string, statusName: string): Record<string, string> {
+// `billFullName` je voliteľný (predvolene "Ján Novák") — issue 297's testy
+// preukazujúce OBNOVU (nie preskočenie) po tom, čo zostal len JEDEN AKTÍVNY
+// vrátkový stav ("Vratený tovar"), potrebujú zmeniť NIEČO medzi dvomi
+// importmi TOHO ISTÉHO stavu, aby dôkaz obnovy nezávisel od zmeny titulku
+// (predtým to robila zmena pod-stavu, dnes už neexistuje druhý AKTÍVNY).
+export function returnStatusRowOf(code: string, statusName: string, billFullName = "Ján Novák"): Record<string, string> {
   return {
     code,
     date: "2026-06-15 10:30:00",
     statusName,
-    billFullName: "Ján Novák",
+    billFullName,
     itemName: "Nohavice",
     itemAmount: "1",
     itemCode: "40237/XL",

--- a/apps/api/tests/orders-ingest-return-upozornenie-reopen.integration.test.ts
+++ b/apps/api/tests/orders-ingest-return-upozornenie-reopen.integration.test.ts
@@ -76,10 +76,13 @@ it("karta vrátená späť medzi otvorené sa ĎALŠÍM importom ZNOVA obnoví �
   expect(afterReturn[0]?.resolvedAt).toBeNull();
 
   // Ďalší import (napr. nasledujúcu noc) — karta je teraz NEVYRIEŠENÁ, takže
-  // pre-check ju NEPRESKOČÍ; ten istý pod-stav sa upsertne (obnoví) ako
-  // ktorákoľvek iná otvorená vrátková karta.
+  // pre-check ju NEPRESKOČÍ; ten istý AKTÍVNY stav ("Vratený tovar", issue
+  // 297 nechalo len JEDEN — "Vybavená výmena" použitá tu predtým je dnes
+  // HOTOVÝ stav, ktorý by kartu namiesto obnovy ZATVORIL, viď dedikovaný
+  // test v `orders-ingest-return-upozornenie.integration.test.ts`) sa s INÝM
+  // menom zákazníka upsertne (obnoví) ako ktorákoľvek iná otvorená karta.
   await ingestOrders(db, {
-    fetchExport: fetcherOf(buildReturnStatusCsv(RETURN_STATUS_CSV_HEADER, [returnStatusRowOf("20700010", "Vybavená výmena")])),
+    fetchExport: fetcherOf(buildReturnStatusCsv(RETURN_STATUS_CSV_HEADER, [returnStatusRowOf("20700010", "Vratený tovar", "Eva Kováčová")])),
     now: new Date("2026-08-07T10:00:00Z"),
     rawDir: dir,
     windowStart: WINDOW_START,
@@ -90,5 +93,5 @@ it("karta vrátená späť medzi otvorené sa ĎALŠÍM importom ZNOVA obnoví �
   expect(after).toHaveLength(1); // stále presne jedna karta, žiadna duplicita
   expect(after[0]?.id).toBe(cardId); // TÁ ISTÁ karta — obnovená, nie nová
   expect(after[0]?.resolvedAt).toBeNull(); // ostáva otvorená
-  expect(after[0]?.title).toContain("vybavená výmena"); // OBNOVENÁ — dôkaz že import ju vôbec nepreskočil
+  expect(after[0]?.details).toContain("Eva Kováčová"); // OBNOVENÁ — dôkaz že import ju vôbec nepreskočil
 });

--- a/apps/api/tests/orders-ingest-return-upozornenie.integration.test.ts
+++ b/apps/api/tests/orders-ingest-return-upozornenie.integration.test.ts
@@ -101,7 +101,7 @@ it("objednávka vo vrátkovom stave vyrobí kartu s odkazom na objednávku, nikd
 it("opakovaný import tej istej objednávky v tom istom vrátkovom stave NEVYROBÍ druhú kartu, len ju obnoví", async () => {
   const { db, dir } = await boot();
   await insertTestVariant(db, "40237/XL");
-  const csv = buildCsv(HEADER, [rowOf("20600003", "Vybavená výmena")]);
+  const csv = buildCsv(HEADER, [rowOf("20600003", "Vratený tovar")]);
 
   await ingestOrders(db, { fetchExport: fetcherOf(csv), now: NOW, rawDir: dir, windowStart: WINDOW_START, windowEnd: WINDOW_END });
   await ingestOrders(db, {
@@ -116,7 +116,13 @@ it("opakovaný import tej istej objednávky v tom istom vrátkovom stave NEVYROB
   expect(rows).toHaveLength(1);
 });
 
-it("prechod z jedného vrátkového stavu do druhého (Vratený tovar -> Vybavený Dobropis) OBNOVÍ tú istú kartu, nikdy druhú", async () => {
+// issue 297 (šéf, cez majiteľa): "Vybavená výmena"/"Vybavený Dobropis" sú
+// HOTOVÉ stavy — majiteľ nepotrebuje upozornenie na prácu, ktorú niekto už
+// spravil. Prechod objednávky z AKTÍVNEHO ("Vratený tovar") do HOTOVÉHO
+// stavu preto existujúcu otvorenú kartu AUTOMATICKY ZATVORÍ (rovnaký princíp
+// ako #268's doručená zásielka), NIKDY neobnoví jej titulok na nový pod-stav
+// (predošlé správanie pred #297).
+it("prechod z AKTÍVNEHO stavu do HOTOVÉHO (Vratený tovar -> Vybavený Dobropis) AUTOMATICKY ZATVORÍ existujúcu kartu", async () => {
   const { db, dir } = await boot();
   await insertTestVariant(db, "40237/XL");
 
@@ -130,6 +136,7 @@ it("prechod z jedného vrátkového stavu do druhého (Vratený tovar -> Vybaven
   const before = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "vratenie:20600004"));
   expect(before).toHaveLength(1);
   expect(before[0]?.title).toContain("vrátený tovar");
+  expect(before[0]?.resolvedAt).toBeNull();
 
   await ingestOrders(db, {
     fetchExport: fetcherOf(buildCsv(HEADER, [rowOf("20600004", "Vybavený Dobropis")])),
@@ -139,9 +146,31 @@ it("prechod z jedného vrátkového stavu do druhého (Vratený tovar -> Vybaven
     windowEnd: WINDOW_END,
   });
   const after = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "vratenie:20600004"));
-  expect(after).toHaveLength(1); // stále JEDNA karta na objednávku, nikdy druhá pre nový pod-stav
-  expect(after[0]?.id).toBe(before[0]?.id);
-  expect(after[0]?.title).toContain("vybavený dobropis");
+  expect(after).toHaveLength(1); // stále JEDNA karta na objednávku, žiadna druhá
+  expect(after[0]?.id).toBe(before[0]?.id); // TÁ istá karta — zatvorená, nie nová
+  expect(after[0]?.resolvedAt).not.toBeNull(); // AUTOMATICKY zatvorená
+  expect(after[0]?.resolvedByUserId).toBeNull(); // "vybavené systémom", nie ručne
+  expect(after[0]?.title).toBe(before[0]?.title); // titulok sa NIKDY neobnoví na nový pod-stav
+});
+
+// issue 297: objednávka, ktorej PRVÝ zistený stav je už HOTOVÝ (nikdy predtým
+// nebola "Vratený tovar", teda nikdy nedostala kartu) NEVYROBÍ žiadnu — na
+// rozdiel od `classifyReturnStatus`'s aktívnych stavov, `autoResolveByDedupKey`
+// je bezpečný no-op, keď žiadna nevyriešená karta pre `dedupKey` neexistuje.
+it("objednávka, ktorej PRVÝ import je už HOTOVÝ vrátkový stav, NEVYROBÍ žiadnu kartu", async () => {
+  const { db, dir } = await boot();
+  await insertTestVariant(db, "40237/XL");
+
+  await ingestOrders(db, {
+    fetchExport: fetcherOf(buildCsv(HEADER, [rowOf("20600010", "Vybavená výmena")])),
+    now: NOW,
+    rawDir: dir,
+    windowStart: WINDOW_START,
+    windowEnd: WINDOW_END,
+  });
+
+  const rows = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "vratenie:20600010"));
+  expect(rows).toHaveLength(0);
 });
 
 // issue 269 (naživo overenie na 0.3.0-dev.160): vybavené vrátenie je
@@ -195,24 +224,25 @@ it("po vybavení karty (Vybavené) opakovaný import UŽ NEVYROBÍ druhú kartu 
 // druhý kandidát bol OMYLOM preskočený spolu s prvým — jeho karta by
 // jednoducho zostala na SVOJICH pôvodných hodnotách, ktoré sú zhodné s tým,
 // čo by upsert aj tak zapísal). Fix: druhý import posiela otvorenej
-// objednávke INÝ vrátkový pod-stav ("Vybavený Dobropis" namiesto "Vybavená
-// výmena", mechanizmus prechodu medzi pod-stavmi má už vlastný test
-// vyššie), takže test genuinely OVERUJE, že jej titulok sa SKUTOČNE ZMENIL —
+// objednávke INÉ meno zákazníka (issue 297 nechalo len JEDEN AKTÍVNY
+// vrátkový stav — "Vybavená výmena"/"Vybavený Dobropis" boli predtým druhý
+// pod-stav použitý na ten istý dôkaz, dnes už HOTOVÉ a mimo `returnCandidates`
+// úplne), takže test genuinely OVERUJE, že jej `details` sa SKUTOČNE ZMENILI —
 // dôkaz, že bola upsertnutá, nie preskočená. Overené AJ opačným smerom
 // (`regression-test-first.md`): dočasná úprava kódu na "preskoč VŠETKÝCH
 // kandidátov v dávke, ak je čo i len JEDEN vyriešený" spadla presne na
-// asercii titulku otvorenej karty nižšie, návrat opravy prešiel znova.
+// asercii `details` otvorenej karty nižšie, návrat opravy prešiel znova.
 it("v jednom importe s viacerými vrátkovými objednávkami ovplyvní vybavenie LEN tú svoju kartu", async () => {
   const { db, dir } = await boot();
   await insertTestVariant(db, "40237/XL");
-  const csv = buildCsv(HEADER, [rowOf("20600008", "Vratený tovar"), rowOf("20600009", "Vybavená výmena")]);
+  const csv = buildCsv(HEADER, [rowOf("20600008", "Vratený tovar"), rowOf("20600009", "Vratený tovar")]);
 
   await ingestOrders(db, { fetchExport: fetcherOf(csv), now: NOW, rawDir: dir, windowStart: WINDOW_START, windowEnd: WINDOW_END });
   const beforeResolved = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "vratenie:20600008"));
   const beforeOpen = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "vratenie:20600009"));
   expect(beforeResolved).toHaveLength(1);
   expect(beforeOpen).toHaveLength(1);
-  expect(beforeOpen[0]?.title).toContain("vybavená výmena");
+  expect(beforeOpen[0]?.details).toContain("Ján Novák");
   const resolvedCardId = beforeResolved[0]?.id;
   const openCardId = beforeOpen[0]?.id;
   if (resolvedCardId === undefined || openCardId === undefined) throw new Error("karty sa nevyrobili");
@@ -225,8 +255,8 @@ it("v jednom importe s viacerými vrátkovými objednávkami ovplyvní vybavenie
   expect(await resolveUpozornenie(db, { id: resolvedCardId, resolvedByUserId: user.id, now: new Date("2026-07-31T09:00:00Z") })).toBe(true);
 
   // Druhý import — vybavená objednávka ostáva v tom istom stave (irelevantné,
-  // je preskočená), otvorená objednávka prejde do INÉHO vrátkového pod-stavu.
-  const csvSecondImport = buildCsv(HEADER, [rowOf("20600008", "Vratený tovar"), rowOf("20600009", "Vybavený Dobropis")]);
+  // je preskočená), otvorená objednávka dostane INÉ meno zákazníka.
+  const csvSecondImport = buildCsv(HEADER, [rowOf("20600008", "Vratený tovar"), rowOf("20600009", "Vratený tovar", "Eva Kováčová")]);
   await ingestOrders(db, {
     fetchExport: fetcherOf(csvSecondImport),
     now: new Date("2026-08-01T10:00:00Z"),
@@ -239,25 +269,23 @@ it("v jednom importe s viacerými vrátkovými objednávkami ovplyvní vybavenie
   expect(afterResolved).toHaveLength(1); // vybavená ostáva vybavená, žiadna nová
   expect(afterResolved[0]?.id).toBe(resolvedCardId);
   expect(afterResolved[0]?.resolvedAt).not.toBeNull();
-  expect(afterResolved[0]?.title).toContain("vrátený tovar"); // nedotknutá — stále pôvodný titulok, nikdy neupsertnutá
+  expect(afterResolved[0]?.details).toContain("Ján Novák"); // nedotknutá — stále pôvodné meno, nikdy neupsertnutá
 
   const afterOpen = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "vratenie:20600009"));
   expect(afterOpen).toHaveLength(1); // stále JEDNA karta, ale STÁLE OBNOVENÁ — nikdy sa nedotkla druhého kandidáta
   expect(afterOpen[0]?.id).toBe(openCardId);
   expect(afterOpen[0]?.resolvedAt).toBeNull();
-  expect(afterOpen[0]?.title).toContain("vybavený dobropis"); // SKUTOČNE ZMENENÝ titulok — dôkaz upsertu, nie preskočenia
+  expect(afterOpen[0]?.details).toContain("Eva Kováčová"); // SKUTOČNE ZMENENÉ meno — dôkaz upsertu, nie preskočenia
 });
 
-// Code review (druhé kolo, finding 1): kľúč, ktorý má SÚČASNE vyriešený AJ
-// otvorený riadok (presne stav, aký pôvodný bug na 0.3.0-dev.160 vyrobil,
-// kým sa importovalo druhýkrát ešte PRED touto opravou) musí naďalej
-// obnoviť svoj OTVORENÝ riadok pri ďalšom importe — pôvodná (jednoduchšia)
-// pre-check logika ho namiesto toho navždy zamrazila, lebo videla "existuje
-// vyriešený riadok pre tento kľúč" a celý kandidát preskočila. Scenár sa
-// simuluje priamym vložením OBOCH riadkov (nie cez appku — appka dnes
-// (post-fix) takýto stav sama nevyrobí), presne ako by ho zanechal
-// historický bug/manuálny zásah.
-it("otvorený súrodenec vedľa vyriešeného (stav pôvodného bugu) sa naďalej obnoví, nikdy sa nezamrzne", async () => {
+// issue 297: kľúč, ktorý má SÚČASNE vyriešený AJ otvorený riadok (presne
+// stav, aký pôvodný bug na 0.3.0-dev.160 vyrobil) — keď objednávka prejde do
+// HOTOVÉHO stavu, `autoResolveByDedupKey`'s `WHERE resolved_at IS NULL`
+// zatvorí LEN otvorený súrodenec, nikdy sa nedotkne už vyriešeného (a
+// nevyrobí tretí riadok). Scenár sa simuluje priamym vložením OBOCH riadkov
+// (nie cez appku — appka takýto stav sama nevyrobí), presne ako by ho
+// zanechal historický bug/manuálny zásah.
+it("otvorený súrodenec vedľa vyriešeného sa PRI PRECHODE DO HOTOVÉHO STAVU tiež ZATVORÍ, nikdy nezostane navždy otvorený", async () => {
   const { db, dir } = await boot();
   await insertTestVariant(db, "40237/XL");
   const dedupKey = "vratenie:20600200";
@@ -304,6 +332,7 @@ it("otvorený súrodenec vedľa vyriešeného (stav pôvodného bugu) sa naďale
   expect(resolvedAfter?.title).toBe("Objednávka 20600200 — vrátený tovar (staršia, už vybavená)"); // nedotknutý
 
   const openAfter = rows.find((r) => r.id === openRow.id);
-  expect(openAfter?.resolvedAt).toBeNull();
-  expect(openAfter?.title).toContain("vybavená výmena"); // OBNOVENÝ — nezamrzol na starom titulku
+  expect(openAfter?.resolvedAt).not.toBeNull(); // ZATVORENÝ — nezostal navždy otvorený
+  expect(openAfter?.resolvedByUserId).toBeNull(); // "vybavené systémom", nie ručne
+  expect(openAfter?.title).toBe("Objednávka 20600200 — vrátený tovar"); // titulok sa NIKDY neupraví, len sa zatvorí
 });

--- a/apps/api/tests/posta-uncollected-run.integration.test.ts
+++ b/apps/api/tests/posta-uncollected-run.integration.test.ts
@@ -264,7 +264,12 @@ it("dva súbežné behy sa serializujú (advisory zámok), nikdy neprebehnú nar
 // (#267's zdieľaná zapisovacia cesta), opakovaný beh ju len OBNOVÍ (nikdy
 // druhú), a keď sa zásielka doručí/vráti, karta sa ZAVRIE SAMA (bez zásahu
 // majiteľa) — presne "hotovo, keď" ticketu.
-it("nevyzdvihnutá zásielka vyrobí kartu na Upozorneniach s odkazom na objednávku", async () => {
+//
+// issue 298: preklik karty vedie PRIAMO na sledovanie zásielky na Pošte SK
+// (`trackingLink`), nie na Shoptet admin objednávku (predošlé správanie) —
+// číslo objednávky ostáva čitateľné v titulku/`details`, len prestalo byť
+// samotným klikateľným odkazom.
+it("nevyzdvihnutá zásielka vyrobí kartu na Upozorneniach s preklikom na sledovanie na Pošte SK", async () => {
   const db = await boot();
   await insertOrder(db, { externalOrderId: "20500010" });
 
@@ -281,9 +286,60 @@ it("nevyzdvihnutá zásielka vyrobí kartu na Upozorneniach s odkazom na objedn�
   expect(rows).toHaveLength(1);
   expect(rows[0]?.type).toBe("nevyzdvihnuta_zasielka");
   expect(rows[0]?.source).toBe("appka");
-  expect(rows[0]?.title).toContain("20500010");
-  expect(rows[0]?.link).toContain("20500010");
+  expect(rows[0]?.title).toContain("20500010"); // číslo objednávky ostáva v titulku, aj bez odkazu naň
+  expect(rows[0]?.link).toBe("https://www.posta.sk/sledovanie-zasielok#parcel=EF123456789SK");
   expect(rows[0]?.resolvedAt).toBeNull();
+});
+
+// issue 298: keď Pošta SK pre zásielku vráti termín vrátenia odosielateľovi
+// (`retainedTill`, `classifyTracking`'s už vypočítaná hodnota — žiadne nové
+// sieťové volanie), karta ho ukáže priamo v `details` ("dokedy leží na
+// pošte").
+it("keď Pošta SK vráti termín vrátenia, karta ho ukáže v details ('Vyzdvihnutie do')", async () => {
+  const db = await boot();
+  await insertOrder(db, { externalOrderId: "20500016" });
+
+  await runPostaUncollected({
+    db,
+    now: TODAY,
+    trackingClient: () =>
+      Promise.resolve({
+        results: [
+          {
+            status: "ok",
+            events: [{ stateCode: "notified", detailCode: "ZNP1AN", localDate: "2026-07-30", postOffice: { name: "Pošta 1" } }],
+            retainedTill: "2026-08-10",
+          },
+        ],
+      }),
+    mailTransport: undefined,
+    bccEmail: "majitel@forestshop.sk",
+    adminBaseUrl: "https://www.forestshop.sk",
+  });
+
+  const rows = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "posta:EF123456789SK"));
+  expect(rows).toHaveLength(1);
+  expect(rows[0]?.details).toContain("Vyzdvihnutie do: 2026-08-10");
+});
+
+// issue 298: keď Pošta SK termín NEVRÁTI (bežný prípad), karta o tom mlčí —
+// žiadny prázdny/zavádzajúci riadok "Vyzdvihnutie do: ".
+it("bez termínu vrátenia karta NEUKÁŽE riadok 'Vyzdvihnutie do'", async () => {
+  const db = await boot();
+  await insertOrder(db, { externalOrderId: "20500017" });
+
+  await runPostaUncollected({
+    db,
+    now: TODAY,
+    trackingClient: notifiedTrackingClient(),
+    mailTransport: undefined,
+    bccEmail: "majitel@forestshop.sk",
+    adminBaseUrl: "https://www.forestshop.sk",
+  });
+
+  const rows = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "posta:EF123456789SK"));
+  expect(rows).toHaveLength(1);
+  expect(rows[0]?.details).not.toContain("Vyzdvihnutie do");
 });
 
 it("opakovaný beh na tú istú zásielku NEVYROBÍ druhú kartu, len ju obnoví", async () => {

--- a/apps/web/src/components/CatalogPage.tsx
+++ b/apps/web/src/components/CatalogPage.tsx
@@ -284,42 +284,44 @@ export function CatalogPage({
       {searchLoaded && total === 0 ? (
         <p data-testid="empty-results">Hľadaniu nezodpovedá žiadny variant.</p>
       ) : (
-        <table>
-          <thead>
-            <tr>
-              <th>Kód</th>
-              <th>Názov</th>
-              <th>Veľkosť</th>
-              <th>Stav</th>
-              <th>Sklad</th>
-              <th>Cena</th>
-              <th>Dostupnosť podľa Shoptetu</th>
-            </tr>
-          </thead>
-          <tbody>
-            {items.map((item) => (
-              <tr key={item.code} data-testid={`variant-${item.code}`}>
-                <td>{item.code}</td>
-                <td>{item.name}</td>
-                <td>{item.sizeLabel ?? "—"}</td>
-                <td>
-                  {STATE_LABELS[item.state]}
-                  {item.missingSince !== null && (
-                    <>
-                      {" "}
-                      <strong data-testid={`missing-${item.code}`}>
-                        (chýba od {formatSkDate(item.missingSince)})
-                      </strong>
-                    </>
-                  )}
-                </td>
-                <td>{item.stock}</td>
-                <td>{item.price === null ? "—" : `${item.price} ${item.currency ?? ""}`}</td>
-                <td>{item.availabilityText === "" ? "—" : item.availabilityText}</td>
+        <div className="fs-table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Kód</th>
+                <th>Názov</th>
+                <th>Veľkosť</th>
+                <th>Stav</th>
+                <th>Sklad</th>
+                <th>Cena</th>
+                <th>Dostupnosť podľa Shoptetu</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {items.map((item) => (
+                <tr key={item.code} data-testid={`variant-${item.code}`}>
+                  <td>{item.code}</td>
+                  <td>{item.name}</td>
+                  <td>{item.sizeLabel ?? "—"}</td>
+                  <td>
+                    {STATE_LABELS[item.state]}
+                    {item.missingSince !== null && (
+                      <>
+                        {" "}
+                        <strong data-testid={`missing-${item.code}`}>
+                          (chýba od {formatSkDate(item.missingSince)})
+                        </strong>
+                      </>
+                    )}
+                  </td>
+                  <td>{item.stock}</td>
+                  <td>{item.price === null ? "—" : `${item.price} ${item.currency ?? ""}`}</td>
+                  <td>{item.availabilityText === "" ? "—" : item.availabilityText}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       )}
     </section>
   );

--- a/apps/web/src/components/OrderReminderSection.tsx
+++ b/apps/web/src/components/OrderReminderSection.tsx
@@ -193,122 +193,130 @@ export function OrderReminderSection({
           {result.noNote.length === 0 ? (
             <p data-testid="order-reminder-no-note-empty">Žiadna objednávka bez poznámky.</p>
           ) : (
-            <table>
-              <thead>
-                <tr>
-                  <th>Objednávka</th>
-                  <th>Zákazník</th>
-                  <th>Telefón</th>
-                  <th>E-mail</th>
-                  <th>Položka</th>
-                  <th>Dní nečinnosti</th>
-                  <th>Akcia</th>
-                </tr>
-              </thead>
-              <tbody>
-                {result.noNote.map((row) => (
-                  <OrderReminderNoteRow
-                    key={row.orderCode}
-                    row={row}
-                    busy={busyOrderCode === row.orderCode}
-                    onSend={(code) => {
-                      runAction(code, "send");
-                    }}
-                    onContact={(code) => {
-                      runAction(code, "contact");
-                    }}
-                  />
-                ))}
-              </tbody>
-            </table>
-          )}
-
-          {result.noEmail.length > 0 && (
-            <div className="card order-reminder-box" data-testid="order-reminder-no-email-box">
-              <h3>✉️ Bez e-mailovej adresy ({result.noEmail.length})</h3>
+            <div className="fs-table-wrap">
               <table>
                 <thead>
                   <tr>
                     <th>Objednávka</th>
                     <th>Zákazník</th>
                     <th>Telefón</th>
+                    <th>E-mail</th>
                     <th>Položka</th>
                     <th>Dní nečinnosti</th>
+                    <th>Akcia</th>
                   </tr>
                 </thead>
                 <tbody>
-                  {result.noEmail.map((row) => (
-                    <OrderReminderNoEmailRow key={row.orderCode} row={row} />
+                  {result.noNote.map((row) => (
+                    <OrderReminderNoteRow
+                      key={row.orderCode}
+                      row={row}
+                      busy={busyOrderCode === row.orderCode}
+                      onSend={(code) => {
+                        runAction(code, "send");
+                      }}
+                      onContact={(code) => {
+                        runAction(code, "contact");
+                      }}
+                    />
                   ))}
                 </tbody>
               </table>
+            </div>
+          )}
+
+          {result.noEmail.length > 0 && (
+            <div className="card order-reminder-box" data-testid="order-reminder-no-email-box">
+              <h3>✉️ Bez e-mailovej adresy ({result.noEmail.length})</h3>
+              <div className="fs-table-wrap">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Objednávka</th>
+                      <th>Zákazník</th>
+                      <th>Telefón</th>
+                      <th>Položka</th>
+                      <th>Dní nečinnosti</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {result.noEmail.map((row) => (
+                      <OrderReminderNoEmailRow key={row.orderCode} row={row} />
+                    ))}
+                  </tbody>
+                </table>
+              </div>
             </div>
           )}
 
           {result.emailed.length > 0 && (
             <div className="card order-reminder-box" data-testid="order-reminder-emailed-box">
               <h3>🟠 Pripomienka odoslaná ({result.emailed.length})</h3>
-              <table>
-                <thead>
-                  <tr>
-                    <th>Objednávka</th>
-                    <th>Zákazník</th>
-                    <th>E-mail</th>
-                    <th>Položka</th>
-                    <th>Odoslané</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {result.emailed.map((row) => (
-                    <OrderReminderEmailedRow key={row.orderCode} row={row} />
-                  ))}
-                </tbody>
-              </table>
+              <div className="fs-table-wrap">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Objednávka</th>
+                      <th>Zákazník</th>
+                      <th>E-mail</th>
+                      <th>Položka</th>
+                      <th>Odoslané</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {result.emailed.map((row) => (
+                      <OrderReminderEmailedRow key={row.orderCode} row={row} />
+                    ))}
+                  </tbody>
+                </table>
+              </div>
             </div>
           )}
 
           {(result.contacted.length > 0 || result.pending.length > 0) && (
             <div className="card order-reminder-box" data-testid="order-reminder-skipped-box">
               <h3>Preskočené ({result.contacted.length + result.pending.length})</h3>
-              <table>
-                <thead>
-                  <tr>
-                    <th>Objednávka</th>
-                    <th>Zákazník</th>
-                    <th>Dôvod</th>
-                    <th>Dní nečinnosti</th>
-                    <th>Akcia</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {result.contacted.map((row) => (
-                    <OrderReminderSkippedRow
-                      key={row.orderCode}
-                      row={row}
-                      icon={row.resolvedBy === "manual" ? "✋" : "⚪"}
-                      reason={row.resolvedBy === "manual" ? "vybavil ručne človek" : "AI usúdila, že zákazník je už kontaktovaný"}
-                      busy={busyOrderCode === row.orderCode}
-                      onPreview={openPreview}
-                      onSend={(code) => {
-                        runAction(code, "send");
-                      }}
-                    />
-                  ))}
-                  {result.pending.map((row) => (
-                    <OrderReminderSkippedRow
-                      key={row.orderCode}
-                      row={row}
-                      icon="⚠️"
-                      reason={row.reason}
-                      busy={busyOrderCode === row.orderCode}
-                      onPreview={openPreview}
-                      onSend={(code) => {
-                        runAction(code, "send");
-                      }}
-                    />
-                  ))}
-                </tbody>
-              </table>
+              <div className="fs-table-wrap">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Objednávka</th>
+                      <th>Zákazník</th>
+                      <th>Dôvod</th>
+                      <th>Dní nečinnosti</th>
+                      <th>Akcia</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {result.contacted.map((row) => (
+                      <OrderReminderSkippedRow
+                        key={row.orderCode}
+                        row={row}
+                        icon={row.resolvedBy === "manual" ? "✋" : "⚪"}
+                        reason={row.resolvedBy === "manual" ? "vybavil ručne človek" : "AI usúdila, že zákazník je už kontaktovaný"}
+                        busy={busyOrderCode === row.orderCode}
+                        onPreview={openPreview}
+                        onSend={(code) => {
+                          runAction(code, "send");
+                        }}
+                      />
+                    ))}
+                    {result.pending.map((row) => (
+                      <OrderReminderSkippedRow
+                        key={row.orderCode}
+                        row={row}
+                        icon="⚠️"
+                        reason={row.reason}
+                        busy={busyOrderCode === row.orderCode}
+                        onPreview={openPreview}
+                        onSend={(code) => {
+                          runAction(code, "send");
+                        }}
+                      />
+                    ))}
+                  </tbody>
+                </table>
+              </div>
             </div>
           )}
         </>

--- a/apps/web/src/components/OrderSearchPanel.test.tsx
+++ b/apps/web/src/components/OrderSearchPanel.test.tsx
@@ -1,0 +1,107 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { OrderSearchPanel } from "./OrderSearchPanel.js";
+
+const { globalSearch } = vi.hoisted(() => ({ globalSearch: vi.fn() }));
+
+// `SearchUnauthorizedError` ostáva SKUTOČNÁ trieda z reálneho modulu —
+// rovnaký dôvod ako `SearchSection.test.tsx`: `instanceof` v komponente
+// musí fungovať aj v teste.
+vi.mock("../searchApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../searchApi.js")>();
+  return { ...actual, globalSearch };
+});
+
+const { SearchUnauthorizedError } = await import("../searchApi.js");
+
+const PRODUKT = {
+  productKey: "PD-1",
+  variantCode: "PD-1",
+  productName: "Test produkt PD-1",
+  sizeLabel: null,
+  supplier: "Test dodávateľ",
+  externalCode: "EXT-1",
+  state: "sellable" as const,
+};
+
+const OBJEDNAVKA = {
+  orderId: "order-1",
+  externalOrderId: "9001",
+  customerName: "Zákazník Alfa",
+  email: "alfa@example.com",
+  statusName: "Vybavuje sa",
+  placedAt: "2026-07-01T10:00:00.000Z",
+  adminUrl: "https://www.forestshop.sk/admin/objednavky-detail/?id=58728",
+};
+
+function submitOrderSearch(query: string): void {
+  fireEvent.change(screen.getByLabelText("Objednávka"), { target: { value: query } });
+  fireEvent.click(screen.getByRole("button", { name: "Hľadať objednávku" }));
+}
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+it("renderuje popísané pole 'Objednávka'", () => {
+  render(<OrderSearchPanel onSessionExpired={() => {}} />);
+  expect(screen.getByLabelText("Objednávka")).toBeTruthy();
+  expect(screen.getByRole("button", { name: "Hľadať objednávku" })).toBeTruthy();
+});
+
+it("hľadanie čísla objednávky zavolá globalSearch a zobrazí nájdenú objednávku s odkazom do Shoptetu", async () => {
+  globalSearch.mockResolvedValue({ products: [PRODUKT], orders: [OBJEDNAVKA] });
+
+  render(<OrderSearchPanel onSessionExpired={() => {}} />);
+  submitOrderSearch("9001");
+
+  expect(globalSearch).toHaveBeenCalledWith("9001");
+  const riadok = await screen.findByTestId("search-order-9001");
+  expect(riadok.textContent).toContain("Zákazník Alfa");
+
+  const odkaz = screen.getByTestId("search-order-admin-link-9001");
+  expect(odkaz).toHaveProperty("href", "https://www.forestshop.sk/admin/objednavky-detail/?id=58728");
+  // .products polovica odpovede sa v tomto paneli vôbec nevykresľuje.
+  expect(screen.queryByTestId("search-products")).toBeNull();
+});
+
+it("neexistujúce číslo objednávky zobrazí informačnú vetu namiesto tabuľky", async () => {
+  globalSearch.mockResolvedValue({ products: [], orders: [] });
+
+  render(<OrderSearchPanel onSessionExpired={() => {}} />);
+  submitOrderSearch("99999999");
+
+  await screen.findByTestId("search-order-empty");
+  expect(screen.queryByTestId("search-orders")).toBeNull();
+});
+
+it("prázdny dopyt zobrazí informačnú vetu, nie chybu", async () => {
+  globalSearch.mockResolvedValue({ products: [], orders: [] });
+
+  render(<OrderSearchPanel onSessionExpired={() => {}} />);
+  submitOrderSearch("");
+
+  await screen.findByTestId("search-order-empty");
+});
+
+it("pri 401 pri hľadaní objednávky zavolá onSessionExpired", async () => {
+  globalSearch.mockRejectedValue(new SearchUnauthorizedError());
+  const onSessionExpired = vi.fn();
+
+  render(<OrderSearchPanel onSessionExpired={onSessionExpired} />);
+  submitOrderSearch("9001");
+
+  await waitFor(() => {
+    expect(onSessionExpired).toHaveBeenCalledTimes(1);
+  });
+});
+
+it("sieťová chyba zobrazí chybovú hlášku", async () => {
+  globalSearch.mockRejectedValue(new Error("network down"));
+
+  render(<OrderSearchPanel onSessionExpired={() => {}} />);
+  submitOrderSearch("9001");
+
+  await screen.findByText("Vyhľadávanie zlyhalo — server neodpovedal.");
+});

--- a/apps/web/src/components/OrderSearchPanel.tsx
+++ b/apps/web/src/components/OrderSearchPanel.tsx
@@ -82,38 +82,40 @@ export function OrderSearchPanel({
       {result.length > 0 && (
         <div data-testid="search-orders">
           <h3>Objednávky</h3>
-          <table>
-            <thead>
-              <tr>
-                <th>Číslo</th>
-                <th>Zákazník</th>
-                <th>Stav</th>
-                <th />
-              </tr>
-            </thead>
-            <tbody>
-              {result.map((o) => (
-                <tr key={o.orderId} data-testid={`search-order-${o.externalOrderId}`}>
-                  <td>{o.externalOrderId}</td>
-                  <td>
-                    {o.customerName}
-                    {o.email !== null && ` (${o.email})`}
-                  </td>
-                  <td>{o.statusName}</td>
-                  <td>
-                    <a
-                      href={o.adminUrl}
-                      target="_blank"
-                      rel="noreferrer noopener"
-                      data-testid={`search-order-admin-link-${o.externalOrderId}`}
-                    >
-                      Otvoriť v Shoptete
-                    </a>
-                  </td>
+          <div className="fs-table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Číslo</th>
+                  <th>Zákazník</th>
+                  <th>Stav</th>
+                  <th />
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {result.map((o) => (
+                  <tr key={o.orderId} data-testid={`search-order-${o.externalOrderId}`}>
+                    <td>{o.externalOrderId}</td>
+                    <td>
+                      {o.customerName}
+                      {o.email !== null && ` (${o.email})`}
+                    </td>
+                    <td>{o.statusName}</td>
+                    <td>
+                      <a
+                        href={o.adminUrl}
+                        target="_blank"
+                        rel="noreferrer noopener"
+                        data-testid={`search-order-admin-link-${o.externalOrderId}`}
+                      >
+                        Otvoriť v Shoptete
+                      </a>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </div>
       )}
     </div>

--- a/apps/web/src/components/OrderSearchPanel.tsx
+++ b/apps/web/src/components/OrderSearchPanel.tsx
@@ -1,0 +1,121 @@
+import { useCallback, useRef, useState, type SyntheticEvent, type JSX } from "react";
+import { globalSearch, SearchUnauthorizedError, type OrderSearchHit } from "../searchApi.js";
+
+// issue 289: "Eshop → Vyhľadať" — druhé, NEZÁVISLÉ pole "Objednávka" (vlastný
+// dopyt/výsledok/stav, nič zdieľané s `SearchSection.tsx`'s "Produkt" pole
+// okrem tej istej `GET /api/search` cesty, ktorá vždy vracia OBOJE — tento
+// panel si z odpovede vezme len `.orders`). Vydelené do vlastného súboru,
+// nie len kvôli `max-lines`: `SearchSection.tsx` vie namontovať tento panel
+// AJ počas zobrazenia detailu produktu (mimo jej `if (selectedProductKey…)`
+// vetvy), takže hľadanie objednávky prežije prechod do/z detailu produktu
+// bez straty dopytu/výsledku — presne to isté správanie, aké malo pôvodné
+// jedno spoločné pole (issue 240), keď `result` žil v tom istom komponente,
+// ktorý sa nikdy neodmountoval.
+export function OrderSearchPanel({
+  onSessionExpired,
+}: {
+  readonly onSessionExpired: () => void;
+}): JSX.Element {
+  const [query, setQuery] = useState("");
+  const [result, setResult] = useState<readonly OrderSearchHit[]>([]);
+  const [searched, setSearched] = useState(false);
+  const [searchError, setSearchError] = useState("");
+
+  // Len najnovšia požiadavka smie zapísať výsledok — rovnaký vzor ako
+  // `SearchSection.tsx`'s `searchSeq`.
+  const searchSeq = useRef(0);
+
+  const search = useCallback(
+    (q: string) => {
+      const seq = (searchSeq.current += 1);
+      setSearchError("");
+      globalSearch(q)
+        .then((r) => {
+          if (seq !== searchSeq.current) return;
+          setResult(r.orders);
+          setSearched(true);
+        })
+        .catch((err: unknown) => {
+          if (seq !== searchSeq.current) return;
+          setSearched(true);
+          if (err instanceof SearchUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setResult([]);
+          setSearchError("Vyhľadávanie zlyhalo — server neodpovedal.");
+        });
+    },
+    [onSessionExpired],
+  );
+
+  function submit(event: SyntheticEvent): void {
+    event.preventDefault();
+    search(query);
+  }
+
+  return (
+    <div data-testid="search-order-panel">
+      <form onSubmit={submit}>
+        <div className="field">
+          <label htmlFor="search-order-q">Objednávka</label>
+          <input
+            id="search-order-q"
+            type="search"
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value);
+            }}
+          />
+        </div>
+        <div className="form-actions">
+          <button type="submit" className="btn good">
+            Hľadať objednávku
+          </button>
+        </div>
+      </form>
+
+      {searchError !== "" && <p role="alert">{searchError}</p>}
+
+      {searched && result.length === 0 && <p data-testid="search-order-empty">Objednávke nezodpovedá nič.</p>}
+
+      {result.length > 0 && (
+        <div data-testid="search-orders">
+          <h3>Objednávky</h3>
+          <table>
+            <thead>
+              <tr>
+                <th>Číslo</th>
+                <th>Zákazník</th>
+                <th>Stav</th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              {result.map((o) => (
+                <tr key={o.orderId} data-testid={`search-order-${o.externalOrderId}`}>
+                  <td>{o.externalOrderId}</td>
+                  <td>
+                    {o.customerName}
+                    {o.email !== null && ` (${o.email})`}
+                  </td>
+                  <td>{o.statusName}</td>
+                  <td>
+                    <a
+                      href={o.adminUrl}
+                      target="_blank"
+                      rel="noreferrer noopener"
+                      data-testid={`search-order-admin-link-${o.externalOrderId}`}
+                    >
+                      Otvoriť v Shoptete
+                    </a>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/PairingSection.tsx
+++ b/apps/web/src/components/PairingSection.tsx
@@ -451,23 +451,25 @@ export function PairingSection({
       {searchLoaded && total === 0 ? (
         <p data-testid="pairing-empty">Hľadaniu nezodpovedá žiadny variant.</p>
       ) : (
-        <table>
-          <thead>
-            <tr>
-              <th>Kód</th>
-              <th>Produkt</th>
-              <th>Veľkosť</th>
-              <th>Dodávateľ</th>
-              <th>Adresa u dodávateľa</th>
-              <th>Stav</th>
-              <th>Potvrdil</th>
-              {canConfirm && <th>Akcie</th>}
-            </tr>
-          </thead>
-          <tbody>
-            {groups.flatMap((group) => renderGroup(group))}
-          </tbody>
-        </table>
+        <div className="fs-table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Kód</th>
+                <th>Produkt</th>
+                <th>Veľkosť</th>
+                <th>Dodávateľ</th>
+                <th>Adresa u dodávateľa</th>
+                <th>Stav</th>
+                <th>Potvrdil</th>
+                {canConfirm && <th>Akcie</th>}
+              </tr>
+            </thead>
+            <tbody>
+              {groups.flatMap((group) => renderGroup(group))}
+            </tbody>
+          </table>
+        </div>
       )}
     </section>
   );

--- a/apps/web/src/components/PostaUncollectedSection.tsx
+++ b/apps/web/src/components/PostaUncollectedSection.tsx
@@ -172,26 +172,28 @@ export function PostaUncollectedSection({
       )}
 
       {result !== null && result.uncollected.length > 0 && (
-        <table>
-          <thead>
-            <tr>
-              <th>Zásielka</th>
-              <th>Pošta</th>
-              <th>Objednávka</th>
-              <th>Zákazník</th>
-              <th>Dní čaká</th>
-              <th>Vyzdvihnúť do</th>
-              <th>E-maily</th>
-              <th>Posledný e-mail</th>
-              <th>Náhľad</th>
-            </tr>
-          </thead>
-          <tbody>
-            {result.uncollected.map((shipment) => (
-              <PostaUncollectedRow key={shipment.packageNumber} shipment={shipment} onPreview={openPreview} />
-            ))}
-          </tbody>
-        </table>
+        <div className="fs-table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Zásielka</th>
+                <th>Pošta</th>
+                <th>Objednávka</th>
+                <th>Zákazník</th>
+                <th>Dní čaká</th>
+                <th>Vyzdvihnúť do</th>
+                <th>E-maily</th>
+                <th>Posledný e-mail</th>
+                <th>Náhľad</th>
+              </tr>
+            </thead>
+            <tbody>
+              {result.uncollected.map((shipment) => (
+                <PostaUncollectedRow key={shipment.packageNumber} shipment={shipment} onPreview={openPreview} />
+              ))}
+            </tbody>
+          </table>
+        </div>
       )}
 
       {result !== null && result.invalid.length > 0 && (

--- a/apps/web/src/components/RestockSection.tsx
+++ b/apps/web/src/components/RestockSection.tsx
@@ -198,32 +198,34 @@ export function RestockSection({
               Feed pre porovnávače hovorí niečo iné než my — tieto varianty sa nestanú kandidátmi na
               prepnutie, kým sa rozpor nevysvetlí.
             </p>
-            <table>
-              <thead>
-                <tr>
-                  <th scope="col">Kód</th>
-                  <th scope="col">Názov</th>
-                  <th scope="col">Náš stav</th>
-                  <th scope="col">Feed hovorí</th>
-                  <th scope="col">Náš produkt</th>
-                </tr>
-              </thead>
-              <tbody>
-                {feedConflicts.rows.map((row) => (
-                  <tr key={row.variantCode} data-testid={`restock-feed-conflict-${row.variantCode}`}>
-                    <td>{row.variantCode}</td>
-                    <td>{row.productName}</td>
-                    <td>{STATE_LABEL[row.ourState]}</td>
-                    <td>{row.feedAvailability}</td>
-                    <td>
-                      <a href={row.ourUrl} target="_blank" rel="noreferrer noopener">
-                        náš ↗
-                      </a>
-                    </td>
+            <div className="fs-table-wrap">
+              <table>
+                <thead>
+                  <tr>
+                    <th scope="col">Kód</th>
+                    <th scope="col">Názov</th>
+                    <th scope="col">Náš stav</th>
+                    <th scope="col">Feed hovorí</th>
+                    <th scope="col">Náš produkt</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {feedConflicts.rows.map((row) => (
+                    <tr key={row.variantCode} data-testid={`restock-feed-conflict-${row.variantCode}`}>
+                      <td>{row.variantCode}</td>
+                      <td>{row.productName}</td>
+                      <td>{STATE_LABEL[row.ourState]}</td>
+                      <td>{row.feedAvailability}</td>
+                      <td>
+                        <a href={row.ourUrl} target="_blank" rel="noreferrer noopener">
+                          náš ↗
+                        </a>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           </>
         )}
       </div>
@@ -233,32 +235,34 @@ export function RestockSection({
         {events.length === 0 ? (
           <p className="empty">Zatiaľ nič — automatizácia ešte nič neprepla.</p>
         ) : (
-          <table>
-            <thead>
-              <tr>
-                <th scope="col">Kedy</th>
-                <th scope="col">Kód</th>
-                <th scope="col">Názov</th>
-                <th scope="col">Dodávateľ</th>
-                <th scope="col">Čo dodávateľ hlásil</th>
-              </tr>
-            </thead>
-            <tbody>
-              {events.map((event) => (
-                <tr key={event.id} data-testid={`restock-event-${event.variantCode}`}>
-                  <td>{formatSkDateTime(event.at)}</td>
-                  <td>{event.variantCode}</td>
-                  <td>{event.productName}</td>
-                  <td>{event.supplier ?? "—"}</td>
-                  <td>
-                    <a href={event.supplierLink} target="_blank" rel="noreferrer noopener">
-                      {event.supplierAvailabilityText === "" ? "skladom" : event.supplierAvailabilityText}
-                    </a>
-                  </td>
+          <div className="fs-table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th scope="col">Kedy</th>
+                  <th scope="col">Kód</th>
+                  <th scope="col">Názov</th>
+                  <th scope="col">Dodávateľ</th>
+                  <th scope="col">Čo dodávateľ hlásil</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {events.map((event) => (
+                  <tr key={event.id} data-testid={`restock-event-${event.variantCode}`}>
+                    <td>{formatSkDateTime(event.at)}</td>
+                    <td>{event.variantCode}</td>
+                    <td>{event.productName}</td>
+                    <td>{event.supplier ?? "—"}</td>
+                    <td>
+                      <a href={event.supplierLink} target="_blank" rel="noreferrer noopener">
+                        {event.supplierAvailabilityText === "" ? "skladom" : event.supplierAvailabilityText}
+                      </a>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         )}
       </div>
 
@@ -322,41 +326,43 @@ export function RestockSection({
         ) : waitingList.rows.length === 0 ? (
           <p className="empty">Nič nečaká — žiadny vypredaný produkt nemá čerstvé potvrdenie od dodávateľa.</p>
         ) : (
-          <table>
-            <thead>
-              <tr>
-                <th scope="col">Kód</th>
-                <th scope="col">Názov</th>
-                <th scope="col">Dodávateľ</th>
-                <th scope="col">Náš produkt</th>
-                <th scope="col">U dodávateľa</th>
-                <th scope="col">Čo hlási</th>
-              </tr>
-            </thead>
-            <tbody>
-              {waitingList.rows.map((row) => (
-                <tr key={row.variantCode} data-testid={`restock-waiting-${row.variantCode}`}>
-                  <td>{row.variantCode}</td>
-                  <td>{row.productName}</td>
-                  <td>{row.supplier ?? "—"}</td>
-                  <td>
-                    <a href={ourProductLink(row.variantCode, row.ourUrl)} target="_blank" rel="noreferrer noopener">
-                      náš ↗
-                    </a>
-                  </td>
-                  <td>
-                    <a href={row.supplierLink} target="_blank" rel="noreferrer noopener">
-                      dodávateľ ↗
-                    </a>
-                  </td>
-                  <td>
-                    {row.supplierAvailabilityText === "" ? "skladom" : row.supplierAvailabilityText}
-                    {row.supplierPrice !== null && ` · ${row.supplierPrice}`}
-                  </td>
+          <div className="fs-table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th scope="col">Kód</th>
+                  <th scope="col">Názov</th>
+                  <th scope="col">Dodávateľ</th>
+                  <th scope="col">Náš produkt</th>
+                  <th scope="col">U dodávateľa</th>
+                  <th scope="col">Čo hlási</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {waitingList.rows.map((row) => (
+                  <tr key={row.variantCode} data-testid={`restock-waiting-${row.variantCode}`}>
+                    <td>{row.variantCode}</td>
+                    <td>{row.productName}</td>
+                    <td>{row.supplier ?? "—"}</td>
+                    <td>
+                      <a href={ourProductLink(row.variantCode, row.ourUrl)} target="_blank" rel="noreferrer noopener">
+                        náš ↗
+                      </a>
+                    </td>
+                    <td>
+                      <a href={row.supplierLink} target="_blank" rel="noreferrer noopener">
+                        dodávateľ ↗
+                      </a>
+                    </td>
+                    <td>
+                      {row.supplierAvailabilityText === "" ? "skladom" : row.supplierAvailabilityText}
+                      {row.supplierPrice !== null && ` · ${row.supplierPrice}`}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         )}
       </div>
     </div>

--- a/apps/web/src/components/SchedulerSection.tsx
+++ b/apps/web/src/components/SchedulerSection.tsx
@@ -54,30 +54,32 @@ export function SchedulerSection({
         <p data-testid="scheduler-empty">Žiadny beh zatiaľ nie je zaznamenaný.</p>
       )}
       {runs.length > 0 && (
-        <table>
-          <thead>
-            <tr>
-              <th>Úloha</th>
-              <th>Naposledy spustená</th>
-              <th>Stav</th>
-              <th>Dokončená</th>
-              <th>Detail</th>
-            </tr>
-          </thead>
-          <tbody>
-            {runs.map((run) => (
-              <tr key={run.jobName} data-testid={`job-${run.jobName}`}>
-                <td>{jobLabel(run.jobName)}</td>
-                <td>{formatSkDateTime(run.startedAt)}</td>
-                <td>{STATUS_LABELS[run.status]}</td>
-                <td>
-                  {formatSkDateTime(run.finishedAt)}
-                </td>
-                <td>{detailText(run)}</td>
+        <div className="fs-table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Úloha</th>
+                <th>Naposledy spustená</th>
+                <th>Stav</th>
+                <th>Dokončená</th>
+                <th>Detail</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {runs.map((run) => (
+                <tr key={run.jobName} data-testid={`job-${run.jobName}`}>
+                  <td>{jobLabel(run.jobName)}</td>
+                  <td>{formatSkDateTime(run.startedAt)}</td>
+                  <td>{STATUS_LABELS[run.status]}</td>
+                  <td>
+                    {formatSkDateTime(run.finishedAt)}
+                  </td>
+                  <td>{detailText(run)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       )}
     </section>
   );

--- a/apps/web/src/components/SearchSection.test.tsx
+++ b/apps/web/src/components/SearchSection.test.tsx
@@ -70,9 +70,12 @@ const DETAIL_BEZ_LINKY = {
   ],
 };
 
-function submitSearch(query: string): void {
-  fireEvent.change(screen.getByLabelText("Hľadať"), { target: { value: query } });
-  fireEvent.click(screen.getByRole("button", { name: "Hľadať" }));
+// issue 289: dve NEZÁVISLÉ polia — "Produkt" (tento súbor) a "Objednávka"
+// (`OrderSearchPanel.test.tsx`). Obe volajú tú istú `globalSearch(q)`, každé
+// si berie len svoju polovicu odpovede.
+function submitProductSearch(query: string): void {
+  fireEvent.change(screen.getByLabelText("Produkt"), { target: { value: query } });
+  fireEvent.click(screen.getByRole("button", { name: "Hľadať produkt" }));
 }
 
 afterEach(() => {
@@ -80,37 +83,37 @@ afterEach(() => {
   vi.resetAllMocks();
 });
 
-it("prázdny výsledok zobrazí informačnú vetu namiesto tabuliek", async () => {
+it("prázdny výsledok produktu zobrazí informačnú vetu namiesto tabuľky", async () => {
   globalSearch.mockResolvedValue({ products: [], orders: [] });
 
   render(<SearchSection role="citanie" onSessionExpired={() => {}} />);
-  submitSearch("nieco-co-nikde-nie-je");
+  submitProductSearch("nieco-co-nikde-nie-je");
 
-  await screen.findByTestId("search-empty");
+  await screen.findByTestId("search-product-empty");
   expect(screen.queryByTestId("search-products")).toBeNull();
+});
+
+it("obe polia (Produkt aj Objednávka) sú vždy prítomné a nezávislé — hľadanie produktu nevolá do poľa objednávky", async () => {
+  globalSearch.mockResolvedValue({ products: [PRODUKT], orders: [] });
+
+  render(<SearchSection role="citanie" onSessionExpired={() => {}} />);
+  expect(screen.getByLabelText("Produkt")).toBeTruthy();
+  expect(screen.getByLabelText("Objednávka")).toBeTruthy();
+
+  submitProductSearch("spolocne");
+
+  const produkty = await screen.findByTestId("search-products");
+  expect(produkty.textContent).toContain("Test produkt PD-1");
+  // Pole "Objednávka" hľadanie produktu vôbec nezasiahlo — žiadny jeho blok.
   expect(screen.queryByTestId("search-orders")).toBeNull();
 });
 
-it("produkty aj objednávky sa zobrazia ako dva oddelené bloky, produkty prvé", async () => {
-  globalSearch.mockResolvedValue({ products: [PRODUKT], orders: [OBJEDNAVKA] });
-
-  render(<SearchSection role="citanie" onSessionExpired={() => {}} />);
-  submitSearch("spolocne");
-
-  const produkty = await screen.findByTestId("search-products");
-  const objednavky = await screen.findByTestId("search-orders");
-  expect(produkty.textContent).toContain("Test produkt PD-1");
-  expect(objednavky.textContent).toContain("Zákazník Alfa");
-  // Produkty sa vykresľujú PRED objednávkami v DOM poradí.
-  expect(produkty.compareDocumentPosition(objednavky) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-});
-
-it("pri 401 pri hľadaní zavolá onSessionExpired", async () => {
+it("pri 401 pri hľadaní produktu zavolá onSessionExpired", async () => {
   globalSearch.mockRejectedValue(new SearchUnauthorizedError());
   const onSessionExpired = vi.fn();
 
   render(<SearchSection role="citanie" onSessionExpired={onSessionExpired} />);
-  submitSearch("hocico");
+  submitProductSearch("hocico");
 
   await waitFor(() => {
     expect(onSessionExpired).toHaveBeenCalledTimes(1);
@@ -122,7 +125,7 @@ it("klik na 'Otvoriť' pri produkte otvorí detail so všetkými variantmi", asy
   fetchProductDetail.mockResolvedValue(DETAIL_BEZ_LINKY);
 
   render(<SearchSection role="citanie" onSessionExpired={() => {}} />);
-  submitSearch("PD-1");
+  submitProductSearch("PD-1");
 
   fireEvent.click(await screen.findByTestId("search-product-open-PD-1"));
 
@@ -133,12 +136,24 @@ it("klik na 'Otvoriť' pri produkte otvorí detail so všetkými variantmi", asy
   expect(screen.getByTestId("search-detail-shop-link-PD-1")).toHaveProperty("href", "https://www.forestshop.sk/pd-1/");
 });
 
+it("detail produktu neschová pole Objednávka — zostáva namontované vedľa", async () => {
+  globalSearch.mockResolvedValue({ products: [PRODUKT], orders: [] });
+  fetchProductDetail.mockResolvedValue(DETAIL_BEZ_LINKY);
+
+  render(<SearchSection role="citanie" onSessionExpired={() => {}} />);
+  submitProductSearch("PD-1");
+  fireEvent.click(await screen.findByTestId("search-product-open-PD-1"));
+
+  await screen.findByTestId("search-detail-section");
+  expect(screen.getByLabelText("Objednávka")).toBeTruthy();
+});
+
 it("späť z detailu vráti na hľadanie", async () => {
   globalSearch.mockResolvedValue({ products: [PRODUKT], orders: [] });
   fetchProductDetail.mockResolvedValue(DETAIL_BEZ_LINKY);
 
   render(<SearchSection role="citanie" onSessionExpired={() => {}} />);
-  submitSearch("PD-1");
+  submitProductSearch("PD-1");
   fireEvent.click(await screen.findByTestId("search-product-open-PD-1"));
   await screen.findByTestId("search-detail-section");
 
@@ -151,7 +166,7 @@ it("rola citanie nevidí tlačidlo na úpravu linky", async () => {
   fetchProductDetail.mockResolvedValue(DETAIL_BEZ_LINKY);
 
   render(<SearchSection role="citanie" onSessionExpired={() => {}} />);
-  submitSearch("PD-1");
+  submitProductSearch("PD-1");
   fireEvent.click(await screen.findByTestId("search-product-open-PD-1"));
 
   await screen.findByTestId("search-detail-section");
@@ -169,7 +184,7 @@ it("rola manazer doplní dodávateľskú linku, uloženie ju pošle na server a 
   saveProductLink.mockResolvedValue(undefined);
 
   render(<SearchSection role="manazer" onSessionExpired={() => {}} />);
-  submitSearch("PD-1");
+  submitProductSearch("PD-1");
   fireEvent.click(await screen.findByTestId("search-product-open-PD-1"));
   await screen.findByTestId("search-detail-section");
 
@@ -193,7 +208,7 @@ it("neplatná URL sa odmietne OKAMŽITE, bez volania saveProductLink", async () 
   fetchProductDetail.mockResolvedValue(DETAIL_BEZ_LINKY);
 
   render(<SearchSection role="manazer" onSessionExpired={() => {}} />);
-  submitSearch("PD-1");
+  submitProductSearch("PD-1");
   fireEvent.click(await screen.findByTestId("search-product-open-PD-1"));
   await screen.findByTestId("search-detail-section");
 
@@ -212,7 +227,7 @@ it("pri 401 pri načítaní detailu zavolá onSessionExpired", async () => {
   const onSessionExpired = vi.fn();
 
   render(<SearchSection role="citanie" onSessionExpired={onSessionExpired} />);
-  submitSearch("PD-1");
+  submitProductSearch("PD-1");
   fireEvent.click(await screen.findByTestId("search-product-open-PD-1"));
 
   await waitFor(() => {
@@ -227,7 +242,7 @@ it("pri 401 pri ukladaní linky zavolá onSessionExpired", async () => {
   const onSessionExpired = vi.fn();
 
   render(<SearchSection role="manazer" onSessionExpired={onSessionExpired} />);
-  submitSearch("PD-1");
+  submitProductSearch("PD-1");
   fireEvent.click(await screen.findByTestId("search-product-open-PD-1"));
   await screen.findByTestId("search-detail-section");
 
@@ -240,4 +255,18 @@ it("pri 401 pri ukladaní linky zavolá onSessionExpired", async () => {
   await waitFor(() => {
     expect(onSessionExpired).toHaveBeenCalledTimes(1);
   });
+});
+
+// Objednávka OBJEDNAVKA je tu len ako potvrdenie, že `globalSearch`'s
+// `.orders` polovica pri hľadaní PRODUKTU (Produkt pole) neovplyvní jeho
+// vlastný výsledok — plné pokrytie hľadania objednávky je v
+// `OrderSearchPanel.test.tsx`.
+it("hľadanie produktu ignoruje .orders polovicu odpovede", async () => {
+  globalSearch.mockResolvedValue({ products: [PRODUKT], orders: [OBJEDNAVKA] });
+
+  render(<SearchSection role="citanie" onSessionExpired={() => {}} />);
+  submitProductSearch("spolocne");
+
+  await screen.findByTestId("search-products");
+  expect(screen.queryByTestId("search-orders")).toBeNull();
 });

--- a/apps/web/src/components/SearchSection.tsx
+++ b/apps/web/src/components/SearchSection.tsx
@@ -6,19 +6,28 @@ import {
   fetchProductDetail,
   globalSearch,
   SearchUnauthorizedError,
-  type GlobalSearchResult,
   type ProductDetail,
   type ProductDetailVariant,
+  type ProductSearchHit,
 } from "../searchApi.js";
 import { saveProductLink, SupplierLinksUnauthorizedError } from "../supplierLinksApi.js";
+import { OrderSearchPanel } from "./OrderSearchPanel.js";
 
-// issue 240: "Eshop → Vyhľadať" — jedno pole, ktoré hľadá naprieč katalógom aj
-// objednávkami; klik na produktový výsledok otvorí detail so VŠETKÝMI jeho
-// variantmi a editovateľnou dodávateľskou linkou. Editácia linky znovupoužíva
-// PRESNE ten istý zápis + stavový vzor ako `SupplierLinksSection.tsx` (#239) —
-// `saveProductLink` (`POST /api/product-links/:productKey`), žiadna nová
-// zapisovacia cesta. Rozsah hľadania (čo sa prehľadáva a čo vedome nie) je
-// zapísaný v návrhovom komentári na ticket, nie tu.
+// issue 289: "Eshop → Vyhľadať" — DVE nezávislé, popísané polia namiesto
+// jedného spoločného (issue 240): "Produkt" (tento súbor — kód, názov,
+// dodávateľ, kód u dodávateľa; klik otvorí detail produktu) a "Objednávka"
+// (`OrderSearchPanel.tsx`, vlastný stav). Obe volajú TÚ ISTÚ `GET
+// /api/search` cestu (backend vždy vracia oba zoznamy naraz — pozri
+// `apps/api/src/modules/search/queries.ts`), každé pole si z odpovede
+// vezme len svoju polovicu — žiadna nová backendová cesta nebola potrebná.
+// Klik na nájdenú objednávku vedie do Shoptet detailu objednávky
+// (`adminUrl`, `buildShoptetAdminOrderUrl` — ten istý helper ako
+// `OrderReminderRow.tsx`/`MailLogSection.tsx`/Upozornenia, rozhodnuté na
+// ticket-e, appka ho tu len znovupoužíva). Editácia linky znovupoužíva
+// PRESNE ten istý zápis + stavový vzor ako `SupplierLinksSection.tsx`
+// (#239) — `saveProductLink` (`POST /api/product-links/:productKey`),
+// žiadna nová zapisovacia cesta. Rozsah hľadania (čo sa prehľadáva a čo
+// vedome nie) je zapísaný v návrhovom komentári na ticket, nie tu.
 const CAN_EDIT_ROLES: ReadonlySet<Me["role"]> = new Set(["admin", "manazer"]);
 
 const STATE_LABELS: Record<ProductDetailVariant["state"], string> = {
@@ -59,7 +68,7 @@ export function SearchSection({
   readonly onSessionExpired: () => void;
 }): JSX.Element {
   const [query, setQuery] = useState("");
-  const [result, setResult] = useState<GlobalSearchResult>({ products: [], orders: [] });
+  const [result, setResult] = useState<readonly ProductSearchHit[]>([]);
   const [searched, setSearched] = useState(false);
   const [searchError, setSearchError] = useState("");
   const canEdit = CAN_EDIT_ROLES.has(role);
@@ -86,7 +95,7 @@ export function SearchSection({
       globalSearch(q)
         .then((r) => {
           if (seq !== searchSeq.current) return;
-          setResult(r);
+          setResult(r.products);
           setSearched(true);
         })
         .catch((err: unknown) => {
@@ -96,7 +105,7 @@ export function SearchSection({
             onSessionExpired();
             return;
           }
-          setResult({ products: [], orders: [] });
+          setResult([]);
           setSearchError("Vyhľadávanie zlyhalo — server neodpovedal.");
         });
     },
@@ -186,244 +195,215 @@ export function SearchSection({
 
   if (selectedProductKey !== null) {
     return (
-      <section data-testid="search-detail-section">
-        <p>
-          <button type="button" className="btn sm ghost" data-testid="search-back" onClick={backToSearch}>
-            ← Späť na hľadanie
-          </button>
-        </p>
-
-        {!detailLoaded ? (
-          <p>Načítavam…</p>
-        ) : detail === null ? (
-          <p role="alert" data-testid="search-detail-not-found">
-            Produkt sa nenašiel.
+      <>
+        <section data-testid="search-detail-section">
+          <p>
+            <button type="button" className="btn sm ghost" data-testid="search-back" onClick={backToSearch}>
+              ← Späť na hľadanie
+            </button>
           </p>
-        ) : detailError !== "" ? (
-          <p role="alert">{detailError}</p>
-        ) : (
-          <>
-            <h3 data-testid="search-detail-name">{detail.productName}</h3>
-            <p data-testid="search-detail-supplier">Dodávateľ: {detail.supplier ?? "(bez dodávateľa)"}</p>
 
-            <div className="ord-supplier-row" data-testid="search-detail-link-row">
-              <strong>Dodávateľská linka: </strong>
-              {editingLink ? (
-                <div className="ord-supplier-link-edit" data-testid="search-detail-link-edit">
-                  <input
-                    type="url"
-                    className="ord-supplier-link-edit-input"
-                    data-testid="search-detail-link-edit-input"
-                    aria-label={`Odkaz na dodávateľa produktu ${detail.productName}`}
-                    placeholder="https://…"
-                    value={urlDraft}
-                    disabled={busy}
-                    autoFocus
-                    onChange={(e) => {
-                      setUrlDraft(e.target.value);
-                    }}
-                    onKeyDown={(e) => {
-                      if (e.key === "Escape") {
-                        e.preventDefault();
-                        cancelEditLink();
-                      }
-                    }}
-                  />
+          {!detailLoaded ? (
+            <p>Načítavam…</p>
+          ) : detail === null ? (
+            <p role="alert" data-testid="search-detail-not-found">
+              Produkt sa nenašiel.
+            </p>
+          ) : detailError !== "" ? (
+            <p role="alert">{detailError}</p>
+          ) : (
+            <>
+              <h3 data-testid="search-detail-name">{detail.productName}</h3>
+              <p data-testid="search-detail-supplier">Dodávateľ: {detail.supplier ?? "(bez dodávateľa)"}</p>
+
+              <div className="ord-supplier-row" data-testid="search-detail-link-row">
+                <strong>Dodávateľská linka: </strong>
+                {editingLink ? (
+                  <div className="ord-supplier-link-edit" data-testid="search-detail-link-edit">
+                    <input
+                      type="url"
+                      className="ord-supplier-link-edit-input"
+                      data-testid="search-detail-link-edit-input"
+                      aria-label={`Odkaz na dodávateľa produktu ${detail.productName}`}
+                      placeholder="https://…"
+                      value={urlDraft}
+                      disabled={busy}
+                      autoFocus
+                      onChange={(e) => {
+                        setUrlDraft(e.target.value);
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === "Escape") {
+                          e.preventDefault();
+                          cancelEditLink();
+                        }
+                      }}
+                    />
+                    <button
+                      type="button"
+                      className="btn sm good"
+                      data-testid="search-detail-link-save"
+                      disabled={busy || urlDraft.trim() === ""}
+                      onClick={saveLink}
+                    >
+                      💾
+                    </button>
+                    <button
+                      type="button"
+                      className="btn sm ghost"
+                      data-testid="search-detail-link-cancel"
+                      disabled={busy}
+                      onClick={cancelEditLink}
+                    >
+                      ✖
+                    </button>
+                  </div>
+                ) : detail.supplierLinkUrl !== null ? (
+                  <a href={detail.supplierLinkUrl} target="_blank" rel="noreferrer noopener" data-testid="search-detail-link-value">
+                    {detail.supplierLinkUrl}
+                  </a>
+                ) : (
+                  <span data-testid="search-detail-link-value">—</span>
+                )}
+                {!editingLink && canEdit && (
                   <button
                     type="button"
-                    className="btn sm good"
-                    data-testid="search-detail-link-save"
-                    disabled={busy || urlDraft.trim() === ""}
-                    onClick={saveLink}
+                    className="ord-supplier-link-edit-toggle"
+                    data-testid="search-detail-link-edit-toggle"
+                    aria-label={
+                      detail.supplierLinkUrl !== null
+                        ? `Upraviť odkaz na dodávateľa — ${detail.productName}`
+                        : `Doplniť odkaz na dodávateľa — ${detail.productName}`
+                    }
+                    onClick={startEditLink}
                   >
-                    💾
+                    ✏️
                   </button>
-                  <button
-                    type="button"
-                    className="btn sm ghost"
-                    data-testid="search-detail-link-cancel"
-                    disabled={busy}
-                    onClick={cancelEditLink}
-                  >
-                    ✖
-                  </button>
-                </div>
-              ) : detail.supplierLinkUrl !== null ? (
-                <a href={detail.supplierLinkUrl} target="_blank" rel="noreferrer noopener" data-testid="search-detail-link-value">
-                  {detail.supplierLinkUrl}
-                </a>
-              ) : (
-                <span data-testid="search-detail-link-value">—</span>
-              )}
-              {!editingLink && canEdit && (
-                <button
-                  type="button"
-                  className="ord-supplier-link-edit-toggle"
-                  data-testid="search-detail-link-edit-toggle"
-                  aria-label={
-                    detail.supplierLinkUrl !== null
-                      ? `Upraviť odkaz na dodávateľa — ${detail.productName}`
-                      : `Doplniť odkaz na dodávateľa — ${detail.productName}`
-                  }
-                  onClick={startEditLink}
-                >
-                  ✏️
-                </button>
-              )}
-              <span data-testid="search-detail-link-status"> {linkStatusLabel(detail)}</span>
-            </div>
-            {actionError !== "" && <p role="alert">{actionError}</p>}
+                )}
+                <span data-testid="search-detail-link-status"> {linkStatusLabel(detail)}</span>
+              </div>
+              {actionError !== "" && <p role="alert">{actionError}</p>}
 
-            <table>
-              <thead>
-                <tr>
-                  <th>Veľkosť</th>
-                  <th>Kód</th>
-                  <th>Cena</th>
-                  <th>Sklad</th>
-                  <th>Stav u nás</th>
-                  <th>Dostupnosť u dodávateľa</th>
-                  <th>Adresa u nás</th>
-                  <th>Kód u dodávateľa</th>
-                </tr>
-              </thead>
-              <tbody>
-                {detail.variants.map((v) => (
-                  <tr key={v.code} data-testid={`search-detail-variant-${v.code}`}>
-                    <td>{v.sizeLabel ?? "—"}</td>
-                    <td>{v.code}</td>
-                    <td>{v.price !== null ? `${v.price} ${v.currency ?? ""}` : "—"}</td>
-                    <td>{v.stock}</td>
-                    <td>
-                      {STATE_LABELS[v.state]} ({v.availabilityText})
-                    </td>
-                    <td data-testid={`search-detail-supplier-stock-${v.code}`}>{supplierAvailabilityLabel(v)}</td>
-                    <td>
-                      {v.ourShopUrl !== null ? (
-                        <a href={v.ourShopUrl} target="_blank" rel="noreferrer noopener" data-testid={`search-detail-shop-link-${v.code}`}>
-                          Otvoriť
-                        </a>
-                      ) : (
-                        "—"
-                      )}
-                    </td>
-                    <td>{v.externalCode ?? "—"}</td>
+              <table>
+                <thead>
+                  <tr>
+                    <th>Veľkosť</th>
+                    <th>Kód</th>
+                    <th>Cena</th>
+                    <th>Sklad</th>
+                    <th>Stav u nás</th>
+                    <th>Dostupnosť u dodávateľa</th>
+                    <th>Adresa u nás</th>
+                    <th>Kód u dodávateľa</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
-          </>
-        )}
-      </section>
+                </thead>
+                <tbody>
+                  {detail.variants.map((v) => (
+                    <tr key={v.code} data-testid={`search-detail-variant-${v.code}`}>
+                      <td>{v.sizeLabel ?? "—"}</td>
+                      <td>{v.code}</td>
+                      <td>{v.price !== null ? `${v.price} ${v.currency ?? ""}` : "—"}</td>
+                      <td>{v.stock}</td>
+                      <td>
+                        {STATE_LABELS[v.state]} ({v.availabilityText})
+                      </td>
+                      <td data-testid={`search-detail-supplier-stock-${v.code}`}>{supplierAvailabilityLabel(v)}</td>
+                      <td>
+                        {v.ourShopUrl !== null ? (
+                          <a href={v.ourShopUrl} target="_blank" rel="noreferrer noopener" data-testid={`search-detail-shop-link-${v.code}`}>
+                            Otvoriť
+                          </a>
+                        ) : (
+                          "—"
+                        )}
+                      </td>
+                      <td>{v.externalCode ?? "—"}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </>
+          )}
+        </section>
+        <OrderSearchPanel onSessionExpired={onSessionExpired} />
+      </>
     );
   }
 
   return (
-    <section data-testid="search-section">
-      <p>
-        Nájdite konkrétny tovar (podľa kódu, názvu, dodávateľa alebo kódu u dodávateľa) alebo objednávku
-        (podľa čísla, mena či e-mailu zákazníka). Kliknutím na produkt sa otvorí jeho detail, kde sa dá
-        rovno opraviť dodávateľská linka.
-      </p>
+    <>
+      <section data-testid="search-section">
+        <form onSubmit={submit}>
+          <div className="field">
+            <label htmlFor="search-product-q">Produkt</label>
+            <p>
+              Nájdite konkrétny tovar podľa kódu, názvu, dodávateľa alebo kódu u dodávateľa. Kliknutím na
+              produkt sa otvorí jeho detail, kde sa dá rovno opraviť dodávateľská linka.
+            </p>
+            <input
+              id="search-product-q"
+              type="search"
+              value={query}
+              autoFocus
+              onChange={(e) => {
+                setQuery(e.target.value);
+              }}
+            />
+          </div>
+          <div className="form-actions">
+            <button type="submit" className="btn good">
+              Hľadať produkt
+            </button>
+          </div>
+        </form>
 
-      <form onSubmit={submit}>
-        <label htmlFor="search-q">Hľadať</label>
-        <input
-          id="search-q"
-          type="search"
-          value={query}
-          autoFocus
-          onChange={(e) => {
-            setQuery(e.target.value);
-          }}
-        />
-        <button type="submit">Hľadať</button>
-      </form>
+        {searchError !== "" && <p role="alert">{searchError}</p>}
 
-      {searchError !== "" && <p role="alert">{searchError}</p>}
+        {searched && result.length === 0 && <p data-testid="search-product-empty">Produktu nezodpovedá nič.</p>}
 
-      {searched && result.products.length === 0 && result.orders.length === 0 && (
-        <p data-testid="search-empty">Hľadaniu nezodpovedá nič.</p>
-      )}
-
-      {result.products.length > 0 && (
-        <div data-testid="search-products">
-          <h3>Produkty</h3>
-          <table>
-            <thead>
-              <tr>
-                <th>Kód</th>
-                <th>Názov</th>
-                <th>Dodávateľ</th>
-                <th>Kód u dodávateľa</th>
-                <th>Stav</th>
-                <th />
-              </tr>
-            </thead>
-            <tbody>
-              {result.products.map((p) => (
-                <tr key={p.variantCode} data-testid={`search-product-${p.variantCode}`}>
-                  <td>{p.variantCode}</td>
-                  <td>{p.productName}</td>
-                  <td>{p.supplier ?? "(bez dodávateľa)"}</td>
-                  <td>{p.externalCode ?? "—"}</td>
-                  <td>{STATE_LABELS[p.state]}</td>
-                  <td>
-                    <button
-                      type="button"
-                      className="btn sm ghost"
-                      data-testid={`search-product-open-${p.variantCode}`}
-                      onClick={() => {
-                        openDetail(p.productKey);
-                      }}
-                    >
-                      Otvoriť
-                    </button>
-                  </td>
+        {result.length > 0 && (
+          <div data-testid="search-products">
+            <h3>Produkty</h3>
+            <table>
+              <thead>
+                <tr>
+                  <th>Kód</th>
+                  <th>Názov</th>
+                  <th>Dodávateľ</th>
+                  <th>Kód u dodávateľa</th>
+                  <th>Stav</th>
+                  <th />
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
+              </thead>
+              <tbody>
+                {result.map((p) => (
+                  <tr key={p.variantCode} data-testid={`search-product-${p.variantCode}`}>
+                    <td>{p.variantCode}</td>
+                    <td>{p.productName}</td>
+                    <td>{p.supplier ?? "(bez dodávateľa)"}</td>
+                    <td>{p.externalCode ?? "—"}</td>
+                    <td>{STATE_LABELS[p.state]}</td>
+                    <td>
+                      <button
+                        type="button"
+                        className="btn sm ghost"
+                        data-testid={`search-product-open-${p.variantCode}`}
+                        onClick={() => {
+                          openDetail(p.productKey);
+                        }}
+                      >
+                        Otvoriť
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
 
-      {result.orders.length > 0 && (
-        <div data-testid="search-orders">
-          <h3>Objednávky</h3>
-          <table>
-            <thead>
-              <tr>
-                <th>Číslo</th>
-                <th>Zákazník</th>
-                <th>Stav</th>
-                <th />
-              </tr>
-            </thead>
-            <tbody>
-              {result.orders.map((o) => (
-                <tr key={o.orderId} data-testid={`search-order-${o.externalOrderId}`}>
-                  <td>{o.externalOrderId}</td>
-                  <td>
-                    {o.customerName}
-                    {o.email !== null && ` (${o.email})`}
-                  </td>
-                  <td>{o.statusName}</td>
-                  <td>
-                    <a
-                      href={o.adminUrl}
-                      target="_blank"
-                      rel="noreferrer noopener"
-                      data-testid={`search-order-admin-link-${o.externalOrderId}`}
-                    >
-                      Otvoriť v Shoptete
-                    </a>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
-    </section>
+      <OrderSearchPanel onSessionExpired={onSessionExpired} />
+    </>
   );
 }

--- a/apps/web/src/components/SearchSection.tsx
+++ b/apps/web/src/components/SearchSection.tsx
@@ -284,44 +284,46 @@ export function SearchSection({
               </div>
               {actionError !== "" && <p role="alert">{actionError}</p>}
 
-              <table>
-                <thead>
-                  <tr>
-                    <th>Veľkosť</th>
-                    <th>Kód</th>
-                    <th>Cena</th>
-                    <th>Sklad</th>
-                    <th>Stav u nás</th>
-                    <th>Dostupnosť u dodávateľa</th>
-                    <th>Adresa u nás</th>
-                    <th>Kód u dodávateľa</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {detail.variants.map((v) => (
-                    <tr key={v.code} data-testid={`search-detail-variant-${v.code}`}>
-                      <td>{v.sizeLabel ?? "—"}</td>
-                      <td>{v.code}</td>
-                      <td>{v.price !== null ? `${v.price} ${v.currency ?? ""}` : "—"}</td>
-                      <td>{v.stock}</td>
-                      <td>
-                        {STATE_LABELS[v.state]} ({v.availabilityText})
-                      </td>
-                      <td data-testid={`search-detail-supplier-stock-${v.code}`}>{supplierAvailabilityLabel(v)}</td>
-                      <td>
-                        {v.ourShopUrl !== null ? (
-                          <a href={v.ourShopUrl} target="_blank" rel="noreferrer noopener" data-testid={`search-detail-shop-link-${v.code}`}>
-                            Otvoriť
-                          </a>
-                        ) : (
-                          "—"
-                        )}
-                      </td>
-                      <td>{v.externalCode ?? "—"}</td>
+              <div className="fs-table-wrap">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Veľkosť</th>
+                      <th>Kód</th>
+                      <th>Cena</th>
+                      <th>Sklad</th>
+                      <th>Stav u nás</th>
+                      <th>Dostupnosť u dodávateľa</th>
+                      <th>Adresa u nás</th>
+                      <th>Kód u dodávateľa</th>
                     </tr>
-                  ))}
-                </tbody>
-              </table>
+                  </thead>
+                  <tbody>
+                    {detail.variants.map((v) => (
+                      <tr key={v.code} data-testid={`search-detail-variant-${v.code}`}>
+                        <td>{v.sizeLabel ?? "—"}</td>
+                        <td>{v.code}</td>
+                        <td>{v.price !== null ? `${v.price} ${v.currency ?? ""}` : "—"}</td>
+                        <td>{v.stock}</td>
+                        <td>
+                          {STATE_LABELS[v.state]} ({v.availabilityText})
+                        </td>
+                        <td data-testid={`search-detail-supplier-stock-${v.code}`}>{supplierAvailabilityLabel(v)}</td>
+                        <td>
+                          {v.ourShopUrl !== null ? (
+                            <a href={v.ourShopUrl} target="_blank" rel="noreferrer noopener" data-testid={`search-detail-shop-link-${v.code}`}>
+                              Otvoriť
+                            </a>
+                          ) : (
+                            "—"
+                          )}
+                        </td>
+                        <td>{v.externalCode ?? "—"}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
             </>
           )}
         </section>
@@ -364,41 +366,43 @@ export function SearchSection({
         {result.length > 0 && (
           <div data-testid="search-products">
             <h3>Produkty</h3>
-            <table>
-              <thead>
-                <tr>
-                  <th>Kód</th>
-                  <th>Názov</th>
-                  <th>Dodávateľ</th>
-                  <th>Kód u dodávateľa</th>
-                  <th>Stav</th>
-                  <th />
-                </tr>
-              </thead>
-              <tbody>
-                {result.map((p) => (
-                  <tr key={p.variantCode} data-testid={`search-product-${p.variantCode}`}>
-                    <td>{p.variantCode}</td>
-                    <td>{p.productName}</td>
-                    <td>{p.supplier ?? "(bez dodávateľa)"}</td>
-                    <td>{p.externalCode ?? "—"}</td>
-                    <td>{STATE_LABELS[p.state]}</td>
-                    <td>
-                      <button
-                        type="button"
-                        className="btn sm ghost"
-                        data-testid={`search-product-open-${p.variantCode}`}
-                        onClick={() => {
-                          openDetail(p.productKey);
-                        }}
-                      >
-                        Otvoriť
-                      </button>
-                    </td>
+            <div className="fs-table-wrap">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Kód</th>
+                    <th>Názov</th>
+                    <th>Dodávateľ</th>
+                    <th>Kód u dodávateľa</th>
+                    <th>Stav</th>
+                    <th />
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {result.map((p) => (
+                    <tr key={p.variantCode} data-testid={`search-product-${p.variantCode}`}>
+                      <td>{p.variantCode}</td>
+                      <td>{p.productName}</td>
+                      <td>{p.supplier ?? "(bez dodávateľa)"}</td>
+                      <td>{p.externalCode ?? "—"}</td>
+                      <td>{STATE_LABELS[p.state]}</td>
+                      <td>
+                        <button
+                          type="button"
+                          className="btn sm ghost"
+                          data-testid={`search-product-open-${p.variantCode}`}
+                          onClick={() => {
+                            openDetail(p.productKey);
+                          }}
+                        >
+                          Otvoriť
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           </div>
         )}
       </section>

--- a/apps/web/src/components/Sidebar.test.tsx
+++ b/apps/web/src/components/Sidebar.test.tsx
@@ -15,12 +15,17 @@ const FOLDERS = [
   },
 ];
 
+const ORIGINAL_INNER_WIDTH = window.innerWidth;
+
 afterEach(() => {
   cleanup();
   // issue 190: zbalenie panela sa pamätá v `localStorage` — jsdom ho medzi
   // testami NEVYNULUJE, takže bez tohto by jeden test prepol stav všetkým
   // nasledujúcim.
   window.localStorage.clear();
+  // issue 291: rovnaký dôvod pre `window.innerWidth` — testy nižšie ju menia
+  // pred vykreslením, treba ju vrátiť na pôvodnú hodnotu pre ďalšie testy.
+  Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: ORIGINAL_INNER_WIDTH });
 });
 
 it("vykreslí presne dva priečinky s jednou záložkou každý a označí aktívnu", () => {
@@ -159,4 +164,40 @@ it("priečinok zbalený pred zbalením panela nechá svoje ikony v lište vidite
   fireEvent.click(screen.getByTestId("sidebar-rail-toggle"));
 
   expect(screen.getByRole("button", { name: "Sync zo Shoptetu" })).toBeTruthy();
+});
+
+// issue 291: na úzkej (telefónnej) obrazovke sa panel PRVOTNE (pri prvom
+// vykreslení, bez akéhokoľvek uloženého stavu) zbalí sám — na širokej
+// (počítačovej) ostáva pôvodné rozbalené správanie. Nastavenie
+// `window.innerWidth` pred vykreslením je jediný spôsob, ako v jsdom overiť
+// "prvotný stav podľa šírky", keďže jsdom skutočný CSS layout nevykresľuje.
+function setWindowInnerWidth(width: number): void {
+  Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: width });
+}
+
+it("na úzkej obrazovke (375px) sa panel bez uloženej voľby prvotne zbalí", () => {
+  setWindowInnerWidth(375);
+
+  render(<Sidebar folders={FOLDERS} activeTabId="sync" onSelectTab={() => {}} />);
+
+  expect(screen.getByTestId("sidebar-rail-toggle").getAttribute("aria-expanded")).toBe("false");
+  expect(screen.queryByRole("button", { name: "Systém" })).toBeNull();
+});
+
+it("na širokej (počítačovej) obrazovke (1280px) sa panel bez uloženej voľby prvotne rozbalí", () => {
+  setWindowInnerWidth(1280);
+
+  render(<Sidebar folders={FOLDERS} activeTabId="sync" onSelectTab={() => {}} />);
+
+  expect(screen.getByTestId("sidebar-rail-toggle").getAttribute("aria-expanded")).toBe("true");
+  expect(screen.getByRole("button", { name: "Systém" })).toBeTruthy();
+});
+
+it("uložená voľba (užívateľ predtým panel ručne rozbalil) vyhráva aj na úzkej obrazovke", () => {
+  window.localStorage.setItem("forestshop:sidebar-rail", "0");
+  setWindowInnerWidth(375);
+
+  render(<Sidebar folders={FOLDERS} activeTabId="sync" onSelectTab={() => {}} />);
+
+  expect(screen.getByTestId("sidebar-rail-toggle").getAttribute("aria-expanded")).toBe("true");
 });

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -8,12 +8,37 @@ import { Footer } from "./Footer.js";
 // prefixovaný názvom appky, na doméne bežia aj iné projekty.
 const RAIL_KEY = "forestshop:sidebar-rail";
 
-function readRail(): boolean {
+// issue 291: pod touto šírkou sa panel PRVOTNE zbalí sám (telefón) — nad ňou
+// (tablet/počítač) zostáva pôvodné správanie (rozbalený). Toto je len
+// PRVOTNÝ (na mount) predvolený stav; nejde o živú reakciu na zmenu šírky
+// okna počas behu appky (mimo dohodnutého rozsahu ticketu).
+const NARROW_VIEWPORT_MAX_WIDTH = 640;
+
+function readStoredRail(): boolean | null {
   try {
-    return window.localStorage.getItem(RAIL_KEY) === "1";
+    const v = window.localStorage.getItem(RAIL_KEY);
+    if (v === "1") return true;
+    if (v === "0") return false;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function isNarrowViewport(): boolean {
+  try {
+    return window.innerWidth <= NARROW_VIEWPORT_MAX_WIDTH;
   } catch {
     return false;
   }
+}
+
+// issue 291: ak už appka na tomto zariadení niekedy uložila výslovnú voľbu
+// (užívateľ panel ručne prepol), tá VŽDY vyhráva — širka obrazovky sa berie
+// do úvahy LEN keď žiadna uložená voľba ešte neexistuje.
+function initialRail(): boolean {
+  const stored = readStoredRail();
+  return stored ?? isNarrowViewport();
 }
 
 // Ľavé menu — vlastný dizajn appky (issue 57): značka hore, priečinky so
@@ -47,7 +72,7 @@ export function Sidebar({
   readonly badgeStatus?: Readonly<Record<string, "on" | "off">>;
 }): JSX.Element {
   const [collapsed, setCollapsed] = useState<Readonly<Record<string, boolean>>>({});
-  const [rail, setRail] = useState<boolean>(readRail);
+  const [rail, setRail] = useState<boolean>(initialRail);
 
   useEffect(() => {
     try {

--- a/apps/web/src/components/SupplierLinksSection.tsx
+++ b/apps/web/src/components/SupplierLinksSection.tsx
@@ -267,6 +267,7 @@ export function SupplierLinksSection({
       {searchLoaded && total === 0 ? (
         <p data-testid="product-links-empty">Hľadaniu nezodpovedá žiadny produkt.</p>
       ) : (
+        <div className="fs-table-wrap">
         <table>
           <thead>
             <tr>
@@ -379,6 +380,7 @@ export function SupplierLinksSection({
             })}
           </tbody>
         </table>
+        </div>
       )}
     </section>
   );

--- a/apps/web/src/components/SupplierStockSection.tsx
+++ b/apps/web/src/components/SupplierStockSection.tsx
@@ -149,33 +149,35 @@ export function SupplierStockSection({
         {unreadable.length === 0 ? (
           <p className="empty">Zatiaľ žiadne — všetky sledované odkazy sa darí prečítať.</p>
         ) : (
-          <table>
-            <thead>
-              <tr>
-                <th scope="col">Dodávateľ</th>
-                <th scope="col">Odkazov</th>
-                <th scope="col">Ukážky</th>
-              </tr>
-            </thead>
-            <tbody>
-              {unreadable.map((host) => (
-                <tr key={host.host} data-testid={`ss-unreadable-${host.host}`}>
-                  <td>{host.host}</td>
-                  <td>{host.count}</td>
-                  <td>
-                    {host.samples.map((sample) => (
-                      <div key={`${sample.link}|${sample.sizeLabel}`}>
-                        <a href={sample.link} target="_blank" rel="noreferrer noopener">
-                          {sample.link}
-                        </a>
-                        {sample.sizeLabel !== "" && ` [${sample.sizeLabel}]`}
-                      </div>
-                    ))}
-                  </td>
+          <div className="fs-table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th scope="col">Dodávateľ</th>
+                  <th scope="col">Odkazov</th>
+                  <th scope="col">Ukážky</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {unreadable.map((host) => (
+                  <tr key={host.host} data-testid={`ss-unreadable-${host.host}`}>
+                    <td>{host.host}</td>
+                    <td>{host.count}</td>
+                    <td>
+                      {host.samples.map((sample) => (
+                        <div key={`${sample.link}|${sample.sizeLabel}`}>
+                          <a href={sample.link} target="_blank" rel="noreferrer noopener">
+                            {sample.link}
+                          </a>
+                          {sample.sizeLabel !== "" && ` [${sample.sizeLabel}]`}
+                        </div>
+                      ))}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         )}
       </div>
 
@@ -187,30 +189,32 @@ export function SupplierStockSection({
         {hostOverview.length === 0 ? (
           <p className="empty">Zatiaľ nič — kontrola ešte nebežala.</p>
         ) : (
-          <table>
-            <thead>
-              <tr>
-                <th scope="col">Doména</th>
-                <th scope="col">Odkazov</th>
-                <th scope="col">Číta sa</th>
-                <th scope="col">Neviem</th>
-                <th scope="col">Zlyhalo</th>
-                <th scope="col">Naposledy potvrdené</th>
-              </tr>
-            </thead>
-            <tbody>
-              {hostOverview.map((host) => (
-                <tr key={host.host} data-testid={`ss-host-${host.host}`}>
-                  <td>{host.host}</td>
-                  <td>{host.total}</td>
-                  <td>{host.readable}</td>
-                  <td>{host.unknown}</td>
-                  <td>{host.failed}</td>
-                  <td>{formatSkDateTime(host.lastConfirmedAt)}</td>
+          <div className="fs-table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th scope="col">Doména</th>
+                  <th scope="col">Odkazov</th>
+                  <th scope="col">Číta sa</th>
+                  <th scope="col">Neviem</th>
+                  <th scope="col">Zlyhalo</th>
+                  <th scope="col">Naposledy potvrdené</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {hostOverview.map((host) => (
+                  <tr key={host.host} data-testid={`ss-host-${host.host}`}>
+                    <td>{host.host}</td>
+                    <td>{host.total}</td>
+                    <td>{host.readable}</td>
+                    <td>{host.unknown}</td>
+                    <td>{host.failed}</td>
+                    <td>{formatSkDateTime(host.lastConfirmedAt)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         )}
       </div>
 
@@ -219,39 +223,41 @@ export function SupplierStockSection({
         {rows.length === 0 ? (
           <p className="empty">Zatiaľ nič — kontrola ešte nebežala.</p>
         ) : (
-          <table>
-            <thead>
-              <tr>
-                <th scope="col">Dodávateľ</th>
-                <th scope="col">Odkaz</th>
-                <th scope="col">Veľkosť</th>
-                <th scope="col">Dostupnosť</th>
-                <th scope="col">Cena</th>
-                <th scope="col">Kontrolované</th>
-              </tr>
-            </thead>
-            <tbody>
-              {rows.map((row) => (
-                // Kľúč MUSÍ niesť aj veľkosť — odkaz s pravidlom na veľkosti
-                // (issue 224) má pre TÚ ISTÚ linku viac riadkov naraz.
-                <tr key={`${row.link}|${row.sizeLabel}`} data-testid={`ss-row-${row.link}-${row.sizeLabel}`}>
-                  <td>{row.host}</td>
-                  <td>
-                    <a href={row.link} target="_blank" rel="noreferrer noopener">
-                      {row.link}
-                    </a>
-                  </td>
-                  <td>{row.sizeLabel === "" ? "—" : row.sizeLabel}</td>
-                  <td>
-                    {row.ok ? AVAILABILITY_LABEL[row.availability] : "Kontrola zlyhala"}
-                    {row.availabilityText !== "" && ` (${row.availabilityText})`}
-                  </td>
-                  <td>{row.price === null ? "—" : `${row.price} €`}</td>
-                  <td>{formatSkDateTime(row.checkedAt)}</td>
+          <div className="fs-table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th scope="col">Dodávateľ</th>
+                  <th scope="col">Odkaz</th>
+                  <th scope="col">Veľkosť</th>
+                  <th scope="col">Dostupnosť</th>
+                  <th scope="col">Cena</th>
+                  <th scope="col">Kontrolované</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  // Kľúč MUSÍ niesť aj veľkosť — odkaz s pravidlom na veľkosti
+                  // (issue 224) má pre TÚ ISTÚ linku viac riadkov naraz.
+                  <tr key={`${row.link}|${row.sizeLabel}`} data-testid={`ss-row-${row.link}-${row.sizeLabel}`}>
+                    <td>{row.host}</td>
+                    <td>
+                      <a href={row.link} target="_blank" rel="noreferrer noopener">
+                        {row.link}
+                      </a>
+                    </td>
+                    <td>{row.sizeLabel === "" ? "—" : row.sizeLabel}</td>
+                    <td>
+                      {row.ok ? AVAILABILITY_LABEL[row.availability] : "Kontrola zlyhala"}
+                      {row.availabilityText !== "" && ` (${row.availabilityText})`}
+                    </td>
+                    <td>{row.price === null ? "—" : `${row.price} €`}</td>
+                    <td>{formatSkDateTime(row.checkedAt)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         )}
       </div>
     </div>

--- a/apps/web/src/components/SyncSection.tsx
+++ b/apps/web/src/components/SyncSection.tsx
@@ -220,28 +220,30 @@ export function SyncSection({
           {runs.length === 0 ? (
             <p className="empty" data-testid="sync-history-empty">Žiadny beh zatiaľ nie je zaznamenaný.</p>
           ) : (
-            <table>
-              <thead>
-                <tr>
-                  <th>Úloha</th>
-                  <th>Naposledy spustená</th>
-                  <th>Stav</th>
-                  <th>Dokončená</th>
-                  <th>Detail</th>
-                </tr>
-              </thead>
-              <tbody>
-                {runs.map((run) => (
-                  <tr key={run.jobName} data-testid={`sync-job-${run.jobName}`}>
-                    <td>{jobLabel(run.jobName)}</td>
-                    <td>{formatSkDateTime(run.startedAt)}</td>
-                    <td>{STATUS_LABELS[run.status]}</td>
-                    <td>{formatSkDateTime(run.finishedAt)}</td>
-                    <td>{detailText(run)}</td>
+            <div className="fs-table-wrap">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Úloha</th>
+                    <th>Naposledy spustená</th>
+                    <th>Stav</th>
+                    <th>Dokončená</th>
+                    <th>Detail</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {runs.map((run) => (
+                    <tr key={run.jobName} data-testid={`sync-job-${run.jobName}`}>
+                      <td>{jobLabel(run.jobName)}</td>
+                      <td>{formatSkDateTime(run.startedAt)}</td>
+                      <td>{STATUS_LABELS[run.status]}</td>
+                      <td>{formatSkDateTime(run.finishedAt)}</td>
+                      <td>{detailText(run)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           )}
         </>
       )}

--- a/apps/web/src/components/UpozorneniaSection.test.tsx
+++ b/apps/web/src/components/UpozorneniaSection.test.tsx
@@ -52,6 +52,26 @@ const VRATENIE_KARTA = {
   status: "otvorene" as const,
 };
 
+// issue 298: karta z automatického zdroja "Nevyzdvihnutá zásielka" — preklik
+// vedie PRIAMO na sledovanie na Pošte SK (predtým Shoptet admin objednávka,
+// rovnaký odkaz ako `VRATENIE_KARTA` mala). Samostatná fixtúra, aby test
+// mohol overiť INÝ štítok (`LINK_LABELS` v `UpozornenieCard.tsx` je teraz
+// per-typ rôzny, nie zdieľaný).
+const NEVYZDVIHNUTA_KARTA = {
+  id: "posta-1",
+  type: "nevyzdvihnuta_zasielka" as const,
+  source: "appka" as const,
+  title: "Zásielka pre objednávku 20500010 sa nevyzdvihla — 5 dní na pošte",
+  details: "Zákazník: Ján Novák\nČíslo zásielky: EF123456789SK\nDopravca: Slovenská pošta\nČaká: 5 dní na pošte\nVyzdvihnutie do: 2026-08-15",
+  link: "https://www.posta.sk/sledovanie-zasielok#parcel=EF123456789SK",
+  dueAt: null,
+  postponedUntil: null,
+  seenAt: "2026-08-05T08:00:00.000Z",
+  resolvedAt: null,
+  createdAt: "2026-08-05T08:00:00.000Z",
+  status: "otvorene" as const,
+};
+
 afterEach(() => {
   cleanup();
   vi.resetAllMocks();
@@ -68,6 +88,20 @@ it("karta s odkazom (automatický zdroj) zobrazí štítok 'Otvoriť objednávku
   expect(link.getAttribute("href")).toBe(VRATENIE_KARTA.link);
   expect(link.getAttribute("target")).toBe("_blank");
   expect(link.getAttribute("rel")).toBe("noreferrer");
+});
+
+it("issue 298: karta 'Nevyzdvihnutá zásielka' zobrazí štítok 'Sledovať zásielku na Pošte' s odkazom na Poštu SK, aj termín vyzdvihnutia v details", async () => {
+  markUpozorneniaSeen.mockResolvedValue(undefined);
+  fetchUpozornenia.mockResolvedValue([NEVYZDVIHNUTA_KARTA]);
+  render(<UpozorneniaSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("upozornenie-posta-1");
+
+  const link = screen.getByTestId<HTMLAnchorElement>("upozornenie-link-posta-1");
+  expect(link.textContent).toBe("Sledovať zásielku na Pošte");
+  expect(link.getAttribute("href")).toBe(NEVYZDVIHNUTA_KARTA.link);
+  expect(link.getAttribute("target")).toBe("_blank");
+  expect(link.getAttribute("rel")).toBe("noreferrer");
+  expect(screen.getByText(/Vyzdvihnutie do: 2026-08-15/)).toBeTruthy();
 });
 
 it("prázdny zoznam zobrazí informačnú vetu (po označení videných)", async () => {

--- a/apps/web/src/components/UpozornenieCard.tsx
+++ b/apps/web/src/components/UpozornenieCard.tsx
@@ -20,15 +20,17 @@ const TYPE_LABELS: Readonly<Record<UpozornenieRow["type"], string>> = {
 };
 
 // Code review (issue 269, druhé kolo, finding 10): štítok odkazu sa odvodzuje
-// od TYPU karty, nikdy ako natvrdo napísaný literál na mieste vykreslenia —
-// oba dnešné automatické zdroje (#268 nevyzdvihnutá zásielka, #269 vrátenie)
-// odkazujú na Shoptet administráciu objednávky (`buildShoptetAdminOrderUrl`),
-// takže majú rovnaký štítok. `vlastna_poznamka` nikdy nenesie `link` (server
-// ho nikdy nevyplní), takže sem nepotrebuje vlastný záznam — `??` fallback
-// nižšie pokrýva AJ ňu, AJ akýkoľvek budúci typ, čo by omylom dostal odkaz
-// bez vlastného štítku, namiesto tichého predpokladu "je to vždy Shoptet".
+// od TYPU karty, nikdy ako natvrdo napísaný literál na mieste vykreslenia.
+// `vratenie` odkazuje na Shoptet administráciu objednávky
+// (`buildShoptetAdminOrderUrl`). issue 298: `nevyzdvihnuta_zasielka` odkazuje
+// PRIAMO na sledovanie zásielky na Pošte SK (`trackingLink`,
+// `posta-uncollected/constants.ts`) — šéfova žiadosť "preklik do pošty",
+// namiesto predošlého odkazu na Shoptet admin objednávku. `vlastna_poznamka`
+// nikdy nenesie `link` (server ho nikdy nevyplní), takže sem nepotrebuje
+// vlastný záznam — `??` fallback nižšie pokrýva AJ ňu, AJ akýkoľvek budúci
+// typ, čo by omylom dostal odkaz bez vlastného štítku.
 const LINK_LABELS: Readonly<Partial<Record<UpozornenieRow["type"], string>>> = {
-  nevyzdvihnuta_zasielka: "Otvoriť objednávku v Shoptete",
+  nevyzdvihnuta_zasielka: "Sledovať zásielku na Pošte",
   vratenie: "Otvoriť objednávku v Shoptete",
 };
 const DEFAULT_LINK_LABEL = "Otvoriť odkaz";

--- a/apps/web/src/formatDate.test.ts
+++ b/apps/web/src/formatDate.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from "vitest";
-import { formatSkDate, formatSkDateTime } from "./formatDate.js";
+import { formatSkDate, formatSkDateInZone, formatSkDateTime } from "./formatDate.js";
 
 // issue 293: jediná spoločná funkcia na slovenský tvar dátumu/času —
 // `timeZone: "Europe/Bratislava"` je VÝSLOVNE nastavené, takže výsledok
@@ -12,6 +12,15 @@ it("formatSkDate: bežný okamih v slovenskom tvare", () => {
 it("formatSkDate: okamih tesne PO slovenskej polnoci sa zobrazí ako DNEŠNÝ deň, nie UTC-VČEREJŠÍ", () => {
   // 2026-08-05T22:10:00Z = 2026-08-06 00:10 Europe/Bratislava (letný čas).
   expect(formatSkDate("2026-08-05T22:10:00.000Z")).toBe("6. 8. 2026");
+});
+
+it("formatSkDateInZone: bare YYYY-MM-DD kalendárny deň sa formátuje rovnako bez ohľadu na znamienko posunu pásma", () => {
+  // Pacific/Honolulu je vždy UTC-10 (žiadny letný čas — deterministický
+  // záporný posun). `new Date("2026-08-06")` je UTC polnoc; v Bratislave
+  // (kladný posun) to vždy vyjde ako ten istý/nasledujúci deň, takže
+  // formatSkDate samotné (pevné na Europe/Bratislava) tento bug nevidí —
+  // preto sa testuje priamo cez formatSkDateInZone so záporným pásmom.
+  expect(formatSkDateInZone("2026-08-06", "Pacific/Honolulu")).toBe("6. 8. 2026");
 });
 
 it("formatSkDate: prijme aj Date objekt priamo", () => {

--- a/apps/web/src/formatDate.ts
+++ b/apps/web/src/formatDate.ts
@@ -35,7 +35,7 @@ export function formatSkDateInZone(value: string | Date | null | undefined, zone
   if (typeof value === "string" && BARE_DATE_RE.test(value)) {
     if (toValidDate(value) === null) return "—";
     const [y, m, day] = value.split("-");
-    return `${Number(day)}. ${Number(m)}. ${Number(y)}`;
+    return `${String(Number(day))}. ${String(Number(m))}. ${String(Number(y))}`;
   }
   const d = toValidDate(value);
   if (d === null) return "—";

--- a/apps/web/src/formatDate.ts
+++ b/apps/web/src/formatDate.ts
@@ -16,12 +16,19 @@ function toValidDate(value: string | Date | null | undefined): Date | null {
   return Number.isNaN(d.getTime()) ? null : d;
 }
 
+/** Jadro `formatSkDate` s explicitným pásmom (testovateľné samostatne —
+ * `TIME_ZONE` nižšie je zámerne kladný posun, takže bug pri bare
+ * `YYYY-MM-DD` vstupe cez ňu nejde vidieť). */
+export function formatSkDateInZone(value: string | Date | null | undefined, zone: string): string {
+  const d = toValidDate(value);
+  if (d === null) return "—";
+  return d.toLocaleDateString("sk-SK", { timeZone: zone });
+}
+
 /** Slovenský tvar dátumu, napr. "6. 8. 2026". Prázdny/nerozpoznateľný
  * vstup → "—". */
 export function formatSkDate(value: string | Date | null | undefined): string {
-  const d = toValidDate(value);
-  if (d === null) return "—";
-  return d.toLocaleDateString("sk-SK", { timeZone: TIME_ZONE });
+  return formatSkDateInZone(value, TIME_ZONE);
 }
 
 /** Slovenský tvar dátumu + času (bez sekúnd), napr. "6. 8. 2026 14:40".

--- a/apps/web/src/formatDate.ts
+++ b/apps/web/src/formatDate.ts
@@ -16,10 +16,27 @@ function toValidDate(value: string | Date | null | undefined): Date | null {
   return Number.isNaN(d.getTime()) ? null : d;
 }
 
+const BARE_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
 /** Jadro `formatSkDate` s explicitným pásmom (testovateľné samostatne —
  * `TIME_ZONE` nižšie je zámerne kladný posun, takže bug pri bare
- * `YYYY-MM-DD` vstupe cez ňu nejde vidieť). */
+ * `YYYY-MM-DD` vstupe cez ňu nejde vidieť).
+ *
+ * Bare `YYYY-MM-DD` (žiadna časová zložka) sa formátuje PRIAMO zo svojich
+ * Y/M/D znakov, nikdy cez inštanciu (`new Date(...)`) prehnanú cez `zone` —
+ * `new Date("YYYY-MM-DD")` parsuje ako UTC POLNOC a jej prevod do pásma so
+ * ZÁPORNÝM posunom vráti PREDCHÁDZAJÚCI kalendárny deň (pozri red test
+ * vyššie). `Date` sa tu použije LEN na validáciu (odmietnutie neplatného
+ * kalendárneho dátumu, napr. "2026-13-45"), nikdy na výpočet zobrazeného
+ * dňa. Plný ISO okamih s časovou zložkou ide ĎALEJ cez pôvodnú,
+ * inštanciovú vetvu — tá je correct, lebo vtedy naozaj ide o okamih, nie o
+ * čistý kalendárny deň. */
 export function formatSkDateInZone(value: string | Date | null | undefined, zone: string): string {
+  if (typeof value === "string" && BARE_DATE_RE.test(value)) {
+    if (toValidDate(value) === null) return "—";
+    const [y, m, day] = value.split("-");
+    return `${Number(day)}. ${Number(m)}. ${Number(y)}`;
+  }
   const d = toValidDate(value);
   if (d === null) return "—";
   return d.toLocaleDateString("sk-SK", { timeZone: zone });

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -169,6 +169,15 @@ table {
   overflow: hidden;
   font-size: var(--fs-text-sm);
 }
+/* issue 291: KAŽDÁ obyčajná tabuľka v appke dostáva svoj VLASTNÝ vodorovný
+   posuvný obal namiesto posúvania celej stránky — rovnaký princíp ako
+   `.orders-table-wrap`/`.ml-table-wrap` (tie dve už mali vlastný obal pred
+   týmto ticketom, preto zostávajú samostatné triedy so svojím vlastným
+   `min-width`/`table-layout`; táto zdieľaná trieda je pre všetky OSTATNÉ
+   jednoduché tabuľky, ktoré žiadne osobitné rozloženie nepotrebujú). */
+.fs-table-wrap {
+  overflow-x: auto;
+}
 th {
   text-align: left;
   font-size: var(--fs-text-xs);
@@ -493,17 +502,38 @@ tr:last-child td {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
+  /* issue 291: na úzkej obrazovke sa lišta ZALOMÍ namiesto orezania
+     používateľského menu — dovtedy tu `flex-wrap` chýbal úplne, takže sa
+     "Prihlásený: …" na telefóne strácalo mimo viditeľnú oblasť. */
+  flex-wrap: wrap;
   gap: var(--fs-space-4);
   background: var(--fs-canvas);
   border-bottom: 1px solid var(--fs-border);
   padding: var(--fs-space-5) var(--fs-space-6) var(--fs-space-4);
 }
+.topbar-head {
+  min-width: 0;
+  flex: 1 1 auto;
+}
 .topbar-head h1 {
   margin: 0;
+  overflow-wrap: break-word;
 }
 .topbar-user {
   position: relative;
-  flex: 0 0 auto;
+  /* issue 291: PREDTÝM `flex: 0 0 auto` — na úzkej obrazovke, keď `.topbar`
+     zalomí tento blok na VLASTNÝ riadok (nad `flex-wrap: wrap` pridaným
+     vyššie), `flex-shrink: 0` mu bránilo zmenšiť sa aj keď na svojom
+     riadku nemal dosť miesta — celý blok (koliesko + meno) tak pretŕčal
+     mimo viditeľnú šírku (naživo namerané: 298px blok v 239px dostupnom
+     mieste pri 375px okne). `min-width: 0` dovolí zmenšenie AJ POD
+     obsahovú šírku detí (rovnaký dôvod ako `.topbar-head` nižšie) —
+     samotné zmenšenie potom prevezme `.usermenu-btn`'s existujúce
+     orezanie mena (`overflow:hidden;text-overflow:ellipsis`).
+     `.usermenu-btn` samo dostáva `flex: 1 1 auto` nižšie, aby zmenšenie
+     prednostne obralo JEHO, nie `.themecolor-btn`'s pevné koliesko. */
+  flex: 0 1 auto;
+  min-width: 0;
   /* issue 264: koliesko "Farby aplikácie" sedí VEDĽA mena používateľa, nie
      nad/pod ním — `.usermenu-panel` nižšie ostáva absolútne pozicovaný
      voči tomuto (position:relative) rodičovi bez ohľadu na flex. */
@@ -523,6 +553,12 @@ tr:last-child td {
   color: var(--fs-ink);
   cursor: pointer;
   max-width: 260px;
+  /* issue 291: nechá zmenšenie `.topbar-user` (vyššie) prednostne obrať
+     TOTO tlačidlo, nie pevné `.themecolor-btn` koliesko vedľa neho — bez
+     `min-width: 0` by prvok nešiel zmenšiť pod svoju obsahovú (meno +
+     šípka) šírku, aj keby mal na to priestor v rodičovi. */
+  flex: 1 1 auto;
+  min-width: 0;
 }
 .usermenu-btn:hover {
   border-color: var(--fs-ink-faint);

--- a/apps/web/tests/e2e/mobile-responsive.spec.ts
+++ b/apps/web/tests/e2e/mobile-responsive.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from "@playwright/test";
+
+const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
+// issue 291: VLASTNÝ, IZOLOVANÝ účet len pre tento súbor — rovnaký dôvod aj
+// mechanizmus ako ostatné `E2E_*_EMAIL` konštanty v `scripts/e2e-setup.ts`
+// (zdieľaný `e2e@forestshop.sk` je už na hranici `MAX_ATTEMPTS`, `.claude/
+// rules/frontend-design.md`). Musí sa zhodovať s hodnotou tam.
+const E2E_MOBIL_EMAIL = "e2e-mobil@forestshop.sk";
+
+// issue 291 (majiteľ: "responzivnost na mobil... mne sa appka na mobile
+// nedá zobraziť"). Dohodnutý ZÁKLADNÝ rozsah (viď scoping komentár na
+// tickete): menu sa na úzkej obrazovke zbalí samo, horná lišta sa zalomí,
+// každá tabuľka dostane vlastný vodorovný posuvný obal namiesto posúvania
+// celej stránky. Akceptačný prípad z tiketu: "Sync zo Shoptetu" mala pri
+// 375px okne `document.documentElement.scrollWidth` 4085px — jej história
+// behov nemala vlastný posuvný obal.
+test("na telefónnej šírke (375px) sa stránka nikdy neposúva vodorovne, panel sa zbalí sám, konzola je čistá", async ({
+  page,
+}) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.setViewportSize({ width: 375, height: 800 });
+  await page.goto("/");
+  await page.getByLabel("E-mail").fill(E2E_MOBIL_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+
+  // Predvolená obrazovka po prihlásení je "Sync zo Shoptetu" — presne tá,
+  // ktorú majiteľ nahlásil ako neúnosnú.
+  await expect(page.getByRole("heading", { name: "Sync zo Shoptetu" })).toBeVisible();
+
+  // Bod 1 dohodnutého rozsahu: panel sa na úzkej obrazovke bez uloženej
+  // voľby zbalí sám (priamy dôkaz `Sidebar.tsx`'s `initialRail`).
+  await expect(page.getByTestId("sidebar-rail-toggle")).toHaveAttribute("aria-expanded", "false");
+
+  // Bod 2: horná lišta sa zalomí — meno prihláseného ostáva DOSIAHNUTEĽNÉ
+  // (celé v šírke okna), nie orezané mimo viditeľnú oblasť.
+  const greeting = page.getByTestId("greeting");
+  await expect(greeting).toBeVisible();
+  const greetingBox = await greeting.boundingBox();
+  expect(greetingBox).not.toBeNull();
+  if (greetingBox !== null) {
+    expect(greetingBox.x + greetingBox.width, "meno prihláseného musí byť celé vo viditeľnej šírke").toBeLessThanOrEqual(
+      375,
+    );
+  }
+
+  // Bod 3 + akceptačná kontrola tiketu: žiadne vodorovné posúvanie STRÁNKY.
+  const syncSirky = await page.evaluate(() => ({
+    scrollWidth: document.documentElement.scrollWidth,
+    innerWidth: window.innerWidth,
+  }));
+  expect(syncSirky.scrollWidth, "Sync zo Shoptetu: scrollWidth vs innerWidth pri 375px").toBeLessThanOrEqual(
+    syncSirky.innerWidth,
+  );
+
+  // Druhá, tabuľkovo najhustejšia obrazovka — "Na objednanie" (`orders-
+  // table-wrap`, mala už VLASTNÝ posuvný obal aj pred týmto tiketom — tu sa
+  // overuje, že aj s VŠETKÝMI ostatnými novo-obalenými tabuľkami zostáva
+  // stránka samotná bez vodorovného posúvania). Záložka je dosiahnuteľná aj
+  // v zbalenej lište (prístupný názov prežije, `Sidebar.tsx`'s `railLabel`).
+  await page.getByRole("button", { name: "Na objednanie" }).click();
+  await expect(page.getByRole("heading", { name: "Na objednanie" })).toBeVisible();
+  const ordersSirky = await page.evaluate(() => ({
+    scrollWidth: document.documentElement.scrollWidth,
+    innerWidth: window.innerWidth,
+  }));
+  expect(ordersSirky.scrollWidth, "Na objednanie: scrollWidth vs innerWidth pri 375px").toBeLessThanOrEqual(
+    ordersSirky.innerWidth,
+  );
+
+  expect(chyby).toEqual([]);
+});

--- a/apps/web/tests/e2e/search.spec.ts
+++ b/apps/web/tests/e2e/search.spec.ts
@@ -6,10 +6,12 @@ const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáz
 // `E2E_VYHLADAT_EMAIL` v `scripts/e2e-fixtures-search.ts`.
 const E2E_VYHLADAT_EMAIL = "e2e-vyhladat@forestshop.sk";
 
-// issue 240: "Eshop → Vyhľadať" — nájsť produkt podľa kódu aj názvu a
-// objednávku podľa čísla, otvoriť detail produktu, zmeniť dodávateľskú
-// linku, uložiť a vidieť stav.
-test("nájde produkt podľa kódu, otvorí detail, zmení a uloží dodávateľskú linku so stavom, konzola je čistá", async ({
+// issue 289: "Eshop → Vyhľadať" — DVE nezávislé, popísané polia namiesto
+// jedného spoločného (issue 240): "Produkt" (nájsť podľa kódu/názvu, otvoriť
+// detail, zmeniť dodávateľskú linku) a "Objednávka" (nájsť podľa čísla,
+// klik vedie do detailu objednávky v Shoptete). Obe polia fungujú
+// NEZÁVISLE — písanie do jedného nemaže výsledok druhého.
+test("Produkt a Objednávka sú dve nezávislé polia — nájde produkt aj objednávku, oboje prežije prechod do detailu, konzola je čistá", async ({
   page,
 }) => {
   const chyby: string[] = [];
@@ -28,16 +30,30 @@ test("nájde produkt podľa kódu, otvorí detail, zmení a uloží dodávateľs
   await page.getByRole("button", { name: "Vyhľadať" }).click();
   await expect(page.getByRole("heading", { name: "Vyhľadať" })).toBeVisible();
 
-  // Hľadanie podľa PRESNÉHO kódu variantu.
-  await page.getByLabel("Hľadať").fill("E2E-SEARCH-1");
-  await page.getByRole("button", { name: "Hľadať", exact: true }).click();
+  // Obe polia sú viditeľné a POPÍSANÉ hneď od začiatku, ešte pred hľadaním.
+  await expect(page.getByLabel("Produkt")).toBeVisible();
+  await expect(page.getByLabel("Objednávka")).toBeVisible();
+
+  // Hľadanie OBJEDNÁVKY podľa čísla — najprv, aby sa overilo, že produktové
+  // pole zostáva prázdne (polia sa navzájom neovplyvňujú).
+  await page.getByLabel("Objednávka").fill("9101");
+  await page.getByRole("button", { name: "Hľadať objednávku" }).click();
+  const objednavkaRiadok = page.getByTestId("search-order-9101");
+  await expect(objednavkaRiadok).toBeVisible();
+  await expect(objednavkaRiadok).toContainText("E2E Zákazník Vyhľadávanie");
+  await expect(page.getByTestId("search-products")).toHaveCount(0);
+
+  // Hľadanie PRODUKTU podľa PRESNÉHO kódu variantu — objednávkový výsledok
+  // z predošlého kroku ostáva netknutý (nezávislé polia).
+  await page.getByLabel("Produkt").fill("E2E-SEARCH-1");
+  await page.getByRole("button", { name: "Hľadať produkt" }).click();
 
   const produktRiadok = page.getByTestId("search-product-E2E-SEARCH-1");
   await expect(produktRiadok).toBeVisible();
   await expect(produktRiadok).toContainText("E2E Vyhľadávací Produkt Alfa");
   await expect(produktRiadok).toContainText("E2E Dodávateľ Vyhľadávanie");
-  // Objednávky sa nenašli pre tento dopyt — žiadny blok "Objednávky".
-  await expect(page.getByTestId("search-orders")).toHaveCount(0);
+  // Objednávkový výsledok z predošlého hľadania stále stojí.
+  await expect(objednavkaRiadok).toBeVisible();
 
   await page.getByTestId("search-product-open-E2E-SEARCH-1").click();
 
@@ -74,21 +90,34 @@ test("nájde produkt podľa kódu, otvorí detail, zmení a uloží dodávateľs
   );
   await expect(page.getByTestId("search-detail-link-status")).toContainText("čaká na odoslanie");
 
-  // Späť na hľadanie a nájsť objednávku podľa čísla.
+  // Pole "Objednávka" je namontované AJ počas detailu produktu (nezávislé
+  // od navigácie v produktovom poli) — jeho predošlý výsledok tu stále je.
+  await expect(page.getByTestId("search-order-9101")).toBeVisible();
+
+  // Späť na hľadanie a nájsť produkt podľa ČASTI názvu — objednávkový
+  // výsledok stále stojí, nikdy nebol vymazaný.
   await page.getByTestId("search-back").click();
   await expect(page.getByTestId("search-section")).toBeVisible();
+  await expect(page.getByTestId("search-order-9101")).toBeVisible();
 
-  await page.getByLabel("Hľadať").fill("9101");
-  await page.getByRole("button", { name: "Hľadať", exact: true }).click();
-  const objednavkaRiadok = page.getByTestId("search-order-9101");
-  await expect(objednavkaRiadok).toBeVisible();
-  await expect(objednavkaRiadok).toContainText("E2E Zákazník Vyhľadávanie");
-  await expect(page.getByTestId("search-products")).toHaveCount(0);
-
-  // Hľadanie podľa ČASTI názvu produktu tiež nájde ten istý produkt.
-  await page.getByLabel("Hľadať").fill("Vyhľadávací Produkt");
-  await page.getByRole("button", { name: "Hľadať", exact: true }).click();
+  await page.getByLabel("Produkt").fill("Vyhľadávací Produkt");
+  await page.getByRole("button", { name: "Hľadať produkt" }).click();
   await expect(page.getByTestId("search-product-E2E-SEARCH-1")).toBeVisible();
+
+  // Neexistujúce číslo objednávky zobrazí jasnú hlášku "nič sa nenašlo",
+  // nie ticho prázdny blok.
+  await page.getByLabel("Objednávka").fill("99999999");
+  await page.getByRole("button", { name: "Hľadať objednávku" }).click();
+  await expect(page.getByTestId("search-order-empty")).toBeVisible();
+  await expect(page.getByTestId("search-orders")).toHaveCount(0);
+  // Produktové pole tým nebolo ovplyvnené.
+  await expect(page.getByTestId("search-product-E2E-SEARCH-1")).toBeVisible();
+
+  // Nič-nezodpovedajúci dopyt na produkt zobrazí rovnaký druh hlášky.
+  await page.getByLabel("Produkt").fill("nieco-co-nikde-nie-je");
+  await page.getByRole("button", { name: "Hľadať produkt" }).click();
+  await expect(page.getByTestId("search-product-empty")).toBeVisible();
+  await expect(page.getByTestId("search-products")).toHaveCount(0);
 
   expect(chyby).toEqual([]);
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.167",
+  "version": "0.3.0-dev.168",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.169",
+  "version": "0.3.0-dev.170",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.168",
+  "version": "0.3.0-dev.169",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.166",
+  "version": "0.3.0-dev.167",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -199,6 +199,11 @@ const E2E_FARBY_EMAIL = "e2e-farby@forestshop.sk"; // musí sa zhodovať s hodno
 // `admin`/`manazer`.
 const E2E_UPOZORNENIA_EMAIL = "e2e-upozornenia@forestshop.sk"; // musí sa zhodovať s hodnotou v upozornenia.spec.ts
 
+// issue 291: rovnaký mechanizmus a dôvod ako `E2E_UPOZORNENIA_EMAIL` vyššie —
+// nový spec súbor (`mobile-responsive.spec.ts` — kontrola vodorovného
+// posúvania stránky na telefónnej šírke) dostáva VLASTNÝ izolovaný účet.
+const E2E_MOBIL_EMAIL = "e2e-mobil@forestshop.sk"; // musí sa zhodovať s hodnotou v mobile-responsive.spec.ts
+
 const { db, pool } = createDb();
 // Konštantný literál bez interpolácie — obyčajný reťazec je tu rovnako bezpečný
 // ako `sql` tagovaná šablóna (tú používa ekvivalentný apps/api/tests/helpers/db.ts),
@@ -360,6 +365,7 @@ await db.insert(users).values({ email: E2E_RACE_EMAIL, passwordHash: await hashP
 await db.insert(users).values({ email: E2E_ZLUCENIE_EMAIL, passwordHash: await hashPassword(E2E_HESLO), displayName: "E2E Manažér", role: "manazer" });
 await db.insert(users).values({ email: E2E_FARBY_EMAIL, passwordHash: await hashPassword(E2E_HESLO), displayName: "E2E Manažér", role: "manazer" });
 await db.insert(users).values({ email: E2E_UPOZORNENIA_EMAIL, passwordHash: await hashPassword(E2E_HESLO), displayName: "E2E Manažér", role: "manazer" });
+await db.insert(users).values({ email: E2E_MOBIL_EMAIL, passwordHash: await hashPassword(E2E_HESLO), displayName: "E2E Manažér", role: "manazer" });
 
 // Katalóg pre E2E: tá istá commitnutá fixtúra ako v jednotkových testoch, cez tú istú
 // službu importu — E2E tak overuje skutočnú cestu dát, nie ručne nasypané riadky.


### PR DESCRIPTION
## Čo to robí

Päť vecí naraz — počas výpadku GitHubu sa nedalo nasadzovať, tak sa nazbierali.

**Vyhľadať má dve popísané polia (issue 289).** Namiesto jedného spoločného políčka je teraz **Produkt** a pod ním **Objednávka**. Do druhého sa napíše číslo objednávky, appka ju nájde a kliknutím sa otvorí jej detail v Shoptete — tam, kam vedú odkazy na objednávky všade inde v appke. Obe polia fungujú nezávisle, jedno nemaže výsledky druhého.

**Appka sa dá otvoriť na telefóne (issue 291, základ).** Úvodná obrazovka bola pri šírke telefónu široká 4085 px, čiže sa rolovala do strán jedenásťkrát viac, než sa zmestí. Teraz je presne 375 px — stránka sa do strán neroluje vôbec. Menu sa na úzkej obrazovke samo zbalí (ak si ho používateľ ručne rozbalí, jeho voľba platí), horná lišta sa zalomí namiesto orezania a 19 tabuliek dostalo vlastné vodorovné rolovanie. Na počítači sa nemení nič. Väčšia prerábka (tabuľky ako karty) sa zámerne nerobila — je popísaná aj s cenou na tikete.

**Nástenka prestane upozorňovať na už vybavené veci (issue 297).** Zakladala kartu aj pre stavy *Vybavená výmena* a *Vybavený Dobropis*, čo sú hotové veci — majiteľ ich musel odklikávať zbytočne. Odteraz sa pre ne karta nezaloží, a keď sa objednávka do takého stavu dostane, jej otvorená karta sa zavrie sama. História ostáva, nič sa nemaže.

**Karta nevyzdvihnutej zásielky je akčná (issue 298).** Ukazuje číslo zásielky, ako dlho čaká a dokedy je uložená, a má preklik na sledovanie na Pošte. Odkaz nie je vymyslený — používa sa ten istý, aký appka už má v tabuľke výsledkov.

**Tri drobnosti z revízie časovej opravy (issue 293).** Holý dátum sa už neprepočítava cez okamih (dnes to vychádzalo správne len vďaka tomu, že máme kladný posun); jedno miesto v maile o zásielke ide cez spoločnú funkciu; nočné mazanie starých objednávok sa posunulo z 2:00 na 2:10, lebo 2:00 v deň prechodu na letný čas neexistuje.

## Overenie

- `pnpm typecheck`, `pnpm lint` — čisté
- api unit 611, web unit 492, api integračné 560, e2e 47/47 — všetko prešlo
- Nové testy: dve polia vo Vyhľadať, mobilná šírka bez vodorovného rolovania, nezakladanie kariet pre hotové stavy, samozatvorenie karty

Nadväzuje na issue 289, issue 291, issue 293, issue 297 a issue 298.