### PR TITLE
Upozornenie na dlho visiace objednávky + štart na obrazovke Na objednanie

### DIFF
--- a/.claude/rules/orders.md
+++ b/.claude/rules/orders.md
@@ -584,3 +584,14 @@ paths:
   stavia kódovaciu tabuľku DYNAMICKY (dekóduje všetkých 256 bajtov cez
   `TextDecoder("windows-1250")` a obráti mapu), namiesto ručne písanej
   tabuľky kódových bodov alebo novej závislosti (`iconv-lite`).
+- **Issue 301: TA ISTÁ transakcia navyše volá `applyStuckUpozornenia`
+  (`orders/stuck-upozornenia.ts`) hneď VEDĽA `applyReturnUpozornenia` — karta
+  na objednávku, čo dlho visí v nevybavenom stave ("Vybavuje sa"/
+  "Nevybavená", `orders/stuck-status.ts`).** Plné odôvodnenie (prah 14 dní
+  vs. `order-reminder`'s 4-dňový, prečo je táto kategória ZNOVA-OHLÁSITEĽNÁ
+  na rozdiel od `vratenie`'s KONEČNEJ, dávkovaný auto-resolve pre-check bez
+  `.for("update")`) je v `.claude/rules/upozornenia.md`, aby sa nepísalo
+  dvakrát. Testovací vzor (vlastný `rowOf` s nastaviteľným `date` stĺpcom,
+  cp1250 cez zdieľané `helpers/orders-return-csv.ts`) je v
+  `orders-ingest-stuck-upozornenie.integration.test.ts` — rovnaký dôvod na
+  cp1250 ako vyššie (stav "Nevybavená" nesie diakritiku).

--- a/.claude/rules/upozornenia.md
+++ b/.claude/rules/upozornenia.md
@@ -326,3 +326,38 @@ paths:
   `posta-vratena:<číslo>`) sú SAMOSTATNÉ mená priestorov nad tou istou
   zásielkou, aby mohli koexistovať/prepínať sa bez kolízie na čiastočnom
   unique indexe.
+- **Issue 301: PIATA pgEnum hodnota `objednavka_visi` — objednávka, ktorá dlho
+  visí v NEVYBAVENOM stave** (`orders/stuck-status.ts`/`orders/stuck-
+  upozornenia.ts`, napojené na TEN ISTÝ denný beh ako `vratenie` — import
+  objednávok, `orders/ingest.ts`). Nevybavené stavy ("Vybavuje sa"/
+  "Nevybavená") sú ZÁMERNE VLASTNÝ, nezávislý zoznam od admin-nastaviteľného
+  `order_open_status` (`open-statuses.ts`) — presne tá istá úvaha ako
+  `return-status.ts`'s vlastný vrátkový zoznam: keby šéf zajtra zmenil, čo sa
+  ukazuje na "Na objednanie", TOTO upozornenie sa nesmie ticho spolu s ním
+  prehodnotiť. `ORDER_STUCK_THRESHOLD_DAYS = 14` je zámerne ODLIŠNÝ (dlhší)
+  prah než `order-reminder/constants.ts`'s `MIN_DAYS = 4` — ten rieši
+  KRATŠIU, zákaznícky orientovanú vec (pripomenúť ZÁKAZNÍKOVI jeho
+  objednávku), toto rieši ŠÉFOVI, že objednávka niekde v procese zamrzla;
+  zdieľať jeden prah medzi oboma by bolo nesprávne, aj keby čísla náhodou
+  vyšli rovnaké.
+  **Kategorizačné rozhodnutie (`.claude/rules/upozornenia.md`'s vlastné
+  poučenie z #269 vyššie — "rozhodni sa VOPRED, do ktorej z dvoch kategórií
+  patrí"): `objednavka_visi` je ZNOVA-OHLÁSITEĽNÁ** (rodina #268's zásielky),
+  NIE KONEČNÁ (rodina #269's `vratenie`) — objednávka, čo sa vráti späť do
+  nevybaveného stavu a znova visí dosť dlho, má dostať NOVÚ kartu. Preto tu
+  NIE JE potrebný žiadny `.for("update")` "je už KONEČNE vybavené" pre-check
+  na `INSERT`-e — len jednoduchý `upsertUpozornenie`/`autoResolveByDedupKey`
+  pár.
+  **Auto-resolve VÝKONOVÁ past, ktorú by inak vyrobila práve TÁTO
+  znova-ohlásiteľná voľba:** na rozdiel od `vratenie`'s malej množiny
+  "HOTOVÝCH" kandidátov (`finishedReturnDedupKeys`) je "nie je nevybavené" pre
+  túto kartu skoro KAŽDÁ objednávka v 90-dňovom okne — naivný `for`-cyklus,
+  čo pre KAŽDÚ z nich zavolá `autoResolveByDedupKey` (bezpečný no-op bez
+  existujúcej karty), by spravil stovky zbytočných `UPDATE`ov na KAŽDOM behu
+  importu. `stuck-upozornenia.ts` preto NAJPRV dávkovo prečíta VŠETKY
+  otvorené `objednavka_visi` dedup kľúče JEDNÝM dopytom a auto-resolve
+  cyklus obmedzí LEN na tie — rovnaký "batch pre-check namiesto dopytu v
+  cykle" princíp ako `#269`'s `.for("update")` pre-check vyššie v tomto
+  súbore, len tu bez potreby zámku (kategória je znova-ohlásiteľná, takže
+  TOCTOU na INSERTe nehrozí — zámok by tu riešil problém, čo v tejto
+  kategórii vôbec neexistuje).

--- a/apps/api/drizzle/0042_easy_morg.sql
+++ b/apps/api/drizzle/0042_easy_morg.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."upozornenie_type" ADD VALUE 'objednavka_visi';

--- a/apps/api/drizzle/meta/0042_snapshot.json
+++ b/apps/api/drizzle/meta/0042_snapshot.json
@@ -1,0 +1,2804 @@
+{
+  "id": "63236f8d-6882-41b7-9af4-9012e6f93787",
+  "prevId": "fcce327b-9a33-46ad-9695-53a66acb83c8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_code": {
+          "name": "external_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_open_status": {
+      "name": "order_open_status",
+      "schema": "",
+      "columns": {
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Vybavuje sa'"
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop_remark": {
+          "name": "shop_remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shoptet_order_id": {
+          "name": "shoptet_order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_updated_at": {
+          "name": "comment_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_synced_at": {
+          "name": "comment_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_carrier_name": {
+          "name": "shipping_carrier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_price_with_vat": {
+          "name": "total_price_with_vat",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_link_override": {
+      "name": "product_supplier_link_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_link_override_product_key_product_key_fk": {
+          "name": "product_supplier_link_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_link_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_override": {
+      "name": "product_supplier_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_override_product_key_product_key_fk": {
+          "name": "product_supplier_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing": {
+      "name": "pairing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_url": {
+          "name": "supplier_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "pairing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'navrhnute'"
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pairing_state_idx": {
+          "name": "pairing_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_confirmed_by_idx": {
+          "name": "pairing_confirmed_by_idx",
+          "columns": [
+            {
+              "expression": "confirmed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_variant_code_variant_code_fk": {
+          "name": "pairing_variant_code_variant_code_fk",
+          "tableFrom": "pairing",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pairing_confirmed_by_users_id_fk": {
+          "name": "pairing_confirmed_by_users_id_fk",
+          "tableFrom": "pairing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pairing_variant_code_unique": {
+          "name": "pairing_variant_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pairing_confirmation_ck": {
+          "name": "pairing_confirmation_ck",
+          "value": "(\"pairing\".\"state\" = 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)\n        OR (\"pairing\".\"state\" != 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NULL AND \"pairing\".\"confirmed_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier": {
+      "name": "supplier",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wholesale_base_url": {
+          "name": "wholesale_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_key": {
+          "name": "adapter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_settings": {
+      "name": "posta_uncollected_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_state": {
+      "name": "posta_uncollected_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notify_count": {
+          "name": "notify_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_state": {
+          "name": "terminal_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_settings": {
+      "name": "order_reminder_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_state": {
+      "name": "order_reminder_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_replacement_link": {
+      "name": "nedostupne_replacement_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nedostupne_replacement_link_variant_idx": {
+          "name": "nedostupne_replacement_link_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_state": {
+      "name": "nedostupne_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "nedostupne_email_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nedostupne_state_order_variant_type_uq": {
+          "name": "nedostupne_state_order_variant_type_uq",
+          "columns": [
+            {
+              "expression": "order_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template_history": {
+      "name": "mail_template_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "mail_template_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_template_history_key_idx": {
+          "name": "mail_template_history_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_template_history_changed_by_user_id_users_id_fk": {
+          "name": "mail_template_history_changed_by_user_id_users_id_fk",
+          "tableFrom": "mail_template_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template": {
+      "name": "mail_template",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail_template_updated_by_user_id_users_id_fk": {
+          "name": "mail_template_updated_by_user_id_users_id_fk",
+          "tableFrom": "mail_template",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_log": {
+      "name": "mail_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "mail_log_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_log_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "mail_log_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_log_created_idx": {
+          "name": "mail_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_log_source_created_idx": {
+          "name": "mail_log_source_created_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_log_actor_user_id_users_id_fk": {
+          "name": "mail_log_actor_user_id_users_id_fk",
+          "tableFrom": "mail_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_stock": {
+      "name": "supplier_stock",
+      "schema": "",
+      "columns": {
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "supplier_availability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "supplier_stock_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "supplier_stock_host_idx": {
+          "name": "supplier_stock_host_idx",
+          "columns": [
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "supplier_stock_avail_idx": {
+          "name": "supplier_stock_avail_idx",
+          "columns": [
+            {
+              "expression": "availability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "supplier_stock_link_size_label_pk": {
+          "name": "supplier_stock_link_size_label_pk",
+          "columns": [
+            "link",
+            "size_label"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_event": {
+      "name": "restock_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_link": {
+          "name": "supplier_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_availability_text": {
+          "name": "supplier_availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "supplier_price": {
+          "name": "supplier_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "restock_event_at_idx": {
+          "name": "restock_event_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "restock_event_variant_idx": {
+          "name": "restock_event_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_settings": {
+      "name": "restock_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shop_product_url": {
+      "name": "shop_product_url",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.theme_color": {
+      "name": "theme_color",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "theme_color_updated_by_user_id_users_id_fk": {
+          "name": "theme_color_updated_by_user_id_users_id_fk",
+          "tableFrom": "theme_color",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upozornenie": {
+      "name": "upozornenie",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "upozornenie_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "upozornenie_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedup_key": {
+          "name": "dedup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postponed_until": {
+          "name": "postponed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seen_at": {
+          "name": "seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "upozornenie_dedup_key_uq": {
+          "name": "upozornenie_dedup_key_uq",
+          "columns": [
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "resolved_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upozornenie_resolved_at_idx": {
+          "name": "upozornenie_resolved_at_idx",
+          "columns": [
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upozornenie_dedup_key_idx": {
+          "name": "upozornenie_dedup_key_idx",
+          "columns": [
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upozornenie_resolved_by_user_id_users_id_fk": {
+          "name": "upozornenie_resolved_by_user_id_users_id_fk",
+          "tableFrom": "upozornenie",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "upozornenie_created_by_user_id_users_id_fk": {
+          "name": "upozornenie_created_by_user_id_users_id_fk",
+          "tableFrom": "upozornenie",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne"
+      ]
+    },
+    "public.pairing_state": {
+      "name": "pairing_state",
+      "schema": "public",
+      "values": [
+        "navrhnute",
+        "potvrdene"
+      ]
+    },
+    "public.nedostupne_email_type": {
+      "name": "nedostupne_email_type",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "alternativa"
+      ]
+    },
+    "public.mail_template_action": {
+      "name": "mail_template_action",
+      "schema": "public",
+      "values": [
+        "save",
+        "reset"
+      ]
+    },
+    "public.mail_log_source": {
+      "name": "mail_log_source",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "posta_uncollected",
+        "order_reminder",
+        "supplier_order",
+        "order_merge"
+      ]
+    },
+    "public.mail_log_status": {
+      "name": "mail_log_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.mail_log_trigger": {
+      "name": "mail_log_trigger",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "manual"
+      ]
+    },
+    "public.supplier_availability": {
+      "name": "supplier_availability",
+      "schema": "public",
+      "values": [
+        "available",
+        "unavailable",
+        "unknown"
+      ]
+    },
+    "public.supplier_stock_source": {
+      "name": "supplier_stock_source",
+      "schema": "public",
+      "values": [
+        "json_ld",
+        "meta",
+        "text",
+        "size_list",
+        "none"
+      ]
+    },
+    "public.upozornenie_source": {
+      "name": "upozornenie_source",
+      "schema": "public",
+      "values": [
+        "vlastne",
+        "appka"
+      ]
+    },
+    "public.upozornenie_type": {
+      "name": "upozornenie_type",
+      "schema": "public",
+      "values": [
+        "vlastna_poznamka",
+        "nevyzdvihnuta_zasielka",
+        "vratenie",
+        "vratena_zasielka",
+        "objednavka_visi"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -295,6 +295,13 @@
       "when": 1786084381095,
       "tag": "0041_tiny_puma",
       "breakpoints": true
+    },
+    {
+      "idx": 42,
+      "version": "7",
+      "when": 1786090097268,
+      "tag": "0042_easy_morg",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema-upozornenia.ts
+++ b/apps/api/src/db/schema-upozornenia.ts
@@ -12,17 +12,22 @@ import { users } from "./schema-users.js";
 // stavu) a `vratena_zasielka` (tretí automatický zdroj, #299: TEN ISTÝ denný
 // beh ako `nevyzdvihnuta_zasielka`, ale iný VÝZNAM — zásielka, ktorú Pošta SK
 // hlási ako vrátenú ODOSIELATEĽOVI, nikdy nezamieňať s `vratenie`, ktorá
-// sleduje vrátenie TOVARU zákazníkom cez stav objednávky). Ďalší budúci
-// automatický zdroj pridá SVOJU hodnotu vlastnou migráciou (`ALTER TYPE ...
-// ADD VALUE`, rovnaký vzor ako `nedostupneEmailType`/`.claude/rules/
-// testing.md`'s "Nová pgEnum hodnota" past). `source` je NEZÁVISLÝ, navždy
-// 2-hodnotový enum — určuje UI schopnosť (len `vlastne` karty majú
-// Upraviť/Zmazať), `type` je len farebný štítok.
+// sleduje vrátenie TOVARU zákazníkom cez stav objednávky) a `objednavka_visi`
+// (štvrtý automatický zdroj, #301: TEN ISTÝ denný beh ako `vratenie` —
+// import objednávok, `orders/ingest.ts` — ale iný VÝZNAM: objednávka, ktorá
+// dlho visí v NEVYBAVENOM stave, nezávisle od toho, či je/nie je vo
+// vrátkovom stave). Ďalší budúci automatický zdroj pridá SVOJU hodnotu
+// vlastnou migráciou (`ALTER TYPE ... ADD VALUE`, rovnaký vzor ako
+// `nedostupneEmailType`/`.claude/rules/testing.md`'s "Nová pgEnum hodnota"
+// past). `source` je NEZÁVISLÝ, navždy 2-hodnotový enum — určuje UI
+// schopnosť (len `vlastne` karty majú Upraviť/Zmazať), `type` je len farebný
+// štítok.
 export const upozornenieType = pgEnum("upozornenie_type", [
   "vlastna_poznamka",
   "nevyzdvihnuta_zasielka",
   "vratenie",
   "vratena_zasielka",
+  "objednavka_visi",
 ]);
 export const upozornenieSource = pgEnum("upozornenie_source", ["vlastne", "appka"]);
 

--- a/apps/api/src/modules/orders/ingest.ts
+++ b/apps/api/src/modules/orders/ingest.ts
@@ -18,6 +18,7 @@ import {
   type OrderRowIssue,
 } from "./parser.js";
 import { applyReturnUpozornenia } from "./return-upozornenia.js";
+import { applyStuckUpozornenia } from "./stuck-upozornenia.js";
 
 // Zámok je JEDEN pevný kľúč, NIE odvodený z obsahu — rovnaký dôvod ako
 // katalógov `INGEST_ADVISORY_LOCK_KEY` (`catalog/ingest.ts`): serializuje
@@ -498,6 +499,17 @@ export async function ingestOrders(db: Database, options: OrdersIngestOptions): 
         batchSize: ORDERS_INGEST_BATCH_SIZE,
       });
 
+      // issue 301: štvrtý automatický zdroj pre Upozornenia — objednávka, čo
+      // dlho visí v nevybavenom stave (`stuck-upozornenia.ts`'s vlastné
+      // komentáre nesú plné odôvodnenie).
+      const { stuckOrderCount, autoResolvedStuckOrderCount } = await applyStuckUpozornenia({
+        tx,
+        orderInfo,
+        orderIdsByCode,
+        adminBaseUrl,
+        now: options.now,
+      });
+
       log.info(
         {
           orderCount: orderInfo.size,
@@ -507,6 +519,8 @@ export async function ingestOrders(db: Database, options: OrdersIngestOptions): 
           issueCount: issues.length,
           skippedResolvedReturnCount,
           autoResolvedFinishedReturnCount,
+          stuckOrderCount,
+          autoResolvedStuckOrderCount,
         },
         "objednávky naimportované",
       );

--- a/apps/api/src/modules/orders/stuck-status.test.ts
+++ b/apps/api/src/modules/orders/stuck-status.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { ORDER_STUCK_THRESHOLD_DAYS, daysStuck, isUnfinishedOrderStatus, stuckOrderUpozornenieDedupKey } from "./stuck-status.js";
+
+// issue 301: tretie automatické Upozornenie — objednávka, ktorá dlho visí v
+// NEVYBAVENOM stave. Naživo overené stavy (7. 8. 2026): "Vybavuje sa" (31
+// objednávok), "Nevybavená" (3 objednávky) — presne tieto dva, žiadny ďalší.
+describe("isUnfinishedOrderStatus", () => {
+  it("rozpozná oba naživo overené nevybavené stavy", () => {
+    expect(isUnfinishedOrderStatus("Vybavuje sa")).toBe(true);
+    expect(isUnfinishedOrderStatus("Nevybavená")).toBe(true);
+  });
+
+  it("hotové/iné stavy vrátia false", () => {
+    expect(isUnfinishedOrderStatus("Vybavená")).toBe(false);
+    expect(isUnfinishedOrderStatus("Kompletná")).toBe(false);
+    expect(isUnfinishedOrderStatus("Zabalená")).toBe(false);
+    expect(isUnfinishedOrderStatus("Stornovaná")).toBe(false);
+    expect(isUnfinishedOrderStatus("")).toBe(false);
+  });
+
+  it("normalizuje (NFC + orez) rovnako ako `order.status_name`, nikdy bajtovo presnú zhodu", () => {
+    expect(isUnfinishedOrderStatus("  Vybavuje sa  ")).toBe(true);
+    expect(isUnfinishedOrderStatus("Nevybavená".normalize("NFD"))).toBe(true);
+  });
+});
+
+describe("daysStuck", () => {
+  it("počíta celé dni medzi placedAt a now", () => {
+    expect(daysStuck(new Date("2026-04-30T10:00:00Z"), new Date("2026-08-07T10:00:00Z"))).toBe(99);
+  });
+
+  it("nikdy nevráti záporné číslo (budúci placedAt sa berie ako 0)", () => {
+    expect(daysStuck(new Date("2026-08-10T10:00:00Z"), new Date("2026-08-07T10:00:00Z"))).toBe(0);
+  });
+});
+
+describe("ORDER_STUCK_THRESHOLD_DAYS", () => {
+  it("je pomenovaná konštanta, nie natvrdo napísané číslo na mieste použitia", () => {
+    expect(ORDER_STUCK_THRESHOLD_DAYS).toBe(14);
+  });
+});
+
+describe("stuckOrderUpozornenieDedupKey", () => {
+  it("je stabilný na objednávku, vo VLASTNOM menom priestore (nekoliduje s posta:/posta-vratena:/vratenie:)", () => {
+    expect(stuckOrderUpozornenieDedupKey("20260805")).toBe("objednavka-visi:20260805");
+  });
+});

--- a/apps/api/src/modules/orders/stuck-status.ts
+++ b/apps/api/src/modules/orders/stuck-status.ts
@@ -1,0 +1,60 @@
+import { normalizeStatusName } from "./parser.js";
+
+// issue 301: tretie automatické Upozornenie — objednávka, ktorá dlho visí v
+// NEVYBAVENOM stave (šéf: "objednávky, ktoré je potrebné riešiť"). Naživo
+// overené na produkcii (7. 8. 2026): 31 objednávok v stave "Vybavuje sa"
+// (najstaršia od 30. 4. 2026), 3 v stave "Nevybavená" (najstaršia od
+// 7. 5. 2026) — presne TIETO dva stavy, žiadny ďalší (rozšírenie zoznamu
+// vyžaduje ROVNAKÉ živé overenie proti produkčnej DB ako `return-status.ts`,
+// nikdy odhad).
+//
+// ZÁMERNE NEZDIEĽANÉ s `open-statuses.ts`'s admin-nastaviteľným
+// `order_open_status` zoznamom (ten rozhoduje, čo appka ukáže na "Na
+// objednanie" a šéf ho sám edituje) — "visí príliš dlho" je NEZÁVISLÝ,
+// fixný pojem: aj keby šéf zajtra pridal/odobral stav zo zoznamu "Na
+// objednanie", toto upozornenie musí zostať naviazané na tie ISTÉ dva stavy,
+// ktoré naživo videl v dátach. Rovnaký princíp ako `return-status.ts`'s
+// vlastný nezávislý zoznam vrátkových stavov.
+const UNFINISHED_ORDER_STATUS_NAMES: ReadonlySet<string> = new Set([
+  normalizeStatusName("Vybavuje sa"),
+  normalizeStatusName("Nevybavená"),
+]);
+
+// Prečo 14 dní: appka už má KRATŠÍ vekový prah pre PRÍBUZNÚ, ale INÚ vec —
+// `order-reminder/constants.ts`'s `MIN_DAYS = 4` rozhoduje, kedy pripomenúť
+// ZÁKAZNÍKOVI jeho vlastnú objednávku (rýchla, zákaznícky orientovaná
+// akcia). Toto upozornenie je opačné — má upozorniť ŠÉFA, že objednávka sa v
+// appke/dodávateľskom procese niekde zasekla, nie že zákazník ešte čaká pár
+// dní na bežné vybavenie. Bežné dodávateľské vybavenie (objednanie u
+// dodávateľa, doručenie, zabalenie) trvá v tomto obchode rutinne dni až
+// nižšie jednotky týždňov — 14 dní (dva týždne) dáva tomuto bežnému postupu
+// priestor bez toho, aby appka spamovala kartami za KAŽDÚ objednávku, čo je
+// len pár dní stará, a zároveň chytí objednávky, čo naozaj "zabudnuté visia"
+// (naživo overené najstaršie prípady sú v desiatkach dní, nie v jednotkách).
+// Prvá verzia — šéf ho podľa ticketu doladí po tom, čo kartu uvidí naživo.
+export const ORDER_STUCK_THRESHOLD_DAYS = 14;
+
+/** `true`, keď je stav objednávky jeden z NEVYBAVENÝCH stavov, za ktoré
+ * appka počíta dni "visenia" (`daysStuck` nižšie). Normalizované rovnakou
+ * funkciou, akou appka ukladá `order.status_name` (`parser.ts`), presne ako
+ * `return-status.ts`. */
+export function isUnfinishedOrderStatus(statusName: string): boolean {
+  return UNFINISHED_ORDER_STATUS_NAMES.has(normalizeStatusName(statusName));
+}
+
+/** Celé dni od `placedAt` po `now` — nikdy záporné (rovnaký zámer ako
+ * `order-reminder/logic.ts`'s `daysOpen`; zámerne DUPLIKOVANÁ jednoriadková
+ * formula namiesto importu odtiaľ — import by vytvoril závislosť "orders"
+ * modulu na satelitnom `order-reminder` module, opačný smer než architektúra
+ * tohto repa, `.claude/rules/mvp-philosophy.md`). */
+export function daysStuck(placedAt: Date, now: Date): number {
+  return Math.max(0, Math.floor((now.getTime() - placedAt.getTime()) / 86_400_000));
+}
+
+/** Stabilný dedup kľúč NA OBJEDNÁVKU — samostatný menný priestor od
+ * `posta:`/`posta-vratena:`/`vratenie:` (`.claude/rules/upozornenia.md`), aby
+ * TÁ ISTÁ objednávka mohla mať súčasne otvorenú kartu "visí" AJ kartu
+ * "vrátenie" bez kolízie na čiastočnom unique indexe. */
+export function stuckOrderUpozornenieDedupKey(externalOrderId: string): string {
+  return `objednavka-visi:${externalOrderId}`;
+}

--- a/apps/api/src/modules/orders/stuck-upozornenia.ts
+++ b/apps/api/src/modules/orders/stuck-upozornenia.ts
@@ -1,0 +1,81 @@
+import { and, eq, isNull } from "drizzle-orm";
+import { upozornenie } from "../../db/schema.js";
+import { buildShoptetAdminOrderUrl } from "./queries.js";
+import { daysStuck, isUnfinishedOrderStatus, ORDER_STUCK_THRESHOLD_DAYS, stuckOrderUpozornenieDedupKey } from "./stuck-status.js";
+import { autoResolveByDedupKey, upsertUpozornenie, type UpozornenieExecutor } from "../upozornenia/service.js";
+
+// issue 301: štvrtý automatický zdroj pre nástenku Upozornenia (#267) —
+// objednávka, ktorá dlho visí v NEVYBAVENOM stave (`stuck-status.ts`), dostane/
+// obnoví kartu; objednávka, ktorá sa medzičasom posunula do VYBAVENÉHO stavu,
+// existujúcu otvorenú kartu AUTOMATICKY ZATVORÍ (rovnaký princíp ako #268's
+// doručená zásielka a #297's HOTOVÝ vrátkový stav). `dedupKey` je NA
+// OBJEDNÁVKU (`objednavka-visi:<externalOrderId>`) — vlastný menný priestor,
+// aby súčasne mohla existovať aj NEZÁVISLÁ karta "vratenie" pre tú istú
+// objednávku bez kolízie na čiastočnom unique indexe.
+//
+// Na rozdiel od `return-upozornenia.ts`'s `vratenie` (KONEČNÁ kategória —
+// vybavené sa NIKDY znova neohlási) je "visí" kategória ZNOVA-OHLÁSITEĽNÁ,
+// rovnaká rodina ako #268's zásielka: ak sa objednávka niekedy vráti späť do
+// nevybaveného stavu a znova visí dosť dlho, má dostať NOVÉ upozornenie —
+// preto tu NIE JE potrebný žiadny `.for("update")` "je už KONEČNE vybavené"
+// pre-check, len jednoduchý upsert/auto-resolve pár (`.claude/rules/
+// upozornenia.md`'s poučenie "rozhodni sa VOPRED, do ktorej z dvoch
+// kategórií patrí").
+//
+// Vyčlenené do VLASTNÉHO súboru presne z rovnakého dôvodu ako
+// `return-upozornenia.ts` (eslint `max-lines: 400`, `.claude/rules/
+// testing.md`) — volá sa TESNE PRED commitom tej istej transakcie, spolu s
+// `applyReturnUpozornenia`.
+export interface ApplyStuckUpozorneniaOptions {
+  readonly tx: UpozornenieExecutor;
+  readonly orderInfo: ReadonlyMap<string, { readonly customerName: string; readonly statusName: string; readonly placedAt: Date }>;
+  readonly orderIdsByCode: ReadonlyMap<string, number>;
+  readonly adminBaseUrl: string;
+  readonly now: Date;
+}
+
+export interface ApplyStuckUpozorneniaResult {
+  readonly stuckOrderCount: number;
+  readonly autoResolvedStuckOrderCount: number;
+}
+
+export async function applyStuckUpozornenia(options: ApplyStuckUpozorneniaOptions): Promise<ApplyStuckUpozorneniaResult> {
+  const { tx, orderInfo, orderIdsByCode, adminBaseUrl, now } = options;
+
+  // Dávkovo prečítané VOPRED (rovnaká disciplína ako `return-upozornenia.ts`'s
+  // pre-check nižšie v tom istom module, len iný dôvod): väčšina objednávok
+  // v okne NIKDY nedostala kartu "visí" (len tie, čo naozaj prekročili prah),
+  // takže auto-resolve by inak musel bežať ako no-op UPDATE pre KAŽDÚ
+  // objednávku v 90-dňovom okne, nie len pre tie, čo majú čo zatvárať. Jeden
+  // dopyt namiesto stoviek zbytočných dotazov.
+  const openRows = await tx
+    .select({ dedupKey: upozornenie.dedupKey })
+    .from(upozornenie)
+    .where(and(eq(upozornenie.type, "objednavka_visi"), isNull(upozornenie.resolvedAt)));
+  const openDedupKeys = new Set(openRows.map((r) => r.dedupKey).filter((k): k is string => k !== null));
+
+  let stuckOrderCount = 0;
+  let autoResolvedStuckOrderCount = 0;
+  for (const [externalOrderId, info] of orderInfo) {
+    const dedupKey = stuckOrderUpozornenieDedupKey(externalOrderId);
+    if (isUnfinishedOrderStatus(info.statusName)) {
+      const days = daysStuck(info.placedAt, now);
+      if (days < ORDER_STUCK_THRESHOLD_DAYS) continue;
+      await upsertUpozornenie(tx, {
+        type: "objednavka_visi",
+        source: "appka",
+        title: `Objednávka ${externalOrderId} visí ${String(days)} dní v stave „${info.statusName}“`,
+        details: `Zákazník: ${info.customerName}`,
+        link: buildShoptetAdminOrderUrl(adminBaseUrl, externalOrderId, orderIdsByCode.get(externalOrderId) ?? null),
+        dedupKey,
+        now,
+      });
+      stuckOrderCount += 1;
+      continue;
+    }
+    if (!openDedupKeys.has(dedupKey)) continue;
+    if (await autoResolveByDedupKey(tx, dedupKey, now)) autoResolvedStuckOrderCount += 1;
+  }
+
+  return { stuckOrderCount, autoResolvedStuckOrderCount };
+}

--- a/apps/api/tests/orders-ingest-stuck-upozornenie.integration.test.ts
+++ b/apps/api/tests/orders-ingest-stuck-upozornenie.integration.test.ts
@@ -1,0 +1,180 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { eq } from "drizzle-orm";
+import { afterEach, expect, it } from "vitest";
+import { upozornenie } from "../src/db/schema.js";
+import { ingestOrders, type OrdersExportFetcher } from "../src/modules/orders/ingest.js";
+import { withCleanDb } from "./helpers/db.js";
+import { insertTestVariant } from "./helpers/orders.js";
+import { buildReturnStatusCsv, RETURN_STATUS_CSV_HEADER } from "./helpers/orders-return-csv.js";
+
+// issue 301: import objednávok vyrobí/obnoví/zatvorí kartu na Upozorneniach
+// (#267), keď objednávka dlho visí v nevybavenom stave ("Vybavuje sa"/
+// "Nevybavená") — vydelené do VLASTNÉHO súboru (rovnaký dôvod ako
+// `orders-ingest-return-upozornenie.integration.test.ts`, `.claude/rules/
+// testing.md`'s eslint `max-lines: 400`).
+const WINDOW_START = new Date("2020-01-01T00:00:00Z");
+const WINDOW_END = new Date("2030-01-01T00:00:00Z");
+// Zhoduje sa s ticketom citovaným "dnes" (7. 8. 2026) — najstaršie naživo
+// overené "visiace" objednávky boli od 30. 4./7. 5. 2026.
+const NOW = new Date("2026-08-07T10:00:00Z");
+
+let close: (() => Promise<void>) | undefined;
+let rawDir: string | undefined;
+
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  if (rawDir !== undefined) await rm(rawDir, { recursive: true, force: true });
+  rawDir = undefined;
+});
+
+async function boot(): Promise<{ db: Awaited<ReturnType<typeof withCleanDb>>["db"]; dir: string }> {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  rawDir = await mkdtemp(join(tmpdir(), "forestshop-orders-stuck-raw-"));
+  return { db: ctx.db, dir: rawDir };
+}
+
+function fetcherOf(body: Buffer): OrdersExportFetcher {
+  return () => Promise.resolve({ body, sourceLabel: "fixtúra" });
+}
+
+const HEADER = RETURN_STATUS_CSV_HEADER;
+const buildCsv = buildReturnStatusCsv;
+
+// `date` je Europe/Bratislava LOKÁLNY čas (`.claude/rules/orders.md`'s
+// `parseShopLocalDateTime`) — testy tu zámerne držia hrubú rezervu (dni, nie
+// hodiny) okolo 14-dňového prahu, aby letný UTC+2 posun nikdy nerozhodol o
+// výsledku.
+function rowOf(code: string, statusName: string, date: string, billFullName = "Ján Novák"): Record<string, string> {
+  return { code, date, statusName, billFullName, itemName: "Nohavice", itemAmount: "1", itemCode: "40237/XL" };
+}
+
+it("objednávka NEVYBAVENÁ len pár dní (pod prahom) NEVYROBÍ kartu 'visí'", async () => {
+  const { db, dir } = await boot();
+  await insertTestVariant(db, "40237/XL");
+
+  await ingestOrders(db, {
+    fetchExport: fetcherOf(buildCsv(HEADER, [rowOf("20700001", "Vybavuje sa", "2026-08-01 10:00:00")])),
+    now: NOW,
+    rawDir: dir,
+    windowStart: WINDOW_START,
+    windowEnd: WINDOW_END,
+  });
+
+  const rows = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "objednavka-visi:20700001"));
+  expect(rows).toHaveLength(0);
+});
+
+it("objednávka NEVYBAVENÁ dlhšie než prah vyrobí kartu s číslom, dňami a odkazom do Shoptetu", async () => {
+  const { db, dir } = await boot();
+  await insertTestVariant(db, "40237/XL");
+
+  const result = await ingestOrders(db, {
+    fetchExport: fetcherOf(buildCsv(HEADER, [rowOf("20700002", "Vybavuje sa", "2026-07-18 10:00:00")])),
+    now: NOW,
+    rawDir: dir,
+    windowStart: WINDOW_START,
+    windowEnd: WINDOW_END,
+    adminBaseUrl: "https://www.forestshop.sk",
+  });
+  expect(result.status).toBe("accepted");
+
+  const rows = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "objednavka-visi:20700002"));
+  expect(rows).toHaveLength(1);
+  expect(rows[0]?.type).toBe("objednavka_visi");
+  expect(rows[0]?.source).toBe("appka");
+  expect(rows[0]?.title).toContain("20700002");
+  expect(rows[0]?.title).toContain("20 dní");
+  expect(rows[0]?.link).toContain("20700002");
+  expect(rows[0]?.resolvedAt).toBeNull();
+});
+
+it("Nevybavená (druhý naživo overený nevybavený stav) tiež vyrobí kartu po prekročení prahu", async () => {
+  const { db, dir } = await boot();
+  await insertTestVariant(db, "40237/XL");
+
+  await ingestOrders(db, {
+    fetchExport: fetcherOf(buildCsv(HEADER, [rowOf("20700003", "Nevybavená", "2026-07-10 10:00:00")])),
+    now: NOW,
+    rawDir: dir,
+    windowStart: WINDOW_START,
+    windowEnd: WINDOW_END,
+  });
+
+  const rows = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "objednavka-visi:20700003"));
+  expect(rows).toHaveLength(1);
+  expect(rows[0]?.title).toContain("Nevybavená");
+});
+
+it("opakovaný import tej istej stuck objednávky NEVYROBÍ druhú kartu, len obnoví počet dní", async () => {
+  const { db, dir } = await boot();
+  await insertTestVariant(db, "40237/XL");
+  const csv = buildCsv(HEADER, [rowOf("20700004", "Vybavuje sa", "2026-07-18 10:00:00")]);
+
+  await ingestOrders(db, { fetchExport: fetcherOf(csv), now: NOW, rawDir: dir, windowStart: WINDOW_START, windowEnd: WINDOW_END });
+  const before = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "objednavka-visi:20700004"));
+  expect(before).toHaveLength(1);
+  const cardId = before[0]?.id;
+
+  await ingestOrders(db, {
+    fetchExport: fetcherOf(csv),
+    now: new Date("2026-08-08T10:00:00Z"),
+    rawDir: dir,
+    windowStart: WINDOW_START,
+    windowEnd: WINDOW_END,
+  });
+
+  const after = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "objednavka-visi:20700004"));
+  expect(after).toHaveLength(1);
+  expect(after[0]?.id).toBe(cardId); // TÁ istá karta, žiadna druhá
+  expect(after[0]?.title).toContain("21 dní"); // deň sa posunul, obnovené
+});
+
+it("prechod z nevybaveného do vybaveného stavu AUTOMATICKY ZATVORÍ existujúcu kartu", async () => {
+  const { db, dir } = await boot();
+  await insertTestVariant(db, "40237/XL");
+
+  await ingestOrders(db, {
+    fetchExport: fetcherOf(buildCsv(HEADER, [rowOf("20700005", "Vybavuje sa", "2026-07-18 10:00:00")])),
+    now: NOW,
+    rawDir: dir,
+    windowStart: WINDOW_START,
+    windowEnd: WINDOW_END,
+  });
+  const before = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "objednavka-visi:20700005"));
+  expect(before).toHaveLength(1);
+  expect(before[0]?.resolvedAt).toBeNull();
+
+  await ingestOrders(db, {
+    fetchExport: fetcherOf(buildCsv(HEADER, [rowOf("20700005", "Vybavená", "2026-07-18 10:00:00")])),
+    now: new Date("2026-08-08T10:00:00Z"),
+    rawDir: dir,
+    windowStart: WINDOW_START,
+    windowEnd: WINDOW_END,
+  });
+
+  const after = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "objednavka-visi:20700005"));
+  expect(after).toHaveLength(1); // stále jedna karta, žiadna nová
+  expect(after[0]?.id).toBe(before[0]?.id);
+  expect(after[0]?.resolvedAt).not.toBeNull(); // AUTOMATICKY zatvorená
+  expect(after[0]?.resolvedByUserId).toBeNull(); // "vybavené systémom", nie ručne
+});
+
+it("objednávka, ktorej PRVÝ import je už vybavený stav, NEVYROBÍ žiadnu kartu", async () => {
+  const { db, dir } = await boot();
+  await insertTestVariant(db, "40237/XL");
+
+  await ingestOrders(db, {
+    fetchExport: fetcherOf(buildCsv(HEADER, [rowOf("20700006", "Vybavená", "2026-07-01 10:00:00")])),
+    now: NOW,
+    rawDir: dir,
+    windowStart: WINDOW_START,
+    windowEnd: WINDOW_END,
+  });
+
+  const rows = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "objednavka-visi:20700006"));
+  expect(rows).toHaveLength(0);
+});

--- a/apps/web/src/components/UpozorneniaResolvedList.tsx
+++ b/apps/web/src/components/UpozorneniaResolvedList.tsx
@@ -16,6 +16,8 @@ const TYPE_LABELS: Readonly<Record<ResolvedUpozornenieRow["type"], string>> = {
   // issue 299: zásielka vrátená ODOSIELATEĽOVI (Pošta SK) — nezamieňať s
   // `vratenie` vyššie (vrátený TOVAR, stav objednávky).
   vratena_zasielka: "Vrátená zásielka",
+  // issue 301: objednávka dlho visiaca v nevybavenom stave.
+  objednavka_visi: "Objednávka visí",
 };
 
 export function UpozorneniaResolvedList({

--- a/apps/web/src/components/UpozorneniaSection.test.tsx
+++ b/apps/web/src/components/UpozorneniaSection.test.tsx
@@ -91,6 +91,25 @@ const VRATENA_ZASIELKA_KARTA = {
   status: "otvorene" as const,
 };
 
+// issue 301: štvrtý automatický zdroj — objednávka, ktorá dlho visí v
+// nevybavenom stave. Preklik ide na TEN ISTÝ Shoptet-admin odkaz ako
+// `VRATENIE_KARTA` (obe sú "otvoriť objednávku v administrácii"), preto
+// zdieľa jej `LINK_LABELS` štítok.
+const OBJEDNAVKA_VISI_KARTA = {
+  id: "visi-1",
+  type: "objednavka_visi" as const,
+  source: "appka" as const,
+  title: "Objednávka 20700002 visí 20 dní v stave „Vybavuje sa“",
+  details: "Zákazník: Ján Novák",
+  link: "https://www.forestshop.sk/admin/vyhladavanie/?string=20700002&src=orders",
+  dueAt: null,
+  postponedUntil: null,
+  seenAt: "2026-08-07T08:00:00.000Z",
+  resolvedAt: null,
+  createdAt: "2026-08-07T08:00:00.000Z",
+  status: "otvorene" as const,
+};
+
 afterEach(() => {
   cleanup();
   vi.resetAllMocks();
@@ -135,6 +154,18 @@ it("issue 299: karta 'Vrátená zásielka' zobrazí vlastný typový štítok a 
   expect(link.getAttribute("href")).toBe(VRATENA_ZASIELKA_KARTA.link);
   expect(link.getAttribute("target")).toBe("_blank");
   expect(link.getAttribute("rel")).toBe("noreferrer");
+});
+
+it("issue 301: karta 'Objednávka visí' zobrazí vlastný typový štítok a odkaz do Shoptet administrácie", async () => {
+  markUpozorneniaSeen.mockResolvedValue(undefined);
+  fetchUpozornenia.mockResolvedValue([OBJEDNAVKA_VISI_KARTA]);
+  render(<UpozorneniaSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("upozornenie-visi-1");
+
+  expect(screen.getByTestId("upozornenie-type-visi-1").textContent).toBe("Objednávka visí");
+  const link = screen.getByTestId<HTMLAnchorElement>("upozornenie-link-visi-1");
+  expect(link.textContent).toBe("Otvoriť objednávku v Shoptete");
+  expect(link.getAttribute("href")).toBe(OBJEDNAVKA_VISI_KARTA.link);
 });
 
 it("prázdny zoznam zobrazí informačnú vetu (po označení videných)", async () => {

--- a/apps/web/src/components/UpozornenieCard.tsx
+++ b/apps/web/src/components/UpozornenieCard.tsx
@@ -20,6 +20,8 @@ const TYPE_LABELS: Readonly<Record<UpozornenieRow["type"], string>> = {
   // issue 299: zásielka vrátená ODOSIELATEĽOVI (Pošta SK) — nezamieňať s
   // `vratenie` vyššie (vrátený TOVAR, stav objednávky).
   vratena_zasielka: "Vrátená zásielka",
+  // issue 301: objednávka dlho visiaca v nevybavenom stave.
+  objednavka_visi: "Objednávka visí",
 };
 
 // Code review (issue 269, druhé kolo, finding 10): štítok odkazu sa odvodzuje
@@ -38,6 +40,10 @@ const LINK_LABELS: Readonly<Partial<Record<UpozornenieRow["type"], string>>> = {
   // issue 299: rovnaký `trackingLink` helper ako `nevyzdvihnuta_zasielka`
   // (obe sú Pošta SK zásielkové odkazy), preto rovnaký štítok.
   vratena_zasielka: "Sledovať zásielku na Pošte",
+  // issue 301: rovnaký `buildShoptetAdminOrderUrl` odkaz ako `vratenie`
+  // vyššie (obe sú "otvoriť objednávku v administrácii"), preto rovnaký
+  // štítok.
+  objednavka_visi: "Otvoriť objednávku v Shoptete",
 };
 const DEFAULT_LINK_LABEL = "Otvoriť odkaz";
 

--- a/apps/web/src/nav.test.ts
+++ b/apps/web/src/nav.test.ts
@@ -44,11 +44,13 @@ it("NAV má tri priečinky (Eshop/Systém/Automatizácie), s 6/3/4 záložkami v
   ]);
 });
 
-// issue 287: DEFAULT_TAB_ID sa už NEODVODZUJE od NAV[0] (to je teraz "eshop")
-// — zámerne pevne "sync", aby sa poradie priečinkov v menu nedotklo
-// predvolenej obrazovky po prihlásení (nezadané, mimo rozsahu ticketu).
-it("DEFAULT_TAB_ID je pevne 'sync' — nezávisí od poradia priečinkov v NAV", () => {
-  expect(DEFAULT_TAB_ID).toBe("sync");
+// issue 287: DEFAULT_TAB_ID sa NEODVODZUJE od NAV[0] (to je "eshop", priečinok,
+// nie záložka) — je to PEVNÝ literál, nezávislý od poradia priečinkov v NAV.
+// issue 302 (šéf, cez Discord): "keď štartnem appku, nešlo by to na Na
+// objednanie namiesto Sync zo Shoptetu?" — literál sa zmenil zo "sync" na
+// "orders", priame odkazy na ostatné obrazovky (`?tab=<id>`) sa nedotkli.
+it("DEFAULT_TAB_ID je pevne 'orders' — nezávisí od poradia priečinkov v NAV", () => {
+  expect(DEFAULT_TAB_ID).toBe("orders");
 });
 
 it("findTab nájde viditeľnú aj skrytú záložku podľa id, neznáme id vráti undefined", () => {

--- a/apps/web/src/nav.ts
+++ b/apps/web/src/nav.ts
@@ -146,13 +146,19 @@ export const HIDDEN_TABS: Readonly<Record<string, NavTab>> = {
   scheduler: { id: "scheduler", label: "Plánovač", icon: "🗓️", Component: SchedulerSection },
 };
 
-// issue 287: priečinky v `NAV` sa preusporiadali (Eshop je teraz prvý), ale
-// predvolená obrazovka PO PRIHLÁSENÍ sa zámerne NEMENÍ — zadanie žiadalo len
-// vizuálne poradie priečinkov v menu, nie zmenu landing obrazovky. Preto sa
-// `DEFAULT_TAB_ID` už neodvodzuje od `NAV[0]` (to by ticho prepnutím
-// priečinkov zmenilo predvolenú obrazovku na "Na objednanie"), ale pevne
-// ukazuje na "sync" — presne rovnaké správanie ako pred touto zmenou.
-export const DEFAULT_TAB_ID: string = "sync";
+// issue 287: `DEFAULT_TAB_ID` sa NEODVODZUJE od `NAV[0]` (to je priečinok
+// "eshop", nie záložka) — je to pevný literál, nezávislý od poradia
+// priečinkov v menu, aby prípadné budúce preusporiadanie `NAV` nikdy ticho
+// nezmenilo landing obrazovku.
+//
+// issue 302 (šéf, cez Discord, 7. 8. 2026): "keď štartnem appku — nešlo by
+// to do tejto obrazovky (Sync zo Shoptetu) — ale to na objednanie?" — po
+// prihlásení appka predtým otvárala "Sync zo Shoptetu", šéf s ňou reálne
+// nepracuje. Literál sa preto zmenil zo "sync" na "orders" — priame odkazy
+// na OSTATNÉ obrazovky (`?tab=<id>`, vrátane `HIDDEN_TABS`) sa touto zmenou
+// vôbec nedotknú, mení sa len to, kam appka ide, keď žiadna obrazovka nie
+// je v URL určená (`App.tsx`'s `initialTabId`).
+export const DEFAULT_TAB_ID: string = "orders";
 
 /** Nájde záložku podľa id — najprv medzi viditeľnými (NAV), potom v skrytých. */
 export function findTab(id: string): NavTab | undefined {

--- a/apps/web/src/upozorneniaApi.ts
+++ b/apps/web/src/upozorneniaApi.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 
 const rowSchema = z.object({
   id: z.string(),
-  type: z.enum(["vlastna_poznamka", "nevyzdvihnuta_zasielka", "vratenie", "vratena_zasielka"]),
+  type: z.enum(["vlastna_poznamka", "nevyzdvihnuta_zasielka", "vratenie", "vratena_zasielka", "objednavka_visi"]),
   source: z.enum(["vlastne", "appka"]),
   title: z.string(),
   details: z.string(),

--- a/apps/web/tests/e2e/login.spec.ts
+++ b/apps/web/tests/e2e/login.spec.ts
@@ -105,11 +105,13 @@ test("zmena hesla: zlé staré heslo/nezhoda odmietnuté, úspešná zmena zruš
   await page.getByLabel("Nové heslo", { exact: true }).fill(NOVE_HESLO);
   await page.getByLabel("Nové heslo znova").fill(NOVE_HESLO);
   await page.getByRole("button", { name: "Zmeniť heslo" }).click();
-  // #115: bare `getByRole("alert")` je odteraz nejednoznačný — na predvolenej
-  // obrazovke "Sync zo Shoptetu" pod týmto panelom svieti aj `role="alert"`
-  // staleness upozornenie (`sync-stale-Katalóg`). Rovnaký vzor ako
-  // `.claude/rules/testing.md`'s existujúca kolízna poznámka pri
-  // `getByLabel`u: oprava na strane KOLÍDUJÚCEHO (existujúceho) locatora
+  // #115: bare `getByRole("alert")` bol na tomto mieste nejednoznačný, kým
+  // bola predvolená obrazovka "Sync zo Shoptetu" (pod týmto panelom vtedy
+  // svietil aj `role="alert"` staleness upozornenie, `sync-stale-Katalóg`).
+  // Issue 302 zmenilo predvolenú obrazovku na "Na objednanie" — filter tu
+  // ostáva zámerne (robustné bez ohľadu na to, čo je práve predvolené),
+  // rovnaký vzor ako `.claude/rules/testing.md`'s existujúca kolízna
+  // poznámka pri `getByLabel`u: oprava na strane KOLÍDUJÚCEHO locatora
   // (`.filter({ hasText })`), nie odobratím `role="alert"` novému prvku.
   await expect(page.getByRole("alert").filter({ hasText: "Nesprávne staré heslo" })).toHaveText(
     "Nesprávne staré heslo",

--- a/apps/web/tests/e2e/mobile-responsive.spec.ts
+++ b/apps/web/tests/e2e/mobile-responsive.spec.ts
@@ -14,6 +14,13 @@ const E2E_MOBIL_EMAIL = "e2e-mobil@forestshop.sk";
 // celej stránky. Akceptačný prípad z tiketu: "Sync zo Shoptetu" mala pri
 // 375px okne `document.documentElement.scrollWidth` 4085px — jej história
 // behov nemala vlastný posuvný obal.
+//
+// issue 302: predvolená obrazovka po prihlásení sa zmenila zo "Sync zo
+// Shoptetu" na "Na objednanie" (`nav.ts`'s `DEFAULT_TAB_ID`) — test teraz
+// najprv overí PREDVOLENÚ obrazovku ("Na objednanie", aj tak najhustejšiu
+// tabuľku v appke), potom klikne na "Sync zo Shoptetu" a overí AJ tú, presne
+// v opačnom poradí ako predtým. Obe obrazovky ostávajú overené, len sa
+// zmenilo, ktorá je predvolená.
 test("na telefónnej šírke (375px) sa stránka nikdy neposúva vodorovne, panel sa zbalí sám, konzola je čistá", async ({
   page,
 }) => {
@@ -31,9 +38,10 @@ test("na telefónnej šírke (375px) sa stránka nikdy neposúva vodorovne, pane
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
-  // Predvolená obrazovka po prihlásení je "Sync zo Shoptetu" — presne tá,
-  // ktorú majiteľ nahlásil ako neúnosnú.
-  await expect(page.getByRole("heading", { name: "Sync zo Shoptetu" })).toBeVisible();
+  // issue 302: predvolená obrazovka po prihlásení je odvtedy "Na
+  // objednanie" — tabuľkovo najhustejšia obrazovka v appke (`orders-table-
+  // wrap`, mala už VLASTNÝ posuvný obal aj pred issue 291).
+  await expect(page.getByRole("heading", { name: "Na objednanie" })).toBeVisible();
 
   // Bod 1 dohodnutého rozsahu: panel sa na úzkej obrazovke bez uloženej
   // voľby zbalí sám (priamy dôkaz `Sidebar.tsx`'s `initialRail`).
@@ -52,27 +60,27 @@ test("na telefónnej šírke (375px) sa stránka nikdy neposúva vodorovne, pane
   }
 
   // Bod 3 + akceptačná kontrola tiketu: žiadne vodorovné posúvanie STRÁNKY.
-  const syncSirky = await page.evaluate(() => ({
-    scrollWidth: document.documentElement.scrollWidth,
-    innerWidth: window.innerWidth,
-  }));
-  expect(syncSirky.scrollWidth, "Sync zo Shoptetu: scrollWidth vs innerWidth pri 375px").toBeLessThanOrEqual(
-    syncSirky.innerWidth,
-  );
-
-  // Druhá, tabuľkovo najhustejšia obrazovka — "Na objednanie" (`orders-
-  // table-wrap`, mala už VLASTNÝ posuvný obal aj pred týmto tiketom — tu sa
-  // overuje, že aj s VŠETKÝMI ostatnými novo-obalenými tabuľkami zostáva
-  // stránka samotná bez vodorovného posúvania). Záložka je dosiahnuteľná aj
-  // v zbalenej lište (prístupný názov prežije, `Sidebar.tsx`'s `railLabel`).
-  await page.getByRole("button", { name: "Na objednanie" }).click();
-  await expect(page.getByRole("heading", { name: "Na objednanie" })).toBeVisible();
   const ordersSirky = await page.evaluate(() => ({
     scrollWidth: document.documentElement.scrollWidth,
     innerWidth: window.innerWidth,
   }));
   expect(ordersSirky.scrollWidth, "Na objednanie: scrollWidth vs innerWidth pri 375px").toBeLessThanOrEqual(
     ordersSirky.innerWidth,
+  );
+
+  // Druhá overená obrazovka — "Sync zo Shoptetu" (akceptačný prípad z
+  // tiketu 291: mala pri 375px `document.documentElement.scrollWidth`
+  // 4085px — jej história behov nemala vlastný posuvný obal). Záložka je
+  // dosiahnuteľná aj v zbalenej lište (prístupný názov prežije,
+  // `Sidebar.tsx`'s `railLabel`).
+  await page.getByRole("button", { name: "Sync zo Shoptetu" }).click();
+  await expect(page.getByRole("heading", { name: "Sync zo Shoptetu" })).toBeVisible();
+  const syncSirky = await page.evaluate(() => ({
+    scrollWidth: document.documentElement.scrollWidth,
+    innerWidth: window.innerWidth,
+  }));
+  expect(syncSirky.scrollWidth, "Sync zo Shoptetu: scrollWidth vs innerWidth pri 375px").toBeLessThanOrEqual(
+    syncSirky.innerWidth,
   );
 
   expect(chyby).toEqual([]);

--- a/apps/web/tests/e2e/nav.spec.ts
+++ b/apps/web/tests/e2e/nav.spec.ts
@@ -55,14 +55,11 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s trinástim
   await expect(page.getByRole("button", { name: "Zlúčenie objednávok" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Upozornenia" })).toBeVisible();
 
-  // Predvolená obrazovka (bez kliknutia) je "Sync zo Shoptetu".
-  await expect(page.getByRole("heading", { name: "Sync zo Shoptetu" })).toBeVisible();
-
-  // Klik na "Na objednanie" prepne titulok aj obsah. `scripts/e2e-setup.ts`
-  // vždy seeduje dve otvorené objednávky (`orders.spec.ts`'s prvý test) — táto
-  // obrazovka teda NIKDY nie je prázdna v E2E prostredí, overujeme preto
-  // skutočne prítomnú skupinu dodávateľa, nie prázdny stav.
-  await page.getByRole("button", { name: "Na objednanie" }).click();
+  // issue 302: predvolená obrazovka (bez kliknutia) je odvtedy "Na
+  // objednanie", nie "Sync zo Shoptetu". `scripts/e2e-setup.ts` vždy seeduje
+  // dve otvorené objednávky (`orders.spec.ts`'s prvý test) — táto obrazovka
+  // teda NIKDY nie je prázdna v E2E prostredí, overujeme preto skutočne
+  // prítomnú skupinu dodávateľa, nie prázdny stav.
   await expect(page.getByRole("heading", { name: "Na objednanie" })).toBeVisible();
   await expect(page.getByTestId("supplier-DODAVATEL-TEST-1")).toBeVisible();
 
@@ -201,6 +198,12 @@ test("Sync zo Shoptetu ukazuje stav katalógu aj objednávok a tlačidlo 'Stiahn
   await page.getByLabel("E-mail").fill(E2E_NAV_EMAIL);
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+
+  // issue 302: predvolená obrazovka po prihlásení je odvtedy "Na
+  // objednanie", nie "Sync zo Shoptetu" — tento test overuje práve obrazovku
+  // "Sync zo Shoptetu", takže tam teraz musí prejsť explicitným klikom.
+  await page.getByRole("button", { name: "Sync zo Shoptetu" }).click();
+  await expect(page.getByRole("heading", { name: "Sync zo Shoptetu" })).toBeVisible();
 
   // #115: katalóg má seedovaný, roky starý úspešný beh — pill NESMIE ukázať
   // "✅ OK", musí ukázať zastaraný/varovný stav so slovenským vysvetlením

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.171",
+  "version": "0.3.0-dev.172",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Dve veci, ktoré si šéf vypýtal.

## 1. Appka štartuje na obrazovke „Na objednanie" (issue 302)

Po prihlásení sa doteraz otvárala obrazovka **Sync zo Shoptetu**. Teraz sa otvorí **Na objednanie** — obrazovka, s ktorou sa reálne pracuje. Priame odkazy na ostatné obrazovky fungujú ďalej; mení sa len to, kam appka ide, keď žiadna obrazovka nie je určená.

## 2. Tretie upozornenie: objednávky, ktoré dlho visia nevybavené (issue 301)

Na nástenke Upozornenia pribudne karta pre objednávku, ktorá **14 a viac dní** visí v nevybavenom stave (`Vybavuje sa`, `Nevybavená`). Na karte je číslo objednávky, zákazník, v akom stave visí, koľko dní, a preklik na detail objednávky v Shoptete (ten istý odkaz, aký appka používa vo Vyhľadať). Keď sa objednávka posunie do vybaveného stavu, karta sa zavrie sama.

Žiadna nová nočná automatizácia — vezie sa to na existujúcom dennom behu nad objednávkami. Žiadne nové pripojenie, žiadne nové prístupy.

**Prečo 14 dní.** Pripomienky objednávok používajú 4 dni, ale to je iná vec (píše sa zákazníkovi). Tu ide o objednávku, na ktorú sa zabudlo — 14 dní nechá bežné dodanie od dodávateľa v pokoji dobehnúť a zachytí len tie skutočne zanedbané. V produkcii je dnes 31 objednávok „Vybavuje sa" a 3 „Nevybavená", najstaršie od konca apríla.

**Karta sa môže založiť znova.** Ak objednávka spadne späť do nevybaveného stavu, vznikne nová karta — na rozdiel od upozornenia o vrátení, ktoré je konečné.

## Overenie

- `pnpm typecheck`, `pnpm lint` — čisté
- API unit 624/624 · web unit 494/494 · API integračné 571/571 · e2e 47/47
- Nové testy: rozpoznanie visiacej objednávky, založenie karty v dennom behu, samozatvorenie po vybavení, popis na nástenke, úvodná obrazovka

Nadväzuje na issue 301 a issue 302. Oba tikety ostávajú otvorené do overenia naživo po nasadení.
