### PR TITLE
Celá appka hustejšie — menšie medzery a menšie objekty

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -987,3 +987,41 @@ paths:
   (izolovaný re-beh prešiel čisto). Pred hľadaním regresie v diffe: over
   `uptime`/`ps aux | grep vitest` PRED panikou, over izolovaným re-behom
   PRESNE zlyhaného súboru.
+- **"Zmenši medzery/objekty naprieč CELOU appkou" (issue 303, majiteľ:
+  "vsetko zabera priatelia miesta ... uz mam okuliare, vidim celkom
+  dobre") sa rieši VÝHRADNE zmenou `:root`'s `--fs-space-*`/`--fs-text-*`
+  ČÍSEL v `app.css`, nikdy súbor-po-súbore — appka je od issue 57 postavená
+  tak, že KAŽDÁ obrazovka/tabuľka/dialóg čerpá odsadenie/písmo z týchto
+  tokenov, takže jedna centrálna zmena čísel sa prejaví VŠADE naraz.
+  Zvolená škála (jeden krok hustejšie): `--fs-space-1` ostáva 4px
+  (najmenšia atomická jednotka), `-2..-7` 8/12/16/24/32/48px →
+  6/8/12/16/24/32px; `--fs-text-xs/-sm` (12/13px, tabuľky + drobné
+  popisky — dnešná čitateľnosti podlaha) ostávajú NA MIESTE, `-base/-md/
+  -lg/-xl` (15/17/21/26px → 14/15/18/22px) klesajú o jeden krok; `body`
+  `line-height` 1.5 → 1.4. Klikacie plochy s VLASTNÝM pevným
+  `min-width`/`min-height` (36×36px "veľké tlačidlá", `.rail-toggle`'s
+  40px) NIE sú odvodené z tejto škály, takže sa nezmenšili — zámerne,
+  zadanie žiada zachovať rýchlu prácu myšou. Keďže ide o čisto vizuálnu
+  zmenu bez zmeny správania, nemá zmysel red/green pár — namiesto toho
+  over, že VŠETKY existujúce testy (unit + integration + e2e) prejdú
+  bezo zmeny (kontrolujú HORNÉ hranice výšky riadku / šírky stĺpca, nie
+  presné pixely, takže zmenšenie ich neprelomí) a urob živé Playwright
+  overenie proti lokálnemu dev serveru. Pri ĎALŠOM "appka je príliš X"
+  tickete over NAJPRV, či sa dá vyriešiť len posunom týchto tokenov, než
+  siahneš po úprave jednotlivej obrazovky.
+- **`pnpm exec tsx scripts/e2e-setup.ts` spustený SÚBEŽNE s bežiacim
+  `pnpm --filter @forestshop/api test:integration` na TEJ ISTEJ
+  `DATABASE_URL` spôsobí SKUTOČNÉ, nesúvisiace zlyhanie integračného
+  testu** — `e2e-setup.ts`'s vlastný `TRUNCATE` zoznam (`.claude/rules/
+  testing.md`) nie je chránený `withCleanDb()`'s advisory zámkom, takže
+  jeho TRUNCATE `sessions`/`users` môže padnúť presne do okna bežiaceho
+  testu a zneplatniť jeho session (issue 303: `supplier-mail.integration
+  .test.ts` dostalo 401 namiesto očakávaného 503 — vyzeralo to ako
+  regresia, bol to len súbežný beh). Fix nie je v kóde: NIKDY nespúšťaj
+  `e2e-setup.ts` (ani manuálne pre živé Playwright overenie), kým beží
+  `test:integration` na tej istej DB — počkaj na jeho koniec
+  (`ps aux | grep vitest`), až POTOM seeduj/over naživo. Pri
+  podozrivom, na prvý pohľad nesúvisiacom zlyhaní integračného testu
+  (najmä auth-kódy 401/403 tam, kde sa to nečaká) skontroluj najprv, či
+  medzitým nebežal iný proces mutujúci zdieľané tabuľky, a over
+  IZOLOVANÝM opakovaným behom, než hľadáš regresiu v diffe.

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -57,26 +57,41 @@
   --chip-active-bg: #dda43c;
   --chip-active-text: #3b1d00;
 
-  /* typografia */
+  /* typografia
+     issue 303 (majiteľ: "všetko zaberá miesta... potreboval by som to
+     hustejšie... už mám okuliare, vidím celkom dobre"): --fs-text-xs/-sm
+     (12px/13px, tabuľky + drobné popisky) ostávajú NA MIESTE — to je dnešná
+     podlaha čitateľnosti a tabuľky ňou už bežia. Zvyšné tri stupne (base/md/
+     lg/xl — bežný text, tlačidlá, nadpisy) idú o JEDEN krok dole (~1-2px);
+     nadpisy klesajú citeľnejšie než súvislý text, presne ako pri predošlom
+     dláždicovom zmenšení (issue 258). */
   --fs-font: "Segoe UI", Inter, -apple-system, Roboto, sans-serif;
   --fs-text-xs: 0.75rem;
   --fs-text-sm: 0.8125rem;
-  --fs-text-base: 0.9375rem;
-  --fs-text-md: 1.0625rem;
-  --fs-text-lg: 1.3125rem;
-  --fs-text-xl: 1.625rem;
+  --fs-text-base: 0.875rem;
+  --fs-text-md: 0.9375rem;
+  --fs-text-lg: 1.125rem;
+  --fs-text-xl: 1.375rem;
   --fs-weight-medium: 500;
   --fs-weight-semibold: 600;
   --fs-weight-bold: 700;
 
-  /* rozostupy (4px základ) */
+  /* rozostupy (4px základ)
+     issue 303: celá škála posunutá o jeden krok hustejšie (--fs-space-1
+     ostáva 4px — je to už najmenšia atomická jednotka, ňou odsadené miesta
+     sú dnes tesné) — každý ĎALŠÍ token je centrálne zmenšený, takže sa to
+     prejaví naprieč VŠETKÝMI obrazovkami/tabuľkami/formulármi naraz (tie
+     používajú tokeny, nie vlastné px hodnoty — `.claude/rules/
+     frontend-design.md`). Klikacie plochy s VLASTNÝM pevným `min-width`/
+     `min-height` (36×36px "veľké tlačidlá", `.rail-toggle`'s 40px, …) tento
+     posun NEZMENŠUJE — tie rozmery nie sú odvodené z tejto škály. */
   --fs-space-1: 0.25rem;
-  --fs-space-2: 0.5rem;
-  --fs-space-3: 0.75rem;
-  --fs-space-4: 1rem;
-  --fs-space-5: 1.5rem;
-  --fs-space-6: 2rem;
-  --fs-space-7: 3rem;
+  --fs-space-2: 0.375rem;
+  --fs-space-3: 0.5rem;
+  --fs-space-4: 0.75rem;
+  --fs-space-5: 1rem;
+  --fs-space-6: 1.5rem;
+  --fs-space-7: 2rem;
 
   --fs-radius-sm: 6px;
   --fs-radius-md: 10px;
@@ -106,7 +121,10 @@ body {
   color: var(--fs-ink);
   font-family: var(--fs-font);
   font-size: var(--fs-text-base);
-  line-height: 1.5;
+  /* issue 303: 1.5 → 1.4 — o niečo tesnejšie riadkovanie pre ĽUBOVOĽNÝ
+     zalomený viacriadkový text (poznámky, mená produktov, …), stále
+     pohodlné na celodenné čítanie (netrhá sa nič pod 1.4). */
+  line-height: 1.4;
   -webkit-font-smoothing: antialiased;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.172",
+  "version": "0.3.0-dev.173",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Zadanie od šéfa: *„strašne každá vec zaberá miesta - veľké medzery sú medzi všetkým — potreboval by som to všetko všade hustejšie - nie také medzery - nie také veľké objekty"*.

## Čo sa zmenilo

Appka je hustejšia — na obrazovku sa zmestí výrazne viac obsahu a menej sa roluje. Zmena je spravená **na jednom mieste** (spoločné vizuálne nastavenia), takže platí naraz na všetkých obrazovkách, vo všetkých tabuľkách, kartách aj dialógoch — nerozíde sa to.

- Medzery a odsadenia: 8/12/16/24/32/48 → 6/8/12/16/24/32 bodov
- Písmo v texte, tlačidlách a nadpisoch: o jeden stupeň menšie (15/17/21/26 → 14/15/18/22)
- Riadkovanie 1,5 → 1,4 — zbierajú sa tým viacriadkové poznámky a dlhé názvy produktov

## Čo zámerne ostalo

- **Najmenšie písmo v tabuľkách a popiskoch** (12/13) — to je dnešná hranica čitateľnosti, nižšie sa nešlo
- **Veľkosť klikacích tlačidiel** (36×36, prepínač menu 40) — nie sú odvodené od tejto škály, takže sa nezmenšili; rýchla práca myšou ostáva rovnaká

## Overenie

- `pnpm typecheck`, `pnpm lint` — čisté
- API unit 624/624 · web unit 494/494 · API integračné 571/571 · e2e 47/47
- Prešli aj testy, ktoré strážia výšku riadkov v tabuľke objednávok a mobilné rozloženie

Nadväzuje na issue 303. Tiket ostáva otvorený do overenia naživo po nasadení.

**Prvý odhad hustoty, doladí sa so šéfom** — keď to uvidí, povie či ešte hustejšie alebo naopak.
