### PR TITLE
Doladenie hustoty — karty na nástenke nižšie o tretinu

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -1025,3 +1025,37 @@ paths:
   (najmä auth-kódy 401/403 tam, kde sa to nečaká) skontroluj najprv, či
   medzitým nebežal iný proces mutujúci zdieľané tabuľky, a over
   IZOLOVANÝM opakovaným behom, než hľadáš regresiu v diffe.
+- **Issue 303 follow-up (majiteľ: "menšie objekty"): globálne
+  `input:not([type="hidden"]) {width:100%}` (app.css §1) je PIATY tvar
+  issue 105's flex-basis-z-width pasce — tentoraz cez `width: 100%`, nie
+  fixný `width`.** `.upozornenie-actions` (`UpozornenieCard.tsx`, karta
+  nástenky Upozornenia) má `display:flex` bez `flex` na svojich deťoch —
+  dátumové pole "odložiť do" tak dostalo `flex-basis` z `width:100%`, teda
+  CELÚ šírku riadku (naživo namerané: 1491px pri 1600px okne), a tri
+  ovládacie prvky sa zalomili na tri riadky (104px vysoký pás, karta 269px
+  namiesto ~150px pre rovnaký obsah). Fix: `.upozornenie-actions
+  input[type="date"] { width:auto; min-width:9.5rem; flex:0 0 auto; }` —
+  `width:auto` necháva prehliadačovu VLASTNÚ intrinzickú šírku dátumového
+  poľa (namerané Chromium/sk-SK: 136px), `min-width` je len poistka pre
+  širší formát iného jazyka/OS, `flex:0 0 auto` bráni ROVNAKÉMU riadku
+  znova ho naťahovať. Overovacia technika (rovnaká ako issue 105/107/…):
+  `page.addStyleTag` s kandidátnymi šírkami proti LOKÁLNEMU dev serveru
+  (`.upozornenie-form label input[type=date]` je INÝ prípad — stĺpcový
+  `<label>`, tam je `width:100%` správne, zámerné, netreba opravovať).
+  KAŽDÝ ĎALŠÍ bare `<input>`/`<select>` priamo v `display:flex` riadku BEZ
+  vlastnej width-obmedzujúcej CSS triedy (na rozdiel od zavedených
+  `.ord-supplier-assign-input`/`.ord-comment-input`/`.tosup-emailinput`)
+  zdedí rovnakú pascu z tohto globálneho resetu — grep `apps/web/src/
+  styles/app.css` na existujúcu triedu PRED tým, než sa pridá nový bare
+  `<input>` do flex riadku.
+- **RED/GREEN overenie ČISTO-CSS opravy bez existujúceho testu: `git
+  stash push --keep-index -- <css-súbor>` dočasne vráti CSS do
+  PRED-opravového stavu (bez straty už napísaného, staged testu), beží sa
+  proti live Vite HMR (žiadny rebuild potrebný), `git stash pop` opravu
+  vráti späť.** Použité tu, lebo issue 303's fix bol objavený/zmeraný
+  PRED napísaním regresného testu (živé meranie cez Playwright MCP proti
+  `pnpm --filter @forestshop/web dev`) — namiesto prepisovania CSS ručne
+  vzad a vpred stačí jeden `git stash` cyklus okolo `playwright test -g
+  "<názov testu>"` na dôkaz RED, potom `stash pop` + rovnaký beh na dôkaz
+  GREEN. Rýchlejšie než plný `pnpm --filter @forestshop/web e2e` cyklus
+  pri overovaní JEDNÉHO testu.

--- a/.claude/rules/upozornenia.md
+++ b/.claude/rules/upozornenia.md
@@ -5,6 +5,7 @@ paths:
   - "apps/api/src/db/schema-upozornenia.ts"
   - "apps/web/src/upozorneniaApi.ts"
   - "apps/web/src/components/Upozornenia*.tsx"
+  - "apps/web/src/components/UpozornenieCard.tsx"
   - "apps/web/tests/e2e/upozornenia.spec.ts"
 ---
 

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2097,6 +2097,21 @@ tr:last-child td {
   flex-wrap: wrap;
   margin-top: var(--fs-space-2);
 }
+/* issue 303: the global `input:not([type="hidden"]) { width: 100% }` reset
+   (app.css §1) stretched the "odložiť do" date field to the FULL width of
+   this flex row (measured live: 1491px at 1600px desktop) — same trap as
+   issue 105's flex-basis-from-width, just via `width: 100%` instead of a
+   fixed `width` — which forced the row to wrap onto three lines (104px tall)
+   even though the three controls need ~470px combined. `width: auto` lets
+   Chromium's own intrinsic date-input size through (measured: 136px at this
+   viewport); `min-width` is a floor for a wider locale/OS date format, never
+   a fixed size. `flex: 0 0 auto` keeps it from being stretched again by the
+   row's own flex layout — a date field never needs to grow. */
+.upozornenie-actions input[type="date"] {
+  width: auto;
+  min-width: 9.5rem;
+  flex: 0 0 auto;
+}
 .upozornenie-form {
   display: flex;
   flex-direction: column;

--- a/apps/web/tests/e2e/upozornenia.spec.ts
+++ b/apps/web/tests/e2e/upozornenia.spec.ts
@@ -126,3 +126,46 @@ test("vlastná poznámka — vytvorenie, 'Nové' zmizne po znovuotvorení, úpra
 
   expect(chyby).toEqual([]);
 });
+
+// issue 303 (majiteľ: "menšie objekty" — celá appka hustejšia). Naživo na
+// nasadenej appke bol pás akcií karty (`.upozornenie-actions`) 104px vysoký
+// a karta 269px, hoci obsah bol len 5 krátkych riadkov textu — príčina bolo
+// globálne `input:not([type="hidden"]) {width:100%}` (app.css §1), ktoré
+// dátumové pole "odložiť do" naťahovalo na CELÚ šírku pásu (naživo namerané:
+// 1491px pri 1600px okne), takže tri ovládacie prvky (✓ Vybavené / dátum /
+// Odložiť) sa zalomili na tri samostatné riadky namiesto jedného.
+test("desktop (1600px): pás akcií karty je jednoriadkový, nie zalomený na viac riadkov (issue 303)", async ({ page }) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.setViewportSize({ width: 1600, height: 1000 });
+  await page.goto("/?tab=upozornenia");
+  await page.getByLabel("E-mail").fill(E2E_UPOZORNENIA_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await expect(page.getByRole("heading", { name: "Upozornenia" })).toBeVisible();
+
+  await page.getByTestId("upozornenie-new").click();
+  await page.getByTestId("upozornenie-form-title").fill("Hustota — pás akcií na jednom riadku");
+  await page.getByTestId("upozornenie-form-save").click();
+  await expect(page.getByTestId("upozornenie-form")).toBeHidden();
+
+  const card = kartaSNadpisom(page, "Hustota — pás akcií na jednom riadku");
+  await expect(card).toBeVisible();
+
+  // Strop 50px necháva malú rezervu nad nameraným jednoriadkovým 35.59px
+  // (dátumové pole je vyššie než tlačidlá, takže ono určuje výšku riadku) bez
+  // toho, aby maskoval skutočné zalomenie späť na viac riadkov (namerané
+  // zalomené: 104px — ďaleko nad 50px stropom).
+  const actionsHeight = await card.evaluate((el) => el.querySelector(".upozornenie-actions")?.getBoundingClientRect().height ?? 0);
+  expect(actionsHeight, "pás akcií karty musí byť jednoriadkový (<=50px), nie zalomený na viac riadkov").toBeLessThanOrEqual(50);
+
+  await card.getByRole("button", { name: "Zmazať", exact: false }).click(); // upratanie po teste
+
+  expect(chyby).toEqual([]);
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.173",
+  "version": "0.3.0-dev.174",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Doladenie hustoty po prvom nasadení (issue 303).

## Čo sa opravilo

Karty na nástenke Upozornenia boli zbytočne vysoké — pole s dátumom pri „Odložiť" si bralo celú šírku riadku, takže tlačidlá „✓ Vybavené" a „Odložiť" spadli pod seba do troch riadkov. Teraz sú všetky tri vedľa seba na jednom riadku.

**Namerané (šírka okna 1600):** riadok s tlačidlami 104 → 36 bodov, výška karty 218 → 150 bodov.

**Príčina.** Appka má všeobecné pravidlo, že políčko na vpisovanie sa roztiahne na celú šírku. Pri poli s dátumom to nedáva zmysel — dostalo teda vlastnú, primeranú šírku (~136 bodov, so spodnou hranicou pre dlhšie formáty dátumu). Rovnaký vzor som prezrel aj inde v appke — všetky ostatné vpisovacie polia už svoju šírku obmedzenú majú, toto bol jediný prípad.

Na úzkej obrazovke (mobil) sa tlačidlá môžu zalomiť ďalej — to je správne. Veľkosť tlačidiel sa nemenila.

## Overenie

- Nový test: riadok s tlačidlami na karte musí na bežnej šírke ostať jednoriadkový (najprv padal na nameraných 104 bodoch, po oprave prešiel na 36)
- `pnpm typecheck`, `pnpm lint` — čisté
- API unit 624/624 · web unit 494/494 · API integračné 571/571 · e2e 48/48

Nadväzuje na issue 303. Tiket ostáva otvorený do overenia naživo po nasadení.
