### PR TITLE
feat: Výmena tovaru / Vrátený tovar / Reklamácie (issue 290)

### DIFF
--- a/apps/api/drizzle/0043_lame_miracleman.sql
+++ b/apps/api/drizzle/0043_lame_miracleman.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "order" ADD COLUMN "claim_marked_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "order" ADD COLUMN "claim_note" text;

--- a/apps/api/drizzle/meta/0043_snapshot.json
+++ b/apps/api/drizzle/meta/0043_snapshot.json
@@ -1,0 +1,2816 @@
+{
+  "id": "25bff396-9555-4df6-8929-b2ffcd9f3a93",
+  "prevId": "63236f8d-6882-41b7-9af4-9012e6f93787",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_code": {
+          "name": "external_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_open_status": {
+      "name": "order_open_status",
+      "schema": "",
+      "columns": {
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Vybavuje sa'"
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop_remark": {
+          "name": "shop_remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shoptet_order_id": {
+          "name": "shoptet_order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_updated_at": {
+          "name": "comment_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_synced_at": {
+          "name": "comment_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_carrier_name": {
+          "name": "shipping_carrier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_price_with_vat": {
+          "name": "total_price_with_vat",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_marked_at": {
+          "name": "claim_marked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_note": {
+          "name": "claim_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_link_override": {
+      "name": "product_supplier_link_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_link_override_product_key_product_key_fk": {
+          "name": "product_supplier_link_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_link_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_override": {
+      "name": "product_supplier_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_override_product_key_product_key_fk": {
+          "name": "product_supplier_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing": {
+      "name": "pairing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_url": {
+          "name": "supplier_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "pairing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'navrhnute'"
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pairing_state_idx": {
+          "name": "pairing_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_confirmed_by_idx": {
+          "name": "pairing_confirmed_by_idx",
+          "columns": [
+            {
+              "expression": "confirmed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_variant_code_variant_code_fk": {
+          "name": "pairing_variant_code_variant_code_fk",
+          "tableFrom": "pairing",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pairing_confirmed_by_users_id_fk": {
+          "name": "pairing_confirmed_by_users_id_fk",
+          "tableFrom": "pairing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pairing_variant_code_unique": {
+          "name": "pairing_variant_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pairing_confirmation_ck": {
+          "name": "pairing_confirmation_ck",
+          "value": "(\"pairing\".\"state\" = 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)\n        OR (\"pairing\".\"state\" != 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NULL AND \"pairing\".\"confirmed_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier": {
+      "name": "supplier",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wholesale_base_url": {
+          "name": "wholesale_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_key": {
+          "name": "adapter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_settings": {
+      "name": "posta_uncollected_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_state": {
+      "name": "posta_uncollected_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notify_count": {
+          "name": "notify_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_state": {
+          "name": "terminal_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_settings": {
+      "name": "order_reminder_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_state": {
+      "name": "order_reminder_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_replacement_link": {
+      "name": "nedostupne_replacement_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nedostupne_replacement_link_variant_idx": {
+          "name": "nedostupne_replacement_link_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_state": {
+      "name": "nedostupne_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "nedostupne_email_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nedostupne_state_order_variant_type_uq": {
+          "name": "nedostupne_state_order_variant_type_uq",
+          "columns": [
+            {
+              "expression": "order_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template_history": {
+      "name": "mail_template_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "mail_template_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_template_history_key_idx": {
+          "name": "mail_template_history_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_template_history_changed_by_user_id_users_id_fk": {
+          "name": "mail_template_history_changed_by_user_id_users_id_fk",
+          "tableFrom": "mail_template_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template": {
+      "name": "mail_template",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail_template_updated_by_user_id_users_id_fk": {
+          "name": "mail_template_updated_by_user_id_users_id_fk",
+          "tableFrom": "mail_template",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_log": {
+      "name": "mail_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "mail_log_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_log_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "mail_log_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_log_created_idx": {
+          "name": "mail_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_log_source_created_idx": {
+          "name": "mail_log_source_created_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_log_actor_user_id_users_id_fk": {
+          "name": "mail_log_actor_user_id_users_id_fk",
+          "tableFrom": "mail_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_stock": {
+      "name": "supplier_stock",
+      "schema": "",
+      "columns": {
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "supplier_availability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "supplier_stock_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "supplier_stock_host_idx": {
+          "name": "supplier_stock_host_idx",
+          "columns": [
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "supplier_stock_avail_idx": {
+          "name": "supplier_stock_avail_idx",
+          "columns": [
+            {
+              "expression": "availability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "supplier_stock_link_size_label_pk": {
+          "name": "supplier_stock_link_size_label_pk",
+          "columns": [
+            "link",
+            "size_label"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_event": {
+      "name": "restock_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_link": {
+          "name": "supplier_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_availability_text": {
+          "name": "supplier_availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "supplier_price": {
+          "name": "supplier_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "restock_event_at_idx": {
+          "name": "restock_event_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "restock_event_variant_idx": {
+          "name": "restock_event_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_settings": {
+      "name": "restock_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shop_product_url": {
+      "name": "shop_product_url",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.theme_color": {
+      "name": "theme_color",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "theme_color_updated_by_user_id_users_id_fk": {
+          "name": "theme_color_updated_by_user_id_users_id_fk",
+          "tableFrom": "theme_color",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upozornenie": {
+      "name": "upozornenie",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "upozornenie_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "upozornenie_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedup_key": {
+          "name": "dedup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postponed_until": {
+          "name": "postponed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seen_at": {
+          "name": "seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "upozornenie_dedup_key_uq": {
+          "name": "upozornenie_dedup_key_uq",
+          "columns": [
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "resolved_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upozornenie_resolved_at_idx": {
+          "name": "upozornenie_resolved_at_idx",
+          "columns": [
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upozornenie_dedup_key_idx": {
+          "name": "upozornenie_dedup_key_idx",
+          "columns": [
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upozornenie_resolved_by_user_id_users_id_fk": {
+          "name": "upozornenie_resolved_by_user_id_users_id_fk",
+          "tableFrom": "upozornenie",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "upozornenie_created_by_user_id_users_id_fk": {
+          "name": "upozornenie_created_by_user_id_users_id_fk",
+          "tableFrom": "upozornenie",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne"
+      ]
+    },
+    "public.pairing_state": {
+      "name": "pairing_state",
+      "schema": "public",
+      "values": [
+        "navrhnute",
+        "potvrdene"
+      ]
+    },
+    "public.nedostupne_email_type": {
+      "name": "nedostupne_email_type",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "alternativa"
+      ]
+    },
+    "public.mail_template_action": {
+      "name": "mail_template_action",
+      "schema": "public",
+      "values": [
+        "save",
+        "reset"
+      ]
+    },
+    "public.mail_log_source": {
+      "name": "mail_log_source",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "posta_uncollected",
+        "order_reminder",
+        "supplier_order",
+        "order_merge"
+      ]
+    },
+    "public.mail_log_status": {
+      "name": "mail_log_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.mail_log_trigger": {
+      "name": "mail_log_trigger",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "manual"
+      ]
+    },
+    "public.supplier_availability": {
+      "name": "supplier_availability",
+      "schema": "public",
+      "values": [
+        "available",
+        "unavailable",
+        "unknown"
+      ]
+    },
+    "public.supplier_stock_source": {
+      "name": "supplier_stock_source",
+      "schema": "public",
+      "values": [
+        "json_ld",
+        "meta",
+        "text",
+        "size_list",
+        "none"
+      ]
+    },
+    "public.upozornenie_source": {
+      "name": "upozornenie_source",
+      "schema": "public",
+      "values": [
+        "vlastne",
+        "appka"
+      ]
+    },
+    "public.upozornenie_type": {
+      "name": "upozornenie_type",
+      "schema": "public",
+      "values": [
+        "vlastna_poznamka",
+        "nevyzdvihnuta_zasielka",
+        "vratenie",
+        "vratena_zasielka",
+        "objednavka_visi"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -302,6 +302,13 @@
       "when": 1786090097268,
       "tag": "0042_easy_morg",
       "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "7",
+      "when": 1786102119346,
+      "tag": "0043_lame_miracleman",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema-orders.ts
+++ b/apps/api/src/db/schema-orders.ts
@@ -141,6 +141,20 @@ export const orders = pgTable(
     // Používa sa VÝHRADNE na dashboardovú tržbu (`orders/overview.ts`) —
     // appka doteraz žiadnu peňažnú sumu neukladala vôbec.
     totalPriceWithVat: numeric("total_price_with_vat", { precision: 12, scale: 2 }),
+    // issue 290: appkina VLASTNÁ reklamácia-značka — Shoptet nemá pre
+    // reklamácie žiadny použiteľný stav ani políčko v produkčných dátach
+    // (jeho číselníkový stav "REKLAMACIA" nikdy nedostane priradenú žiadnu
+    // objednávku, overené naživo proti produkcii), takže appka si ju musí
+    // viesť sama. `null` = neoznačená (bežná objednávka). Vyplnené =
+    // obsluha ju ručne označila cez "Eshop → Reklamácie" — jediný zápis
+    // do tohto poľa, `modules/orders/order-flags.ts`'s `markOrderClaim`/
+    // `clearOrderClaim`. NIKDY sa neodvodzuje z `statusName`/`comment`/AI
+    // dohadu (rozhodnuté na tickete — žiadne AI dohady o reklamácii).
+    claimMarkedAt: timestamp("claim_marked_at", { withTimezone: true }),
+    // Nepovinná krátka poznámka obsluhy k reklamácii (napr. "chybný zips,
+    // čaká sa na vrátenie") — vypĺňa sa/maže spolu s `claimMarkedAt` vyššie,
+    // nikdy samostatne.
+    claimNote: text("claim_note"),
   },
   (t) => [index("order_placed_at_idx").on(t.placedAt)],
 );

--- a/apps/api/src/http/app.ts
+++ b/apps/api/src/http/app.ts
@@ -17,6 +17,7 @@ import { registerOrderReminderRoutes, type OrderReminderRunDeps } from "./order-
 import { registerMailLogRoutes } from "./mail-log-routes.js";
 import { registerMailTemplateRoutes } from "./mail-template-routes.js";
 import { registerNedostupneRoutes, type NedostupneRunDeps } from "./nedostupne-routes.js";
+import { registerOrderFlagsRoutes } from "./order-flags-routes.js";
 import { registerOrderMergeRoutes, type OrderMergeRunDeps } from "./order-merge-routes.js";
 import { requireSameOrigin } from "./origin-check.js";
 import { registerPairingRoutes } from "./pairing-routes.js";
@@ -292,6 +293,10 @@ export function createApp(
   // dependency (na rozdiel od nedostupne/orderReminder vyššie) — táto
   // obrazovka neposiela mail ani nekontaktuje tretiu stranu.
   registerUpozorneniaRoutes(app, db);
+  // issue 290: "Eshop → Výmena tovaru / Vrátený tovar / Reklamácie" — tri
+  // READ-ONLY pohľady + appkina vlastná reklamácia-značka. Žiadny voliteľný
+  // dependency (rovnaký dôvod ako `upozornenia` vyššie).
+  registerOrderFlagsRoutes(app, db, options.adminBaseUrl ?? "https://www.forestshop.sk");
 
   // Musí byť registrovaný AŽ PO všetkých skutočných /api/* trasách vyššie — Hono
   // vyberá presnejšiu zhodu, takže tie majú prednosť a sem sa dostane len to, čo

--- a/apps/api/src/http/order-flags-routes.ts
+++ b/apps/api/src/http/order-flags-routes.ts
@@ -1,0 +1,72 @@
+import { zValidator } from "@hono/zod-validator";
+import type { Hono } from "hono";
+import { z } from "zod";
+import type { Database } from "../db/client.js";
+import { clearOrderClaim, markOrderClaim } from "../modules/orders/order-flags-state.js";
+import { countOrderFlags, listClaimOrders, listExchangeOrders, listReturnedOrders } from "../modules/orders/order-flags-queries.js";
+import { requireRole, requireUser, type AppBindings } from "./middleware.js";
+import { requireSameOrigin } from "./origin-check.js";
+
+// issue 290: "Eshop → Výmena tovaru / Vrátený tovar / Reklamácie". Čítanie
+// má rovnaké oprávnenie ako zvyšok obrazovky "Na objednanie"/"Nedostupné
+// tovary" (`requireUser`, žiadne obmedzenie roly — každý prihlásený
+// zamestnanec smie vidieť). Označenie/zrušenie reklamácie MENÍ dáta
+// objednávky, rovnaká rola ako ostatné mutácie v `orders-routes.ts`
+// (`requireRole("admin", "manazer")`).
+
+const markClaimBody = z.object({
+  orderCode: z.string().trim().min(1).max(60),
+  note: z.string().trim().max(2000).optional(),
+});
+const claimIdParam = z.object({ id: z.string().uuid() });
+
+export function registerOrderFlagsRoutes(app: Hono<AppBindings>, db: Database, adminBaseUrl: string): void {
+  app.get("/api/order-flags/counts", requireUser(db), async (c) => c.json(await countOrderFlags(db)));
+
+  app.get("/api/order-flags/exchange", requireUser(db), async (c) =>
+    c.json({ orders: await listExchangeOrders(db, adminBaseUrl) }),
+  );
+
+  app.get("/api/order-flags/returned", requireUser(db), async (c) =>
+    c.json({ orders: await listReturnedOrders(db, adminBaseUrl) }),
+  );
+
+  app.get("/api/order-flags/claims", requireUser(db), async (c) => c.json({ orders: await listClaimOrders(db, adminBaseUrl) }));
+
+  app.post(
+    "/api/order-flags/claims",
+    requireSameOrigin(),
+    requireUser(db),
+    requireRole("admin", "manazer"),
+    zValidator("json", markClaimBody),
+    async (c) => {
+      const body = c.req.valid("json");
+      const result = await markOrderClaim(db, {
+        orderCode: body.orderCode,
+        note: body.note !== undefined && body.note !== "" ? body.note : null,
+        actorUserId: c.get("user").userId,
+        now: new Date(),
+      });
+      if (result.status === "not_found") {
+        return c.json({ ok: false, error: "Objednávka s týmto číslom sa nenašla." });
+      }
+      return c.json({ ok: true, orderId: result.orderId });
+    },
+  );
+
+  app.post(
+    "/api/order-flags/claims/:id/clear",
+    requireSameOrigin(),
+    requireUser(db),
+    requireRole("admin", "manazer"),
+    zValidator("param", claimIdParam),
+    async (c) => {
+      const { id } = c.req.valid("param");
+      const result = await clearOrderClaim(db, { orderId: id, actorUserId: c.get("user").userId, now: new Date() });
+      if (result === "not_found") {
+        return c.json({ ok: false, error: "Reklamácia sa nenašla — pravdepodobne bola už zrušená." });
+      }
+      return c.json({ ok: true });
+    },
+  );
+}

--- a/apps/api/src/modules/orders/order-flags-queries.ts
+++ b/apps/api/src/modules/orders/order-flags-queries.ts
@@ -1,0 +1,172 @@
+import { and, desc, eq, inArray, isNotNull, isNull } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { orders, upozornenie } from "../../db/schema.js";
+import { isExchangeOrderStatus, isReturnedOrderStatus } from "./order-flags.js";
+import { buildShoptetAdminOrderUrl } from "./queries.js";
+import { returnUpozornenieDedupKey } from "./return-status.js";
+
+// issue 290: čítacia strana pre "Eshop → Výmena tovaru / Vrátený tovar /
+// Reklamácie" — TRI READ-ONLY pohľady nad objednávkami, ŽIADNA nová
+// zapisovacia cesta do `upozornenie` (to ostáva výhradne `return-
+// upozornenia.ts`/#267/#269/#297). `unresolved` sa dopočítava DVOJKROKOVO
+// (najprv objednávky, potom otvorené "vratenie" karty pre ich dedup kľúče)
+// — rovnaká technika ako `return-upozornenia.ts`'s dávkový pre-check,
+// len bez `.for("update")` (toto je čisté čítanie, nič nezapisuje).
+
+interface OrderFlagBaseRow {
+  readonly id: string;
+  readonly externalOrderId: string;
+  readonly customerName: string;
+  readonly statusName: string;
+  readonly placedAt: Date;
+  readonly totalPriceWithVat: string | null;
+  readonly comment: string | null;
+  readonly shoptetOrderId: number | null;
+}
+
+export interface OrderFlagRow {
+  readonly id: string;
+  readonly externalOrderId: string;
+  readonly customerName: string;
+  readonly statusName: string;
+  readonly placedAt: string;
+  readonly totalPriceWithVat: string | null;
+  readonly comment: string | null;
+  readonly adminUrl: string;
+  // `true` = objednávka má ešte OTVORENÚ "vratenie" kartu na Upozorneniach
+  // (`return-status.ts`'s aktívny vrátkový stav ju stále drží otvorenú,
+  // alebo ju ešte nikdy nezavrel žiadny import do hotového stavu) — toto
+  // JE "nevybavené" v zmysle tickety, nikdy nový, samostatný appkin stav.
+  readonly unresolved: boolean;
+}
+
+// `order.status_name` nemá vlastný indexovaný zoznam pre "Výmena"/"Vrátený
+// tovar" (na rozdiel od `order_open_status`) — appka má rádovo stovky
+// objednávok (rovnaká úvaha o rozumnom rozsahu appky ako
+// `open-statuses.ts`), takže JEDEN SELECT všetkých objednávok + filter v
+// JS (obe klasifikačné funkcie sú čisté `normalizeStatusName` porovnania)
+// je jednoduchšie a nepotrebuje žiadny natvrdo vypísaný zoznam reťazcov v
+// SQL `inArray`.
+async function selectAllBaseRows(db: Database): Promise<readonly OrderFlagBaseRow[]> {
+  return db
+    .select({
+      id: orders.id,
+      externalOrderId: orders.externalOrderId,
+      customerName: orders.customerName,
+      statusName: orders.statusName,
+      placedAt: orders.placedAt,
+      totalPriceWithVat: orders.totalPriceWithVat,
+      comment: orders.comment,
+      shoptetOrderId: orders.shoptetOrderId,
+    })
+    .from(orders)
+    .orderBy(desc(orders.placedAt));
+}
+
+/** Množina "vratenie" dedup kľúčov (`return-status.ts`), ktoré MAJÚ ešte
+ * otvorenú (nevyriešenú) kartu — pre presne tie objednávky, čo `rows`
+ * odovzdá. Prázdny vstup nikdy nesiahne na DB (`inArray([])` by inak
+ * vygenerovalo vždy-nepravdivú podmienku zbytočne). */
+async function unresolvedDedupKeySet(db: Database, rows: readonly OrderFlagBaseRow[]): Promise<ReadonlySet<string>> {
+  if (rows.length === 0) return new Set();
+  const dedupKeys = rows.map((r) => returnUpozornenieDedupKey(r.externalOrderId));
+  const openCards = await db
+    .select({ dedupKey: upozornenie.dedupKey })
+    .from(upozornenie)
+    .where(and(eq(upozornenie.type, "vratenie"), inArray(upozornenie.dedupKey, dedupKeys), isNull(upozornenie.resolvedAt)));
+  return new Set(openCards.map((c) => c.dedupKey).filter((k): k is string => k !== null));
+}
+
+function toFlagRow(row: OrderFlagBaseRow, adminBaseUrl: string, unresolved: boolean): OrderFlagRow {
+  return {
+    id: row.id,
+    externalOrderId: row.externalOrderId,
+    customerName: row.customerName,
+    statusName: row.statusName,
+    placedAt: row.placedAt.toISOString(),
+    totalPriceWithVat: row.totalPriceWithVat,
+    comment: row.comment,
+    adminUrl: buildShoptetAdminOrderUrl(adminBaseUrl, row.externalOrderId, row.shoptetOrderId),
+    unresolved,
+  };
+}
+
+/** Zdieľané jadro pre "Výmena tovaru"/"Vrátený tovar": vyfiltruje podľa
+ * `statusFilter`, dopočíta `unresolved` (viď `unresolvedDedupKeySet`
+ * vyššie), vráti surové riadky BEZ `adminUrl` — volajúci (list alebo
+ * count) si adminUrl doplní/vynechá podľa potreby. */
+async function selectFlaggedByStatus(
+  db: Database,
+  statusFilter: (statusName: string) => boolean,
+): Promise<readonly (OrderFlagBaseRow & { readonly unresolved: boolean })[]> {
+  const rows = (await selectAllBaseRows(db)).filter((r) => statusFilter(r.statusName));
+  const openSet = await unresolvedDedupKeySet(db, rows);
+  return rows.map((r) => ({ ...r, unresolved: openSet.has(returnUpozornenieDedupKey(r.externalOrderId)) }));
+}
+
+export async function listExchangeOrders(db: Database, adminBaseUrl: string): Promise<readonly OrderFlagRow[]> {
+  const rows = await selectFlaggedByStatus(db, isExchangeOrderStatus);
+  return rows.map((r) => toFlagRow(r, adminBaseUrl, r.unresolved));
+}
+
+export async function listReturnedOrders(db: Database, adminBaseUrl: string): Promise<readonly OrderFlagRow[]> {
+  const rows = await selectFlaggedByStatus(db, isReturnedOrderStatus);
+  return rows.map((r) => toFlagRow(r, adminBaseUrl, r.unresolved));
+}
+
+export interface ClaimOrderRow extends OrderFlagRow {
+  readonly claimNote: string | null;
+  readonly claimMarkedAt: string;
+}
+
+/** Aktuálne označené reklamácie — appka nemá koncept "vybavené" mimo
+ * samotného zrušenia označenia (`clearOrderClaim`, `order-flags-state.ts`),
+ * takže KAŽDÁ tu vrátená objednávka je "nevybavená" (rozhodnuté na
+ * tickete — žiadny druhý stav navyše). */
+export async function listClaimOrders(db: Database, adminBaseUrl: string): Promise<readonly ClaimOrderRow[]> {
+  const rows = await db
+    .select({
+      id: orders.id,
+      externalOrderId: orders.externalOrderId,
+      customerName: orders.customerName,
+      statusName: orders.statusName,
+      placedAt: orders.placedAt,
+      totalPriceWithVat: orders.totalPriceWithVat,
+      comment: orders.comment,
+      shoptetOrderId: orders.shoptetOrderId,
+      claimNote: orders.claimNote,
+      claimMarkedAt: orders.claimMarkedAt,
+    })
+    .from(orders)
+    .where(isNotNull(orders.claimMarkedAt))
+    .orderBy(desc(orders.claimMarkedAt));
+  return rows.map((r) => ({
+    ...toFlagRow(r, adminBaseUrl, true),
+    claimNote: r.claimNote,
+    // `where(isNotNull(...))` vyššie zaručuje non-null — `??` len upokojí
+    // TS bez `!` assercie na `Date | null`.
+    claimMarkedAt: (r.claimMarkedAt ?? new Date(0)).toISOString(),
+  }));
+}
+
+export interface OrderFlagCounts {
+  readonly exchange: number;
+  readonly returned: number;
+  readonly claims: number;
+}
+
+/** Počty pre odznaky v ľavom menu (`nav.ts`) — `exchange`/`returned` =
+ * počet NEVYBAVENÝCH (`unresolved`), `claims` = počet AKTUÁLNE OZNAČENÝCH
+ * (žiadny ďalší "vybavené" koncept, viď `listClaimOrders` vyššie). */
+export async function countOrderFlags(db: Database): Promise<OrderFlagCounts> {
+  const [exchangeRows, returnedRows, claimRows] = await Promise.all([
+    selectFlaggedByStatus(db, isExchangeOrderStatus),
+    selectFlaggedByStatus(db, isReturnedOrderStatus),
+    db.select({ id: orders.id }).from(orders).where(isNotNull(orders.claimMarkedAt)),
+  ]);
+  return {
+    exchange: exchangeRows.filter((r) => r.unresolved).length,
+    returned: returnedRows.filter((r) => r.unresolved).length,
+    claims: claimRows.length,
+  };
+}

--- a/apps/api/src/modules/orders/order-flags-state.ts
+++ b/apps/api/src/modules/orders/order-flags-state.ts
@@ -1,0 +1,70 @@
+import { eq } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { orders } from "../../db/schema.js";
+import { record } from "../audit/service.js";
+
+// issue 290: JEDINÁ zapisovacia cesta pre appkinu vlastnú reklamácia-
+// značku (`schema-orders.ts`'s `claimMarkedAt`/`claimNote`) — rovnaký
+// "celý zápis v jednej transakcii spolu s auditom" vzor ako `orders/
+// state.ts`'s `setOrderLineState`.
+
+export type MarkOrderClaimResult = { readonly status: "ok"; readonly orderId: string } | { readonly status: "not_found" };
+
+export interface MarkOrderClaimInput {
+  readonly orderCode: string;
+  readonly note: string | null;
+  readonly actorUserId: string;
+  readonly now: Date;
+}
+
+/** Označí objednávku (podľa Shoptet čísla, presne to, čo obsluha pozná a
+ * má poruke) ako reklamáciu. Opakované označenie tej istej objednávky
+ * jednoducho PREPÍŠE poznámku a čas — nie je to chyba, obsluha si tak môže
+ * poznámku doplniť/opraviť bez toho, aby musela najprv zrušiť a znova
+ * označiť. */
+export async function markOrderClaim(db: Database, input: MarkOrderClaimInput): Promise<MarkOrderClaimResult> {
+  return db.transaction(async (tx) => {
+    const [order] = await tx.select({ id: orders.id }).from(orders).where(eq(orders.externalOrderId, input.orderCode)).limit(1);
+    if (order === undefined) return { status: "not_found" };
+
+    await tx.update(orders).set({ claimMarkedAt: input.now, claimNote: input.note }).where(eq(orders.id, order.id));
+
+    await record(tx, {
+      at: input.now,
+      actorUserId: input.actorUserId,
+      action: "order.claim.marked",
+      entity: "order",
+      entityId: order.id,
+      data: { orderCode: input.orderCode, note: input.note },
+    });
+
+    return { status: "ok", orderId: order.id };
+  });
+}
+
+export type ClearOrderClaimResult = "ok" | "not_found";
+
+export interface ClearOrderClaimInput {
+  readonly orderId: string;
+  readonly actorUserId: string;
+  readonly now: Date;
+}
+
+export async function clearOrderClaim(db: Database, input: ClearOrderClaimInput): Promise<ClearOrderClaimResult> {
+  return db.transaction(async (tx) => {
+    const [order] = await tx.select({ id: orders.id }).from(orders).where(eq(orders.id, input.orderId)).limit(1);
+    if (order === undefined) return "not_found";
+
+    await tx.update(orders).set({ claimMarkedAt: null, claimNote: null }).where(eq(orders.id, input.orderId));
+
+    await record(tx, {
+      at: input.now,
+      actorUserId: input.actorUserId,
+      action: "order.claim.cleared",
+      entity: "order",
+      entityId: input.orderId,
+    });
+
+    return "ok";
+  });
+}

--- a/apps/api/src/modules/orders/order-flags.test.ts
+++ b/apps/api/src/modules/orders/order-flags.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { isExchangeOrderStatus, isReturnedOrderStatus } from "./order-flags.js";
+
+// issue 290: priradenie OVERENÉ NAŽIVO na produkcii (tiket) — "Výmena
+// tovaru" = presne "Vybavená výmena", "Vrátený tovar" = "Vratený tovar" +
+// "Vybavený Dobropis". Rovnaká normalizačná disciplína ako `return-
+// status.test.ts` (NFC + orez, nikdy bajtovo presná zhoda).
+describe("isExchangeOrderStatus", () => {
+  it("rozpozná jediný priradený stav 'Vybavená výmena'", () => {
+    expect(isExchangeOrderStatus("Vybavená výmena")).toBe(true);
+  });
+
+  it("'Výmena tovaru' (rozpracovaný stav) NIE JE priradený — dnes nemá žiadnu objednávku", () => {
+    expect(isExchangeOrderStatus("Výmena tovaru")).toBe(false);
+  });
+
+  it("vrátkové/bežné stavy nie sú výmena", () => {
+    expect(isExchangeOrderStatus("Vratený tovar")).toBe(false);
+    expect(isExchangeOrderStatus("Vybavený Dobropis")).toBe(false);
+    expect(isExchangeOrderStatus("Vybavená")).toBe(false);
+    expect(isExchangeOrderStatus("")).toBe(false);
+  });
+
+  it("normalizuje (NFC + orez) rovnako ako order.status_name", () => {
+    expect(isExchangeOrderStatus("  Vybavená výmena  ")).toBe(true);
+    expect(isExchangeOrderStatus("Vybavená výmena".normalize("NFD"))).toBe(true);
+  });
+});
+
+describe("isReturnedOrderStatus", () => {
+  it("rozpozná OBA priradené stavy — 'Vratený tovar' aj jeho hotovú podobu 'Vybavený Dobropis'", () => {
+    expect(isReturnedOrderStatus("Vratený tovar")).toBe(true);
+    expect(isReturnedOrderStatus("Vybavený Dobropis")).toBe(true);
+  });
+
+  it("výmenový/bežné stavy nie sú vrátený tovar", () => {
+    expect(isReturnedOrderStatus("Vybavená výmena")).toBe(false);
+    expect(isReturnedOrderStatus("Vybavená")).toBe(false);
+    expect(isReturnedOrderStatus("Stornovaná")).toBe(false);
+    expect(isReturnedOrderStatus("")).toBe(false);
+  });
+
+  it("normalizuje (NFC + orez) rovnako ako order.status_name", () => {
+    expect(isReturnedOrderStatus("  Vratený tovar  ")).toBe(true);
+    expect(isReturnedOrderStatus("Vybavený Dobropis".normalize("NFD"))).toBe(true);
+  });
+});

--- a/apps/api/src/modules/orders/order-flags.ts
+++ b/apps/api/src/modules/orders/order-flags.ts
@@ -1,0 +1,32 @@
+import { normalizeStatusName } from "./parser.js";
+
+// issue 290: "Eshop → Výmena tovaru / Vrátený tovar / Reklamácie" — TRI
+// nové READ-ONLY stránky nad `order.status_name` (Výmena/Vrátený tovar) a
+// nad appkiným vlastným `order.claim_marked_at` (Reklamácie, `state.ts`
+// vedľa tohto súboru). Priradenie stavov je OVERENÉ NAŽIVO na produkcii
+// (issue 290, komentár na tickete, 2026-08-07), nie odhadnuté zo starej
+// appky — rovnaká disciplína ako `return-status.ts`'s zoznam vyššie v tomto
+// module, ale ÚPLNE SAMOSTATNÝ menný priestor: tieto tri stránky nikdy
+// nečítajú `return-status.ts`'s mapy priamo (mali by iný, neúmyselne
+// prepojený rozsah, keby sa niekedy zmenil dôvod #297's rozdelenia
+// aktívne/hotové), len ROVNAKÚ funkciu (`normalizeStatusName`) na
+// porovnanie, presne ako `open-statuses.ts`.
+const EXCHANGE_STATUS = normalizeStatusName("Vybavená výmena");
+const RETURNED_GOODS_STATUS = normalizeStatusName("Vratený tovar");
+const RETURNED_CREDIT_STATUS = normalizeStatusName("Vybavený Dobropis");
+
+/** `true`, keď objednávka patrí na stránku "Výmena tovaru" — presne stav
+ * "Vybavená výmena" (jediný, čo majiteľ na produkcii reálne má; "Výmena
+ * tovaru" — rozpracovaný stav — dnes nemá priradenú žiadnu objednávku,
+ * rozhodnuté na tickete). */
+export function isExchangeOrderStatus(statusName: string): boolean {
+  return normalizeStatusName(statusName) === EXCHANGE_STATUS;
+}
+
+/** `true`, keď objednávka patrí na stránku "Vrátený tovar" — "Vratený
+ * tovar" (rozpracované) ALEBO "Vybavený Dobropis" (jeho hotová podoba,
+ * rozhodnuté na tickete). */
+export function isReturnedOrderStatus(statusName: string): boolean {
+  const normalized = normalizeStatusName(statusName);
+  return normalized === RETURNED_GOODS_STATUS || normalized === RETURNED_CREDIT_STATUS;
+}

--- a/apps/api/tests/order-flags-http.integration.test.ts
+++ b/apps/api/tests/order-flags-http.integration.test.ts
@@ -1,0 +1,275 @@
+import { eq } from "drizzle-orm";
+import { afterEach, describe, expect, it } from "vitest";
+import { auditEvents, orders, users } from "../src/db/schema.js";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import type { UserRole } from "../src/modules/auth/service.js";
+import { returnUpozornenieDedupKey } from "../src/modules/orders/return-status.js";
+import { resolveUpozornenie, upsertUpozornenie } from "../src/modules/upozornenia/service.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 290: HTTP vrstva pre "Eshop → Výmena tovaru / Vrátený tovar /
+// Reklamácie". Vlastný súbor (rovnaký dôvod ako `upozornenia-http
+// .integration.test.ts`, eslint `max-lines: 400`).
+const HESLO = "test-heslo-abc"; // testovacie údaje, nie tajomstvo
+
+let close: (() => Promise<void>) | undefined;
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  resetLoginRateLimit();
+});
+
+async function boot(role: UserRole) {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const [pouzivatel] = await ctx.db
+    .insert(users)
+    .values({ email: "pouzivatel@forestshop.sk", passwordHash: await hashPassword(HESLO), displayName: "Test", role })
+    .returning({ id: users.id });
+  if (pouzivatel === undefined) throw new Error("testovací používateľ sa nepodarilo vložiť");
+  const app = createApp(ctx.db, { cookieSecure: false });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "pouzivatel@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie, db: ctx.db, userId: pouzivatel.id };
+}
+
+let poradie = 0;
+async function insertOrder(
+  db: Awaited<ReturnType<typeof boot>>["db"],
+  statusName: string,
+  options: { readonly comment?: string | null } = {},
+): Promise<{ id: string; externalOrderId: string }> {
+  poradie += 1;
+  const externalOrderId = `9${String(poradie).padStart(5, "0")}`;
+  const [order] = await db
+    .insert(orders)
+    .values({
+      externalOrderId,
+      customerName: "Zákazník testovaný",
+      statusName,
+      comment: options.comment ?? null,
+      placedAt: new Date("2026-07-20T00:00:00Z"),
+      totalPriceWithVat: "42.00",
+    })
+    .returning({ id: orders.id, externalOrderId: orders.externalOrderId });
+  if (order === undefined) throw new Error("insert objednávky zlyhal");
+  return order;
+}
+
+describe("GET /api/order-flags/exchange", () => {
+  it("vráti len objednávky v stave 'Vybavená výmena', s nevybavenosťou podľa otvorenej vratenie karty", async () => {
+    const { app, cookie, db } = await boot("citanie");
+    const vymena = await insertOrder(db, "Vybavená výmena", { comment: "poznámka k výmene" });
+    await insertOrder(db, "Vybavená"); // iný stav — nesmie sa objaviť
+    await insertOrder(db, "Vratený tovar"); // iný stav — nesmie sa objaviť
+    await upsertUpozornenie(db, {
+      type: "vratenie",
+      source: "appka",
+      title: "test",
+      dedupKey: returnUpozornenieDedupKey(vymena.externalOrderId),
+      now: new Date("2026-07-21T00:00:00Z"),
+    });
+
+    const res = await app.request("/api/order-flags/exchange", { headers: { cookie } });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { orders: readonly Record<string, unknown>[] };
+    expect(body.orders).toHaveLength(1);
+    expect(body.orders[0]?.["externalOrderId"]).toBe(vymena.externalOrderId);
+    expect(body.orders[0]?.["statusName"]).toBe("Vybavená výmena");
+    expect(body.orders[0]?.["comment"]).toBe("poznámka k výmene");
+    expect(body.orders[0]?.["unresolved"]).toBe(true);
+  });
+
+  it("objednávka bez otvorenej vratenie karty je unresolved: false", async () => {
+    const { app, cookie, db } = await boot("citanie");
+    await insertOrder(db, "Vybavená výmena");
+
+    const res = await app.request("/api/order-flags/exchange", { headers: { cookie } });
+    const body = (await res.json()) as { orders: readonly Record<string, unknown>[] };
+    expect(body.orders).toHaveLength(1);
+    expect(body.orders[0]?.["unresolved"]).toBe(false);
+  });
+
+  it("VYRIEŠENÁ vratenie karta neznamená unresolved — len otvorená karta počíta", async () => {
+    const { app, cookie, db, userId } = await boot("citanie");
+    const vymena = await insertOrder(db, "Vybavená výmena");
+    const card = await upsertUpozornenie(db, {
+      type: "vratenie",
+      source: "appka",
+      title: "test",
+      dedupKey: returnUpozornenieDedupKey(vymena.externalOrderId),
+      now: new Date("2026-07-21T00:00:00Z"),
+    });
+    await resolveUpozornenie(db, { id: card.id, resolvedByUserId: userId, now: new Date("2026-07-22T00:00:00Z") });
+
+    const res = await app.request("/api/order-flags/exchange", { headers: { cookie } });
+    const body = (await res.json()) as { orders: readonly Record<string, unknown>[] };
+    expect(body.orders[0]?.["unresolved"]).toBe(false);
+  });
+
+  it("bez prihlásenia vráti 401", async () => {
+    const { app } = await boot("manazer");
+    const res = await app.request("/api/order-flags/exchange");
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /api/order-flags/returned", () => {
+  it("vráti objednávky v OBOCH stavoch — 'Vratený tovar' aj 'Vybavený Dobropis'", async () => {
+    const { app, cookie, db } = await boot("citanie");
+    const vrateny = await insertOrder(db, "Vratený tovar");
+    const dobropis = await insertOrder(db, "Vybavený Dobropis");
+    await insertOrder(db, "Vybavená výmena"); // iná stránka — nesmie sa objaviť
+
+    const res = await app.request("/api/order-flags/returned", { headers: { cookie } });
+    const body = (await res.json()) as { orders: readonly Record<string, unknown>[] };
+    const ids = body.orders.map((o) => o["externalOrderId"]);
+    expect(ids).toHaveLength(2);
+    expect(ids).toContain(vrateny.externalOrderId);
+    expect(ids).toContain(dobropis.externalOrderId);
+  });
+});
+
+describe("GET /api/order-flags/claims", () => {
+  it("prázdny zoznam, kým nikto nič neoznačil", async () => {
+    const { app, cookie, db } = await boot("citanie");
+    await insertOrder(db, "Vybavená");
+    const res = await app.request("/api/order-flags/claims", { headers: { cookie } });
+    const body = (await res.json()) as { orders: readonly unknown[] };
+    expect(body.orders).toEqual([]);
+  });
+
+  it("po označení sa objednávka objaví so svojou poznámkou, unresolved vždy true", async () => {
+    const { app, cookie, db } = await boot("manazer");
+    const objednavka = await insertOrder(db, "Vybavená");
+
+    const mark = await app.request("/api/order-flags/claims", {
+      method: "POST",
+      headers: { cookie, "content-type": "application/json" },
+      body: JSON.stringify({ orderCode: objednavka.externalOrderId, note: "chybný zips" }),
+    });
+    expect(mark.status).toBe(200);
+    expect(((await mark.json()) as { ok: boolean }).ok).toBe(true);
+
+    const res = await app.request("/api/order-flags/claims", { headers: { cookie } });
+    const body = (await res.json()) as { orders: readonly Record<string, unknown>[] };
+    expect(body.orders).toHaveLength(1);
+    expect(body.orders[0]?.["claimNote"]).toBe("chybný zips");
+    expect(body.orders[0]?.["unresolved"]).toBe(true);
+  });
+});
+
+describe("POST /api/order-flags/claims", () => {
+  it("čítanie ('citanie') nemôže označiť reklamáciu — 403", async () => {
+    const { app, cookie, db } = await boot("citanie");
+    const objednavka = await insertOrder(db, "Vybavená");
+    const res = await app.request("/api/order-flags/claims", {
+      method: "POST",
+      headers: { cookie, "content-type": "application/json" },
+      body: JSON.stringify({ orderCode: objednavka.externalOrderId }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("neexistujúce číslo objednávky vráti ok:false s hláškou, nič neuloží", async () => {
+    const { app, cookie } = await boot("manazer");
+    const res = await app.request("/api/order-flags/claims", {
+      method: "POST",
+      headers: { cookie, "content-type": "application/json" },
+      body: JSON.stringify({ orderCode: "neexistuje-123" }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; error?: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toBeTruthy();
+  });
+
+  it("označenie zapíše audit záznam s kým a poznámkou", async () => {
+    const { app, cookie, db, userId } = await boot("manazer");
+    const objednavka = await insertOrder(db, "Vybavená");
+    await app.request("/api/order-flags/claims", {
+      method: "POST",
+      headers: { cookie, "content-type": "application/json" },
+      body: JSON.stringify({ orderCode: objednavka.externalOrderId, note: "poznámka" }),
+    });
+
+    const [event] = await db.select().from(auditEvents).where(eq(auditEvents.action, "order.claim.marked"));
+    expect(event?.actorUserId).toBe(userId);
+    expect(event?.entityId).toBe(objednavka.id);
+  });
+});
+
+describe("POST /api/order-flags/claims/:id/clear", () => {
+  it("zruší označenie — objednávka zmizne zo zoznamu reklamácií", async () => {
+    const { app, cookie, db } = await boot("manazer");
+    const objednavka = await insertOrder(db, "Vybavená");
+    await app.request("/api/order-flags/claims", {
+      method: "POST",
+      headers: { cookie, "content-type": "application/json" },
+      body: JSON.stringify({ orderCode: objednavka.externalOrderId }),
+    });
+
+    const clear = await app.request(`/api/order-flags/claims/${objednavka.id}/clear`, {
+      method: "POST",
+      headers: { cookie },
+    });
+    expect(clear.status).toBe(200);
+    expect(((await clear.json()) as { ok: boolean }).ok).toBe(true);
+
+    const res = await app.request("/api/order-flags/claims", { headers: { cookie } });
+    const body = (await res.json()) as { orders: readonly unknown[] };
+    expect(body.orders).toEqual([]);
+  });
+
+  it("zrušenie NEOZNAČENEJ objednávky (nič neoznačené) je no-op ok:true — nikdy nespadne", async () => {
+    const { app, cookie, db } = await boot("manazer");
+    const objednavka = await insertOrder(db, "Vybavená");
+    const res = await app.request(`/api/order-flags/claims/${objednavka.id}/clear`, {
+      method: "POST",
+      headers: { cookie },
+    });
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as { ok: boolean }).ok).toBe(true);
+  });
+
+  it("neexistujúce id objednávky vráti ok:false", async () => {
+    const { app, cookie } = await boot("manazer");
+    const res = await app.request("/api/order-flags/claims/00000000-0000-0000-0000-000000000000/clear", {
+      method: "POST",
+      headers: { cookie },
+    });
+    const body = (await res.json()) as { ok: boolean };
+    expect(body.ok).toBe(false);
+  });
+});
+
+describe("GET /api/order-flags/counts", () => {
+  it("spočíta nevybavené výmeny/vrátenia + aktuálne označené reklamácie", async () => {
+    const { app, cookie, db } = await boot("manazer");
+    const vymena = await insertOrder(db, "Vybavená výmena");
+    await upsertUpozornenie(db, {
+      type: "vratenie",
+      source: "appka",
+      title: "t",
+      dedupKey: returnUpozornenieDedupKey(vymena.externalOrderId),
+      now: new Date("2026-07-21T00:00:00Z"),
+    });
+    await insertOrder(db, "Vratený tovar"); // bez karty → 0 do returned count
+    const reklamacia = await insertOrder(db, "Vybavená");
+    await app.request("/api/order-flags/claims", {
+      method: "POST",
+      headers: { cookie, "content-type": "application/json" },
+      body: JSON.stringify({ orderCode: reklamacia.externalOrderId }),
+    });
+
+    const res = await app.request("/api/order-flags/counts", { headers: { cookie } });
+    const body = (await res.json()) as { exchange: number; returned: number; claims: number };
+    expect(body).toEqual({ exchange: 1, returned: 0, claims: 1 });
+  });
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -125,7 +125,13 @@ export function App(): JSX.Element {
       if (orderFlagCounts.claims > 0) counts["claims"] = orderFlagCounts.claims;
     }
     return counts;
-  }, [ordersRemainingCount, upozorneniaCount]);
+    // Code review (pred mergom, issue 290): `orderFlagCounts` sa v tele číta,
+    // ale chýbal v dependency poli — appka tu NEMÁ `eslint-plugin-react-hooks`
+    // (`.claude/rules/frontend-design.md`'s zdokumentovaná past, presne ten
+    // istý tvar bugu ako `UpozorneniaSection.tsx`'s `withBusy`), takže lint
+    // to nezachytí a stará hodnota (chýbajúce odznaky hneď po prihlásení,
+    // kým sa nespustí NEJAKÝ INÝ trigger) prežije bez varovania.
+  }, [ordersRemainingCount, upozorneniaCount, orderFlagCounts]);
 
   // issue 185: stav zapnuté/vypnuté pre "Automatizácie" priečinok v menu.
   // Na rozdiel od `ordersRemainingCount` vyššie (publikované OBRAZOVKOU

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -247,34 +247,34 @@ export function App(): JSX.Element {
     <OrdersRemainingCountContext.Provider value={ordersRemainingCountContextValue}>
       <UpozorneniaBadgeRefreshContext.Provider value={upozorneniaBadgeContextValue}>
         <OrderFlagsBadgeRefreshContext.Provider value={orderFlagsBadgeContextValue}>
-        <div className="app-shell">
-          <Sidebar
-            folders={NAV}
-            activeTabId={activeTabId}
-            onSelectTab={selectTab}
-            badgeCounts={badgeCounts}
-            badgeStatus={automationStatus}
-          />
-          <div className="main">
-            <Topbar
-              title={isVisibleTabId(activeTabId) ? (tab?.label ?? null) : null}
-              greeting={`Prihlásený: ${me.displayName} (${me.role})`}
-              role={me.role}
-              onSessionExpired={reload}
-              onLogout={logout}
-              passwordPanelOpen={passwordPanelOpen}
-              onTogglePasswordPanel={() => {
-                setPasswordPanelOpen((open) => !open);
-              }}
-            >
-              <ChangePasswordForm email={me.email} onSessionExpired={reload} />
-            </Topbar>
-            <main className={tab?.wide === true ? "main-wide" : undefined}>
-              {logoutError !== "" && <p role="alert">{logoutError}</p>}
-              {ActiveComponent !== null && <ActiveComponent role={me.role} onSessionExpired={reload} />}
-            </main>
+          <div className="app-shell">
+            <Sidebar
+              folders={NAV}
+              activeTabId={activeTabId}
+              onSelectTab={selectTab}
+              badgeCounts={badgeCounts}
+              badgeStatus={automationStatus}
+            />
+            <div className="main">
+              <Topbar
+                title={isVisibleTabId(activeTabId) ? (tab?.label ?? null) : null}
+                greeting={`Prihlásený: ${me.displayName} (${me.role})`}
+                role={me.role}
+                onSessionExpired={reload}
+                onLogout={logout}
+                passwordPanelOpen={passwordPanelOpen}
+                onTogglePasswordPanel={() => {
+                  setPasswordPanelOpen((open) => !open);
+                }}
+              >
+                <ChangePasswordForm email={me.email} onSessionExpired={reload} />
+              </Topbar>
+              <main className={tab?.wide === true ? "main-wide" : undefined}>
+                {logoutError !== "" && <p role="alert">{logoutError}</p>}
+                {ActiveComponent !== null && <ActiveComponent role={me.role} onSessionExpired={reload} />}
+              </main>
+            </div>
           </div>
-        </div>
         </OrderFlagsBadgeRefreshContext.Provider>
       </UpozorneniaBadgeRefreshContext.Provider>
     </OrdersRemainingCountContext.Provider>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -7,6 +7,8 @@ import { LoginForm } from "./components/LoginForm.js";
 import { Sidebar } from "./components/Sidebar.js";
 import { Topbar } from "./components/Topbar.js";
 import { DEFAULT_TAB_ID, NAV, findTab, isVisibleTabId } from "./nav.js";
+import { fetchOrderFlagCounts } from "./orderFlagsApi.js";
+import { OrderFlagsBadgeRefreshContext } from "./orderFlagsBadgeContext.js";
 import { fetchOrderReminderStatus } from "./orderReminderApi.js";
 import { OrdersRemainingCountContext } from "./ordersRemainingCountContext.js";
 import { fetchPostaUncollectedStatus } from "./postaUncollectedApi.js";
@@ -76,10 +78,52 @@ export function App(): JSX.Element {
     };
   }, [me, activeTabId, upozorneniaRefreshNonce]);
 
+  // issue 290: odznaky "Výmena tovaru"/"Vrátený tovar"/"Reklamácie" — rovnaký
+  // priamy vzor ako `upozorneniaCount` vyššie (JEDEN endpoint, `App.tsx` si
+  // ho volá sám, počty musia byť známe hneď po prihlásení). Na rozdiel od
+  // Upozornení má JEDEN spoločný refresh-spúšťač namiesto troch, lebo
+  // mutuje ich len JEDNA z troch obrazoviek (`ClaimOrdersSection`), ale
+  // odznak potrebujú refetchovať všetky tri naraz (mark/clear môže zmeniť
+  // len `claims`, no netreba to rozlišovať — samostatný refetch pre jedno
+  // číslo by bol zbytočná zložitosť navyše pre appku tejto veľkosti).
+  const [orderFlagCounts, setOrderFlagCounts] = useState<{ readonly exchange: number; readonly returned: number; readonly claims: number } | null>(
+    null,
+  );
+  const [orderFlagsRefreshNonce, setOrderFlagsRefreshNonce] = useState(0);
+  const orderFlagsBadgeRefresh = useCallback(() => {
+    setOrderFlagsRefreshNonce((n) => n + 1);
+  }, []);
+  const orderFlagsBadgeContextValue = useMemo(() => ({ refresh: orderFlagsBadgeRefresh }), [orderFlagsBadgeRefresh]);
+  useEffect(() => {
+    if (me === null) return;
+    let cancelled = false;
+    fetchOrderFlagCounts()
+      .then((counts) => {
+        if (!cancelled) setOrderFlagCounts(counts);
+      })
+      .catch(() => {
+        // `fetchOrderFlagCounts` už interne zachytáva všetky chyby a vždy
+        // vráti nuly (`orderFlagsApi.ts`) — tento catch je len poistka pre
+        // eslint `no-floating-promises`, nikdy by sa reálne nemal spustiť.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [me, activeTabId, orderFlagsRefreshNonce]);
+
   const badgeCounts = useMemo<Readonly<Record<string, number>>>(() => {
     const counts: Record<string, number> = {};
     if (ordersRemainingCount !== null) counts["orders"] = ordersRemainingCount;
     if (upozorneniaCount !== null) counts["upozornenia"] = upozorneniaCount;
+    // issue 290: na rozdiel od "orders"/"upozornenia" vyššie (odznak sa
+    // ukazuje AJ pri nule — appka tým hovorí "toto číslo poznám, je 0")
+    // tieto tri odznaky sa VÔBEC nezobrazujú pri nule (ticket: "shown only
+    // when >0") — chýbajúci kľúč v `badgeCounts`, nie "0" hodnota.
+    if (orderFlagCounts !== null) {
+      if (orderFlagCounts.exchange > 0) counts["exchange"] = orderFlagCounts.exchange;
+      if (orderFlagCounts.returned > 0) counts["returned"] = orderFlagCounts.returned;
+      if (orderFlagCounts.claims > 0) counts["claims"] = orderFlagCounts.claims;
+    }
     return counts;
   }, [ordersRemainingCount, upozorneniaCount]);
 
@@ -202,6 +246,7 @@ export function App(): JSX.Element {
   return (
     <OrdersRemainingCountContext.Provider value={ordersRemainingCountContextValue}>
       <UpozorneniaBadgeRefreshContext.Provider value={upozorneniaBadgeContextValue}>
+        <OrderFlagsBadgeRefreshContext.Provider value={orderFlagsBadgeContextValue}>
         <div className="app-shell">
           <Sidebar
             folders={NAV}
@@ -230,6 +275,7 @@ export function App(): JSX.Element {
             </main>
           </div>
         </div>
+        </OrderFlagsBadgeRefreshContext.Provider>
       </UpozorneniaBadgeRefreshContext.Provider>
     </OrdersRemainingCountContext.Provider>
   );

--- a/apps/web/src/components/ClaimOrdersSection.test.tsx
+++ b/apps/web/src/components/ClaimOrdersSection.test.tsx
@@ -1,0 +1,97 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { ClaimOrdersSection } from "./ClaimOrdersSection.js";
+
+const { fetchClaimOrders, markOrderClaim, clearOrderClaim } = vi.hoisted(() => ({
+  fetchClaimOrders: vi.fn(),
+  markOrderClaim: vi.fn(),
+  clearOrderClaim: vi.fn(),
+}));
+
+vi.mock("../orderFlagsApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../orderFlagsApi.js")>();
+  return { ...actual, fetchClaimOrders, markOrderClaim, clearOrderClaim };
+});
+
+const CLAIM = {
+  id: "order-3",
+  externalOrderId: "20600003",
+  customerName: "Zákazník testovaný",
+  statusName: "Vybavená",
+  placedAt: "2026-08-01T10:00:00.000Z",
+  totalPriceWithVat: "10.00",
+  comment: null,
+  adminUrl: "https://www.forestshop.sk/admin/objednavky-detail/?id=3",
+  unresolved: true,
+  claimNote: "chybný zips",
+  claimMarkedAt: "2026-08-02T10:00:00.000Z",
+};
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+it("prázdny zoznam zobrazí informačnú vetu", async () => {
+  fetchClaimOrders.mockResolvedValue([]);
+  render(<ClaimOrdersSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("claims-empty");
+});
+
+it("zobrazí označenú reklamáciu s poznámkou", async () => {
+  fetchClaimOrders.mockResolvedValue([CLAIM]);
+  render(<ClaimOrdersSection role="manazer" onSessionExpired={vi.fn()} />);
+  const row = await screen.findByTestId("claim-row-20600003");
+  expect(row.textContent).toContain("chybný zips");
+});
+
+it("manažér označí objednávku ako reklamáciu — formulár sa vyprázdni, zoznam sa obnoví", async () => {
+  fetchClaimOrders.mockResolvedValueOnce([]).mockResolvedValueOnce([CLAIM]);
+  markOrderClaim.mockResolvedValue({ ok: true, orderId: "order-3" });
+  render(<ClaimOrdersSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("claims-empty");
+
+  fireEvent.change(screen.getByTestId("claim-order-code"), { target: { value: "20600003" } });
+  fireEvent.change(screen.getByTestId("claim-note-input"), { target: { value: "chybný zips" } });
+  fireEvent.click(screen.getByTestId("claim-mark-submit"));
+
+  await waitFor(() => {
+    expect(markOrderClaim).toHaveBeenCalledWith("20600003", "chybný zips");
+  });
+  await screen.findByTestId("claim-row-20600003");
+  expect(screen.getByTestId<HTMLInputElement>("claim-order-code").value).toBe("");
+});
+
+it("neexistujúce číslo objednávky ukáže chybu z odpovede, nič sa nezmení", async () => {
+  fetchClaimOrders.mockResolvedValue([]);
+  markOrderClaim.mockResolvedValue({ ok: false, error: "Objednávka s týmto číslom sa nenašla." });
+  render(<ClaimOrdersSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("claims-empty");
+
+  fireEvent.change(screen.getByTestId("claim-order-code"), { target: { value: "neexistuje" } });
+  fireEvent.click(screen.getByTestId("claim-mark-submit"));
+
+  await screen.findByText("Objednávka s týmto číslom sa nenašla.");
+});
+
+it("zrušenie reklamácie zavolá clearOrderClaim a obnoví zoznam", async () => {
+  fetchClaimOrders.mockResolvedValueOnce([CLAIM]).mockResolvedValueOnce([]);
+  clearOrderClaim.mockResolvedValue(undefined);
+  render(<ClaimOrdersSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("claim-row-20600003");
+
+  fireEvent.click(screen.getByTestId("claim-clear-20600003"));
+
+  await waitFor(() => {
+    expect(clearOrderClaim).toHaveBeenCalledWith("order-3");
+  });
+  await screen.findByTestId("claims-empty");
+});
+
+it("rola citanie NEVIDÍ formulár na označenie ani tlačidlo zrušenia", async () => {
+  fetchClaimOrders.mockResolvedValue([CLAIM]);
+  render(<ClaimOrdersSection role="citanie" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("claim-row-20600003");
+  expect(screen.queryByTestId("claim-order-code")).toBeNull();
+  expect(screen.queryByTestId("claim-clear-20600003")).toBeNull();
+});

--- a/apps/web/src/components/ClaimOrdersSection.tsx
+++ b/apps/web/src/components/ClaimOrdersSection.tsx
@@ -1,0 +1,190 @@
+import { useCallback, useContext, useEffect, useState, type JSX, type SyntheticEvent } from "react";
+import type { Me } from "../api.js";
+import { formatSkDate } from "../formatDate.js";
+import {
+  clearOrderClaim,
+  fetchClaimOrders,
+  markOrderClaim,
+  OrderFlagsUnauthorizedError,
+  type ClaimOrderRow,
+} from "../orderFlagsApi.js";
+import { OrderFlagsBadgeRefreshContext } from "../orderFlagsBadgeContext.js";
+
+// issue 290: "Eshop → Reklamácie" — Shoptet nemá pre reklamácie žiadny
+// použiteľný stav/príznak (overené naživo na produkcii, tiket), appka si
+// preto vedie VLASTNÚ značku (`order.claim_marked_at`/`claim_note`,
+// `modules/orders/order-flags-state.ts`). Na rozdiel od Výmena/Vrátený
+// tovar (čisto READ-ONLY pohľad na Shoptet stav) má táto obrazovka JEDINÚ
+// mutáciu appky mimo Upozornení — obsluha si sama označí/zruší reklamáciu,
+// nikdy AI dohad.
+const CONTROL_ROLES: ReadonlySet<Me["role"]> = new Set(["admin", "manazer"]);
+
+export function ClaimOrdersSection({ role, onSessionExpired }: { readonly role: Me["role"]; readonly onSessionExpired: () => void }): JSX.Element {
+  const [rows, setRows] = useState<readonly ClaimOrderRow[] | null>(null);
+  const [error, setError] = useState("");
+  const [orderCode, setOrderCode] = useState("");
+  const [note, setNote] = useState("");
+  const [markError, setMarkError] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [busyClearId, setBusyClearId] = useState("");
+  const canControl = CONTROL_ROLES.has(role);
+  const badgeRefresh = useContext(OrderFlagsBadgeRefreshContext);
+
+  const load = useCallback(() => {
+    fetchClaimOrders()
+      .then(setRows)
+      .catch((err: unknown) => {
+        if (err instanceof OrderFlagsUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setError("Zoznam reklamácií sa nepodarilo načítať.");
+      });
+  }, [onSessionExpired]);
+
+  useEffect(load, [load]);
+
+  const mark = useCallback(
+    (e: SyntheticEvent) => {
+      e.preventDefault();
+      if (orderCode.trim() === "") return;
+      setBusy(true);
+      setMarkError("");
+      markOrderClaim(orderCode.trim(), note)
+        .then((result) => {
+          if (!result.ok) {
+            setMarkError(result.error);
+            return;
+          }
+          setOrderCode("");
+          setNote("");
+          load();
+          badgeRefresh.refresh();
+        })
+        .catch((err: unknown) => {
+          if (err instanceof OrderFlagsUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setMarkError(err instanceof Error ? err.message : "Označenie zlyhalo.");
+        })
+        .finally(() => {
+          setBusy(false);
+        });
+    },
+    [orderCode, note, load, onSessionExpired, badgeRefresh],
+  );
+
+  const clear = useCallback(
+    (orderId: string) => {
+      setBusyClearId(orderId);
+      clearOrderClaim(orderId)
+        .then(() => {
+          load();
+          badgeRefresh.refresh();
+        })
+        .catch((err: unknown) => {
+          if (err instanceof OrderFlagsUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setError(err instanceof Error ? err.message : "Zrušenie reklamácie zlyhalo.");
+        })
+        .finally(() => {
+          setBusyClearId("");
+        });
+    },
+    [load, onSessionExpired, badgeRefresh],
+  );
+
+  if (error !== "") return <p role="alert">{error}</p>;
+  if (rows === null) return <p>Načítavam…</p>;
+
+  return (
+    <section>
+      <p>Objednávky ručne označené ako reklamácia — Shoptet pre reklamácie nemá vlastný stav, appka si ich preto vedie sama.</p>
+
+      {canControl && (
+        <form className="card" onSubmit={mark}>
+          <label>
+            Číslo objednávky
+            <input
+              type="text"
+              value={orderCode}
+              onChange={(e) => {
+                setOrderCode(e.target.value);
+              }}
+              data-testid="claim-order-code"
+            />
+          </label>
+          <label>
+            Poznámka (nepovinné)
+            <input
+              type="text"
+              value={note}
+              onChange={(e) => {
+                setNote(e.target.value);
+              }}
+              data-testid="claim-note-input"
+            />
+          </label>
+          {markError !== "" && <p role="alert">{markError}</p>}
+          <button type="submit" className="btn" disabled={busy || orderCode.trim() === ""} data-testid="claim-mark-submit">
+            Označiť ako reklamáciu
+          </button>
+        </form>
+      )}
+
+      {rows.length === 0 ? (
+        <p data-testid="claims-empty">Momentálne nie je označená žiadna reklamácia.</p>
+      ) : (
+        <div className="fs-table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Objednávka</th>
+                <th>Zákazník</th>
+                <th>Dátum</th>
+                <th>Suma</th>
+                <th>Stav</th>
+                <th>Poznámka</th>
+                {canControl && <th>Akcia</th>}
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr key={row.id} data-testid={`claim-row-${row.externalOrderId}`}>
+                  <td>
+                    <a href={row.adminUrl} target="_blank" rel="noreferrer">
+                      č. {row.externalOrderId}
+                    </a>
+                  </td>
+                  <td>{row.customerName}</td>
+                  <td>{formatSkDate(row.placedAt)}</td>
+                  <td>{row.totalPriceWithVat === null ? "—" : `${row.totalPriceWithVat} €`}</td>
+                  <td>{row.statusName}</td>
+                  <td>{row.claimNote === null || row.claimNote === "" ? "—" : row.claimNote}</td>
+                  {canControl && (
+                    <td>
+                      <button
+                        type="button"
+                        className="btn sm ghost"
+                        disabled={busyClearId === row.id}
+                        onClick={() => {
+                          clear(row.id);
+                        }}
+                        data-testid={`claim-clear-${row.externalOrderId}`}
+                      >
+                        Zrušiť reklamáciu
+                      </button>
+                    </td>
+                  )}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/ExchangeOrdersSection.test.tsx
+++ b/apps/web/src/components/ExchangeOrdersSection.test.tsx
@@ -1,0 +1,60 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { ExchangeOrdersSection } from "./ExchangeOrdersSection.js";
+
+const { fetchExchangeOrders } = vi.hoisted(() => ({ fetchExchangeOrders: vi.fn() }));
+
+vi.mock("../orderFlagsApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../orderFlagsApi.js")>();
+  return { ...actual, fetchExchangeOrders };
+});
+
+const { OrderFlagsUnauthorizedError } = await import("../orderFlagsApi.js");
+
+const ROW = {
+  id: "order-1",
+  externalOrderId: "20600001",
+  customerName: "Zákazník testovaný",
+  statusName: "Vybavená výmena",
+  placedAt: "2026-08-01T10:00:00.000Z",
+  totalPriceWithVat: "42.00",
+  comment: "poznámka",
+  adminUrl: "https://www.forestshop.sk/admin/objednavky-detail/?id=1",
+  unresolved: true,
+};
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+it("prázdny zoznam zobrazí informačnú vetu", async () => {
+  fetchExchangeOrders.mockResolvedValue([]);
+  render(<ExchangeOrdersSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("exchange-empty");
+});
+
+it("zobrazí riadok objednávky s odkazom aj štítkom 'nevybavené', keď má otvorenú vratenie kartu", async () => {
+  fetchExchangeOrders.mockResolvedValue([ROW]);
+  render(<ExchangeOrdersSection role="manazer" onSessionExpired={vi.fn()} />);
+  const row = await screen.findByTestId("exchange-row-20600001");
+  expect(row.textContent).toContain("20600001");
+  expect(row.textContent).toContain("Vybavená výmena");
+  await screen.findByTestId("exchange-row-unresolved-20600001");
+});
+
+it("objednávka bez otvorenej karty NEMÁ štítok 'nevybavené'", async () => {
+  fetchExchangeOrders.mockResolvedValue([{ ...ROW, unresolved: false }]);
+  render(<ExchangeOrdersSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("exchange-row-20600001");
+  expect(screen.queryByTestId("exchange-row-unresolved-20600001")).toBeNull();
+});
+
+it("401 (Unauthorized) volá onSessionExpired namiesto zobrazenia chyby", async () => {
+  fetchExchangeOrders.mockRejectedValue(new OrderFlagsUnauthorizedError());
+  const onSessionExpired = vi.fn();
+  render(<ExchangeOrdersSection role="manazer" onSessionExpired={onSessionExpired} />);
+  await waitFor(() => {
+    expect(onSessionExpired).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/ExchangeOrdersSection.tsx
+++ b/apps/web/src/components/ExchangeOrdersSection.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useState, type JSX } from "react";
+import type { Me } from "../api.js";
+import { fetchExchangeOrders, OrderFlagsUnauthorizedError, type OrderFlagRow } from "../orderFlagsApi.js";
+import { OrderFlagTable } from "./OrderFlagTable.js";
+
+// issue 290: "Eshop → Výmena tovaru" — READ-ONLY zoznam objednávok v stave
+// "Vybavená výmena" (jediný priradený stav, `modules/orders/order-flags
+// .ts`). Žiadna mutácia tu — vybavovanie ostáva výhradne na nástenke
+// Upozornenia (`return-status.ts`/#267/#269/#297), táto obrazovka len
+// ZOBRAZUJE tie isté objednávky + či majú ešte otvorenú kartu.
+export function ExchangeOrdersSection({ onSessionExpired }: { readonly role: Me["role"]; readonly onSessionExpired: () => void }): JSX.Element {
+  const [rows, setRows] = useState<readonly OrderFlagRow[] | null>(null);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    fetchExchangeOrders()
+      .then(setRows)
+      .catch((err: unknown) => {
+        if (err instanceof OrderFlagsUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setError("Zoznam výmen sa nepodarilo načítať.");
+      });
+  }, [onSessionExpired]);
+
+  if (error !== "") return <p role="alert">{error}</p>;
+  if (rows === null) return <p>Načítavam…</p>;
+
+  return (
+    <section>
+      <p>Objednávky, ktoré Shoptet eviduje v stave „Vybavená výmena“. Farebný štítok „nevybavené“ znamená, že na nástenke Upozornenia je k tejto objednávke ešte otvorená karta.</p>
+      {rows.length === 0 ? (
+        <p data-testid="exchange-empty">Momentálne žiadna objednávka nie je vo výmene.</p>
+      ) : (
+        <OrderFlagTable testIdPrefix="exchange-row" rows={rows} />
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/OrderFlagTable.tsx
+++ b/apps/web/src/components/OrderFlagTable.tsx
@@ -1,0 +1,49 @@
+import type { JSX } from "react";
+import type { OrderFlagRow } from "../orderFlagsApi.js";
+import { formatSkDate } from "../formatDate.js";
+
+// issue 290: zdieľaná READ-ONLY tabuľka pre "Výmena tovaru"/"Vrátený tovar"
+// — obe stránky majú IDENTICKÝ tvar riadku (`OrderFlagRow`), líšia sa len
+// zdrojovým filtrom (`ExchangeOrdersSection.tsx`/`ReturnedOrdersSection
+// .tsx`). "Reklamácie" má VLASTNÚ tabuľku (`ClaimOrdersSection.tsx`) — nesie
+// navyše poznámku obsluhy a tlačidlo na zrušenie, spoločný tvar by ich
+// musel robiť voliteľné pre polovicu použití zbytočne.
+export function OrderFlagTable({ testIdPrefix, rows }: { readonly testIdPrefix: string; readonly rows: readonly OrderFlagRow[] }): JSX.Element {
+  return (
+    <div className="fs-table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>Objednávka</th>
+            <th>Zákazník</th>
+            <th>Dátum</th>
+            <th>Suma</th>
+            <th>Stav</th>
+            <th>Poznámka</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.id} data-testid={`${testIdPrefix}-${row.externalOrderId}`}>
+              <td>
+                <a href={row.adminUrl} target="_blank" rel="noreferrer">
+                  č. {row.externalOrderId}
+                </a>
+                {row.unresolved && (
+                  <span className="pill" data-testid={`${testIdPrefix}-unresolved-${row.externalOrderId}`}>
+                    nevybavené
+                  </span>
+                )}
+              </td>
+              <td>{row.customerName}</td>
+              <td>{formatSkDate(row.placedAt)}</td>
+              <td>{row.totalPriceWithVat === null ? "—" : `${row.totalPriceWithVat} €`}</td>
+              <td>{row.statusName}</td>
+              <td>{row.comment === null || row.comment === "" ? "—" : row.comment}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/src/components/ReturnedOrdersSection.test.tsx
+++ b/apps/web/src/components/ReturnedOrdersSection.test.tsx
@@ -1,0 +1,52 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { ReturnedOrdersSection } from "./ReturnedOrdersSection.js";
+
+const { fetchReturnedOrders } = vi.hoisted(() => ({ fetchReturnedOrders: vi.fn() }));
+
+vi.mock("../orderFlagsApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../orderFlagsApi.js")>();
+  return { ...actual, fetchReturnedOrders };
+});
+
+const { OrderFlagsUnauthorizedError } = await import("../orderFlagsApi.js");
+
+const ROW = {
+  id: "order-2",
+  externalOrderId: "20600002",
+  customerName: "Zákazník testovaný",
+  statusName: "Vratený tovar",
+  placedAt: "2026-08-01T10:00:00.000Z",
+  totalPriceWithVat: null,
+  comment: null,
+  adminUrl: "https://www.forestshop.sk/admin/objednavky-detail/?id=2",
+  unresolved: true,
+};
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+it("prázdny zoznam zobrazí informačnú vetu", async () => {
+  fetchReturnedOrders.mockResolvedValue([]);
+  render(<ReturnedOrdersSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("returned-empty");
+});
+
+it("zobrazí objednávku, chýbajúca suma/poznámka sa ukáže ako pomlčka", async () => {
+  fetchReturnedOrders.mockResolvedValue([ROW]);
+  render(<ReturnedOrdersSection role="manazer" onSessionExpired={vi.fn()} />);
+  const row = await screen.findByTestId("returned-row-20600002");
+  expect(row.textContent).toContain("Vratený tovar");
+  expect(row.textContent).toContain("—");
+});
+
+it("401 (Unauthorized) volá onSessionExpired", async () => {
+  fetchReturnedOrders.mockRejectedValue(new OrderFlagsUnauthorizedError());
+  const onSessionExpired = vi.fn();
+  render(<ReturnedOrdersSection role="manazer" onSessionExpired={onSessionExpired} />);
+  await waitFor(() => {
+    expect(onSessionExpired).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/ReturnedOrdersSection.tsx
+++ b/apps/web/src/components/ReturnedOrdersSection.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useState, type JSX } from "react";
+import type { Me } from "../api.js";
+import { fetchReturnedOrders, OrderFlagsUnauthorizedError, type OrderFlagRow } from "../orderFlagsApi.js";
+import { OrderFlagTable } from "./OrderFlagTable.js";
+
+// issue 290: "Eshop → Vrátený tovar" — READ-ONLY zoznam objednávok v
+// stave "Vratený tovar" (rozpracované) alebo "Vybavený Dobropis" (jeho
+// hotová podoba), `modules/orders/order-flags.ts`. Rovnaký vzor ako
+// `ExchangeOrdersSection.tsx` — žiadna mutácia, vybavovanie ostáva
+// výhradne na nástenke Upozornenia.
+export function ReturnedOrdersSection({ onSessionExpired }: { readonly role: Me["role"]; readonly onSessionExpired: () => void }): JSX.Element {
+  const [rows, setRows] = useState<readonly OrderFlagRow[] | null>(null);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    fetchReturnedOrders()
+      .then(setRows)
+      .catch((err: unknown) => {
+        if (err instanceof OrderFlagsUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setError("Zoznam vrátení sa nepodarilo načítať.");
+      });
+  }, [onSessionExpired]);
+
+  if (error !== "") return <p role="alert">{error}</p>;
+  if (rows === null) return <p>Načítavam…</p>;
+
+  return (
+    <section>
+      <p>Objednávky, ktoré Shoptet eviduje v stave „Vratený tovar“ alebo „Vybavený Dobropis“. Farebný štítok „nevybavené“ znamená, že na nástenke Upozornenia je k tejto objednávke ešte otvorená karta.</p>
+      {rows.length === 0 ? (
+        <p data-testid="returned-empty">Momentálne žiadny tovar nie je vrátený.</p>
+      ) : (
+        <OrderFlagTable testIdPrefix="returned-row" rows={rows} />
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/nav.test.ts
+++ b/apps/web/src/nav.test.ts
@@ -16,16 +16,22 @@ import { DEFAULT_TAB_ID, HIDDEN_TABS, NAV, findTab, isVisibleTabId } from "./nav
 // priečinkov (majiteľ: "Eshop dať uplne ako prvý... šéf ho používa
 // najčastejšie") — Eshop je teraz prvý, Systém druhý, Automatizácie tretie;
 // položky vnútri každého priečinka ostali nezmenené.
+// Issue 290 pridalo TRI ďalšie položky ("Výmena tovaru"/"Vrátený
+// tovar"/"Reklamácie") HNEĎ POD "Nedostupné tovary" (šéfovo zadanie:
+// "pridať dalšie polička - pod nedostupné tovarý").
 // Tento test je najbližšie k tomu, čo strojovo overiť dá (registrácia, nie DOM).
-it("NAV má tri priečinky (Eshop/Systém/Automatizácie), s 6/3/4 záložkami v poradí podľa dôležitosti", () => {
+it("NAV má tri priečinky (Eshop/Systém/Automatizácie), s 9/3/4 záložkami v poradí podľa dôležitosti", () => {
   expect(NAV).toHaveLength(3);
   expect(NAV.map((f) => f.label)).toEqual(["Eshop", "Systém", "Automatizácie"]);
-  expect(NAV[0]?.tabs).toHaveLength(6);
+  expect(NAV[0]?.tabs).toHaveLength(9);
   expect(NAV[1]?.tabs).toHaveLength(3);
   expect(NAV[2]?.tabs).toHaveLength(4);
   expect(NAV[0]?.tabs.map((t) => t.label)).toEqual([
     "Na objednanie",
     "Nedostupné tovary",
+    "Výmena tovaru",
+    "Vrátený tovar",
+    "Reklamácie",
     "Párovanie produktov",
     "Vyhľadať",
     "Zlúčenie objednávok",
@@ -62,6 +68,9 @@ it("findTab nájde viditeľnú aj skrytú záložku podľa id, neznáme id vrát
   expect(findTab("posta-uncollected")?.label).toBe("Nevyzdvihnuté zásielky");
   expect(findTab("order-reminder")?.label).toBe("Pripomienky objednávok");
   expect(findTab("search")?.label).toBe("Vyhľadať");
+  expect(findTab("exchange")?.label).toBe("Výmena tovaru");
+  expect(findTab("returned")?.label).toBe("Vrátený tovar");
+  expect(findTab("claims")?.label).toBe("Reklamácie");
   expect(findTab("neexistuje")).toBeUndefined();
 });
 
@@ -74,6 +83,10 @@ it("isVisibleTabId rozlíši viditeľné (NAV) od skrytých (HIDDEN_TABS)", () =
   expect(isVisibleTabId("nedostupne")).toBe(true);
   // issue 240: nová viditeľná záložka "Vyhľadať".
   expect(isVisibleTabId("search")).toBe(true);
+  // issue 290: tri nové viditeľné záložky pod "Nedostupné tovary".
+  expect(isVisibleTabId("exchange")).toBe(true);
+  expect(isVisibleTabId("returned")).toBe(true);
+  expect(isVisibleTabId("claims")).toBe(true);
   for (const hiddenId of Object.keys(HIDDEN_TABS)) {
     expect(isVisibleTabId(hiddenId)).toBe(false);
   }

--- a/apps/web/src/nav.ts
+++ b/apps/web/src/nav.ts
@@ -1,6 +1,8 @@
 import type { ComponentType } from "react";
 import type { Me } from "./api.js";
 import { CatalogPage } from "./components/CatalogPage.js";
+import { ClaimOrdersSection } from "./components/ClaimOrdersSection.js";
+import { ExchangeOrdersSection } from "./components/ExchangeOrdersSection.js";
 import { MailLogSection } from "./components/MailLogSection.js";
 import { MailTemplatesSection } from "./components/MailTemplatesSection.js";
 import { NedostupneSection } from "./components/NedostupneSection.js";
@@ -10,6 +12,7 @@ import { OrdersSection } from "./components/OrdersSection.js";
 import { PairingSection } from "./components/PairingSection.js";
 import { PostaUncollectedSection } from "./components/PostaUncollectedSection.js";
 import { RestockSection } from "./components/RestockSection.js";
+import { ReturnedOrdersSection } from "./components/ReturnedOrdersSection.js";
 import { SchedulerSection } from "./components/SchedulerSection.js";
 import { SearchSection } from "./components/SearchSection.js";
 import { SupplierLinksSection } from "./components/SupplierLinksSection.js";
@@ -74,6 +77,15 @@ export const NAV: readonly NavFolder[] = [
     tabs: [
       { id: "orders", label: "Na objednanie", icon: "📦", Component: OrdersSection, wide: true },
       { id: "nedostupne", label: "Nedostupné tovary", icon: "🚫", Component: NedostupneSection, wide: true },
+      // issue 290: šéfovo zadanie (Discord, 6.8.2026) — tri nové položky
+      // "hneď pod Nedostupné tovary". READ-ONLY pohľady nad `order.status_
+      // name` (Výmena/Vrátený tovar) + appkina vlastná reklamácia-značka
+      // (Reklamácie) — žiadna z nich nezakladá novú kartu na Upozorneniach,
+      // rozhodnuté na tickete (`.claude/rules/upozornenia.md`,
+      // `order-flags.ts`).
+      { id: "exchange", label: "Výmena tovaru", icon: "🔃", Component: ExchangeOrdersSection, wide: true },
+      { id: "returned", label: "Vrátený tovar", icon: "↩️", Component: ReturnedOrdersSection, wide: true },
+      { id: "claims", label: "Reklamácie", icon: "⚠️", Component: ClaimOrdersSection, wide: true },
       // issue 239: majiteľ, "vypisovat produkty ktore nemaju dodavatelsku
       // linku, dat moznost ju tam rovno vlozit, a poslat do Shoptetu" — patrí
       // sem (nie do Automatizácie), je to obrazovka, na ktorej obsluha

--- a/apps/web/src/orderFlagsApi.ts
+++ b/apps/web/src/orderFlagsApi.ts
@@ -1,0 +1,100 @@
+import { z } from "zod";
+
+// issue 290: "Eshop → Výmena tovaru / Vrátený tovar / Reklamácie" — zrkadlí
+// `OrderFlagRow`/`ClaimOrderRow`/`OrderFlagCounts`
+// (`apps/api/src/modules/orders/order-flags-queries.ts`).
+
+const orderFlagRowSchema = z.object({
+  id: z.string(),
+  externalOrderId: z.string(),
+  customerName: z.string(),
+  statusName: z.string(),
+  placedAt: z.string(),
+  totalPriceWithVat: z.string().nullable(),
+  comment: z.string().nullable(),
+  adminUrl: z.string(),
+  unresolved: z.boolean(),
+});
+export type OrderFlagRow = z.infer<typeof orderFlagRowSchema>;
+
+const claimOrderRowSchema = orderFlagRowSchema.extend({
+  claimNote: z.string().nullable(),
+  claimMarkedAt: z.string(),
+});
+export type ClaimOrderRow = z.infer<typeof claimOrderRowSchema>;
+
+const listSchema = z.object({ orders: z.array(orderFlagRowSchema) });
+const claimListSchema = z.object({ orders: z.array(claimOrderRowSchema) });
+
+const countsSchema = z.object({ exchange: z.number(), returned: z.number(), claims: z.number() });
+export type OrderFlagCounts = z.infer<typeof countsSchema>;
+
+export class OrderFlagsUnauthorizedError extends Error {
+  constructor() {
+    super("Neprihlásený");
+  }
+}
+
+const errorBodySchema = z.object({ error: z.string() });
+
+async function serverErrorMessage(response: Response, fallback: string): Promise<string> {
+  try {
+    const parsed = errorBodySchema.safeParse(await response.json());
+    if (parsed.success) return parsed.data.error;
+  } catch {
+    // telo nie je platný JSON — použi všeobecnú hlášku
+  }
+  return fallback;
+}
+
+async function readJson(response: Response, fallback: string): Promise<unknown> {
+  if (response.status === 401) throw new OrderFlagsUnauthorizedError();
+  if (!response.ok) throw new Error(await serverErrorMessage(response, fallback));
+  return await response.json();
+}
+
+export async function fetchExchangeOrders(): Promise<readonly OrderFlagRow[]> {
+  const response = await fetch("/api/order-flags/exchange");
+  return listSchema.parse(await readJson(response, "Zoznam výmen sa nepodarilo načítať")).orders;
+}
+
+export async function fetchReturnedOrders(): Promise<readonly OrderFlagRow[]> {
+  const response = await fetch("/api/order-flags/returned");
+  return listSchema.parse(await readJson(response, "Zoznam vrátení sa nepodarilo načítať")).orders;
+}
+
+export async function fetchClaimOrders(): Promise<readonly ClaimOrderRow[]> {
+  const response = await fetch("/api/order-flags/claims");
+  return claimListSchema.parse(await readJson(response, "Zoznam reklamácií sa nepodaril načítať")).orders;
+}
+
+// Rovnaký "tichý fallback na nuly" vzor ako `upozorneniaApi.ts`'s
+// `fetchUpozorneniaCount` — odznaky v menu nesmú zhodiť appku pri
+// sieťovom výpadku, len ostanú na predchádzajúcej hodnote.
+const ZERO_COUNTS: OrderFlagCounts = { exchange: 0, returned: 0, claims: 0 };
+export async function fetchOrderFlagCounts(): Promise<OrderFlagCounts> {
+  try {
+    const response = await fetch("/api/order-flags/counts");
+    if (!response.ok) return ZERO_COUNTS;
+    return countsSchema.parse(await response.json());
+  } catch {
+    return ZERO_COUNTS;
+  }
+}
+
+const markResultSchema = z.union([z.object({ ok: z.literal(true), orderId: z.string() }), z.object({ ok: z.literal(false), error: z.string() })]);
+export type MarkClaimResult = z.infer<typeof markResultSchema>;
+
+export async function markOrderClaim(orderCode: string, note: string): Promise<MarkClaimResult> {
+  const response = await fetch("/api/order-flags/claims", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ orderCode, note: note.trim() === "" ? undefined : note.trim() }),
+  });
+  return markResultSchema.parse(await readJson(response, "Označenie reklamácie zlyhalo"));
+}
+
+export async function clearOrderClaim(orderId: string): Promise<void> {
+  const response = await fetch(`/api/order-flags/claims/${encodeURIComponent(orderId)}/clear`, { method: "POST" });
+  await readJson(response, "Zrušenie reklamácie zlyhalo");
+}

--- a/apps/web/src/orderFlagsBadgeContext.ts
+++ b/apps/web/src/orderFlagsBadgeContext.ts
@@ -1,0 +1,19 @@
+import { createContext } from "react";
+
+// issue 290: rovnaký most ako `upozorneniaBadgeContext.ts` (issue 267) — most
+// medzi `ClaimOrdersSection` (jediná z troch nových obrazoviek, čo MUTUJE
+// dáta — označenie/zrušenie reklamácie) a `App.tsx` (vlastní odznaky v
+// ľavom menu, `badgeCounts`). Nesie LEN účinok "niečo sa zmenilo" —
+// `App.tsx` si počty naďalej načítava a vlastní SÁM (musí byť známe hneď
+// po prihlásení, nie až po prvom otvorení záložky), len teraz dostáva aj
+// DRUHÝ spúšťač refetchu okrem zmeny záložky.
+export interface OrderFlagsBadgeRefreshContextValue {
+  readonly refresh: () => void;
+}
+
+export const OrderFlagsBadgeRefreshContext = createContext<OrderFlagsBadgeRefreshContextValue>({
+  refresh: () => {
+    // Predvolená hodnota mimo Provider-a (napr. test, čo rendruje
+    // ClaimOrdersSection samostatne bez App.tsx) — bezpečné no-op.
+  },
+});

--- a/apps/web/tests/e2e/nav.spec.ts
+++ b/apps/web/tests/e2e/nav.spec.ts
@@ -20,8 +20,11 @@ const E2E_NAV_EMAIL = "e2e-nav@forestshop.sk";
 // samostatnom `order-merge.spec.ts`, rovnaký vzor ako "Vyhľadať"/
 // `search.spec.ts`). Issue 267 (2026-08-05) pridáva "Upozornenia" pod
 // "Eshop" — trinásta záložka (funkčný test v samostatnom
-// `upozornenia.spec.ts`, rovnaký vzor).
-test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s trinástimi záložkami, klik prepne obrazovku, panel sa zbalí do lišty a stav si pamätá, konzola je čistá", async ({
+// `upozornenia.spec.ts`, rovnaký vzor). Issue 290 (2026-08-07) pridáva TRI
+// ďalšie záložky HNEĎ POD "Nedostupné tovary" — "Výmena tovaru"/"Vrátený
+// tovar"/"Reklamácie" — šestnásta záložka celkovo (funkčný test v
+// samostatnom `order-flags.spec.ts`, rovnaký vzor).
+test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) so šestnástimi záložkami, klik prepne obrazovku, panel sa zbalí do lišty a stav si pamätá, konzola je čistá", async ({
   page,
 }) => {
   const chyby: string[] = [];
@@ -42,14 +45,17 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s trinástim
   await expect(page.getByRole("button", { name: "Eshop" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Automatizácie" })).toBeVisible();
 
-  // Presne trinásť záložiek v CELOM menu.
-  await expect(page.locator(".side-nav .tab")).toHaveCount(13);
+  // Presne šestnásť záložiek v CELOM menu.
+  await expect(page.locator(".side-nav .tab")).toHaveCount(16);
   await expect(page.getByRole("button", { name: "Sync zo Shoptetu" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Texty e-mailov" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Na objednanie" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Nevyzdvihnuté zásielky" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Pripomienky objednávok" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Nedostupné tovary" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Výmena tovaru" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Vrátený tovar" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Reklamácie" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Párovanie produktov" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Vyhľadať" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Zlúčenie objednávok" })).toBeVisible();
@@ -110,6 +116,21 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s trinástim
   // požiadanie) — žiadny stavový odznak v menu, ani "Zastavené".
   await expect(page.getByTestId("nav-status-nedostupne")).toHaveCount(0);
 
+  // issue 290: rovnaký dôvod ako "Nedostupné tovary" vyššie — žiadny
+  // plán/zapnuté-vypnuté koncept, teda žiadny stavový odznak v menu (majú
+  // však odznak POČTU nevybavených, funkčne overený v `order-flags.spec.ts`).
+  await page.getByRole("button", { name: "Výmena tovaru" }).click();
+  await expect(page.getByRole("heading", { name: "Výmena tovaru" })).toBeVisible();
+  await expect(page.getByTestId("nav-status-exchange")).toHaveCount(0);
+
+  await page.getByRole("button", { name: "Vrátený tovar" }).click();
+  await expect(page.getByRole("heading", { name: "Vrátený tovar" })).toBeVisible();
+  await expect(page.getByTestId("nav-status-returned")).toHaveCount(0);
+
+  await page.getByRole("button", { name: "Reklamácie" }).click();
+  await expect(page.getByRole("heading", { name: "Reklamácie" })).toBeVisible();
+  await expect(page.getByTestId("nav-status-claims")).toHaveCount(0);
+
   // issue 239: rovnaký dôvod ako "Nedostupné tovary" vyššie — žiadny
   // plán/zapnuté-vypnuté koncept, teda žiadny stavový odznak v menu.
   await page.getByRole("button", { name: "Párovanie produktov" }).click();
@@ -157,7 +178,7 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s trinástim
 
   // Hlavičky priečinkov zmiznú, ikony všetkých modulov ostanú.
   await expect(page.getByRole("button", { name: "Systém" })).toHaveCount(0);
-  await expect(page.locator(".side-nav .tab")).toHaveCount(13);
+  await expect(page.locator(".side-nav .tab")).toHaveCount(16);
   // Názov sa v lište ukáže bublinou pri prejdení myšou.
   await expect(page.getByRole("button", { name: "Na objednanie" })).toHaveAttribute(
     "title",

--- a/apps/web/tests/e2e/order-flags.spec.ts
+++ b/apps/web/tests/e2e/order-flags.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from "@playwright/test";
+
+const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
+const E2E_OBJEDNAVKY_VYMENA_EMAIL = "e2e-vymena@forestshop.sk"; // musí sa zhodovať s hodnotou v scripts/e2e-fixtures-order-flags.ts
+
+// issue 290: "Eshop → Výmena tovaru / Vrátený tovar / Reklamácie" — tri nové
+// READ-ONLY stránky pod "Nedostupné tovary" + odznaky počtu v ľavom menu.
+// Fixtúrové objednávky "9201"–"9204" (`scripts/e2e-fixtures-order-flags.ts`)
+// patria VÝHRADNE tomuto spec súboru — žiadny iný spec s nimi nepracuje.
+// "unresolved" (otvorená vratenie karta) NEMÁ e2e pokrytie — `upozornenie`
+// je globálna tabuľka zdieľaná so `upozornenia.spec.ts` (jeho "žiadne
+// upozornenia" prázdny stav), rovnaká past ako `.claude/rules/posta-
+// uncollected.md`'s zamietnutý pokus pri issue 298; tú logiku pokrýva
+// `order-flags-http.integration.test.ts` (izolovaná DB) + `ExchangeOrdersSection
+// .test.tsx` (mock).
+test("Výmena tovaru/Vrátený tovar zobrazia zoznam, Reklamácie umožnia označiť a zrušiť s odznakom v menu, konzola je čistá", async ({ page }) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/");
+  await page.getByLabel("E-mail").fill(E2E_OBJEDNAVKY_VYMENA_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await expect(page.getByRole("heading", { name: "Na objednanie" })).toBeVisible();
+
+  // Reklamácie majú aspoň jednu (9203, pred-označená fixtúrou) — odznak
+  // počtu je preto viditeľný hneď po prihlásení, ešte pred otvorením
+  // záložky (rovnaký vzor ako "Upozornenia"/"Na objednanie").
+  const claimsOdznak = page.getByTestId("nav-badge-claims");
+  await expect(claimsOdznak).toBeVisible();
+  await expect(claimsOdznak).toHaveText(/^\d+$/);
+
+  // Výmena tovaru.
+  await page.getByRole("button", { name: "Výmena tovaru" }).click();
+  await expect(page.getByRole("heading", { name: "Výmena tovaru" })).toBeVisible();
+  const vymenaRiadok = page.getByTestId("exchange-row-9201");
+  await expect(vymenaRiadok).toBeVisible();
+  await expect(vymenaRiadok).toContainText("E2E Zákazník Výmena");
+  await expect(vymenaRiadok).toContainText("Vybavená výmena");
+  await expect(vymenaRiadok).toContainText("30.00 €");
+
+  // Vrátený tovar.
+  await page.getByRole("button", { name: "Vrátený tovar" }).click();
+  await expect(page.getByRole("heading", { name: "Vrátený tovar" })).toBeVisible();
+  const vrateniRiadok = page.getByTestId("returned-row-9202");
+  await expect(vrateniRiadok).toBeVisible();
+  await expect(vrateniRiadok).toContainText("E2E Zákazník Vrátenie");
+  await expect(vrateniRiadok).toContainText("Vratený tovar");
+
+  // Reklamácie — 9203 je vopred označená fixtúrou.
+  await page.getByRole("button", { name: "Reklamácie" }).click();
+  await expect(page.getByRole("heading", { name: "Reklamácie" })).toBeVisible();
+  const reklamaciaRiadok = page.getByTestId("claim-row-9203");
+  await expect(reklamaciaRiadok).toBeVisible();
+  await expect(reklamaciaRiadok).toContainText("e2e — vopred označená reklamácia");
+
+  // Označenie NOVEJ reklamácie (9204, doteraz neoznačená) — celý zápisový
+  // cyklus vrátane odznaku v menu.
+  await page.getByTestId("claim-order-code").fill("9204");
+  await page.getByTestId("claim-note-input").fill("e2e — nová reklamácia");
+  await page.getByTestId("claim-mark-submit").click();
+  const novaRiadok = page.getByTestId("claim-row-9204");
+  await expect(novaRiadok).toBeVisible();
+  await expect(novaRiadok).toContainText("e2e — nová reklamácia");
+  await expect(claimsOdznak).toHaveText(/^\d+$/);
+
+  // Zrušenie tej istej reklamácie — riadok zmizne.
+  await page.getByTestId("claim-clear-9204").click();
+  await expect(page.getByTestId("claim-row-9204")).toBeHidden();
+  // Vopred označená 9203 ostáva nedotknutá.
+  await expect(page.getByTestId("claim-row-9203")).toBeVisible();
+
+  expect(chyby).toEqual([]);
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.174",
+  "version": "0.3.0-dev.175",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-fixtures-order-flags.ts
+++ b/scripts/e2e-fixtures-order-flags.ts
@@ -1,0 +1,78 @@
+// issue 290: "Eshop → Výmena tovaru / Vrátený tovar / Reklamácie" —
+// vyčlenené do VLASTNÉHO súboru (rovnaký dôvod ako `e2e-fixtures-search.ts`,
+// eslint `max-lines: 400`, `.claude/rules/testing.md`). VLASTNÝ izolovaný
+// E2E účet (zdieľaný `e2e@forestshop.sk` je už na hranici `MAX_ATTEMPTS`) +
+// štyri VLASTNÉ objednávky (externé čísla 92xx, dovtedy nepoužité žiadnym
+// iným spec súborom), aby žiadna existujúca "Na objednanie"/prehľadová
+// presná asercia nikdy nezachytila tieto stavy. `placedAt` je zámerne PEVNÝ
+// dátum HLBOKO V MINULOSTI (rovnaký dôvod ako `e2e-fixtures-search.ts`) —
+// NIE `teraz`, inak by tieto 4 objednávky posunuli `orders-overview.spec
+// .ts`'s presné "1 objednávka dnes" počty (živo nájdené pri prvom pokuse
+// tohto tiketu).
+//
+// ZÁMERNE BEZ `upozornenie` (`vratenie`) fixtúry — `upozornenie` je
+// GLOBÁLNA tabuľka zdieľaná naprieč VŠETKÝMI e2e účtami/spec súbormi
+// (rovnaká past ako `.claude/rules/posta-uncollected.md`'s zamietnutý pokus
+// o seedovanú kartu pri issue 298): trvalo vložená "vratenie" karta by
+// zmenila `upozornenia.spec.ts`'s "žiadne upozornenia" prázdny stav (živo
+// overené — presne toto sa stalo pri prvom pokuse). "unresolved" príznak
+// (otvorená vratenie karta) preto NEMÁ e2e pokrytie — má ho integračný
+// test (`order-flags-http.integration.test.ts`, izolovaná DB per test) a
+// vitest komponentový test (`ExchangeOrdersSection.test.tsx`).
+import type { Database } from "../apps/api/src/db/client.js";
+import { orders, users } from "../apps/api/src/db/schema.js";
+import { hashPassword } from "../apps/api/src/modules/auth/passwords.js";
+
+// Musí sa zhodovať s hodnotou v `apps/web/tests/e2e/order-flags.spec.ts`.
+export const E2E_OBJEDNAVKY_VYMENA_EMAIL = "e2e-vymena@forestshop.sk";
+
+const MINULY_DATUM = new Date("2026-07-05T09:00:00Z");
+
+export async function seedOrderFlagsFixtures(db: Database, heslo: string): Promise<void> {
+  await db.insert(users).values({
+    email: E2E_OBJEDNAVKY_VYMENA_EMAIL,
+    passwordHash: await hashPassword(heslo),
+    displayName: "E2E Manažér Výmena/Vrátenie",
+    role: "manazer",
+  });
+
+  await db.insert(orders).values({
+    externalOrderId: "9201",
+    customerName: "E2E Zákazník Výmena",
+    statusName: "Vybavená výmena",
+    placedAt: MINULY_DATUM,
+    totalPriceWithVat: "30.00",
+  });
+
+  await db.insert(orders).values({
+    externalOrderId: "9202",
+    customerName: "E2E Zákazník Vrátenie",
+    statusName: "Vratený tovar",
+    placedAt: MINULY_DATUM,
+    totalPriceWithVat: "18.50",
+  });
+
+  // "Reklamácie" — už OZNAČENÁ (appka nemá seedovací endpoint, priamy zápis
+  // do stĺpca je jediná cesta pre pred-pripravenú fixtúru). `claim_marked_at`
+  // NIE JE globálne zdieľaná tabuľka ako `upozornenie` vyššie — je to stĺpec
+  // na TEJTO konkrétnej objednávke, nijaký iný spec súbor sa naň nepozerá.
+  await db.insert(orders).values({
+    externalOrderId: "9203",
+    customerName: "E2E Zákazník Reklamácia",
+    statusName: "Vybavená",
+    placedAt: MINULY_DATUM,
+    totalPriceWithVat: "9.90",
+    claimMarkedAt: MINULY_DATUM,
+    claimNote: "e2e — vopred označená reklamácia",
+  });
+
+  // BEZ reklamácie — na túto obsluha v e2e teste sama klikne "Označiť ako
+  // reklamáciu" a potom "Zrušiť reklamáciu", aby sa overil celý zápisový cyklus.
+  await db.insert(orders).values({
+    externalOrderId: "9204",
+    customerName: "E2E Zákazník Bez Reklamácie",
+    statusName: "Vybavená",
+    placedAt: MINULY_DATUM,
+    totalPriceWithVat: "5.00",
+  });
+}

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -17,6 +17,7 @@ import { DEFAULT_SNAPSHOT_LIMITS } from "../apps/api/src/modules/catalog/validat
 import { DEFAULT_ORDER_OPEN_STATUS } from "../apps/api/src/modules/orders/open-statuses.js";
 import { POSTA_UNCOLLECTED_SETTINGS_ID } from "../apps/api/src/modules/posta-uncollected/settings.js";
 import { ORDER_REMINDER_SETTINGS_ID } from "../apps/api/src/modules/order-reminder/settings.js";
+import { seedOrderFlagsFixtures } from "./e2e-fixtures-order-flags.js";
 import { seedProductLinksFixtures } from "./e2e-fixtures-product-links.js";
 import { seedSearchFixtures } from "./e2e-fixtures-search.js";
 
@@ -785,5 +786,8 @@ await seedProductLinksFixtures(db, teraz, snapshotPrepinanie, E2E_HESLO);
 
 // issue 240: fixtúra vyčlenená do vlastného súboru, rovnaký dôvod ako vyššie.
 await seedSearchFixtures(db, teraz, snapshotPrepinanie, E2E_HESLO);
+
+// issue 290: fixtúra vyčlenená do vlastného súboru, rovnaký dôvod ako vyššie.
+await seedOrderFlagsFixtures(db, E2E_HESLO);
 
 await pool.end();


### PR DESCRIPTION
## Čo pridáva

Tri nové stránky v ľavom menu, hneď pod "Nedostupné tovary" (šéfovo
zadanie cez Discord, issue 290):

- **Výmena tovaru** — zoznam objednávok v stave „Vybavená výmena".
- **Vrátený tovar** — zoznam objednávok v stave „Vratený tovar" alebo
  „Vybavený Dobropis".
- **Reklamácie** — Shoptet nemá pre reklamácie žiadny použiteľný stav
  (overené naživo na produkcii), appka si ich preto vedie SAMA cez nový
  nullable stĺpec `order.claim_marked_at`/`claim_note` a jednoduchý
  formulár (číslo objednávky + poznámka) na označenie/zrušenie.

Prvé dve stránky sú čisto READ-ONLY pohľady — nepridávajú žiadnu novú
kartu na nástenku Upozornenia a nič do nej nezapisujú (`upozornenie`
tabuľka ostáva výhradne vlastníctvom `return-status.ts`/
`return-upozornenia.ts`). "Nevybavené" pri riadku sa dopočítava
READ-ONLY dotazom na to, či pre danú objednávku ešte existuje otvorená
`vratenie:` karta. V menu má každá z troch nových položiek počítadlo
nevybavených, zobrazené len keď je > 0.

## Rozhodovací kontext

Ticket mal predtým dočasne pozastavenú/zrušenú verziu riešenia (staršie
komentáre na #290), ktorá presúvala vybavovanie z Upozornení na tieto
nové stránky — to majiteľ výslovne odmietol. Táto implementácia ide
podľa POSLEDNÉHO, aktuálne platného rozhodnutia na tickete (komentár
zo 7.8.2026): tri READ-ONLY stránky + počítadlo, žiadne druhé miesto na
vybavovanie.

## Gate

- typecheck ✅, lint ✅
- API unit testy: 631/631 ✅ (nové: `order-flags.test.ts`)
- Web unit testy: 507/507 ✅ (nové komponentové testy pre všetky tri
  obrazovky)
- API integračné testy: 585/585 ✅ (nový `order-flags-http.integration
  .test.ts` — pokrýva unresolved-join logiku, role gating, audit log)
- E2E: 49/49 ✅ (nový `order-flags.spec.ts`, aktualizovaný `nav.spec.ts`
  na 16 záložiek)
- Code review (`superpowers:requesting-code-review`, subagent nad celým
  diffom): našiel 1× 🔴 (chýbajúca `useMemo` dependency v `App.tsx`,
  opravené v `738b274`) + 1× informačnú 🟡 poznámku (očakávané
  správanie, nie chyba) — 0 zvyšných nálezov.

issue 290 (nie `Closes` — ostáva otvorený, kým sa nasadenie naživo
neoverí, pozri CLAUDE.md-ovu poznámku o predčasnom zatváraní ticketov).
