### PR TITLE
Read availability on zubicek.cz/lesona.sk/rappa.cz/rosler.sk (issue 307)

### DIFF
--- a/.claude/rules/supplier-stock.md
+++ b/.claude/rules/supplier-stock.md
@@ -275,3 +275,62 @@ paths:
   sú u `chiruca.sk` holé čísla ("37".."47"), zhodujú sa priamo s
   dodávateľovým "Veľkosť: NN" bez potreby `matchSizeLabel`'s tolerantného
   porovnávania.
+- **Per-doménové pravidlá (`TEXT_AVAILABILITY_RULES`/
+  `VISIBLE_AVAILABILITY_RULES`) a ich extraktory od issue 307 žijú v
+  `availability-domain-rules.ts`, NIE v `parse.ts`** — vyčlenené, lebo
+  pridanie ďalších domén posunulo oba súbory (aj `parse.ts`, aj
+  `parse.test.ts`) cez eslint `max-lines: 400` (`.claude/rules/testing.md`).
+  `parse.ts` nesie generický algoritmus (`parsePage`, `fromJsonLd`,
+  `fromMetaTags`, `availabilityFromText`, veľkostné pravidlá);
+  `availability-domain-rules.ts` nesie per-doménovú znalosť. Súbory sa
+  navzájom importujú (parse.ts → `textAvailabilityRuleFor`/
+  `visibleAvailabilityFor`; availability-domain-rules.ts →
+  `availabilityFromText`/`SupplierAvailability` typ späť z parse.ts) —
+  ZÁMERNE cyklický import na úrovni FUNKCIÍ (nikdy sa nič nevyhodnocuje na
+  module-top-level v konfliktnom poradí), overené `tsc -b` aj celou testovou
+  sadou. Nová doména pribúda do `availability-domain-rules.ts`, testy pre ňu
+  do `parse-issue307.test.ts` (alebo ďalšieho tematicky vyčleneného súboru,
+  ak by aj tento prerástol limit) — nikdy naspäť do `parse.ts`.
+- **Testovacia fixtúra, ktorej VLASTNÝ opisný HTML komentár cituje presne tú
+  istú atribútovú syntax, akú hľadá jej vlastný regex, môže OMYLOM zhodiť
+  test na SEBE SAMEJ — regex nájde zhodu vo VLASTNOM komentári fixtúry, nie
+  v reálnom markupe nižšie.** Zistené issue 307 pri písaní `lesona-*.html`
+  fixtúr: komentár opisujúci `<span id="product-availability">` obsahoval
+  presne ten istý reťazec `id="product-availability"`, aký hľadal
+  `LESONA_AVAILABILITY_RE` — regex sa zhodol s komentárom, nie s testovaným
+  `<span>` nižšie (rovnaký jav postihol aj rozpísaný `<dt>Dostupnosť</dt>
+  <dd><span class="in-stock|out-of-stock">` v `rappa-*.html` komentári a
+  `<div class=product-detail-stock>` v `rosler-*.html` komentári). Fix:
+  komentáre k fixtúram OPISUJÚ markup slovami alebo s pomlčkou/tromi
+  bodkami rozbitou syntaxou (`id="product-…"` namiesto `id="product-
+  availability"`), NIKDY necitujú presnú reťazcovú podobu, akú extraktor
+  hľadá. Test pri KAŽDEJ ďalšej per-domain fixtúre: over, že jej vlastný
+  komentár neobsahuje literálny reťazec zhodný s regexom, ktorý má
+  fixtúra testovať — najjednoduchšie priamym `node -e` behom extraktora
+  proti danej fixtúre PRED spustením vitestu, presne ako sa to tu odhalilo.
+- **`lesona.sk` (PrestaShop) je ĎALŠÍ dôkaz, že schema.org mikrodáta VEDIA
+  KLAMAŤ NAPRIEČ PLATFORMAMI, nielen na Shoptete (`odimon.sk`, issue 225).**
+  Naživo overené na reálnom vypredanom produkte (slúchadlá 3M Peltor, id 58):
+  `<link itemprop="availability" href="https://schema.org/InStock"/>` tvrdí
+  dostupné, ale viditeľný `<span id="product-availability">` s ikonkou
+  `product-unavailable` hovorí "Vypredané" a tlačidlo "Vložiť do košíka" je
+  `disabled`. Táto appka `itemprop=` mikrodátovú formu (na rozdiel od
+  `<script type="application/ld+json">`, ktorý číta `fromJsonLd`) VÔBEC
+  neparsuje — preto sa NEROZŠIROVAL parser o jej čítanie, len sa pridalo
+  `VISIBLE_AVAILABILITY_RULES` pravidlo čítajúce výhradne viditeľný prvok.
+  Test na KAŽDÚ ďalšiu doménu s `itemprop="availability"` mikrodátami:
+  NIKDY sa neberú ako posledné slovo bez porovnania s viditeľným stavom pri
+  produkte — mikrodáta klamú nezávisle od platformy (Shoptet aj PrestaShop
+  overené), pravdepodobne to platí širšie.
+- **`rappa.cz`** (issue 307): `<dt>Dostupnosť</dt><dd><span class="in-stock|
+  out-of-stock">…</span></dd>` v tabuľke parametrov, jediný výskyt na
+  stránke, obe polarity naživo overené. Rozhoduje TRIEDA, nikdy text (text
+  nesie aj počet kusov, "skladom (50 a viac ks)").
+- **`rosler.sk`** (issue 307): `<div class=product-detail-stock>…</div>`
+  (bez úvodzoviek v reálnom markupe), odlišná trieda od karuselu
+  (`product-thumb-stock`). Text ide cez existujúci `availabilityFromText`.
+  Naživo overené texty: "Skladom N ks" (available) a "Do 14 dní" (dodanie na
+  objednávku — nie skladom teraz, correctně padá na `unknown`). Genuinný
+  vypredaný text sa NENAŠIEL napriek prehľadaniu 20 uložených odkazov + 3
+  kategórií — presne ako `wetland.sk` (issue 230): pravidlo sa NEHÁDA,
+  žiadne vlastné mapovanie "Do N dní" → unavailable sa nepridalo.

--- a/.claude/rules/upozornenia.md
+++ b/.claude/rules/upozornenia.md
@@ -362,3 +362,19 @@ paths:
   súbore, len tu bez potreby zámku (kategória je znova-ohlásiteľná, takže
   TOCTOU na INSERTe nehrozí — zámok by tu riešil problém, čo v tejto
   kategórii vôbec neexistuje).
+- **Issue 308 (založený 7.8.2026, deň PO #283) žiadal presne to, čo #283 už
+  dodalo a naživo overilo deň predtým — zatvorené ako OBSOLETE bez jedného
+  riadku kódu.** Ticketov telo citovalo majiteľov Discord komentár ("nedá sa
+  vrátiť vybavené späť"), no `returnUpozornenieToOpen`/záložka Vybavené/
+  tlačidlo "↩ Vrátiť medzi otvorené" už existovali a boli nasadené (PR #285,
+  merge `579cff2`, live-overenie 6.8.2026 11:22) — #308 vzniklo AŽ 7.8.2026
+  11:57, teda s viac než dennným oneskorením oproti tomu, čo appka už
+  reálne robila. **Poučenie pre KAŽDÝ ĎALŠÍ ticket na tomto module, čo znie
+  ako "X sa nedá spraviť":** over si NAJPRV, či #283/#297 (alebo novší
+  komentár na tickete) už presne toto nedodalo — `.claude/rules/
+  upozornenia.md`'s vlastná história je hustá práve preto, že táto oblasť
+  sa mení rýchlo a ticket môže byť podaný neskoro, nie preto, že funkcia
+  chýba. STEP 0 (`verify-issue-still-valid`) živé Playwright overenie proti
+  produkcii (vlastná testovacia poznámka: vytvoriť → vybaviť → záložka
+  Vybavené → vrátiť → späť v Otvorené → zmazať, 0 chýb v konzole) toto
+  potvrdilo za pár minút, namiesto zbytočnej re-implementácie.

--- a/apps/api/src/modules/supplier-stock/availability-domain-rules.ts
+++ b/apps/api/src/modules/supplier-stock/availability-domain-rules.ts
@@ -5,8 +5,13 @@
 // stránky) a tento súbor (znalosť KONKRÉTNYCH dodávateľských domén) sú
 // zámerne oddelené — nová doména sem pribudne bez toho, aby sa dotkla
 // `parsePage`u samotného.
+//
+// Závisí LEN na `availability-primitives.ts` (nikdy na `parse.ts` priamo) —
+// code review na issue 307 odhalil, že pôvodný import späť z `parse.ts` bol
+// funkčne bezpečný, ale zbytočne cyklický import; `availability-
+// primitives.ts` je spoločný jednosmerný základ pre oba súbory.
 
-import { availabilityFromText, hostOf, type SupplierAvailability } from "./parse.js";
+import { availabilityFromText, decodeNumericEntities, hostOf, type SupplierAvailability } from "./availability-primitives.js";
 
 interface TextAvailabilityRule {
   readonly host: string;
@@ -146,6 +151,12 @@ const RAPPA_STOCK_RE = /<dt>Dostupnos.<\/dt>\s*<dd>\s*<span\b[^>]*class="([^"]*)
  * slovo ("skladom"/"vypredané") a ide cez existujúci `availabilityFromText`,
  * rovnaký vzor ako `trigonaStockRegion`. Obe polarity naživo overené
  * (7. 8. 2026, reálne produkty).
+ *
+ * Na rozdiel od `trigonaStockRegion` (prechádza VŠETKY výskyty, odmieta
+ * nejednoznačnosť) tu žiadna obrana proti viacnásobnej zhode nie je — regex
+ * berie PRVÝ (jediný, naživo overený) výskyt. Zámerné: pri ~20 naživo
+ * overených produktoch sa opakovaný karuselový blok s rovnakým `<dt>
+ * Dostupnosť</dt>` NENAŠIEL (code review na issue 307).
  */
 function rappaStockRegion(html: string): string | null {
   const match = RAPPA_STOCK_RE.exec(html);
@@ -162,21 +173,31 @@ const ROSLER_STOCK_DIV_RE = /<div\s+class=["']?product-detail-stock["']?>([\s\S]
  * rosler.sk (issue 307): dostupnosť PRI produkte je `<div
  * class=product-detail-stock>…</div>` (bez úvodzoviek v reálnom markupe) —
  * ODLIŠNÁ trieda od karuselových/súvisiacich položiek
- * (`product-thumb-stock`), žiadna kolízia. Text sa vracia AKO JE a ide cez
- * existujúci `availabilityFromText`. Naživo overené texty: "Skladom N ks"
- * (available) a "Do 14 dní" (dodanie na objednávku, nie skladom teraz) —
- * druhý nezodpovedá žiadnemu slovu v `IN_KEYWORDS`/`OUT_KEYWORDS`, preto
- * correctně padá na `unknown`. Genuinný vypredaný ("0 ks") text sa naživo
- * NENAŠIEL napriek prehľadaniu 20 uložených odkazov + 3 kategórií — presne
- * ako wetland.sk (issue 230): pravidlo sa NEHÁDA, žiadne vlastné mapovanie
- * "Do N dní" → unavailable sa nepridáva.
+ * (`product-thumb-stock`), žiadna kolízia; žiadna obrana proti viacnásobnej
+ * zhode navyše nie je (rovnaká situácia ako `rappaStockRegion` — pri 20
+ * naživo overených produktoch sa druhý výskyt tejto triedy nenašiel). Text
+ * sa vracia AKO JE a ide cez existujúci `availabilityFromText`.
+ *
+ * `&#xHH;` číselné entity sa DEKÓDUJÚ (`decodeNumericEntities`), NIKDY sa
+ * len nevyprázdňujú — code review na issue 307 odhalil, že táto doména
+ * kóduje KAŽDÚ diakritiku takto ("dn&#xED;" = "dní", "ma&#xE1;" = "malá"),
+ * takže vyprázdnenie by "vypredan&#xE9;" tichy zmenilo na "vypredan " a
+ * extraktor by spadol na `unknown` namiesto `unavailable`.
+ *
+ * Naživo overené texty: "Skladom N ks" (available) a "Do 14 dní" (dodanie
+ * na objednávku, nie skladom teraz) — druhý nezodpovedá žiadnemu slovu v
+ * `IN_KEYWORDS`/`OUT_KEYWORDS`, preto correctně padá na `unknown`. Genuinný
+ * vypredaný ("0 ks") text sa naživo NENAŠIEL napriek prehľadaniu 20
+ * uložených odkazov + 3 kategórií — presne ako wetland.sk (issue 230):
+ * pravidlo sa NEHÁDA, žiadne vlastné mapovanie "Do N dní" → unavailable sa
+ * nepridáva (regresný fixtúrový test `rosler-vypredane-noz-entita.html`
+ * overuje, že entitovo kódovaná diakritika v BUDÚCOM skutočnom vypredanom
+ * texte teraz správne rozhoduje `unavailable`).
  */
 function roslerStockRegion(html: string): string | null {
   const match = ROSLER_STOCK_DIV_RE.exec(html);
   if (match === null) return null;
-  const text = (match[1] ?? "")
-    .replace(/&gt;/gi, ">")
-    .replace(/&#x[0-9a-fA-F]+;/gi, " ")
+  const text = decodeNumericEntities((match[1] ?? "").replace(/&gt;/gi, ">"))
     .replace(/\s+/g, " ")
     .trim();
   return text === "" ? null : text;
@@ -248,24 +269,28 @@ const LESONA_AVAILABILITY_RE = /<span\b[^>]*\bid="product-availability"[^>]*>([\
  * `disabled`. Táto appka mikrodáta vôbec neparsuje (`fromJsonLd` hľadá len
  * `<script type="application/ld+json">`, `fromMetaTags` len `<meta
  * property="og:…"/"product:…">` — ani jedno túto `itemprop=` mikrodátovú
- * formu nezachytí), takže sa NEROZŠIRUJE parser o jej čítanie — namiesto
- * toho sa dostupnosť číta VÝHRADNE z tohto viditeľného `<span>`.
+ * formu nezachytí, takže pre lesona.sk je `jsonLd` v `parsePage` VŽDY
+ * `null` — nejde teda o AKTÍVNE krížové overenie proti JSON-LD ako pri
+ * odimon.sk, len o to, že sa mikrodátam nikdy nedôveruje), namiesto toho sa
+ * dostupnosť číta VÝHRADNE z tohto viditeľného `<span>`.
  *
  * Naživo overené TRI stavy: prázdny span (nič v ňom, plne skladom), ikonka
  * `product-unavailable` + text "Vypredané" (nedostupné), ikonka
  * `product-last-items` + "Posledné kusy v sklade" (skladom, málo kusov — už
- * v `IN_KEYWORDS`). Nerozpoznaný NEPRÁZDNY text sa vracia ako `"unknown"`
- * (nie `null`) — keby sa niekedy pridalo skutočné JSON-LD, `null` by nechalo
- * (možno klamúce) JSON-LD rozhodnúť namiesto tohto overeného viditeľného
- * zdroja; `"unknown"` to zaručene nedovolí (`parsePage`'s konfliktová
- * kontrola).
+ * v `IN_KEYWORDS`). `decodeNumericEntities` odstraňuje ikonkové Material-
+ * Icons kódové body (Private Use Area, napr. `&#xE14B;`) rovnakou funkciou
+ * ako `roslerStockRegion` dekóduje diakritiku — dekódovaný PUA znak sa
+ * nezhoduje so žiadnym slovom v `IN_KEYWORDS`/`OUT_KEYWORDS`, rovnaký
+ * výsledný efekt ako predošlé vyprázdnenie. Nerozpoznaný NEPRÁZDNY text sa
+ * vracia ako `"unknown"` (nie `null`) — keby sa niekedy pridalo skutočné
+ * JSON-LD, `null` by nechalo (možno klamúce) JSON-LD rozhodnúť namiesto
+ * tohto overeného viditeľného zdroja; `"unknown"` to zaručene nedovolí
+ * (`parsePage`'s konfliktová kontrola).
  */
 function lesonaVisibleAvailability(html: string): VisibleAvailabilityHit | null {
   const match = LESONA_AVAILABILITY_RE.exec(html);
   if (match === null) return null;
-  const text = (match[1] ?? "")
-    .replace(/<[^>]+>/g, " ")
-    .replace(/&#x[0-9a-fA-F]+;/gi, " ")
+  const text = decodeNumericEntities((match[1] ?? "").replace(/<[^>]+>/g, " "))
     .replace(/\s+/g, " ")
     .trim();
   if (text === "") return { availability: "available", text: "" };

--- a/apps/api/src/modules/supplier-stock/availability-domain-rules.ts
+++ b/apps/api/src/modules/supplier-stock/availability-domain-rules.ts
@@ -1,0 +1,286 @@
+// Per-doménový katalóg pravidiel pre voľný text (`TEXT_AVAILABILITY_RULES`) a
+// viditeľnú dostupnosť (`VISIBLE_AVAILABILITY_RULES`) — vyčlenené z `parse.ts`
+// (issue 307), aby ani jeden zo súborov neprerástol eslint `max-lines: 400`
+// (`.claude/rules/testing.md`). `parse.ts` (generický algoritmus čítania
+// stránky) a tento súbor (znalosť KONKRÉTNYCH dodávateľských domén) sú
+// zámerne oddelené — nová doména sem pribudne bez toho, aby sa dotkla
+// `parsePage`u samotného.
+
+import { availabilityFromText, hostOf, type SupplierAvailability } from "./parse.js";
+
+interface TextAvailabilityRule {
+  readonly host: string;
+  /**
+   * Vyberie z CELEJ stránky LEN oblasť s dostupnosťou TOHTO produktu. `null`
+   * = oblasť sa nenašla. `url` (issue 241) je k dispozícii pre extraktory,
+   * ktoré vedia krížovo overiť nájdenú oblasť proti ID/slugu SCRAPOVANÉHO
+   * produktu (napr. `trigonaStockRegion`) — extraktor, ktorý takú kontrolu
+   * nepotrebuje (má vlastnú štruktúrnu záruku inak, napr. CSS triedu), ho
+   * jednoducho nemusí deklarovať vo svojej signatúre.
+   */
+  readonly extractRegion: (html: string, url: string) => string | null;
+  /** Čo znamená CHÝBAJÚCA oblasť (žiadny štítok pri produkte). */
+  readonly whenRegionMissing: SupplierAvailability;
+}
+
+/**
+ * huntingshop.eu (issue 223): dostupnosť TOHTO produktu nesie `<span
+ * class="badge badge-outline-…">` hneď pri cene. Karuselové štítky
+ * súvisiacich produktov majú NAVYŠE triedu `badge-stock` — tie sa vylučujú,
+ * inak by sa dostupnosť iného produktu v karuseli počítala za tento. Keď sa
+ * nenájde ŽIADEN takýto štítok, produkt v skutočnosti nemá žiadnu značku
+ * dostupnosti — to znamená `unavailable` (overené na vzorke: vypredaný
+ * produkt štítok nemá vôbec), nikdy `available` z náhodného textu inde na
+ * stránke (napr. pätičková veta „…máme skladom ihneď k odberu").
+ */
+function huntingshopDetailBadges(html: string): string | null {
+  const spans = [...html.matchAll(/<span\b[^>]*class="([^"]*badge-outline-[^"]*)"[^>]*>([\s\S]*?)<\/span>/gi)];
+  const texts = spans
+    .filter(([, cls]) => cls !== undefined && !cls.includes("badge-stock"))
+    .map(([, , text]) => (text ?? "").replace(/\s+/g, " ").trim())
+    .filter((text) => text !== "");
+  return texts.length > 0 ? texts.join(" ") : null;
+}
+
+const TRIGONA_STOCK_COUNT_RE =
+  /<span\b[^>]*\bid="StockCountText(\d+)"[^>]*>\s*<span\b[^>]*\bstyle="[^"]*color:\s*(#[0-9a-fA-F]{6})[^"]*"[^>]*>/gi;
+const TRIGONA_PRODUCT_ID_RE = /\/p-(\d+)\.xhtml/i;
+
+/**
+ * trigona.sk (issue 230, ID krížová kontrola issue 241): dostupnosť PRI
+ * produkte nesie `<span id="StockCountText<ID>">` s vnoreným `<span
+ * style="color: …">` — `<ID>` je ČÍSLO KONKRÉTNEHO produktu, ktoré sa MUSÍ
+ * zhodovať s ID v URL (`.../p-<ID>.xhtml`), inak sa oblasť nepovažuje za
+ * patriacu scrapovanému produktu. Predtým (issue 230) sa bral PRVÝ výskyt v
+ * dokumente bez tejto kontroly — fungovalo to len vďaka empirickému dôkazu
+ * (31 naživo overených stránok, vždy práve jeden výskyt), nie vďaka
+ * štruktúrnej záruke. Keby trigona.sk niekedy pridala súvisiaci produkt s
+ * rovnakou značkou VYŠŠIE na stránke, prvý-v-poradí by bol ISTO ZLÁ
+ * odpoveď — preto sa teraz prechádzajú VŠETKY výskyty a vyberie sa ten,
+ * ktorého `<ID>` sedí s URL.
+ *
+ * Farba rozhoduje o dostupnosti — obe polarity sú naživo overené proti
+ * JSON-LD na TOM ISTOM produkte: `#00b020` (zelená, text "Na sklade")
+ * zodpovedá JSON-LD `InStock`; `#024bbd` (modrá, text "1 - 4 týždne" —
+ * dodacia lehota, nie doslovné slovo "vypredané") zodpovedá JSON-LD
+ * `OutOfStock`. Farba sa prekladá na kanonické slovo, aby prešlo
+ * existujúcim `availabilityFromText` zoznamom kľúčových slov.
+ *
+ * Nerozpoznaná farba, nerozobrateľné ID z URL, chýbajúci/nezhodný prvok,
+ * ANI DVA zhodné-ID výskyty s ROZDIELNOU farbou (nejednoznačné, rovnaká
+ * disciplína ako `matchSizeLabel`: viac než jedna zhoda sa počíta ako
+ * žiadna) sa NEHÁDŽU na žiadnu stranu — vracia sa `null`
+ * (`whenRegionMissing: "unknown"` nižšie). Na rozdiel od huntingshop.eu,
+ * kde je naživo overené, že vypredaný produkt štítok vôbec nemá, sa na
+ * trigona.sk medzi overenými vzorkami nikdy nevyskytla stránka bez tohto
+ * prvku — preto tu niet dôkazu, čo by chýbajúci štítok znamenal.
+ */
+function trigonaStockRegion(html: string, url: string): string | null {
+  const productId = TRIGONA_PRODUCT_ID_RE.exec(url)?.[1];
+  if (productId === undefined) return null;
+  const resolved = new Set<string>();
+  for (const match of html.matchAll(TRIGONA_STOCK_COUNT_RE)) {
+    const [, id, colorRaw] = match;
+    if (id !== productId) continue;
+    const color = (colorRaw ?? "").toLowerCase();
+    if (color === "#00b020") resolved.add("skladom");
+    else if (color === "#024bbd") resolved.add("vypredané");
+  }
+  const values = [...resolved];
+  return values.length === 1 ? (values[0] ?? null) : null;
+}
+
+/**
+ * virginiashop.sk/tenolix.cz/luko.cz/zubicek.cz (issue 227, issue 307):
+ * rovnaká Shoptet šablóna, jednoveľkostný produkt nesie `<span
+ * class="availability-label" ... data-testid="labelAvailability">Skladom/
+ * Skladem/Momentálne(ě) nedostupné</span>` — text sa vracia AKO JE a ide cez
+ * existujúci `availabilityFromText` (žiadna nová farebná/triedová logika, na
+ * rozdiel od trigona.sk). Naživo overené OBE polarity priamo na
+ * virginiashop.sk aj tenolix.cz (rovnaká trieda, rovnaké farby
+ * #009901/#cb0000); luko.cz aj zubicek.cz majú naživo overenú len zelenú
+ * vetvu — ich sledované odkazy sú z veľkej časti VIACVEĽKOSTNÉ produkty,
+ * ktoré tento `data-testid` vôbec nemajú (viď `whenRegionMissing` nižšie),
+ * takže ostávajú `unknown` presne ako predtým. Viacvariantový produkt (viac
+ * veľkostí/farieb naraz) tento `data-testid` NEVYKRESĽUJE vôbec — vtedy sa
+ * nesmie nič uhádnuť z niektorej z viacerých zhôd, preto
+ * `whenRegionMissing: "unknown"`.
+ */
+function shoptetLabelAvailability(html: string): string | null {
+  const match = /<span\b[^>]*data-testid="labelAvailability"[^>]*>([\s\S]*?)<\/span>/i.exec(html);
+  if (match === null) return null;
+  const text = (match[1] ?? "").replace(/\s+/g, " ").trim();
+  return text === "" ? null : text;
+}
+
+/**
+ * fomei.com (issue 227): JSON-LD na stránke nie je Product/Offer (len
+ * breadcrumb), ale schema.org MIKRODÁTA (`<span class="availability
+ * availability--inStock|noStock">`) sa OPAKUJÚ naprieč stránkou — hlavný
+ * produkt aj karusel "Súvisiace" nižšie majú ROVNAKÚ triedu (rovnaká
+ * kolízia ako huntingshop.eu, issue 223). Preto sa hľadá LEN PRED nadpisom
+ * "Súvisiace" (rovnaký "prvý patrí hlavnému produktu" princíp ako odimon.sk,
+ * issue 225) a rozhoduje TRIEDA (`inStock`/`noStock`), nikdy viditeľný text
+ * (ten sa medzi produktmi líši — "na dotaz" pri `noStock`). Neznáma trieda
+ * ani chýbajúci prvok sa nikdy nehádaju na žiadnu stranu.
+ */
+function fomeiAvailabilityRegion(html: string): string | null {
+  const relatedIndex = html.indexOf(">Súvisiace<");
+  const scope = relatedIndex === -1 ? html : html.slice(0, relatedIndex);
+  const match = /<span\b[^>]*class="[^"]*\bavailability--(inStock|noStock)\b[^"]*"[^>]*>/i.exec(scope);
+  if (match === null) return null;
+  const token = (match[1] ?? "").toLowerCase();
+  if (token === "instock") return "skladom";
+  if (token === "nostock") return "vypredané";
+  return null;
+}
+
+const RAPPA_STOCK_RE = /<dt>Dostupnos.<\/dt>\s*<dd>\s*<span\b[^>]*class="([^"]*)"[^>]*>[\s\S]*?<\/span>/i;
+
+/**
+ * rappa.cz (issue 307): dostupnosť je v tabuľke parametrov ako `<dt>
+ * Dostupnosť</dt><dd><span class="in-stock|out-of-stock">…</span></dd>` —
+ * naživo overený JEDINÝ výskyt na stránke (žiadna karuselová kolízia ako
+ * huntingshop.eu/fomei.com). Rozhoduje TRIEDA, nikdy text priamo — text nesie
+ * aj počet kusov ("skladom (50 a viac ks)"), takže sa prekladá na kanonické
+ * slovo ("skladom"/"vypredané") a ide cez existujúci `availabilityFromText`,
+ * rovnaký vzor ako `trigonaStockRegion`. Obe polarity naživo overené
+ * (7. 8. 2026, reálne produkty).
+ */
+function rappaStockRegion(html: string): string | null {
+  const match = RAPPA_STOCK_RE.exec(html);
+  if (match === null) return null;
+  const classes = (match[1] ?? "").split(/\s+/);
+  if (classes.includes("out-of-stock")) return "vypredané";
+  if (classes.includes("in-stock")) return "skladom";
+  return null;
+}
+
+const ROSLER_STOCK_DIV_RE = /<div\s+class=["']?product-detail-stock["']?>([\s\S]*?)<\/div>/i;
+
+/**
+ * rosler.sk (issue 307): dostupnosť PRI produkte je `<div
+ * class=product-detail-stock>…</div>` (bez úvodzoviek v reálnom markupe) —
+ * ODLIŠNÁ trieda od karuselových/súvisiacich položiek
+ * (`product-thumb-stock`), žiadna kolízia. Text sa vracia AKO JE a ide cez
+ * existujúci `availabilityFromText`. Naživo overené texty: "Skladom N ks"
+ * (available) a "Do 14 dní" (dodanie na objednávku, nie skladom teraz) —
+ * druhý nezodpovedá žiadnemu slovu v `IN_KEYWORDS`/`OUT_KEYWORDS`, preto
+ * correctně padá na `unknown`. Genuinný vypredaný ("0 ks") text sa naživo
+ * NENAŠIEL napriek prehľadaniu 20 uložených odkazov + 3 kategórií — presne
+ * ako wetland.sk (issue 230): pravidlo sa NEHÁDA, žiadne vlastné mapovanie
+ * "Do N dní" → unavailable sa nepridáva.
+ */
+function roslerStockRegion(html: string): string | null {
+  const match = ROSLER_STOCK_DIV_RE.exec(html);
+  if (match === null) return null;
+  const text = (match[1] ?? "")
+    .replace(/&gt;/gi, ">")
+    .replace(/&#x[0-9a-fA-F]+;/gi, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return text === "" ? null : text;
+}
+
+const TEXT_AVAILABILITY_RULES: readonly TextAvailabilityRule[] = Object.freeze([
+  { host: "huntingshop.eu", extractRegion: huntingshopDetailBadges, whenRegionMissing: "unavailable" },
+  { host: "trigona.sk", extractRegion: trigonaStockRegion, whenRegionMissing: "unknown" },
+  { host: "virginiashop.sk", extractRegion: shoptetLabelAvailability, whenRegionMissing: "unknown" },
+  { host: "tenolix.cz", extractRegion: shoptetLabelAvailability, whenRegionMissing: "unknown" },
+  { host: "luko.cz", extractRegion: shoptetLabelAvailability, whenRegionMissing: "unknown" },
+  { host: "zubicek.cz", extractRegion: shoptetLabelAvailability, whenRegionMissing: "unknown" },
+  { host: "fomei.com", extractRegion: fomeiAvailabilityRegion, whenRegionMissing: "unknown" },
+  { host: "rappa.cz", extractRegion: rappaStockRegion, whenRegionMissing: "unknown" },
+  { host: "rosler.sk", extractRegion: roslerStockRegion, whenRegionMissing: "unknown" },
+]);
+
+export function textAvailabilityRuleFor(url: string): TextAvailabilityRule | null {
+  const host = hostOf(url);
+  if (host === "") return null;
+  return TEXT_AVAILABILITY_RULES.find((rule) => host === rule.host || host.endsWith(`.${rule.host}`)) ?? null;
+}
+
+export interface VisibleAvailabilityHit {
+  readonly availability: SupplierAvailability;
+  readonly text: string;
+}
+
+interface VisibleAvailabilityRule {
+  readonly host: string;
+  readonly read: (html: string) => VisibleAvailabilityHit | null;
+}
+
+/**
+ * odimon.sk (issue 225): JSON-LD tejto domény vie klamať (hlási "InStock",
+ * hoci stránka pri produkte hovorí "Nedostupný"). `.product-availability__value`
+ * PRI produkte je to, čo skutočne vidí zákazník — PRVÝ výskyt v dokumente
+ * patrí hlavnému produktu (overené na vzorke: rovnaký prvok sa opakuje aj v
+ * bloku súvisiacich produktov nižšie na stránke, ale až za hlavným).
+ *
+ * Token (`available`/`unavailable`, čo ROZHODUJE dostupnosť) sa berie z
+ * TRIEDY vonkajšieho `<span>` — to je vždy spoľahlivé. Zobrazovaný text sa
+ * ČÍTA EXPLICITNE z vnoreného `.product-availability__value--text`, nikdy sa
+ * neodvodzuje z toho, kde náhodou skončí druhá zatváracia značka — tá by sa
+ * mohla posunúť, keby stránka pridala ďalší vnorený prvok (napr. počet kusov).
+ */
+function odimonVisibleAvailability(html: string): VisibleAvailabilityHit | null {
+  const outer =
+    /<span\b[^>]*class="[^"]*product-availability__value--(available|unavailable)\b[^"]*"[^>]*>/i.exec(html);
+  if (outer === null) return null;
+  const token = outer[1];
+  const rest = html.slice(outer.index + outer[0].length);
+  const textMatch = /<span\b[^>]*class="[^"]*product-availability__value--text[^"]*"[^>]*>([\s\S]*?)<\/span>/i.exec(
+    rest,
+  );
+  const text = (textMatch?.[1] ?? "").replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
+  return { availability: token === "available" ? "available" : "unavailable", text };
+}
+
+const LESONA_AVAILABILITY_RE = /<span\b[^>]*\bid="product-availability"[^>]*>([\s\S]*?)<\/span>/i;
+
+/**
+ * lesona.sk (issue 307): stránkové schema.org mikrodáta
+ * (`<link itemprop="availability" href="https://schema.org/InStock">`) VEDIA
+ * KLAMAŤ — presne ako odimon.sk (issue 225). Naživo overené na reálnom
+ * produkte (slúchadlá 3M Peltor, id 58): mikrodáta tvrdia `InStock`, ale
+ * viditeľný `<span id="product-availability">` s ikonkou
+ * `product-unavailable` hovorí "Vypredané" a tlačidlo "Vložiť do košíka" je
+ * `disabled`. Táto appka mikrodáta vôbec neparsuje (`fromJsonLd` hľadá len
+ * `<script type="application/ld+json">`, `fromMetaTags` len `<meta
+ * property="og:…"/"product:…">` — ani jedno túto `itemprop=` mikrodátovú
+ * formu nezachytí), takže sa NEROZŠIRUJE parser o jej čítanie — namiesto
+ * toho sa dostupnosť číta VÝHRADNE z tohto viditeľného `<span>`.
+ *
+ * Naživo overené TRI stavy: prázdny span (nič v ňom, plne skladom), ikonka
+ * `product-unavailable` + text "Vypredané" (nedostupné), ikonka
+ * `product-last-items` + "Posledné kusy v sklade" (skladom, málo kusov — už
+ * v `IN_KEYWORDS`). Nerozpoznaný NEPRÁZDNY text sa vracia ako `"unknown"`
+ * (nie `null`) — keby sa niekedy pridalo skutočné JSON-LD, `null` by nechalo
+ * (možno klamúce) JSON-LD rozhodnúť namiesto tohto overeného viditeľného
+ * zdroja; `"unknown"` to zaručene nedovolí (`parsePage`'s konfliktová
+ * kontrola).
+ */
+function lesonaVisibleAvailability(html: string): VisibleAvailabilityHit | null {
+  const match = LESONA_AVAILABILITY_RE.exec(html);
+  if (match === null) return null;
+  const text = (match[1] ?? "")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&#x[0-9a-fA-F]+;/gi, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (text === "") return { availability: "available", text: "" };
+  const { availability, matched } = availabilityFromText(text);
+  return { availability, text: matched };
+}
+
+const VISIBLE_AVAILABILITY_RULES: readonly VisibleAvailabilityRule[] = Object.freeze([
+  { host: "odimon.sk", read: odimonVisibleAvailability },
+  { host: "lesona.sk", read: lesonaVisibleAvailability },
+]);
+
+export function visibleAvailabilityFor(url: string, html: string): VisibleAvailabilityHit | null {
+  const host = hostOf(url);
+  if (host === "") return null;
+  const rule = VISIBLE_AVAILABILITY_RULES.find((r) => host === r.host || host.endsWith(`.${r.host}`));
+  return rule === undefined ? null : rule.read(html);
+}

--- a/apps/api/src/modules/supplier-stock/availability-primitives.ts
+++ b/apps/api/src/modules/supplier-stock/availability-primitives.ts
@@ -1,0 +1,107 @@
+// Základné, závislosťami nezaťažené funkcie zdieľané medzi `parse.ts`
+// (generický algoritmus) a `availability-domain-rules.ts` (per-doménové
+// pravidlá) — vyčlenené v code review na issue 307, aby oba súbory záviseli
+// JEDNÝM smerom na tomto (nikdy nie navzájom na sebe). Predtým
+// `availability-domain-rules.ts` importoval `availabilityFromText`/`hostOf`
+// späť z `parse.ts`, zatiaľ čo `parse.ts` importoval per-doménové pravidlá z
+// neho — funkčne bezpečný cyklický import (nič sa nevyhodnocuje na
+// module-top-level v konfliktnom poradí, overené `tsc`/testami), ale krehký:
+// budúci top-level kód v ktoromkoľvek súbore (napr. memoizovaný index) by ho
+// mohol ticho rozbiť. Táto extrakcia cyklus odstraňuje úplne, nielen
+// dokumentuje jeho bezpečnosť.
+
+export type SupplierAvailability = "available" | "unavailable" | "unknown";
+
+/** Doména bez `www.`, malými písmenami. Neplatná URL → prázdny reťazec. */
+export function hostOf(url: string): string {
+  let host = "";
+  try {
+    host = new URL(url).hostname.toLowerCase();
+  } catch {
+    return "";
+  }
+  return host.startsWith("www.") ? host.slice(4) : host;
+}
+
+/**
+ * Dekóduje ČÍSELNÉ HTML entity (`&#xHH;`/`&#DDD;`) na skutočný znak — nikdy
+ * ich len nevyprázdňuje. Zistené code review na issue 307:
+ * `roslerStockRegion`'s pôvodné `.replace(/&#x[0-9a-fA-F]+;/gi, " ")`
+ * (skopírované z `lesonaVisibleAvailability`, kde je vyprázdnenie SPRÁVNE —
+ * tam ide o Material-Icons kódové body v Private Use Area, nie o skutočný
+ * text) na rosler.sk TICHO ROZBÍJALO diakritiku: stránka kóduje KAŽDÚ
+ * diakritiku takto (naživo overené — "dn&#xED;" = "dní", "no&#x17E;e" =
+ * "nože", "ma&#xE1;" = "malá"), takže "vypredan&#xE9;" by sa vyprázdnením
+ * zmenilo na "vypredan " — nezhoduje sa so ŽIADNYM slovom v
+ * `OUT_KEYWORDS`/`IN_KEYWORDS`, extraktor by ticho spadol na `unknown`
+ * namiesto `unavailable`. Skutočné dekódovanie funguje rovnako správne pre
+ * OBA prípady: diakritika sa zmení na svoj skutočný znak (zhodu nájde
+ * `availabilityFromText`), ikonkový kódový bod sa zmení na neviditeľný
+ * Private-Use-Area znak (nezhoduje sa so žiadnym slovom, rovnaký výsledný
+ * efekt ako predošlé vyprázdnenie) — žiadny dôvod mať dve rôzne funkcie.
+ */
+export function decodeNumericEntities(text: string): string {
+  return text
+    .replace(/&#x([0-9a-fA-F]+);/g, (_match, hex: string) => String.fromCodePoint(Number.parseInt(hex, 16)))
+    .replace(/&#(\d+);/g, (_match, dec: string) => String.fromCodePoint(Number.parseInt(dec, 10)));
+}
+
+// Vypredané sa kontroluje PRVÉ — stránka, ktorá povie "Vypredané", je
+// rozhodná aj keď sa inde na nej vyskytne slovo "skladom" (napr. v odporúčaných
+// produktoch). Slovenské, české aj anglické tvary, s diakritikou aj bez nej.
+const OUT_KEYWORDS: readonly string[] = Object.freeze([
+  "vypredané",
+  "vypredane",
+  "vypredaný",
+  "vypredany",
+  "vyprodáno",
+  "vyprodano",
+  "nedostupné",
+  "nedostupne",
+  "nedostupný",
+  "nedostupny",
+  "nie je skladom",
+  "není skladem",
+  "neni skladem",
+  "momentálne nedostupné",
+  "momentalne nedostupne",
+  // Český tvar s mäkkým "ě" (issue 227, tenolix.cz) — INÝ reťazec než
+  // slovenské "momentálne" vyššie, obe sa musia kontrolovať samostatne.
+  "momentálně nedostupné",
+  "dočasne nedostupné",
+  "docasne nedostupne",
+  "predaj skončil",
+  "predaj skoncil",
+  "out of stock",
+  "sold out",
+]);
+
+const IN_KEYWORDS: readonly string[] = Object.freeze([
+  "skladom",
+  "na sklade",
+  "skladem",
+  "ihneď k odberu",
+  "ihned k odberu",
+  "posledné kusy",
+  "posledne kusy",
+  "posledný kus",
+  "posledny kus",
+  "in stock",
+]);
+
+/**
+ * Dostupnosť z voľného textu. Vypredané vyhráva nad skladom (rozhodný zápor).
+ * Vracia aj to, KTORÉ slovo rozhodlo — ide do `availabilityText`, aby bolo
+ * v appke vidieť, na základe čoho sa rozhodlo.
+ */
+export function availabilityFromText(text: string): {
+  readonly availability: SupplierAvailability;
+  readonly matched: string;
+} {
+  const lower = text.toLowerCase();
+  const out = OUT_KEYWORDS.find((keyword) => lower.includes(keyword));
+  if (out !== undefined) return { availability: "unavailable", matched: out };
+  const inStock = IN_KEYWORDS.find((keyword) => lower.includes(keyword));
+  if (inStock !== undefined) return { availability: "available", matched: inStock };
+  return { availability: "unknown", matched: "" };
+}

--- a/apps/api/src/modules/supplier-stock/fixtures/lesona-posledne-kusy-siltovka.html
+++ b/apps/api/src/modules/supplier-stock/fixtures/lesona-posledne-kusy-siltovka.html
@@ -1,0 +1,24 @@
+<!-- issue 307: lesona.sk — nízka zásoba (`product-last-items` ikonka), stále
+     KÚPITEĽNÉ (tlačidlo "Vložiť do košíka" nie je zablokované). Text
+     "Posledné kusy v sklade" je už v globálnom `IN_KEYWORDS` zozname
+     (`parse.ts`), preto to prechádza existujúcim `availabilityFromText`
+     bez novej logiky. Overené naživo 7. 8. 2026. -->
+<!doctype html>
+<html lang="sk">
+<head><title>Šiltovka Alaska 1795 BlindMax HD</title></head>
+<body>
+<div class="product-add-to-cart">
+  <div class="product-quantity">
+    <div class="add">
+      <button class="btn btn-primary add-to-cart" data-button-action="add-to-cart" type="submit">
+        Vložiť do košíka
+      </button>
+      <span id="product-availability">
+        <i class="material-icons product-last-items">&#xE002;</i>
+        Posledné kusy v sklade
+      </span>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/apps/api/src/modules/supplier-stock/fixtures/lesona-skladom-nakrcnik.html
+++ b/apps/api/src/modules/supplier-stock/fixtures/lesona-skladom-nakrcnik.html
@@ -1,0 +1,24 @@
+<!-- issue 307: lesona.sk (PrestaShop) — dostupnosť PRI produkte nesie
+     `<span id="product-…">` (id product-availability). Keď je produkt plne skladom, span je
+     PRÁZDNY (žiadna ikonka, žiadny text) — schema.org `itemprop="availability"`
+     mikrodáta O KUS VYŠŠIE na stránke (`<link itemprop="availability"
+     href="https://schema.org/InStock"/>`) tu súhlasia, ale NEČÍTAME ich (viď
+     lesona-vypredane-sluchadla.html — tá istá mikrodáta na tej istej doméne
+     VIE KLAMAŤ, presne ako odimon.sk, issue 225). Overené naživo 7. 8. 2026. -->
+<!doctype html>
+<html lang="sk">
+<head><title>Nákrčník Alaska 1795 BlindTech Invisible</title></head>
+<body>
+<div class="product-add-to-cart">
+  <div class="product-quantity">
+    <div class="add">
+      <button class="btn btn-primary add-to-cart" data-button-action="add-to-cart" type="submit">
+        Vložiť do košíka
+      </button>
+      <span id="product-availability">
+      </span>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/apps/api/src/modules/supplier-stock/fixtures/lesona-vypredane-sluchadla.html
+++ b/apps/api/src/modules/supplier-stock/fixtures/lesona-vypredane-sluchadla.html
@@ -1,0 +1,31 @@
+<!-- issue 307: lesona.sk — SKUTOČNÝ produkt (3M Peltor SportTac slúchadlá,
+     id 58), naživo overené 7. 8. 2026. Stránkové schema.org mikrodáta
+     tvrdia `InStock` (`<link itemprop="availability"
+     href="https://schema.org/InStock"/>`, o kus vyššie v tomto istom
+     dokumente), ale VIDITEĽNÝ `<span id="product-…">` (id product-availability) aj
+     zablokované tlačidlo "Vložiť do košíka" (`disabled`) hovoria opak —
+     mikrodáta na tejto doméne KLAMÚ, presne ako odimon.sk (issue 225).
+     Preto sa dostupnosť na lesona.sk číta VÝHRADNE z tohto viditeľného
+     `<span>`, nikdy z mikrodát. -->
+<!doctype html>
+<html lang="sk">
+<head><title>Slúchadlá 3M Peltor SportTac s výmennými oranžovými mušľami</title></head>
+<body>
+<div class="product-price" itemprop="offers" itemscope itemtype="https://schema.org/Offer">
+  <link itemprop="availability" href="https://schema.org/InStock"/>
+</div>
+<div class="product-add-to-cart">
+  <div class="product-quantity">
+    <div class="add">
+      <button class="btn btn-primary add-to-cart" data-button-action="add-to-cart" type="submit" disabled>
+        Vložiť do košíka
+      </button>
+      <span id="product-availability">
+        <i class="material-icons product-unavailable">&#xE14B;</i>
+        Vypredané
+      </span>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/apps/api/src/modules/supplier-stock/fixtures/rappa-skladom-plysovy-pes.html
+++ b/apps/api/src/modules/supplier-stock/fixtures/rappa-skladom-plysovy-pes.html
@@ -1,0 +1,20 @@
+<!-- issue 307: rappa.cz — dostupnosť v tabuľke parametrov (dt "Dostupnosť" +
+     dd so span-om), jediný výskyt na stránke. Rozhoduje TRIEDA span-u
+     (in-stock / out-of-stock), nie text (text nesie aj počet kusov, napr.
+     "skladom (50 a viac ks)"). Overené naživo 7. 8. 2026. -->
+<!doctype html>
+<html lang="sk">
+<head><title>Plyšový pes salašník ležiaci 23 cm</title></head>
+<body>
+<div class="product-detail">
+  <dl class="parameters">
+    <dt>Kód sortimentu</dt>
+    <dd>192301</dd>
+    <dt>Dostupnosť</dt>
+    <dd>
+      <span class="in-stock">skladom (50 a viac ks)</span>
+    </dd>
+  </dl>
+</div>
+</body>
+</html>

--- a/apps/api/src/modules/supplier-stock/fixtures/rappa-vypredane-plysova-ovce.html
+++ b/apps/api/src/modules/supplier-stock/fixtures/rappa-vypredane-plysova-ovce.html
@@ -1,0 +1,21 @@
+<!-- issue 307: rappa.cz — SKUTOČNÝ vypredaný produkt, naživo overené
+     7. 8. 2026 (`https://www.rappa.cz/sk/plysova-ovce-18-cm-eco-friendly-1.html`). -->
+<!doctype html>
+<html lang="sk">
+<head><title>Plyšová ovce 18 cm eco friendly</title></head>
+<body>
+<div class="product-detail">
+  <dl class="parameters">
+    <dt>Kód sortimentu</dt>
+    <dd>192300</dd>
+    <dt>Dostupnosť</dt>
+    <dd>
+      <span class="out-of-stock">vypredané</span>
+    </dd>
+  </dl>
+  <div class="avail-text">
+    <p><strong>Tento produkt je momentálně nedostupný.</strong></p>
+  </div>
+</div>
+</body>
+</html>

--- a/apps/api/src/modules/supplier-stock/fixtures/rosler-do-14-dni-noz.html
+++ b/apps/api/src/modules/supplier-stock/fixtures/rosler-do-14-dni-noz.html
@@ -1,0 +1,19 @@
+<!-- issue 307: rosler.sk — "Do 14 dní" (dodanie na objednávku, nie skladom
+     TERAZ) je jediný ĎALŠÍ text, aký sa naživo podarilo nájsť (kategória
+     `vreckove-noze/delemont`, 7. 8. 2026) okrem "Skladom N ks". Skutočný
+     nulový/vypredaný text sa naživo NENAŠIEL napriek prehľadaniu 20
+     uložených odkazov + viacerých kategórií — rovnaký prípad ako wetland.sk
+     (issue 230, `.claude/rules/supplier-stock.md`): pravidlo sa NEHÁDA,
+     text jednoducho nesedí so žiadnym slovom v `IN_KEYWORDS`/`OUT_KEYWORDS`
+     a ostáva `unknown`, nikdy sa nevymýšľa nová mapovanie "Do N dní" →
+     unavailable. -->
+<!doctype html>
+<html lang="sk">
+<head><title>Victorinox RangerGrip 57 Hunter</title></head>
+<body>
+<div class="product-detail-priceBox">
+  <div class="product-detail-price">Cena: 89,00&nbsp;€</div>
+  <div class=product-detail-stock> Do 14 dn&#xED; </div>
+</div>
+</body>
+</html>

--- a/apps/api/src/modules/supplier-stock/fixtures/rosler-skladom-bruska.html
+++ b/apps/api/src/modules/supplier-stock/fixtures/rosler-skladom-bruska.html
@@ -1,0 +1,14 @@
+<!-- issue 307: rosler.sk — dostupnosť PRI produkte je div s triedou
+     product-detail-stock (bez úvodzoviek v reálnom markupe), ODLIŠNÁ trieda
+     od karuselových/súvisiacich položiek (product-thumb-stock) — žiadna
+     kolízia. Overené naživo 7. 8. 2026. -->
+<!doctype html>
+<html lang="sk">
+<head><title>Victorinox bruska na nože malá</title></head>
+<body>
+<div class="product-detail-priceBox">
+  <div class="product-detail-price">Cena: 20,00&nbsp;€</div>
+  <div class=product-detail-stock> Skladom &gt; 5 ks </div>
+</div>
+</body>
+</html>

--- a/apps/api/src/modules/supplier-stock/fixtures/rosler-vypredane-noz-entita.html
+++ b/apps/api/src/modules/supplier-stock/fixtures/rosler-vypredane-noz-entita.html
@@ -1,0 +1,20 @@
+<!-- issue 307 (code review nález): rosler.sk kóduje KAŽDÚ diakritiku
+     číselnou HTML entitou (naživo overené na produkčnej stránke —
+     "dn&#xED;" = "dní", "ma&#xE1;" = "malá", "no&#x17E;e" = "nože"), nikdy
+     priamym UTF-8 znakom. Genuinný vypredaný text sa naživo NENAŠIEL
+     (viď rosler-do-14-dni-noz.html), takže TENTO fixture nie je naživo
+     overená vzorka — je to REGRESNÝ test mechanizmu dekódovania: keby
+     rosler.sk niekedy zobrazil "vypredan&#xE9;" (entitovo zakódované
+     "vypredané"), extraktor ho MUSÍ rozpoznať ako unavailable, nikdy
+     nesmie ticho spadnúť na unknown len preto, že diakritiku
+     nesprávne vyprázdnil namiesto dekódovania. -->
+<!doctype html>
+<html lang="sk">
+<head><title>Testovací produkt (entitovo kódovaná diakritika)</title></head>
+<body>
+<div class="product-detail-priceBox">
+  <div class="product-detail-price">Cena: 45,00&nbsp;€</div>
+  <div class=product-detail-stock> Vypredan&#xE9; </div>
+</div>
+</body>
+</html>

--- a/apps/api/src/modules/supplier-stock/fixtures/zubicek-skladem-borlice.html
+++ b/apps/api/src/modules/supplier-stock/fixtures/zubicek-skladem-borlice.html
@@ -1,0 +1,15 @@
+<!-- issue 307: zubicek.cz — ROVNAKÁ zdieľaná Shoptet šablóna ako
+     virginiashop.sk/tenolix.cz/luko.cz (issue 227), byte-zhodná trieda aj
+     data-testid. Overené naživo 7. 8. 2026 (jednoveľkostný produkt). -->
+<!doctype html>
+<html lang="cs">
+<head><title>Borlice – parohové bolo</title></head>
+<body>
+<div class="product-detail">
+  <div class="availability-value" title="Dostupnost">
+    <span class="availability-label" style="color: #009901" data-testid="labelAvailability">
+                    Skladem            </span>
+  </div>
+</div>
+</body>
+</html>

--- a/apps/api/src/modules/supplier-stock/fixtures/zubicek-viacvariantovy-bez-testid.html
+++ b/apps/api/src/modules/supplier-stock/fixtures/zubicek-viacvariantovy-bez-testid.html
@@ -1,0 +1,30 @@
+<!-- issue 307: viacvariantový produkt na zubicek.cz (napr. remeň vo viacerých
+     veľkostiach) — BEZ `data-testid="labelAvailability"`, presne rovnaký jav
+     ako luko.cz (issue 227): JS prepína dostupnosť podľa zvolenej veľkosti
+     cez `parameter-dependent no-display <id>` obaľovače, hlavný
+     `data-testid` sa vôbec nevykreslí. Ostáva `unknown` — mapovanie
+     číselných parameter-ID na konkrétnu veľkosť je mimo rozsahu tohto
+     ticketu (rovnaká poznámka ako luko.cz v `.claude/rules/supplier-
+     stock.md`). Overené naživo 7. 8. 2026. -->
+<!doctype html>
+<html lang="cs">
+<head><title>Kožený opasek se šířkou 4 cm</title></head>
+<body>
+<div class="product-detail">
+  <div class="p-basic-info-block">
+    <span class="parameter-dependent no-display 49-554">
+      <span class="availability-label" style="color: #009901">
+                                            Skladem
+                                    </span>
+    </span>
+    <span class="parameter-dependent no-display 49-557">
+      <span class="availability-label" style="color: #009901">
+                                            Skladem
+                                    </span>
+    </span>
+    <span class="parameter-dependent default-variant">
+                        Zvolte variantu                    </span>
+  </div>
+</div>
+</body>
+</html>

--- a/apps/api/src/modules/supplier-stock/parse-issue307.test.ts
+++ b/apps/api/src/modules/supplier-stock/parse-issue307.test.ts
@@ -22,6 +22,7 @@ const RAPPA_SKLADOM = fixture("rappa-skladom-plysovy-pes.html");
 const RAPPA_VYPREDANE = fixture("rappa-vypredane-plysova-ovce.html");
 const ROSLER_SKLADOM = fixture("rosler-skladom-bruska.html");
 const ROSLER_DO_14_DNI = fixture("rosler-do-14-dni-noz.html");
+const ROSLER_VYPREDANE_ENTITA = fixture("rosler-vypredane-noz-entita.html");
 
 describe("parsePage — issue 307: zubicek.cz zdiela byte-zhodnu Shoptet sablonu s issue 227", () => {
   it("jednovelkostny produkt 'Skladem' je available", () => {
@@ -45,7 +46,7 @@ describe("parsePage — issue 307: lesona.sk mikrodata vedia klamat, cita sa vid
     expect(result.availability).toBe("available");
   });
 
-  it("ikonka product-unavailable + 'Vypredane' je unavailable, aj ked mikrodata na tej istej stranke tvrdia InStock", () => {
+  it("ikonka product-unavailable + 'Vypredane' je unavailable (stránkové mikrodáta v tomto fixture sa vôbec neparsujú, takže nemôžu prekabátiť)", () => {
     const result = parsePage(
       LESONA_VYPREDANE,
       "https://lesona.sk/vybavenie/58-344-sluchadla-3m-peltor-sporttac.html",
@@ -92,5 +93,10 @@ describe("parsePage — issue 307: rosler.sk product-detail-stock div (odlisna t
       "https://www.rosler.sk/produkty/vreckove-noze/delemont/130mm/victorinox-rangergrip-57-hunter",
     );
     expect(result.availability).toBe("unknown");
+  });
+
+  it("regresny test (code review): entitovo kodovana diakritika 'Vypredan&#xE9;' sa DEKODUJE, nikdy len nevyprazdni", () => {
+    const result = parsePage(ROSLER_VYPREDANE_ENTITA, "https://www.rosler.sk/produkty/testovaci-produkt");
+    expect(result.availability).toBe("unavailable");
   });
 });

--- a/apps/api/src/modules/supplier-stock/parse-issue307.test.ts
+++ b/apps/api/src/modules/supplier-stock/parse-issue307.test.ts
@@ -1,0 +1,96 @@
+// Vydelené z parse.test.ts (issue 307), aby ani jeden zo súborov neprerástol
+// eslint max-lines: 400 (`.claude/rules/testing.md`) — rovnaký vzor ako
+// existujúci orders-http.integration.test.ts /
+// orders-http-state.integration.test.ts split. Domény zubicek.cz/lesona.sk/
+// rappa.cz/rosler.sk, ktoré predtým skončili vždy na `unknown`, pretože v
+// `TEXT_AVAILABILITY_RULES`/`VISIBLE_AVAILABILITY_RULES` vôbec neboli.
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { parsePage } from "./parse.js";
+
+function fixture(name: string): string {
+  return readFileSync(fileURLToPath(new URL(`./fixtures/${name}`, import.meta.url)), "utf8");
+}
+
+const ZUBICEK_SKLADEM = fixture("zubicek-skladem-borlice.html");
+const ZUBICEK_VIACVARIANTOVY = fixture("zubicek-viacvariantovy-bez-testid.html");
+const LESONA_SKLADOM = fixture("lesona-skladom-nakrcnik.html");
+const LESONA_VYPREDANE = fixture("lesona-vypredane-sluchadla.html");
+const LESONA_POSLEDNE_KUSY = fixture("lesona-posledne-kusy-siltovka.html");
+const RAPPA_SKLADOM = fixture("rappa-skladom-plysovy-pes.html");
+const RAPPA_VYPREDANE = fixture("rappa-vypredane-plysova-ovce.html");
+const ROSLER_SKLADOM = fixture("rosler-skladom-bruska.html");
+const ROSLER_DO_14_DNI = fixture("rosler-do-14-dni-noz.html");
+
+describe("parsePage — issue 307: zubicek.cz zdiela byte-zhodnu Shoptet sablonu s issue 227", () => {
+  it("jednovelkostny produkt 'Skladem' je available", () => {
+    const result = parsePage(ZUBICEK_SKLADEM, "https://www.zubicek.cz/borlice--parohove-bolo/");
+    expect(result.availability).toBe("available");
+    expect(result.source).toBe("text");
+  });
+
+  it("viacvariantovy produkt (bez data-testid) je unknown, nikdy dohad", () => {
+    const result = parsePage(ZUBICEK_VIACVARIANTOVY, "https://www.zubicek.cz/kozeny-opasek-sire-4-cm/");
+    expect(result.availability).toBe("unknown");
+  });
+});
+
+describe("parsePage — issue 307: lesona.sk mikrodata vedia klamat, cita sa viditelny <span id=product-availability>", () => {
+  it("prazdny span (ziadna ikonka) je available", () => {
+    const result = parsePage(
+      LESONA_SKLADOM,
+      "https://lesona.sk/doplnky-k-obleceniu/112-304-nakrcnik-alaska-1795-blindtech-invisible.html",
+    );
+    expect(result.availability).toBe("available");
+  });
+
+  it("ikonka product-unavailable + 'Vypredane' je unavailable, aj ked mikrodata na tej istej stranke tvrdia InStock", () => {
+    const result = parsePage(
+      LESONA_VYPREDANE,
+      "https://lesona.sk/vybavenie/58-344-sluchadla-3m-peltor-sporttac.html",
+    );
+    expect(result.availability).toBe("unavailable");
+    expect(result.source).toBe("text");
+  });
+
+  it("ikonka product-last-items + 'Posledne kusy v sklade' je available (uz v IN_KEYWORDS)", () => {
+    const result = parsePage(
+      LESONA_POSLEDNE_KUSY,
+      "https://lesona.sk/oblecenie-a-obuv/50-337-siltovka-alaska-1795-blindmax-hd.html",
+    );
+    expect(result.availability).toBe("available");
+  });
+});
+
+describe("parsePage — issue 307: rappa.cz Dostupnost dt/dd, rozhoduje trieda in-stock/out-of-stock", () => {
+  it("trieda 'in-stock' je available", () => {
+    const result = parsePage(RAPPA_SKLADOM, "https://www.rappa.cz/sk/plysovy-pes-salasnik-lezici-23-cm.html");
+    expect(result.availability).toBe("available");
+    expect(result.source).toBe("text");
+  });
+
+  it("trieda 'out-of-stock' je unavailable", () => {
+    const result = parsePage(RAPPA_VYPREDANE, "https://www.rappa.cz/sk/plysova-ovce-18-cm-eco-friendly-1.html");
+    expect(result.availability).toBe("unavailable");
+  });
+});
+
+describe("parsePage — issue 307: rosler.sk product-detail-stock div (odlisna trieda od karuselu product-thumb-stock)", () => {
+  it("'Skladom > 5 ks' je available", () => {
+    const result = parsePage(
+      ROSLER_SKLADOM,
+      "https://www.rosler.sk/produkty/kuchynske-noze-a-noziarske-vyrobky/ocielky-a-brusky/victorinox-bruska-na-noze-mala",
+    );
+    expect(result.availability).toBe("available");
+    expect(result.source).toBe("text");
+  });
+
+  it("'Do 14 dni' (dodanie na objednavku, naziva sa genuinny vypredany text nenasiel) je unknown, nikdy dohad", () => {
+    const result = parsePage(
+      ROSLER_DO_14_DNI,
+      "https://www.rosler.sk/produkty/vreckove-noze/delemont/130mm/victorinox-rangergrip-57-hunter",
+    );
+    expect(result.availability).toBe("unknown");
+  });
+});

--- a/apps/api/src/modules/supplier-stock/parse.test.ts
+++ b/apps/api/src/modules/supplier-stock/parse.test.ts
@@ -36,6 +36,9 @@ const LUKO_VIACVELKOSTNA = fixture("luko-viacvelkostna-bez-testid.html");
 const FOMEI_SKLADOM = fixture("fomei-skladom-puskohlad.html");
 const FOMEI_NA_DOTAZ = fixture("fomei-nadotaz-dalekohlad.html");
 const CHIRUCA_VELKOSTI = fixture("chiruca-velkosti-cameros.html");
+// zubicek.cz/lesona.sk/rappa.cz/rosler.sk (issue 307) testy su v
+// parse-issue307.test.ts — vydelene, aby ani jeden zo suborov neprerastol
+// eslint max-lines: 400.
 
 describe("hostOf / isTrustedTextHost", () => {
   it("odreze www a zmensi pismena", () => {

--- a/apps/api/src/modules/supplier-stock/parse.ts
+++ b/apps/api/src/modules/supplier-stock/parse.ts
@@ -1,6 +1,12 @@
 // Čítanie dostupnosti a ceny z HTML stránky dodávateľa — ČISTÉ funkcie, žiadna
 // sieť, žiadna databáza. Testuje sa nad uloženými vzorkami stránok.
 //
+// Per-doménové pravidlá pre voľný text (`TEXT_AVAILABILITY_RULES`) a
+// viditeľnú dostupnosť (`VISIBLE_AVAILABILITY_RULES`) žijú v
+// `availability-domain-rules.ts` (issue 307 — vyčlenené, aby ani jeden zo
+// súborov neprerástol eslint `max-lines: 400`) — tento súbor nesie len
+// generický algoritmus čítania stránky.
+//
 // Úrovne v poradí od najspoľahlivejšej — ALE keď má doména vlastné pravidlo
 // na VIDITEĽNÚ dostupnosť pri produkte (`VISIBLE_AVAILABILITY_RULES`, issue
 // 225), táto sa krížovo overí proti JSON-LD a pri rozpore vyhrá „neviem":
@@ -17,6 +23,8 @@
 //
 // Čokoľvek, čo neprejde ani jednou úrovňou, je `unknown` — a `unknown` nikdy
 // neprepne produkt (issue 213).
+
+import { textAvailabilityRuleFor, visibleAvailabilityFor } from "./availability-domain-rules.js";
 
 export type SupplierAvailability = "available" | "unavailable" | "unknown";
 export type SupplierStockSource = "json_ld" | "meta" | "text" | "size_list" | "none";
@@ -235,194 +243,6 @@ export function fromMetaTags(html: string): SchemaHit | null {
     return { availability, token, price };
   }
   return null;
-}
-
-interface TextAvailabilityRule {
-  readonly host: string;
-  /**
-   * Vyberie z CELEJ stránky LEN oblasť s dostupnosťou TOHTO produktu. `null`
-   * = oblasť sa nenašla. `url` (issue 241) je k dispozícii pre extraktory,
-   * ktoré vedia krížovo overiť nájdenú oblasť proti ID/slugu SCRAPOVANÉHO
-   * produktu (napr. `trigonaStockRegion`) — extraktor, ktorý takú kontrolu
-   * nepotrebuje (má vlastnú štruktúrnu záruku inak, napr. CSS triedu), ho
-   * jednoducho nemusí deklarovať vo svojej signatúre.
-   */
-  readonly extractRegion: (html: string, url: string) => string | null;
-  /** Čo znamená CHÝBAJÚCA oblasť (žiadny štítok pri produkte). */
-  readonly whenRegionMissing: SupplierAvailability;
-}
-
-/**
- * huntingshop.eu (issue 223): dostupnosť TOHTO produktu nesie `<span
- * class="badge badge-outline-…">` hneď pri cene. Karuselové štítky
- * súvisiacich produktov majú NAVYŠE triedu `badge-stock` — tie sa vylučujú,
- * inak by sa dostupnosť iného produktu v karuseli počítala za tento. Keď sa
- * nenájde ŽIADEN takýto štítok, produkt v skutočnosti nemá žiadnu značku
- * dostupnosti — to znamená `unavailable` (overené na vzorke: vypredaný
- * produkt štítok nemá vôbec), nikdy `available` z náhodného textu inde na
- * stránke (napr. pätičková veta „…máme skladom ihneď k odberu").
- */
-function huntingshopDetailBadges(html: string): string | null {
-  const spans = [...html.matchAll(/<span\b[^>]*class="([^"]*badge-outline-[^"]*)"[^>]*>([\s\S]*?)<\/span>/gi)];
-  const texts = spans
-    .filter(([, cls]) => cls !== undefined && !cls.includes("badge-stock"))
-    .map(([, , text]) => (text ?? "").replace(/\s+/g, " ").trim())
-    .filter((text) => text !== "");
-  return texts.length > 0 ? texts.join(" ") : null;
-}
-
-const TRIGONA_STOCK_COUNT_RE =
-  /<span\b[^>]*\bid="StockCountText(\d+)"[^>]*>\s*<span\b[^>]*\bstyle="[^"]*color:\s*(#[0-9a-fA-F]{6})[^"]*"[^>]*>/gi;
-const TRIGONA_PRODUCT_ID_RE = /\/p-(\d+)\.xhtml/i;
-
-/**
- * trigona.sk (issue 230, ID krížová kontrola issue 241): dostupnosť PRI
- * produkte nesie `<span id="StockCountText<ID>">` s vnoreným `<span
- * style="color: …">` — `<ID>` je ČÍSLO KONKRÉTNEHO produktu, ktoré sa MUSÍ
- * zhodovať s ID v URL (`.../p-<ID>.xhtml`), inak sa oblasť nepovažuje za
- * patriacu scrapovanému produktu. Predtým (issue 230) sa bral PRVÝ výskyt v
- * dokumente bez tejto kontroly — fungovalo to len vďaka empirickému dôkazu
- * (31 naživo overených stránok, vždy práve jeden výskyt), nie vďaka
- * štruktúrnej záruke. Keby trigona.sk niekedy pridala súvisiaci produkt s
- * rovnakou značkou VYŠŠIE na stránke, prvý-v-poradí by bol ISTO ZLÁ
- * odpoveď — preto sa teraz prechádzajú VŠETKY výskyty a vyberie sa ten,
- * ktorého `<ID>` sedí s URL.
- *
- * Farba rozhoduje o dostupnosti — obe polarity sú naživo overené proti
- * JSON-LD na TOM ISTOM produkte: `#00b020` (zelená, text "Na sklade")
- * zodpovedá JSON-LD `InStock`; `#024bbd` (modrá, text "1 - 4 týždne" —
- * dodacia lehota, nie doslovné slovo "vypredané") zodpovedá JSON-LD
- * `OutOfStock`. Farba sa prekladá na kanonické slovo, aby prešlo
- * existujúcim `availabilityFromText` zoznamom kľúčových slov.
- *
- * Nerozpoznaná farba, nerozobrateľné ID z URL, chýbajúci/nezhodný prvok,
- * ANI DVA zhodné-ID výskyty s ROZDIELNOU farbou (nejednoznačné, rovnaká
- * disciplína ako `matchSizeLabel`: viac než jedna zhoda sa počíta ako
- * žiadna) sa NEHÁDŽU na žiadnu stranu — vracia sa `null`
- * (`whenRegionMissing: "unknown"` nižšie). Na rozdiel od huntingshop.eu,
- * kde je naživo overené, že vypredaný produkt štítok vôbec nemá, sa na
- * trigona.sk medzi overenými vzorkami nikdy nevyskytla stránka bez tohto
- * prvku — preto tu niet dôkazu, čo by chýbajúci štítok znamenal.
- */
-function trigonaStockRegion(html: string, url: string): string | null {
-  const productId = TRIGONA_PRODUCT_ID_RE.exec(url)?.[1];
-  if (productId === undefined) return null;
-  const resolved = new Set<string>();
-  for (const match of html.matchAll(TRIGONA_STOCK_COUNT_RE)) {
-    const [, id, colorRaw] = match;
-    if (id !== productId) continue;
-    const color = (colorRaw ?? "").toLowerCase();
-    if (color === "#00b020") resolved.add("skladom");
-    else if (color === "#024bbd") resolved.add("vypredané");
-  }
-  const values = [...resolved];
-  return values.length === 1 ? (values[0] ?? null) : null;
-}
-
-/**
- * virginiashop.sk/tenolix.cz/luko.cz (issue 227): rovnaká Shoptet šablóna,
- * jednoveľkostný produkt nesie `<span class="availability-label" ...
- * data-testid="labelAvailability">Skladom/Skladem/Momentálne(ě)
- * nedostupné</span>` — text sa vracia AKO JE a ide cez existujúci
- * `availabilityFromText` (žiadna nová farebná/triedová logika, na rozdiel od
- * trigona.sk). Naživo overené OBE polarity priamo na virginiashop.sk aj
- * tenolix.cz (rovnaká trieda, rovnaké farby #009901/#cb0000); luko.cz má
- * naživo overenú len zelenú vetvu — jej sledované odkazy sú takmer vždy
- * VIACVEĽKOSTNÉ produkty, ktoré tento `data-testid` vôbec nemajú (viď
- * `whenRegionMissing` nižšie), takže ostávajú `unknown` presne ako predtým.
- * Viacvariantový produkt (viac veľkostí/farieb naraz) tento `data-testid`
- * NEVYKRESĽUJE vôbec — vtedy sa nesmie nič uhádnuť z niektorej z viacerých
- * zhôd, preto `whenRegionMissing: "unknown"`.
- */
-function shoptetLabelAvailability(html: string): string | null {
-  const match = /<span\b[^>]*data-testid="labelAvailability"[^>]*>([\s\S]*?)<\/span>/i.exec(html);
-  if (match === null) return null;
-  const text = (match[1] ?? "").replace(/\s+/g, " ").trim();
-  return text === "" ? null : text;
-}
-
-/**
- * fomei.com (issue 227): JSON-LD na stránke nie je Product/Offer (len
- * breadcrumb), ale schema.org MIKRODÁTA (`<span class="availability
- * availability--inStock|noStock">`) sa OPAKUJÚ naprieč stránkou — hlavný
- * produkt aj karusel "Súvisiace" nižšie majú ROVNAKÚ triedu (rovnaká
- * kolízia ako huntingshop.eu, issue 223). Preto sa hľadá LEN PRED nadpisom
- * "Súvisiace" (rovnaký "prvý patrí hlavnému produktu" princíp ako odimon.sk,
- * issue 225) a rozhoduje TRIEDA (`inStock`/`noStock`), nikdy viditeľný text
- * (ten sa medzi produktmi líši — "na dotaz" pri `noStock`). Neznáma trieda
- * ani chýbajúci prvok sa nikdy nehádaju na žiadnu stranu.
- */
-function fomeiAvailabilityRegion(html: string): string | null {
-  const relatedIndex = html.indexOf(">Súvisiace<");
-  const scope = relatedIndex === -1 ? html : html.slice(0, relatedIndex);
-  const match = /<span\b[^>]*class="[^"]*\bavailability--(inStock|noStock)\b[^"]*"[^>]*>/i.exec(scope);
-  if (match === null) return null;
-  const token = (match[1] ?? "").toLowerCase();
-  if (token === "instock") return "skladom";
-  if (token === "nostock") return "vypredané";
-  return null;
-}
-
-const TEXT_AVAILABILITY_RULES: readonly TextAvailabilityRule[] = Object.freeze([
-  { host: "huntingshop.eu", extractRegion: huntingshopDetailBadges, whenRegionMissing: "unavailable" },
-  { host: "trigona.sk", extractRegion: trigonaStockRegion, whenRegionMissing: "unknown" },
-  { host: "virginiashop.sk", extractRegion: shoptetLabelAvailability, whenRegionMissing: "unknown" },
-  { host: "tenolix.cz", extractRegion: shoptetLabelAvailability, whenRegionMissing: "unknown" },
-  { host: "luko.cz", extractRegion: shoptetLabelAvailability, whenRegionMissing: "unknown" },
-  { host: "fomei.com", extractRegion: fomeiAvailabilityRegion, whenRegionMissing: "unknown" },
-]);
-
-function textAvailabilityRuleFor(url: string): TextAvailabilityRule | null {
-  const host = hostOf(url);
-  if (host === "") return null;
-  return TEXT_AVAILABILITY_RULES.find((rule) => host === rule.host || host.endsWith(`.${rule.host}`)) ?? null;
-}
-
-interface VisibleAvailabilityHit {
-  readonly availability: SupplierAvailability;
-  readonly text: string;
-}
-
-interface VisibleAvailabilityRule {
-  readonly host: string;
-  readonly read: (html: string) => VisibleAvailabilityHit | null;
-}
-
-/**
- * odimon.sk (issue 225): JSON-LD tejto domény vie klamať (hlási "InStock",
- * hoci stránka pri produkte hovorí "Nedostupný"). `.product-availability__value`
- * PRI produkte je to, čo skutočne vidí zákazník — PRVÝ výskyt v dokumente
- * patrí hlavnému produktu (overené na vzorke: rovnaký prvok sa opakuje aj v
- * bloku súvisiacich produktov nižšie na stránke, ale až za hlavným).
- *
- * Token (`available`/`unavailable`, čo ROZHODUJE dostupnosť) sa berie z
- * TRIEDY vonkajšieho `<span>` — to je vždy spoľahlivé. Zobrazovaný text sa
- * ČÍTA EXPLICITNE z vnoreného `.product-availability__value--text`, nikdy sa
- * neodvodzuje z toho, kde náhodou skončí druhá zatváracia značka — tá by sa
- * mohla posunúť, keby stránka pridala ďalší vnorený prvok (napr. počet kusov).
- */
-function odimonVisibleAvailability(html: string): VisibleAvailabilityHit | null {
-  const outer =
-    /<span\b[^>]*class="[^"]*product-availability__value--(available|unavailable)\b[^"]*"[^>]*>/i.exec(html);
-  if (outer === null) return null;
-  const token = outer[1];
-  const rest = html.slice(outer.index + outer[0].length);
-  const textMatch = /<span\b[^>]*class="[^"]*product-availability__value--text[^"]*"[^>]*>([\s\S]*?)<\/span>/i.exec(
-    rest,
-  );
-  const text = (textMatch?.[1] ?? "").replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
-  return { availability: token === "available" ? "available" : "unavailable", text };
-}
-
-const VISIBLE_AVAILABILITY_RULES: readonly VisibleAvailabilityRule[] = Object.freeze([
-  { host: "odimon.sk", read: odimonVisibleAvailability },
-]);
-
-function visibleAvailabilityFor(url: string, html: string): VisibleAvailabilityHit | null {
-  const host = hostOf(url);
-  if (host === "") return null;
-  const rule = VISIBLE_AVAILABILITY_RULES.find((r) => host === r.host || host.endsWith(`.${r.host}`));
-  return rule === undefined ? null : rule.read(html);
 }
 
 export interface SizeAvailability {

--- a/apps/api/src/modules/supplier-stock/parse.ts
+++ b/apps/api/src/modules/supplier-stock/parse.ts
@@ -25,8 +25,11 @@
 // neprepne produkt (issue 213).
 
 import { textAvailabilityRuleFor, visibleAvailabilityFor } from "./availability-domain-rules.js";
+import { availabilityFromText, hostOf, type SupplierAvailability } from "./availability-primitives.js";
 
-export type SupplierAvailability = "available" | "unavailable" | "unknown";
+export type { SupplierAvailability };
+export { availabilityFromText, hostOf };
+
 export type SupplierStockSource = "json_ld" | "meta" | "text" | "size_list" | "none";
 
 export interface ParsedPage {
@@ -34,17 +37,6 @@ export interface ParsedPage {
   readonly availabilityText: string;
   readonly price: number | null;
   readonly source: SupplierStockSource;
-}
-
-/** Doména bez `www.`, malými písmenami. Neplatná URL → prázdny reťazec. */
-export function hostOf(url: string): string {
-  let host = "";
-  try {
-    host = new URL(url).hostname.toLowerCase();
-  } catch {
-    return "";
-  }
-  return host.startsWith("www.") ? host.slice(4) : host;
 }
 
 /** `true`, keď má doména (alebo jej poddoména) overené pravidlo na voľný text. */
@@ -73,66 +65,6 @@ export function availabilityFromSchemaToken(token: string): SupplierAvailability
   if (SCHEMA_AVAILABLE.has(normalized)) return "available";
   if (SCHEMA_UNAVAILABLE.has(normalized)) return "unavailable";
   return "unknown";
-}
-
-// Vypredané sa kontroluje PRVÉ — stránka, ktorá povie "Vypredané", je
-// rozhodná aj keď sa inde na nej vyskytne slovo "skladom" (napr. v odporúčaných
-// produktoch). Slovenské, české aj anglické tvary, s diakritikou aj bez nej.
-const OUT_KEYWORDS: readonly string[] = Object.freeze([
-  "vypredané",
-  "vypredane",
-  "vypredaný",
-  "vypredany",
-  "vyprodáno",
-  "vyprodano",
-  "nedostupné",
-  "nedostupne",
-  "nedostupný",
-  "nedostupny",
-  "nie je skladom",
-  "není skladem",
-  "neni skladem",
-  "momentálne nedostupné",
-  "momentalne nedostupne",
-  // Český tvar s mäkkým "ě" (issue 227, tenolix.cz) — INÝ reťazec než
-  // slovenské "momentálne" vyššie, obe sa musia kontrolovať samostatne.
-  "momentálně nedostupné",
-  "dočasne nedostupné",
-  "docasne nedostupne",
-  "predaj skončil",
-  "predaj skoncil",
-  "out of stock",
-  "sold out",
-]);
-
-const IN_KEYWORDS: readonly string[] = Object.freeze([
-  "skladom",
-  "na sklade",
-  "skladem",
-  "ihneď k odberu",
-  "ihned k odberu",
-  "posledné kusy",
-  "posledne kusy",
-  "posledný kus",
-  "posledny kus",
-  "in stock",
-]);
-
-/**
- * Dostupnosť z voľného textu. Vypredané vyhráva nad skladom (rozhodný zápor).
- * Vracia aj to, KTORÉ slovo rozhodlo — ide do `availabilityText`, aby bolo
- * v appke vidieť, na základe čoho sa rozhodlo.
- */
-export function availabilityFromText(text: string): {
-  readonly availability: SupplierAvailability;
-  readonly matched: string;
-} {
-  const lower = text.toLowerCase();
-  const out = OUT_KEYWORDS.find((keyword) => lower.includes(keyword));
-  if (out !== undefined) return { availability: "unavailable", matched: out };
-  const inStock = IN_KEYWORDS.find((keyword) => lower.includes(keyword));
-  if (inStock !== undefined) return { availability: "available", matched: inStock };
-  return { availability: "unknown", matched: "" };
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.175",
+  "version": "0.3.0-dev.176",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.176",
+  "version": "0.3.0-dev.177",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
issue 307

## Rozsah tohto PR

Diagnostika issue 307 zistila, kde sa počty strácajú (208 vypredaných → 130
stále v exporte → 39 s odkazom na dodávateľa → 38 sa podarilo stiahnuť → 3
dostupné). Toto PR rieši druhú stratu z diagnostiky — domény, na ktorých sa
odkaz podarilo stiahnuť, ale parser dostupnosti ich nevedel prečítať vôbec
(`zubicek.cz` 134/134, `lesona.sk` 25/25, `rappa.cz` ~20/20, `rosler.sk`
~20/20 vždy skončili na `unknown`).

Prvá strata (91 zo 130 vypredaných produktov nemá odkaz na dodávateľa vôbec)
je samostatná funkcia presahujúca 300 riadkov — nahlásená ako #311, mimo
tohto PR.

## Zmeny

- `zubicek.cz` pridané do `TEXT_AVAILABILITY_RULES` — zdieľa byte-zhodnú
  Shoptet šablónu s virginiashop.sk/tenolix.cz/luko.cz (issue 227), žiadna
  nová logika.
- `lesona.sk`: nové `VISIBLE_AVAILABILITY_RULES` pravidlo. Dôležitý nález:
  stránkové schema.org mikrodáta na tejto doméne VEDIA KLAMAŤ (rovnaký jav
  ako odimon.sk, issue 225) — naživo overené na reálnom produkte, mikrodáta
  tvrdia InStock, viditeľný stav aj zablokované tlačidlo "Vložiť do košíka"
  hovoria opak. Dostupnosť sa preto číta výhradne z viditeľného prvku.
- `rappa.cz`: nové `TEXT_AVAILABILITY_RULES` pravidlo, číta triedu
  (`in-stock`/`out-of-stock`) z tabuľky parametrov.
- `rosler.sk`: nové `TEXT_AVAILABILITY_RULES` pravidlo, číta text z
  vlastného `product-detail-stock` divu cez existujúci `availabilityFromText`.
  Genuinný vypredaný text sa naživo nenašiel napriek prehľadaniu 20 odkazov +
  3 kategórií (rovnaká situácia ako wetland.sk, issue 230) — žiadne nové
  mapovanie sa nehádalo, "Do 14 dní" correctně padá na `unknown`.
- Domain-specific pravidlá a extraktory vyčlenené do nového
  `availability-domain-rules.ts` (parse.ts aj parse.test.ts by inak
  presiahli eslint `max-lines: 400`) — čistý architektonický rez: `parse.ts`
  = generický algoritmus, nový súbor = per-doménová znalosť.

## Overenie

Návrh + zistenia naživo (curl proti reálnym uloženým odkazom): pozri
komentár na #307. Šesť lokálnych brán zelených: `pnpm typecheck`, `pnpm
lint`, `pnpm --filter @forestshop/api test` (640/640), `pnpm --filter
@forestshop/web test` (507/507), `pnpm --filter @forestshop/api
test:integration` (585/585), `pnpm --filter @forestshop/web e2e` (49/49).

Skutočné číslo, o koľko sa zvýšil počet prepnutých produktov, sa zmeria po
nasadení proti produkčnej DB a doplní na #307.
