### PR TITLE
fix: run Shoptet Playwright login/import in an isolated child process (issue 313)

### DIFF
--- a/.claude/rules/shoptet-writeback.md
+++ b/.claude/rules/shoptet-writeback.md
@@ -179,13 +179,70 @@ paths:
   `WritebackRow`/`buildWritebackCsv` je automaticky chránená, pokiaľ ide
   cez `dataRowToLine` — nová cesta k zápisu Shoptet CSV musí VŽDY ísť cez
   `buildWritebackCsv`, nikdy cez vlastné skladanie stĺpcov mimo neho.
-- **Ručný ("Spustiť teraz") beh Playwright login flow-u DO Shoptet
+- **OPRAVA k nižšie ponechanému pôvodnému nálezu — "cez deň zlyháva, v noci
+  funguje" NEBOLA skutočná príčina, len zhoda okolností (issue 313, vyriešené).**
+  Skutočný vzor, zistený desiatkami A/B testov priamo na produkcii: `.fill()`
+  na prihlasovacie polia (`admin-login.ts`) spoľahlivo NEDRŽÍ vyplnenú
+  hodnotu, keď `loginToShoptetAdmin`/`chromium.launch()` beží PRIAMO v
+  appka's vlastnom dlho bežiacom procese (potvrdené cez HTTP aj scheduler
+  spúšťací kanál, aj hneď po čerstvom reštarte kontajnera) — ÚPLNE TEN ISTÝ
+  skompilovaný kód spustený ako čerstvý SAMOSTATNÝ proces (`docker exec ...
+  node ...`) funguje spoľahlivo, opakovane, striedavo s in-process
+  zlyhaniami v tom istom časovom okne. Presný nízko-úrovňový mechanizmus
+  (Node/V8/Chromium interakcia v takomto procese) sa NEPODARILO
+  jednoznačne vystopovať napriek rozsiahlej diagnostike (elementFromPoint,
+  document.activeElement, `document.querySelector(...).value` čítané ihneď
+  po `.fill()`, skutočné klávesové písanie namiesto `.fill()`, 1,5s pauza
+  pred kliknutím, `init: true`/`tini` namiesto appky ako PID 1 — nič z
+  tohto problém nezmenilo). **Oprava: `runShoptetImport`
+  (`playwright-import.ts`) aj `runOrderNoteWriteback`
+  (`order-note-playwright.ts`) majú od issue 313 IZOLOVANÝ variant
+  (`runShoptetImportIsolated`/`runOrderNoteWritebackIsolated`), ktorý CELÝ
+  Chromium beh deleguje do krátko žijúceho DIEŤA procesu cez `child-
+  runner.ts`'s `runInChildProcess` (`node:child_process`'s `fork()`) —
+  appka's vlastný proces už Chromium sám nespúšťa vôbec. VŠETCI produkční
+  volajúci (`run-writeback.ts`, `restock/run.ts`,
+  `run-order-note-writeback.ts`) musia volať IZOLOVANÝ variant, nikdy
+  priamo `runShoptetImport`/`runOrderNoteWriteback` — tie zostávajú
+  exportované LEN pre testy proti fixture a pre samotné `import-worker.ts`/
+  `order-note-worker.ts` (vstupné body dieťa procesu).**
+  **Vzor pre KAŽDÚ ĎALŠIU Playwright automatizáciu pridanú do tohto
+  modulu:** nová funkcia, čo sama volá `chromium.launch()`, potrebuje
+  VLASTNÝ dieťa-proces worker (rovnaký vzor ako `import-worker.ts`/
+  `order-note-worker.ts`) a volania cez `runInChildProcess` — NIKDY priamy
+  in-process `chromium.launch()` z produkčného volajúceho kódu, aj keby
+  lokálne/v teste fungoval spoľahlivo (presne to je klamlivé — fungoval aj
+  tu, kým appka nebežala dosť dlho/za reálnych podmienok).
+  **Worker skript (`.js` v `dist/`) sa v testoch/lokálnom vývoji (vitest,
+  žiadny `tsc -b` build) NENÁJDE** — `child-runner.ts`'s `resolveWorker`
+  preto s existenciou skompilovaného `.js` súboru počíta ako s VOLITEĽNOU:
+  keď chýba, spustí SESTERSKÝ `.ts` súbor cez `node_modules/.bin/tsx`
+  namiesto plain node (rovnaký `TSX_BIN` vzor ako
+  `e2e-setup-user-isolation.integration.test.ts`) — tsx je len devDependency,
+  nikdy v produkčnom obraze, preto je to VÝHRADNE záložka pre chýbajúci
+  build, nikdy predvolená cesta.
+  **`Buffer` cez `fork()`'s `serialization: "advanced"` (V8 structured
+  clone) NEPRICHÁDZA na druhej strane ako skutočná `Buffer` inštancia —
+  príde ako obyčajný `Object`, čo `writeFile(cesta, csv)` odmietne
+  ("data argument must be ... Buffer").** Test na KAŽDÝ ďalší dieťa-proces
+  vstup nesúci binárny obsah: pošli ho ako base64 REŤAZEC
+  (`ImportWorkerInput`'s `csvBase64`), dekóduj `Buffer.from(str, "base64")`
+  AŽ VNÚTRI workera — nikdy sa nespoliehaj na to, že "advanced" serializácia
+  Buffer prenesie bezo zmeny typu.
+  **Vedľajší nález, nesúvisiaci s hlavnou príčinou, ale opravený v tom istom
+  PR:** appka bola PID 1 vo vlastnom kontajneri bez skutočného init procesu
+  — `docker-compose.prod.yml`'s `app` service dostala `init: true`
+  (zabudovaný Docker `tini`), čo naživo overene rieši nazbierané zombie
+  Chromium/crashpad procesy (osirelé po KAŽDOM `browser.close()`, keďže nič
+  ich predtým nereapovalo) — appka je odvtedy PID 2+, appka's vlastný
+  SIGTERM handler (issue 78) sa nemení.
+- **PÔVODNÝ (mylný) nález, ponechaný pre históriu — pozri opravu vyššie:**
+  Ručný ("Spustiť teraz") beh Playwright login flow-u DO Shoptet
   administrácie cez DEŇ vie zlyhať s "prihlasovací formulár stále
-  viditeľný" — nočný naplánovaný beh (okolo 4:50) funguje spoľahlivo**
+  viditeľný" — nočný naplánovaný beh (okolo 4:50) funguje spoľahlivo
   (issue 313, zistené pri post-deploy overovaní issue 307). `job_run`
   história ukázala jasný vzor: noc = úspech, ručný denný pokus = zlyhanie
-  (aj DVAKRÁT po sebe). Príčina zatiaľ NEPRESKÚMANÁ (možný rozdiel v
-  Shoptet-ovej záťaži/rate-limite/session cez deň vs v noci) — pri
-  ĎALŠOM podobnom "funguje v noci, zlyháva pri ručnom denné teste" jave v
-  tomto module najprv skontroluj `job_run` históriu podľa `started_at`
-  hodiny dňa, než začneš hľadať bug v kóde samotnom.
+  (aj DVAKRÁT po sebe). Skutočná príčina a oprava sú v bode vyššie — vzor
+  "noc funguje, deň nefunguje" bol len zhoda okolností (kontajner bol
+  reštartovaný v ten deň krátko pred zlyhaniami), nie skutočná časová
+  závislosť.

--- a/apps/api/src/modules/restock/run.ts
+++ b/apps/api/src/modules/restock/run.ts
@@ -9,7 +9,7 @@ import type { Database } from "../../db/client.js";
 import { restockEvents, restockSettings } from "../../db/schema.js";
 import type { ShoptetImportConfig } from "../shoptet-writeback/config.js";
 import { buildRestockCsv } from "../shoptet-writeback/csv.js";
-import { runShoptetImport } from "../shoptet-writeback/playwright-import.js";
+import { runShoptetImportIsolated } from "../shoptet-writeback/playwright-import.js";
 import {
   AVAILABILITY_IN_STOCK_TEXT,
   MAX_PER_RUN,
@@ -38,7 +38,7 @@ export interface RunRestockOptions {
   readonly now: Date;
   readonly config: ShoptetImportConfig;
   /** Iba pre testy — nahradí skutočný Playwright zápis do Shoptetu. */
-  readonly importToShoptet?: typeof runShoptetImport;
+  readonly importToShoptet?: typeof runShoptetImportIsolated;
   readonly limit?: number;
 }
 
@@ -56,7 +56,7 @@ export async function runRestock(options: RunRestockOptions): Promise<RestockRun
 
 async function runRestockLocked(options: RunRestockOptions): Promise<RestockRunResult> {
   const { db, now, config } = options;
-  const importToShoptet = options.importToShoptet ?? runShoptetImport;
+  const importToShoptet = options.importToShoptet ?? runShoptetImportIsolated;
   const limit = options.limit ?? MAX_PER_RUN;
 
   const { picked, overLimit } = await selectRestockCandidates(db, now, limit);

--- a/apps/api/src/modules/shoptet-writeback/child-runner.test.ts
+++ b/apps/api/src/modules/shoptet-writeback/child-runner.test.ts
@@ -1,0 +1,44 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveWorker } from "./child-runner.js";
+
+// Issue 313, code review PR 315 finding 4: `runInChildProcess` skutočne
+// spustí produkčnú (skompilovaný `.js`, plain `node`) vetvu LEN v Docker
+// obraze — vitest v tomto repe nikdy nebeží proti `tsc -b` výstupu, takže tá
+// vetva nemá vlastný test pri KAŽDOM behu. Skutočne SPUSTIŤ dieťa proces by
+// si vyžadovalo build pred testom (rozbilo by "žiadny build pred testom"
+// vzor tohto repa) — namiesto toho tento test overuje SAMOTNÉ VETVENIE
+// (`resolveWorker`), ktoré rozhoduje MEDZI oboma cestami, priamo a lacno.
+describe("resolveWorker (issue 313 — kompilovaný .js vs .ts+tsx záložka)", () => {
+  let tmpDir: string | undefined;
+
+  afterEach(async () => {
+    if (tmpDir !== undefined) await rm(tmpDir, { recursive: true, force: true });
+    tmpDir = undefined;
+  });
+
+  it("keď skompilovaný .js SÚBOR EXISTUJE, spustí ho priamo plain nodom (žiadny execPath override)", async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "resolve-worker-"));
+    const jsPath = join(tmpDir, "some-worker.js");
+    await writeFile(jsPath, "// fake compiled worker\n");
+
+    const { modulePath, execOptions } = resolveWorker(pathToFileURL(jsPath));
+
+    expect(modulePath).toBe(jsPath);
+    expect(execOptions.execPath).toBeUndefined();
+  });
+
+  it("keď skompilovaný .js súbor CHÝBA, spustí sesterský .ts cez tsx (node_modules/.bin/tsx)", async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "resolve-worker-"));
+    const jsPath = join(tmpDir, "missing-worker.js");
+    // .js súbor sa NIKDY nevytvorí — presne stav testov/lokálneho vývoja.
+
+    const { modulePath, execOptions } = resolveWorker(pathToFileURL(jsPath));
+
+    expect(modulePath).toBe(join(tmpDir, "missing-worker.ts"));
+    expect(execOptions.execPath).toMatch(/node_modules[/\\]\.bin[/\\]tsx$/);
+  });
+});

--- a/apps/api/src/modules/shoptet-writeback/child-runner.ts
+++ b/apps/api/src/modules/shoptet-writeback/child-runner.ts
@@ -56,7 +56,14 @@ function isWorkerMessage<TOutput>(value: unknown): value is WorkerMessage<TOutpu
 const REPO_ROOT = fileURLToPath(new URL("../../../../../", import.meta.url));
 const TSX_BIN = join(REPO_ROOT, "node_modules/.bin/tsx");
 
-function resolveWorker(workerScriptUrl: URL): { readonly modulePath: string; readonly execOptions: ForkOptions } {
+/** Exportované LEN pre `resolve-worker.test.ts` — over VETVENIE (kompilovaný
+ * `.js` vs `.ts`+tsx záložka) priamo, bez nutnosti skutočne forkovať proces
+ * (code review PR 315, finding 4: produkčná `.js` vetva nemá vlastný test —
+ * spustiť skutočný skompilovaný worker by potrebovalo `tsc -b` PRED testom,
+ * čo by rozbilo "žiadny build pred testom" vzor tohto repa; test LOGIKY
+ * vetvenia bez skutočného forku je lacnejší, rovnako dôkazný pre samotné
+ * rozhodovanie). */
+export function resolveWorker(workerScriptUrl: URL): { readonly modulePath: string; readonly execOptions: ForkOptions } {
   const jsPath = fileURLToPath(workerScriptUrl);
   if (existsSync(jsPath)) {
     return { modulePath: jsPath, execOptions: {} };
@@ -71,7 +78,7 @@ function resolveWorker(workerScriptUrl: URL): { readonly modulePath: string; rea
 // ~30 s (`.claude/rules/supplier-stock.md`'s poznámka o meraní trvania
 // celého supplier-stock behu je iný beh; TENTO strop je pre JEDEN Playwright
 // login+import/zápis, nie pre celý nočný sweep) — 5 minút je bohatá rezerva.
-const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
+export const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
 
 export function runInChildProcess<TOutput>(
   workerScriptUrl: URL,
@@ -81,34 +88,58 @@ export function runInChildProcess<TOutput>(
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const { modulePath, execOptions } = resolveWorker(workerScriptUrl);
   return new Promise<TOutput>((resolve, reject) => {
+    // `detached: true` dáva dieťaťu VLASTNÚ skupinu procesov (PGID == PID) —
+    // pri timeoute zabíjame `-child.pid` (celú skupinu), nie len samotný
+    // fork()nutý node/tsx proces. Bez toho by SIGKILL nechal Chromium
+    // (VNÚTORNÉ dieťa workera, nie priame dieťa tohto fork()) osirelé —
+    // presne tá istá trieda problému ako zombie nález, čo `init: true`
+    // rieši pre bežnú cestu, ale NIE pre násilné ukončenie na timeout
+    // (code review PR 315, finding 3).
     const child = fork(modulePath, [], {
       ...execOptions,
+      detached: true,
       serialization: "advanced",
       stdio: ["ignore", "inherit", "inherit", "ipc"],
     });
     let settled = false;
 
+    function killChildGroup(signal: NodeJS.Signals): void {
+      if (child.pid === undefined) return;
+      try {
+        process.kill(-child.pid, signal);
+      } catch {
+        // skupina už neexistuje (dieťa aj jeho potomkovia už skončili) — nič
+        // nerob, toto je bežný, nie chybový stav.
+      }
+    }
+
     const timer = setTimeout(() => {
       if (settled) return;
       settled = true;
-      child.kill("SIGKILL");
+      killChildGroup("SIGKILL");
       reject(new Error(`Dieťa proces (${modulePath}) neodpovedal do ${String(timeoutMs)} ms`));
     }, timeoutMs);
 
+    let pendingResult: { readonly ok: boolean; readonly result?: TOutput; readonly error?: string } | undefined;
+
     child.once("message", (raw: unknown) => {
       if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      child.kill();
       if (!isWorkerMessage<TOutput>(raw)) {
+        settled = true;
+        clearTimeout(timer);
+        killChildGroup("SIGTERM");
         reject(new Error("Dieťa proces poslal neplatnú správu"));
         return;
       }
-      if (raw.ok) {
-        resolve(raw.result as TOutput);
-      } else {
-        reject(new Error(raw.error ?? "Dieťa proces zlyhal bez popisu"));
-      }
+      // NEuzatváraj promise tu — `'message'` len ZACHYTÍ výsledok. Node
+      // NEZARUČUJE, že `'message'` doručí PRED `'exit'`(IPC zápis je
+      // asynchrónny) — naživo overené (code review PR 315, finding 1):
+      // súbežné behy pod záťažou stratili doručenú správu 100 % prípadov,
+      // keď sa promise uzatvárala tu. Skutočné rozhodnutie sa robí až v
+      // `'close'` nižšie, ktoré Node GARANTUJE až PO doručení/spracovaní
+      // všetkých IPC správ.
+      pendingResult = raw;
+      killChildGroup("SIGTERM");
     });
 
     child.once("error", (error) => {
@@ -118,11 +149,24 @@ export function runInChildProcess<TOutput>(
       reject(error);
     });
 
-    child.once("exit", (code) => {
+    // `'close'` (nie `'exit'`) — fires AŽ PO tom, čo sa STDIO prúdy (vrátane
+    // IPC kanála) skutočne zatvoria, čo garantuje, že KAŽDÁ už doručená
+    // `'message'` bola spracovaná skôr, než sa sem dostaneme (code review
+    // PR 315, finding 1 — over verifikované 200/200 pod záťažou po tejto
+    // oprave, predtým až 100 % strata).
+    child.once("close", (code) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
-      reject(new Error(`Dieťa proces skončil bez výsledku (exit code ${String(code)})`));
+      if (pendingResult === undefined) {
+        reject(new Error(`Dieťa proces skončil bez výsledku (exit code ${String(code)})`));
+        return;
+      }
+      if (pendingResult.ok) {
+        resolve(pendingResult.result as TOutput);
+      } else {
+        reject(new Error(pendingResult.error ?? "Dieťa proces zlyhal bez popisu"));
+      }
     });
 
     child.send(input);

--- a/apps/api/src/modules/shoptet-writeback/child-runner.ts
+++ b/apps/api/src/modules/shoptet-writeback/child-runner.ts
@@ -19,8 +19,14 @@ import { fileURLToPath } from "node:url";
  * (poznámka objednávky), obe spúšťajú Chromium cez tú istú
  * `loginToShoptetAdmin`.
  *
- * `serialization: "advanced"` (V8 structured clone, nie JSON) — `input`
- * môže niesť `Buffer` (CSV obsah) priamo, bez ručného base64 kódovania.
+ * `serialization: "advanced"` (V8 structured clone, nie JSON) — POZOR:
+ * naživo overené, že ani TOTO neprenesie `Buffer` ako skutočnú `Buffer`
+ * inštanciu (príde na druhej strane ako obyčajný `Object`) — volajúci s
+ * binárnym obsahom (napr. `playwright-import.ts`'s `runShoptetImportIsolated`)
+ * ho preto MUSIA poslať ako base64 reťazec a dekódovať späť VNÚTRI workera,
+ * nikdy sa nespoliehať na to, že "advanced" mode Buffer prenesie bezo zmeny
+ * typu. `serialization: "advanced"` tu ostáva pre ostatné JS typy (Map, Set,
+ * `undefined` polia a pod.), ktoré JSON serializácia stráca/skresľuje.
  */
 export interface RunInChildProcessOptions {
   readonly timeoutMs?: number;

--- a/apps/api/src/modules/shoptet-writeback/child-runner.ts
+++ b/apps/api/src/modules/shoptet-writeback/child-runner.ts
@@ -1,0 +1,124 @@
+import { existsSync } from "node:fs";
+import { fork, type ForkOptions, type Serializable } from "node:child_process";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Issue 313: spustí `input` v KRÁTKO ŽIJÚCOM DIEŤA procese (`workerScriptUrl`
+ * — vždy odkazuje na skompilovaný `.js` súbor v `dist/`, aj z volajúceho
+ * kódu, ktorý sám ešte nie je skompilovaný — pozri `resolveWorker` nižšie)
+ * namiesto v bežiacom appka procese. Naživo overené na produkcii (desiatky
+ * opakovaných A/B testov, `.claude/rules/shoptet-writeback.md`): appka's
+ * vlastný dlho bežiaci proces spúšťal Chromium PRIAMO v sebe a `.fill()` na
+ * prihlasovacie polia v ňom nedržalo vyplnenú hodnotu (naprieč HTTP aj
+ * scheduler spúšťacím kanálom), hoci ÚPLNE TEN ISTÝ kód spustený ako čerstvý
+ * samostatný proces funguje spoľahlivo. Presný nízko-úrovňový mechanizmus sa
+ * nepodarilo vystopovať, ale IZOLÁCIA je overená ako spoľahlivá oprava —
+ * táto funkcia je jediné miesto, ktoré ju implementuje, aby ju vedeli
+ * zdieľať `runShoptetImport` (CSV import) aj `runOrderNoteWriteback`
+ * (poznámka objednávky), obe spúšťajú Chromium cez tú istú
+ * `loginToShoptetAdmin`.
+ *
+ * `serialization: "advanced"` (V8 structured clone, nie JSON) — `input`
+ * môže niesť `Buffer` (CSV obsah) priamo, bez ručného base64 kódovania.
+ */
+export interface RunInChildProcessOptions {
+  readonly timeoutMs?: number;
+}
+
+interface WorkerMessage<TOutput> {
+  readonly ok: boolean;
+  readonly result?: TOutput;
+  readonly error?: string;
+}
+
+function isWorkerMessage<TOutput>(value: unknown): value is WorkerMessage<TOutput> {
+  if (typeof value !== "object" || value === null || !("ok" in value)) return false;
+  return typeof value.ok === "boolean";
+}
+
+// `tests/` (integračné testy) aj `src/` (unit testy) bežia priamo cez vitest
+// bez samostatného `tsc -b` buildu — v tom prípade `dist/.../<worker>.js`
+// ešte neexistuje. Repo koreň je 5 úrovní nad `dist/modules/shoptet-
+// writeback/child-runner.js` (produkcia) AJ nad `src/modules/shoptet-
+// writeback/child-runner.ts` (rovnaká hĺbka v oboch prípadoch — `apps/api/
+// {dist|src}/modules/shoptet-writeback/`), takže jeden literál pokrýva obe.
+// Rovnaký vzor ako `apps/api/tests/e2e-setup-user-isolation.integration
+// .test.ts`'s `TSX_BIN` — tsx JE k dispozícii lokálne/v CI (devDependency),
+// ale NIKDY v produkčnom obraze (`pnpm install --prod`), preto sa použije
+// LEN ako záložka, keď skompilovaný `.js` súbor chýba.
+const REPO_ROOT = fileURLToPath(new URL("../../../../../", import.meta.url));
+const TSX_BIN = join(REPO_ROOT, "node_modules/.bin/tsx");
+
+function resolveWorker(workerScriptUrl: URL): { readonly modulePath: string; readonly execOptions: ForkOptions } {
+  const jsPath = fileURLToPath(workerScriptUrl);
+  if (existsSync(jsPath)) {
+    return { modulePath: jsPath, execOptions: {} };
+  }
+  // Skompilovaný .js chýba — bežíme zo zdrojového `src/` (test/dev, žiadny
+  // build). Spusti SESTERSKÝ `.ts` súbor cez tsx namiesto plain node.
+  const tsPath = jsPath.replace(/\.js$/, ".ts");
+  return { modulePath: tsPath, execOptions: { execPath: TSX_BIN } };
+}
+
+// Najdlhší naživo nameraný beh (CSV import proti reálnemu Shoptetu) je
+// ~30 s (`.claude/rules/supplier-stock.md`'s poznámka o meraní trvania
+// celého supplier-stock behu je iný beh; TENTO strop je pre JEDEN Playwright
+// login+import/zápis, nie pre celý nočný sweep) — 5 minút je bohatá rezerva.
+const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
+
+export function runInChildProcess<TOutput>(
+  workerScriptUrl: URL,
+  input: Serializable,
+  options: RunInChildProcessOptions = {},
+): Promise<TOutput> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const { modulePath, execOptions } = resolveWorker(workerScriptUrl);
+  return new Promise<TOutput>((resolve, reject) => {
+    const child = fork(modulePath, [], {
+      ...execOptions,
+      serialization: "advanced",
+      stdio: ["ignore", "inherit", "inherit", "ipc"],
+    });
+    let settled = false;
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      child.kill("SIGKILL");
+      reject(new Error(`Dieťa proces (${modulePath}) neodpovedal do ${String(timeoutMs)} ms`));
+    }, timeoutMs);
+
+    child.once("message", (raw: unknown) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      child.kill();
+      if (!isWorkerMessage<TOutput>(raw)) {
+        reject(new Error("Dieťa proces poslal neplatnú správu"));
+        return;
+      }
+      if (raw.ok) {
+        resolve(raw.result as TOutput);
+      } else {
+        reject(new Error(raw.error ?? "Dieťa proces zlyhal bez popisu"));
+      }
+    });
+
+    child.once("error", (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(error);
+    });
+
+    child.once("exit", (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(new Error(`Dieťa proces skončil bez výsledku (exit code ${String(code)})`));
+    });
+
+    child.send(input);
+  });
+}

--- a/apps/api/src/modules/shoptet-writeback/import-worker.ts
+++ b/apps/api/src/modules/shoptet-writeback/import-worker.ts
@@ -8,17 +8,32 @@ import { runShoptetImport, type ImportWorkerInput, type ShoptetImportOutcome } f
  * `fork()` z `child-runner.ts`. `csvBase64` sa tu dekóduje späť na skutočný
  * `Buffer` (`playwright-import.ts`'s `ImportWorkerInput` vysvetľuje prečo).
  */
+
+// `process.send(msg, callback)` — NIKDY holé `process.send(msg)` + `exit()`
+// hneď potom. Node negarantuje, že `'message'` na strane rodiča príde PRED
+// `'exit'`/`'close'` (asynchrónny IPC zápis) — naživo overené (code review
+// PR 315, finding 1): pod záťažou stratil rodič doručenú správu až 100 %
+// prípadov, keď dieťa exitovalo skôr, než zápis skutočne odišiel. Callback
+// tu čaká na SKUTOČNÉ odoslanie pred `process.exit`. Ak `process.send`
+// chýba (bez IPC kanála — nemalo by sa stať, vždy sa spúšťa cez `fork()`),
+// exituj rovno, aby proces nikdy nezostal visieť.
+function sendAndExit(message: { readonly ok: boolean; readonly result?: ShoptetImportOutcome; readonly error?: string }): void {
+  const exitCode = message.ok ? 0 : 1;
+  if (process.send === undefined) {
+    process.exit(exitCode);
+    return;
+  }
+  process.send(message, () => process.exit(exitCode));
+}
+
 process.once("message", (input: ImportWorkerInput) => {
   const { csvBase64, ...rest } = input;
   runShoptetImport({ ...rest, csv: Buffer.from(csvBase64, "base64") })
     .then((result: ShoptetImportOutcome) => {
-      process.send?.({ ok: true, result });
+      sendAndExit({ ok: true, result });
     })
     .catch((error: unknown) => {
       const message = error instanceof Error ? error.message : String(error);
-      process.send?.({ ok: false, error: message });
-    })
-    .finally(() => {
-      process.exit(0);
+      sendAndExit({ ok: false, error: message });
     });
 });

--- a/apps/api/src/modules/shoptet-writeback/import-worker.ts
+++ b/apps/api/src/modules/shoptet-writeback/import-worker.ts
@@ -1,0 +1,24 @@
+import { runShoptetImport, type ImportWorkerInput, type ShoptetImportOutcome } from "./playwright-import.js";
+
+/**
+ * Issue 313: DIEŤA proces vstupný bod pre `runShoptetImportIsolated`
+ * (`child-runner.ts`) — spustí NEZMENENÝ `runShoptetImport` (skutočný
+ * Chromium beh) mimo appka's vlastného dlho bežiaceho procesu a pošle
+ * výsledok späť rodičovi cez IPC. Nikdy sa nespúšťa priamo — vždy len cez
+ * `fork()` z `child-runner.ts`. `csvBase64` sa tu dekóduje späť na skutočný
+ * `Buffer` (`playwright-import.ts`'s `ImportWorkerInput` vysvetľuje prečo).
+ */
+process.once("message", (input: ImportWorkerInput) => {
+  const { csvBase64, ...rest } = input;
+  runShoptetImport({ ...rest, csv: Buffer.from(csvBase64, "base64") })
+    .then((result: ShoptetImportOutcome) => {
+      process.send?.({ ok: true, result });
+    })
+    .catch((error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      process.send?.({ ok: false, error: message });
+    })
+    .finally(() => {
+      process.exit(0);
+    });
+});

--- a/apps/api/src/modules/shoptet-writeback/order-note-playwright.ts
+++ b/apps/api/src/modules/shoptet-writeback/order-note-playwright.ts
@@ -2,7 +2,7 @@ import { chromium, type Browser, type Page } from "playwright";
 import { log } from "../../logger.js";
 import { buildShoptetAdminOrderUrl } from "../orders/queries.js";
 import { loginToShoptetAdmin } from "./admin-login.js";
-import { runInChildProcess } from "./child-runner.js";
+import { DEFAULT_TIMEOUT_MS, runInChildProcess } from "./child-runner.js";
 import type { OrderNoteWritebackConfig } from "./config.js";
 import { mergeShopRemark } from "./note-block.js";
 import type { OrderNoteToSync } from "./order-note-select.js";
@@ -64,6 +64,23 @@ export async function runOrderNoteWriteback(
   return results;
 }
 
+// `child-runner.ts`'s DEFAULT_TIMEOUT_MS (5 min) je odvodený z JEDNÉHO CSV
+// importu (~30s) — tento beh je NAMIESTO toho SLUČKA cez `options.orders`
+// (2 navigácie + fill + save NA OBJEDNÁVKU), takže pri väčšom počte
+// čakajúcich poznámok by pevný 5-min strop vedel zabiť beh v polovici a
+// stratiť VŠETKY výsledky vrátane už úspešne zapísaných (code review PR
+// 315, finding 2 — `run-order-note-writeback.ts`'s `selectChangedOrderNotes`
+// nemá žiadny strop na počet, na rozdiel od `restock`'s `MAX_PER_RUN`).
+// 20s/objednávku (naživo nameraných ~2-3s proti fixture, štedrá rezerva pre
+// reálny Shoptet) + 60s základ (prihlásenie + réžia), nikdy menej než
+// zdieľaný default.
+const PER_ORDER_TIMEOUT_MS = 20_000;
+const BASE_TIMEOUT_MS = 60_000;
+
+function orderNoteTimeoutMs(orderCount: number): number {
+  return Math.max(DEFAULT_TIMEOUT_MS, BASE_TIMEOUT_MS + orderCount * PER_ORDER_TIMEOUT_MS);
+}
+
 /**
  * Issue 313: rovnaké API/výsledok ako `runOrderNoteWriteback`, ale beh sa
  * deleguje do izolovaného dieťa procesu (`child-runner.ts`, rovnaký dôvod
@@ -76,7 +93,9 @@ export async function runOrderNoteWriteback(
 export function runOrderNoteWritebackIsolated(
   options: RunOrderNoteWritebackOptions,
 ): Promise<readonly OrderNoteWriteResult[]> {
-  return runInChildProcess(new URL("./order-note-worker.js", import.meta.url), options);
+  return runInChildProcess(new URL("./order-note-worker.js", import.meta.url), options, {
+    timeoutMs: orderNoteTimeoutMs(options.orders.length),
+  });
 }
 
 async function writeOneOrderNote(

--- a/apps/api/src/modules/shoptet-writeback/order-note-playwright.ts
+++ b/apps/api/src/modules/shoptet-writeback/order-note-playwright.ts
@@ -2,6 +2,7 @@ import { chromium, type Browser, type Page } from "playwright";
 import { log } from "../../logger.js";
 import { buildShoptetAdminOrderUrl } from "../orders/queries.js";
 import { loginToShoptetAdmin } from "./admin-login.js";
+import { runInChildProcess } from "./child-runner.js";
 import type { OrderNoteWritebackConfig } from "./config.js";
 import { mergeShopRemark } from "./note-block.js";
 import type { OrderNoteToSync } from "./order-note-select.js";
@@ -61,6 +62,21 @@ export async function runOrderNoteWriteback(
     await browser?.close();
   }
   return results;
+}
+
+/**
+ * Issue 313: rovnaké API/výsledok ako `runOrderNoteWriteback`, ale beh sa
+ * deleguje do izolovaného dieťa procesu (`child-runner.ts`, rovnaký dôvod
+ * ako `playwright-import.ts`'s `runShoptetImportIsolated`). Toto je
+ * funkcia, ktorú má volať `run-order-note-writeback.ts`;
+ * `runOrderNoteWriteback` samotné zostáva exportované pre testy proti
+ * fixture (aj pre `order-note-worker.ts`, ktorý ho spúšťa VNÚTRI dieťa
+ * procesu).
+ */
+export function runOrderNoteWritebackIsolated(
+  options: RunOrderNoteWritebackOptions,
+): Promise<readonly OrderNoteWriteResult[]> {
+  return runInChildProcess(new URL("./order-note-worker.js", import.meta.url), options);
 }
 
 async function writeOneOrderNote(

--- a/apps/api/src/modules/shoptet-writeback/order-note-worker.ts
+++ b/apps/api/src/modules/shoptet-writeback/order-note-worker.ts
@@ -1,0 +1,25 @@
+import {
+  runOrderNoteWriteback,
+  type OrderNoteWriteResult,
+  type RunOrderNoteWritebackOptions,
+} from "./order-note-playwright.js";
+
+/**
+ * Issue 313: DIEŤA proces vstupný bod pre `runOrderNoteWritebackIsolated`
+ * (`child-runner.ts`) — rovnaký vzor ako `import-worker.ts`, len pre
+ * per-objednávkový zápis poznámky namiesto hromadného CSV importu. Nikdy sa
+ * nespúšťa priamo — vždy len cez `fork()` z `child-runner.ts`.
+ */
+process.once("message", (input: RunOrderNoteWritebackOptions) => {
+  runOrderNoteWriteback(input)
+    .then((result: readonly OrderNoteWriteResult[]) => {
+      process.send?.({ ok: true, result });
+    })
+    .catch((error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      process.send?.({ ok: false, error: message });
+    })
+    .finally(() => {
+      process.exit(0);
+    });
+});

--- a/apps/api/src/modules/shoptet-writeback/order-note-worker.ts
+++ b/apps/api/src/modules/shoptet-writeback/order-note-worker.ts
@@ -10,16 +10,30 @@ import {
  * per-objednávkový zápis poznámky namiesto hromadného CSV importu. Nikdy sa
  * nespúšťa priamo — vždy len cez `fork()` z `child-runner.ts`.
  */
+
+// Rovnaký dôvod ako `import-worker.ts`'s `sendAndExit` — čakaj na SKUTOČNÉ
+// odoslanie IPC správy pred `process.exit`, nikdy holé `process.send()` +
+// okamžitý exit (code review PR 315, finding 1).
+function sendAndExit(message: {
+  readonly ok: boolean;
+  readonly result?: readonly OrderNoteWriteResult[];
+  readonly error?: string;
+}): void {
+  const exitCode = message.ok ? 0 : 1;
+  if (process.send === undefined) {
+    process.exit(exitCode);
+    return;
+  }
+  process.send(message, () => process.exit(exitCode));
+}
+
 process.once("message", (input: RunOrderNoteWritebackOptions) => {
   runOrderNoteWriteback(input)
     .then((result: readonly OrderNoteWriteResult[]) => {
-      process.send?.({ ok: true, result });
+      sendAndExit({ ok: true, result });
     })
     .catch((error: unknown) => {
       const message = error instanceof Error ? error.message : String(error);
-      process.send?.({ ok: false, error: message });
-    })
-    .finally(() => {
-      process.exit(0);
+      sendAndExit({ ok: false, error: message });
     });
 });

--- a/apps/api/src/modules/shoptet-writeback/playwright-import.ts
+++ b/apps/api/src/modules/shoptet-writeback/playwright-import.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { chromium, type Browser, type Page } from "playwright";
 import { log } from "../../logger.js";
 import { loginToShoptetAdmin } from "./admin-login.js";
+import { runInChildProcess } from "./child-runner.js";
 import type { ShoptetImportConfig } from "./config.js";
 import { entryKey, hasLogEntries, parseImportLog, pickResultRow, resultExitCode } from "./log-attribution.js";
 
@@ -203,4 +204,28 @@ export async function runShoptetImport(options: RunShoptetImportOptions): Promis
     await browser?.close();
     await rm(tmpDir, { recursive: true, force: true });
   }
+}
+
+/** Cez IPC ide `csv` ako base64 reťazec (`ImportWorkerInput`), nikdy priamo
+ * ako `Buffer` — naživo overené (issue 313), že Node's `fork()` "advanced"
+ * serializácia posiela `Buffer` na druhú stranu ako obyčajný `Object`, nie
+ * ako skutočnú `Buffer` inštanciu, čo `writeFile(csvPath, csv)` vnútri
+ * `runShoptetImport` odmietne ("data argument must be ... Buffer"). Base64
+ * reťazec je jednoznačný a prenosný nezávisle od serializačných detailov. */
+export interface ImportWorkerInput extends Omit<RunShoptetImportOptions, "csv"> {
+  readonly csvBase64: string;
+}
+
+/**
+ * Issue 313: rovnaké API/výsledok ako `runShoptetImport`, ale beh sa
+ * deleguje do izolovaného dieťa procesu (`child-runner.ts`) — appka's
+ * vlastný bežiaci proces už Chromium sám nespúšťa. Toto je funkcia, ktorú
+ * majú volať PRODUKČNÍ volajúci (`run-writeback.ts`, `restock/run.ts`);
+ * `runShoptetImport` samotné zostáva exportované pre testy proti fixture
+ * (aj pre `import-worker.ts`, ktorý ho spúšťa VNÚTRI dieťa procesu).
+ */
+export function runShoptetImportIsolated(options: RunShoptetImportOptions): Promise<ShoptetImportOutcome> {
+  const { csv, ...rest } = options;
+  const input: ImportWorkerInput = { ...rest, csvBase64: csv.toString("base64") };
+  return runInChildProcess(new URL("./import-worker.js", import.meta.url), input);
 }

--- a/apps/api/src/modules/shoptet-writeback/run-order-note-writeback.ts
+++ b/apps/api/src/modules/shoptet-writeback/run-order-note-writeback.ts
@@ -1,7 +1,7 @@
 import type { Database } from "../../db/client.js";
 import type { OrderNoteWritebackConfig } from "./config.js";
 import { markOrderNoteSynced } from "./order-note-mark-synced.js";
-import { runOrderNoteWriteback } from "./order-note-playwright.js";
+import { runOrderNoteWritebackIsolated } from "./order-note-playwright.js";
 import { selectChangedOrderNotes } from "./order-note-select.js";
 
 export type OrderNoteWritebackRunResult =
@@ -33,7 +33,7 @@ export async function runOrderNoteWritebackJob(
     return { status: "nothing_changed", skippedCount };
   }
 
-  const results = await runOrderNoteWriteback({ config, orders: toSync });
+  const results = await runOrderNoteWritebackIsolated({ config, orders: toSync });
 
   let succeeded = 0;
   for (const result of results) {

--- a/apps/api/src/modules/shoptet-writeback/run-writeback.ts
+++ b/apps/api/src/modules/shoptet-writeback/run-writeback.ts
@@ -2,7 +2,7 @@ import type { Database } from "../../db/client.js";
 import { buildWritebackCsv } from "./csv.js";
 import type { ShoptetImportConfig } from "./config.js";
 import { markSuppliersLinksSynced } from "./mark-synced.js";
-import { runShoptetImport } from "./playwright-import.js";
+import { runShoptetImportIsolated } from "./playwright-import.js";
 import { selectChangedSupplierLinks } from "./select-changes.js";
 
 export type WritebackRunResult =
@@ -34,7 +34,7 @@ export async function runShoptetWriteback(
   if (rows.length === 0) return { status: "nothing_changed" };
 
   const csv = buildWritebackCsv(rows);
-  const outcome = await runShoptetImport({ config, csv, expectedRows: rows.length });
+  const outcome = await runShoptetImportIsolated({ config, csv, expectedRows: rows.length });
 
   if (!outcome.ok) {
     return {

--- a/apps/api/tests/order-note-playwright.integration.test.ts
+++ b/apps/api/tests/order-note-playwright.integration.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { runOrderNoteWriteback } from "../src/modules/shoptet-writeback/order-note-playwright.js";
+import { runOrderNoteWriteback, runOrderNoteWritebackIsolated } from "../src/modules/shoptet-writeback/order-note-playwright.js";
 import { startOrderDetailFixture, type OrderDetailFixture } from "./helpers/shoptet-order-detail-fixture.js";
 
 // Reálny Chromium proti LOKÁLNEJ fixture appke (nikdy proti skutočnému
@@ -152,6 +152,50 @@ describe("runOrderNoteWriteback (proti fixture, nikdy proti reálnemu Shoptetu)"
 
       await expect(
         runOrderNoteWriteback({
+          config: { loginUrl: `${fixture.baseUrl}/admin/`, adminBaseUrl: fixture.baseUrl, user: "manager", password: "ZLE-heslo" },
+          orders: [{ orderId: "order-1", externalOrderId: "20261273", shoptetOrderId: 59783, comment: "x" }],
+        }),
+      ).rejects.toThrow(/prihlásenie/i);
+    },
+    TEST_TIMEOUT_MS,
+  );
+});
+
+// Issue 313: rovnaký dieťa-proces izolačný vzor ako `runShoptetImportIsolated`
+// (`shoptet-writeback-playwright.integration.test.ts`) — `loginToShoptetAdmin`
+// je zdieľaná, appka's vlastný bežiaci proces spúšťal Chromium PRIAMO v
+// sebe pre TÚTO automatizáciu rovnako ako pre CSV import.
+describe("runOrderNoteWritebackIsolated (dieťa proces, issue 313)", () => {
+  let fixture: OrderDetailFixture | undefined;
+
+  afterEach(async () => {
+    await fixture?.close();
+    fixture = undefined;
+  });
+
+  it(
+    "appends our block to an EMPTY shopRemark, run in an isolated child process",
+    async () => {
+      fixture = await startOrderDetailFixture({ user: "manager", password: "tajneheslo" });
+
+      const results = await runOrderNoteWritebackIsolated({
+        config: { loginUrl: `${fixture.baseUrl}/admin/`, adminBaseUrl: fixture.baseUrl, user: "manager", password: "tajneheslo" },
+        orders: [{ orderId: "order-1", externalOrderId: "20261273", shoptetOrderId: 59783, comment: "Zavolať zajtra" }],
+      });
+
+      expect(results).toEqual([{ orderId: "order-1", externalOrderId: "20261273", ok: true, errorDetail: null }]);
+      expect(fixture.getShopRemark(59783)).toBe("--- poznámka z appky ---\nZavolať zajtra\n--- koniec ---");
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "propagates a login failure back through the child process as a rejected promise",
+    async () => {
+      fixture = await startOrderDetailFixture({ user: "manager", password: "tajneheslo" });
+
+      await expect(
+        runOrderNoteWritebackIsolated({
           config: { loginUrl: `${fixture.baseUrl}/admin/`, adminBaseUrl: fixture.baseUrl, user: "manager", password: "ZLE-heslo" },
           orders: [{ orderId: "order-1", externalOrderId: "20261273", shoptetOrderId: 59783, comment: "x" }],
         }),

--- a/apps/api/tests/shoptet-writeback-playwright.integration.test.ts
+++ b/apps/api/tests/shoptet-writeback-playwright.integration.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { buildWritebackCsv } from "../src/modules/shoptet-writeback/csv.js";
-import { runShoptetImport } from "../src/modules/shoptet-writeback/playwright-import.js";
+import { runShoptetImport, runShoptetImportIsolated } from "../src/modules/shoptet-writeback/playwright-import.js";
 import { startShoptetFixture, type ShoptetFixture } from "./helpers/shoptet-fixture.js";
 
 // Reálny Chromium proti LOKÁLNEJ fixture appke (nikdy proti skutočnému
@@ -155,6 +155,77 @@ describe("runShoptetImport (proti fixture, nikdy proti reálnemu Shoptetu)", () 
       expect(outcome.ok).toBe(false);
       expect(outcome.processed).toBe(2);
       expect(outcome.failed).toBe(1);
+    },
+    TEST_TIMEOUT_MS,
+  );
+});
+
+// Issue 313: appka's vlastný bežiaci proces spúšťal Chromium PRIAMO v sebe —
+// naživo overené (desiatky ráz, striedavo s funkčnými samostatnými pokusmi na
+// TOM ISTOM kontajneri), že `.fill()` na prihlasovacie polia v TOMTO
+// konkrétnom (dlho bežiacom appka) procese nedrží vyplnenú hodnotu, hoci
+// úplne ten istý kód spustený ako čerstvý samostatný proces funguje
+// spoľahlivo. `runShoptetImportIsolated` deleguje CELÝ beh (login → import →
+// výsledok) do krátko žijúceho DIEŤA procesu (`.claude/rules/shoptet-
+// writeback.md`) — tento test dokazuje, že samotná IPC/dieťa-proces
+// mechanika funguje end-to-end proti fixture (nikdy proti reálnemu
+// Shoptetu), nielen že sa dá príčina obísť na produkcii.
+describe("runShoptetImportIsolated (dieťa proces, issue 313)", () => {
+  let fixture: ShoptetFixture | undefined;
+
+  afterEach(async () => {
+    await fixture?.close();
+    fixture = undefined;
+  });
+
+  it(
+    "prihlási sa, nahrá CSV a potvrdí úspech — rovnaký výsledok ako in-process runShoptetImport, len spustený v dieťa procese",
+    async () => {
+      fixture = await startShoptetFixture({ user: "manager", password: "tajneheslo" });
+      fixture.seedPastEntry();
+      const csv = buildWritebackCsv([{ code: "A/S", pairCode: "1", internalNote: "https://dodavatel.example/a" }]);
+
+      const outcome = await runShoptetImportIsolated({
+        config: {
+          loginUrl: `${fixture.baseUrl}/admin/`,
+          importUrl: `${fixture.baseUrl}/admin/import-produktov/`,
+          logUrl: `${fixture.baseUrl}/admin/import-produktov/log/`,
+          user: "manager",
+          password: "tajneheslo",
+        },
+        csv,
+        expectedRows: 1,
+        resultPollRetries: 3,
+        resultPollWaitMs: 100,
+      });
+
+      expect(outcome.ok).toBe(true);
+      expect(outcome.processed).toBe(1);
+      expect(outcome.errorDetail).toBeNull();
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "propaguje zlyhanie (zlé heslo) späť cez dieťa proces ako odmietnutý promise, nikdy tiché ok:true",
+    async () => {
+      fixture = await startShoptetFixture({ user: "manager", password: "tajneheslo" });
+      fixture.seedPastEntry();
+      const csv = buildWritebackCsv([{ code: "A", pairCode: "", internalNote: "https://x.example/a" }]);
+
+      await expect(
+        runShoptetImportIsolated({
+          config: {
+            loginUrl: `${fixture.baseUrl}/admin/`,
+            importUrl: `${fixture.baseUrl}/admin/import-produktov/`,
+            logUrl: `${fixture.baseUrl}/admin/import-produktov/log/`,
+            user: "manager",
+            password: "ZLE-heslo",
+          },
+          csv,
+          expectedRows: 1,
+        }),
+      ).rejects.toThrow(/prihlásenie/i);
     },
     TEST_TIMEOUT_MS,
   );

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -37,6 +37,20 @@ services:
   app:
     image: ghcr.io/zbynekdrlik/forestshop-app:${IMAGE_TAG:-latest}
     restart: unless-stopped
+    # issue 313 (vedľajší nález, nie hlavná oprava tiketu): appka bez tohto
+    # bola PID 1 vo vlastnom kontajneri, bez skutočného init procesu —
+    # `apps/api/src/shutdown.ts`'s SIGTERM handler (issue 78) to rieši pre
+    # appku samotnú, ale osirelé Playwright/Chromium potomkovia (zombie `Z`
+    # procesy po KAŽDOM `browser.close()`) sa bez init procesu nikdy
+    # nezožnú — naživo overené na produkcii (desiatky nazbieraných zombie
+    # procesov pod appka PID 1). `init: true` necháva Docker vložiť
+    # zabudovaný `tini` ako PID 1 namiesto appky (appka je odvtedy PID 2+,
+    # nič iné sa nemení) — štandardná, dokumentovaná Docker oprava presne
+    # pre túto triedu problému. Naživo overené ako neškodné (appka nabehla
+    # aj po tejto zmene identicky) — NEBOLO to však samo osebe dosť na
+    # opravu tohto tiketu (skutočná príčina a oprava: `.claude/rules/
+    # shoptet-writeback.md`'s izolovaný dieťa proces).
+    init: true
     # Doplnok k appka's vlastnému SIGTERM handleru (apps/api/src/shutdown.ts,
     # issue 78) — appka sa dnes ukončí za pár ms, ale 15s dáva rezervu pre
     # prípad pomalšieho zatvárania DB spojení pod záťažou. Toto NIE JE

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.178",
+  "version": "0.3.0-dev.179",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Čo a prečo

issue 313: ručný beh "Vypredané → Skladom" (`⚡ Spustiť teraz`) zlyhával
na prihlásení do Shoptet administrácie. Naživo overená skutočná príčina
(rozsiahle A/B testovanie priamo na produkcii, popísané v komentároch na
issue 313): `.fill()` na prihlasovacie polia nedrží vyplnenú hodnotu, keď
Chromium beží PRIAMO v appka's vlastnom dlho bežiacom procese — úplne
ten istý kód spustený ako čerstvý samostatný proces funguje spoľahlivo.
Pôvodná hypotéza "cez deň zlyháva, v noci funguje" bola len zhoda
okolností, nie skutočná príčina.

## Riešenie

`runShoptetImport`/`runOrderNoteWriteback` zostávajú nezmenené (testy
proti fixture). Všetci produkční volajúci (`restock`, CSV writeback,
`order-note-writeback`) teraz volajú nové
`runShoptetImportIsolated`/`runOrderNoteWritebackIsolated`, ktoré celý
Chromium beh delegujú do krátko žijúceho dieťa procesu
(`child-runner.ts`, `node:child_process`'s `fork()`).

Vedľajší, naživo overený neškodný fix: `docker-compose.prod.yml`'s `app`
service dostáva `init: true` (rieši nazbierané zombie Chromium procesy
po každom `browser.close()` — appka bola PID 1 bez init procesu).

## Testy

- RED→GREEN: `runShoptetImportIsolated`/`runOrderNoteWritebackIsolated`
  proti fixture (nikdy proti reálnemu Shoptetu) — úspech aj zlyhanie
  (zlé heslo) sa správne propagujú cez dieťa proces.
- Celá lokálna sada zelená: unit (641), integration (589, 79 súborov),
  e2e (49).

## Post-deploy

Po merge nasleduje naživo overenie priamo na produkcii (ručný beh cez
deň, počas ktorého predtým zlyhávalo) — issue 313 zostáva otvorený,
zavriem ho ručne až po tomto overení.
