### PR TITLE
Vypredané → Skladom: návrhy odkazov pre vypredané produkty bez linky (issue 311)

### DIFF
--- a/.claude/rules/restock-links.md
+++ b/.claude/rules/restock-links.md
@@ -1,0 +1,73 @@
+---
+paths:
+  - "apps/api/src/modules/restock-links/**"
+  - "apps/api/src/http/restock-links-routes.ts"
+  - "apps/api/tests/restock-links-http.integration.test.ts"
+  - "apps/web/src/restockLinksApi.ts"
+  - "apps/web/src/components/RestockLinkSuggestionsSection.tsx"
+  - "scripts/e2e-fixtures-restock-links.ts"
+---
+
+# Vypredané → Skladom: návrhy odkazov (issue 311)
+
+- **Populácia je presne "restock kandidát bez linky", nie "produkt bez
+  linky" vo všeobecnosti.** Diagnostika #307: automatika "Vypredané →
+  Skladom" (`restock/queries.ts`'s `allRestockCandidates`) nikdy neposúdi
+  produkt, ktorého efektívna linka je `null` — 91 zo 130 vypredaných
+  produktov také bolo. Táto obrazovka preto berie PRESNE tú istú populáciu
+  ako `allRestockCandidates` (`variant.state = 'out_of_stock'` +
+  `product_visibility = 'visible'` + `missing_since IS NULL`), len BEZ
+  podmienok o potvrdení dodávateľa (tie sem nepatria — produkt bez linky
+  nemá čo potvrdiť) A s efektívnou linkou `null`. **Zámerne odlišná od**
+  "Párovanie produktov" (#239, `product-links/queries.ts`'s
+  `listProductLinks`), ktorá vypisuje VŠETKY produkty katalógu bez linky,
+  bez ohľadu na to, či sú vypredané — dve rôzne, prekrývajúce sa množiny.
+- **Kandidát sa hľadá DETERMINISTICKY (nikdy AI), porovnaním významných slov
+  názvu (3+ znaky, diakritika normalizovaná) medzi produktom bez linky a
+  produktmi, čo UŽ linku majú** — `suggestCandidates`
+  (`restock-links/queries.ts`). Zhodný `product.supplier` pridáva veľký
+  bonus (100), aby VŽDY vyhral nad čisto textovou zhodou naprieč cudzími
+  dodávateľmi. Toto JE "vyhľadanie podľa názvu cez existujúci mechanizmus",
+  ktorý ticket žiadal — rovnaký princíp ako `search/queries.ts`'s
+  `globalSearch`, len nad VLASTNÝM katalógom (appka nemá a NEBUDE mať
+  nástroj na vyhľadávanie na internete). Kandidáti sa počítajú ŽIVO pri
+  KAŽDOM načítaní (rovnaký princíp ako `feed-cross-check.ts` — nikdy
+  perzistovaná odvodená hodnota, tá by zastarala pri ďalšom katalógovom
+  importe).
+- **Návrh sa NIKDY neuloží sám — klik na kandidáta len PREDVYPLNÍ vstup.**
+  `RestockLinkSuggestionsSection.tsx`'s "💡 Použiť" tlačidlo nastaví
+  `urlDraft`, skutočné uloženie ide AŽ cez explicitný klik na 💾 (rovnaká
+  podmienka ako ticket žiadal: "ČLOVEK potvrdí, nikdy automaticky
+  nepriradiť"). Regresný e2e dôkaz (`restock-links.spec.ts`) klikne na
+  návrh a OVERÍ, že `saveProductLink` sa ešte NEZAVOLALO, až potom klikne
+  Uložiť.
+- **Žiadna nová zapisovacia trasa ani nová tabuľka.** Potvrdený odkaz ide
+  cez UŽ EXISTUJÚCU `POST /api/product-links/:productKey` (#239,
+  `setProductSupplierLinkForProduct`, `product_supplier_link_override`) —
+  `restockLinksApi.ts` má len ČÍTACIU `searchRestockLinkSuggestions`,
+  komponent priamo importuje `saveProductLink` z `supplierLinksApi.ts`.
+  Dôsledok: obe obrazovky ("Vypredané → Skladom: návrhy odkazov" aj
+  "Párovanie produktov") ukazujú TÚ ISTÚ hodnotu okamžite po uložení —
+  overené e2e testom naprieč OBOMA obrazovkami naraz.
+- **Nová obrazovka je SAMOSTATNÁ od "Vypredané → Skladom" (#213,
+  `RestockSection.tsx`), nie ďalšia karta v nej** — `RestockSection.tsx` je
+  už na 370 riadkoch (eslint `max-lines: 400`, `.claude/rules/testing.md`)
+  a rieši úplne iný problém (PREPÍNANIE už-linkovaných produktov). Zdieľajú
+  len susedné miesto v menu (`nav.ts`, priečinok Automatizácie, hneď za
+  sebou) a rovnaký cieľ (viac kandidátov pre prepínanie).
+- **E2E fixtúra (`scripts/e2e-fixtures-restock-links.ts`) potrebuje TRI
+  produkty naraz na jeden zmysluplný test:** vypredaný bez linky
+  ("E2E-RL-CHYBA"), kandidát s ROVNAKÝM dodávateľom + prekrývajúcim sa
+  menom, čo UŽ linku má ("E2E-RL-NAVRH"), a CUDZÍ dodávateľ bez prekryvu
+  mena ("E2E-RL-CUDZI") — dokazuje, že sa nikdy nenavrhne bez zhody. Vlastný
+  izolovaný e2e účet (`E2E_NAVRHY_ODKAZOV_EMAIL`, rovnaký mechanizmus a
+  dôvod ako `E2E_PAROVANIE_EMAIL` — zdieľaný `e2e@forestshop.sk` je na
+  hranici `MAX_ATTEMPTS`).
+- **Nová viditeľná záložka "Vypredané → Skladom: návrhy odkazov" substring-om
+  KOLIDOVALA s existujúcim `restock-waiting.spec.ts`'s
+  `getByRole("button", {name: "Vypredané → Skladom"})`** (rovnaká trieda
+  chyby ako issue 240's "Vyhľadať"/"Hľadať" kolízia, `.claude/rules/
+  testing.md`) — opravené na strane KOLÍDUJÚCEHO existujúceho locatora
+  (`{ exact: true }`), nikdy premenovaním novej záložky. Test pri KAŽDEJ
+  ďalšej záložke pridanej HNEĎ VEDĽA existujúcej s podobným menom: `grep -rn
+  'name: "<časť existujúceho mena>"' apps/web/tests/e2e/` bez `exact: true`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,3 +104,4 @@ Per-area rules live in `.claude/rules/<area>.md` with `paths:` frontmatter.
 - Párovanie produktov (#239 — samostatná od `pairing`, zdieľaný upsert s #121, live-overenie bez AI-dohady) → `.claude/rules/product-links.md`
 - Eshop → Vyhľadať (#240 — dve oddelené polia produkty/objednávky, detail produktu, zdieľaná zapisovacia cesta s #239) → `.claude/rules/search.md`
 - Eshop → Upozornenia (#267 — nástenka, čiastočný unique dedup index, počítaný stav bez cron-u, zdieľaná zapisovacia cesta pre budúce #268/#269) → `.claude/rules/upozornenia.md`
+- Vypredané → Skladom: návrhy odkazov (#311 — deterministický návrh podľa zhody mena+dodávateľa, zdieľaná zapisovacia cesta s #239, žiadne AI dohady) → `.claude/rules/restock-links.md`

--- a/apps/api/src/http/app.ts
+++ b/apps/api/src/http/app.ts
@@ -24,6 +24,7 @@ import { registerPairingRoutes } from "./pairing-routes.js";
 import { registerPostaUncollectedRoutes, type PostaUncollectedRunDeps } from "./posta-uncollected-routes.js";
 import { registerProductLinksRoutes } from "./product-links-routes.js";
 import { registerProductDetailRoutes } from "./product-detail-routes.js";
+import { registerRestockLinksRoutes } from "./restock-links-routes.js";
 import { registerSearchRoutes } from "./search-routes.js";
 import type { PageFetcher, PageFetchResult } from "../modules/supplier-stock/page-fetcher.js";
 import { registerSupplierStockRoutes } from "./supplier-stock-routes.js";
@@ -196,6 +197,10 @@ export function createApp(
   // `product_supplier_link_override` tabuľky ako #121, žiadna nová cesta do
   // Shoptetu).
   registerProductLinksRoutes(app, db);
+  // issue 311: "Vypredané → Skladom: návrhy odkazov" — LEN čítanie (navrhne
+  // kandidáta pre vypredaný produkt bez linky); zápis potvrdenia ide cez
+  // `registerProductLinksRoutes` vyššie (#239), žiadna nová zapisovacia cesta.
+  registerRestockLinksRoutes(app, db);
   // issue 240: "Eshop → Vyhľadať" — hľadanie naprieč katalógom + objednávkami,
   // a detail produktu (za výsledkom hľadania) so VŠETKÝMI jeho variantmi.
   // Editácia dodávateľskej linky ide cez existujúcu `registerProductLinksRoutes`

--- a/apps/api/src/http/restock-links-routes.ts
+++ b/apps/api/src/http/restock-links-routes.ts
@@ -1,0 +1,28 @@
+import { zValidator } from "@hono/zod-validator";
+import type { Hono } from "hono";
+import { z } from "zod";
+import type { Database } from "../db/client.js";
+import { listRestockLinkSuggestions } from "../modules/restock-links/queries.js";
+import { requireUser, type AppBindings } from "./middleware.js";
+
+// Prázdna hodnota (`page=`) sa má správať ako neprítomný parameter, rovnaký
+// vzor ako `product-links-routes.ts`'s `pageParam`.
+const pageParam = z.preprocess(
+  (value) => (value === "" ? undefined : value),
+  z.coerce.number().int().min(1).max(100_000).default(1),
+);
+
+const restockLinksQuery = z.object({
+  q: z.string().max(200).default(""),
+  page: pageParam,
+  pageSize: z.coerce.number().int().min(1).max(200).default(50),
+});
+
+// issue 311: LEN čítanie — zápis potvrdeného odkazu ide cez UŽ existujúcu
+// `POST /api/product-links/:productKey` (#239, `product-links-routes.ts`),
+// žiadna nová zapisovacia trasa.
+export function registerRestockLinksRoutes(app: Hono<AppBindings>, db: Database): void {
+  app.get("/api/restock-links", requireUser(db), zValidator("query", restockLinksQuery), async (c) =>
+    c.json(await listRestockLinkSuggestions(db, c.req.valid("query"))),
+  );
+}

--- a/apps/api/src/modules/restock-links/queries.ts
+++ b/apps/api/src/modules/restock-links/queries.ts
@@ -1,0 +1,197 @@
+import { and, eq, isNull } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { productSupplierLinkOverrides, products, variants } from "../../db/schema.js";
+import { resolveEffectiveSupplierLink } from "../orders/effective-supplier-link.js";
+import { SELLABLE_VISIBILITY } from "../restock/constants.js";
+
+// issue 311: diagnostika #307 zistila, že 91 zo 130 vypredaných produktov
+// (rovnaká populácia ako `restock/queries.ts`'s `allRestockCandidates` —
+// `out_of_stock` + `product_visibility = 'visible'` + `missing_since IS
+// NULL`, BEZ podmienok o potvrdení dodávateľa, tie sem nepatria) nemá VÔBEC
+// žiadnu dodávateľskú linku v poznámke — automatika ich preto nikdy
+// neposúdi. Táto obrazovka NAVRHNE kandidáta (deterministické zhodovanie
+// VÝZNAMNÝCH SLOV názvu, rovnaký princíp ako `search/queries.ts`'s
+// `globalSearch`, len nad VLASTNÝM katalógom — nikdy AI dohad, `.claude/
+// rules/supplier-stock.md`), ČLOVEK potvrdí/upraví a zápis ide cez UŽ
+// EXISTUJÚCU `POST /api/product-links/:productKey` (#239,
+// `setProductSupplierLinkForProduct`) — žiadna nová zapisovacia cesta,
+// žiadna nová tabuľka. Kandidáti sa počítajú ŽIVO pri každom načítaní,
+// nikdy sa neperzistujú (rovnaký princíp ako `feed-cross-check.ts`).
+export interface RestockLinkCandidate {
+  readonly productKey: string;
+  readonly productName: string;
+  readonly supplier: string | null;
+  readonly url: string;
+}
+
+export interface RestockLinkMissingItem {
+  readonly productKey: string;
+  readonly productName: string;
+  readonly supplier: string | null;
+  readonly candidates: readonly RestockLinkCandidate[];
+}
+
+export interface RestockLinksSearchInput {
+  readonly q: string;
+  readonly page: number;
+  readonly pageSize: number;
+}
+
+export interface RestockLinksSearchResult {
+  readonly total: number;
+  readonly items: readonly RestockLinkMissingItem[];
+}
+
+const CANDIDATE_LIMIT = 3;
+// Bonus pridaný ku skóre zhody mien, keď oba produkty majú ROVNAKÉHO
+// dodávateľa (`product.supplier`, case/orez-insensitive) — vždy vyhrá nad
+// akoukoľvek čisto textovou zhodou naprieč cudzími dodávateľmi.
+const SAME_SUPPLIER_BONUS = 100;
+
+// Slovenská diakritika → ASCII, aby sa tokeny porovnávali nezávisle od
+// pravopisu ("Nôž" ~ "noz").
+const SK_DIACRITICS: Readonly<Record<string, string>> = {
+  á: "a",
+  ä: "a",
+  č: "c",
+  ď: "d",
+  é: "e",
+  í: "i",
+  ľ: "l",
+  ĺ: "l",
+  ň: "n",
+  ó: "o",
+  ô: "o",
+  ŕ: "r",
+  š: "s",
+  ť: "t",
+  ú: "u",
+  ý: "y",
+  ž: "z",
+};
+
+function normalizeChar(ch: string): string {
+  return SK_DIACRITICS[ch] ?? ch;
+}
+
+// Významné slová názvu — 3+ znaky (krátke spojky "na"/"v"/"a" sa nikdy
+// nezhodujú náhodou, veľkosti ako "XL" majú presne 2 znaky a sú tu zámerne
+// vylúčené — zhoda podľa veľkosti by bola falošný signál medzi úplne
+// rôznymi produktmi rovnakej veľkostnej rady). Čisto deterministické, žiadny
+// slovník, žiadna AI.
+function significantTokens(name: string): ReadonlySet<string> {
+  const normalized = name
+    .toLowerCase()
+    .split("")
+    .map(normalizeChar)
+    .join("");
+  const tokens = normalized.split(/[^a-z0-9]+/).filter((t) => t.length >= 3);
+  return new Set(tokens);
+}
+
+interface LinkedProduct {
+  readonly productKey: string;
+  readonly productName: string;
+  readonly supplier: string | null;
+  readonly url: string;
+  readonly tokens: ReadonlySet<string>;
+}
+
+function normalizeSupplierKey(supplier: string | null): string | null {
+  const trimmed = supplier?.trim().toLowerCase() ?? "";
+  return trimmed === "" ? null : trimmed;
+}
+
+function overlapScore(a: ReadonlySet<string>, b: ReadonlySet<string>): number {
+  let score = 0;
+  for (const token of a) {
+    if (b.has(token)) score += 1;
+  }
+  return score;
+}
+
+function suggestCandidates(
+  target: { readonly productName: string; readonly supplier: string | null },
+  linked: readonly LinkedProduct[],
+): readonly RestockLinkCandidate[] {
+  const targetTokens = significantTokens(target.productName);
+  const targetSupplier = normalizeSupplierKey(target.supplier);
+
+  const scored: { readonly candidate: LinkedProduct; readonly score: number }[] = [];
+  for (const candidate of linked) {
+    const nameScore = overlapScore(targetTokens, candidate.tokens);
+    if (nameScore === 0) continue;
+    const sameSupplier = targetSupplier !== null && normalizeSupplierKey(candidate.supplier) === targetSupplier;
+    scored.push({ candidate, score: nameScore + (sameSupplier ? SAME_SUPPLIER_BONUS : 0) });
+  }
+  scored.sort((a, b) => b.score - a.score || a.candidate.productName.localeCompare(b.candidate.productName, "sk"));
+
+  return scored.slice(0, CANDIDATE_LIMIT).map(({ candidate }) => ({
+    productKey: candidate.productKey,
+    productName: candidate.productName,
+    supplier: candidate.supplier,
+    url: candidate.url,
+  }));
+}
+
+export async function listRestockLinkSuggestions(
+  db: Database,
+  input: RestockLinksSearchInput,
+): Promise<RestockLinksSearchResult> {
+  const productRows = await db
+    .select({
+      productKey: products.key,
+      productName: products.name,
+      supplier: products.supplier,
+      internalNote: products.internalNote,
+      overrideUrl: productSupplierLinkOverrides.url,
+    })
+    .from(products)
+    .leftJoin(productSupplierLinkOverrides, eq(productSupplierLinkOverrides.productKey, products.key));
+
+  const soldOutRows = await db
+    .selectDistinct({ productKey: variants.productKey })
+    .from(variants)
+    .where(
+      and(
+        eq(variants.state, "out_of_stock"),
+        eq(variants.productVisibility, SELLABLE_VISIBILITY),
+        isNull(variants.missingSince),
+      ),
+    );
+  const soldOutKeys = new Set(soldOutRows.map((row) => row.productKey));
+
+  const linked: LinkedProduct[] = [];
+  const missing: { productKey: string; productName: string; supplier: string | null }[] = [];
+  for (const row of productRows) {
+    const effective = resolveEffectiveSupplierLink(row.internalNote, row.overrideUrl);
+    if (effective.url !== null) {
+      linked.push({
+        productKey: row.productKey,
+        productName: row.productName,
+        supplier: row.supplier,
+        url: effective.url,
+        tokens: significantTokens(row.productName),
+      });
+    } else if (soldOutKeys.has(row.productKey)) {
+      missing.push({ productKey: row.productKey, productName: row.productName, supplier: row.supplier });
+    }
+  }
+
+  const q = input.q.trim().toLowerCase();
+  const filtered = missing.filter(
+    (item) => q === "" || item.productKey.toLowerCase().includes(q) || item.productName.toLowerCase().includes(q),
+  );
+  filtered.sort((a, b) => a.productName.localeCompare(b.productName, "sk"));
+
+  const total = filtered.length;
+  const start = (input.page - 1) * input.pageSize;
+  const page = filtered.slice(start, start + input.pageSize);
+
+  const items: RestockLinkMissingItem[] = page.map((item) => ({
+    ...item,
+    candidates: suggestCandidates(item, linked),
+  }));
+
+  return { total, items };
+}

--- a/apps/api/tests/restock-links-http.integration.test.ts
+++ b/apps/api/tests/restock-links-http.integration.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, expect, it } from "vitest";
-import { products, users, variants } from "../src/db/schema.js";
+import { productSupplierLinkOverrides, products, users, variants } from "../src/db/schema.js";
 import { createApp } from "../src/http/app.js";
 import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
 import { hashPassword } from "../src/modules/auth/passwords.js";
@@ -134,7 +134,7 @@ it("vypredaný viditeľný produkt bez linky sa zobrazí, s odvodeným kandidát
   });
 });
 
-it("produkt s efektívnou linkou (aj cez override) sa v zozname nezobrazí", async () => {
+it("produkt s efektívnou linkou z internalNote sa v zozname nezobrazí", async () => {
   const { app, cookie, db } = await boot("citanie");
   const snapshotId = await insertTestSnapshot(db);
   await seedVariant(db, snapshotId, "RL-HASLINK", "RL-HASLINK/1", {
@@ -145,6 +145,26 @@ it("produkt s efektívnou linkou (aj cez override) sa v zozname nezobrazí", asy
 
   const telo = (await (await app.request("/api/restock-links?q=RL-HASLINK", { headers: { cookie } })).json()) as Telo;
   expect(telo.items.some((i) => i.productKey === "RL-HASLINK")).toBe(false);
+});
+
+// Code review (issue 311): pôvodný test vyššie mal v názve "aj cez
+// override", ale žiadny override riadok nikdy nevkladal — nový kód
+// (`resolveEffectiveSupplierLink`'s override vetva, `queries.ts`) tak
+// zostal touto sadou testov neotestovaný. Produkt tu NEMÁ `internalNote`
+// vôbec (`null`), efektívna linka pochádza VÝHRADNE z override riadku.
+it("produkt s efektívnou linkou LEN z override (bez internalNote) sa v zozname nezobrazí", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedVariant(db, snapshotId, "RL-OVERRIDE", "RL-OVERRIDE/1", {
+    name: "Vypredaná bunda s override linkou",
+    state: "out_of_stock",
+  });
+  await db
+    .insert(productSupplierLinkOverrides)
+    .values({ productKey: "RL-OVERRIDE", url: "https://dodavatel.example.com/z-override", updatedAt: new Date() });
+
+  const telo = (await (await app.request("/api/restock-links?q=RL-OVERRIDE", { headers: { cookie } })).json()) as Telo;
+  expect(telo.items.some((i) => i.productKey === "RL-OVERRIDE")).toBe(false);
 });
 
 it("predajný (nie vypredaný) produkt bez linky sa v zozname nezobrazí", async () => {
@@ -180,4 +200,63 @@ it("vypredaný produkt, ktorý už zmizol z exportu (missingSince), sa v zozname
 
   const telo = (await (await app.request("/api/restock-links?q=RL-MISSINGSINCE", { headers: { cookie } })).json()) as Telo;
   expect(telo.items).toHaveLength(0);
+});
+
+// Code review (issue 311): pridané, lebo `SAME_SUPPLIER_BONUS` — jediná
+// netriviálna obchodná logika tejto zmeny — dovtedy nemala ŽIADEN priamy
+// test. Kandidát s ROVNAKÝM dodávateľom, ale NIŽŠÍM prekryvom slov mena
+// (1 slovo), musí vyhrať nad kandidátom s CUDZÍM dodávateľom a VYŠŠÍM
+// prekryvom (2 slová) — bonus (100) musí prebiť akýkoľvek rozdiel v
+// samotnom textovom skóre.
+it("kandidát s ROVNAKÝM dodávateľom vyhrá nad kandidátom s vyšším prekryvom mena z CUDZIEHO dodávateľa", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedVariant(db, snapshotId, "RL-SKORE-CHYBA", "RL-SKORE-CHYBA/1", {
+    name: "Bunda Alfa Zimná",
+    supplier: "DODAVATEL-RL-SKORE",
+    state: "out_of_stock",
+  });
+  // Rovnaký dodávateľ, zdieľa LEN jedno slovo ("bunda") — skóre 1 + bonus 100.
+  await seedVariant(db, snapshotId, "RL-SKORE-VYHRA", "RL-SKORE-VYHRA/1", {
+    name: "Bunda Iná",
+    supplier: "DODAVATEL-RL-SKORE",
+    internalNote: "https://dodavatel.example.com/rovnaky-dodavatel",
+  });
+  // Cudzí dodávateľ, zdieľa DVE slová ("bunda", "alfa") — skóre 2, bez bonusu.
+  await seedVariant(db, snapshotId, "RL-SKORE-PREHRA", "RL-SKORE-PREHRA/1", {
+    name: "Bunda Alfa Extra",
+    supplier: "INY-DODAVATEL-RL-SKORE",
+    internalNote: "https://iny.example.com/cudzi-dodavatel",
+  });
+
+  const telo = (await (await app.request("/api/restock-links?q=RL-SKORE-CHYBA", { headers: { cookie } })).json()) as Telo;
+  const item = telo.items.find((i) => i.productKey === "RL-SKORE-CHYBA");
+  expect(item?.candidates.map((c) => c.productKey)).toEqual(["RL-SKORE-VYHRA", "RL-SKORE-PREHRA"]);
+});
+
+// Code review (issue 311): `CANDIDATE_LIMIT = 3` (queries.ts) tiež nemal
+// žiadny priamy test — 4 rovnako skórované kandidáti (rovnaký dodávateľ,
+// rovnaký jedno-slovný prekryv) musia vrátiť LEN 3, zoradené abecedne pri
+// zhodnom skóre (tie-break v `suggestCandidates`).
+it("vráti najviac 3 kandidátov aj keď rovnako skórovaných vyhovuje viac", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedVariant(db, snapshotId, "RL-STROP-CHYBA", "RL-STROP-CHYBA/1", {
+    name: "Bunda Alfa Zimná",
+    supplier: "DODAVATEL-RL-STROP",
+    state: "out_of_stock",
+  });
+  for (const suffix of ["D4", "C3", "B2", "A1"]) {
+    await seedVariant(db, snapshotId, `RL-STROP-${suffix}`, `RL-STROP-${suffix}/1`, {
+      name: `Bunda ${suffix}`,
+      supplier: "DODAVATEL-RL-STROP",
+      internalNote: `https://dodavatel.example.com/strop-${suffix.toLowerCase()}`,
+    });
+  }
+
+  const telo = (await (await app.request("/api/restock-links?q=RL-STROP-CHYBA", { headers: { cookie } })).json()) as Telo;
+  const item = telo.items.find((i) => i.productKey === "RL-STROP-CHYBA");
+  expect(item?.candidates).toHaveLength(3);
+  // Rovnaké skóre pre všetky 4 → tie-break podľa mena, abecedne.
+  expect(item?.candidates.map((c) => c.productKey)).toEqual(["RL-STROP-A1", "RL-STROP-B2", "RL-STROP-C3"]);
 });

--- a/apps/api/tests/restock-links-http.integration.test.ts
+++ b/apps/api/tests/restock-links-http.integration.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, expect, it } from "vitest";
+import { products, users, variants } from "../src/db/schema.js";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import type { UserRole } from "../src/modules/auth/service.js";
+import { insertTestSnapshot } from "./helpers/catalog.js";
+import { withCleanDb } from "./helpers/db.js";
+import type { Database } from "../src/db/client.js";
+
+// issue 311: "Vypredané → Skladom: návrhy odkazov" — LEN čítanie
+// (`GET /api/restock-links`). Zápis potvrdeného odkazu ide cez UŽ
+// existujúcu `POST /api/product-links/:productKey` trasu, otestovanú v
+// `product-links-http.integration.test.ts` — tu sa neduplikuje.
+
+const HESLO = "test-heslo-abc"; // testovacie údaje, nie tajomstvo
+
+let close: (() => Promise<void>) | undefined;
+
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  resetLoginRateLimit();
+});
+
+async function boot(role: UserRole) {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const [pouzivatel] = await ctx.db
+    .insert(users)
+    .values({ email: "manazer@forestshop.sk", passwordHash: await hashPassword(HESLO), displayName: "Manažér", role })
+    .returning({ id: users.id });
+  if (pouzivatel === undefined) throw new Error("testovací používateľ sa nepodarilo vložiť");
+
+  const app = createApp(ctx.db, { cookieSecure: false });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "manazer@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie, db: ctx.db };
+}
+
+interface Telo {
+  readonly total: number;
+  readonly items: {
+    readonly productKey: string;
+    readonly productName: string;
+    readonly supplier: string | null;
+    readonly candidates: { readonly productKey: string; readonly productName: string; readonly url: string }[];
+  }[];
+}
+
+async function seedVariant(
+  db: Database,
+  snapshotId: string,
+  productKey: string,
+  code: string,
+  over: {
+    readonly name: string;
+    readonly supplier?: string | null;
+    readonly internalNote?: string | null;
+    readonly state?: "sellable" | "out_of_stock" | "discontinued";
+    readonly productVisibility?: string;
+    readonly missingSince?: Date | null;
+  },
+): Promise<void> {
+  const now = new Date("2026-08-07T00:00:00Z");
+  await db.insert(products).values({
+    key: productKey,
+    name: over.name,
+    supplier: over.supplier ?? null,
+    internalNote: over.internalNote ?? null,
+    firstSeenAt: now,
+    lastSeenAt: now,
+    lastSeenSnapshotId: snapshotId,
+  });
+  await db.insert(variants).values({
+    code,
+    productKey,
+    guid: productKey,
+    name: over.name,
+    stock: 0,
+    availabilityInStockText: "Skladom",
+    availabilityOutOfStockText: "Vypredané",
+    availabilityText: over.state === "out_of_stock" ? "Vypredané" : "Skladom",
+    productVisibility: over.productVisibility ?? "visible",
+    state: over.state ?? "sellable",
+    missingSince: over.missingSince ?? null,
+    firstSeenAt: now,
+    lastSeenAt: now,
+    lastSeenSnapshotId: snapshotId,
+  });
+}
+
+it("bez prihlásenia vráti 401", async () => {
+  const { app } = await boot("manazer");
+  expect((await app.request("/api/restock-links")).status).toBe(401);
+});
+
+it("vypredaný viditeľný produkt bez linky sa zobrazí, s odvodeným kandidátom podľa zhody mena + dodávateľa", async () => {
+  const { app, cookie, db } = await boot("citanie"); // čítanie smie vidieť zoznam
+  const snapshotId = await insertTestSnapshot(db);
+
+  // Chýbajúca linka — vypredaný, viditeľný, stále v exporte.
+  await seedVariant(db, snapshotId, "RL-MISSING", "RL-MISSING/1", {
+    name: "Bunda Alfa Zimná",
+    supplier: "DODAVATEL-RL",
+    state: "out_of_stock",
+  });
+  // Kandidát — ROVNAKÝ dodávateľ, prekrývajúce sa slová názvu ("Bunda"/"Alfa").
+  await seedVariant(db, snapshotId, "RL-CANDIDATE", "RL-CANDIDATE/1", {
+    name: "Bunda Alfa Letná",
+    supplier: "DODAVATEL-RL",
+    internalNote: "https://dodavatel.example.com/bunda-alfa-letna",
+  });
+  // Cudzí dodávateľ, žiadna zhoda mena — nesmie sa nikdy navrhnúť.
+  await seedVariant(db, snapshotId, "RL-UNRELATED", "RL-UNRELATED/1", {
+    name: "Šál Zeta",
+    supplier: "INY-DODAVATEL",
+    internalNote: "https://iny.example.com/sal-zeta",
+  });
+
+  const res = await app.request("/api/restock-links?q=RL-MISSING", { headers: { cookie } });
+  expect(res.status).toBe(200);
+  const telo = (await res.json()) as Telo;
+  const item = telo.items.find((i) => i.productKey === "RL-MISSING");
+  expect(item?.productName).toBe("Bunda Alfa Zimná");
+  expect(item?.candidates).toHaveLength(1);
+  expect(item?.candidates[0]).toMatchObject({
+    productKey: "RL-CANDIDATE",
+    url: "https://dodavatel.example.com/bunda-alfa-letna",
+  });
+});
+
+it("produkt s efektívnou linkou (aj cez override) sa v zozname nezobrazí", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedVariant(db, snapshotId, "RL-HASLINK", "RL-HASLINK/1", {
+    name: "Vypredaná bunda s linkou",
+    internalNote: "https://dodavatel.example.com/uz-ma-linku",
+    state: "out_of_stock",
+  });
+
+  const telo = (await (await app.request("/api/restock-links?q=RL-HASLINK", { headers: { cookie } })).json()) as Telo;
+  expect(telo.items.some((i) => i.productKey === "RL-HASLINK")).toBe(false);
+});
+
+it("predajný (nie vypredaný) produkt bez linky sa v zozname nezobrazí", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedVariant(db, snapshotId, "RL-SELLABLE", "RL-SELLABLE/1", { name: "Predajný produkt bez linky", state: "sellable" });
+
+  const telo = (await (await app.request("/api/restock-links?q=RL-SELLABLE", { headers: { cookie } })).json()) as Telo;
+  expect(telo.items).toHaveLength(0);
+});
+
+it("vypredaný produkt skrytý pred zákazníkom (nie 'visible') sa v zozname nezobrazí", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedVariant(db, snapshotId, "RL-HIDDEN", "RL-HIDDEN/1", {
+    name: "Vypredaný skrytý produkt",
+    state: "out_of_stock",
+    productVisibility: "hidden",
+  });
+
+  const telo = (await (await app.request("/api/restock-links?q=RL-HIDDEN", { headers: { cookie } })).json()) as Telo;
+  expect(telo.items).toHaveLength(0);
+});
+
+it("vypredaný produkt, ktorý už zmizol z exportu (missingSince), sa v zozname nezobrazí", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedVariant(db, snapshotId, "RL-MISSINGSINCE", "RL-MISSINGSINCE/1", {
+    name: "Vypredaný zmiznutý produkt",
+    state: "out_of_stock",
+    missingSince: new Date("2026-08-01T00:00:00Z"),
+  });
+
+  const telo = (await (await app.request("/api/restock-links?q=RL-MISSINGSINCE", { headers: { cookie } })).json()) as Telo;
+  expect(telo.items).toHaveLength(0);
+});

--- a/apps/web/src/components/RestockLinkSuggestionsSection.test.tsx
+++ b/apps/web/src/components/RestockLinkSuggestionsSection.test.tsx
@@ -1,0 +1,133 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { RestockLinkSuggestionsSection } from "./RestockLinkSuggestionsSection.js";
+
+const { searchRestockLinkSuggestions } = vi.hoisted(() => ({ searchRestockLinkSuggestions: vi.fn() }));
+const { saveProductLink } = vi.hoisted(() => ({ saveProductLink: vi.fn() }));
+
+// `*UnauthorizedError` ostávajú SKUTOČNÉ triedy z reálnych modulov — rovnaký
+// dôvod ako `SupplierLinksSection.test.tsx`: `instanceof` v komponente musí
+// fungovať aj v teste.
+vi.mock("../restockLinksApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../restockLinksApi.js")>();
+  return { ...actual, searchRestockLinkSuggestions };
+});
+vi.mock("../supplierLinksApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../supplierLinksApi.js")>();
+  return { ...actual, saveProductLink };
+});
+
+const { RestockLinksUnauthorizedError } = await import("../restockLinksApi.js");
+
+const BEZ_NAVRHU = { productKey: "RL-1", productName: "Test bunda RL-1", supplier: "Test dodávateľ", candidates: [] };
+const S_NAVRHOM = {
+  productKey: "RL-2",
+  productName: "Test bunda RL-2",
+  supplier: "Test dodávateľ",
+  candidates: [
+    { productKey: "RL-CAND", productName: "Test bunda RL-CAND", supplier: "Test dodávateľ", url: "https://dodavatel.example.com/rl-cand" },
+  ],
+};
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+it("keď zoznam nezodpovedá žiadnemu produktu, zobrazí informačnú vetu namiesto holej tabuľky", async () => {
+  searchRestockLinkSuggestions.mockResolvedValue({ total: 0, items: [] });
+
+  render(<RestockLinkSuggestionsSection role="citanie" onSessionExpired={() => {}} />);
+
+  await screen.findByTestId("restock-links-empty");
+  expect(screen.queryByRole("table")).toBeNull();
+});
+
+it("zobrazí produkt bez návrhu ako pomlčku a produkt s návrhom s jeho odkazom", async () => {
+  searchRestockLinkSuggestions.mockResolvedValue({ total: 2, items: [BEZ_NAVRHU, S_NAVRHOM] });
+
+  render(<RestockLinkSuggestionsSection role="citanie" onSessionExpired={() => {}} />);
+
+  const bezNavrhuRiadok = await screen.findByTestId("restock-link-row-RL-1");
+  expect(bezNavrhuRiadok.textContent).toContain("Test bunda RL-1");
+  expect(screen.getByTestId("restock-link-candidates-RL-1").textContent).toBe("—");
+
+  const sNavrhomBunka = screen.getByTestId("restock-link-candidates-RL-2");
+  expect(sNavrhomBunka.textContent).toContain("https://dodavatel.example.com/rl-cand");
+});
+
+it("pri 401 zavolá onSessionExpired namiesto zobrazenia všeobecnej chyby", async () => {
+  searchRestockLinkSuggestions.mockRejectedValue(new RestockLinksUnauthorizedError());
+  const onSessionExpired = vi.fn();
+
+  render(<RestockLinkSuggestionsSection role="citanie" onSessionExpired={onSessionExpired} />);
+
+  await waitFor(() => {
+    expect(onSessionExpired).toHaveBeenCalledTimes(1);
+  });
+});
+
+it("rola citanie nevidí stĺpec Akcie ani tlačidlo 'Použiť návrh'", async () => {
+  searchRestockLinkSuggestions.mockResolvedValue({ total: 1, items: [S_NAVRHOM] });
+
+  render(<RestockLinkSuggestionsSection role="citanie" onSessionExpired={() => {}} />);
+
+  await screen.findByTestId("restock-link-row-RL-2");
+  expect(screen.queryByTestId("restock-link-edit-toggle-RL-2")).toBeNull();
+  expect(screen.queryByTestId("restock-link-use-candidate-RL-2-RL-CAND")).toBeNull();
+});
+
+it("rola manazer klikne na návrh — vyplní vstup, NEULOŽÍ automaticky, potom potvrdí uložením", async () => {
+  const S_NAVRHOM_PO_ULOZENI = { ...S_NAVRHOM, candidates: [] };
+  searchRestockLinkSuggestions.mockResolvedValueOnce({ total: 1, items: [S_NAVRHOM] });
+  searchRestockLinkSuggestions.mockResolvedValueOnce({ total: 0, items: [] });
+  saveProductLink.mockResolvedValue(undefined);
+
+  render(<RestockLinkSuggestionsSection role="manazer" onSessionExpired={() => {}} />);
+
+  fireEvent.click(await screen.findByTestId("restock-link-use-candidate-RL-2-RL-CAND"));
+  const vstup = screen.getByTestId<HTMLInputElement>("restock-link-edit-input-RL-2");
+  expect(vstup.value).toBe("https://dodavatel.example.com/rl-cand");
+  // Kliknutie na návrh SAMO OSEBE nič neuloží — potvrdenie je až explicitné
+  // kliknutie na Uložiť (ticketova podmienka "nikdy automaticky priradiť").
+  expect(saveProductLink).not.toHaveBeenCalled();
+
+  fireEvent.click(screen.getByTestId("restock-link-save-RL-2"));
+  await waitFor(() => {
+    expect(saveProductLink).toHaveBeenCalledWith("RL-2", "https://dodavatel.example.com/rl-cand");
+  });
+  expect(searchRestockLinkSuggestions).toHaveBeenCalledTimes(2);
+  void S_NAVRHOM_PO_ULOZENI;
+});
+
+it("rola manazer doplní VLASTNÝ odkaz (bez návrhu) cez tlačidlo Doplniť", async () => {
+  searchRestockLinkSuggestions.mockResolvedValueOnce({ total: 1, items: [BEZ_NAVRHU] });
+  searchRestockLinkSuggestions.mockResolvedValueOnce({ total: 0, items: [] });
+  saveProductLink.mockResolvedValue(undefined);
+
+  render(<RestockLinkSuggestionsSection role="manazer" onSessionExpired={() => {}} />);
+
+  fireEvent.click(await screen.findByTestId("restock-link-edit-toggle-RL-1"));
+  const vstup = screen.getByTestId<HTMLInputElement>("restock-link-edit-input-RL-1");
+  expect(vstup.value).toBe(""); // žiadny návrh na predvyplnenie
+  fireEvent.change(vstup, { target: { value: "https://dodavatel.example.com/rl-1" } });
+  fireEvent.click(screen.getByTestId("restock-link-save-RL-1"));
+
+  await waitFor(() => {
+    expect(saveProductLink).toHaveBeenCalledWith("RL-1", "https://dodavatel.example.com/rl-1");
+  });
+});
+
+it("neplatná URL sa odmietne OKAMŽITE v prehliadači, bez volania saveProductLink", async () => {
+  searchRestockLinkSuggestions.mockResolvedValue({ total: 1, items: [BEZ_NAVRHU] });
+
+  render(<RestockLinkSuggestionsSection role="manazer" onSessionExpired={() => {}} />);
+
+  fireEvent.click(await screen.findByTestId("restock-link-edit-toggle-RL-1"));
+  const vstup = screen.getByTestId("restock-link-edit-input-RL-1");
+  fireEvent.change(vstup, { target: { value: "nieje-url" } });
+  fireEvent.click(screen.getByTestId("restock-link-save-RL-1"));
+
+  await screen.findByText("Odkaz musí byť platná adresa začínajúca http:// alebo https://.");
+  expect(saveProductLink).not.toHaveBeenCalled();
+});

--- a/apps/web/src/components/RestockLinkSuggestionsSection.test.tsx
+++ b/apps/web/src/components/RestockLinkSuggestionsSection.test.tsx
@@ -78,7 +78,6 @@ it("rola citanie nevidí stĺpec Akcie ani tlačidlo 'Použiť návrh'", async (
 });
 
 it("rola manazer klikne na návrh — vyplní vstup, NEULOŽÍ automaticky, potom potvrdí uložením", async () => {
-  const S_NAVRHOM_PO_ULOZENI = { ...S_NAVRHOM, candidates: [] };
   searchRestockLinkSuggestions.mockResolvedValueOnce({ total: 1, items: [S_NAVRHOM] });
   searchRestockLinkSuggestions.mockResolvedValueOnce({ total: 0, items: [] });
   saveProductLink.mockResolvedValue(undefined);
@@ -97,7 +96,6 @@ it("rola manazer klikne na návrh — vyplní vstup, NEULOŽÍ automaticky, poto
     expect(saveProductLink).toHaveBeenCalledWith("RL-2", "https://dodavatel.example.com/rl-cand");
   });
   expect(searchRestockLinkSuggestions).toHaveBeenCalledTimes(2);
-  void S_NAVRHOM_PO_ULOZENI;
 });
 
 it("rola manazer doplní VLASTNÝ odkaz (bez návrhu) cez tlačidlo Doplniť", async () => {

--- a/apps/web/src/components/RestockLinkSuggestionsSection.tsx
+++ b/apps/web/src/components/RestockLinkSuggestionsSection.tsx
@@ -1,0 +1,298 @@
+import { useCallback, useEffect, useRef, useState, type SyntheticEvent, type JSX } from "react";
+import type { Me } from "../api.js";
+import { validateSupplierLinkUrl } from "../ordersApi.js";
+import { saveProductLink, SupplierLinksUnauthorizedError } from "../supplierLinksApi.js";
+import {
+  RestockLinksUnauthorizedError,
+  searchRestockLinkSuggestions,
+  type RestockLinkMissingItem,
+} from "../restockLinksApi.js";
+
+// issue 311: "Vypredané → Skladom: návrhy odkazov" — priamy náprotivok
+// `SupplierLinksSection.tsx` (#239), len ZÚŽENÝ na populáciu vypredaných
+// produktov (rovnaká ako `restock/queries.ts`'s kandidáti, `.claude/rules/
+// restock-links.md`) a s NAVRHOVANÝM kandidátom (odvodený zo zhody mena +
+// dodávateľa s produktmi, čo UŽ linku majú). Zápis potvrdenia ide cez UŽ
+// existujúcu `saveProductLink` (#239) — žiadna nová zapisovacia trasa.
+const CAN_EDIT_ROLES: ReadonlySet<Me["role"]> = new Set(["admin", "manazer"]);
+
+export function RestockLinkSuggestionsSection({
+  role,
+  onSessionExpired,
+}: {
+  readonly role: Me["role"];
+  readonly onSessionExpired: () => void;
+}): JSX.Element {
+  const [items, setItems] = useState<readonly RestockLinkMissingItem[]>([]);
+  const [total, setTotal] = useState(0);
+  const [searchLoaded, setSearchLoaded] = useState(false);
+  const [query, setQuery] = useState("");
+  const [searchError, setSearchError] = useState("");
+  const [actionError, setActionError] = useState("");
+  const canEdit = CAN_EDIT_ROLES.has(role);
+
+  const [editingKey, setEditingKey] = useState<string | null>(null);
+  const [urlDraft, setUrlDraft] = useState("");
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+
+  // Len najnovšia požiadavka smie zapísať výsledok (rovnaký dôvod ako
+  // `SupplierLinksSection.tsx`'s `searchSeq`).
+  const searchSeq = useRef(0);
+
+  // Rovnaký dôvod ako `SupplierLinksSection.tsx` (issue 251, StrictMode).
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const search = useCallback((q: string) => {
+    const seq = (searchSeq.current += 1);
+    setSearchError("");
+    searchRestockLinkSuggestions({ q, page: 1 })
+      .then((result) => {
+        if (!mountedRef.current) return;
+        if (seq !== searchSeq.current) return;
+        setItems(result.items);
+        setTotal(result.total);
+        setSearchLoaded(true);
+      })
+      .catch((err: unknown) => {
+        if (!mountedRef.current) return;
+        if (seq !== searchSeq.current) return;
+        setSearchLoaded(true);
+        if (err instanceof RestockLinksUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setItems([]);
+        setTotal(0);
+        setSearchError("Zoznam sa nepodarilo načítať.");
+      });
+  }, [onSessionExpired]);
+
+  useEffect(() => {
+    search("");
+  }, [search]);
+
+  function submit(event: SyntheticEvent): void {
+    event.preventDefault();
+    search(query);
+  }
+
+  // "Latest ref" vzor (rovnaký dôvod ako `SupplierLinksSection.tsx`, issue
+  // 251) — `refetch` volaný zo `save()`'s `.then()` (mikrotaska) musí čítať
+  // AKTUÁLNY dopyt, nie ten zafixovaný v uzávere v momente kliknutia.
+  const queryRef = useRef(query);
+  queryRef.current = query;
+  const refetch = useCallback(() => {
+    search(queryRef.current);
+  }, [search]);
+
+  const editingKeyRef = useRef(editingKey);
+  editingKeyRef.current = editingKey;
+
+  const startEdit = useCallback((item: RestockLinkMissingItem) => {
+    setEditingKey(item.productKey);
+    // Predvyplní PRVÝM (najlepšie skórovaným) návrhom, keď existuje — človek
+    // ho môže rovno uložiť, alebo prepísať vlastnou adresou. Nikdy sa
+    // neuloží samo — toto je len predvyplnenie vstupu.
+    setUrlDraft(item.candidates[0]?.url ?? "");
+    setActionError("");
+  }, []);
+
+  const cancelEdit = useCallback(() => {
+    setEditingKey(null);
+    setActionError("");
+  }, []);
+
+  const save = useCallback(
+    (productKey: string) => {
+      setActionError("");
+      const validationError = validateSupplierLinkUrl(urlDraft);
+      if (validationError !== null) {
+        setActionError(validationError);
+        return;
+      }
+      setBusyKey(productKey);
+      saveProductLink(productKey, urlDraft.trim())
+        .then(() => {
+          if (editingKeyRef.current === productKey) setEditingKey(null);
+          refetch();
+        })
+        .catch((err: unknown) => {
+          if (err instanceof SupplierLinksUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setActionError(err instanceof Error ? err.message : "Uloženie odkazu sa nepodarilo.");
+        })
+        .finally(() => {
+          setBusyKey(null);
+        });
+    },
+    [refetch, onSessionExpired, urlDraft],
+  );
+
+  return (
+    <section data-testid="restock-links-section">
+      <p>
+        Vypredané produkty, ktoré nemajú VÔBEC žiadny odkaz na dodávateľa — automatika „Vypredané →
+        Skladom“ ich preto nikdy neposúdi. Appka podľa názvu a dodávateľa navrhne najpodobnejší
+        produkt, čo linku už má — návrh nikdy nič neuloží sám, len predvyplní vstup, ktorý potvrdíš
+        alebo prepíšeš vlastnou adresou.
+      </p>
+
+      <form onSubmit={submit}>
+        <label htmlFor="restock-links-q">Hľadať produkt (kód alebo názov)</label>
+        <input
+          id="restock-links-q"
+          type="search"
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+          }}
+        />
+        <button type="submit">Zobraziť</button>
+      </form>
+
+      {searchError !== "" && <p role="alert">{searchError}</p>}
+      {actionError !== "" && <p role="alert">{actionError}</p>}
+      <p data-testid="restock-links-total">Nájdených: {total}</p>
+
+      {searchLoaded && total === 0 ? (
+        <p data-testid="restock-links-empty">Žiadny vypredaný produkt bez linky sa nenašiel.</p>
+      ) : (
+        <div className="fs-table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Kód</th>
+                <th>Názov</th>
+                <th>Dodávateľ</th>
+                <th>Návrh</th>
+                <th>Odkaz na dodávateľa</th>
+                {canEdit && <th>Akcie</th>}
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((item) => {
+                const editing = editingKey === item.productKey;
+                const busyHere = busyKey === item.productKey;
+                return (
+                  <tr key={item.productKey} data-testid={`restock-link-row-${item.productKey}`}>
+                    <td>{item.productKey}</td>
+                    <td>{item.productName}</td>
+                    <td>{item.supplier ?? "(bez dodávateľa)"}</td>
+                    <td data-testid={`restock-link-candidates-${item.productKey}`}>
+                      {item.candidates.length === 0 ? (
+                        <span>—</span>
+                      ) : (
+                        item.candidates.map((candidate) => (
+                          <div key={candidate.productKey}>
+                            {canEdit ? (
+                              <button
+                                type="button"
+                                className="btn sm ghost"
+                                data-testid={`restock-link-use-candidate-${item.productKey}-${candidate.productKey}`}
+                                aria-label={`Použiť návrh — ${candidate.productName} (${candidate.url})`}
+                                onClick={() => {
+                                  setEditingKey(item.productKey);
+                                  setUrlDraft(candidate.url);
+                                  setActionError("");
+                                }}
+                              >
+                                💡 {candidate.productName}: {candidate.url}
+                              </button>
+                            ) : (
+                              <span>
+                                💡 {candidate.productName}: {candidate.url}
+                              </span>
+                            )}
+                          </div>
+                        ))
+                      )}
+                    </td>
+                    <td>
+                      {editing ? (
+                        <div className="ord-supplier-link-edit" data-testid={`restock-link-edit-${item.productKey}`}>
+                          <input
+                            type="url"
+                            className="ord-supplier-link-edit-input"
+                            data-testid={`restock-link-edit-input-${item.productKey}`}
+                            aria-label={`Odkaz na dodávateľa produktu ${item.productName} / ${item.productKey}`}
+                            placeholder="https://…"
+                            value={urlDraft}
+                            disabled={busyHere}
+                            autoFocus
+                            onChange={(e) => {
+                              setUrlDraft(e.target.value);
+                            }}
+                            onKeyDown={(e) => {
+                              if (e.key === "Enter") {
+                                e.preventDefault();
+                                save(item.productKey);
+                                return;
+                              }
+                              if (e.key === "Escape") {
+                                e.preventDefault();
+                                cancelEdit();
+                              }
+                            }}
+                          />
+                          <button
+                            type="button"
+                            className="btn sm good"
+                            data-testid={`restock-link-save-${item.productKey}`}
+                            aria-label={`Uložiť odkaz na dodávateľa produktu ${item.productName} / ${item.productKey}`}
+                            disabled={busyHere || urlDraft.trim() === ""}
+                            onClick={() => {
+                              save(item.productKey);
+                            }}
+                          >
+                            💾
+                          </button>
+                          <button
+                            type="button"
+                            className="btn sm ghost"
+                            data-testid={`restock-link-cancel-${item.productKey}`}
+                            aria-label="Zrušiť úpravu"
+                            disabled={busyHere}
+                            onClick={cancelEdit}
+                          >
+                            ✖
+                          </button>
+                        </div>
+                      ) : (
+                        <span data-testid={`restock-link-url-${item.productKey}`}>—</span>
+                      )}
+                    </td>
+                    {canEdit && (
+                      <td>
+                        {!editing && (
+                          <button
+                            type="button"
+                            className="btn sm ghost"
+                            data-testid={`restock-link-edit-toggle-${item.productKey}`}
+                            aria-label={`Doplniť odkaz na dodávateľa — ${item.productName} (${item.productKey})`}
+                            onClick={() => {
+                              startEdit(item);
+                            }}
+                          >
+                            ✏️ Doplniť
+                          </button>
+                        )}
+                      </td>
+                    )}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/nav.test.ts
+++ b/apps/web/src/nav.test.ts
@@ -18,14 +18,17 @@ import { DEFAULT_TAB_ID, HIDDEN_TABS, NAV, findTab, isVisibleTabId } from "./nav
 // položky vnútri každého priečinka ostali nezmenené.
 // Issue 290 pridalo TRI ďalšie položky ("Výmena tovaru"/"Vrátený
 // tovar"/"Reklamácie") HNEĎ POD "Nedostupné tovary" (šéfovo zadanie:
-// "pridať dalšie polička - pod nedostupné tovarý").
+// "pridať dalšie polička - pod nedostupné tovarý"). Issue 311 pridalo
+// "Vypredané → Skladom: návrhy odkazov" hneď za "Vypredané → Skladom" v
+// Automatizáciách (rovnaká automatizácia, doplnenie chýbajúcich odkazov,
+// ktoré ju živia).
 // Tento test je najbližšie k tomu, čo strojovo overiť dá (registrácia, nie DOM).
-it("NAV má tri priečinky (Eshop/Systém/Automatizácie), s 9/3/4 záložkami v poradí podľa dôležitosti", () => {
+it("NAV má tri priečinky (Eshop/Systém/Automatizácie), s 9/3/5 záložkami v poradí podľa dôležitosti", () => {
   expect(NAV).toHaveLength(3);
   expect(NAV.map((f) => f.label)).toEqual(["Eshop", "Systém", "Automatizácie"]);
   expect(NAV[0]?.tabs).toHaveLength(9);
   expect(NAV[1]?.tabs).toHaveLength(3);
-  expect(NAV[2]?.tabs).toHaveLength(4);
+  expect(NAV[2]?.tabs).toHaveLength(5);
   expect(NAV[0]?.tabs.map((t) => t.label)).toEqual([
     "Na objednanie",
     "Nedostupné tovary",
@@ -44,6 +47,8 @@ it("NAV má tri priečinky (Eshop/Systém/Automatizácie), s 9/3/4 záložkami v
   expect(NAV[2]?.tabs.map((t) => t.label)).toEqual([
     // issue 213: prepínanie vypredaných produktov späť na skladom.
     "Vypredané → Skladom",
+    // issue 311: návrh dodávateľského odkazu pre vypredané produkty bez neho.
+    "Vypredané → Skladom: návrhy odkazov",
     "Nevyzdvihnuté zásielky",
     "Pripomienky objednávok",
     "Odoslané e-maily",
@@ -71,6 +76,7 @@ it("findTab nájde viditeľnú aj skrytú záložku podľa id, neznáme id vrát
   expect(findTab("exchange")?.label).toBe("Výmena tovaru");
   expect(findTab("returned")?.label).toBe("Vrátený tovar");
   expect(findTab("claims")?.label).toBe("Reklamácie");
+  expect(findTab("restock-links")?.label).toBe("Vypredané → Skladom: návrhy odkazov");
   expect(findTab("neexistuje")).toBeUndefined();
 });
 
@@ -87,6 +93,8 @@ it("isVisibleTabId rozlíši viditeľné (NAV) od skrytých (HIDDEN_TABS)", () =
   expect(isVisibleTabId("exchange")).toBe(true);
   expect(isVisibleTabId("returned")).toBe(true);
   expect(isVisibleTabId("claims")).toBe(true);
+  // issue 311: nová viditeľná záložka "Vypredané → Skladom: návrhy odkazov".
+  expect(isVisibleTabId("restock-links")).toBe(true);
   for (const hiddenId of Object.keys(HIDDEN_TABS)) {
     expect(isVisibleTabId(hiddenId)).toBe(false);
   }

--- a/apps/web/src/nav.ts
+++ b/apps/web/src/nav.ts
@@ -11,6 +11,7 @@ import { OrderReminderSection } from "./components/OrderReminderSection.js";
 import { OrdersSection } from "./components/OrdersSection.js";
 import { PairingSection } from "./components/PairingSection.js";
 import { PostaUncollectedSection } from "./components/PostaUncollectedSection.js";
+import { RestockLinkSuggestionsSection } from "./components/RestockLinkSuggestionsSection.js";
 import { RestockSection } from "./components/RestockSection.js";
 import { ReturnedOrdersSection } from "./components/ReturnedOrdersSection.js";
 import { SchedulerSection } from "./components/SchedulerSection.js";
@@ -137,6 +138,12 @@ export const NAV: readonly NavFolder[] = [
       // dodávateľ zase má skladom — beží na plán a má Štart/Stop, takže
       // patrí sem, nie do Systému (tam je len scraper, ktorý nič neprepína).
       { id: "restock", label: "Vypredané → Skladom", icon: "🔁", Component: RestockSection, wide: true },
+      // issue 311: diagnostika #307 zistila, že 91 zo 130 vypredaných
+      // produktov nemá VÔBEC žiadnu linku na dodávateľa — automatika ich
+      // preto nikdy neposúdi. Táto obrazovka NAVRHNE kandidáta, patrí hneď
+      // vedľa "Vypredané → Skladom" (rovnaká automatizácia, jedna sa stará
+      // o prepínanie, druhá o doplnenie chýbajúcich odkazov, ktoré ju živia).
+      { id: "restock-links", label: "Vypredané → Skladom: návrhy odkazov", icon: "🪄", Component: RestockLinkSuggestionsSection, wide: true },
       { id: "posta-uncollected", label: "Nevyzdvihnuté zásielky", icon: "📮", Component: PostaUncollectedSection },
       { id: "order-reminder", label: "Pripomienky objednávok", icon: "⏰", Component: OrderReminderSection },
       { id: "mail-log", label: "Odoslané e-maily", icon: "📨", Component: MailLogSection, wide: true },

--- a/apps/web/src/restockLinksApi.ts
+++ b/apps/web/src/restockLinksApi.ts
@@ -1,0 +1,60 @@
+import { z } from "zod";
+
+// issue 311: "Vypredané → Skladom: návrhy odkazov" — zrkadlí
+// `GET /api/restock-links` (`apps/api/src/http/restock-links-routes.ts`).
+// Zápis potvrdeného odkazu ide cez UŽ existujúcu `saveProductLink`
+// (`supplierLinksApi.ts`, #239) — táto obrazovka ju len znovupoužije,
+// žiadna nová zapisovacia funkcia tu.
+const candidateSchema = z.object({
+  productKey: z.string(),
+  productName: z.string(),
+  supplier: z.string().nullable(),
+  url: z.string(),
+});
+export type RestockLinkCandidate = z.infer<typeof candidateSchema>;
+
+const itemSchema = z.object({
+  productKey: z.string(),
+  productName: z.string(),
+  supplier: z.string().nullable(),
+  candidates: z.array(candidateSchema),
+});
+export type RestockLinkMissingItem = z.infer<typeof itemSchema>;
+
+const searchSchema = z.object({ total: z.number(), items: z.array(itemSchema) });
+
+export const PAGE_SIZE = 50;
+
+/** Relácia medzitým vypršala (401) — rovnaký vzor ako `SupplierLinksUnauthorizedError`. */
+export class RestockLinksUnauthorizedError extends Error {
+  constructor() {
+    super("Neprihlásený");
+  }
+}
+
+const errorBodySchema = z.object({ error: z.string() });
+
+async function serverErrorMessage(response: Response, fallback: string): Promise<string> {
+  try {
+    const parsed = errorBodySchema.safeParse(await response.json());
+    if (parsed.success) return parsed.data.error;
+  } catch {
+    // Telo nie je platný JSON (alebo chýba) — použi všeobecnú hlášku.
+  }
+  return fallback;
+}
+
+async function readJson(response: Response, fallback: string): Promise<unknown> {
+  if (response.status === 401) throw new RestockLinksUnauthorizedError();
+  if (!response.ok) throw new Error(await serverErrorMessage(response, fallback));
+  return await response.json();
+}
+
+export async function searchRestockLinkSuggestions(input: {
+  readonly q: string;
+  readonly page: number;
+}): Promise<z.infer<typeof searchSchema>> {
+  const query = new URLSearchParams({ q: input.q, page: String(input.page), pageSize: String(PAGE_SIZE) });
+  const response = await fetch(`/api/restock-links?${query.toString()}`);
+  return searchSchema.parse(await readJson(response, "Zoznam vypredaných produktov bez linky sa nepodarilo načítať"));
+}

--- a/apps/web/tests/e2e/catalog.spec.ts
+++ b/apps/web/tests/e2e/catalog.spec.ts
@@ -29,18 +29,20 @@ test("manažér vidí stav katalógu, vyhľadá variant a konzola je čistá", a
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
-  // 40 = 35 riadkov fixtúry + 2 seedované kandidáty na prepnutie ("PREP-1",
+  // 43 = 35 riadkov fixtúry + 2 seedované kandidáty na prepnutie ("PREP-1",
   // issue 217; "PREP-2", issue 226 — rozpor voči feedu, `scripts/e2e-setup.ts`)
   // + 2 seedované produkty pre "Párovanie produktov" ("E2E-PL-CHYBA"/
   // "E2E-PL-OPRAVA", issue 239, `scripts/e2e-fixtures-product-links.ts`)
   // + 1 seedovaný produkt pre "Vyhľadať" ("E2E-SEARCH-1", issue 240,
-  // `scripts/e2e-fixtures-search.ts`).
-  // Prví dvaja sú `out_of_stock` (nemenia "sellable"/"missing" nižšie), zvyšní
-  // traja sú `sellable` (posúvajú filter "sellable" 7→10 nižšie), "missing"(1)
-  // sa nemení ani jedným z nich.
+  // `scripts/e2e-fixtures-search.ts`) + 3 seedované produkty pre "Vypredané →
+  // Skladom: návrhy odkazov" ("E2E-RL-CHYBA"/"E2E-RL-NAVRH"/"E2E-RL-CUDZI",
+  // issue 311, `scripts/e2e-fixtures-restock-links.ts`).
+  // Prví dvaja (PREP-1/PREP-2) aj "E2E-RL-CHYBA" sú `out_of_stock` (nemenia
+  // "sellable"/"missing" nižšie), zvyšných 5 sú `sellable` (posúvajú filter
+  // "sellable" 7→12 nižšie), "missing"(1) sa nemení ani jedným z nich.
   await expect(page.getByTestId("snapshot")).toContainText("Posledný import: prijatý");
-  await expect(page.getByTestId("counts")).toContainText("Variantov v katalógu (vrátane chýbajúcich): 40");
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 40");
+  await expect(page.getByTestId("counts")).toContainText("Variantov v katalógu (vrátane chýbajúcich): 43");
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 43");
 
   await page.getByLabel("Kód alebo názov").fill("40237/3XL");
   await page.getByRole("button", { name: "Hľadať", exact: true }).click();
@@ -60,15 +62,16 @@ test("filter podľa stavu zúži zoznam na predajné varianty", async ({ page })
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 40");
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 43");
   await page.getByLabel("Stav", { exact: true }).selectOption("sellable");
   await page.getByRole("button", { name: "Hľadať", exact: true }).click();
 
-  // 10 = 7 od issue 219 (variant "40237/L" má oba texty dostupnosti prázdne,
+  // 12 = 7 od issue 219 (variant "40237/L" má oba texty dostupnosti prázdne,
   // čo znamená predvolenú dostupnosť Shoptetu — "Skladom", nie vypredané) +
   // 2 sellable produkty issue 239's fixtúry ("E2E-PL-CHYBA"/"E2E-PL-OPRAVA")
-  // + 1 sellable produkt issue 240's fixtúry ("E2E-SEARCH-1").
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 10");
+  // + 1 sellable produkt issue 240's fixtúry ("E2E-SEARCH-1") + 2 sellable
+  // produkty issue 311's fixtúry ("E2E-RL-NAVRH"/"E2E-RL-CUDZI").
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 12");
   await expect(page.getByTestId("variant-40237/M")).toBeVisible();
 });
 
@@ -80,7 +83,7 @@ test("filter 'Chýbajúce' nájde presne označený variant a riadok ukazuje, od
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 40");
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 43");
   await page.getByLabel("Stav", { exact: true }).selectOption("missing");
   await page.getByRole("button", { name: "Hľadať", exact: true }).click();
 
@@ -137,7 +140,7 @@ test("import (ešte prebiehajúci) nesmie prepísať MEDZITÝM zmenený filter z
   await page.getByLabel("E-mail").fill(E2E_RACE_EMAIL);
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 40");
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 43");
 
   await page.getByRole("button", { name: "Stiahnuť a naimportovať export" }).click();
 

--- a/apps/web/tests/e2e/nav.spec.ts
+++ b/apps/web/tests/e2e/nav.spec.ts
@@ -23,8 +23,11 @@ const E2E_NAV_EMAIL = "e2e-nav@forestshop.sk";
 // `upozornenia.spec.ts`, rovnaký vzor). Issue 290 (2026-08-07) pridáva TRI
 // ďalšie záložky HNEĎ POD "Nedostupné tovary" — "Výmena tovaru"/"Vrátený
 // tovar"/"Reklamácie" — šestnásta záložka celkovo (funkčný test v
-// samostatnom `order-flags.spec.ts`, rovnaký vzor).
-test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) so šestnástimi záložkami, klik prepne obrazovku, panel sa zbalí do lišty a stav si pamätá, konzola je čistá", async ({
+// samostatnom `order-flags.spec.ts`, rovnaký vzor). Issue 311 (2026-08-07)
+// pridáva "Vypredané → Skladom: návrhy odkazov" HNEĎ ZA "Vypredané →
+// Skladom" — sedemnásta záložka celkovo (funkčný test v samostatnom
+// `restock-links.spec.ts`, rovnaký vzor).
+test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) so sedemnástimi záložkami, klik prepne obrazovku, panel sa zbalí do lišty a stav si pamätá, konzola je čistá", async ({
   page,
 }) => {
   const chyby: string[] = [];
@@ -45,8 +48,8 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) so šestnás
   await expect(page.getByRole("button", { name: "Eshop" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Automatizácie" })).toBeVisible();
 
-  // Presne šestnásť záložiek v CELOM menu.
-  await expect(page.locator(".side-nav .tab")).toHaveCount(16);
+  // Presne sedemnásť záložiek v CELOM menu.
+  await expect(page.locator(".side-nav .tab")).toHaveCount(17);
   await expect(page.getByRole("button", { name: "Sync zo Shoptetu" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Texty e-mailov" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Na objednanie" })).toBeVisible();
@@ -178,7 +181,7 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) so šestnás
 
   // Hlavičky priečinkov zmiznú, ikony všetkých modulov ostanú.
   await expect(page.getByRole("button", { name: "Systém" })).toHaveCount(0);
-  await expect(page.locator(".side-nav .tab")).toHaveCount(16);
+  await expect(page.locator(".side-nav .tab")).toHaveCount(17);
   // Názov sa v lište ukáže bublinou pri prejdení myšou.
   await expect(page.getByRole("button", { name: "Na objednanie" })).toHaveAttribute(
     "title",

--- a/apps/web/tests/e2e/restock-links.spec.ts
+++ b/apps/web/tests/e2e/restock-links.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from "@playwright/test";
+
+const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
+// VLASTNÝ izolovaný účet (rovnaký mechanizmus ako `E2E_PAROVANIE_EMAIL`,
+// `.claude/rules/frontend-design.md`) — zdieľaný `e2e@forestshop.sk` je už
+// na hranici `MAX_ATTEMPTS`. Musí sa zhodovať s `scripts/e2e-fixtures-
+// restock-links.ts`'s `E2E_NAVRHY_ODKAZOV_EMAIL`.
+const E2E_NAVRHY_ODKAZOV_EMAIL = "e2e-navrhy-odkazov@forestshop.sk";
+
+// issue 311: "Vypredané → Skladom: návrhy odkazov" — VIDITEĽNÁ záložka
+// (`nav.ts`, priečinok Automatizácie). Fixtúry (`scripts/e2e-fixtures-
+// restock-links.ts`): "E2E-RL-CHYBA" (vypredaný, viditeľný, BEZ linky —
+// má sa zobraziť s návrhom), "E2E-RL-NAVRH" (rovnaký dodávateľ + prekryv
+// mena "Bunda Alfa" — zdroj návrhu, UŽ MÁ linku) a "E2E-RL-CUDZI" (cudzí
+// dodávateľ, žiadny prekryv mena — dokazuje, že sa NIKDY nenavrhne bez
+// zhody). Potvrdenie ide cez ROVNAKÚ `product_supplier_link_override`
+// tabuľku ako "Párovanie produktov" (#239) — druhá polovica testu to
+// overuje NA TEJ DRUHEJ obrazovke, dôkaz zdieľanej zápisovej cesty.
+
+test("vypredaný produkt bez linky ponúkne návrh podľa zhody mena + dodávateľa, potvrdenie sa zapíše a zdieľa sa s Párovaním produktov; konzola je čistá", async ({
+  page,
+}) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/");
+  await page.getByLabel("E-mail").fill(E2E_NAVRHY_ODKAZOV_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+
+  await page.getByRole("button", { name: "Vypredané → Skladom: návrhy odkazov" }).click();
+  await expect(page.getByRole("heading", { name: "Vypredané → Skladom: návrhy odkazov" })).toBeVisible();
+
+  await page.getByLabel("Hľadať produkt (kód alebo názov)").fill("E2E-RL-CHYBA");
+  await page.getByRole("button", { name: "Zobraziť" }).click();
+
+  const riadok = page.getByTestId("restock-link-row-E2E-RL-CHYBA");
+  await expect(riadok).toBeVisible();
+  await expect(riadok).toContainText("E2E Bunda Alfa Vypredaná");
+
+  // Návrh (kandidát z rovnakého dodávateľa + prekrývajúceho sa mena) je
+  // VIDITEĽNÝ, ale NIČ sa nikdy neuloží samo — len klik na "Použiť" ho
+  // predvyplní do vstupu.
+  const navrhTlacidlo = riadok.getByTestId("restock-link-use-candidate-E2E-RL-CHYBA-E2E-RL-NAVRH");
+  await expect(navrhTlacidlo).toContainText("https://e2e-dodavatel.example.com/bunda-alfa-navrh");
+  // Nesúvisiaci produkt sa v návrhu NIKDY neobjaví.
+  await expect(riadok).not.toContainText("E2E Šál Zeta Cudzí");
+
+  await navrhTlacidlo.click();
+  const vstup = page.getByTestId("restock-link-edit-input-E2E-RL-CHYBA");
+  await expect(vstup).toHaveValue("https://e2e-dodavatel.example.com/bunda-alfa-navrh");
+
+  await page.getByTestId("restock-link-save-E2E-RL-CHYBA").click();
+
+  // Produkt teraz MÁ linku — táto obrazovka zobrazuje LEN produkty BEZ nej,
+  // takže po uložení riadok zmizne (skutočný, nie len optimistický dôkaz
+  // uloženia — refetch to potvrdzuje).
+  await expect(page.getByTestId("restock-links-empty")).toBeVisible();
+
+  // Zdieľaná zápisová cesta (#239's `product_supplier_link_override`) — tá
+  // istá hodnota je vidno aj na "Párovanie produktov", úplne INEJ
+  // obrazovke nad tou istou tabuľkou.
+  await page.getByRole("button", { name: "Párovanie produktov" }).click();
+  await expect(page.getByRole("heading", { name: "Párovanie produktov" })).toBeVisible();
+  await page.getByLabel("Zobraziť produkty").selectOption("all");
+  await page.getByLabel("Hľadať produkt (kód alebo názov)").fill("E2E-RL-CHYBA");
+  await page.getByRole("button", { name: "Zobraziť" }).click();
+  await expect(page.getByTestId("product-link-url-E2E-RL-CHYBA")).toHaveAttribute(
+    "href",
+    "https://e2e-dodavatel.example.com/bunda-alfa-navrh",
+  );
+
+  expect(chyby).toEqual([]);
+});

--- a/apps/web/tests/e2e/restock-waiting.spec.ts
+++ b/apps/web/tests/e2e/restock-waiting.spec.ts
@@ -23,7 +23,7 @@ test("zoznam pripravených na prepnutie ponúkne odkaz na náš produkt aj k dod
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
   // Obrazovka je dostupná z ľavého menu pod "Automatizácie".
-  await page.getByRole("button", { name: "Vypredané → Skladom" }).click();
+  await page.getByRole("button", { name: "Vypredané → Skladom", exact: true }).click();
   await expect(page.getByTestId("restock-waiting-list")).toBeVisible();
 
   // Seedovaný kandidát (`scripts/e2e-setup.ts`) — vypredaný, viditeľný,
@@ -68,7 +68,7 @@ test("rozpor nášho stavu s feedom sa ukáže ako varovanie a kandidáta vylú�
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
-  await page.getByRole("button", { name: "Vypredané → Skladom" }).click();
+  await page.getByRole("button", { name: "Vypredané → Skladom", exact: true }).click();
   await expect(page.getByTestId("restock-waiting-list")).toBeVisible();
 
   const karta = page.getByTestId("restock-feed-conflicts");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.180",
+  "version": "0.3.0-dev.181",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-fixtures-restock-links.ts
+++ b/scripts/e2e-fixtures-restock-links.ts
@@ -1,0 +1,86 @@
+// issue 311: "Vypredané → Skladom: návrhy odkazov" — vyčlenené z
+// `e2e-setup.ts` (eslint `max-lines: 400`, `.claude/rules/testing.md`),
+// rovnaký vzor ako existujúci `e2e-fixtures-product-links.ts` (#239). DVA
+// VLASTNÉ, dovtedy nepoužité jednovariantné produkty: jeden vypredaný,
+// viditeľný, stále v exporte, BEZ efektívnej linky (kandidát na návrh),
+// druhý s UŽ ULOŽENOU linkou (`internalNote`) a prekrývajúcimi sa slovami
+// názvu + ROVNAKÝM dodávateľom (zdroj návrhu). Tretí, s NEsúvisiacim menom
+// a CUDZÍM dodávateľom, dokazuje, že sa nikdy nenavrhne bez zhody.
+import type { Database } from "../apps/api/src/db/client.js";
+import { products, users, variants } from "../apps/api/src/db/schema.js";
+import { hashPassword } from "../apps/api/src/modules/auth/passwords.js";
+
+// Musí sa zhodovať s hodnotou v `apps/web/tests/e2e/restock-links.spec.ts` —
+// VLASTNÝ izolovaný účet (rovnaký mechanizmus ako `E2E_PAROVANIE_EMAIL` —
+// zdieľaný `e2e@forestshop.sk` je už na hranici `MAX_ATTEMPTS`).
+export const E2E_NAVRHY_ODKAZOV_EMAIL = "e2e-navrhy-odkazov@forestshop.sk";
+
+export async function seedRestockLinksFixtures(db: Database, teraz: Date, snapshotId: string, heslo: string): Promise<void> {
+  await db.insert(users).values({
+    email: E2E_NAVRHY_ODKAZOV_EMAIL,
+    passwordHash: await hashPassword(heslo),
+    displayName: "E2E Manažér",
+    role: "manazer",
+  });
+
+  async function seedProdukt(
+    key: string,
+    code: string,
+    name: string,
+    over: { readonly internalNote?: string | null; readonly state?: "sellable" | "out_of_stock" } = {},
+  ): Promise<void> {
+    await db.insert(products).values({
+      key,
+      name,
+      supplier: "E2E Dodávateľ Návrhy",
+      internalNote: over.internalNote ?? null,
+      firstSeenAt: teraz,
+      lastSeenAt: teraz,
+      lastSeenSnapshotId: snapshotId,
+    });
+    await db.insert(variants).values({
+      code,
+      productKey: key,
+      guid: key,
+      name,
+      stock: over.state === "out_of_stock" ? 0 : 5,
+      availabilityInStockText: "Skladom",
+      availabilityOutOfStockText: "Vypredané",
+      availabilityText: over.state === "out_of_stock" ? "Vypredané" : "Skladom",
+      productVisibility: "visible",
+      state: over.state ?? "sellable",
+      firstSeenAt: teraz,
+      lastSeenAt: teraz,
+      lastSeenSnapshotId: snapshotId,
+    });
+  }
+
+  await seedProdukt("E2E-RL-CHYBA", "E2E-RL-CHYBA", "E2E Bunda Alfa Vypredaná", { state: "out_of_stock" });
+  await seedProdukt("E2E-RL-NAVRH", "E2E-RL-NAVRH", "E2E Bunda Alfa Skladom", {
+    internalNote: "https://e2e-dodavatel.example.com/bunda-alfa-navrh",
+  });
+  await db.insert(products).values({
+    key: "E2E-RL-CUDZI",
+    name: "E2E Šál Zeta Cudzí",
+    supplier: "E2E Iný Dodávateľ",
+    internalNote: "https://iny-dodavatel.example.com/sal-zeta",
+    firstSeenAt: teraz,
+    lastSeenAt: teraz,
+    lastSeenSnapshotId: snapshotId,
+  });
+  await db.insert(variants).values({
+    code: "E2E-RL-CUDZI",
+    productKey: "E2E-RL-CUDZI",
+    guid: "E2E-RL-CUDZI",
+    name: "E2E Šál Zeta Cudzí",
+    stock: 5,
+    availabilityInStockText: "Skladom",
+    availabilityOutOfStockText: "Vypredané",
+    availabilityText: "Skladom",
+    productVisibility: "visible",
+    state: "sellable",
+    firstSeenAt: teraz,
+    lastSeenAt: teraz,
+    lastSeenSnapshotId: snapshotId,
+  });
+}

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -19,6 +19,7 @@ import { POSTA_UNCOLLECTED_SETTINGS_ID } from "../apps/api/src/modules/posta-unc
 import { ORDER_REMINDER_SETTINGS_ID } from "../apps/api/src/modules/order-reminder/settings.js";
 import { seedOrderFlagsFixtures } from "./e2e-fixtures-order-flags.js";
 import { seedProductLinksFixtures } from "./e2e-fixtures-product-links.js";
+import { seedRestockLinksFixtures } from "./e2e-fixtures-restock-links.js";
 import { seedSearchFixtures } from "./e2e-fixtures-search.js";
 
 const E2E_HESLO = "e2e-test-heslo"; // musí sa zhodovať s hodnotou v login.spec.ts/catalog.spec.ts/orders.spec.ts
@@ -789,5 +790,8 @@ await seedSearchFixtures(db, teraz, snapshotPrepinanie, E2E_HESLO);
 
 // issue 290: fixtúra vyčlenená do vlastného súboru, rovnaký dôvod ako vyššie.
 await seedOrderFlagsFixtures(db, E2E_HESLO);
+
+// issue 311: fixtúra vyčlenená do vlastného súboru, rovnaký dôvod ako vyššie.
+await seedRestockLinksFixtures(db, teraz, snapshotPrepinanie, E2E_HESLO);
 
 await pool.end();


### PR DESCRIPTION
Rieši issue 311 (plain reference, nie automatické zatvorenie — pozri nižšie).

## Čo a prečo

Diagnostika issue 307 zistila, že 91 zo 130 vypredaných produktov nemá
VÔBEC žiadny odkaz na dodávateľa v poznámke, takže automatika "Vypredané →
Skladom" ich nikdy ani neposúdi. Tento PR pridáva novú obrazovku
("Vypredané → Skladom: návrhy odkazov"), ktorá pre presne túto populáciu
NAVRHNE kandidátsky odkaz (deterministická zhoda významných slov mena +
dodávateľa oproti produktom, čo linku už majú — nikdy AI dohad) a človek ho
POTVRDÍ alebo prepíše vlastným — nikdy sa nič neuloží samo.

Potvrdenie ide cez UŽ EXISTUJÚCU `POST /api/product-links/:productKey`
(issue 239) — žiadna nová zapisovacia trasa, žiadna nová tabuľka.

## Prečo ticket zostáva otvorený (`plain issue 311`, nie `Closes`)

Ticket má akceptačnú podmienku, ktorú nejde overiť pred mergom (naživo
overiť na produkcii, že sa návrh správne zobrazí a potvrdenie sa reálne
zapíše aj pošle do Shoptetu) — zavriem ho ručne AŽ po post-deploy overení
(`.claude/rules/database-migrations.md`, `CLAUDE.md`'s vlastné pravidlo pre
tento repozitár).

## Overené lokálne

- `pnpm typecheck`, `pnpm lint` — čisté
- `pnpm --filter @forestshop/api test` (643/643), `test:integration`
  (vrátane 9 nových testov pre `restock-links`)
- `pnpm --filter @forestshop/web test` (514/514, vrátane 7 nových)
- `pnpm --filter @forestshop/web e2e` — celý balík 50/50 zelený
- Code review (`superpowers:requesting-code-review`): 0 🔴, 2 🟡 (opravené),
  2 🔵 (jeden opravený, druhý ponechaný ako nízko-prínosný) — viď komentáre
  na issue 311.

## Playbook

Nové pravidlo `.claude/rules/restock-links.md` + router záznam v `CLAUDE.md`.
