### PR TITLE
DPD: objednať prepravu jedným tlačidlom — náhľad + robot (issue 292)

### DIFF
--- a/.claude/rules/dpd.md
+++ b/.claude/rules/dpd.md
@@ -1,0 +1,126 @@
+---
+paths:
+  - "apps/api/src/modules/dpd/**"
+  - "apps/api/src/http/dpd-routes.ts"
+  - "apps/api/tests/dpd-http.integration.test.ts"
+  - "apps/web/src/dpdApi.ts"
+  - "apps/web/src/components/DpdSection.tsx"
+  - "apps/web/tests/e2e/dpd.spec.ts"
+  - "scripts/e2e-fixtures-dpd.ts"
+---
+
+# DPD preprava (issue 292)
+
+- **Portál `dpdshipper.sk` zmapovaný naživo (read-only guard, 7.8.2026):**
+  menu `Zásielky (/shipments) / Objednávky zvozu (/pickup-orders,
+  "Pravidelný zvoz" + "Jednorazové zvozy") / Príjemcovia (/recipients) /
+  Nastavenia / Importné profily (/import-profiles)`. Prihlásenie je
+  `/login`, jedno pole meno + jedno heslo, žiadna CAPTCHA/2FA. Formulár na
+  JEDNU zásielku je `/shipments/0` ("Pridať objednávku"). **Prihlasovacie
+  selektory SÚ naživo overené a fungujú** (`modules/dpd/login.ts`):
+  `input[name=loginName], #loginName` / `input[type=password]` /
+  `button:has-text('Prihlásiť'), input[type=submit]`, úspech = presmerovanie
+  na `/shipments` + prihlasovacie pole zmizne (rovnaká dvojitá istota ako
+  Shoptet, `.claude/rules/shoptet-writeback.md`).
+- **Importné profily (hromadný súborový import zásielok) boli na účte
+  PRÁZDNE — presný formát súboru sa dá zistiť len ZALOŽENÍM profilu, čo je
+  ZÁPIS.** Bezpečnostné pravidlo tohto tiketu (žiadny zápis/objednanie do
+  reálneho DPD účtu z vývojárskej session) preto vylúčilo hromadný import
+  ako cestu — appka ide per-zásielkovým formulárom (`/shipments/0`).
+  Ak sa niekedy neskôr profil založí (majiteľom, naživo), bulk import cez
+  Importné profily zostáva rýchlejšia/spoľahlivejšia alternatíva k
+  per-objednávkovému formuláru — over najprv, či medzitým nevznikol profil,
+  než sa znova rieši per-formulárová cesta.
+- **Presné selektory formulára `/shipments/0` NIE SÚ domapované** — appka
+  (`modules/dpd/shipment-playwright.ts`'s `fillShipmentFields`,
+  `pickup-playwright.ts`'s `fillPickupForm`) zámerne zlyhá NAHLAS s presným
+  popisom namiesto TICHÉHO odoslania vymyslených polí. Dôvod: dopĺňanie
+  chýbajúceho DPD prihlásenia (`secret request`) cez noc nikdy neprišlo —
+  žiaden ďalší pokus nesmie NAHRADIŤ tento fail-loud vzor odhadnutými
+  selektormi, aj keby "vyzerali rozumne" (DPD Shipper vocabular nie je
+  overený, hádanie by tichým zlyhaním vyzeralo ako úspech alebo poslalo zlé
+  dáta). **Prvé ďalšie použitie tohto modulu MUSÍ najprv urobiť READ-ONLY
+  naživo mapovanie** (rovnaký `readOnly` route-guard vzor ako
+  `dpd-mapuj.mjs`/`dpd-formulare.mjs` v scratchpad histórii issue 292 —
+  `let readOnly=false; ctx.route("**/*", …); readOnly=true;` hneď po
+  prihlásení) PRED doplnením skutočných selektorov do `fillShipmentFields`/
+  `fillPickupForm` — nikdy priamo skúšať naostro.
+- **`secret request` má LEN 600s (10 min) platnosť URL na zadanie hodnoty —
+  fired-and-forget nefunguje cez noc.** Pri opakovanom čakaní na
+  `DPD_PORTAL_USER`/`PASSWORD` (majiteľ spal) sa muselo volať znova zakaždým,
+  keď uplynulo 10 minút — žiadny spôsob "vypýtať raz, počkať hodiny". Pri
+  podobnom nočnom čakaní na credential: buď volať `secret request` tesne
+  PRED momentom, keď sa reálne bude čítať (nie hodiny vopred), alebo počítať
+  s viacnásobným re-requestom a ukladať KAŽDÝ pokus ako `gh issue comment`
+  (durable tracking), nie len dúfať v jeden úspešný pokus.
+- **Shoptet export nemá samostatný stĺpec "spôsob platby" na objednávke —
+  je to `itemName` na `BILLING*` pseudo-riadku**, presne rovnaký trik ako
+  `shippingCarrierName` z `SHIPPING*` (issue 172, `.claude/rules/
+  orders.md`). Naživo overené (7.8.2026, 90-dňový reálny export, LEN
+  agregáty čítané, žiadne PII zapísané nikam): `"Dobierka (hotovosť) + karta
+  (len SR)"` (268×), `"V hotovosti"` (9×). `paid`/`amountPaid`/`priceToPay`
+  stĺpce sú v reálnom exporte prítomné, ale `paid`/`amountPaid` sú TAKMER
+  VŽDY prázdne — appka preto rozpoznáva dobierku podľa toho, či
+  `paymentMethodName` obsahuje "dobierka" (case-insensitive,
+  `modules/dpd/preview.ts`'s `COD_PAYMENT_NAME_RE`), NIE podľa `paid`/
+  `amountPaid`. Ďalší stĺpec, ktorý potrebuje podobnú "je na pseudo-riadku"
+  extrakciu, patrí do `parser.ts`'s `extractOrderLevelExtra`/
+  `mergeOrderLevelExtra`, rovnaký vzor.
+- **`weight` stĺpec exportu je v reálnych dátach TAKMER VŽDY `0`** (obchod
+  hmotnosť dôsledne nezapisuje — potvrdené na 90-dňovom vzorku). Appka preto
+  NIKDY neposiela nulovú/chýbajúcu hmotnosť portálu — `preview.ts`'s
+  `DEFAULT_PARCEL_WEIGHT_KG = "1.00"` je použitá, keď je uložená hodnota
+  `null` alebo `<= 0`, a obsluha ju v UI (`DpdSection.tsx`, editovateľný
+  `<input type=number>` na riadku) môže pred odoslaním prepísať — appka
+  sama NIKDY nehádaje reálnu hmotnosť konkrétneho balíka, len ponúka
+  rozumný štartovací bod.
+- **"Pripravené na odoslanie" (appka's vlastný zoznam,
+  `modules/dpd/queries.ts`'s `listDpdShippableOrders`) je ZÁMERNE nezávislé
+  od Shoptet `status_name`** — appka nemá spoľahlivý zoznam stavov "zabalené,
+  čaká na kuriéra" (na rozdiel od "Na objednanie"'s `order_open_status`,
+  ktorý rieši INÝ problém — dodávateľské objednávanie). Kritérium je
+  namiesto toho appka-vlastné: `order.package_number IS NULL` (Shoptet
+  nezaznamenal inú prepravu) A žiadny `dpd_shipment` riadok so `status =
+  'submitted'`. Obsluha si sama vyberie, ktoré reálne zabalené objednávky
+  odošle — ĎALŠIA funkcia, čo by potrebovala podobný "ešte neriešené"
+  filter, nech zváži rovnaký princíp (appka-vlastný stavový záznam) skôr
+  než sa spolieha na Shoptet `status_name`, ktorý na to nemá spoľahlivý
+  slovník.
+- **`dpd_shipment` je JEDEN riadok NA OBJEDNÁVKU (`orderId` unique,
+  upsert)** — opakovaný pokus (retry po zlyhaní) PREPÍŠE ten istý riadok,
+  appka teda vidí len POSLEDNÝ pokus, nikdy históriu pokusov (MVP, netreba
+  viac). `dpd_pickup_request` je NAOPAK nezávislý insert na KAŽDÝ pokus
+  (jednorazový zvoz nie je viazaný na objednávku, každý deň je samostatná
+  udalosť) — nezamieňaj tieto dva vzory pri ďalšom podobnom "appka-vlastný
+  záznam pokusu" dizajne.
+- **`dpd_shipment` NETREBA pridávať do `tests/helpers/db.ts`/`scripts/
+  e2e-setup.ts` TRUNCATE zoznamov — má reálny FK do `"order"` (`onDelete:
+  cascade`), takže `TRUNCATE "order" CASCADE` ho strhne automaticky.**
+  `dpd_pickup_request` NEMÁ FK v žiadnom smere (dátum-kľúčovaný) — TEN treba
+  pridať RUČNE do OBOCH zoznamov (rovnaký test ako `.claude/rules/
+  testing.md`'s "nová koreňová tabuľka" pravidlo).
+- **HTTP routes injektujú `createShipment`/`orderPickup` ako funkcie
+  (`http/dpd-routes.ts`'s `DpdRunDeps`), predvolene skutočný izolovaný
+  Playwright robot** — presne rovnaký DI vzor ako `postaUncollected
+  .trackingClient`/`nedostupne.mailTransport`, NIE priamy import volaný
+  vnútri route handlera. Bez tejto injekcie by `dpd-http.integration
+  .test.ts` musel spúšťať skutočný Chromium (pomalé, a riskuje dotknutie sa
+  reálneho účtu, keby `config` bol reálny) — testy namiesto toho dodávajú
+  falošnú funkciu, appka sa NIKDY nedotkne skutočného DPD portálu z testu.
+- **`parseDecimalComma` (`catalog/money.ts`) zaokrúhľuje na PRESNE 2
+  desatinné miesta (`roundToTwoDecimals`, hardcoded)** — `order.weight`/
+  `dpd_shipment.weight_kg` preto dostali `numeric(_, 2)` presnosť (nie 3,
+  ako by sa pre "kg" mohlo zdať prirodzené), aby sedeli s tým, čo parser
+  reálne vracia. Ďalší stĺpec parsovaný cez `parseDecimalComma` s inou
+  scale ako 2 by ticho strácal presnosť — over `roundToTwoDecimals` PRED
+  voľbou `scale` na novom `numeric` stĺpci.
+- **E2E test pre "appka je fail-closed bez DPD prihlásenia" (`dpd.spec.ts`)
+  je JEDINÝ bezpečný spôsob overiť UI naživo bez credentials** — appka MUSÍ
+  zobraziť zoznam (čisto DB čítanie, nezávisí od Playwright robota) a
+  zablokovať tlačidlá "Objednať prepravu DPD"/"Objednať zvoz na deň", keď
+  `configured: false`. Skutočný preview→confirm→odoslanie flow (kde appka
+  by inak volala robota) je pokrytý LEN `DpdSection.test.tsx`'s izolovaným
+  falošným API klientom — e2e prostredie nemá a NEMÁ MAŤ `DPD_PORTAL_USER`/
+  `PASSWORD` nastavené, presne rovnaká disciplína ako `MAIL_HOST`/
+  `SHOPTET_ADMIN_USER` v e2e prostredí (appka sa nikdy nedotkne skutočnej
+  tretej strany z testu).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,3 +105,4 @@ Per-area rules live in `.claude/rules/<area>.md` with `paths:` frontmatter.
 - Eshop → Vyhľadať (#240 — dve oddelené polia produkty/objednávky, detail produktu, zdieľaná zapisovacia cesta s #239) → `.claude/rules/search.md`
 - Eshop → Upozornenia (#267 — nástenka, čiastočný unique dedup index, počítaný stav bez cron-u, zdieľaná zapisovacia cesta pre budúce #268/#269) → `.claude/rules/upozornenia.md`
 - Vypredané → Skladom: návrhy odkazov (#311 — deterministický návrh podľa zhody mena+dodávateľa, zdieľaná zapisovacia cesta s #239, žiadne AI dohady) → `.claude/rules/restock-links.md`
+- Preprava DPD (#292 — per-zásielkový Playwright robot na dpdshipper.sk, appka-vlastný `dpd_shipment`/`dpd_pickup_request` záznam, náhľad pred odoslaním, fail-loud nedomapovaný formulár) → `.claude/rules/dpd.md`

--- a/apps/api/drizzle/0044_lovely_franklin_storm.sql
+++ b/apps/api/drizzle/0044_lovely_franklin_storm.sql
@@ -1,0 +1,33 @@
+CREATE TYPE "public"."dpd_operation_status" AS ENUM('submitted', 'failed');--> statement-breakpoint
+CREATE TABLE "dpd_pickup_request" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"pickup_date" date NOT NULL,
+	"status" "dpd_operation_status" NOT NULL,
+	"error_message" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "dpd_shipment" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"order_id" uuid NOT NULL,
+	"status" "dpd_operation_status" NOT NULL,
+	"parcel_number" text,
+	"weight_kg" numeric(10, 2) NOT NULL,
+	"cod_amount" numeric(12, 2),
+	"error_message" text,
+	"submitted_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "order" ADD COLUMN "delivery_full_name" text;--> statement-breakpoint
+ALTER TABLE "order" ADD COLUMN "delivery_company" text;--> statement-breakpoint
+ALTER TABLE "order" ADD COLUMN "delivery_street" text;--> statement-breakpoint
+ALTER TABLE "order" ADD COLUMN "delivery_house_number" text;--> statement-breakpoint
+ALTER TABLE "order" ADD COLUMN "delivery_city" text;--> statement-breakpoint
+ALTER TABLE "order" ADD COLUMN "delivery_zip" text;--> statement-breakpoint
+ALTER TABLE "order" ADD COLUMN "delivery_country_name" text;--> statement-breakpoint
+ALTER TABLE "order" ADD COLUMN "weight" numeric(10, 2);--> statement-breakpoint
+ALTER TABLE "order" ADD COLUMN "payment_method_name" text;--> statement-breakpoint
+ALTER TABLE "order" ADD COLUMN "price_to_pay" numeric(12, 2);--> statement-breakpoint
+ALTER TABLE "dpd_shipment" ADD CONSTRAINT "dpd_shipment_order_id_order_id_fk" FOREIGN KEY ("order_id") REFERENCES "public"."order"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "dpd_shipment_order_uq" ON "dpd_shipment" USING btree ("order_id");

--- a/apps/api/drizzle/meta/0044_snapshot.json
+++ b/apps/api/drizzle/meta/0044_snapshot.json
@@ -1,0 +1,3031 @@
+{
+  "id": "74eaaf58-9a21-409c-991d-6b25d7d2422a",
+  "prevId": "25bff396-9555-4df6-8929-b2ffcd9f3a93",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_code": {
+          "name": "external_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_open_status": {
+      "name": "order_open_status",
+      "schema": "",
+      "columns": {
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Vybavuje sa'"
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop_remark": {
+          "name": "shop_remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shoptet_order_id": {
+          "name": "shoptet_order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_updated_at": {
+          "name": "comment_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_synced_at": {
+          "name": "comment_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_carrier_name": {
+          "name": "shipping_carrier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_price_with_vat": {
+          "name": "total_price_with_vat",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_marked_at": {
+          "name": "claim_marked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_note": {
+          "name": "claim_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_full_name": {
+          "name": "delivery_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_company": {
+          "name": "delivery_company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_street": {
+          "name": "delivery_street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_house_number": {
+          "name": "delivery_house_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_city": {
+          "name": "delivery_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_zip": {
+          "name": "delivery_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_country_name": {
+          "name": "delivery_country_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_name": {
+          "name": "payment_method_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_to_pay": {
+          "name": "price_to_pay",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_link_override": {
+      "name": "product_supplier_link_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_link_override_product_key_product_key_fk": {
+          "name": "product_supplier_link_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_link_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_override": {
+      "name": "product_supplier_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_override_product_key_product_key_fk": {
+          "name": "product_supplier_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing": {
+      "name": "pairing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_url": {
+          "name": "supplier_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "pairing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'navrhnute'"
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pairing_state_idx": {
+          "name": "pairing_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_confirmed_by_idx": {
+          "name": "pairing_confirmed_by_idx",
+          "columns": [
+            {
+              "expression": "confirmed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_variant_code_variant_code_fk": {
+          "name": "pairing_variant_code_variant_code_fk",
+          "tableFrom": "pairing",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pairing_confirmed_by_users_id_fk": {
+          "name": "pairing_confirmed_by_users_id_fk",
+          "tableFrom": "pairing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pairing_variant_code_unique": {
+          "name": "pairing_variant_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pairing_confirmation_ck": {
+          "name": "pairing_confirmation_ck",
+          "value": "(\"pairing\".\"state\" = 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)\n        OR (\"pairing\".\"state\" != 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NULL AND \"pairing\".\"confirmed_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier": {
+      "name": "supplier",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wholesale_base_url": {
+          "name": "wholesale_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_key": {
+          "name": "adapter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_settings": {
+      "name": "posta_uncollected_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_state": {
+      "name": "posta_uncollected_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notify_count": {
+          "name": "notify_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_state": {
+          "name": "terminal_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_settings": {
+      "name": "order_reminder_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_state": {
+      "name": "order_reminder_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_replacement_link": {
+      "name": "nedostupne_replacement_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nedostupne_replacement_link_variant_idx": {
+          "name": "nedostupne_replacement_link_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_state": {
+      "name": "nedostupne_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "nedostupne_email_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nedostupne_state_order_variant_type_uq": {
+          "name": "nedostupne_state_order_variant_type_uq",
+          "columns": [
+            {
+              "expression": "order_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template_history": {
+      "name": "mail_template_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "mail_template_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_template_history_key_idx": {
+          "name": "mail_template_history_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_template_history_changed_by_user_id_users_id_fk": {
+          "name": "mail_template_history_changed_by_user_id_users_id_fk",
+          "tableFrom": "mail_template_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template": {
+      "name": "mail_template",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail_template_updated_by_user_id_users_id_fk": {
+          "name": "mail_template_updated_by_user_id_users_id_fk",
+          "tableFrom": "mail_template",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_log": {
+      "name": "mail_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "mail_log_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_log_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "mail_log_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_log_created_idx": {
+          "name": "mail_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_log_source_created_idx": {
+          "name": "mail_log_source_created_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_log_actor_user_id_users_id_fk": {
+          "name": "mail_log_actor_user_id_users_id_fk",
+          "tableFrom": "mail_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_stock": {
+      "name": "supplier_stock",
+      "schema": "",
+      "columns": {
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "supplier_availability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "supplier_stock_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "supplier_stock_host_idx": {
+          "name": "supplier_stock_host_idx",
+          "columns": [
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "supplier_stock_avail_idx": {
+          "name": "supplier_stock_avail_idx",
+          "columns": [
+            {
+              "expression": "availability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "supplier_stock_link_size_label_pk": {
+          "name": "supplier_stock_link_size_label_pk",
+          "columns": [
+            "link",
+            "size_label"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_event": {
+      "name": "restock_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_link": {
+          "name": "supplier_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_availability_text": {
+          "name": "supplier_availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "supplier_price": {
+          "name": "supplier_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "restock_event_at_idx": {
+          "name": "restock_event_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "restock_event_variant_idx": {
+          "name": "restock_event_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_settings": {
+      "name": "restock_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shop_product_url": {
+      "name": "shop_product_url",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.theme_color": {
+      "name": "theme_color",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "theme_color_updated_by_user_id_users_id_fk": {
+          "name": "theme_color_updated_by_user_id_users_id_fk",
+          "tableFrom": "theme_color",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upozornenie": {
+      "name": "upozornenie",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "upozornenie_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "upozornenie_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedup_key": {
+          "name": "dedup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postponed_until": {
+          "name": "postponed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seen_at": {
+          "name": "seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "upozornenie_dedup_key_uq": {
+          "name": "upozornenie_dedup_key_uq",
+          "columns": [
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "resolved_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upozornenie_resolved_at_idx": {
+          "name": "upozornenie_resolved_at_idx",
+          "columns": [
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upozornenie_dedup_key_idx": {
+          "name": "upozornenie_dedup_key_idx",
+          "columns": [
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upozornenie_resolved_by_user_id_users_id_fk": {
+          "name": "upozornenie_resolved_by_user_id_users_id_fk",
+          "tableFrom": "upozornenie",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "upozornenie_created_by_user_id_users_id_fk": {
+          "name": "upozornenie_created_by_user_id_users_id_fk",
+          "tableFrom": "upozornenie",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dpd_pickup_request": {
+      "name": "dpd_pickup_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "pickup_date": {
+          "name": "pickup_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "dpd_operation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dpd_shipment": {
+      "name": "dpd_shipment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "dpd_operation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parcel_number": {
+          "name": "parcel_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cod_amount": {
+          "name": "cod_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dpd_shipment_order_uq": {
+          "name": "dpd_shipment_order_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dpd_shipment_order_id_order_id_fk": {
+          "name": "dpd_shipment_order_id_order_id_fk",
+          "tableFrom": "dpd_shipment",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne"
+      ]
+    },
+    "public.pairing_state": {
+      "name": "pairing_state",
+      "schema": "public",
+      "values": [
+        "navrhnute",
+        "potvrdene"
+      ]
+    },
+    "public.nedostupne_email_type": {
+      "name": "nedostupne_email_type",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "alternativa"
+      ]
+    },
+    "public.mail_template_action": {
+      "name": "mail_template_action",
+      "schema": "public",
+      "values": [
+        "save",
+        "reset"
+      ]
+    },
+    "public.mail_log_source": {
+      "name": "mail_log_source",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "posta_uncollected",
+        "order_reminder",
+        "supplier_order",
+        "order_merge"
+      ]
+    },
+    "public.mail_log_status": {
+      "name": "mail_log_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.mail_log_trigger": {
+      "name": "mail_log_trigger",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "manual"
+      ]
+    },
+    "public.supplier_availability": {
+      "name": "supplier_availability",
+      "schema": "public",
+      "values": [
+        "available",
+        "unavailable",
+        "unknown"
+      ]
+    },
+    "public.supplier_stock_source": {
+      "name": "supplier_stock_source",
+      "schema": "public",
+      "values": [
+        "json_ld",
+        "meta",
+        "text",
+        "size_list",
+        "none"
+      ]
+    },
+    "public.upozornenie_source": {
+      "name": "upozornenie_source",
+      "schema": "public",
+      "values": [
+        "vlastne",
+        "appka"
+      ]
+    },
+    "public.upozornenie_type": {
+      "name": "upozornenie_type",
+      "schema": "public",
+      "values": [
+        "vlastna_poznamka",
+        "nevyzdvihnuta_zasielka",
+        "vratenie",
+        "vratena_zasielka",
+        "objednavka_visi"
+      ]
+    },
+    "public.dpd_operation_status": {
+      "name": "dpd_operation_status",
+      "schema": "public",
+      "values": [
+        "submitted",
+        "failed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -309,6 +309,13 @@
       "when": 1786102119346,
       "tag": "0043_lame_miracleman",
       "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "7",
+      "when": 1786139744428,
+      "tag": "0044_lovely_franklin_storm",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema-dpd.ts
+++ b/apps/api/src/db/schema-dpd.ts
@@ -1,0 +1,52 @@
+import { date, numeric, pgEnum, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { orders } from "./schema-orders.js";
+
+// issue 292: appka-VLASTNÝ záznam každého pokusu vytvoriť DPD zásielku
+// (nikdy Shoptetovo pole, nikdy re-importom prepísané) — na rozdiel od
+// `order.package_number` (Shoptetov vlastný, coalesce-refreshed stĺpec),
+// toto je appkina vlastná história pokusov cez `dpdshipper.sk` robota.
+export const dpdOperationStatus = pgEnum("dpd_operation_status", ["submitted", "failed"]);
+
+// Jeden riadok NA OBJEDNÁVKU (`orderId` unique) — opakovaný pokus (retry po
+// zlyhaní) PREPÍŠE ten istý riadok (upsert podľa `orderId`), appka teda vždy
+// vidí LEN posledný pokus pre danú objednávku, nikdy celú históriu pokusov
+// (MVP — netreba viac, `modules/dpd/queries.ts`'s "pripravené na odoslanie"
+// zoznam číta len `status`).
+export const dpdShipments = pgTable(
+  "dpd_shipment",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    orderId: uuid("order_id")
+      .notNull()
+      .references(() => orders.id, { onDelete: "cascade" }),
+    status: dpdOperationStatus("status").notNull(),
+    // Vyplnené len pri `status = 'submitted'` — číslo zásielky prečítané z
+    // portálu po úspešnom založení, appka ho ukáže na obrazovke na
+    // sledovanie.
+    parcelNumber: text("parcel_number"),
+    // Hmotnosť SKUTOČNE odoslaná robotom (obsluha ju mohla v náhľade
+    // upraviť oproti `order.weight`) — appka si ju pamätá kvôli auditu, aj
+    // keď sa pôvodná hodnota na objednávke neskôr zmení.
+    weightKg: numeric("weight_kg", { precision: 10, scale: 2 }).notNull(),
+    // Dobierková suma SKUTOČNE odoslaná robotom, `null` = nebola to dobierka.
+    codAmount: numeric("cod_amount", { precision: 12, scale: 2 }),
+    // Vyplnené len pri `status = 'failed'` — dôvod zlyhania (chyba z
+    // portálu, timeout, nenájdený formulár…).
+    errorMessage: text("error_message"),
+    submittedAt: timestamp("submitted_at", { withTimezone: true }).notNull().defaultNow(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [uniqueIndex("dpd_shipment_order_uq").on(t.orderId)],
+);
+
+// issue 292: "Objednať zvoz na deň" — jednorazový zvoz kuriéra NIE JE
+// viazaný na konkrétnu objednávku (portál ho objednáva na CELÚ zvozovú
+// adresu naraz, `.claude/rules/dpd.md`) — samostatná tabuľka, žiadny FK na
+// `order`.
+export const dpdPickupRequests = pgTable("dpd_pickup_request", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  pickupDate: date("pickup_date").notNull(),
+  status: dpdOperationStatus("status").notNull(),
+  errorMessage: text("error_message"),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+});

--- a/apps/api/src/db/schema-orders.ts
+++ b/apps/api/src/db/schema-orders.ts
@@ -155,6 +155,38 @@ export const orders = pgTable(
     // čaká sa na vrátenie") — vypĺňa sa/maže spolu s `claimMarkedAt` vyššie,
     // nikdy samostatne.
     claimNote: text("claim_note"),
+    // issue 292: doručovacia adresa + hmotnosť + spôsob platby — appka ich
+    // predtým vôbec neukladala (potreba DPD prepravy). Rovnaká rodina ako
+    // `email`/`phone`/`packageNumber`/`shippingCarrierName` (issue 172) —
+    // VŽDY Shoptetovo pole, `ingest.ts` ho pri re-importe OSVIEŽÍ, nikdy
+    // appkou/manažérom vlastnené. Nullable, chýbajúca hodnota = `null`.
+    deliveryFullName: text("delivery_full_name"),
+    deliveryCompany: text("delivery_company"),
+    deliveryStreet: text("delivery_street"),
+    deliveryHouseNumber: text("delivery_house_number"),
+    deliveryCity: text("delivery_city"),
+    deliveryZip: text("delivery_zip"),
+    deliveryCountryName: text("delivery_country_name"),
+    // issue 292: export's `weight` stĺpec (kg), Shoptet-ova desatinná
+    // čiarka — parsuje sa rovnakým `parseDecimalComma` ako `totalPriceWithVat`
+    // vyššie (preto rovnaká `scale: 2` presnosť — `parseDecimalComma` sama
+    // zaokrúhľuje na 2 desatinné miesta, `money.ts`'s `roundToTwoDecimals`).
+    // Väčšina reálnych objednávok má `0` (obchod hmotnosť dôsledne
+    // nezapisuje) — appka preto pri DPD náhľade dopĺňa rozumný predvolený
+    // odhad, keď je `0`/`null` (`modules/dpd/preview.ts`), toto pole nesie
+    // SUROVÚ (možno nulovú) hodnotu z exportu, nikdy dopočítaný odhad.
+    weight: numeric("weight", { precision: 10, scale: 2 }),
+    // issue 292: spôsob platby — Shoptet ho NEMÁ ako samostatný stĺpec
+    // objednávky, ale ako `itemName` na `BILLING*` pseudo-riadku (rovnaký
+    // trik ako `shippingCarrierName` z `SHIPPING*` pseudo-riadku vyššie).
+    // Naživo overené (7.8.2026, 90-dňový export): "Dobierka (hotovosť) +
+    // karta (len SR)" a "V hotovosti" — appka rozpozná dobierku podľa toho,
+    // či reťazec obsahuje "dobierka" (bez ohľadu na veľkosť písmen).
+    paymentMethodName: text("payment_method_name"),
+    // issue 292: export's `priceToPay` stĺpec — suma, ktorú má zákazník
+    // ešte zaplatiť (dobierková suma, keď `paymentMethodName` je dobierka).
+    // Rovnaký `parseDecimalComma` parser ako `totalPriceWithVat`/`weight`.
+    priceToPay: numeric("price_to_pay", { precision: 12, scale: 2 }),
   },
   (t) => [index("order_placed_at_idx").on(t.placedAt)],
 );

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -13,3 +13,4 @@ export * from "./schema-restock.js";
 export * from "./schema-shop-feed.js";
 export * from "./schema-theme-colors.js";
 export * from "./schema-upozornenia.js";
+export * from "./schema-dpd.js";

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -90,6 +90,18 @@ const envSchema = z.object({
   // zdieľané všeobecné `MAIL_BCC`). Chýbajúca = automatizácia NEPOŠLE ani
   // jeden e-mail zákazníkovi (fail-closed).
   ORDER_MERGE_BCC_EMAIL: z.string().email().optional(),
+  // issue 292: prihlasovacie údaje do portálu `dpdshipper.sk` (Playwright
+  // robot na objednávanie prepravy/zvozu) — rovnaké pravidlo ako
+  // `SHOPTET_ADMIN_USER`/`PASSWORD` vyššie, nikdy do repa/commit
+  // správy/logu. Nepovinné: bez nich appka beží ďalej, "Preprava DPD"
+  // obrazovka len ukáže "nenakonfigurované" namiesto tlačidiel na
+  // odoslanie/zvoz.
+  DPD_PORTAL_USER: z.string().min(1).optional(),
+  DPD_PORTAL_PASSWORD: z.string().min(1).optional(),
+  // Prihlasovacia URL portálu — nenesie žiadny tajný `hash`/token, ale
+  // ostáva konfigurovateľná (rovnaký princíp ako `SHOPTET_ADMIN_BASE_URL`),
+  // pre prípad zmeny adresy alebo testovacieho prostredia DPD.
+  DPD_PORTAL_BASE_URL: z.string().url().default("https://www.dpdshipper.sk"),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/apps/api/src/http/app.ts
+++ b/apps/api/src/http/app.ts
@@ -10,6 +10,7 @@ import { login, logout, resolveSession } from "../modules/auth/service.js";
 import type { MailTransport } from "../modules/mail/transport.js";
 import { appVersion } from "../version.js";
 import { registerCatalogRoutes, type RunIngest } from "./catalog-routes.js";
+import { registerDpdRoutes, type DpdRunDeps } from "./dpd-routes.js";
 import { checkLoginRateLimit, clientIp } from "./login-rate-limit.js";
 import { SESSION_COOKIE, requireUser, type AppBindings } from "./middleware.js";
 import { registerOrdersRoutes, type RunOrdersIngest } from "./orders-routes.js";
@@ -85,6 +86,12 @@ export function createApp(
     // administrácie. Voliteľné z rovnakého dôvodu ako ostatné; testy
     // dodajú vlastný zápis a NIKDY sa nedotknú skutočného Shoptetu.
     readonly restock?: RestockRunDeps;
+    // issue 292: "Eshop → Preprava DPD" — prihlasovacie údaje do
+    // `dpdshipper.sk`. Voliteľné z rovnakého dôvodu ako `nedostupne`
+    // vyššie; `config: undefined` (predvolené nižšie) = appka beží ďalej,
+    // len akcie odosielajúce do DPD vrátia 503 "nenakonfigurované" namiesto
+    // tichého zápisu s prázdnymi prihlasovacími údajmi.
+    readonly dpd?: DpdRunDeps;
   },
 ): Hono<AppBindings> {
   const app = new Hono<AppBindings>();
@@ -302,6 +309,10 @@ export function createApp(
   // READ-ONLY pohľady + appkina vlastná reklamácia-značka. Žiadny voliteľný
   // dependency (rovnaký dôvod ako `upozornenia` vyššie).
   registerOrderFlagsRoutes(app, db, options.adminBaseUrl ?? "https://www.forestshop.sk");
+  // issue 292: "Eshop → Preprava DPD" — bez dodanej konfigurácie sa do DPD
+  // NEODOSIELA vôbec (fail-closed, rovnaký princíp ako `restock`/
+  // `nedostupne` vyššie): akcie vrátia 503 "nenakonfigurované".
+  registerDpdRoutes(app, db, options.dpd ?? { config: undefined });
 
   // Musí byť registrovaný AŽ PO všetkých skutočných /api/* trasách vyššie — Hono
   // vyberá presnejšiu zhodu, takže tie majú prednosť a sem sa dostane len to, čo

--- a/apps/api/src/http/dpd-routes.ts
+++ b/apps/api/src/http/dpd-routes.ts
@@ -1,0 +1,138 @@
+import { zValidator } from "@hono/zod-validator";
+import type { Hono } from "hono";
+import { z } from "zod";
+import type { Database } from "../db/client.js";
+import { log } from "../logger.js";
+import { record } from "../modules/audit/service.js";
+import type { DpdPortalConfig } from "../modules/dpd/config.js";
+import { runOrderDpdPickupIsolated } from "../modules/dpd/pickup-playwright.js";
+import { getDpdShipmentPreviews, listDpdShippableOrders } from "../modules/dpd/queries.js";
+import { recordDpdPickupRequest, recordDpdShipmentFailure, recordDpdShipmentSuccess } from "../modules/dpd/record.js";
+import { runCreateDpdShipmentIsolated } from "../modules/dpd/shipment-playwright.js";
+import { requireRole, requireUser, type AppBindings } from "./middleware.js";
+import { requireSameOrigin } from "./origin-check.js";
+
+// HTTP vrstva dodá `db`; prihlasovacie údaje do DPD portálu zostavuje
+// `index.ts` raz pri štarte (rovnaký vzor ako `restock-routes.ts`'s
+// `RestockRunDeps`) — `config: undefined` = appka beží ďalej, len akcie
+// odosielajúce do DPD vrátia 503 "nenakonfigurované".
+export interface DpdRunDeps {
+  readonly config: DpdPortalConfig | undefined;
+}
+
+const orderIdsBody = z.object({
+  orderIds: z.array(z.string().uuid()).min(1).max(50),
+  // Kľúč = `orderId`, hodnota = obsluhou upravená hmotnosť (kg, desatinná
+  // BODKA — appka ju z UI dostáva už normalizovanú, nie Shoptet-ovu čiarku).
+  weightOverrides: z.record(z.string().uuid(), z.string().regex(/^\d+(\.\d{1,2})?$/)).optional(),
+});
+
+const pickupBody = z.object({ pickupDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/) });
+
+function toWeightOverrides(raw: Record<string, string> | undefined): Map<string, string> {
+  return new Map(Object.entries(raw ?? {}));
+}
+
+const NOT_CONFIGURED_MESSAGE = "DPD preprava nie je nakonfigurovaná (chýba DPD_PORTAL_USER/DPD_PORTAL_PASSWORD)";
+
+export function registerDpdRoutes(app: Hono<AppBindings>, db: Database, deps: DpdRunDeps): void {
+  app.get("/api/dpd/orders", requireUser(db), async (c) => {
+    const orders = await listDpdShippableOrders(db);
+    return c.json({ configured: deps.config !== undefined, orders });
+  });
+
+  app.post("/api/dpd/preview", requireUser(db), zValidator("json", orderIdsBody), async (c) => {
+    const { orderIds, weightOverrides } = c.req.valid("json");
+    const previews = await getDpdShipmentPreviews(db, orderIds, toWeightOverrides(weightOverrides));
+    return c.json({ previews });
+  });
+
+  // issue 292: appka NIKDY neodošle objednávku, ktorej adresa je neúplná —
+  // taký riadok sa vráti ako `skipped`, nikdy sa neposiela robotovi (ten by
+  // len narazil na prázdne polia). Skutočné odoslanie je vždy per-objednávka
+  // (nie jeden hromadný beh) — jedno zlyhanie NESMIE zablokovať úspech
+  // ostatných, rovnaká disciplína ako `shoptet-writeback`'s per-objednávkový
+  // zápis poznámky (`.claude/rules/orders.md`).
+  app.post(
+    "/api/dpd/shipments",
+    requireSameOrigin(),
+    requireUser(db),
+    requireRole("admin", "manazer"),
+    zValidator("json", orderIdsBody),
+    async (c) => {
+      const { config } = deps;
+      if (config === undefined) return c.json({ error: NOT_CONFIGURED_MESSAGE }, 503);
+
+      const { orderIds, weightOverrides } = c.req.valid("json");
+      const previews = await getDpdShipmentPreviews(db, orderIds, toWeightOverrides(weightOverrides));
+      const user = c.get("user");
+
+      const results = await Promise.all(
+        previews.map(async (shipment) => {
+          if (!shipment.addressComplete) {
+            return { orderId: shipment.orderId, ok: false as const, error: "Chýba doručovacia adresa" };
+          }
+          try {
+            const outcome = await runCreateDpdShipmentIsolated({ config, shipment });
+            const attempt = { orderId: shipment.orderId, weightKg: shipment.weightKg, codAmount: shipment.codAmount };
+            if (outcome.ok && outcome.parcelNumber !== null) {
+              await recordDpdShipmentSuccess(db, attempt, outcome.parcelNumber);
+              await record(db, {
+                at: new Date(),
+                actorUserId: user.userId,
+                action: "dpd.shipment.created",
+                entity: "dpd_shipment",
+                entityId: shipment.orderId,
+                data: { externalOrderId: shipment.externalOrderId, parcelNumber: outcome.parcelNumber },
+              });
+              return { orderId: shipment.orderId, ok: true as const, parcelNumber: outcome.parcelNumber };
+            }
+            const errorDetail = outcome.errorDetail ?? "Neznáma chyba";
+            await recordDpdShipmentFailure(db, attempt, errorDetail);
+            return { orderId: shipment.orderId, ok: false as const, error: errorDetail };
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            log.error({ err: message, externalOrderId: shipment.externalOrderId }, "DPD zásielka: neočakávaná chyba");
+            await recordDpdShipmentFailure(db, { orderId: shipment.orderId, weightKg: shipment.weightKg, codAmount: shipment.codAmount }, message);
+            return { orderId: shipment.orderId, ok: false as const, error: message };
+          }
+        }),
+      );
+      return c.json({ results });
+    },
+  );
+
+  app.post(
+    "/api/dpd/pickup-orders",
+    requireSameOrigin(),
+    requireUser(db),
+    requireRole("admin", "manazer"),
+    zValidator("json", pickupBody),
+    async (c) => {
+      const { config } = deps;
+      if (config === undefined) return c.json({ error: NOT_CONFIGURED_MESSAGE }, 503);
+
+      const { pickupDate } = c.req.valid("json");
+      const user = c.get("user");
+      let outcome: { readonly ok: boolean; readonly errorDetail: string | null };
+      try {
+        outcome = await runOrderDpdPickupIsolated({ config, pickupDate });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        outcome = { ok: false, errorDetail: message };
+      }
+      await recordDpdPickupRequest(db, { pickupDate, status: outcome.ok ? "submitted" : "failed", errorMessage: outcome.errorDetail });
+      if (outcome.ok) {
+        await record(db, {
+          at: new Date(),
+          actorUserId: user.userId,
+          action: "dpd.pickup.requested",
+          entity: "dpd_pickup_request",
+          data: { pickupDate },
+        });
+      }
+      log.info({ actorUserId: user.userId, pickupDate, ok: outcome.ok }, "DPD zvoz: pokus");
+      return c.json({ ok: outcome.ok, error: outcome.errorDetail });
+    },
+  );
+}

--- a/apps/api/src/http/dpd-routes.ts
+++ b/apps/api/src/http/dpd-routes.ts
@@ -51,7 +51,7 @@ export function registerDpdRoutes(app: Hono<AppBindings>, db: Database, deps: Dp
     return c.json({ configured: deps.config !== undefined, orders });
   });
 
-  app.post("/api/dpd/preview", requireUser(db), zValidator("json", orderIdsBody), async (c) => {
+  app.post("/api/dpd/preview", requireSameOrigin(), requireUser(db), zValidator("json", orderIdsBody), async (c) => {
     const { orderIds, weightOverrides } = c.req.valid("json");
     const previews = await getDpdShipmentPreviews(db, orderIds, toWeightOverrides(weightOverrides));
     return c.json({ previews });

--- a/apps/api/src/http/dpd-routes.ts
+++ b/apps/api/src/http/dpd-routes.ts
@@ -5,9 +5,11 @@ import type { Database } from "../db/client.js";
 import { log } from "../logger.js";
 import { record } from "../modules/audit/service.js";
 import type { DpdPortalConfig } from "../modules/dpd/config.js";
+import type { OrderDpdPickupOutcome, RunOrderDpdPickupOptions } from "../modules/dpd/pickup-playwright.js";
 import { runOrderDpdPickupIsolated } from "../modules/dpd/pickup-playwright.js";
 import { getDpdShipmentPreviews, listDpdShippableOrders } from "../modules/dpd/queries.js";
 import { recordDpdPickupRequest, recordDpdShipmentFailure, recordDpdShipmentSuccess } from "../modules/dpd/record.js";
+import type { CreateDpdShipmentOutcome, RunCreateDpdShipmentOptions } from "../modules/dpd/shipment-playwright.js";
 import { runCreateDpdShipmentIsolated } from "../modules/dpd/shipment-playwright.js";
 import { requireRole, requireUser, type AppBindings } from "./middleware.js";
 import { requireSameOrigin } from "./origin-check.js";
@@ -15,9 +17,15 @@ import { requireSameOrigin } from "./origin-check.js";
 // HTTP vrstva dodá `db`; prihlasovacie údaje do DPD portálu zostavuje
 // `index.ts` raz pri štarte (rovnaký vzor ako `restock-routes.ts`'s
 // `RestockRunDeps`) — `config: undefined` = appka beží ďalej, len akcie
-// odosielajúce do DPD vrátia 503 "nenakonfigurované".
+// odosielajúce do DPD vrátia 503 "nenakonfigurované". `createShipment`/
+// `orderPickup` sú INJEKTOVANÉ (predvolene skutočný izolovaný Playwright
+// robot) presne z rovnakého dôvodu ako `postaUncollected.trackingClient`/
+// `nedostupne.mailTransport` — testy nahradia falošnou implementáciou a
+// NIKDY sa nedotknú reálneho DPD účtu ani nespustia skutočný Chromium.
 export interface DpdRunDeps {
   readonly config: DpdPortalConfig | undefined;
+  readonly createShipment?: (options: RunCreateDpdShipmentOptions) => Promise<CreateDpdShipmentOutcome>;
+  readonly orderPickup?: (options: RunOrderDpdPickupOptions) => Promise<OrderDpdPickupOutcome>;
 }
 
 const orderIdsBody = z.object({
@@ -36,6 +44,8 @@ function toWeightOverrides(raw: Record<string, string> | undefined): Map<string,
 const NOT_CONFIGURED_MESSAGE = "DPD preprava nie je nakonfigurovaná (chýba DPD_PORTAL_USER/DPD_PORTAL_PASSWORD)";
 
 export function registerDpdRoutes(app: Hono<AppBindings>, db: Database, deps: DpdRunDeps): void {
+  const createShipment = deps.createShipment ?? runCreateDpdShipmentIsolated;
+  const orderPickup = deps.orderPickup ?? runOrderDpdPickupIsolated;
   app.get("/api/dpd/orders", requireUser(db), async (c) => {
     const orders = await listDpdShippableOrders(db);
     return c.json({ configured: deps.config !== undefined, orders });
@@ -73,7 +83,7 @@ export function registerDpdRoutes(app: Hono<AppBindings>, db: Database, deps: Dp
             return { orderId: shipment.orderId, ok: false as const, error: "Chýba doručovacia adresa" };
           }
           try {
-            const outcome = await runCreateDpdShipmentIsolated({ config, shipment });
+            const outcome = await createShipment({ config, shipment });
             const attempt = { orderId: shipment.orderId, weightKg: shipment.weightKg, codAmount: shipment.codAmount };
             if (outcome.ok && outcome.parcelNumber !== null) {
               await recordDpdShipmentSuccess(db, attempt, outcome.parcelNumber);
@@ -116,7 +126,7 @@ export function registerDpdRoutes(app: Hono<AppBindings>, db: Database, deps: Dp
       const user = c.get("user");
       let outcome: { readonly ok: boolean; readonly errorDetail: string | null };
       try {
-        outcome = await runOrderDpdPickupIsolated({ config, pickupDate });
+        outcome = await orderPickup({ config, pickupDate });
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         outcome = { ok: false, errorDetail: message };

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -39,6 +39,7 @@ import { runSupplierStock } from "./modules/supplier-stock/run.js";
 import { runRestock } from "./modules/restock/run.js";
 import { startScheduler } from "./modules/scheduler/scheduler.js";
 import { orderNoteWritebackConfigFromBaseUrl, shoptetImportConfigFromBaseUrl } from "./modules/shoptet-writeback/config.js";
+import { dpdPortalConfigFromBaseUrl } from "./modules/dpd/config.js";
 import { runOrderNoteWritebackJob } from "./modules/shoptet-writeback/run-order-note-writeback.js";
 import { runShoptetWriteback } from "./modules/shoptet-writeback/run-writeback.js";
 import { createShutdownHandler } from "./shutdown.js";
@@ -217,6 +218,16 @@ const orderMergeDeps = {
   bccEmail: env.ORDER_MERGE_BCC_EMAIL,
 };
 
+// issue 292: "Eshop → Preprava DPD" — vlastné prihlasovacie údaje
+// (`DPD_PORTAL_USER`/`PASSWORD`), nezdieľané so Shoptet-om.
+// `config: undefined` = appka beží ďalej, akcie odosielajúce do DPD vrátia
+// 503 "nenakonfigurované" (fail-closed, `http/dpd-routes.ts`).
+const dpdUser = env.DPD_PORTAL_USER;
+const dpdPassword = env.DPD_PORTAL_PASSWORD;
+const dpdDeps = {
+  config: dpdUser === undefined || dpdPassword === undefined ? undefined : dpdPortalConfigFromBaseUrl(env.DPD_PORTAL_BASE_URL, dpdUser, dpdPassword),
+};
+
 const app = createApp(db, {
   cookieSecure: env.SESSION_COOKIE_SECURE,
   ...(runIngest === undefined ? {} : { runIngest }),
@@ -228,6 +239,7 @@ const app = createApp(db, {
   nedostupne: nedostupneDeps,
   orderMerge: orderMergeDeps,
   fetchSupplierPage,
+  dpd: dpdDeps,
 });
 
 // F2 (#12/#3) + F3 (#22/#28): nočný import katalógu/objednávok, mazanie

--- a/apps/api/src/modules/dpd/config.ts
+++ b/apps/api/src/modules/dpd/config.ts
@@ -1,0 +1,25 @@
+/**
+ * issue 292: prihlasovacie/cieľové adresy portálu `dpdshipper.sk` — rovnaký
+ * vzor ako `shoptet-writeback/config.ts`. `baseUrl` bez koncového lomítka.
+ */
+export interface DpdPortalConfig {
+  readonly loginUrl: string;
+  readonly newShipmentUrl: string;
+  readonly user: string;
+  readonly password: string;
+}
+
+export function dpdPortalConfigFromBaseUrl(baseUrl: string, user: string, password: string): DpdPortalConfig {
+  const base = baseUrl.replace(/\/+$/, "");
+  return {
+    loginUrl: `${base}/login`,
+    // "Pridať objednávku" — naživo overené (7.8.2026, read-only mapovanie,
+    // `.claude/rules/dpd.md`): jediný formulár na založenie JEDNEJ zásielky
+    // (Importné profily na hromadný súborový import boli na účte prázdne,
+    // presný formát sa nedal zistiť bez zápisu, ktorý bezpečnostné pravidlo
+    // tiketu zakazuje).
+    newShipmentUrl: `${base}/shipments/0`,
+    user,
+    password,
+  };
+}

--- a/apps/api/src/modules/dpd/login.ts
+++ b/apps/api/src/modules/dpd/login.ts
@@ -1,0 +1,29 @@
+import type { Page } from "playwright";
+import type { DpdPortalConfig } from "./config.js";
+
+/**
+ * Prihlásenie do `dpdshipper.sk` — naživo overené (7.8.2026, read-only
+ * mapovanie, `dpd-mapuj.mjs` v `.claude/rules/dpd.md`'s prieskume): jedno
+ * meno + jedno heslo, žiadna CAPTCHA, žiadne 2FA, žiadna ochrana proti
+ * robotom. Úspešné prihlásenie skončí na `/shipments` — na rozdiel od
+ * Shoptet admina (kde úspech aj zlyhanie zdieľajú tú istú URL,
+ * `shoptet-writeback/admin-login.ts`) tu je presmerovanie spoľahlivý signál,
+ * ale appka NAVYŠE overuje, že prihlasovacie pole zmizlo (rovnaká dvojitá
+ * istota ako Shoptet — nikdy sa nespolieha len na URL substring).
+ */
+export async function loginToDpdPortal(page: Page, config: DpdPortalConfig): Promise<void> {
+  await page.goto(config.loginUrl, { waitUntil: "domcontentloaded" });
+  await page.locator("input[name=loginName], #loginName").first().fill(config.user);
+  await page.locator("input[type=password]").first().fill(config.password);
+  await Promise.all([
+    page.waitForLoadState("networkidle").catch(() => {
+      // networkidle nemusí nikdy nastať (dlho bežiace polling volania na
+      // portáli) — appka sa spolieha na explicitné overenie nižšie, nie na
+      // toto čakanie samotné.
+    }),
+    page.locator("button:has-text('Prihlásiť'), input[type=submit]").first().click(),
+  ]);
+  if ((await page.locator("input[name=loginName], #loginName").count()) > 0) {
+    throw new Error("Prihlásenie do DPD portálu zlyhalo (prihlasovací formulár stále viditeľný) — over DPD_PORTAL_USER/PASSWORD");
+  }
+}

--- a/apps/api/src/modules/dpd/pickup-playwright.ts
+++ b/apps/api/src/modules/dpd/pickup-playwright.ts
@@ -1,0 +1,68 @@
+import { chromium, type Browser } from "playwright";
+import { log } from "../../logger.js";
+import { resolveChromiumExecutablePath } from "../shoptet-writeback/playwright-import.js";
+import { runInChildProcess } from "../shoptet-writeback/child-runner.js";
+import { loginToDpdPortal } from "./login.js";
+import type { DpdPortalConfig } from "./config.js";
+
+// issue 292: "Objednávky zvozu" (`/pickup-orders`) — naživo overené
+// (7.8.2026): stránka má "Pravidelný zvoz" + "Jednorazové zvozy" so `+`
+// tlačidlom na pridanie NOVÉHO jednorazového zvozu. Samotný formulár, ktorý
+// sa po kliku na `+` otvorí, NIE JE naživo domapovaný (rovnaký dôvod ako
+// `shipment-playwright.ts`'s `fillShipmentFields` — čaká sa na
+// `DPD_PORTAL_USER`/`PASSWORD`). Rovnaká disciplína: zlyhaj NAHLAS, nikdy
+// tichy odošli vymyslené polia.
+const PICKUP_ORDERS_PATH = "/pickup-orders";
+
+function fillPickupForm(): never {
+  throw new Error(
+    "DPD formulár jednorazového zvozu (/pickup-orders) ešte nie je naživo domapovaný (čaká sa na DPD_PORTAL_USER/PASSWORD) — " +
+      "zvoz sa neobjednal. Pozri issue 292, fillPickupForm v pickup-playwright.ts.",
+  );
+}
+
+export interface RunOrderDpdPickupOptions {
+  readonly config: DpdPortalConfig;
+  readonly pickupDate: string;
+  readonly headless?: boolean;
+  readonly executablePath?: string;
+}
+
+export interface OrderDpdPickupOutcome {
+  readonly ok: boolean;
+  readonly errorDetail: string | null;
+}
+
+export async function runOrderDpdPickup(options: RunOrderDpdPickupOptions): Promise<OrderDpdPickupOutcome> {
+  const executablePath = options.executablePath ?? resolveChromiumExecutablePath();
+  let browser: Browser | undefined;
+  try {
+    browser = await chromium.launch({
+      headless: options.headless ?? true,
+      ...(executablePath === undefined ? {} : { executablePath }),
+      args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage", "--disable-gpu"],
+    });
+    const context = await browser.newContext({ acceptDownloads: false });
+    const page = await context.newPage();
+
+    await loginToDpdPortal(page, options.config);
+    await page.goto(`${new URL(options.config.loginUrl).origin}${PICKUP_ORDERS_PATH}`, { waitUntil: "domcontentloaded" });
+    await page.waitForLoadState("networkidle");
+
+    fillPickupForm();
+
+    return { ok: false, errorDetail: "unreachable" };
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.error({ err: message, pickupDate: options.pickupDate }, "DPD zvoz: pokus zlyhal");
+    return { ok: false, errorDetail: message };
+  } finally {
+    await browser?.close();
+  }
+}
+
+export type OrderPickupWorkerInput = RunOrderDpdPickupOptions;
+
+export function runOrderDpdPickupIsolated(options: RunOrderDpdPickupOptions): Promise<OrderDpdPickupOutcome> {
+  return runInChildProcess(new URL("./pickup-worker.js", import.meta.url), options);
+}

--- a/apps/api/src/modules/dpd/pickup-worker.ts
+++ b/apps/api/src/modules/dpd/pickup-worker.ts
@@ -1,0 +1,23 @@
+import { runOrderDpdPickup, type OrderDpdPickupOutcome, type OrderPickupWorkerInput } from "./pickup-playwright.js";
+
+/** Issue 292: rovnaký vzor ako `shipment-worker.ts` — DIEŤA proces vstupný
+ * bod pre `runOrderDpdPickupIsolated`. */
+function sendAndExit(message: { readonly ok: boolean; readonly result?: OrderDpdPickupOutcome; readonly error?: string }): void {
+  const exitCode = message.ok ? 0 : 1;
+  if (process.send === undefined) {
+    process.exit(exitCode);
+    return;
+  }
+  process.send(message, () => process.exit(exitCode));
+}
+
+process.once("message", (input: OrderPickupWorkerInput) => {
+  runOrderDpdPickup(input)
+    .then((result: OrderDpdPickupOutcome) => {
+      sendAndExit({ ok: true, result });
+    })
+    .catch((error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      sendAndExit({ ok: false, error: message });
+    });
+});

--- a/apps/api/src/modules/dpd/preview.test.ts
+++ b/apps/api/src/modules/dpd/preview.test.ts
@@ -76,6 +76,7 @@ describe("buildDpdShipmentPreview", () => {
 
   it("addressComplete je false, keď chýba ktorékoľvek z povinných adresných polí", () => {
     expect(buildDpdShipmentPreview(order({ deliveryStreet: null })).addressComplete).toBe(false);
+    expect(buildDpdShipmentPreview(order({ deliveryHouseNumber: null })).addressComplete).toBe(false);
     expect(buildDpdShipmentPreview(order({ deliveryCity: "" })).addressComplete).toBe(false);
     expect(buildDpdShipmentPreview(order({ deliveryZip: null })).addressComplete).toBe(false);
     expect(buildDpdShipmentPreview(order({ deliveryCountryName: null })).addressComplete).toBe(false);

--- a/apps/api/src/modules/dpd/preview.test.ts
+++ b/apps/api/src/modules/dpd/preview.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { buildDpdShipmentPreview, DEFAULT_PARCEL_WEIGHT_KG, type DpdOrderSource } from "./preview.js";
+
+function order(overrides: Partial<DpdOrderSource> = {}): DpdOrderSource {
+  return {
+    id: "order-1",
+    externalOrderId: "20300001",
+    customerName: "Ján Novák",
+    phone: "+421900123456",
+    deliveryFullName: "Ján Novák",
+    deliveryCompany: null,
+    deliveryStreet: "Hlavná",
+    deliveryHouseNumber: "12",
+    deliveryCity: "Poprad",
+    deliveryZip: "05801",
+    deliveryCountryName: "Slovensko",
+    weight: "1.50",
+    paymentMethodName: "Dobierka (hotovosť) + karta (len SR)",
+    priceToPay: "32.50",
+    totalPriceWithVat: "32.50",
+    ...overrides,
+  };
+}
+
+describe("buildDpdShipmentPreview", () => {
+  it("skladá príjemcu z uloženej doručovacej adresy", () => {
+    const preview = buildDpdShipmentPreview(order());
+    expect(preview).toMatchObject({
+      orderId: "order-1",
+      externalOrderId: "20300001",
+      recipientName: "Ján Novák",
+      street: "Hlavná",
+      houseNumber: "12",
+      city: "Poprad",
+      zip: "05801",
+      countryName: "Slovensko",
+      addressComplete: true,
+      weightKg: "1.50",
+      isCod: true,
+      codAmount: "32.50",
+    });
+  });
+
+  it("meno príjemcu padá na customerName, keď deliveryFullName chýba", () => {
+    const preview = buildDpdShipmentPreview(order({ deliveryFullName: null, customerName: "Fakturačné Meno" }));
+    expect(preview.recipientName).toBe("Fakturačné Meno");
+  });
+
+  it("dopĺňa predvolenú hmotnosť, keď je uložená hmotnosť null alebo 0", () => {
+    expect(buildDpdShipmentPreview(order({ weight: null })).weightKg).toBe(DEFAULT_PARCEL_WEIGHT_KG);
+    expect(buildDpdShipmentPreview(order({ weight: "0" })).weightKg).toBe(DEFAULT_PARCEL_WEIGHT_KG);
+    expect(buildDpdShipmentPreview(order({ weight: "0.00" })).weightKg).toBe(DEFAULT_PARCEL_WEIGHT_KG);
+  });
+
+  it("obsluhou zadaný weightKgOverride vyhráva nad uloženou aj predvolenou hodnotou", () => {
+    expect(buildDpdShipmentPreview(order(), "2.75").weightKg).toBe("2.75");
+    expect(buildDpdShipmentPreview(order({ weight: null }), "3.00").weightKg).toBe("3.00");
+  });
+
+  it('rozpozná dobierku podľa "dobierka" v názve platby, case-insensitive', () => {
+    expect(buildDpdShipmentPreview(order({ paymentMethodName: "DOBIERKA (hotovosť)" })).isCod).toBe(true);
+    expect(buildDpdShipmentPreview(order({ paymentMethodName: "Platba kartou vopred" })).isCod).toBe(false);
+    expect(buildDpdShipmentPreview(order({ paymentMethodName: null })).isCod).toBe(false);
+  });
+
+  it("nedobierková objednávka nemá codAmount, aj keď priceToPay existuje", () => {
+    const preview = buildDpdShipmentPreview(order({ paymentMethodName: "Platba kartou vopred", priceToPay: "10.00" }));
+    expect(preview.isCod).toBe(false);
+    expect(preview.codAmount).toBeNull();
+  });
+
+  it("codAmount padá na totalPriceWithVat, keď priceToPay chýba", () => {
+    const preview = buildDpdShipmentPreview(order({ priceToPay: null, totalPriceWithVat: "40.00" }));
+    expect(preview.codAmount).toBe("40.00");
+  });
+
+  it("addressComplete je false, keď chýba ktorékoľvek z povinných adresných polí", () => {
+    expect(buildDpdShipmentPreview(order({ deliveryStreet: null })).addressComplete).toBe(false);
+    expect(buildDpdShipmentPreview(order({ deliveryCity: "" })).addressComplete).toBe(false);
+    expect(buildDpdShipmentPreview(order({ deliveryZip: null })).addressComplete).toBe(false);
+    expect(buildDpdShipmentPreview(order({ deliveryCountryName: null })).addressComplete).toBe(false);
+  });
+});

--- a/apps/api/src/modules/dpd/preview.ts
+++ b/apps/api/src/modules/dpd/preview.ts
@@ -74,8 +74,15 @@ export function buildDpdShipmentPreview(order: DpdOrderSource, weightKgOverride?
   const isCod = order.paymentMethodName !== null && COD_PAYMENT_NAME_RE.test(order.paymentMethodName);
   const codAmount = isCod ? (order.priceToPay ?? order.totalPriceWithVat) : null;
   const weightKg = weightKgOverride ?? (isUsableWeight(order.weight) ? (order.weight as string) : DEFAULT_PARCEL_WEIGHT_KG);
+  // issue 292 review finding: súpisné/orientačné číslo je súčasťou adresy,
+  // ktorú DPD potrebuje presne rovnako ako ulicu — objednávka bez neho nie
+  // je "úplná adresa", aj keď ulica/mesto/PSČ/krajina sú vyplnené.
   const addressComplete =
-    nonEmpty(order.deliveryStreet) && nonEmpty(order.deliveryCity) && nonEmpty(order.deliveryZip) && nonEmpty(order.deliveryCountryName);
+    nonEmpty(order.deliveryStreet) &&
+    nonEmpty(order.deliveryHouseNumber) &&
+    nonEmpty(order.deliveryCity) &&
+    nonEmpty(order.deliveryZip) &&
+    nonEmpty(order.deliveryCountryName);
 
   return {
     orderId: order.id,

--- a/apps/api/src/modules/dpd/preview.ts
+++ b/apps/api/src/modules/dpd/preview.ts
@@ -1,0 +1,96 @@
+/**
+ * issue 292: deterministický náhľad DPD zásielky priamo z uložených
+ * objednávkových polí — ŽIADNE AI dohady (rovnaká disciplína ako
+ * `.claude/rules/supplier-stock.md`/`restock-links.md`), obsluha si náhľad
+ * môže pred odoslaním upraviť (hmotnosť), ale appka sama nič nehádaje.
+ */
+
+// Väčšina reálnych objednávok má `weight = 0` (obchod hmotnosť dôsledne
+// nezapisuje, naživo overené na 90-dňovom exporte 7.8.2026) — appka preto
+// dopĺňa tento rozumný predvolený odhad namiesto odoslania nezmyselnej
+// nulovej hmotnosti portálu. Obsluha ho v náhľade môže pred odoslaním
+// prepísať (`ShipmentConfirmInput.weightKgOverride`).
+export const DEFAULT_PARCEL_WEIGHT_KG = "1.00";
+
+// Naživo overené (7.8.2026, 90-dňový export): obe reálne používané spôsoby
+// platby ("Dobierka (hotovosť) + karta (len SR)", "V hotovosti") obsahujú
+// "hotovosť"/"dobierka" — appka rozpozná dobierku podľa toho, či názov
+// platby obsahuje "dobierka" (bez ohľadu na veľkosť písmen). `paid`/
+// `amountPaid` stĺpce sú v reálnom exporte takmer vždy nespoľahlivé/prázdne
+// (`.claude/rules/dpd.md`), preto sa NEPOUŽÍVAJÚ ako zdroj tohto rozhodnutia.
+const COD_PAYMENT_NAME_RE = /dobierka/i;
+
+export interface DpdOrderSource {
+  readonly id: string;
+  readonly externalOrderId: string;
+  readonly customerName: string;
+  readonly phone: string | null;
+  readonly deliveryFullName: string | null;
+  readonly deliveryCompany: string | null;
+  readonly deliveryStreet: string | null;
+  readonly deliveryHouseNumber: string | null;
+  readonly deliveryCity: string | null;
+  readonly deliveryZip: string | null;
+  readonly deliveryCountryName: string | null;
+  readonly weight: string | null;
+  readonly paymentMethodName: string | null;
+  readonly priceToPay: string | null;
+  readonly totalPriceWithVat: string | null;
+}
+
+export interface DpdShipmentPreview {
+  readonly orderId: string;
+  readonly externalOrderId: string;
+  readonly recipientName: string;
+  readonly recipientCompany: string | null;
+  readonly recipientPhone: string | null;
+  readonly street: string | null;
+  readonly houseNumber: string | null;
+  readonly city: string | null;
+  readonly zip: string | null;
+  readonly countryName: string | null;
+  // `false` = appka nemá dosť adresy na založenie zásielky (obsluha musí
+  // adresu doplniť v Shoptete a počkať na ďalší import) — appka sama adresu
+  // nikdy nedopĺňa/nehádaje.
+  readonly addressComplete: boolean;
+  readonly weightKg: string;
+  readonly isCod: boolean;
+  readonly codAmount: string | null;
+}
+
+function nonEmpty(value: string | null): boolean {
+  return value !== null && value.trim() !== "";
+}
+
+/** `true`, keď je uložená hmotnosť chýbajúca ALEBO nulová — obe znamenajú
+ * "appka reálnu hmotnosť nepozná", nie "balík naozaj váži 0". */
+function isUsableWeight(raw: string | null): boolean {
+  if (raw === null) return false;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0;
+}
+
+export function buildDpdShipmentPreview(order: DpdOrderSource, weightKgOverride?: string): DpdShipmentPreview {
+  const isCod = order.paymentMethodName !== null && COD_PAYMENT_NAME_RE.test(order.paymentMethodName);
+  const codAmount = isCod ? (order.priceToPay ?? order.totalPriceWithVat) : null;
+  const weightKg = weightKgOverride ?? (isUsableWeight(order.weight) ? (order.weight as string) : DEFAULT_PARCEL_WEIGHT_KG);
+  const addressComplete =
+    nonEmpty(order.deliveryStreet) && nonEmpty(order.deliveryCity) && nonEmpty(order.deliveryZip) && nonEmpty(order.deliveryCountryName);
+
+  return {
+    orderId: order.id,
+    externalOrderId: order.externalOrderId,
+    recipientName: order.deliveryFullName ?? order.customerName,
+    recipientCompany: order.deliveryCompany,
+    recipientPhone: order.phone,
+    street: order.deliveryStreet,
+    houseNumber: order.deliveryHouseNumber,
+    city: order.deliveryCity,
+    zip: order.deliveryZip,
+    countryName: order.deliveryCountryName,
+    addressComplete,
+    weightKg,
+    isCod,
+    codAmount,
+  };
+}

--- a/apps/api/src/modules/dpd/queries.ts
+++ b/apps/api/src/modules/dpd/queries.ts
@@ -1,0 +1,90 @@
+import { and, desc, eq, inArray, isNull, ne, or } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { dpdShipments, orders } from "../../db/schema.js";
+import { buildDpdShipmentPreview, type DpdOrderSource, type DpdShipmentPreview } from "./preview.js";
+
+// issue 292: "pripravené na odoslanie" = objednávka BEZ appka-vlastného
+// úspešného `dpd_shipment` záznamu (appka teda ešte túto objednávku cez DPD
+// neodoslala) A BEZ Shoptet-ovho vlastného `package_number` (obchod ju
+// mohol odoslať aj mimo tejto appky). Appka zámerne NEFILTRUJE podľa
+// Shoptet `status_name` — nemá spoľahlivý zoznam stavov "zabalené, čaká na
+// kuriéra" (na rozdiel od "Na objednanie"'s `order_open_status`, ktorý rieši
+// INÝ problém — dodávateľské objednávanie, nie expedíciu). Obsluha si sama
+// vyberie, ktoré reálne zabalené objednávky odošle (`.claude/rules/dpd.md`).
+const SELECT_COLUMNS = {
+  id: orders.id,
+  externalOrderId: orders.externalOrderId,
+  customerName: orders.customerName,
+  placedAt: orders.placedAt,
+  phone: orders.phone,
+  deliveryFullName: orders.deliveryFullName,
+  deliveryCompany: orders.deliveryCompany,
+  deliveryStreet: orders.deliveryStreet,
+  deliveryHouseNumber: orders.deliveryHouseNumber,
+  deliveryCity: orders.deliveryCity,
+  deliveryZip: orders.deliveryZip,
+  deliveryCountryName: orders.deliveryCountryName,
+  weight: orders.weight,
+  paymentMethodName: orders.paymentMethodName,
+  priceToPay: orders.priceToPay,
+  totalPriceWithVat: orders.totalPriceWithVat,
+} as const;
+
+function toOrderSource(row: {
+  readonly id: string;
+  readonly externalOrderId: string;
+  readonly customerName: string;
+  readonly phone: string | null;
+  readonly deliveryFullName: string | null;
+  readonly deliveryCompany: string | null;
+  readonly deliveryStreet: string | null;
+  readonly deliveryHouseNumber: string | null;
+  readonly deliveryCity: string | null;
+  readonly deliveryZip: string | null;
+  readonly deliveryCountryName: string | null;
+  readonly weight: string | null;
+  readonly paymentMethodName: string | null;
+  readonly priceToPay: string | null;
+  readonly totalPriceWithVat: string | null;
+}): DpdOrderSource {
+  return row;
+}
+
+export interface DpdShippableOrder {
+  readonly placedAt: Date;
+  readonly preview: DpdShipmentPreview;
+  // Predošlý pokus odoslať TÚTO objednávku zlyhal — appka ju ukáže naďalej v
+  // zozname (obsluha ju vie skúsiť odoslať znova), s dôvodom posledného
+  // zlyhania. `null` = ešte sa vôbec neskúšalo.
+  readonly lastFailure: string | null;
+}
+
+export async function listDpdShippableOrders(db: Database): Promise<readonly DpdShippableOrder[]> {
+  const rows = await db
+    .select({ ...SELECT_COLUMNS, shipmentStatus: dpdShipments.status, shipmentError: dpdShipments.errorMessage })
+    .from(orders)
+    .leftJoin(dpdShipments, eq(dpdShipments.orderId, orders.id))
+    .where(and(isNull(orders.packageNumber), or(isNull(dpdShipments.status), ne(dpdShipments.status, "submitted"))))
+    .orderBy(desc(orders.placedAt));
+
+  return rows.map((row) => ({
+    placedAt: row.placedAt,
+    preview: buildDpdShipmentPreview(toOrderSource(row)),
+    lastFailure: row.shipmentStatus === "failed" ? row.shipmentError : null,
+  }));
+}
+
+/** Náhľad pre PRESNE zvolenú množinu objednávok (potvrdzovací krok pred
+ * odoslaním) — appka číta rovnaké stĺpce ako zoznam vyššie, len filtrované
+ * podľa konkrétnych `orderId`. `weightOverrides` = obsluhou upravená
+ * hmotnosť (kľúč `orderId`), keď v náhľade prepísala predvolenú/uloženú
+ * hodnotu. */
+export async function getDpdShipmentPreviews(
+  db: Database,
+  orderIds: readonly string[],
+  weightOverrides: ReadonlyMap<string, string> = new Map(),
+): Promise<readonly DpdShipmentPreview[]> {
+  if (orderIds.length === 0) return [];
+  const rows = await db.select(SELECT_COLUMNS).from(orders).where(inArray(orders.id, [...orderIds]));
+  return rows.map((row) => buildDpdShipmentPreview(toOrderSource(row), weightOverrides.get(row.id)));
+}

--- a/apps/api/src/modules/dpd/record.ts
+++ b/apps/api/src/modules/dpd/record.ts
@@ -1,0 +1,64 @@
+import { eq } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { dpdPickupRequests, dpdShipments } from "../../db/schema.js";
+
+/**
+ * issue 292: appka-vlastný záznam pokusu o vytvorenie DPD zásielky (nikdy
+ * Shoptetovo pole — na rozdiel od `order.package_number`, ktoré ostáva
+ * NEDOTKNUTÉ). Jeden riadok NA OBJEDNÁVKU (`dpdShipments.orderId` unique) —
+ * OPAKOVANÝ pokus (retry po zlyhaní) PREPÍŠE ten istý riadok, appka teda
+ * vždy vidí len POSLEDNÝ pokus, nikdy históriu (`.claude/rules/dpd.md`).
+ */
+export interface DpdShipmentAttemptInput {
+  readonly orderId: string;
+  readonly weightKg: string;
+  readonly codAmount: string | null;
+}
+
+export async function recordDpdShipmentSuccess(db: Database, input: DpdShipmentAttemptInput, parcelNumber: string): Promise<void> {
+  await db
+    .insert(dpdShipments)
+    .values({ orderId: input.orderId, status: "submitted", weightKg: input.weightKg, codAmount: input.codAmount, parcelNumber })
+    .onConflictDoUpdate({
+      target: dpdShipments.orderId,
+      set: {
+        status: "submitted",
+        weightKg: input.weightKg,
+        codAmount: input.codAmount,
+        parcelNumber,
+        errorMessage: null,
+        submittedAt: new Date(),
+      },
+    });
+}
+
+export async function recordDpdShipmentFailure(db: Database, input: DpdShipmentAttemptInput, errorMessage: string): Promise<void> {
+  await db
+    .insert(dpdShipments)
+    .values({ orderId: input.orderId, status: "failed", weightKg: input.weightKg, codAmount: input.codAmount, errorMessage })
+    .onConflictDoUpdate({
+      target: dpdShipments.orderId,
+      set: {
+        status: "failed",
+        weightKg: input.weightKg,
+        codAmount: input.codAmount,
+        errorMessage,
+        submittedAt: new Date(),
+      },
+    });
+}
+
+export async function listDpdShipmentByOrderId(db: Database, orderId: string) {
+  const rows = await db.select().from(dpdShipments).where(eq(dpdShipments.orderId, orderId)).limit(1);
+  return rows[0] ?? null;
+}
+
+/** "Objednať zvoz na deň" — jednorazový zvoz NIE JE viazaný na objednávku
+ * (`.claude/rules/dpd.md`), appka len zaznamená POKUS (žiadny upsert — každý
+ * deň je nezávislá udalosť, na rozdiel od zásielok vyššie). */
+export async function recordDpdPickupRequest(
+  db: Database,
+  input: { readonly pickupDate: string; readonly status: "submitted" | "failed"; readonly errorMessage: string | null },
+): Promise<void> {
+  await db.insert(dpdPickupRequests).values(input);
+}

--- a/apps/api/src/modules/dpd/shipment-playwright.ts
+++ b/apps/api/src/modules/dpd/shipment-playwright.ts
@@ -1,0 +1,94 @@
+import { chromium, type Browser } from "playwright";
+import { log } from "../../logger.js";
+import { resolveChromiumExecutablePath } from "../shoptet-writeback/playwright-import.js";
+import { runInChildProcess } from "../shoptet-writeback/child-runner.js";
+import { loginToDpdPortal } from "./login.js";
+import type { DpdPortalConfig } from "./config.js";
+import type { DpdShipmentPreview } from "./preview.js";
+
+/**
+ * issue 292: Playwright robot na `dpdshipper.sk` — rovnaký izolovaný
+ * dieťa-proces vzor ako `shoptet-writeback` (issue 313, `.claude/rules/
+ * shoptet-writeback.md`: appka's vlastný dlho bežiaci proces nedrží
+ * `.fill()` hodnotu spoľahlivo). Prihlásenie (`login.ts`) je naživo
+ * OVERENÉ (7.8.2026, read-only mapovanie). Navigácia na formulár
+ * (`/shipments/0`) je naživo overená TIEŽ (rovnaké mapovanie).
+ *
+ * **Vyplnenie SAMOTNÝCH POLÍ formulára (`fillShipmentFields` nižšie) NIE JE
+ * naživo domapované** — Importné profily (hromadný súborový import, plán A)
+ * boli na účte prázdne a jediný spôsob zistiť ich formát je ZALOŽIŤ profil,
+ * čo je ZÁPIS a bezpečnostné pravidlo tohto tiketu ho zakazuje; samotný
+ * formulár `/shipments/0` zase vyžaduje prihlásenie, na ktoré appka čaká
+ * (`DPD_PORTAL_USER`/`PASSWORD`, issue 292's komentár). Táto funkcia preto
+ * zlyhá NAHLAS s presným, akčným popisom namiesto TICHÉHO odoslania
+ * vymyslených/nesprávnych polí do formulára — presne rovnaká disciplína ako
+ * `shoptet-writeback/playwright-import.ts`'s `ensureSafeSettings` (radšej
+ * nahlas zlyhať, než odoslať niečo neisté). Prvé použitie po naživo
+ * domapovaní nahradí LEN telo tejto jednej funkcie, zvyšok (prihlásenie,
+ * navigácia, chybové hlásenia, izolovaný dieťa-proces vzor) sa nemení.
+ */
+function fillShipmentFields(): never {
+  throw new Error(
+    "DPD formulár /shipments/0 ešte nie je naživo domapovaný (čaká sa na DPD_PORTAL_USER/PASSWORD) — " +
+      "žiadna zásielka sa neodoslala. Pozri issue 292, fillShipmentFields v shipment-playwright.ts.",
+  );
+}
+
+export interface RunCreateDpdShipmentOptions {
+  readonly config: DpdPortalConfig;
+  readonly shipment: DpdShipmentPreview;
+  readonly headless?: boolean;
+  readonly executablePath?: string;
+}
+
+export interface CreateDpdShipmentOutcome {
+  readonly ok: boolean;
+  readonly parcelNumber: string | null;
+  readonly errorDetail: string | null;
+}
+
+export async function runCreateDpdShipment(options: RunCreateDpdShipmentOptions): Promise<CreateDpdShipmentOutcome> {
+  const executablePath = options.executablePath ?? resolveChromiumExecutablePath();
+  let browser: Browser | undefined;
+  try {
+    browser = await chromium.launch({
+      headless: options.headless ?? true,
+      ...(executablePath === undefined ? {} : { executablePath }),
+      args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage", "--disable-gpu"],
+    });
+    const context = await browser.newContext({ acceptDownloads: false });
+    const page = await context.newPage();
+
+    await loginToDpdPortal(page, options.config);
+    await page.goto(options.config.newShipmentUrl, { waitUntil: "domcontentloaded" });
+    await page.waitForLoadState("networkidle");
+
+    fillShipmentFields();
+
+    // Nedosiahnuteľné, kým `fillShipmentFields` vyššie hádže — ponechané
+    // ako jasný kontrakt pre dokončenie po naživo domapovaní (submit +
+    // čítanie čísla zásielky z výsledkovej stránky, rovnaký princíp ako
+    // `shoptet-writeback/log-attribution.ts`'s `pollForResult`).
+    return { ok: false, parcelNumber: null, errorDetail: "unreachable" };
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.error({ err: message, externalOrderId: options.shipment.externalOrderId }, "DPD zásielka: pokus zlyhal");
+    return { ok: false, parcelNumber: null, errorDetail: message };
+  } finally {
+    await browser?.close();
+  }
+}
+
+/** Cez IPC ide `shipment` ako obyčajný JSON objekt (žiadny `Buffer`, na
+ * rozdiel od `shoptet-writeback/playwright-import.ts`'s CSV) — netreba
+ * base64 kódovanie. */
+export type CreateShipmentWorkerInput = RunCreateDpdShipmentOptions;
+
+/**
+ * Rovnaký zámer ako `shoptet-writeback/playwright-import.ts`'s
+ * `runShoptetImportIsolated` — appka's vlastný bežiaci proces Chromium
+ * NIKDY sám nespúšťa, vždy cez krátko žijúce dieťa (`child-runner.ts`).
+ */
+export function runCreateDpdShipmentIsolated(options: RunCreateDpdShipmentOptions): Promise<CreateDpdShipmentOutcome> {
+  return runInChildProcess(new URL("./shipment-worker.js", import.meta.url), options);
+}

--- a/apps/api/src/modules/dpd/shipment-worker.ts
+++ b/apps/api/src/modules/dpd/shipment-worker.ts
@@ -1,0 +1,27 @@
+import { runCreateDpdShipment, type CreateDpdShipmentOutcome, type CreateShipmentWorkerInput } from "./shipment-playwright.js";
+
+/**
+ * Issue 292: DIEŤA proces vstupný bod pre `runCreateDpdShipmentIsolated`
+ * (`child-runner.ts`, zdieľaný s `shoptet-writeback`) — rovnaký vzor ako
+ * `shoptet-writeback/import-worker.ts`. Nikdy sa nespúšťa priamo, vždy len
+ * cez `fork()` z `child-runner.ts`.
+ */
+function sendAndExit(message: { readonly ok: boolean; readonly result?: CreateDpdShipmentOutcome; readonly error?: string }): void {
+  const exitCode = message.ok ? 0 : 1;
+  if (process.send === undefined) {
+    process.exit(exitCode);
+    return;
+  }
+  process.send(message, () => process.exit(exitCode));
+}
+
+process.once("message", (input: CreateShipmentWorkerInput) => {
+  runCreateDpdShipment(input)
+    .then((result: CreateDpdShipmentOutcome) => {
+      sendAndExit({ ok: true, result });
+    })
+    .catch((error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      sendAndExit({ ok: false, error: message });
+    });
+});

--- a/apps/api/src/modules/orders/ingest.ts
+++ b/apps/api/src/modules/orders/ingest.ts
@@ -358,6 +358,16 @@ export async function ingestOrders(db: Database, options: OrdersIngestOptions): 
                 phone: extra.phone,
                 packageNumber: extra.packageNumber,
                 shippingCarrierName: extra.shippingCarrierName,
+                deliveryFullName: extra.deliveryFullName,
+                deliveryCompany: extra.deliveryCompany,
+                deliveryStreet: extra.deliveryStreet,
+                deliveryHouseNumber: extra.deliveryHouseNumber,
+                deliveryCity: extra.deliveryCity,
+                deliveryZip: extra.deliveryZip,
+                deliveryCountryName: extra.deliveryCountryName,
+                weight: extra.weight,
+                paymentMethodName: extra.paymentMethodName,
+                priceToPay: extra.priceToPay,
               };
             }),
           )
@@ -405,6 +415,20 @@ export async function ingestOrders(db: Database, options: OrdersIngestOptions): 
               phone: sql`coalesce(excluded.phone, "order"."phone")`,
               packageNumber: sql`coalesce(excluded.package_number, "order"."package_number")`,
               shippingCarrierName: sql`coalesce(excluded.shipping_carrier_name, "order"."shipping_carrier_name")`,
+              // issue 292: rovnaká rodina/dôvod ako `email`/`phone`/
+              // `package_number`/`shipping_carrier_name` vyššie — COALESCE
+              // chráni už zistenú doručovaciu adresu/hmotnosť/spôsob platby
+              // pred tichým vynulovaním jedným pokazeným importovým cyklom.
+              deliveryFullName: sql`coalesce(excluded.delivery_full_name, "order"."delivery_full_name")`,
+              deliveryCompany: sql`coalesce(excluded.delivery_company, "order"."delivery_company")`,
+              deliveryStreet: sql`coalesce(excluded.delivery_street, "order"."delivery_street")`,
+              deliveryHouseNumber: sql`coalesce(excluded.delivery_house_number, "order"."delivery_house_number")`,
+              deliveryCity: sql`coalesce(excluded.delivery_city, "order"."delivery_city")`,
+              deliveryZip: sql`coalesce(excluded.delivery_zip, "order"."delivery_zip")`,
+              deliveryCountryName: sql`coalesce(excluded.delivery_country_name, "order"."delivery_country_name")`,
+              weight: sql`coalesce(excluded.weight, "order"."weight")`,
+              paymentMethodName: sql`coalesce(excluded.payment_method_name, "order"."payment_method_name")`,
+              priceToPay: sql`coalesce(excluded.price_to_pay, "order"."price_to_pay")`,
             },
           })
           .returning({ id: orders.id, externalOrderId: orders.externalOrderId });

--- a/apps/api/src/modules/orders/parser-order-extra.test.ts
+++ b/apps/api/src/modules/orders/parser-order-extra.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import { EMPTY_ORDER_LEVEL_EXTRA, extractOrderLevelExtra, mergeOrderLevelExtra } from "./parser.js";
+
+// Vydelené z `parser.test.ts`, aby ani jeden nenarástol cez eslint's
+// `max-lines: 400` (issue 292 pridalo doručovaciu adresu/hmotnosť/spôsob
+// platby k existujúcim issue-172 poliam, `.claude/rules/testing.md`).
+
+// issue 172/292: "Nevyzdvihnuté zásielky"/"DPD preprava" potrebujú
+// email/telefón/číslo zásielky/doručovaciu adresu/hmotnosť/spôsob platby
+// (objednávkové polia) a meno dopravcu (LEN zo SHIPPING pseudo-riadku).
+describe("extractOrderLevelExtra", () => {
+  it("vytiahne email/phone/packageNumber/doručovaciu adresu/hmotnosť z bežného produktového riadku", () => {
+    const extra = extractOrderLevelExtra({
+      code: "20300001",
+      email: "jan@example.sk",
+      phone: "+421900123456",
+      packageNumber: "EF123456789SK",
+      deliveryFullName: "Ján Novák",
+      deliveryCompany: "",
+      deliveryStreet: "Hlavná",
+      deliveryHouseNumber: "12",
+      deliveryCity: "Poprad",
+      deliveryZip: "05801",
+      deliveryCountryName: "Slovensko",
+      weight: "1,5",
+      priceToPay: "32,50",
+      itemCode: "40237/XL",
+      itemName: "Nohavice FOREST 1003",
+    });
+    expect(extra).toEqual({
+      email: "jan@example.sk",
+      phone: "+421900123456",
+      packageNumber: "EF123456789SK",
+      shippingCarrierName: null,
+      deliveryFullName: "Ján Novák",
+      deliveryCompany: null,
+      deliveryStreet: "Hlavná",
+      deliveryHouseNumber: "12",
+      deliveryCity: "Poprad",
+      deliveryZip: "05801",
+      deliveryCountryName: "Slovensko",
+      weight: "1.5",
+      paymentMethodName: null,
+      priceToPay: "32.50",
+    });
+  });
+
+  it("vytiahne meno dopravcu LEN keď itemCode začína SHIPPING (case-insensitive)", () => {
+    const extra = extractOrderLevelExtra({
+      code: "20300001",
+      itemCode: "shipping6",
+      itemName: "Kuriér",
+    });
+    expect(extra.shippingCarrierName).toBe("Kuriér");
+    expect(extra.paymentMethodName).toBeNull();
+  });
+
+  it("vytiahne spôsob platby LEN keď itemCode začína BILLING (case-insensitive)", () => {
+    const extra = extractOrderLevelExtra({
+      code: "20300001",
+      itemCode: "billing10",
+      itemName: "Dobierka (hotovosť) + karta (len SR)",
+    });
+    expect(extra.paymentMethodName).toBe("Dobierka (hotovosť) + karta (len SR)");
+    expect(extra.shippingCarrierName).toBeNull();
+  });
+
+  it("nezoberie itemName ako dopravcu/platbu pri DISCOUNT pseudo-riadku", () => {
+    expect(extractOrderLevelExtra({ itemCode: "DISCOUNT", itemName: "Zľava" }).shippingCarrierName).toBeNull();
+    expect(extractOrderLevelExtra({ itemCode: "DISCOUNT", itemName: "Zľava" }).paymentMethodName).toBeNull();
+  });
+
+  it("prázdne/chýbajúce polia sa mapujú na null, nikdy na prázdny reťazec", () => {
+    expect(extractOrderLevelExtra({})).toEqual(EMPTY_ORDER_LEVEL_EXTRA);
+    expect(extractOrderLevelExtra({ email: "  ", phone: "", weight: "" })).toEqual(EMPTY_ORDER_LEVEL_EXTRA);
+  });
+});
+
+describe("mergeOrderLevelExtra", () => {
+  it("PRVÁ neprázdna hodnota KAŽDÉHO poľa vyhráva nezávisle od ostatných polí", () => {
+    const fromProductRow = extractOrderLevelExtra({
+      email: "jan@example.sk",
+      itemCode: "40237/XL",
+      itemName: "Nohavice",
+    });
+    const fromShippingRow = extractOrderLevelExtra({
+      packageNumber: "EF123456789SK",
+      itemCode: "SHIPPING6",
+      itemName: "Kuriér",
+    });
+    const fromBillingRow = extractOrderLevelExtra({
+      itemCode: "BILLING10",
+      itemName: "Dobierka (hotovosť) + karta (len SR)",
+    });
+    const merged = mergeOrderLevelExtra(
+      mergeOrderLevelExtra(mergeOrderLevelExtra(EMPTY_ORDER_LEVEL_EXTRA, fromProductRow), fromShippingRow),
+      fromBillingRow,
+    );
+    expect(merged).toEqual({
+      email: "jan@example.sk",
+      phone: null,
+      packageNumber: "EF123456789SK",
+      shippingCarrierName: "Kuriér",
+      deliveryFullName: null,
+      deliveryCompany: null,
+      deliveryStreet: null,
+      deliveryHouseNumber: null,
+      deliveryCity: null,
+      deliveryZip: null,
+      deliveryCountryName: null,
+      weight: null,
+      paymentMethodName: "Dobierka (hotovosť) + karta (len SR)",
+      priceToPay: null,
+    });
+  });
+
+  it("neskoršia hodnota NIKDY neprepíše už zistenú (prvá vyhráva, nie posledná)", () => {
+    const first = extractOrderLevelExtra({ email: "prvy@example.sk" });
+    const second = extractOrderLevelExtra({ email: "druhy@example.sk" });
+    expect(mergeOrderLevelExtra(first, second).email).toBe("prvy@example.sk");
+  });
+});

--- a/apps/api/src/modules/orders/parser.test.ts
+++ b/apps/api/src/modules/orders/parser.test.ts
@@ -3,11 +3,8 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
   decodeCp1250,
-  EMPTY_ORDER_LEVEL_EXTRA,
   extractOrderIdsFromXml,
-  extractOrderLevelExtra,
   mapOrderRow,
-  mergeOrderLevelExtra,
   normalizeStatusName,
   parseDelimited,
   parseShopLocalDateTime,
@@ -382,70 +379,3 @@ describe("extractOrderIdsFromXml", () => {
   });
 });
 
-// issue 172: "Nevyzdvihnuté zásielky" potrebuje email/telefón/číslo zásielky
-// (objednávkové polia) a meno dopravcu (LEN zo SHIPPING pseudo-riadku).
-describe("extractOrderLevelExtra", () => {
-  it("vytiahne email/phone/packageNumber z bežného produktového riadku", () => {
-    const extra = extractOrderLevelExtra({
-      code: "20300001",
-      email: "jan@example.sk",
-      phone: "+421900123456",
-      packageNumber: "EF123456789SK",
-      itemCode: "40237/XL",
-      itemName: "Nohavice FOREST 1003",
-    });
-    expect(extra).toEqual({
-      email: "jan@example.sk",
-      phone: "+421900123456",
-      packageNumber: "EF123456789SK",
-      shippingCarrierName: null,
-    });
-  });
-
-  it("vytiahne meno dopravcu LEN keď itemCode začína SHIPPING (case-insensitive)", () => {
-    const extra = extractOrderLevelExtra({
-      code: "20300001",
-      itemCode: "shipping6",
-      itemName: "Kuriér",
-    });
-    expect(extra.shippingCarrierName).toBe("Kuriér");
-  });
-
-  it("nezoberie itemName ako dopravcu pri BILLING/DISCOUNT pseudo-riadku", () => {
-    expect(extractOrderLevelExtra({ itemCode: "BILLING2", itemName: "Dobierka" }).shippingCarrierName).toBeNull();
-    expect(extractOrderLevelExtra({ itemCode: "DISCOUNT", itemName: "Zľava" }).shippingCarrierName).toBeNull();
-  });
-
-  it("prázdne/chýbajúce polia sa mapujú na null, nikdy na prázdny reťazec", () => {
-    expect(extractOrderLevelExtra({})).toEqual(EMPTY_ORDER_LEVEL_EXTRA);
-    expect(extractOrderLevelExtra({ email: "  ", phone: "" })).toEqual(EMPTY_ORDER_LEVEL_EXTRA);
-  });
-});
-
-describe("mergeOrderLevelExtra", () => {
-  it("PRVÁ neprázdna hodnota KAŽDÉHO poľa vyhráva nezávisle od ostatných polí", () => {
-    const fromProductRow = extractOrderLevelExtra({
-      email: "jan@example.sk",
-      itemCode: "40237/XL",
-      itemName: "Nohavice",
-    });
-    const fromShippingRow = extractOrderLevelExtra({
-      packageNumber: "EF123456789SK",
-      itemCode: "SHIPPING6",
-      itemName: "Kuriér",
-    });
-    const merged = mergeOrderLevelExtra(mergeOrderLevelExtra(EMPTY_ORDER_LEVEL_EXTRA, fromProductRow), fromShippingRow);
-    expect(merged).toEqual({
-      email: "jan@example.sk",
-      phone: null,
-      packageNumber: "EF123456789SK",
-      shippingCarrierName: "Kuriér",
-    });
-  });
-
-  it("neskoršia hodnota NIKDY neprepíše už zistenú (prvá vyhráva, nie posledná)", () => {
-    const first = extractOrderLevelExtra({ email: "prvy@example.sk" });
-    const second = extractOrderLevelExtra({ email: "druhy@example.sk" });
-    expect(mergeOrderLevelExtra(first, second).email).toBe("prvy@example.sk");
-  });
-});

--- a/apps/api/src/modules/orders/parser.ts
+++ b/apps/api/src/modules/orders/parser.ts
@@ -231,25 +231,44 @@ export function extractOrderIdsFromXml(xml: string): Map<string, number> {
 // nie celú rodinu (BILLING/DISCOUNT/…).
 const SHIPPING_ITEM_CODE_RE = /^SHIPPING/i;
 
+// issue 292: rovnaký trik ako `SHIPPING_ITEM_CODE_RE` vyššie, ale pre
+// PLATBU — Shoptet nemá samostatný stĺpec "spôsob platby" na objednávke,
+// zapisuje ho ako `itemName` na `BILLING*` pseudo-riadku (naživo overené na
+// reálnom exporte 7.8.2026: "Dobierka (hotovosť) + karta (len SR)"/"V
+// hotovosti").
+const BILLING_ITEM_CODE_RE = /^BILLING/i;
+
 function trimOrNull(value: string | undefined): string | null {
   const trimmed = (value ?? "").trim();
   return trimmed === "" ? null : trimmed;
 }
 
-// issue 172: "Nevyzdvihnuté zásielky" potrebuje `email`/`phone`/
-// `packageNumber` (objednávkové polia, opakované na KAŽDOM riadku exportu
-// vrátane pseudo-položiek) a meno dopravcu (LEN na SHIPPING pseudo-riadku).
-// Zámerne SAMOSTATNÁ funkcia od `mapOrderRow` vyššie — tá zahadzuje CELÝ
-// pseudo-riadok (nemá zmysel ako POLOŽKA objednávky), ale tieto štyri polia
-// sú OBJEDNÁVKOVÉ, nie položkové, a existujú aj na riadkoch, ktoré
-// `mapOrderRow` zahodí. Nikdy nevyhadzuje/neoznamuje issue — chýbajúca
-// hodnota je legitímny, bežný stav (nie každá objednávka má vyplnené
-// telefónne číslo), mapuje sa jednoducho na `null`.
+// issue 172/292: "Nevyzdvihnuté zásielky" a "DPD preprava" potrebujú
+// `email`/`phone`/`packageNumber`/doručovaciu adresu/hmotnosť/spôsob platby
+// — objednávkové polia, opakované na KAŽDOM riadku exportu vrátane
+// pseudo-položiek (doručovacia adresa/hmotnosť/priceToPay), plus meno
+// dopravcu (LEN na SHIPPING pseudo-riadku) a spôsob platby (LEN na BILLING
+// pseudo-riadku). Zámerne SAMOSTATNÁ funkcia od `mapOrderRow` vyššie — tá
+// zahadzuje CELÝ pseudo-riadok (nemá zmysel ako POLOŽKA objednávky), ale
+// tieto polia sú OBJEDNÁVKOVÉ, nie položkové, a existujú aj na riadkoch,
+// ktoré `mapOrderRow` zahodí. Nikdy nevyhadzuje/neoznamuje issue —
+// chýbajúca hodnota je legitímny, bežný stav, mapuje sa jednoducho na
+// `null`.
 export interface OrderLevelExtra {
   readonly email: string | null;
   readonly phone: string | null;
   readonly packageNumber: string | null;
   readonly shippingCarrierName: string | null;
+  readonly deliveryFullName: string | null;
+  readonly deliveryCompany: string | null;
+  readonly deliveryStreet: string | null;
+  readonly deliveryHouseNumber: string | null;
+  readonly deliveryCity: string | null;
+  readonly deliveryZip: string | null;
+  readonly deliveryCountryName: string | null;
+  readonly weight: string | null;
+  readonly paymentMethodName: string | null;
+  readonly priceToPay: string | null;
 }
 
 export function extractOrderLevelExtra(row: Readonly<Record<string, string>>): OrderLevelExtra {
@@ -259,21 +278,42 @@ export function extractOrderLevelExtra(row: Readonly<Record<string, string>>): O
     phone: trimOrNull(row["phone"]),
     packageNumber: trimOrNull(row["packageNumber"]),
     shippingCarrierName: SHIPPING_ITEM_CODE_RE.test(itemCode) ? trimOrNull(row["itemName"]) : null,
+    deliveryFullName: trimOrNull(row["deliveryFullName"]),
+    deliveryCompany: trimOrNull(row["deliveryCompany"]),
+    deliveryStreet: trimOrNull(row["deliveryStreet"]),
+    deliveryHouseNumber: trimOrNull(row["deliveryHouseNumber"]),
+    deliveryCity: trimOrNull(row["deliveryCity"]),
+    deliveryZip: trimOrNull(row["deliveryZip"]),
+    deliveryCountryName: trimOrNull(row["deliveryCountryName"]),
+    weight: parseDecimalComma(row["weight"] ?? ""),
+    paymentMethodName: BILLING_ITEM_CODE_RE.test(itemCode) ? trimOrNull(row["itemName"]) : null,
+    priceToPay: parseDecimalComma(row["priceToPay"] ?? ""),
   };
 }
 
 // Skladá viac riadkov TEJ ISTEJ objednávky do jedného `OrderLevelExtra` —
 // PRVÁ nájdená neprázdna hodnota KAŽDÉHO POĽA vyhráva nezávisle (nie "prvý
 // riadok vyhráva celý objekt", ako `orderInfo` v `ingest.ts` robí pre
-// customerName/placedAt/…) — `shippingCarrierName` je totiž takmer vždy
-// PRÁZDNE na bežných produktových riadkoch a NEPRÁZDNE len na jednom
-// konkrétnom SHIPPING riadku, ktorý môže byť ktorýkoľvek v poradí.
+// customerName/placedAt/…) — `shippingCarrierName`/`paymentMethodName` sú
+// totiž takmer vždy PRÁZDNE na bežných produktových riadkoch a NEPRÁZDNE len
+// na jednom konkrétnom SHIPPING/BILLING riadku, ktorý môže byť ktorýkoľvek
+// v poradí.
 export function mergeOrderLevelExtra(existing: OrderLevelExtra, incoming: OrderLevelExtra): OrderLevelExtra {
   return {
     email: existing.email ?? incoming.email,
     phone: existing.phone ?? incoming.phone,
     packageNumber: existing.packageNumber ?? incoming.packageNumber,
     shippingCarrierName: existing.shippingCarrierName ?? incoming.shippingCarrierName,
+    deliveryFullName: existing.deliveryFullName ?? incoming.deliveryFullName,
+    deliveryCompany: existing.deliveryCompany ?? incoming.deliveryCompany,
+    deliveryStreet: existing.deliveryStreet ?? incoming.deliveryStreet,
+    deliveryHouseNumber: existing.deliveryHouseNumber ?? incoming.deliveryHouseNumber,
+    deliveryCity: existing.deliveryCity ?? incoming.deliveryCity,
+    deliveryZip: existing.deliveryZip ?? incoming.deliveryZip,
+    deliveryCountryName: existing.deliveryCountryName ?? incoming.deliveryCountryName,
+    weight: existing.weight ?? incoming.weight,
+    paymentMethodName: existing.paymentMethodName ?? incoming.paymentMethodName,
+    priceToPay: existing.priceToPay ?? incoming.priceToPay,
   };
 }
 
@@ -282,6 +322,16 @@ export const EMPTY_ORDER_LEVEL_EXTRA: OrderLevelExtra = Object.freeze({
   phone: null,
   packageNumber: null,
   shippingCarrierName: null,
+  deliveryFullName: null,
+  deliveryCompany: null,
+  deliveryStreet: null,
+  deliveryHouseNumber: null,
+  deliveryCity: null,
+  deliveryZip: null,
+  deliveryCountryName: null,
+  weight: null,
+  paymentMethodName: null,
+  priceToPay: null,
 });
 
 export type OrderRowIssueKind =

--- a/apps/api/tests/dpd-http.integration.test.ts
+++ b/apps/api/tests/dpd-http.integration.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, expect, it } from "vitest";
+import { dpdShipments, orders, users } from "../src/db/schema.js";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import type { DpdRunDeps } from "../src/http/dpd-routes.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import type { UserRole } from "../src/modules/auth/service.js";
+import { dpdPortalConfigFromBaseUrl } from "../src/modules/dpd/config.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 292: HTTP vrstva "Eshop → Preprava DPD". `createShipment`/
+// `orderPickup` sú VŽDY falošné implementácie (`DpdRunDeps`'s injektované
+// funkcie) — appka NIKDY nespustí skutočný Chromium ani sa nedotkne
+// reálneho DPD účtu z testu, rovnaká bezpečnostná podmienka ako pri
+// Shoptet-e (`.claude/rules/dpd.md`).
+const HESLO = "test-heslo-abc";
+const FAKE_CONFIG = dpdPortalConfigFromBaseUrl("https://dpd.example.invalid", "u", "p");
+
+let close: (() => Promise<void>) | undefined;
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  resetLoginRateLimit();
+});
+
+async function boot(role: UserRole, deps: DpdRunDeps = { config: undefined }) {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await ctx.db.insert(users).values({
+    email: "pouzivatel@forestshop.sk",
+    passwordHash: await hashPassword(HESLO),
+    displayName: "Test",
+    role,
+  });
+  const app = createApp(ctx.db, { cookieSecure: false, dpd: deps });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "pouzivatel@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie, db: ctx.db };
+}
+
+const NEW_ORDER = {
+  externalOrderId: "20700001",
+  customerName: "Ján Novák",
+  statusName: "Vybavuje sa",
+  placedAt: new Date("2026-08-01T10:00:00Z"),
+  phone: "+421900123456",
+  deliveryFullName: "Ján Novák",
+  deliveryStreet: "Hlavná",
+  deliveryHouseNumber: "12",
+  deliveryCity: "Poprad",
+  deliveryZip: "05801",
+  deliveryCountryName: "Slovensko",
+  weight: "1.50",
+  paymentMethodName: "Dobierka (hotovosť) + karta (len SR)",
+  priceToPay: "32.50",
+  totalPriceWithVat: "32.50",
+};
+
+it("GET /api/dpd/orders bez prihlásenia vráti 401", async () => {
+  const { app } = await boot("manazer");
+  const res = await app.request("/api/dpd/orders");
+  expect(res.status).toBe(401);
+});
+
+it("GET /api/dpd/orders vráti configured:false, keď appka nemá DPD prihlasovacie údaje", async () => {
+  const { app, cookie } = await boot("manazer");
+  const res = await app.request("/api/dpd/orders", { headers: { cookie } });
+  const body = (await res.json()) as { configured: boolean };
+  expect(body.configured).toBe(false);
+});
+
+it("GET /api/dpd/orders vylúči objednávku s package_number aj s úspešnou dpd_shipment, ale zahrnie zlyhanú", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  const [order1] = await db.insert(orders).values({ ...NEW_ORDER, externalOrderId: "20700001" }).returning({ id: orders.id });
+  const [order2] = await db.insert(orders).values({ ...NEW_ORDER, externalOrderId: "20700002", packageNumber: "EF123SK" }).returning({ id: orders.id });
+  const [order3] = await db.insert(orders).values({ ...NEW_ORDER, externalOrderId: "20700003" }).returning({ id: orders.id });
+  const [order4] = await db.insert(orders).values({ ...NEW_ORDER, externalOrderId: "20700004" }).returning({ id: orders.id });
+  await db.insert(dpdShipments).values({
+    orderId: order3?.id as string,
+    status: "submitted",
+    weightKg: "1.50",
+    parcelNumber: "06565000000001",
+  });
+  await db.insert(dpdShipments).values({
+    orderId: order4?.id as string,
+    status: "failed",
+    weightKg: "1.50",
+    errorMessage: "portál nedostupný",
+  });
+
+  const res = await app.request("/api/dpd/orders", { headers: { cookie } });
+  const body = (await res.json()) as { orders: { preview: { externalOrderId: string }; lastFailure: string | null }[] };
+  const externalIds = body.orders.map((o) => o.preview.externalOrderId).sort();
+  expect(externalIds).toEqual(["20700001", "20700004"]);
+  expect(order1).toBeDefined();
+  expect(order2).toBeDefined();
+  const failed = body.orders.find((o) => o.preview.externalOrderId === "20700004");
+  expect(failed?.lastFailure).toBe("portál nedostupný");
+  const pending = body.orders.find((o) => o.preview.externalOrderId === "20700001");
+  expect(pending?.lastFailure).toBeNull();
+});
+
+it("POST /api/dpd/preview vypočíta náhľad pre zvolené objednávky s obsluhou upravenou hmotnosťou", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  const [order1] = await db.insert(orders).values(NEW_ORDER).returning({ id: orders.id });
+  const orderId = order1?.id as string;
+
+  const res = await app.request("/api/dpd/preview", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ orderIds: [orderId], weightOverrides: { [orderId]: "3.20" } }),
+  });
+  const body = (await res.json()) as { previews: { orderId: string; weightKg: string; isCod: boolean; codAmount: string | null }[] };
+  expect(body.previews).toHaveLength(1);
+  expect(body.previews[0]).toMatchObject({ orderId, weightKg: "3.20", isCod: true, codAmount: "32.50" });
+});
+
+it("POST /api/dpd/shipments vráti 503, keď appka nemá DPD prihlasovacie údaje", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  const [order1] = await db.insert(orders).values(NEW_ORDER).returning({ id: orders.id });
+  const res = await app.request("/api/dpd/shipments", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ orderIds: [order1?.id] }),
+  });
+  expect(res.status).toBe(503);
+});
+
+it("POST /api/dpd/shipments preskočí objednávku s neúplnou adresou bez volania robota", async () => {
+  let called = false;
+  const { app, cookie, db } = await boot("manazer", {
+    config: FAKE_CONFIG,
+    createShipment: () => {
+      called = true;
+      return Promise.resolve({ ok: true, parcelNumber: "06565000000099", errorDetail: null });
+    },
+  });
+  const [order1] = await db.insert(orders).values({ ...NEW_ORDER, deliveryStreet: null }).returning({ id: orders.id });
+
+  const res = await app.request("/api/dpd/shipments", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ orderIds: [order1?.id] }),
+  });
+  const body = (await res.json()) as { results: { orderId: string; ok: boolean; error?: string }[] };
+  expect(called).toBe(false);
+  expect(body.results[0]).toMatchObject({ ok: false, error: "Chýba doručovacia adresa" });
+});
+
+it("POST /api/dpd/shipments zapíše úspech s číslom zásielky a jedna zlyhaná objednávka neovplyvní druhú", async () => {
+  const { app, cookie, db } = await boot("manazer", {
+    config: FAKE_CONFIG,
+    createShipment: (options) =>
+      Promise.resolve(
+        options.shipment.externalOrderId === "20700001"
+          ? { ok: true, parcelNumber: "06565000000042", errorDetail: null }
+          : { ok: false, parcelNumber: null, errorDetail: "DPD formulár /shipments/0 ešte nie je naživo domapovaný" },
+      ),
+  });
+  const [order1] = await db.insert(orders).values({ ...NEW_ORDER, externalOrderId: "20700001" }).returning({ id: orders.id });
+  const [order2] = await db.insert(orders).values({ ...NEW_ORDER, externalOrderId: "20700002" }).returning({ id: orders.id });
+
+  const res = await app.request("/api/dpd/shipments", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ orderIds: [order1?.id, order2?.id] }),
+  });
+  const body = (await res.json()) as { results: { orderId: string; ok: boolean; parcelNumber?: string; error?: string }[] };
+  const success = body.results.find((r) => r.orderId === order1?.id);
+  const failure = body.results.find((r) => r.orderId === order2?.id);
+  expect(success).toMatchObject({ ok: true, parcelNumber: "06565000000042" });
+  expect(failure?.ok).toBe(false);
+
+  const shipmentRows = await db.select().from(dpdShipments);
+  const successRow = shipmentRows.find((r) => r.orderId === order1?.id);
+  const failureRow = shipmentRows.find((r) => r.orderId === order2?.id);
+  expect(successRow).toMatchObject({ status: "submitted", parcelNumber: "06565000000042" });
+  expect(failureRow?.status).toBe("failed");
+
+  // GET /api/dpd/orders už neukáže úspešne odoslanú objednávku.
+  const listRes = await app.request("/api/dpd/orders", { headers: { cookie } });
+  const listBody = (await listRes.json()) as { orders: { preview: { externalOrderId: string } }[] };
+  expect(listBody.orders.map((o) => o.preview.externalOrderId)).toEqual(["20700002"]);
+});
+
+it("POST /api/dpd/pickup-orders zapíše pokus a vráti 503, keď nie je nakonfigurované", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  const res = await app.request("/api/dpd/pickup-orders", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ pickupDate: "2026-08-10" }),
+  });
+  expect(res.status).toBe(503);
+  void db;
+});
+
+it("POST /api/dpd/pickup-orders zapíše úspešný pokus, keď je nakonfigurované", async () => {
+  const { app, cookie, db } = await boot("manazer", {
+    config: FAKE_CONFIG,
+    orderPickup: () => Promise.resolve({ ok: true, errorDetail: null }),
+  });
+  const res = await app.request("/api/dpd/pickup-orders", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ pickupDate: "2026-08-10" }),
+  });
+  const body = (await res.json()) as { ok: boolean };
+  expect(body.ok).toBe(true);
+  const { dpdPickupRequests } = await import("../src/db/schema.js");
+  const rows = await db.select().from(dpdPickupRequests);
+  expect(rows).toHaveLength(1);
+  expect(rows[0]).toMatchObject({ status: "submitted", pickupDate: "2026-08-10" });
+});
+
+it("nemanažér/citanie nemôže odoslať zásielku (403)", async () => {
+  const { app, cookie, db } = await boot("citanie", { config: FAKE_CONFIG });
+  const [order1] = await db.insert(orders).values(NEW_ORDER).returning({ id: orders.id });
+  const res = await app.request("/api/dpd/shipments", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ orderIds: [order1?.id] }),
+  });
+  expect(res.status).toBe(403);
+});

--- a/apps/api/tests/helpers/db.ts
+++ b/apps/api/tests/helpers/db.ts
@@ -59,8 +59,16 @@ export async function withCleanDb(): Promise<{ db: Database; close: () => Promis
     // nielen medzi testami, ale aj medzi CELÝMI behmi: čerstvý zápis z
     // predošlého behu potom vyzerá ako platné potvrdenie a beh preskočí
     // VŠETKY odkazy (presne to sa tu stalo pri druhom spustení).
+    // issue 292: "dpd_pickup_request" is the SAME situation as
+    // "order_open_status"/"supplier_contact" above — no FK in either
+    // direction (its `pickup_date` is a free-standing date, not tied to any
+    // order), so TRUNCATE CASCADE from any listed table never reaches it.
+    // "dpd_shipment" does NOT need listing here — it has a real FK into
+    // "order" (`onDelete: cascade`), so `TRUNCATE "order" CASCADE` already
+    // reaches it automatically (same reasoning as "order_line" via
+    // "variant" above).
     await db.execute(
-      sql`TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, nedostupne_replacement_link, mail_template, mail_template_history, supplier_stock, restock_settings, restock_event, shop_product_url, theme_color RESTART IDENTITY CASCADE`,
+      sql`TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, nedostupne_replacement_link, mail_template, mail_template_history, supplier_stock, restock_settings, restock_event, shop_product_url, theme_color, dpd_pickup_request RESTART IDENTITY CASCADE`,
     );
     // issue 59: `order_open_status` is a NEW table with real production
     // content (the migration seeds it) — TRUNCATE alone would leave every

--- a/apps/web/src/components/DpdSection.test.tsx
+++ b/apps/web/src/components/DpdSection.test.tsx
@@ -1,0 +1,175 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { DpdSection } from "./DpdSection.js";
+
+const { fetchDpdShippableOrders, fetchDpdPreview, sendDpdShipments, requestDpdPickup } = vi.hoisted(() => ({
+  fetchDpdShippableOrders: vi.fn(),
+  fetchDpdPreview: vi.fn(),
+  sendDpdShipments: vi.fn(),
+  requestDpdPickup: vi.fn(),
+}));
+
+// `DpdUnauthorizedError` ostáva SKUTOČNÁ trieda — rovnaký dôvod ako
+// `RestockLinkSuggestionsSection.test.tsx`: `instanceof` v komponente musí
+// fungovať aj v teste.
+vi.mock("../dpdApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../dpdApi.js")>();
+  return { ...actual, fetchDpdShippableOrders, fetchDpdPreview, sendDpdShipments, requestDpdPickup };
+});
+
+const { DpdUnauthorizedError } = await import("../dpdApi.js");
+
+const ORDER_A = {
+  placedAt: "2026-08-01T10:00:00Z",
+  lastFailure: null,
+  preview: {
+    orderId: "order-a",
+    externalOrderId: "20700001",
+    recipientName: "Ján Novák",
+    recipientCompany: null,
+    recipientPhone: "+421900123456",
+    street: "Hlavná",
+    houseNumber: "12",
+    city: "Poprad",
+    zip: "05801",
+    countryName: "Slovensko",
+    addressComplete: true,
+    weightKg: "1.00",
+    isCod: true,
+    codAmount: "32.50",
+  },
+};
+
+const ORDER_B_NO_ADDRESS = {
+  placedAt: "2026-08-02T10:00:00Z",
+  lastFailure: "portál nedostupný",
+  preview: {
+    orderId: "order-b",
+    externalOrderId: "20700002",
+    recipientName: "Eva Malá",
+    recipientCompany: null,
+    recipientPhone: null,
+    street: null,
+    houseNumber: null,
+    city: null,
+    zip: null,
+    countryName: null,
+    addressComplete: false,
+    weightKg: "1.00",
+    isCod: false,
+    codAmount: null,
+  },
+};
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+it("keď appka nie je nakonfigurovaná, zobrazí upozornenie", async () => {
+  fetchDpdShippableOrders.mockResolvedValue({ configured: false, orders: [] });
+
+  render(<DpdSection role="manazer" onSessionExpired={() => {}} />);
+
+  await screen.findByTestId("dpd-not-configured");
+  expect(screen.getByTestId("dpd-empty")).toBeDefined();
+});
+
+it("prázdny zoznam zobrazí informačnú vetu namiesto holej tabuľky", async () => {
+  fetchDpdShippableOrders.mockResolvedValue({ configured: true, orders: [] });
+
+  render(<DpdSection role="manazer" onSessionExpired={() => {}} />);
+
+  await screen.findByTestId("dpd-empty");
+  expect(screen.queryByRole("table")).toBeNull();
+});
+
+it("objednávka s neúplnou adresou má zablokovaný checkbox a zobrazí 'Chýba adresa'", async () => {
+  fetchDpdShippableOrders.mockResolvedValue({ configured: true, orders: [ORDER_B_NO_ADDRESS] });
+
+  render(<DpdSection role="manazer" onSessionExpired={() => {}} />);
+
+  await screen.findByTestId("dpd-address-incomplete-20700002");
+  const checkbox = screen.getByLabelText<HTMLInputElement>("Vybrať objednávku 20700002");
+  expect(checkbox.disabled).toBe(true);
+});
+
+it("pri 401 zavolá onSessionExpired namiesto zobrazenia všeobecnej chyby", async () => {
+  fetchDpdShippableOrders.mockRejectedValue(new DpdUnauthorizedError());
+  const onSessionExpired = vi.fn();
+
+  render(<DpdSection role="manazer" onSessionExpired={onSessionExpired} />);
+
+  await waitFor(() => {
+    expect(onSessionExpired).toHaveBeenCalledTimes(1);
+  });
+});
+
+it("rola citanie nemôže vybrať objednávku ani vidieť tlačidlo 'Objednať prepravu DPD'", async () => {
+  fetchDpdShippableOrders.mockResolvedValue({ configured: true, orders: [ORDER_A] });
+
+  render(<DpdSection role="citanie" onSessionExpired={() => {}} />);
+
+  const checkbox = await screen.findByLabelText<HTMLInputElement>("Vybrať objednávku 20700001");
+  expect(checkbox.disabled).toBe(true);
+  expect(screen.queryByTestId("dpd-open-preview")).toBeNull();
+});
+
+it("výber objednávky → náhľad → potvrdenie odošle IBA po druhom kliku, nikdy pri otvorení náhľadu", async () => {
+  fetchDpdShippableOrders.mockResolvedValueOnce({ configured: true, orders: [ORDER_A] });
+  fetchDpdShippableOrders.mockResolvedValueOnce({ configured: true, orders: [] });
+  fetchDpdPreview.mockResolvedValue([ORDER_A.preview]);
+  sendDpdShipments.mockResolvedValue([{ orderId: "order-a", ok: true, parcelNumber: "06565000000042" }]);
+
+  render(<DpdSection role="manazer" onSessionExpired={() => {}} />);
+
+  fireEvent.click(await screen.findByLabelText("Vybrať objednávku 20700001"));
+  fireEvent.click(screen.getByTestId("dpd-open-preview"));
+
+  await screen.findByTestId("dpd-preview-dialog");
+  expect(sendDpdShipments).not.toHaveBeenCalled();
+  expect(screen.getByTestId("dpd-preview-item-20700001").textContent).toContain("Hlavná 12, Poprad 05801, Slovensko");
+
+  fireEvent.click(screen.getByTestId("dpd-preview-confirm"));
+
+  await waitFor(() => {
+    expect(sendDpdShipments).toHaveBeenCalledWith(["order-a"], {});
+  });
+  await screen.findByTestId("dpd-result-order-a");
+  expect(screen.getByTestId("dpd-result-order-a").textContent).toContain("06565000000042");
+  expect(screen.queryByTestId("dpd-preview-dialog")).toBeNull();
+});
+
+it("úprava hmotnosti v riadku sa pošle ako weightOverride do náhľadu aj odoslania", async () => {
+  fetchDpdShippableOrders.mockResolvedValue({ configured: true, orders: [ORDER_A] });
+  fetchDpdPreview.mockResolvedValue([{ ...ORDER_A.preview, weightKg: "2.50" }]);
+
+  render(<DpdSection role="manazer" onSessionExpired={() => {}} />);
+
+  fireEvent.click(await screen.findByLabelText("Vybrať objednávku 20700001"));
+  const weightInput = screen.getByLabelText<HTMLInputElement>("Hmotnosť objednávky 20700001");
+  fireEvent.change(weightInput, { target: { value: "2.50" } });
+
+  fireEvent.click(screen.getByTestId("dpd-open-preview"));
+
+  await waitFor(() => {
+    expect(fetchDpdPreview).toHaveBeenCalledWith(["order-a"], { "order-a": "2.50" });
+  });
+});
+
+it("Objednať zvoz na deň zavolá requestDpdPickup s vybraným dátumom a zobrazí výsledok", async () => {
+  fetchDpdShippableOrders.mockResolvedValue({ configured: true, orders: [] });
+  requestDpdPickup.mockResolvedValue({ ok: true, error: null });
+
+  render(<DpdSection role="manazer" onSessionExpired={() => {}} />);
+
+  await screen.findByTestId("dpd-pickup");
+  const dateInput = screen.getByLabelText<HTMLInputElement>("Objednať zvoz na deň");
+  fireEvent.change(dateInput, { target: { value: "2026-08-10" } });
+  fireEvent.click(screen.getByTestId("dpd-pickup-submit"));
+
+  await waitFor(() => {
+    expect(requestDpdPickup).toHaveBeenCalledWith("2026-08-10");
+  });
+  expect(screen.getByTestId("dpd-pickup-message").textContent).toContain("Zvoz objednaný.");
+});

--- a/apps/web/src/components/DpdSection.tsx
+++ b/apps/web/src/components/DpdSection.tsx
@@ -93,13 +93,24 @@ export function DpdSection({ role, onSessionExpired }: { readonly role: Me["role
     return weightDrafts[orderKey(order)] ?? order.preview.weightKg;
   }
 
+  // issue 292 review finding: posielať CELÝ `weightDrafts` (aj koncepty pre
+  // objednávky MIMO tejto požiadavky) by mohlo poslať rozpísanú/neplatnú
+  // hodnotu iného riadku (napr. "1." počas písania) a serverova validácia
+  // (`z.record` so spoločným regexom) by tým 400-kla CELÚ požiadavku, aj
+  // keď sa vybraných objednávok vôbec netýka. Odošli len prekryv s
+  // aktuálne posielanými `orderIds`.
+  function weightOverridesFor(orderIds: readonly string[]): Readonly<Record<string, string>> {
+    const ids = new Set(orderIds);
+    return Object.fromEntries(Object.entries(weightDrafts).filter(([id]) => ids.has(id)));
+  }
+
   function openPreview(): void {
     const orderIds = [...selected];
     if (orderIds.length === 0) return;
     setPreviewError("");
     setSendResults(null);
     setPreviewBusy(true);
-    fetchDpdPreview(orderIds, weightDrafts)
+    fetchDpdPreview(orderIds, weightOverridesFor(orderIds))
       .then((items) => {
         setPreviewItems(items);
       })
@@ -124,7 +135,7 @@ export function DpdSection({ role, onSessionExpired }: { readonly role: Me["role
     if (previewItems === null) return;
     const orderIds = previewItems.map((p) => p.orderId);
     setSendBusy(true);
-    sendDpdShipments(orderIds, weightDrafts)
+    sendDpdShipments(orderIds, weightOverridesFor(orderIds))
       .then((results) => {
         setSendResults(results);
         setPreviewItems(null);

--- a/apps/web/src/components/DpdSection.tsx
+++ b/apps/web/src/components/DpdSection.tsx
@@ -1,0 +1,305 @@
+import { useCallback, useEffect, useState, type JSX } from "react";
+import type { Me } from "../api.js";
+import {
+  DpdUnauthorizedError,
+  fetchDpdPreview,
+  fetchDpdShippableOrders,
+  requestDpdPickup,
+  sendDpdShipments,
+  type DpdShipmentPreview,
+  type DpdShipmentResult,
+  type DpdShippableOrder,
+} from "../dpdApi.js";
+import { formatSkDateTime } from "../formatDate.js";
+
+// issue 292: "Eshop → Preprava DPD" — 1) zoznam objednávok bez appka-vlastnej
+// odoslanej zásielky, 2) klik na "Objednať prepravu DPD" ukáže PRESNÝ náhľad
+// (nič sa ešte neposlalo), 3) až potvrdenie v náhľade skutočne spustí robota
+// (per objednávka, jedno zlyhanie neblokuje ostatné), 4) samostatné
+// "Objednať zvoz na deň". Adresa/hmotnosť/dobierka sa NIKDY nedohadujú —
+// appka ich číta priamo z uloženej objednávky (`modules/dpd/preview.ts`).
+const CAN_SEND_ROLES: ReadonlySet<Me["role"]> = new Set(["admin", "manazer"]);
+
+function orderKey(order: DpdShippableOrder): string {
+  return order.preview.orderId;
+}
+
+function todayIso(): string {
+  // Europe/Bratislava, nie UTC — rovnaký dôvod ako `formatDate.ts` (appka
+  // beží na serveri, ktorého systémové pásmo nemusí byť slovenské).
+  const parts = new Intl.DateTimeFormat("en-CA", { timeZone: "Europe/Bratislava" }).formatToParts(new Date());
+  const y = parts.find((p) => p.type === "year")?.value ?? "1970";
+  const m = parts.find((p) => p.type === "month")?.value ?? "01";
+  const d = parts.find((p) => p.type === "day")?.value ?? "01";
+  return `${y}-${m}-${d}`;
+}
+
+export function DpdSection({ role, onSessionExpired }: { readonly role: Me["role"]; readonly onSessionExpired: () => void }): JSX.Element {
+  const [configured, setConfigured] = useState(false);
+  const [orders, setOrders] = useState<readonly DpdShippableOrder[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  const [loadError, setLoadError] = useState("");
+  const canSend = CAN_SEND_ROLES.has(role);
+
+  const [selected, setSelected] = useState<ReadonlySet<string>>(new Set());
+  const [weightDrafts, setWeightDrafts] = useState<Readonly<Record<string, string>>>({});
+
+  const [previewItems, setPreviewItems] = useState<readonly DpdShipmentPreview[] | null>(null);
+  const [previewError, setPreviewError] = useState("");
+  const [previewBusy, setPreviewBusy] = useState(false);
+  const [sendBusy, setSendBusy] = useState(false);
+  const [sendResults, setSendResults] = useState<readonly DpdShipmentResult[] | null>(null);
+
+  const [pickupDate, setPickupDate] = useState(todayIso());
+  const [pickupBusy, setPickupBusy] = useState(false);
+  const [pickupMessage, setPickupMessage] = useState("");
+
+  const load = useCallback(() => {
+    fetchDpdShippableOrders()
+      .then((result) => {
+        setConfigured(result.configured);
+        setOrders(result.orders);
+        setLoaded(true);
+        setLoadError("");
+        setSelected((prev) => {
+          const stillPresent = new Set(result.orders.map(orderKey));
+          return new Set([...prev].filter((id) => stillPresent.has(id)));
+        });
+      })
+      .catch((err: unknown) => {
+        setLoaded(true);
+        if (err instanceof DpdUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setLoadError("Zoznam objednávok na odoslanie sa nepodarilo načítať.");
+      });
+  }, [onSessionExpired]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  function toggleSelected(id: string): void {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  function weightFor(order: DpdShippableOrder): string {
+    return weightDrafts[orderKey(order)] ?? order.preview.weightKg;
+  }
+
+  function openPreview(): void {
+    const orderIds = [...selected];
+    if (orderIds.length === 0) return;
+    setPreviewError("");
+    setSendResults(null);
+    setPreviewBusy(true);
+    fetchDpdPreview(orderIds, weightDrafts)
+      .then((items) => {
+        setPreviewItems(items);
+      })
+      .catch((err: unknown) => {
+        if (err instanceof DpdUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setPreviewError(err instanceof Error ? err.message : "Náhľad sa nepodarilo vypočítať.");
+      })
+      .finally(() => {
+        setPreviewBusy(false);
+      });
+  }
+
+  function closePreview(): void {
+    setPreviewItems(null);
+    setPreviewError("");
+  }
+
+  function confirmSend(): void {
+    if (previewItems === null) return;
+    const orderIds = previewItems.map((p) => p.orderId);
+    setSendBusy(true);
+    sendDpdShipments(orderIds, weightDrafts)
+      .then((results) => {
+        setSendResults(results);
+        setPreviewItems(null);
+        setSelected(new Set());
+        load();
+      })
+      .catch((err: unknown) => {
+        if (err instanceof DpdUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setPreviewError(err instanceof Error ? err.message : "Odoslanie zásielok zlyhalo.");
+      })
+      .finally(() => {
+        setSendBusy(false);
+      });
+  }
+
+  function submitPickup(): void {
+    setPickupBusy(true);
+    setPickupMessage("");
+    requestDpdPickup(pickupDate)
+      .then((result) => {
+        setPickupMessage(result.ok ? "Zvoz objednaný." : (result.error ?? "Objednanie zvozu zlyhalo."));
+      })
+      .catch((err: unknown) => {
+        if (err instanceof DpdUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setPickupMessage(err instanceof Error ? err.message : "Objednanie zvozu zlyhalo.");
+      })
+      .finally(() => {
+        setPickupBusy(false);
+      });
+  }
+
+  return (
+    <section data-testid="dpd-section">
+      <p>
+        Objednávky, ktoré appka ešte cez DPD neodoslala (a Shoptet pre ne nemá vlastné číslo zásielky).
+        Označ pripravené objednávky a klikni „Objednať prepravu DPD“ — appka najprv ukáže presný náhľad,
+        nič sa neodošle bez potvrdenia.
+      </p>
+
+      {!configured && loaded && (
+        <p role="alert" data-testid="dpd-not-configured">
+          DPD preprava nie je nakonfigurovaná (chýba prihlásenie do dpdshipper.sk).
+        </p>
+      )}
+      {loadError !== "" && <p role="alert">{loadError}</p>}
+
+      <div data-testid="dpd-pickup">
+        <label htmlFor="dpd-pickup-date">Objednať zvoz na deň</label>
+        <input
+          id="dpd-pickup-date"
+          type="date"
+          value={pickupDate}
+          onChange={(e) => {
+            setPickupDate(e.target.value);
+          }}
+        />
+        <button type="button" className="btn sm" disabled={!configured || !canSend || pickupBusy} onClick={submitPickup} data-testid="dpd-pickup-submit">
+          🚚 Objednať zvoz na deň
+        </button>
+        {pickupMessage !== "" && <span data-testid="dpd-pickup-message"> {pickupMessage}</span>}
+      </div>
+
+      {loaded && orders.length === 0 && <p data-testid="dpd-empty">Žiadna objednávka nečaká na odoslanie.</p>}
+
+      {orders.length > 0 && (
+        <>
+          <div className="fs-table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th></th>
+                  <th>Objednávka</th>
+                  <th>Dátum</th>
+                  <th>Príjemca</th>
+                  <th>Adresa</th>
+                  <th>Hmotnosť (kg)</th>
+                  <th>Dobierka</th>
+                  <th>Posledné zlyhanie</th>
+                </tr>
+              </thead>
+              <tbody>
+                {orders.map((order) => {
+                  const id = orderKey(order);
+                  const p = order.preview;
+                  return (
+                    <tr key={id} data-testid={`dpd-order-row-${p.externalOrderId}`}>
+                      <td>
+                        <input
+                          type="checkbox"
+                          aria-label={`Vybrať objednávku ${p.externalOrderId}`}
+                          checked={selected.has(id)}
+                          onChange={() => {
+                            toggleSelected(id);
+                          }}
+                          disabled={!canSend || !p.addressComplete}
+                        />
+                      </td>
+                      <td>{p.externalOrderId}</td>
+                      <td>{formatSkDateTime(order.placedAt)}</td>
+                      <td>{p.recipientName}</td>
+                      <td>
+                        {p.addressComplete ? (
+                          <span>
+                            {p.street} {p.houseNumber}, {p.city} {p.zip}, {p.countryName}
+                          </span>
+                        ) : (
+                          <span data-testid={`dpd-address-incomplete-${p.externalOrderId}`}>Chýba adresa</span>
+                        )}
+                      </td>
+                      <td>
+                        <input
+                          type="number"
+                          step="0.01"
+                          min="0.01"
+                          aria-label={`Hmotnosť objednávky ${p.externalOrderId}`}
+                          value={weightFor(order)}
+                          disabled={!canSend}
+                          onChange={(e) => {
+                            setWeightDrafts((prev) => ({ ...prev, [id]: e.target.value }));
+                          }}
+                        />
+                      </td>
+                      <td>{p.isCod ? `${p.codAmount ?? "0"} €` : "—"}</td>
+                      <td>{order.lastFailure ?? "—"}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+
+          {canSend && (
+            <button type="button" className="btn good" disabled={!configured || selected.size === 0 || previewBusy} onClick={openPreview} data-testid="dpd-open-preview">
+              📦 Objednať prepravu DPD ({selected.size})
+            </button>
+          )}
+        </>
+      )}
+
+      {sendResults !== null && (
+        <ul data-testid="dpd-send-results">
+          {sendResults.map((r) => (
+            <li key={r.orderId} data-testid={`dpd-result-${r.orderId}`}>
+              {r.ok ? `Odoslané, číslo zásielky ${r.parcelNumber ?? ""}` : `Zlyhalo: ${r.error ?? ""}`}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {previewItems !== null && (
+        <div role="dialog" aria-label="Náhľad DPD zásielok" data-testid="dpd-preview-dialog">
+          <h3>Náhľad — nič sa ešte neodoslalo</h3>
+          {previewError !== "" && <p role="alert">{previewError}</p>}
+          <ul>
+            {previewItems.map((p) => (
+              <li key={p.orderId} data-testid={`dpd-preview-item-${p.externalOrderId}`}>
+                {p.externalOrderId}: {p.recipientName}, {p.street} {p.houseNumber}, {p.city} {p.zip}, {p.countryName} — {p.weightKg} kg
+                {p.isCod ? `, dobierka ${p.codAmount ?? "0"} €` : ""}
+              </li>
+            ))}
+          </ul>
+          <button type="button" className="btn sm ghost" onClick={closePreview} disabled={sendBusy} data-testid="dpd-preview-cancel">
+            Zrušiť
+          </button>
+          <button type="button" className="btn good" onClick={confirmSend} disabled={sendBusy} data-testid="dpd-preview-confirm">
+            ✅ Potvrdiť a odoslať
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/dpdApi.ts
+++ b/apps/web/src/dpdApi.ts
@@ -1,0 +1,103 @@
+import { z } from "zod";
+
+// issue 292: "Eshop → Preprava DPD" — zrkadlí `apps/api/src/http/dpd-routes.ts`.
+export class DpdUnauthorizedError extends Error {
+  constructor() {
+    super("Neprihlásený");
+  }
+}
+
+const errorBodySchema = z.object({ error: z.string() });
+
+async function serverErrorMessage(response: Response, fallback: string): Promise<string> {
+  try {
+    const parsed = errorBodySchema.safeParse(await response.json());
+    if (parsed.success) return parsed.data.error;
+  } catch {
+    // Telo nie je platný JSON (alebo chýba) — použi všeobecnú hlášku.
+  }
+  return fallback;
+}
+
+async function readJson(response: Response, fallback: string): Promise<unknown> {
+  if (response.status === 401) throw new DpdUnauthorizedError();
+  if (!response.ok) throw new Error(await serverErrorMessage(response, fallback));
+  return await response.json();
+}
+
+const previewSchema = z.object({
+  orderId: z.string(),
+  externalOrderId: z.string(),
+  recipientName: z.string(),
+  recipientCompany: z.string().nullable(),
+  recipientPhone: z.string().nullable(),
+  street: z.string().nullable(),
+  houseNumber: z.string().nullable(),
+  city: z.string().nullable(),
+  zip: z.string().nullable(),
+  countryName: z.string().nullable(),
+  addressComplete: z.boolean(),
+  weightKg: z.string(),
+  isCod: z.boolean(),
+  codAmount: z.string().nullable(),
+});
+export type DpdShipmentPreview = z.infer<typeof previewSchema>;
+
+const shippableOrderSchema = z.object({
+  placedAt: z.string(),
+  preview: previewSchema,
+  lastFailure: z.string().nullable(),
+});
+export type DpdShippableOrder = z.infer<typeof shippableOrderSchema>;
+
+const ordersSchema = z.object({ configured: z.boolean(), orders: z.array(shippableOrderSchema) });
+
+export async function fetchDpdShippableOrders(): Promise<z.infer<typeof ordersSchema>> {
+  const response = await fetch("/api/dpd/orders");
+  return ordersSchema.parse(await readJson(response, "Zoznam objednávok na odoslanie sa nepodarilo načítať"));
+}
+
+const previewsSchema = z.object({ previews: z.array(previewSchema) });
+
+export async function fetchDpdPreview(orderIds: readonly string[], weightOverrides: Readonly<Record<string, string>>): Promise<readonly DpdShipmentPreview[]> {
+  const response = await fetch("/api/dpd/preview", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ orderIds, weightOverrides }),
+  });
+  return previewsSchema.parse(await readJson(response, "Náhľad sa nepodarilo vypočítať")).previews;
+}
+
+const shipmentResultSchema = z.object({
+  orderId: z.string(),
+  ok: z.boolean(),
+  parcelNumber: z.string().optional(),
+  error: z.string().optional(),
+});
+export type DpdShipmentResult = z.infer<typeof shipmentResultSchema>;
+const shipmentResultsSchema = z.object({ results: z.array(shipmentResultSchema) });
+
+export async function sendDpdShipments(
+  orderIds: readonly string[],
+  weightOverrides: Readonly<Record<string, string>>,
+): Promise<readonly DpdShipmentResult[]> {
+  const response = await fetch("/api/dpd/shipments", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ orderIds, weightOverrides }),
+  });
+  if (response.status === 401) throw new DpdUnauthorizedError();
+  if (!response.ok) throw new Error(await serverErrorMessage(response, "Odoslanie zásielok zlyhalo"));
+  return shipmentResultsSchema.parse(await response.json()).results;
+}
+
+export async function requestDpdPickup(pickupDate: string): Promise<{ readonly ok: boolean; readonly error: string | null }> {
+  const response = await fetch("/api/dpd/pickup-orders", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ pickupDate }),
+  });
+  if (response.status === 401) throw new DpdUnauthorizedError();
+  const body = z.object({ ok: z.boolean(), error: z.string().nullable() }).parse(await response.json());
+  return body;
+}

--- a/apps/web/src/nav.test.ts
+++ b/apps/web/src/nav.test.ts
@@ -21,12 +21,13 @@ import { DEFAULT_TAB_ID, HIDDEN_TABS, NAV, findTab, isVisibleTabId } from "./nav
 // "pridať dalšie polička - pod nedostupné tovarý"). Issue 311 pridalo
 // "Vypredané → Skladom: návrhy odkazov" hneď za "Vypredané → Skladom" v
 // Automatizáciách (rovnaká automatizácia, doplnenie chýbajúcich odkazov,
-// ktoré ju živia).
+// ktoré ju živia). Issue 292 pridalo "Preprava DPD" na koniec priečinka
+// "Eshop" (majiteľovo zadanie, jedno tlačidlo na objednanie prepravy).
 // Tento test je najbližšie k tomu, čo strojovo overiť dá (registrácia, nie DOM).
-it("NAV má tri priečinky (Eshop/Systém/Automatizácie), s 9/3/5 záložkami v poradí podľa dôležitosti", () => {
+it("NAV má tri priečinky (Eshop/Systém/Automatizácie), s 10/3/5 záložkami v poradí podľa dôležitosti", () => {
   expect(NAV).toHaveLength(3);
   expect(NAV.map((f) => f.label)).toEqual(["Eshop", "Systém", "Automatizácie"]);
-  expect(NAV[0]?.tabs).toHaveLength(9);
+  expect(NAV[0]?.tabs).toHaveLength(10);
   expect(NAV[1]?.tabs).toHaveLength(3);
   expect(NAV[2]?.tabs).toHaveLength(5);
   expect(NAV[0]?.tabs.map((t) => t.label)).toEqual([
@@ -39,6 +40,7 @@ it("NAV má tri priečinky (Eshop/Systém/Automatizácie), s 9/3/5 záložkami v
     "Vyhľadať",
     "Zlúčenie objednávok",
     "Upozornenia",
+    "Preprava DPD",
   ]);
   // issue 212: "Dodávateľský sklad" — scraper dostupnosti u dodávateľa;
   // patrí do Systému (zadanie majiteľa), nie medzi Automatizácie.

--- a/apps/web/src/nav.ts
+++ b/apps/web/src/nav.ts
@@ -2,6 +2,7 @@ import type { ComponentType } from "react";
 import type { Me } from "./api.js";
 import { CatalogPage } from "./components/CatalogPage.js";
 import { ClaimOrdersSection } from "./components/ClaimOrdersSection.js";
+import { DpdSection } from "./components/DpdSection.js";
 import { ExchangeOrdersSection } from "./components/ExchangeOrdersSection.js";
 import { MailLogSection } from "./components/MailLogSection.js";
 import { MailTemplatesSection } from "./components/MailTemplatesSection.js";
@@ -107,6 +108,12 @@ export const NAV: readonly NavFolder[] = [
       // (nie do Automatizácie) z rovnakého dôvodu ako "Na objednanie" —
       // obsluha na nej pracuje, žiadny plán/zapnuté-vypnuté koncept.
       { id: "upozornenia", label: "Upozornenia", icon: "🔔", Component: UpozorneniaSection, wide: true },
+      // issue 292: majiteľ (Discord, 6.8.2026) — jedno tlačidlo na objednanie
+      // prepravy DPD. Patrí sem (nie do Automatizácie) z rovnakého dôvodu ako
+      // "Na objednanie"/"Zlúčenie objednávok" — obsluha na nej pracuje ručne
+      // (vyberá objednávky, potvrdzuje náhľad), žiadny plán/zapnuté-vypnuté
+      // koncept.
+      { id: "dpd", label: "Preprava DPD", icon: "🚚", Component: DpdSection, wide: true },
     ],
   },
   {

--- a/apps/web/tests/e2e/dpd.spec.ts
+++ b/apps/web/tests/e2e/dpd.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "@playwright/test";
+
+const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
+// VLASTNÝ izolovaný účet (rovnaký mechanizmus ako `E2E_NAVRHY_ODKAZOV_EMAIL`,
+// `.claude/rules/frontend-design.md`) — zdieľaný `e2e@forestshop.sk` je už
+// na hranici `MAX_ATTEMPTS`. Musí sa zhodovať s `scripts/e2e-fixtures-dpd.ts`'s
+// `E2E_DPD_EMAIL`.
+const E2E_DPD_EMAIL = "e2e-dpd@forestshop.sk";
+
+// issue 292: "Eshop → Preprava DPD" — VIDITEĽNÁ záložka (`nav.ts`).
+// E2E prostredie NEMÁ nastavené `DPD_PORTAL_USER`/`PASSWORD` (appka teda
+// beží ako "nenakonfigurovaná", presne ako by bežala pred vypýtaním
+// prístupu) — appka preto MUSÍ ukázať zoznam objednávok (čisto DB čítanie,
+// nezávisí od Playwright robota) a zablokovať tlačidlá, čo by inak volali
+// skutočný DPD portál. Skutočné odoslanie zásielky je mimo dosahu e2e testu
+// (appka sa NIKDY nesmie dotknúť reálneho DPD účtu, `.claude/rules/dpd.md`)
+// — pokrýva ho `DpdSection.test.tsx` (izolované, s falošným API klientom).
+test("zoznam objednávok, neúplná adresa je zablokovaná, appka je fail-closed bez DPD prihlásenia; konzola je čistá", async ({ page }) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/");
+  await page.getByLabel("E-mail").fill(E2E_DPD_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+
+  await page.getByRole("button", { name: "Preprava DPD" }).click();
+  await expect(page.getByRole("heading", { name: "Preprava DPD" })).toBeVisible();
+
+  await expect(page.getByTestId("dpd-not-configured")).toBeVisible();
+
+  // Pripravená objednávka (úplná adresa + dobierka) — checkbox je aktívny,
+  // hmotnosť predvyplnená z uloženej hodnoty, dobierka zobrazená.
+  const pripravena = page.getByTestId("dpd-order-row-9012");
+  await expect(pripravena).toBeVisible();
+  await expect(pripravena).toContainText("Testovacia 1, E2E Mesto 00000, Slovensko");
+  await expect(pripravena).toContainText("19.90 €");
+  const checkboxPripravena = page.getByLabel("Vybrať objednávku 9012");
+  await expect(checkboxPripravena).toBeEnabled();
+  const hmotnostPripravena = page.getByLabel("Hmotnosť objednávky 9012");
+  await expect(hmotnostPripravena).toHaveValue("1.20");
+
+  // Objednávka bez adresy — checkbox je ZABLOKOVANÝ, appka to nikdy
+  // neponúkne na odoslanie robotovi s prázdnymi poľami.
+  const bezAdresy = page.getByTestId("dpd-order-row-9013");
+  await expect(bezAdresy).toBeVisible();
+  await expect(page.getByTestId("dpd-address-incomplete-9013")).toBeVisible();
+  await expect(page.getByLabel("Vybrať objednávku 9013")).toBeDisabled();
+
+  // Appka je fail-closed bez DPD prihlásenia — tlačidlá, čo by inak volali
+  // skutočný portál, sú zablokované, aj keď je objednávka vybraná.
+  await checkboxPripravena.check();
+  await expect(page.getByTestId("dpd-open-preview")).toBeDisabled();
+  await expect(page.getByTestId("dpd-pickup-submit")).toBeDisabled();
+
+  expect(chyby).toEqual([]);
+});

--- a/apps/web/tests/e2e/nav.spec.ts
+++ b/apps/web/tests/e2e/nav.spec.ts
@@ -26,8 +26,10 @@ const E2E_NAV_EMAIL = "e2e-nav@forestshop.sk";
 // samostatnom `order-flags.spec.ts`, rovnaký vzor). Issue 311 (2026-08-07)
 // pridáva "Vypredané → Skladom: návrhy odkazov" HNEĎ ZA "Vypredané →
 // Skladom" — sedemnásta záložka celkovo (funkčný test v samostatnom
-// `restock-links.spec.ts`, rovnaký vzor).
-test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) so sedemnástimi záložkami, klik prepne obrazovku, panel sa zbalí do lišty a stav si pamätá, konzola je čistá", async ({
+// `restock-links.spec.ts`, rovnaký vzor). Issue 292 (2026-08-08) pridáva
+// "Preprava DPD" NA KONIEC priečinka "Eshop" — osemnásta záložka celkovo
+// (funkčný test v samostatnom `dpd.spec.ts`, rovnaký vzor).
+test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s osemnástimi záložkami, klik prepne obrazovku, panel sa zbalí do lišty a stav si pamätá, konzola je čistá", async ({
   page,
 }) => {
   const chyby: string[] = [];
@@ -48,8 +50,8 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) so sedemnás
   await expect(page.getByRole("button", { name: "Eshop" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Automatizácie" })).toBeVisible();
 
-  // Presne sedemnásť záložiek v CELOM menu.
-  await expect(page.locator(".side-nav .tab")).toHaveCount(17);
+  // Presne osemnásť záložiek v CELOM menu.
+  await expect(page.locator(".side-nav .tab")).toHaveCount(18);
   await expect(page.getByRole("button", { name: "Sync zo Shoptetu" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Texty e-mailov" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Na objednanie" })).toBeVisible();
@@ -63,6 +65,7 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) so sedemnás
   await expect(page.getByRole("button", { name: "Vyhľadať" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Zlúčenie objednávok" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Upozornenia" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Preprava DPD" })).toBeVisible();
 
   // issue 302: predvolená obrazovka (bez kliknutia) je odvtedy "Na
   // objednanie", nie "Sync zo Shoptetu". `scripts/e2e-setup.ts` vždy seeduje
@@ -181,7 +184,7 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) so sedemnás
 
   // Hlavičky priečinkov zmiznú, ikony všetkých modulov ostanú.
   await expect(page.getByRole("button", { name: "Systém" })).toHaveCount(0);
-  await expect(page.locator(".side-nav .tab")).toHaveCount(17);
+  await expect(page.locator(".side-nav .tab")).toHaveCount(18);
   // Názov sa v lište ukáže bublinou pri prejdení myšou.
   await expect(page.getByRole("button", { name: "Na objednanie" })).toHaveAttribute(
     "title",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.182",
+  "version": "0.3.0-dev.183",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-fixtures-dpd.ts
+++ b/scripts/e2e-fixtures-dpd.ts
@@ -1,0 +1,47 @@
+// issue 292: "Eshop → Preprava DPD" — vyčlenené z `e2e-setup.ts` (eslint
+// `max-lines: 400`, `.claude/rules/testing.md`), rovnaký vzor ako existujúci
+// `e2e-fixtures-restock-links.ts`. Jedna objednávka s ÚPLNOU doručovacou
+// adresou + dobierkou (appka ju MÁ ponúknuť na výber), jedna s CHÝBAJÚCOU
+// adresou (appka ju MÁ zobraziť ako neúplnú, s zablokovaným checkboxom).
+import type { Database } from "../apps/api/src/db/client.js";
+import { orders, users } from "../apps/api/src/db/schema.js";
+import { hashPassword } from "../apps/api/src/modules/auth/passwords.js";
+
+// Musí sa zhodovať s hodnotou v `apps/web/tests/e2e/dpd.spec.ts` — VLASTNÝ
+// izolovaný účet (rovnaký mechanizmus ako `E2E_NAVRHY_ODKAZOV_EMAIL` —
+// zdieľaný `e2e@forestshop.sk` je už na hranici `MAX_ATTEMPTS`).
+export const E2E_DPD_EMAIL = "e2e-dpd@forestshop.sk";
+
+export async function seedDpdFixtures(db: Database, heslo: string): Promise<void> {
+  await db.insert(users).values({
+    email: E2E_DPD_EMAIL,
+    passwordHash: await hashPassword(heslo),
+    displayName: "E2E Manažér DPD",
+    role: "manazer",
+  });
+
+  await db.insert(orders).values({
+    externalOrderId: "9012",
+    customerName: "E2E Zákazník DPD Pripravená",
+    statusName: "Vybavuje sa",
+    placedAt: new Date("2026-08-01T09:00:00Z"),
+    phone: "+421900111222",
+    deliveryFullName: "E2E Zákazník DPD Pripravená",
+    deliveryStreet: "Testovacia",
+    deliveryHouseNumber: "1",
+    deliveryCity: "E2E Mesto",
+    deliveryZip: "00000",
+    deliveryCountryName: "Slovensko",
+    weight: "1.20",
+    paymentMethodName: "Dobierka (hotovosť) + karta (len SR)",
+    priceToPay: "19.90",
+    totalPriceWithVat: "19.90",
+  });
+
+  await db.insert(orders).values({
+    externalOrderId: "9013",
+    customerName: "E2E Zákazník DPD Bez adresy",
+    statusName: "Vybavuje sa",
+    placedAt: new Date("2026-08-01T09:30:00Z"),
+  });
+}

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -236,7 +236,10 @@ await db.execute(
   // takže CASCADE ich nikdy nestrhne. Bez nich by potvrdenia dodávateľa z
   // PREDOŠLÉHO e2e behu prežili do ďalšieho (presne past popísaná v
   // `.claude/rules/supplier-stock.md`, tam pre `tests/helpers/db.ts`).
-  'TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, nedostupne_replacement_link, mail_template, mail_template_history, supplier_stock, restock_settings, restock_event, shop_product_url, theme_color RESTART IDENTITY CASCADE',
+  // "dpd_pickup_request" (issue 292) je rovnaký prípad znova — bez FK,
+  // pridané ručne (`tests/helpers/db.ts` má rovnaký riadok navyše).
+  // "dpd_shipment" NETREBA — FK do "order" ho CASCADE strhne automaticky.
+  'TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, nedostupne_replacement_link, mail_template, mail_template_history, supplier_stock, restock_settings, restock_event, shop_product_url, theme_color, dpd_pickup_request RESTART IDENTITY CASCADE',
 );
 // Rovnaký dôvod ako `tests/helpers/db.ts`: bez tohto by "Na objednanie" bolo
 // v CELOM e2e behu prázdne pre KAŽDÚ objednávku (žiadny nastavený otvorený

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -17,6 +17,7 @@ import { DEFAULT_SNAPSHOT_LIMITS } from "../apps/api/src/modules/catalog/validat
 import { DEFAULT_ORDER_OPEN_STATUS } from "../apps/api/src/modules/orders/open-statuses.js";
 import { POSTA_UNCOLLECTED_SETTINGS_ID } from "../apps/api/src/modules/posta-uncollected/settings.js";
 import { ORDER_REMINDER_SETTINGS_ID } from "../apps/api/src/modules/order-reminder/settings.js";
+import { seedDpdFixtures } from "./e2e-fixtures-dpd.js";
 import { seedOrderFlagsFixtures } from "./e2e-fixtures-order-flags.js";
 import { seedProductLinksFixtures } from "./e2e-fixtures-product-links.js";
 import { seedRestockLinksFixtures } from "./e2e-fixtures-restock-links.js";
@@ -796,5 +797,8 @@ await seedOrderFlagsFixtures(db, E2E_HESLO);
 
 // issue 311: fixtúra vyčlenená do vlastného súboru, rovnaký dôvod ako vyššie.
 await seedRestockLinksFixtures(db, teraz, snapshotPrepinanie, E2E_HESLO);
+
+// issue 292: fixtúra vyčlenená do vlastného súboru, rovnaký dôvod ako vyššie.
+await seedDpdFixtures(db, E2E_HESLO);
 
 await pool.end();


### PR DESCRIPTION
## Súvisiaci ticket

issue 292 — nechávam OTVORENÝ (nie `Closes`), pretože prvú reálnu zásielku
musí naživo overiť majiteľ sám (bezpečnostné pravidlo tiketu: appka sa z
tejto session nikdy nesmie dotknúť reálneho DPD účtu).

## Čo appka pridáva

1. **Zoznam objednávok pripravených na odoslanie** ("Eshop → Preprava DPD")
   — objednávky bez appka-vlastnej odoslanej DPD zásielky a bez Shoptet-ovho
   vlastného čísla zásielky.
2. **Presný náhľad pred odoslaním** — príjemca, adresa, dobierka, hmotnosť
   (upraviteľná). Nič sa nedeje, kým obsluha náhľad výslovne nepotvrdí.
3. **Playwright robot na `dpdshipper.sk`** — prihlásenie je naživo overené a
   funguje; samotné vyplnenie formulára `/shipments/0` zámerne zlyhá NAHLAS
   (žiadne hádanie polí), pretože prístupové údaje na finálne naživo
   domapovanie neprišli počas tejto session — pozri `UNVERIFIED` nižšie a
   `.claude/rules/dpd.md`.
4. **Samostatné "Objednať zvoz na deň"** pre jednorazový zvoz kuriéra.
5. Rozšírenie importu objednávok o doručovaciu adresu/hmotnosť/spôsob
   platby (Shoptet export ich mal, appka ich doteraz neukladala).

## Bezpečnosť

Appka sa z TEJTO session ani z testov NIKDY nedotkla reálneho DPD účtu —
read-only route guard pri naživo mapovaní portálu, žiadny test nesmeruje na
`dpdshipper.sk`, HTTP trasy injektujú Playwright robota (testy dodávajú
falošnú implementáciu).

## Overenie

- `pnpm typecheck` / `pnpm lint` čisté
- `pnpm --filter @forestshop/api test` (652/652), `pnpm --filter
  @forestshop/api test:integration` (81 súborov, 608 testov)
- `pnpm --filter @forestshop/web test` (522/522)
- `pnpm --filter @forestshop/web e2e` (51/51, konzola čistá)
- Nezávislý code-review subagent (nájdenia opravené, viď issue 292
  komentár)

## UNVERIFIED

Skutočné vytvorenie DPD zásielky/zvozu cez Playwright robota — appka to
zámerne NIKDY neskúsila naostro. Formulár `/shipments/0` a formulár
jednorazového zvozu ešte nie sú naživo domapované (čaká sa na
`DPD_PORTAL_USER`/`PASSWORD`, issue 292 komentár). Prvú reálnu zásielku
klikne majiteľ sám.
