### PR TITLE
fix: wire restock deps into createApp so manual run-now uses real credentials

### DIFF
--- a/.claude/rules/supplier-stock.md
+++ b/.claude/rules/supplier-stock.md
@@ -360,6 +360,32 @@ paths:
   vypredaný text sa NENAŠIEL napriek prehľadaniu 20 uložených odkazov + 3
   kategórií — presne ako `wetland.sk` (issue 230): pravidlo sa NEHÁDA,
   žiadne vlastné mapovanie "Do N dní" → unavailable sa nepridalo.
+- **`index.ts`'s `createApp(db, {...})` volanie MUSÍ reálne odovzdať KAŽDÝ
+  voliteľný HTTP dep kľúč, na ktorý sa `http/app.ts` odvoláva — chýbajúci
+  kľúč sa NEPREJAVÍ pri `tsc`/lint (`AppOptions`'s pole je `?:`, teda platne
+  chýbajúce), len ticho spadne na fail-closed fallback.** Issue 319: `restock`
+  kľúč v `createApp(...)` chýbal úplne (na rozdiel od `postaUncollected`/
+  `orderReminder`/`nedostupne`/`orderMerge`/`dpd`, ktoré tam všetky sú),
+  hoci `runRestockFn` (o pár riadkov vyššie, pre scheduler) má REÁLNE
+  `shoptetAdminUser`/`shoptetAdminPassword` premenné správne zostavené.
+  Dôsledok: manuálne "Spustiť teraz" (`POST /api/restock/run-now`) v
+  produkcii VŽDY zlyhalo na prihlásení do Shoptetu (prázdne prihlasovacie
+  údaje z `http/app.ts`'s fallbacku), zatiaľ čo naplánovaný nočný beh
+  fungoval normálne — appka teda "z väčšiny funguje", takže sa to
+  neprejavilo ako zjavná regresia. Nájdené AŽ živým dôkazom proti produkčnej
+  `job_run`/`audit_events` tabuľke (job_run `failure` riadok s presne
+  predpovedanou chybovou hláškou, tesne po ručnom "Spustiť teraz" kliku, s
+  chýbajúcim zodpovedajúcim `audit_events` záznamom — HTTP handler
+  `record()` sa volá LEN pri úspechu). **Test pri KAŽDEJ ĎALŠEJ novej
+  automatizácii pridávajúcej svoj vlastný voliteľný dep do `AppOptions`
+  (`http/app.ts`):** over PRIAMO, že `index.ts`'s `createApp(db, {...})`
+  volanie ten kľúč SKUTOČNE odovzdáva — `grep -n "options\." apps/api/src/
+  http/app.ts` (čo trasa POTREBUJE) vs. `createApp(db, {` blok v `index.ts`
+  (čo REÁLNE dostáva) sa musia zhodovať. `index.ts` beží celý na
+  module-top-level (migrácia + `serve()`), takže sa nedá bezpečne
+  importovať v teste — regresný test preto overuje ZDROJOVÝ TEXT staticky
+  (`apps/api/src/index-wiring.test.ts`), regexom na skutočné premenné, nie
+  len na prítomnosť reťazca s menom kľúča.
 - **Celý beh (~2160 odkazov, sériový, `PER_HOST_DELAY_MS` medzi rovnakým
   hostom) trvá reálne ~72 minút** (zmerané z `job_run.started_at`/
   `finished_at`, viacero po sebe idúcich nočných behov). Post-deploy

--- a/apps/api/src/index-wiring.test.ts
+++ b/apps/api/src/index-wiring.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// issue 319: `createApp(db, {...})` v `index.ts` MUSÍ obsahovať `restock`
+// kľúč, rovnakým vzorom ako `postaUncollected`/`orderReminder`/
+// `nedostupne`/`orderMerge`/`dpd` — bez neho appka vždy volá
+// `registerRestockRoutes` (`http/app.ts`) s PRÁZDNYMI prihlasovacími
+// údajmi (jeho fail-closed fallback: `shoptetImportConfigFromBaseUrl(...,
+// "", "")`), takže tlačidlo "Spustiť teraz" na obrazovke "Vypredané →
+// Skladom" v produkcii vždy zlyhá na prihlásení do Shoptetu, hoci
+// `SHOPTET_ADMIN_USER`/`PASSWORD` sú reálne nastavené a naplánovaný nočný
+// beh (`restockJob(runRestockFn)`) beží normálne — má VLASTNÚ, správne
+// zostavenú `runRestockFn`, ktorá do `createApp` nikdy nešla.
+//
+// `index.ts` beží celý na module-top-level (migrácia + pripojenie k DB +
+// `serve()`) — nedá sa bezpečne importovať ani zavolať priamo v teste.
+// Jediný spoľahlivý spôsob dokázať, že sa táto medzera nikdy nevráti, je
+// overiť ZDROJOVÝ TEXT statický: nájsť `createApp(db, {...})` volanie a
+// overiť, že jeho `restock:` kľúč skutočne referuje reálne
+// `shoptetAdminUser`/`shoptetAdminPassword` premenné (nie len že reťazec
+// "restock" niekde v súbore existuje).
+describe("index.ts wiring: createApp dostáva restock deps (issue 319)", () => {
+  it("createApp(db, {...}) volanie obsahuje restock kľúč postavený na SHOPTET_ADMIN_USER/PASSWORD premenných", () => {
+    const indexSrc = readFileSync(fileURLToPath(new URL("./index.ts", import.meta.url)), "utf8");
+
+    const callMatch = /const app = createApp\(db, \{[\s\S]*?\}\);/.exec(indexSrc);
+    expect(callMatch, "createApp(db, {...}) volanie sa v index.ts nenašlo").not.toBeNull();
+    const callBlock = callMatch?.[0] ?? "";
+
+    expect(callBlock).toMatch(/restock:\s*\{\s*config:\s*shoptetImportConfigFromBaseUrl\(/);
+    // Nesmie ísť o nový fail-closed literál priamo v index.ts (to by len
+    // presunulo tú istú medzeru inam) — musí použiť REÁLNE premenné, ktoré
+    // `runRestockFn` (o pár riadkov vyššie) už zostavuje pre scheduler.
+    expect(callBlock).toMatch(/shoptetAdminUser\s*\?\?\s*""/);
+    expect(callBlock).toMatch(/shoptetAdminPassword\s*\?\?\s*""/);
+  });
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -228,6 +228,14 @@ const dpdDeps = {
   config: dpdUser === undefined || dpdPassword === undefined ? undefined : dpdPortalConfigFromBaseUrl(env.DPD_PORTAL_BASE_URL, dpdUser, dpdPassword),
 };
 
+// issue 319: chýbajúci kľúč tu (na rozdiel od `postaUncollected`/
+// `orderReminder`/`nedostupne`/`orderMerge`/`dpd` nižšie) nechával
+// `registerRestockRoutes` (`http/app.ts`) vždy padnúť na jeho fail-closed
+// fallback (prázdne prihlasovacie údaje) — manuálne "Spustiť teraz" tak v
+// produkcii vždy zlyhalo na prihlásení do Shoptetu, hoci `runRestockFn`
+// vyššie (pre naplánovaný nočný beh) má tie isté reálne premenné správne
+// zostavené. `?? ""` mimo prítomnosti premenných zachováva presne to isté
+// fail-closed správanie, aké `app.ts`'s fallback mal dovtedy sám.
 const app = createApp(db, {
   cookieSecure: env.SESSION_COOKIE_SECURE,
   ...(runIngest === undefined ? {} : { runIngest }),
@@ -239,6 +247,7 @@ const app = createApp(db, {
   nedostupne: nedostupneDeps,
   orderMerge: orderMergeDeps,
   fetchSupplierPage,
+  restock: { config: shoptetImportConfigFromBaseUrl(env.SHOPTET_ADMIN_BASE_URL, shoptetAdminUser ?? "", shoptetAdminPassword ?? "") },
   dpd: dpdDeps,
 });
 

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -3078,3 +3078,53 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   suite, before the review-triggered debug run), zero console errors.
 - No PR/merge/deploy in this dispatch — supervisor owns CI/PR/merge/deploy
   per the dispatch's HARD CONSTRAINT.
+
+## Issue 292 — DPD: objednať prepravu jedným tlačidlom (2026-08-08)
+
+- Commits: `463279e` (version bump 0.3.0-dev.183) → `1d6a627` (backend:
+  schema/ingest/preview/routes) → `6761e8a` (frontend: "Eshop → Preprava
+  DPD") → `c9985b0` (e2e coverage + fixtures, nav tab-count updates) →
+  `b205a90` (playbook `.claude/rules/dpd.md`) → `dc3a66d` (review fixes).
+- Design: `gh issue comment` on #292 BEFORE first commit — root cause
+  (appka never stored delivery address/weight/payment method, though the
+  Shoptet export already carries them), chosen approach (per-shipment
+  Playwright robot, since Importné profily bulk-import was empty on the
+  account and mapping its format requires a WRITE the ticket's safety
+  rule forbids), rejected alternatives (official DPD Shipper API — owner
+  explicitly reversed that decision on the ticket; deriving
+  "ready to ship" from Shoptet `status_name` — no reliable vocabulary for
+  it, own `dpd_shipment` record used instead).
+- No RED/GREEN pair — new feature, not a bug fix. Tests: unit
+  (`parser-order-extra.test.ts`, `preview.test.ts`, `DpdSection.test.tsx`),
+  integration (`dpd-http.integration.test.ts`, injected fake Playwright
+  runners — never spawns real Chromium/touches the real account),
+  e2e (`dpd.spec.ts` — proves the deployed shape is fail-closed without
+  DPD credentials; the actual send-flow interaction is covered only by
+  the mocked-API component test, e2e correctly has NO real DPD
+  credentials by design).
+- Review: dispatched `general-purpose` code-reviewer subagent, diff
+  `d15c58d..b205a90`. Result: 0 Critical, 2 Important (weight-override
+  map sent unfiltered to the server — could 400 a valid selection because
+  of a stale draft on an unrelated row; `addressComplete` missed house
+  number), 1 Minor (`POST /api/dpd/preview` missing `requireSameOrigin()`
+  for consistency) — all three fixed in `dc3a66d`.
+- Local gates: `pnpm typecheck`/`pnpm lint` clean; API unit 652/652 (46
+  files); API integration 608/608 (81 files); web unit 522/522 (71
+  files); e2e 51/51 (52 spec files incl. new `dpd.spec.ts`), zero console
+  errors.
+- PR #320 merged (`59d6623`) to `main`; main CI + Deploy both green.
+  Post-deploy Playwright verification on
+  `https://forestshop-novy.newlevel.media/?tab=dpd`: version `v0.3.0-dev.183`
+  read from DOM, "Preprava DPD" tab renders, 258 real orders listed (all
+  showing "Chýba adresa" — expected, delivery-address columns are `null`
+  until the next nightly Shoptet re-import backfills them via COALESCE),
+  default weight `1.00` applied correctly, both send/pickup buttons
+  correctly `disabled` (DPD not configured on prod — credentials never
+  arrived this session), 0 console errors.
+- **Issue 292 LEFT OPEN** (never `Closes` in PR/commits) — the actual
+  `/shipments/0` form-fill and pickup-form-fill are intentionally
+  unmapped (fail loudly with a clear message instead of guessing
+  selectors) pending `DPD_PORTAL_USER`/`DPD_PORTAL_PASSWORD` (requested
+  via `secret request` repeatedly overnight, 600s URL TTL expired
+  unused each time — owner was asleep). First real shipment must be
+  clicked by the owner himself once the form is live-mapped.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.183",
+  "version": "0.3.0-dev.184",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Súvis

issue 319 — manuálne "Spustiť teraz" na obrazovke "Vypredané → Skladom" v
produkcii vždy zlyhalo na prihlásení do Shoptetu, hoci naplánovaný nočný
beh fungoval normálne.

Toto PR **nezatvára** issue 319 automaticky — akceptačná podmienka
(overiť naživo po nasadení, klik + reálny `job_run` výsledok) sa dá
potvrdiť až PO merge/deploy. Ticket sa zavrie ručne po tom overení.

## Príčina

`apps/api/src/index.ts`'s `createApp(db, {...})` volanie nikdy neodovzdávalo
`restock` kľúč — na rozdiel od `postaUncollected`/`orderReminder`/
`nedostupne`/`orderMerge`/`dpd`, ktoré tam všetky sú. `http/app.ts`'s
`registerRestockRoutes` preto vždy dostalo fail-closed fallback
(`shoptetImportConfigFromBaseUrl(adminBaseUrl, "", "")` — prázdne
prihlasovacie údaje) pre HTTP trasu `POST /api/restock/run-now`, aj keď
`SHOPTET_ADMIN_USER`/`PASSWORD` v `.env` sú reálne nastavené a naplánovaný
nočný beh (`restockJob(runRestockFn)`) má tie isté premenné správne
zostavené a funguje normálne.

Overené naživo proti produkčnej DB (`job_run`/`audit_events`) — podrobný
dôkaz je v komentároch na issue 319.

## Zmena

Jednoriadková oprava presne podľa návrhu v tickete: `index.ts`'s
`createApp(...)` teraz odovzdáva `restock: { config:
shoptetImportConfigFromBaseUrl(env.SHOPTET_ADMIN_BASE_URL, shoptetAdminUser
?? "", shoptetAdminPassword ?? "") }`, postavené na tých istých premenných,
aké `runRestockFn` (o pár riadkov vyššie) už používa pre scheduler. Keď
premenné chýbajú, správanie sa nemení (rovnaký fail-closed fallback ako
predtým).

Skontrolované, či podobnú medzeru nemá iná trasa registrovaná cez
`createApp` — nemá, `restock` bol jediný chýbajúci kľúč
(`grep -n "options\." apps/api/src/http/app.ts`).

## Testy

- `apps/api/src/index-wiring.test.ts` — nový regresný test (statický,
  keďže `index.ts` beží celý na module-top-level a nedá sa bezpečne
  importovať): `[red]` (`6571eda`) overuje, že `createApp(...)` volanie
  obsahuje `restock:` kľúč postavený na reálnych premenných — pred
  opravou zlyhá, po oprave (`ec4eb5d`) prechádza.
- Všetkých 6 lokálnych brán zelených: `typecheck`, `lint`, `test`
  (api 653 + web 522), `test:integration` (608), `web e2e` (51).
