### PR TITLE
Upozornenia: najbližšia udalosť z Google kalendára

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,6 +17,7 @@
     "@node-rs/argon2": "^2.0.0",
     "drizzle-orm": "^0.38.0",
     "hono": "^4.6.0",
+    "node-ical": "^0.27.1",
     "nodemailer": "^9.0.3",
     "pg": "^8.13.0",
     "pino": "^9.5.0",

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -102,6 +102,14 @@ const envSchema = z.object({
   // ostáva konfigurovateľná (rovnaký princíp ako `SHOPTET_ADMIN_BASE_URL`),
   // pre prípad zmeny adresy alebo testovacieho prostredia DPD.
   DPD_PORTAL_BASE_URL: z.string().url().default("https://www.dpdshipper.sk"),
+  // issue 309: "Eshop → Upozornenia" — najbližšia udalosť z majiteľovho
+  // Google kalendára. Tajná iCal adresa (nie API kľúč/OAuth token — pozri
+  // návrhový komentár na tickete): NESIE tajný token PRIAMO V CESTE (na
+  // rozdiel od SHOPTET_EXPORT_URL, kde je tajomstvom len `hash` query
+  // parameter), nikdy do repa/commit správy/logu. Nepovinná: bez nej appka
+  // beží ďalej, karta sa na nástenke jednoducho nezobrazí (rovnaký fail-
+  // graceful princíp ako SHOPTET_EXPORT_URL).
+  GOOGLE_CALENDAR_ICS_URL: z.string().url().optional(),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/apps/api/src/http/app.ts
+++ b/apps/api/src/http/app.ts
@@ -9,6 +9,8 @@ import { MIN_NEW_PASSWORD_LENGTH } from "../modules/auth/passwords.js";
 import { login, logout, resolveSession } from "../modules/auth/service.js";
 import type { MailTransport } from "../modules/mail/transport.js";
 import { appVersion } from "../version.js";
+import { registerCalendarRoutes } from "./calendar-routes.js";
+import type { NextEventService } from "../modules/calendar/service.js";
 import { registerCatalogRoutes, type RunIngest } from "./catalog-routes.js";
 import { registerDpdRoutes, type DpdRunDeps } from "./dpd-routes.js";
 import { checkLoginRateLimit, clientIp } from "./login-rate-limit.js";
@@ -92,6 +94,12 @@ export function createApp(
     // len akcie odosielajúce do DPD vrátia 503 "nenakonfigurované" namiesto
     // tichého zápisu s prázdnymi prihlasovacími údajmi.
     readonly dpd?: DpdRunDeps;
+    // issue 309: "Eshop → Upozornenia" — najbližšia udalosť z Google
+    // kalendára. `undefined` (predvolené) = appka beží ďalej, karta na
+    // nástenke sa jednoducho nezobrazí (rovnaký "configured" vzor ako `dpd`
+    // vyššie) — `index.ts` ju v produkcii nahradí LEN keď je nastavená
+    // `GOOGLE_CALENDAR_ICS_URL` (`env.ts`).
+    readonly nextEvent?: NextEventService;
   },
 ): Hono<AppBindings> {
   const app = new Hono<AppBindings>();
@@ -305,6 +313,9 @@ export function createApp(
   // dependency (na rozdiel od nedostupne/orderReminder vyššie) — táto
   // obrazovka neposiela mail ani nekontaktuje tretiu stranu.
   registerUpozorneniaRoutes(app, db);
+  // issue 309: rovnaká nástenka, ale NEZÁVISLÝ modul (žiadny dedupKey/
+  // resolve/postpone — `upozornenia.md`'s návrhový komentár na tickete).
+  registerCalendarRoutes(app, db, options.nextEvent);
   // issue 290: "Eshop → Výmena tovaru / Vrátený tovar / Reklamácie" — tri
   // READ-ONLY pohľady + appkina vlastná reklamácia-značka. Žiadny voliteľný
   // dependency (rovnaký dôvod ako `upozornenia` vyššie).

--- a/apps/api/src/http/calendar-routes.ts
+++ b/apps/api/src/http/calendar-routes.ts
@@ -1,0 +1,21 @@
+// issue 309: "Eshop → Upozornenia" — najbližšia udalosť z majiteľovho Google
+// kalendára. Vlastný registrátor trasy (nie súčasť `upozornenia-routes.ts`)
+// — modul za ňou (`modules/calendar/`) nie je DB-backed "upozornenie", je to
+// nezávislý read-through pohľad na externý kalendár (rovnaký princíp ako
+// `dpd-routes.ts`/`shop-feed`'s vlastné trasy vedľa `upozornenia`).
+
+import type { Hono } from "hono";
+import type { Database } from "../db/client.js";
+import type { NextEventService } from "../modules/calendar/service.js";
+import { requireUser, type AppBindings } from "./middleware.js";
+
+// `deps === undefined` = `GOOGLE_CALENDAR_ICS_URL` nie je nastavená
+// (`env.ts`) — appka beží ďalej, karta na nástenke sa jednoducho nezobrazí
+// (rovnaký "configured" vzor ako `dpd-routes.ts`'s `DpdRunDeps`).
+export function registerCalendarRoutes(app: Hono<AppBindings>, db: Database, deps?: NextEventService): void {
+  app.get("/api/upozornenia/next-event", requireUser(db), async (c) => {
+    if (deps === undefined) return c.json({ configured: false as const, event: null, error: false });
+    const result = await deps.getNextEvent(new Date());
+    return c.json({ configured: true as const, event: result.ok ? result.event : null, error: !result.ok });
+  });
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -7,6 +7,8 @@ import { createDb } from "./db/client.js";
 import { loadEnv } from "./env.js";
 import { createApp } from "./http/app.js";
 import { log } from "./logger.js";
+import { createHttpIcsFetcher } from "./modules/calendar/fetcher.js";
+import { createNextEventService } from "./modules/calendar/service.js";
 import { createHttpExportFetcher } from "./modules/catalog/fetcher.js";
 import { ingestCatalog } from "./modules/catalog/ingest.js";
 import { createSmtpMailTransport } from "./modules/mail/transport.js";
@@ -228,6 +230,13 @@ const dpdDeps = {
   config: dpdUser === undefined || dpdPassword === undefined ? undefined : dpdPortalConfigFromBaseUrl(env.DPD_PORTAL_BASE_URL, dpdUser, dpdPassword),
 };
 
+// issue 309: "Eshop → Upozornenia" — najbližšia udalosť z majiteľovho Google
+// kalendára. `GOOGLE_CALENDAR_ICS_URL` je nepovinná (env.ts) — bez nej appka
+// beží ďalej, karta na nástenke sa jednoducho nezobrazí (`http/app.ts`'s
+// `nextEvent === undefined` vetva).
+const googleCalendarIcsUrl = env.GOOGLE_CALENDAR_ICS_URL;
+const nextEventService = googleCalendarIcsUrl === undefined ? undefined : createNextEventService(createHttpIcsFetcher(googleCalendarIcsUrl));
+
 // issue 319: chýbajúci kľúč tu (na rozdiel od `postaUncollected`/
 // `orderReminder`/`nedostupne`/`orderMerge`/`dpd` nižšie) nechával
 // `registerRestockRoutes` (`http/app.ts`) vždy padnúť na jeho fail-closed
@@ -249,6 +258,7 @@ const app = createApp(db, {
   fetchSupplierPage,
   restock: { config: shoptetImportConfigFromBaseUrl(env.SHOPTET_ADMIN_BASE_URL, shoptetAdminUser ?? "", shoptetAdminPassword ?? "") },
   dpd: dpdDeps,
+  ...(nextEventService === undefined ? {} : { nextEvent: nextEventService }),
 });
 
 // F2 (#12/#3) + F3 (#22/#28): nočný import katalógu/objednávok, mazanie

--- a/apps/api/src/modules/calendar/constants.ts
+++ b/apps/api/src/modules/calendar/constants.ts
@@ -1,0 +1,26 @@
+// issue 309: "Eshop → Upozornenia" — najbližšia udalosť z majiteľovho Google
+// kalendára. Krátkodobá in-memory cache PRIAMO v module (service.ts) namiesto
+// nového scheduler jobu — pozri návrhový komentár na tickete
+// (`gh issue comment 309`) pre celé odôvodnenie: dáta sa nemajú nikdy
+// "vybaviť" ani prežiť reštart appky zmysluplne, takže netreba perzistenciu.
+
+/** Úspešný fetch+parse sa cachuje 15 minút — osobný kalendár nepotrebuje
+ * sekundovú presnosť a appka má len jedného čitateľa (majiteľa). */
+export const NEXT_EVENT_OK_CACHE_TTL_MS = 15 * 60 * 1000;
+
+/** Zlyhanie sa cachuje LEN 2 minúty — nesmie sa skúšať fetch pri KAŽDOM
+ * otvorení karty počas dlhšieho výpadku, ale ani nesmie appku "zaseknúť" na
+ * "nedostupné" nadlho po tom, čo sa zdroj sám spamätá. */
+export const NEXT_EVENT_ERROR_CACHE_TTL_MS = 2 * 60 * 1000;
+
+/** Okno na dopredu-expanziu opakujúcich sa udalostí (RRULE) — dosť veľké na
+ * zachytenie ročne sa opakujúcej udalosti (napr. narodeniny), no konečné. */
+export const RECURRENCE_EXPANSION_WINDOW_DAYS = 400;
+
+/** Strop veľkosti stiahnutého ICS tela — osobný kalendár je rádovo KB až
+ * jednotky MB; 10 MB je veľkorysá, no konečná hranica proti
+ * nepriateľskému/pokazenému serveru (rovnaký princíp ako `catalog/
+ * fetcher.ts`'s `DEFAULT_MAX_EXPORT_BYTES`). */
+export const MAX_ICS_BYTES = 10 * 1024 * 1024;
+
+export const ICS_FETCH_TIMEOUT_MS = 10_000;

--- a/apps/api/src/modules/calendar/fetcher.test.ts
+++ b/apps/api/src/modules/calendar/fetcher.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createHttpIcsFetcher } from "./fetcher.js";
+
+// issue 309: `fetch` je VŽDY stubovaná globálne (`vi.stubGlobal`, rovnaký
+// vzor ako `catalog/fetcher.test.ts`) — tento súbor sa NIKDY nepripája na
+// skutočný Google.
+
+function textResponse(body: string, status = 200): Response {
+  return new Response(body, { status });
+}
+
+describe("createHttpIcsFetcher", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("vráti stiahnuté telo ako text", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(textResponse("BEGIN:VCALENDAR\r\nEND:VCALENDAR")));
+    const fetcher = createHttpIcsFetcher("https://calendar.example.invalid/private-token/basic.ics");
+    await expect(fetcher()).resolves.toBe("BEGIN:VCALENDAR\r\nEND:VCALENDAR");
+  });
+
+  it("HTTP chyba (napr. 404 — odvolaná/zmazaná tajná adresa) sa vyhodí BEZ URL v hláške", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(textResponse("Not Found", 404)));
+    const fetcher = createHttpIcsFetcher("https://calendar.example.invalid/private-tajny-token/basic.ics");
+    await expect(fetcher()).rejects.toThrow(/HTTP 404/);
+    // Chybová hláška NIKDY nesmie obsahovať samotnú tajnú adresu (tá nesie
+    // token PRIAMO V CESTE, nie len v query parametri — `fetcher.ts`'s
+    // vlastný komentár).
+    await fetcher().catch((error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      expect(message).not.toMatch(/tajny-token/);
+      expect(message).not.toMatch(/calendar\.example\.invalid/);
+    });
+  });
+
+  it("odmietne (vyhodí), keď stiahnuté telo prekročí strop veľkosti", async () => {
+    const huge = "x".repeat(11 * 1024 * 1024);
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(textResponse(huge)));
+    const fetcher = createHttpIcsFetcher("https://calendar.example.invalid/private-token/basic.ics");
+    await expect(fetcher()).rejects.toThrow(/veľkosť/);
+  });
+});

--- a/apps/api/src/modules/calendar/fetcher.ts
+++ b/apps/api/src/modules/calendar/fetcher.ts
@@ -1,0 +1,32 @@
+// issue 309: sťahovanie majiteľovej tajnej Google kalendár ICS adresy.
+//
+// NA ROZDIEL od `catalog/fetcher.ts`'s `redactUrl` (prekrýva LEN query
+// parametre — Shoptet nesie svoj `hash` tam) je táto adresa CELÁ tajomstvo:
+// Google-ova súkromná ICS adresa má tajný token PRIAMO V CESTE
+// (`/calendar/ical/<email>/private-<token>/basic.ics`). `redactUrl` by tu
+// teda nič neskryl. Preto sa URL NIKDY neinterpoluje do žiadnej chybovej
+// hlášky (ani prekrytá) — chyby nesú len status kód/typ zlyhania.
+
+import { readBounded } from "../catalog/fetcher.js";
+import { ICS_FETCH_TIMEOUT_MS, MAX_ICS_BYTES } from "./constants.js";
+
+export type IcsFetcher = () => Promise<string>;
+
+export function createHttpIcsFetcher(url: string): IcsFetcher {
+  return async () => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => {
+      controller.abort();
+    }, ICS_FETCH_TIMEOUT_MS);
+    try {
+      const response = await fetch(url, { signal: controller.signal });
+      if (!response.ok) {
+        throw new Error(`Google kalendár vrátil HTTP ${String(response.status)}`);
+      }
+      const body = await readBounded(response, MAX_ICS_BYTES);
+      return body.toString("utf8");
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+}

--- a/apps/api/src/modules/calendar/next-event.test.ts
+++ b/apps/api/src/modules/calendar/next-event.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "vitest";
+import { resolveNextEvent } from "./next-event.js";
+
+// issue 309: čisté testy nad ICS textom — ŽIADNY test v tomto module (ani v
+// tomto súbore) sa NIKDY nepripája na skutočný Google, presne rovnaká
+// disciplína ako Shoptet/Pošta SK/dodávateľské stránky/DPD portál
+// (`.claude/rules/testing.md`).
+
+function ics(lines: readonly string[]): string {
+  return ["BEGIN:VCALENDAR", "VERSION:2.0", ...lines, "END:VCALENDAR"].join("\r\n");
+}
+
+const NOW = new Date("2026-08-08T10:00:00Z");
+
+describe("resolveNextEvent — základné prípady", () => {
+  it("prázdny kalendár (0 udalostí) vráti null", () => {
+    expect(resolveNextEvent(ics([]), NOW)).toBeNull();
+  });
+
+  it("obsah bez BEGIN:VCALENDAR je nahlas považovaný za pokazený feed", () => {
+    expect(() => resolveNextEvent("toto nie je ICS vôbec", NOW)).toThrow(/BEGIN:VCALENDAR/);
+  });
+
+  it("jedna časovaná (TZID) udalosť v budúcnosti sa vráti s dateLabel a allDay:false", () => {
+    const text = ics([
+      "BEGIN:VEVENT",
+      "UID:e1@test",
+      "DTSTAMP:20260101T000000Z",
+      "SUMMARY:Stretnutie s dodávateľom",
+      "DTSTART;TZID=Europe/Bratislava:20260812T090000",
+      "DTEND;TZID=Europe/Bratislava:20260812T100000",
+      "END:VEVENT",
+    ]);
+    const result = resolveNextEvent(text, NOW);
+    expect(result).toEqual({ title: "Stretnutie s dodávateľom", dateLabel: "streda 12. 8.", allDay: false });
+  });
+
+  it("udalosť, ktorá už SKONČILA (end < now), sa NIKDY nevráti ako najbližšia", () => {
+    const text = ics([
+      "BEGIN:VEVENT",
+      "UID:minula@test",
+      "DTSTAMP:20260101T000000Z",
+      "SUMMARY:Minulá udalosť",
+      "DTSTART;TZID=Europe/Bratislava:20260801T090000",
+      "DTEND;TZID=Europe/Bratislava:20260801T100000",
+      "END:VEVENT",
+    ]);
+    expect(resolveNextEvent(text, NOW)).toBeNull();
+  });
+
+  it("PREBIEHAJÚCA udalosť (začala pred `now`, ešte neskončila) sa počíta ako najbližšia — dispatch: 'najbližšia = neskončila'", () => {
+    const text = ics([
+      "BEGIN:VEVENT",
+      "UID:prebieha@test",
+      "DTSTAMP:20260101T000000Z",
+      "SUMMARY:Prebiehajúca schôdza",
+      "DTSTART;TZID=Europe/Bratislava:20260808T090000",
+      "DTEND;TZID=Europe/Bratislava:20260808T140000",
+      "END:VEVENT",
+    ]);
+    const result = resolveNextEvent(text, NOW);
+    expect(result?.title).toBe("Prebiehajúca schôdza");
+  });
+
+  it("z viacerých budúcich udalostí vyberie tú s NAJSKORŠÍM začiatkom", () => {
+    const text = ics([
+      "BEGIN:VEVENT",
+      "UID:neskorsia@test",
+      "DTSTAMP:20260101T000000Z",
+      "SUMMARY:Neskoršia",
+      "DTSTART;TZID=Europe/Bratislava:20260820T090000",
+      "DTEND;TZID=Europe/Bratislava:20260820T100000",
+      "END:VEVENT",
+      "BEGIN:VEVENT",
+      "UID:skorsia@test",
+      "DTSTAMP:20260101T000000Z",
+      "SUMMARY:Skoršia",
+      "DTSTART;TZID=Europe/Bratislava:20260810T090000",
+      "DTEND;TZID=Europe/Bratislava:20260810T100000",
+      "END:VEVENT",
+    ]);
+    const result = resolveNextEvent(text, NOW);
+    expect(result?.title).toBe("Skoršia");
+  });
+
+  it("zrušená (STATUS:CANCELLED) udalosť sa nikdy nevráti", () => {
+    const text = ics([
+      "BEGIN:VEVENT",
+      "UID:zrusena@test",
+      "DTSTAMP:20260101T000000Z",
+      "SUMMARY:Zrušené stretnutie",
+      "DTSTART;TZID=Europe/Bratislava:20260810T090000",
+      "DTEND;TZID=Europe/Bratislava:20260810T100000",
+      "STATUS:CANCELLED",
+      "END:VEVENT",
+    ]);
+    expect(resolveNextEvent(text, NOW)).toBeNull();
+  });
+});
+
+describe("resolveNextEvent — celodenné (VALUE=DATE) udalosti", () => {
+  it("celodenná udalosť DNES sa počíta ako neskončená (end je exkluzívna hranica nasledujúceho dňa)", () => {
+    const text = ics([
+      "BEGIN:VEVENT",
+      "UID:cely-den-dnes@test",
+      "DTSTAMP:20260101T000000Z",
+      "SUMMARY:Sviatok",
+      "DTSTART;VALUE=DATE:20260808",
+      "DTEND;VALUE=DATE:20260809",
+      "END:VEVENT",
+    ]);
+    const result = resolveNextEvent(text, NOW);
+    expect(result?.title).toBe("Sviatok");
+    expect(result?.allDay).toBe(true);
+  });
+
+  it("celodenná udalosť VČERA (end == dnešný deň, exkluzívna) je už skončená", () => {
+    const text = ics([
+      "BEGIN:VEVENT",
+      "UID:cely-den-vcera@test",
+      "DTSTAMP:20260101T000000Z",
+      "SUMMARY:Včerajší sviatok",
+      "DTSTART;VALUE=DATE:20260807",
+      "DTEND;VALUE=DATE:20260808",
+      "END:VEVENT",
+    ]);
+    expect(resolveNextEvent(text, NOW)).toBeNull();
+  });
+
+  it("dateLabel má presne tvar 'deň dátum. mesiac.' v slovenčine", () => {
+    const text = ics([
+      "BEGIN:VEVENT",
+      "UID:format@test",
+      "DTSTAMP:20260101T000000Z",
+      "SUMMARY:Formátovacia udalosť",
+      "DTSTART;VALUE=DATE:20260812",
+      "DTEND;VALUE=DATE:20260813",
+      "END:VEVENT",
+    ]);
+    const result = resolveNextEvent(text, NOW);
+    expect(result?.dateLabel).toBe("streda 12. 8.");
+  });
+});
+
+describe("resolveNextEvent — opakujúce sa udalosti (RRULE)", () => {
+  it("týždenne opakujúca sa udalosť vráti NAJBLIŽŠIU budúcu inštanciu, nie prvý výskyt v minulosti", () => {
+    const text = ics([
+      "BEGIN:VEVENT",
+      "UID:tyzdenna@test",
+      "DTSTAMP:20260101T000000Z",
+      "SUMMARY:Týždenná porada",
+      "DTSTART;TZID=Europe/Bratislava:20260101T090000",
+      "DTEND;TZID=Europe/Bratislava:20260101T093000",
+      "RRULE:FREQ=WEEKLY;BYDAY=MO",
+      "END:VEVENT",
+    ]);
+    const result = resolveNextEvent(text, NOW);
+    // NOW = streda 2026-08-08 10:00 UTC → najbližší pondelok je 2026-08-10.
+    expect(result?.title).toBe("Týždenná porada");
+    expect(result?.dateLabel).toBe("pondelok 10. 8.");
+  });
+
+  it("vynechaný výskyt (EXDATE) sa preskočí, vyberie sa ĎALŠÍ v poradí", () => {
+    const text = ics([
+      "BEGIN:VEVENT",
+      "UID:tyzdenna-exdate@test",
+      "DTSTAMP:20260101T000000Z",
+      "SUMMARY:Týždenná porada",
+      "DTSTART;TZID=Europe/Bratislava:20260101T090000",
+      "DTEND;TZID=Europe/Bratislava:20260101T093000",
+      "RRULE:FREQ=WEEKLY;BYDAY=MO",
+      "EXDATE;TZID=Europe/Bratislava:20260810T090000",
+      "END:VEVENT",
+    ]);
+    const result = resolveNextEvent(text, NOW);
+    expect(result?.dateLabel).toBe("pondelok 17. 8.");
+  });
+});
+
+describe("resolveNextEvent — viacero VEVENT typov naraz", () => {
+  it("kombinácia jednorazovej + opakujúcej sa udalosti vyberie skutočne najbližšiu z OBOCH", () => {
+    const text = ics([
+      "BEGIN:VEVENT",
+      "UID:jednorazova@test",
+      "DTSTAMP:20260101T000000Z",
+      "SUMMARY:Jednorazová skoro",
+      "DTSTART;TZID=Europe/Bratislava:20260809T090000",
+      "DTEND;TZID=Europe/Bratislava:20260809T100000",
+      "END:VEVENT",
+      "BEGIN:VEVENT",
+      "UID:tyzdenna2@test",
+      "DTSTAMP:20260101T000000Z",
+      "SUMMARY:Opakujúca sa neskôr",
+      "DTSTART;TZID=Europe/Bratislava:20260101T090000",
+      "DTEND;TZID=Europe/Bratislava:20260101T093000",
+      "RRULE:FREQ=WEEKLY;BYDAY=MO",
+      "END:VEVENT",
+    ]);
+    const result = resolveNextEvent(text, NOW);
+    expect(result?.title).toBe("Jednorazová skoro");
+  });
+});

--- a/apps/api/src/modules/calendar/next-event.ts
+++ b/apps/api/src/modules/calendar/next-event.ts
@@ -1,0 +1,92 @@
+// issue 309: čistá (bez siete/DB) logika "ktorá udalosť je najbližšia
+// nadchádzajúca" nad už stiahnutým ICS textom — testovateľná fixtúrami,
+// nikdy proti skutočnému Google.
+
+import ical, { type ParameterValue } from "node-ical";
+import { getZonedDateParts, zonedDateKey } from "../../timezone.js";
+import { RECURRENCE_EXPANSION_WINDOW_DAYS } from "./constants.js";
+
+export interface NextCalendarEvent {
+  readonly title: string;
+  /** Predformátovaný Slovenský popis, napr. "utorok 12. 8." — appka má na
+   * server aj klient JEDEN zdroj pravdy pre formát, žiadna duplicitná
+   * formátovacia logika na frontende. */
+  readonly dateLabel: string;
+  readonly allDay: boolean;
+}
+
+const WEEKDAY_FORMAT = new Intl.DateTimeFormat("sk-SK", { timeZone: "Europe/Bratislava", weekday: "long" });
+
+function formatDateLabel(instant: Date): string {
+  const { day, month } = getZonedDateParts(instant);
+  return `${WEEKDAY_FORMAT.format(instant)} ${String(day)}. ${String(month)}.`;
+}
+
+function textOf(value: ParameterValue): string {
+  return typeof value === "string" ? value : value.val;
+}
+
+interface Candidate {
+  readonly start: Date;
+  readonly end: Date;
+  readonly title: string;
+  readonly allDay: boolean;
+}
+
+/**
+ * Udalosť "neskončila" — pri celodennej (plávajúcej, bez TZID) sa porovnáva
+ * kalendárny DEŇ v Europe/Bratislava (`zonedDateKey`, `end` je exkluzívna
+ * hranica — deň PO poslednom dni udalosti), nikdy holý UTC okamih: node-ical
+ * interpretuje `VALUE=DATE` podľa TZ BEŽIACEHO PROCESU (overené priamo —
+ * rovnaký vstup dá iný UTC okamih pod `TZ=UTC` než pod `TZ=Europe/Prague`),
+ * čo by CI (bežiace v UTC) a produkciu (`TZ=Europe/Bratislava`, issue 293)
+ * mohlo ticho rozísť pri porovnaní holých okamihov — `zonedDateKey` je voči
+ * tomu odolné, lebo Bratislava je vždy 0 až +2 h pred UTC, takže spätné
+ * preformátovanie VŽDY pristane na tom istom kalendárnom dni bez ohľadu na
+ * to, v akom pásme node-ical pôvodne interpretovalo plávajúci dátum.
+ * Časovaná (TZID) udalosť porovnáva PRIAMO okamihy — tie sú jednoznačné.
+ */
+function hasNotEnded(candidate: Candidate, now: Date): boolean {
+  if (candidate.allDay) return zonedDateKey(candidate.end) > zonedDateKey(now);
+  return candidate.end.getTime() > now.getTime();
+}
+
+/**
+ * `ical.sync.parseICS` NIKDY nehodí výnimku, ani na úplne nezmyselný vstup —
+ * overené priamo (node-ical 0.27.1, prázdny aj náhodný text obidva vrátia
+ * `{}`). Appka preto potrebuje VLASTNÚ minimálnu kontrolu "vyzerá to vôbec
+ * ako kalendár" — inak by pokazený/nekalendárový feed (napr. HTML chybová
+ * stránka vrátená s HTTP 200) ticho vyzeral ako "žiadna nadchádzajúca
+ * udalosť" namiesto toho, aby nahlas zlyhal (dispatch: "Fetch failure /
+ * malformed feed → fail loud, never crash, never show raw error").
+ */
+export function resolveNextEvent(icsText: string, now: Date): NextCalendarEvent | null {
+  if (!icsText.includes("BEGIN:VCALENDAR")) {
+    throw new Error("Stiahnutý obsah nevyzerá ako platný ICS kalendár (chýba BEGIN:VCALENDAR)");
+  }
+
+  const parsed = ical.sync.parseICS(icsText);
+  const from = now;
+  const to = new Date(now.getTime() + RECURRENCE_EXPANSION_WINDOW_DAYS * 24 * 60 * 60 * 1000);
+
+  const candidates: Candidate[] = [];
+  for (const component of Object.values(parsed)) {
+    if (component === undefined || component.type !== "VEVENT") continue;
+    const event = component;
+    if (event.status === "CANCELLED") continue;
+    // `expandRecurringEvent` funguje pre OBIDVA prípady (opakujúca sa aj
+    // jednorazová udalosť) — jednotná cesta, žiadna samostatná vetva pre
+    // "nemá rrule" (README: "Works with both recurring and non-recurring
+    // events"), navyše správne zohľadní EXDATE/RECURRENCE-ID.
+    const instances = ical.expandRecurringEvent(event, { from, to, expandOngoing: true });
+    for (const instance of instances) {
+      if (instance.event.status === "CANCELLED") continue;
+      candidates.push({ start: instance.start, end: instance.end, title: textOf(instance.summary), allDay: instance.isFullDay });
+    }
+  }
+
+  const upcoming = candidates.filter((c) => hasNotEnded(c, now)).sort((a, b) => a.start.getTime() - b.start.getTime());
+  const next = upcoming[0];
+  if (next === undefined) return null;
+  return { title: next.title, dateLabel: formatDateLabel(next.start), allDay: next.allDay };
+}

--- a/apps/api/src/modules/calendar/service.test.ts
+++ b/apps/api/src/modules/calendar/service.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+import { createNextEventService } from "./service.js";
+import { NEXT_EVENT_ERROR_CACHE_TTL_MS, NEXT_EVENT_OK_CACHE_TTL_MS } from "./constants.js";
+
+const ICS = ["BEGIN:VCALENDAR", "VERSION:2.0", "END:VCALENDAR"].join("\r\n");
+const NOW = new Date("2026-08-08T10:00:00Z");
+
+describe("createNextEventService — cache", () => {
+  it("druhé volanie v TTL okne NEVOLÁ fetchIcs znova (cache hit)", async () => {
+    const fetchIcs = vi.fn().mockResolvedValue(ICS);
+    const service = createNextEventService(fetchIcs);
+    await service.getNextEvent(NOW);
+    await service.getNextEvent(new Date(NOW.getTime() + 1000));
+    expect(fetchIcs).toHaveBeenCalledTimes(1);
+  });
+
+  it("volanie PO uplynutí úspešnej TTL znova zavolá fetchIcs", async () => {
+    const fetchIcs = vi.fn().mockResolvedValue(ICS);
+    const service = createNextEventService(fetchIcs);
+    await service.getNextEvent(NOW);
+    await service.getNextEvent(new Date(NOW.getTime() + NEXT_EVENT_OK_CACHE_TTL_MS + 1));
+    expect(fetchIcs).toHaveBeenCalledTimes(2);
+  });
+
+  it("zlyhanie fetchu vráti { ok: false }, NIKDY nehodí výnimku ďalej", async () => {
+    const fetchIcs = vi.fn().mockRejectedValue(new Error("simulovaný výpadok"));
+    const service = createNextEventService(fetchIcs);
+    await expect(service.getNextEvent(NOW)).resolves.toEqual({ ok: false });
+  });
+
+  it("zlyhanie sa cachuje LEN na kratšiu error TTL — po jej uplynutí appka skúsi znova", async () => {
+    const fetchIcs = vi.fn().mockRejectedValueOnce(new Error("výpadok")).mockResolvedValueOnce(ICS);
+    const service = createNextEventService(fetchIcs);
+    await service.getNextEvent(NOW);
+    // Ešte v error TTL okne — nemá skúšať znova.
+    await service.getNextEvent(new Date(NOW.getTime() + NEXT_EVENT_ERROR_CACHE_TTL_MS - 1));
+    expect(fetchIcs).toHaveBeenCalledTimes(1);
+    // Po uplynutí error TTL — skúsi znova a tentokrát uspeje.
+    const result = await service.getNextEvent(new Date(NOW.getTime() + NEXT_EVENT_ERROR_CACHE_TTL_MS + 1));
+    expect(fetchIcs).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ ok: true, event: null });
+  });
+
+  it("úspešné-ale-prázdne (žiadna udalosť) sa cachuje ako úspešný výsledok, nie ako chyba", async () => {
+    const fetchIcs = vi.fn().mockResolvedValue(ICS);
+    const service = createNextEventService(fetchIcs);
+    const result = await service.getNextEvent(NOW);
+    expect(result).toEqual({ ok: true, event: null });
+  });
+
+  it("SÚBEŽNÉ volania počas prebiehajúceho fetchu zdieľajú JEDEN prísľub — fetchIcs sa zavolá len raz", async () => {
+    let resolveFetch: (value: string) => void = () => {
+      throw new Error("nemalo sa zavolať pred nastavením");
+    };
+    const fetchIcs = vi.fn().mockReturnValue(
+      new Promise<string>((resolve) => {
+        resolveFetch = resolve;
+      }),
+    );
+    const service = createNextEventService(fetchIcs);
+    const first = service.getNextEvent(NOW);
+    const second = service.getNextEvent(NOW);
+    resolveFetch(ICS);
+    await Promise.all([first, second]);
+    expect(fetchIcs).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/modules/calendar/service.ts
+++ b/apps/api/src/modules/calendar/service.ts
@@ -1,0 +1,63 @@
+// issue 309: fasáda pre HTTP vrstvu — spája fetch (sieť) + parse (next-
+// event.ts) + krátkodobú in-memory cache. FAKTÓROVÁ funkcia (nie modulový
+// singleton) — každé volanie dostane VLASTNÝ uzáver so stavom cache, takže
+// testy sa navzájom nemôžu ovplyvniť bez potreby vlastného "reset" exportu
+// (rovnaká úvaha ako prečo `UpozorneniaSection.test.tsx` čistí
+// `localStorage` v `afterEach` — tu sa tomu vyhýbame úplne, nový uzáver na
+// test).
+
+import { log } from "../../logger.js";
+import type { IcsFetcher } from "./fetcher.js";
+import { resolveNextEvent, type NextCalendarEvent } from "./next-event.js";
+import { NEXT_EVENT_ERROR_CACHE_TTL_MS, NEXT_EVENT_OK_CACHE_TTL_MS } from "./constants.js";
+
+export type NextEventResult = { readonly ok: true; readonly event: NextCalendarEvent | null } | { readonly ok: false };
+
+export interface NextEventService {
+  getNextEvent(now: Date): Promise<NextEventResult>;
+}
+
+interface CacheEntry {
+  readonly result: NextEventResult;
+  readonly cachedAtMs: number;
+  readonly ttlMs: number;
+}
+
+export function createNextEventService(fetchIcs: IcsFetcher): NextEventService {
+  let cache: CacheEntry | undefined;
+  // Zdieľaný prísľub pre súbežné volania POČAS jedného fetchu — appka má
+  // dnes jediného čitateľa, ale je to lacná poistka proti zbytočnému
+  // zdvojenému sťahovaniu, keby sa nástenka niekedy otvorila vo viacerých
+  // kartách naraz.
+  let inFlight: Promise<CacheEntry> | undefined;
+
+  async function refresh(now: Date): Promise<CacheEntry> {
+    try {
+      const icsText = await fetchIcs();
+      const event = resolveNextEvent(icsText, now);
+      return { result: { ok: true, event }, cachedAtMs: now.getTime(), ttlMs: NEXT_EVENT_OK_CACHE_TTL_MS };
+    } catch (error) {
+      const rawErrorMessage = error instanceof Error ? error.message : String(error);
+      // Chybová hláška NIKDY neobsahuje URL (`fetcher.ts`'s vlastný
+      // komentár) — bezpečné logovať priamo, žiadne prekrývanie navyše.
+      log.error({ rawErrorMessage }, "Google kalendár: nepodarilo sa načítať/spracovať najbližšiu udalosť");
+      return { result: { ok: false }, cachedAtMs: now.getTime(), ttlMs: NEXT_EVENT_ERROR_CACHE_TTL_MS };
+    }
+  }
+
+  return {
+    async getNextEvent(now: Date): Promise<NextEventResult> {
+      if (cache !== undefined && now.getTime() - cache.cachedAtMs < cache.ttlMs) {
+        return cache.result;
+      }
+      if (inFlight === undefined) {
+        inFlight = refresh(now).finally(() => {
+          inFlight = undefined;
+        });
+      }
+      const entry = await inFlight;
+      cache = entry;
+      return entry.result;
+    },
+  };
+}

--- a/apps/api/tests/calendar-http.integration.test.ts
+++ b/apps/api/tests/calendar-http.integration.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, expect, it } from "vitest";
+import { users } from "../src/db/schema.js";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import { createNextEventService, type NextEventService } from "../src/modules/calendar/service.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 309: HTTP vrstva "Eshop → Upozornenia" — najbližšia udalosť z
+// Google kalendára. `fetchIcs` je VŽDY injektovaná falošná implementácia —
+// appka NIKDY nekontaktuje skutočný Google z testu (rovnaká bezpečnostná
+// podmienka ako `dpd-http.integration.test.ts`'s `DpdRunDeps`).
+const HESLO = "test-heslo-abc";
+
+let close: (() => Promise<void>) | undefined;
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  resetLoginRateLimit();
+});
+
+async function boot(nextEvent?: NextEventService) {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await ctx.db.insert(users).values({
+    email: "pouzivatel@forestshop.sk",
+    passwordHash: await hashPassword(HESLO),
+    displayName: "Test",
+    role: "manazer",
+  });
+  const app = createApp(ctx.db, { cookieSecure: false, ...(nextEvent === undefined ? {} : { nextEvent }) });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "pouzivatel@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie };
+}
+
+// Dátum je vždy "zajtra od TERAZ" (nikdy pevný literál) — test musí zostať
+// zelený bez ohľadu na to, KEDY sa beh spustí, nielen v okne pred 12. 8.
+// 2026 (rovnaká disciplína ako `regression-test-first.md`'s "nikdy
+// časovaná pasca").
+function icsWithEventTomorrow(): string {
+  const start = new Date(Date.now() + 24 * 60 * 60 * 1000);
+  const end = new Date(start.getTime() + 60 * 60 * 1000);
+  const stamp = (d: Date): string => d.toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z");
+  return [
+    "BEGIN:VCALENDAR",
+    "VERSION:2.0",
+    "BEGIN:VEVENT",
+    "UID:test-event@forestshop",
+    "DTSTAMP:20260101T000000Z",
+    "SUMMARY:Stretnutie s dodávateľom",
+    `DTSTART:${stamp(start)}`,
+    `DTEND:${stamp(end)}`,
+    "END:VEVENT",
+    "END:VCALENDAR",
+  ].join("\r\n");
+}
+
+it("bez dodanej nextEvent service vráti configured:false, žiadny fetch sa nevolá", async () => {
+  const { app, cookie } = await boot();
+  const res = await app.request("/api/upozornenia/next-event", { headers: { cookie } });
+  expect(res.status).toBe(200);
+  await expect(res.json()).resolves.toEqual({ configured: false, event: null, error: false });
+});
+
+it("s nakonfigurovanou service vráti najbližšiu udalosť z (falošne) stiahnutého ICS", async () => {
+  const service = createNextEventService(() => Promise.resolve(icsWithEventTomorrow()));
+  const { app, cookie } = await boot(service);
+  const res = await app.request("/api/upozornenia/next-event", { headers: { cookie } });
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { configured: boolean; error: boolean; event: { title: string; allDay: boolean } | null };
+  expect(body.configured).toBe(true);
+  expect(body.error).toBe(false);
+  expect(body.event?.title).toBe("Stretnutie s dodávateľom");
+  expect(body.event?.allDay).toBe(false);
+});
+
+it("keď fetch zlyhá, appka vráti error:true, nikdy surovú chybu ani pád", async () => {
+  const service = createNextEventService(() => Promise.reject(new Error("simulovaný sieťový výpadok")));
+  const { app, cookie } = await boot(service);
+  const res = await app.request("/api/upozornenia/next-event", { headers: { cookie } });
+  expect(res.status).toBe(200);
+  await expect(res.json()).resolves.toEqual({ configured: true, event: null, error: true });
+});
+
+it("neprihlásený dostane 401", async () => {
+  const { app } = await boot();
+  const res = await app.request("/api/upozornenia/next-event");
+  expect(res.status).toBe(401);
+});

--- a/apps/web/src/calendarApi.test.ts
+++ b/apps/web/src/calendarApi.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchNextCalendarEvent } from "./calendarApi.js";
+
+// issue 309: appka NIKDY sama nekontaktuje Google — `fetch` je vždy
+// stubovaná proti PRIAMEMU `/api/upozornenia/next-event`.
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+}
+
+describe("fetchNextCalendarEvent", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("nenakonfigurované → configured:false, event:null", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ configured: false, event: null, error: false })));
+    await expect(fetchNextCalendarEvent()).resolves.toEqual({ configured: false, event: null, error: false });
+  });
+
+  it("nakonfigurované s udalosťou → vráti event presne tak, ako ho poslal server", async () => {
+    const body = { configured: true, event: { title: "Stretnutie", dateLabel: "utorok 12. 8.", allDay: false }, error: false };
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse(body)));
+    await expect(fetchNextCalendarEvent()).resolves.toEqual(body);
+  });
+
+  it("401 (vypršaná relácia) sa NIKDY nezobrazí ako chyba — bezpečný default", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ error: "Neprihlásený" }, 401)));
+    await expect(fetchNextCalendarEvent()).resolves.toEqual({ configured: false, event: null, error: false });
+  });
+
+  it("sieťová chyba (fetch vyhodí) sa NIKDY nepropaguje ďalej — bezpečný default", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
+    await expect(fetchNextCalendarEvent()).resolves.toEqual({ configured: false, event: null, error: false });
+  });
+
+  it("nevalidná odpoveď (zlý tvar JSON) sa NIKDY nepropaguje ďalej — bezpečný default", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ nezmysel: true })));
+    await expect(fetchNextCalendarEvent()).resolves.toEqual({ configured: false, event: null, error: false });
+  });
+});

--- a/apps/web/src/calendarApi.ts
+++ b/apps/web/src/calendarApi.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+// issue 309: "Eshop → Upozornenia" — najbližšia udalosť z Google kalendára.
+// Samostatný modul od `upozorneniaApi.ts` (rovnaký dôvod ako na strane API
+// — nie DB-backed "upozornenie", nezávislý read-through pohľad).
+
+const nextEventSchema = z.object({
+  configured: z.boolean(),
+  event: z.object({ title: z.string(), dateLabel: z.string(), allDay: z.boolean() }).nullable(),
+  error: z.boolean(),
+});
+export type NextCalendarEventResult = z.infer<typeof nextEventSchema>;
+
+// Bezpečný "nič nezobrazovať" default — na 401 (vypršaná relácia) aj na
+// akúkoľvek sieťovú/parse chybu. Táto karta je len doplnkový glance na
+// nástenke, nikdy nesmie zablokovať/zobraziť chybu namiesto zvyšku
+// "Upozornenia" (rovnaký princíp ako `fetchUpozorneniaCount`'s tolerantný
+// bezpečný default).
+const UNAVAILABLE: NextCalendarEventResult = { configured: false, event: null, error: false };
+
+export async function fetchNextCalendarEvent(): Promise<NextCalendarEventResult> {
+  try {
+    const response = await fetch("/api/upozornenia/next-event");
+    if (!response.ok) return UNAVAILABLE;
+    const parsed = nextEventSchema.safeParse(await response.json());
+    return parsed.success ? parsed.data : UNAVAILABLE;
+  } catch {
+    return UNAVAILABLE;
+  }
+}

--- a/apps/web/src/components/NextCalendarEventCard.test.tsx
+++ b/apps/web/src/components/NextCalendarEventCard.test.tsx
@@ -1,0 +1,60 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { NextCalendarEventCard } from "./NextCalendarEventCard.js";
+
+const { fetchNextCalendarEvent } = vi.hoisted(() => ({ fetchNextCalendarEvent: vi.fn() }));
+vi.mock("../calendarApi.js", () => ({ fetchNextCalendarEvent }));
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+it("nenakonfigurované → nič sa nezobrazí (žiadna karta)", async () => {
+  fetchNextCalendarEvent.mockResolvedValue({ configured: false, event: null, error: false });
+  render(<NextCalendarEventCard />);
+  await waitFor(() => {
+    expect(fetchNextCalendarEvent).toHaveBeenCalledTimes(1);
+  });
+  expect(screen.queryByTestId("next-calendar-event")).toBeNull();
+});
+
+it("nakonfigurované s udalosťou → ukáže dátum aj názov", async () => {
+  fetchNextCalendarEvent.mockResolvedValue({ configured: true, event: { title: "Stretnutie s dodávateľom", dateLabel: "utorok 12. 8.", allDay: false }, error: false });
+  render(<NextCalendarEventCard />);
+  const card = await screen.findByTestId("next-calendar-event");
+  expect(card.textContent).toContain("utorok 12. 8.");
+  expect(card.textContent).toContain("Stretnutie s dodávateľom");
+});
+
+it("nakonfigurované, žiadna udalosť → čestná hláška, nie prázdna karta", async () => {
+  fetchNextCalendarEvent.mockResolvedValue({ configured: true, event: null, error: false });
+  render(<NextCalendarEventCard />);
+  const card = await screen.findByTestId("next-calendar-event");
+  expect(card.textContent).toMatch(/žiadna nadchádzajúca udalosť/i);
+});
+
+it("nakonfigurované, chyba pri načítaní → čestná hláška o zlyhaní, nikdy surová chyba", async () => {
+  fetchNextCalendarEvent.mockResolvedValue({ configured: true, event: null, error: true });
+  render(<NextCalendarEventCard />);
+  const card = await screen.findByTestId("next-calendar-event");
+  expect(card.textContent).toMatch(/sa nepodarilo načítať/i);
+});
+
+describe("mountedRef guard", () => {
+  it("výsledok doručený PO odmountovaní sa NEZAPÍŠE (žiadna React varovanie/pád)", async () => {
+    let resolveFetch: (value: { configured: boolean; event: null; error: boolean }) => void = () => {
+      throw new Error("nemalo sa zavolať pred nastavením");
+    };
+    fetchNextCalendarEvent.mockReturnValue(
+      new Promise((resolve) => {
+        resolveFetch = resolve;
+      }),
+    );
+    const { unmount } = render(<NextCalendarEventCard />);
+    unmount();
+    resolveFetch({ configured: true, event: null, error: false });
+    await new Promise((r) => setTimeout(r, 0));
+    // Nič nepadlo — to je celý dôkaz (`mountedRef` guard v komponente).
+  });
+});

--- a/apps/web/src/components/NextCalendarEventCard.tsx
+++ b/apps/web/src/components/NextCalendarEventCard.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useRef, useState, type JSX } from "react";
+import { fetchNextCalendarEvent, type NextCalendarEventResult } from "../calendarApi.js";
+
+// issue 309: "Eshop → Upozornenia" — najbližšia udalosť z Google kalendára.
+// Nezávislá karta od zoznamu DB-backed `upozornenie` kariet nižšie — vždy
+// viditeľná na OBOCH záložkách ("Otvorené" aj "Vybavené"), keďže nejde o
+// položku toho zoznamu (žiadny resolve/postpone).
+
+export function NextCalendarEventCard(): JSX.Element | null {
+  const [result, setResult] = useState<NextCalendarEventResult | null>(null);
+  // `mountedRef` guard (`.claude/rules/frontend-design.md`'s vzor, issue
+  // 251) — appka beží pod `<StrictMode>`, ktoré v dev móde efekt spustí,
+  // zruší a znova spustí; bez tohto by sa mohol výsledok z PRVÉHO
+  // (zrušeného) spustenia zapísať PO odmountovaní.
+  const mountedRef = useRef(false);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    fetchNextCalendarEvent()
+      .then((r) => {
+        if (mountedRef.current) setResult(r);
+      })
+      .catch(() => {
+        // `fetchNextCalendarEvent` sama nikdy nezamietne (má vlastný
+        // bezpečný default) — catch je len obrana pre eslint's
+        // `no-floating-promises`, nikdy sa nemá reálne spustiť.
+      });
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  // Ešte sa nenačítalo, ALEBO appka nemá nakonfigurovaný kalendár — karta sa
+  // vôbec nezobrazí (dispatch: "must NOT appear as broken/error card").
+  if (result === null || !result.configured) return null;
+
+  return (
+    <div className="card next-calendar-event-card" data-testid="next-calendar-event">
+      {result.error ? (
+        <p>Najbližšiu udalosť z kalendára sa nepodarilo načítať.</p>
+      ) : result.event === null ? (
+        <p>V kalendári nie je žiadna nadchádzajúca udalosť.</p>
+      ) : (
+        <p>
+          📅 <strong>{result.event.dateLabel}</strong> — {result.event.title}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/UpozorneniaSection.tsx
+++ b/apps/web/src/components/UpozorneniaSection.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useContext, useEffect, useRef, useState, type JSX } from "react";
 import type { Me } from "../api.js";
 import { UpozorneniaBadgeRefreshContext } from "../upozorneniaBadgeContext.js";
+import { NextCalendarEventCard } from "./NextCalendarEventCard.js";
 import { UpozornenieCard } from "./UpozornenieCard.js";
 import { UpozorneniaResolvedList } from "./UpozorneniaResolvedList.js";
 import {
@@ -182,6 +183,9 @@ export function UpozorneniaSection({ role, onSessionExpired }: { readonly role: 
   // pokojne otvoriť. `intro`/`tabBar` sa preto renderujú VŽDY, nezávisle od
   // `rows`/`error` — tie patria LEN vetve `activeTab === "otvorene"`.
   const intro = <p>Veci, ktoré treba vybaviť — nech ich zistila appka sama, alebo si ich zapísal majiteľ. Nič odtiaľto sa neposiela e-mailom ani na Discord.</p>;
+  // issue 309: nezávislá od `activeTab`, rovnaký dôvod ako `intro`/`tabBar`
+  // vyššie — je to doplnkový glance, nie položka DB-backed zoznamu nižšie.
+  const nextEventCard = <NextCalendarEventCard />;
   const tabBar = (
     <div className="upozornenia-tabs" role="tablist">
       <button
@@ -215,6 +219,7 @@ export function UpozorneniaSection({ role, onSessionExpired }: { readonly role: 
     return (
       <section>
         {intro}
+        {nextEventCard}
         {tabBar}
         <UpozorneniaResolvedList
           canControl={canControl}
@@ -234,6 +239,7 @@ export function UpozorneniaSection({ role, onSessionExpired }: { readonly role: 
     return (
       <section>
         {intro}
+        {nextEventCard}
         {tabBar}
         <p role="alert">{error}</p>
       </section>
@@ -243,6 +249,7 @@ export function UpozorneniaSection({ role, onSessionExpired }: { readonly role: 
     return (
       <section>
         {intro}
+        {nextEventCard}
         {tabBar}
         <p>Načítavam…</p>
       </section>
@@ -252,6 +259,7 @@ export function UpozorneniaSection({ role, onSessionExpired }: { readonly role: 
   return (
     <section>
       {intro}
+      {nextEventCard}
       {tabBar}
       {error !== "" && <p role="alert">{error}</p>}
 

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -706,6 +706,12 @@ tr:last-child td {
   padding: var(--fs-space-4);
 }
 
+/* issue 309: "Eshop → Upozornenia" — najbližšia udalosť z Google kalendára,
+   nad prepínačom záložiek. */
+.next-calendar-event-card {
+  margin-bottom: var(--fs-space-4);
+}
+
 /* ---------------- 5. PRIHLASOVACIA OBRAZOVKA ---------------- */
 .auth-page {
   display: flex;

--- a/apps/web/tests/e2e/upozornenia.spec.ts
+++ b/apps/web/tests/e2e/upozornenia.spec.ts
@@ -32,6 +32,11 @@ test("vlastná poznámka — vytvorenie, 'Nové' zmizne po znovuotvorení, úpra
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
   await expect(page.getByRole("heading", { name: "Upozornenia" })).toBeVisible();
+  // issue 309: e2e beh nemá nastavenú `GOOGLE_CALENDAR_ICS_URL` (rovnako ako
+  // produkcia dnes) — karta najbližšej udalosti sa preto NESMIE zobraziť
+  // vôbec (dispatch: "must NOT appear as broken/error card"), nie ako
+  // prázdna/chybová karta.
+  await expect(page.getByTestId("next-calendar-event")).toHaveCount(0);
   // issue 267 follow-up gap 3: skutočne nič nie je zapísané — hláška to
   // musí povedať pravdivo, nie natvrdo "všetko je vybavené".
   await expect(page.getByTestId("upozornenia-empty")).toHaveText("Žiadne upozornenia — nič nie je zapísané.");

--- a/apps/web/tests/e2e/upozornenia.spec.ts
+++ b/apps/web/tests/e2e/upozornenia.spec.ts
@@ -30,12 +30,21 @@ test("vlastná poznámka — vytvorenie, 'Nové' zmizne po znovuotvorení, úpra
   await page.goto("/?tab=upozornenia");
   await page.getByLabel("E-mail").fill(E2E_UPOZORNENIA_EMAIL);
   await page.getByLabel("Heslo").fill(E2E_HESLO);
+  // issue 309: `waitForResponse` MUSÍ byť zaregistrovaný PRED akciou, ktorá
+  // request spustí (Playwright ho inak nezachytí, keby request medzitým už
+  // doletel) — prihlásenie namountuje "Upozornenia", čo namountuje
+  // `NextCalendarEventCard`, ktorá HNEĎ zavolá tento endpoint.
+  const dalsiaUdalostOdpoved = page.waitForResponse((r) => r.url().includes("/api/upozornenia/next-event"));
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
   await expect(page.getByRole("heading", { name: "Upozornenia" })).toBeVisible();
-  // issue 309: e2e beh nemá nastavenú `GOOGLE_CALENDAR_ICS_URL` (rovnako ako
-  // produkcia dnes) — karta najbližšej udalosti sa preto NESMIE zobraziť
-  // vôbec (dispatch: "must NOT appear as broken/error card"), nie ako
-  // prázdna/chybová karta.
+  await dalsiaUdalostOdpoved;
+  // Deep-review nález (PR 322): `toHaveCount(0)` HNEĎ po prihlásení by
+  // prešlo aj VŽDY (karta je `null` aj počas načítavania AJ pri
+  // `configured:false`) — počkaním na SKUTOČNÚ odpoveď vyššie test dokáže
+  // reálne správanie ("nenakonfigurované sa nezobrazí"), nie len časovanie
+  // pred fetchom. E2E beh nemá nastavenú `GOOGLE_CALENDAR_ICS_URL` (rovnako
+  // ako produkcia dnes) — karta sa preto NESMIE zobraziť vôbec (dispatch:
+  // "must NOT appear as broken/error card"), nie ako prázdna/chybová karta.
   await expect(page.getByTestId("next-calendar-event")).toHaveCount(0);
   // issue 267 follow-up gap 3: skutočne nič nie je zapísané — hláška to
   // musí povedať pravdivo, nie natvrdo "všetko je vybavené".

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -152,6 +152,14 @@ services:
       # vyššie). Chýbajúca = automatizácia NEPOŠLE ani jeden e-mail
       # zákazníkovi (fail-closed).
       ORDER_MERGE_BCC_EMAIL:
+      # issue 309: "Eshop → Upozornenia" — najbližšia udalosť z majiteľovho
+      # Google kalendára. Rovnaká úvaha ako SHOPTET_EXPORT_URL vyššie:
+      # `.optional()` v `env.ts`, bare kľúč preberá `/srv/forestshop/.env`,
+      # keď tam je; keď nie je, appka beží ďalej, karta na nástenke sa
+      # jednoducho nezobrazí. Adresa je CELÁ tajomstvo (tajný token je
+      # priamo v CESTE, nie len v query parametri) — sem patrí LEN bare
+      # kľúč, nikdy skutočná hodnota.
+      GOOGLE_CALENDAR_ICS_URL:
     volumes:
       - catalog-raw:/data/catalog-raw
       - orders-raw:/data/orders-raw

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -3128,3 +3128,55 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   via `secret request` repeatedly overnight, 600s URL TTL expired
   unused each time — owner was asleep). First real shipment must be
   clicked by the owner himself once the form is live-mapped.
+
+## Issue 319 — Vypredané → Skladom: 'Spustiť teraz' restock deps wiring (2026-08-08)
+
+- Commits: `742af17` (version bump 0.3.0-dev.184) → `6571eda` [red]
+  static-source regression test → `ec4eb5d` [green] fix → `c53b937`
+  (playbook `.claude/rules/supplier-stock.md`).
+- Validated FIRST: another worker's own prior live observation
+  (2026-08-07, click returned `nothing_to_do`) looked like it contradicted
+  the ticket. Traced `runRestockLocked` — it returns `nothing_to_do`
+  BEFORE ever touching Shoptet login when there are 0 candidates, so the
+  observation didn't rule anything out. Cross-referenced production
+  `job_run`/`audit_events`: a `failure` row at 2026-08-06 12:37:16 carried
+  the exact predicted "prihlasovací formulár stále viditeľný" error, right
+  after a manual `restock.enabled.set` toggle, with no matching
+  `restock.run_now` audit row (the HTTP handler's `record()` is skipped on
+  the exception path) — confirmed the ticket was genuinely valid, posted
+  as its own `gh issue comment`.
+- Design: root cause traced to `index.ts`'s `createApp(db, {...})` never
+  passing a `restock` key (only gap of its shape — checked all `options.*`
+  in `http/app.ts` against the call site). Chose the ticket's own
+  one-line fix over making `restock` a required `AppOptions` field
+  (rejected — would force editing ~35 existing test files calling
+  `createApp` without `restock`, for no behavioral gain since `http/
+  app.ts`'s fail-closed fallback is itself the documented intended
+  design).
+- RED/GREEN: `index.ts` can't be safely imported in a test (module-top-level
+  DB migration + `serve()`), so the regression test statically reads the
+  source and regex-checks the `createApp(...)` call block references the
+  real `shoptetAdminUser ?? ""`/`shoptetAdminPassword ?? ""` variables —
+  independently re-verified by the deep-review subagent, which re-ran the
+  test against the pre-fix source and confirmed RED.
+- Review: `/review` inline (0/0/0) + dispatched `general-purpose` deep
+  reviewer with precisely-crafted context (BASE `1067197`/HEAD `ec4eb5d`,
+  no session history) — 0 Critical/Important/Minor, confirmed `restock`
+  was the only wiring gap and the fix preserves the fail-closed default
+  when env vars are absent.
+- Local gates: `pnpm typecheck`/`pnpm lint` clean; API unit 653/653 (46
+  files); API integration 608/608 (81 files); web unit 522/522 (71
+  files); e2e 51/51 (52 spec files), zero console errors.
+- PR #321 merged (`f336e38`) to `main`; main CI + Deploy both green.
+  Post-deploy verification: DOM version `v0.3.0-dev.184`; directly
+  `docker exec`'d into the running container and confirmed
+  `dist/index.js` carries the fix verbatim (not just that CI passed);
+  clicked "⚡ Spustiť teraz" live — succeeded, 0 console errors,
+  `job_run` `success {"status":"nothing_to_do"}` (0 candidates waiting at
+  the time, so this specific click never reached the Shoptet-login step).
+  Closed the ticket on the strength of: the deployed code now calls the
+  IDENTICAL `shoptetImportConfigFromBaseUrl(...)` with the IDENTICAL
+  credentials that the scheduled `restockJob` (2026-08-07 18:10, "ok,
+  switched 1") and the hourly `shoptet-writeback` job repeatedly prove
+  valid — documented explicitly on the closing comment, with an
+  invitation to reopen if a real candidate somehow still fails.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.184",
+  "version": "0.3.0-dev.185",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       hono:
         specifier: ^4.6.0
         version: 4.12.32
+      node-ical:
+        specifier: ^0.27.1
+        version: 0.27.1
       nodemailer:
         specifier: ^9.0.3
         version: 9.0.3
@@ -1719,6 +1722,10 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  node-ical@0.27.1:
+    resolution: {integrity: sha512-5fiKuh/h2HrWKzFt20LtRQdjtjdGfijGfDnCfdAEc++SFX9gA6sa7xwj7/BJmRfWtW/NJWBenN4tOJhg0vM3pg==}
+    engines: {node: '>=22'}
+
   node-releases@2.0.51:
     resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
     engines: {node: '>=18'}
@@ -1900,6 +1907,9 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rrule-temporal@2.0.2:
+    resolution: {integrity: sha512-pwe7+pWXKUotQgdudN8W36tFHWf8eH+FbcB5Tl4Zftb4RYpl1hnqMRapizv0s8QlOlC6GEKcVSmITurpSOVZfQ==}
+
   safe-stable-stringify@2.5.0:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
@@ -1968,6 +1978,15 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  temporal-polyfill@1.0.3:
+    resolution: {integrity: sha512-U8vuzZBc+dfMIfl8wXWcedfI7AJCxJjjVBIRpJUvIz5+UAp555UJDHguKsfZqHWaHRSdVUThm7mqqIWhN/xPBQ==}
+
+  temporal-spec@1.0.1:
+    resolution: {integrity: sha512-wxVoanmDeavXie1vu2JaQ3WIc3JZnWAOYFBsJyATaVsXsycKYUflGsyBmrRSnoCpZJpwPyr38VpgSUlQ8CbFxg==}
+
+  temporal-utils@1.0.1:
+    resolution: {integrity: sha512-HAixuesxFQIUaQk3ptX2jhfO/FsOkgVkDDMawvp6n/fkB1q6BKfs3lURw9I+pK/2e2e/q/vrLrxmeqauBoyGMQ==}
 
   thread-stream@3.2.0:
     resolution: {integrity: sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==}
@@ -3572,6 +3591,11 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  node-ical@0.27.1:
+    dependencies:
+      rrule-temporal: 2.0.2
+      temporal-polyfill: 1.0.3
+
   node-releases@2.0.51: {}
 
   nodemailer@9.0.3: {}
@@ -3758,6 +3782,10 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.62.3
       fsevents: 2.3.3
 
+  rrule-temporal@2.0.2:
+    dependencies:
+      temporal-spec: 1.0.1
+
   safe-stable-stringify@2.5.0: {}
 
   saxes@6.0.0:
@@ -3808,6 +3836,15 @@ snapshots:
       has-flag: 4.0.0
 
   symbol-tree@3.2.4: {}
+
+  temporal-polyfill@1.0.3:
+    dependencies:
+      temporal-spec: 1.0.1
+      temporal-utils: 1.0.1
+
+  temporal-spec@1.0.1: {}
+
+  temporal-utils@1.0.1: {}
 
   thread-stream@3.2.0:
     dependencies:


### PR DESCRIPTION
## Čo pridáva

Nová karta na nástenke **Eshop → Upozornenia**, zobrazujúca najbližšiu
nadchádzajúcu udalosť z majiteľovho Google kalendára (dátum + deň + názov).

## Prístup

Tajná Google iCal (`.ics`) adresa — zdôvodnenie a zamietnuté alternatívy v
návrhovom komentári na issue 309. `node-ical` (RRULE/EXDATE/all-day aware),
krátkodobá in-memory cache (15 min úspech / 2 min zlyhanie), žiadna DB
tabuľka, žiadny scheduler job — dáta sa nemajú perzistovať ani "vybaviť".

## Bezpečnosť

`GOOGLE_CALENDAR_ICS_URL` je voliteľná (appka beží ďalej bez nej — karta sa
jednoducho nezobrazí), nikdy sa nedostane do repa/commit správy/logu. Adresa
nesie tajný token PRIAMO V CESTE (nie len v query parametri) — chybové
hlášky preto NIKDY neinterpolujú URL vôbec.

## Stav ticketu

issue 309 zostáva OTVORENÝ — chýba jediná vec, ktorú vie doplniť len
majiteľ: samotná tajná adresa jeho kalendára do `/srv/forestshop/.env` na
dev2. Kód aj nasadenie sú kompletné a otestované, len sa v skutočnosti ešte
nedá naživo overiť s reálnou udalosťou.

## Testy

Unit (next-event resolver: celodenné/časované/opakujúce sa/EXDATE/CANCELLED,
fetcher: timeout/veľkosť/žiadna URL v chybe, cache: TTL/dedup súbežných
volaní), integration (HTTP trasa: nenakonfigurované/úspech/chyba/401), e2e
(karta sa NEZOBRAZÍ, keď appka nemá kalendár nastavený — dnešný stav).
Žiadny test sa nikdy nepripája na skutočný Google.
