### PR TITLE
docs: playbook entries for issue 309 (Google kalendár)

### DIFF
--- a/.claude/rules/calendar.md
+++ b/.claude/rules/calendar.md
@@ -1,0 +1,72 @@
+---
+paths:
+  - "apps/api/src/modules/calendar/**"
+  - "apps/api/src/http/calendar-routes.ts"
+  - "apps/web/src/calendarApi.ts"
+  - "apps/web/src/components/NextCalendarEventCard*.tsx"
+---
+
+# Google kalendár — najbližšia udalosť (issue 309)
+
+- **Toto NIE JE DB-backed "upozornenie" (`.claude/rules/upozornenia.md`),
+  hoci karta sedí na tej istej nástenke.** `upsertUpozornenie` je pre
+  položky s dedupKey/resolve/postpone semantikou (niečo, čo treba
+  VYBAVIŤ). Najbližšia kalendárová udalosť je live read-through pohľad —
+  vždy sa len AKTUÁLNE prepočíta, nikdy sa "nevybavuje". Vynucovanie
+  takýchto dát do `upozornenie` tabuľky by znamenalo vymýšľať umelé
+  resolve/dedup semantiky pre niečo, čo žiadne nepotrebuje. Rovnaká úvaha
+  ako `posta-uncollected`'s "Spustiť teraz" STATUS vzor (nie jeho samotný
+  automatický zdroj karty), nie zoznamový DB vzor.
+- **Krátkodobá in-memory cache PRIAMO v module (`service.ts`, 15 min úspech
+  / 2 min zlyhanie) namiesto scheduler jobu.** Netreba perzistenciu (dáta
+  sa nemajú "vybaviť" ani prežiť reštart appky zmysluplne) — lazy fetch na
+  request s TTL cache dosahuje presne to isté, čo by periodický job
+  dosiahol, bez novej tabuľky/migrácie/`job_run` riadku. Zlyhanie fetchu sa
+  NIKDY nenahrádza starou (možno už minulou) cachovanou hodnotou — radšej
+  čestné "nepodarilo sa načítať" než riziko, že appka donekonečna ukáže UŽ
+  MINULÚ udalosť ako "najbližšiu".
+- **`node-ical` interpretuje `VALUE=DATE` (celodenné, plávajúce, bez TZID)
+  udalosti podľa TZ BEŽIACEHO PROCESU** — overené priamo (rovnaký ICS
+  vstup dá iný absolútny UTC okamih pod `TZ=UTC` než pod
+  `TZ=Europe/Prague`). CI beží v UTC, produkcia má `TZ=Europe/Bratislava`
+  (issue 293) — porovnávanie holých UTC okamihov pre celodenné udalosti by
+  sa medzi CI a produkciou ticho rozišlo. Fix: `next-event.ts`'s
+  `hasNotEnded` porovnáva pre celodenné udalosti KALENDÁRNY DEŇ cez
+  `../../timezone.js`'s `zonedDateKey(instant, "Europe/Bratislava")`, nie
+  `.getTime()` — Bratislava je vždy 0 až +2 h PRED UTC, takže spätné
+  preformátovanie VŽDY pristane na tom istom kalendárnom dni bez ohľadu na
+  to, v akom pásme node-ical pôvodne interpretovalo plávajúci dátum.
+  Časovaná (TZID) udalosť porovnáva PRIAMO okamihy (`.getTime()`) — tie sú
+  jednoznačné bez ohľadu na proces. Test pre KAŽDÚ ĎALŠIU prácu s
+  celodennými (`VALUE=DATE`) hodnotami z `node-ical` v tomto module: over
+  najprv, či sa dá vyhnúť priamemu porovnaniu okamihov, a preformátuj cez
+  `zonedDateKey` namiesto toho.
+- **`ical.sync.parseICS` NIKDY nehodí výnimku, ani na úplne nezmyselný
+  vstup — overené priamo (node-ical 0.27.1), prázdny aj náhodný text
+  obidva vrátia `{}`.** Appka preto potrebuje VLASTNÚ minimálnu kontrolu
+  "vyzerá to vôbec ako kalendár" (`next-event.ts`'s `BEGIN:VCALENDAR`
+  substring check) — inak by pokazený/nekalendárový feed (napr. HTML
+  chybová stránka vrátená s HTTP 200) ticho vyzeral ako "žiadna
+  nadchádzajúca udalosť" namiesto toho, aby nahlas zlyhal.
+- **`ical.expandRecurringEvent(event, {from, to, expandOngoing: true})`
+  funguje pre OBIDVA prípady (opakujúca sa aj jednorazová udalosť) —
+  jednotná cesta v `next-event.ts`, žiadna samostatná vetva pre "nemá
+  rrule".** `expandOngoing: true` je POVINNÉ pre "najbližšia = ešte
+  neskončila" sémantiku (dispatch issue 309) — bez neho by viacdňová
+  udalosť, ktorá začala PRED `now`, ale ešte neskončila, vôbec nebola
+  medzi kandidátmi (overené priamo: s `expandOngoing:false` prázdne pole,
+  s `true` správna inštancia).
+- **Google-ova súkromná ICS adresa nesie tajný token PRIAMO V CESTE**
+  (`/calendar/ical/<email>/private-<token>/basic.ics`), NIE len v query
+  parametri ako Shoptet exporty (`hash=...`) — `catalog/fetcher.ts`'s
+  existujúci `redactUrl` (prekrýva LEN query parametre) by tu NIČ
+  neskryl. `calendar/fetcher.ts`'s chybové hlášky preto NIKDY
+  neinterpolujú URL vôbec (ani prekrytú) — len status kód/typ zlyhania.
+  Test na KAŽDÝ ĎALŠÍ zdroj, kde je tajomstvo v CESTE, nie v query: over,
+  že žiadna chybová hláška/log nikdy nezreťazí `url`/`String(url)`.
+- **Deep-review nález (PR 322): `page.waitForResponse(...)` MUSÍ byť
+  zaregistrovaný PRED akciou, čo request spustí** (`upozornenia.spec.ts`)
+  — inak Playwright zmešká response, ktorý doletel skôr, než sa naň
+  začalo čakať. Prvý pokus (`toHaveCount(0)` hneď po prihlásení, bez
+  `waitForResponse`) by prešiel aj VŽDY (komponent renderuje `null` aj
+  počas načítavania, aj pri `configured:false`) — nedokazoval by nič.

--- a/.claude/rules/upozornenia.md
+++ b/.claude/rules/upozornenia.md
@@ -378,3 +378,12 @@ paths:
   produkcii (vlastná testovacia poznámka: vytvoriť → vybaviť → záložka
   Vybavené → vrátiť → späť v Otvorené → zmazať, 0 chýb v konzole) toto
   potvrdilo za pár minút, namiesto zbytočnej re-implementácie.
+- **Issue 309 (najbližšia udalosť z Google kalendára) sedí na TEJTO istej
+  nástenke, ale je to ZÁMERNE samostatný modul** (`.claude/rules/
+  calendar.md`) — žiadny dedupKey/resolve/postpone, live read-through
+  pohľad namiesto DB-backed riadku. `upsertUpozornenie` je pre položky,
+  čo treba VYBAVIŤ — pri KAŽDOM ĎALŠOM "karta na tejto nástenke" tickete
+  over najprv, či nová vec má takú "treba vybaviť" povahu, alebo je to
+  len live status glance (rovnaká úvaha ako `posta-uncollected`'s
+  "Spustiť teraz" vzor) — ak druhé, patrí do vlastného modulu, nie do
+  `upozornenie` tabuľky.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,3 +106,4 @@ Per-area rules live in `.claude/rules/<area>.md` with `paths:` frontmatter.
 - Eshop → Upozornenia (#267 — nástenka, čiastočný unique dedup index, počítaný stav bez cron-u, zdieľaná zapisovacia cesta pre budúce #268/#269) → `.claude/rules/upozornenia.md`
 - Vypredané → Skladom: návrhy odkazov (#311 — deterministický návrh podľa zhody mena+dodávateľa, zdieľaná zapisovacia cesta s #239, žiadne AI dohady) → `.claude/rules/restock-links.md`
 - Preprava DPD (#292 — per-zásielkový Playwright robot na dpdshipper.sk, appka-vlastný `dpd_shipment`/`dpd_pickup_request` záznam, náhľad pred odoslaním, fail-loud nedomapovaný formulár) → `.claude/rules/dpd.md`
+- Google kalendár — najbližšia udalosť (#309 — samostatný modul od `upozornenia` (žiadny dedupKey/resolve), krátkodobá in-memory cache namiesto scheduler jobu, node-ical proces-TZ past pri celodenných udalostiach) → `.claude/rules/calendar.md`

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -3180,3 +3180,76 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   switched 1") and the hourly `shoptet-writeback` job repeatedly prove
   valid — documented explicitly on the closing comment, with an
   invitation to reopen if a real candidate somehow still fails.
+
+## Issue 309 — Upozornenia: najbližšia udalosť z Google kalendára (2026-08-08)
+
+- Commits: `84876f8` (version bump 0.3.0-dev.185) → `f12b7cc` (backend:
+  `modules/calendar/` + `GOOGLE_CALENDAR_ICS_URL` wiring) → `49bde35`
+  (frontend: `NextCalendarEventCard`) → `9a41fc0` (e2e race fix from
+  deep-review finding) → PR #322 merge `398f52c`.
+- Design (posted BEFORE first code commit, `gh issue comment 309`):
+  ticket's own recorded owner-Discord comment already settled the access
+  method (secret iCal URL, option 1) — treated as a technical decision,
+  never re-asked. Architectural choice: independent `modules/calendar/`
+  module, NOT the DB-backed `upozornenie` dedupKey/resolve pattern (no
+  "vybaviť" semantics apply to a live read-through calendar view) —
+  short-lived in-memory cache (15 min ok / 2 min error) instead of a new
+  scheduler job + DB table, since nothing needs to persist or survive a
+  restart meaningfully. `node-ical` chosen over hand-rolled RRULE parsing
+  (`investigate-existing-first`) — RFC 5545 recurrence is a known minefield
+  (DST, EXDATE, RECURRENCE-ID overrides).
+- Real correctness pitfall found + fixed BEFORE any test was written:
+  `node-ical` interprets floating `VALUE=DATE` (all-day) values using the
+  RUNNING PROCESS's timezone — verified empirically (`TZ=UTC` vs
+  `TZ=Europe/Prague` give different absolute instants for the identical
+  ICS text). Since CI runs UTC and production runs `TZ=Europe/Bratislava`
+  (issue 293), a naive instant comparison would silently disagree between
+  environments. Fix: reuse the project's own `timezone.ts`'s
+  `zonedDateKey` to compare CALENDAR DAYS in Europe/Bratislava for all-day
+  events (proven safe regardless of which offset node-ical used
+  internally, since Bratislava is always 0–2h ahead of UTC) — documented
+  in the new `.claude/rules/calendar.md`.
+- Security: the Google secret ICS URL carries its token in the PATH, not
+  a query parameter (unlike every existing Shoptet integration in this
+  repo) — the existing `redactUrl` helper (query-param-only) would leak
+  it. `calendar/fetcher.ts` never interpolates the URL into any thrown
+  error/log line at all; `fetcher.test.ts` asserts this directly.
+- Tests: unit (`next-event.test.ts` 13 cases against the REAL `node-ical`
+  library — all-day, timed, ongoing, RRULE, EXDATE, CANCELLED;
+  `fetcher.test.ts` 3 cases — timeout/size-cap/no-URL-in-error;
+  `service.test.ts` 6 cases — TTL cache, error TTL, concurrent dedup),
+  integration (`calendar-http.integration.test.ts` 4 cases — not
+  configured/success/fetch-failure/401), web unit (`calendarApi.test.ts`
+  5, `NextCalendarEventCard.test.tsx` 5 incl. StrictMode unmount-race
+  guard), e2e (extended `upozornenia.spec.ts` — card absent when
+  unconfigured, real `waitForResponse` proof, not a timing coincidence).
+  No test ever contacts the real Google.
+- Review: manual `/review` on the PR diff (0/0/0) + dispatched
+  `general-purpose` deep reviewer with precisely-crafted context (BASE
+  `f336e38`/HEAD `5a4a3e5`, no session history) — verdict "ready to
+  merge", one legitimate Important finding (E2E `waitForResponse` race —
+  fixed in `9a41fc0`) and one Important finding correctly identified as
+  out-of-scope (the "owner hasn't confirmed the access method" concern —
+  already explicitly settled per the dispatch's own instruction, not a
+  code issue).
+- Local gates: `pnpm typecheck`/`pnpm lint` clean; API unit 675/675 (49
+  files, incl. new calendar tests); API integration 612+/612+ (82+
+  files); web unit 532/532 (73 files); e2e 51/51 (52 spec files), zero
+  console errors, one unrelated known-flaky test (`.claude/rules/
+  testing.md`'s documented shared-box load pattern) reproduced green on
+  isolated re-run.
+- PR #322 merged (`398f52c`) to `main`; main CI + Deploy both green.
+  Post-deploy verification (Playwright, logged-in as the real owner
+  `vychod@varos.sk`): DOM version `v0.3.0-dev.185`, "Upozornenia" tab
+  loads with ZERO console errors, no calendar card renders (matches
+  `configured:false` — production has no `GOOGLE_CALENDAR_ICS_URL` set
+  yet), direct `fetch("/api/upozornenia/next-event")` from the live page
+  confirmed `{"configured":false,"event":null,"error":false}`.
+  **UNVERIFIED: the real-event rendering path** (a genuine calendar
+  event's date/title actually appearing) — the owner has not yet pasted
+  his calendar's secret iCal URL into `/srv/forestshop/.env` on dev2.
+  Issue 309 deliberately left OPEN (`needs-answer` label kept) with a
+  comment explaining the only remaining step is that one paste — no
+  `Closes #309` anywhere in the PR body or any commit message (this repo
+  merges via merge commits, so commit messages reach `main` intact and
+  would auto-close too).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.185",
+  "version": "0.3.0-dev.186",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Čo pridáva

Iba playbook/docs dohĺadenie k PR #322 (issue 309, najbližšia udalosť z
Google kalendára) — žiadna zmena funkčného kódu. Omylom zmergované PR #322
predtým, než sa stihol dokončiť CYCLE krok 11 (`playbook-review`).

- Nové `.claude/rules/calendar.md` (samostatný modul, node-ical proces-TZ
  past, tajný token v CESTE nie v query).
- Krátky doplnok v `.claude/rules/upozornenia.md` (odkaz na nový modul).
- Riadok v `CLAUDE.md`'s Playbook router.
- Záznam v `docs/autopilot-log.md`.
