### PR TITLE
DPD: naživo domapované vyplnenie formulára (issue 292)

### DIFF
--- a/.claude/rules/dpd.md
+++ b/.claude/rules/dpd.md
@@ -57,28 +57,62 @@ paths:
     NAHLAS namiesto tichého preskočenia.
   - **Pole na sumu dobierky sa NEDALO naživo bezpečne domapovať** (jeho DOM
     sa vykreslí AŽ po reálnom zaškrtnutí, ktoré v read-only sandboxe zostáva
-    trvalo disabled) — `fillCodAmount` preto po zaškrtnutí COD počká na
-    NOVO objavený `input` v tom istom `.additional-service` kontajneri;
-    ak sa neobjaví, zlyhá nahlas s presným popisom. **Prvé reálne overenie
-    tejto konkrétnej vetvy (COD zásielka) príde AŽ pri prvom skutočnom
-    COD odoslaní majiteľom** — over jej správanie vtedy, neber ju za
-    naživo overenú predtým.
+    trvalo disabled) — `fillCodAmount` preto SPOČÍTA vstupy v tom istom
+    `.additional-service` kontajneri PRED zaškrtnutím a čaká, kým sa počet
+    GENUINNE zvýši (nie len "prvý input v kontajneri" — code review, issue
+    292, PR 324: pôvodná verzia by omylom vybrala AKÝKOĽVEK existujúci
+    vstup, test na to naschvál obsahuje aj vopred prítomný "vábiaci" vstup
+    v tom istom kontajneri). Ak sa nový vstup neobjaví, zlyhá nahlas.
+    **Prvé reálne overenie tejto konkrétnej vetvy (COD zásielka) príde AŽ
+    pri prvom skutočnom COD odoslaní majiteľom** — over jej správanie
+    vtedy, neber ju za naživo overenú predtým.
+  - **`isCod: true` s nezistiteľnou sumou (`codAmount: null`) TERAZ zlyhá
+    nahlas namiesto tichého odoslania bez dobierky** (code review, issue
+    292, PR 324) — `preview.ts`'s `codAmount` sa dá naparsovať na `null` aj
+    pri dobierkovej objednávke (chýbajúce `priceToPay` AJ
+    `totalPriceWithVat`); appka to predtým ticho preskočila a kuriér by
+    peniaze od zákazníka nevybral. Rovnaká disciplína ako hmotnosť/
+    krajina/telefón — neisté = zlyhaj, nikdy nehádaj 0.
   - **Appka podporuje LEN slovenské doručovacie adresy** — krajina sa
     NEVYBERÁ aktívne (portálový default je už "Slovensko", appka nemá
     spoľahlivé mapovanie Shoptet textu na DPD interné číselné ID pre iné
     krajiny), `portal-fill.ts`'s `assertSlovakDeliveryCountry` zlyhá nahlas
-    na inej krajine namiesto tichého odoslania so zlou predvolenou.
+    na inej krajine namiesto tichého odoslania so zlou predvolenou —
+    volaná VŽDY (aj na `countryName === null` cez `?? ""`, code review PR
+    324: predošlá verzia `null` prípad ticho preskočila).
   - **Telefón**: appka posiela LEN národné číslo (`portal-fill.ts`'s
     `normalizePhoneForDpd` odstráni `+421`/`00421`/vedúcu nulu) — predvoľba
-    `+421` je v portáli SAMOSTATNÉ pole, appka ho nemení.
+    `+421` je v portáli SAMOSTATNÉ pole, appka ho nemení. Kontrola DĹŽKY
+    (presne 9 číslic) platí AŽ PO odstránení prefixu, JEDNOTNE pre všetky
+    vetvy (code review PR 324: pôvodná verzia validovala dĺžku len v
+    jednej vetve, takže napr. "00903123456" — zle zadaná domáca nula
+    namiesto medzinárodnej predvoľby — prešlo ako nezmyselné 10-miestne
+    číslo).
   - **Číslo zásielky po uložení sa NEDALO naživo overiť skutočným kliknutím**
     (bezpečnostné pravidlo — prvý reálny klik patrí majiteľovi) —
     `readParcelNumberAfterSave` skúša najprv toast/notifikáciu, potom
     zoznam Zásielky filtrovaný podľa referencie (appka posiela
-    `externalOrderId` do "Referencia 1", `#referential-info1`). **Toto je
-    jediná časť flow-u, ktorá zostáva UNVERIFIED až do prvého skutočného
-    odoslania majiteľom** — ak sa pri ňom ukáže iný tvar výsledku, uprav
-    LEN túto funkciu.
+    `externalOrderId` do "Referencia 1", `#referential-info1`).
+    **`extractParcelNumber` vyžaduje 10+ číslic A výslovne vylučuje
+    zhodu so samotnou referenciou** (code review, issue 292, PR 324:
+    appka's referencia — typicky 8-miestne Shoptet objednávkové číslo —
+    je v tom riadku VŽDY prítomná, presne preto sa podľa nej riadok
+    hľadá; naivné "prvá 8+ miestna číslica" by ju teda mohlo vrátiť
+    namiesto skutočného, naživo pozorovaného 14-miestneho čísla zásielky).
+    **Toto je jediná časť SHIPMENT flow-u, ktorá zostáva UNVERIFIED až do
+    prvého skutočného odoslania majiteľom** — ak sa pri ňom ukáže iný tvar
+    výsledku, uprav LEN túto funkciu.
+  - **Objednanie zvozu (`pickup-playwright.ts`): "úspech" je NEPRIAMY dôkaz
+    (absencia chyby), NIE potvrdený pozitívny signál — DRUHÁ časť flow-u,
+    ktorá zostáva UNVERIFIED** (code review, issue 292, PR 324 — dovtedy
+    nezdôraznené v tomto súbore, hoci nesie rovnaké riziko ako COD-suma/
+    číslo zásielky vyššie). Presný pozitívny "uložené" signál sa nedal
+    naživo pozorovať (rovnaké bezpečnostné pravidlo). `checkForPortalError`
+    preto kontroluje aj live-overený `#toast-container`/`[id*="toast"]`
+    mechanizmus (ten istý, aký appka videla vypisovať systémové správy na
+    `/pickup-orders`), aj bežné hádané CSS triedy ako zálohu — kým sa
+    skutočný tvar chyby/úspechu neoverí prvým reálnym zvozom, KAŽDÉ
+    `ok:true` tu je optimistické, nie potvrdené.
   - **Testy** (`tests/helpers/dpd-portal-fixture.ts`) imitujú LEN tvar,
     ktorý appka skutočne ovláda (ID/vnorenie/atribúty naživo domapovaných
     prvkov) — NIKDY sa nedotknú `dpdshipper.sk`. **Fixture login formulár
@@ -89,7 +123,23 @@ paths:
     správnym heslom — nie appka bug, fixture bug; rovnaká trieda chyby ako
     `shoptet-fixture.ts`'s file-chooser gotcha, over VŽDY, že fixture
     formulár posiela dáta presne tak, ako by ich poslal skutočný
-    prehliadač).
+    prehliadač). **Fixture, čo si pri "vytvor si vlastný selektor cez
+    zhodu DOM pred/po" domýšľa ROVNAKÝ tvar ako implementácia (code
+    review PR 324), test NEDOKÁŽE odhaliť zlý predpoklad** — vždy pridaj
+    do fixture aj "vábiaci" prvok (napr. vopred prítomný input v tom
+    istom kontajneri), ktorý by naivnú implementáciu (bez skutočného
+    PRED/PO porovnania) prezradil.
+  - **`portal-fill.ts`'s `runOnDpdPortalPage`** zdieľa CELÝ launch→context→
+    page→prihlásenie→`action`→zavri cyklus medzi `shipment-playwright.ts`
+    aj `pickup-playwright.ts` (predtým kopírovaný dvakrát skoro doslovne —
+    code review PR 324); `typeInto` prijíma AJ už-vyriešený `Locator`
+    (nielen selektor reťazec), aby aj polia nájdené za behu (ako COD-suma
+    vyššie) mohli ísť tou istou overenou cestou. **`page.waitForFunction`
+    s priamym `document` odkazom V TOMTO PRIEČINKU (`apps/api/src`) NIKDY**
+    — tsconfig tu nemá DOM lib (rovnaké obmedzenie ako `shoptet-writeback/
+    playwright-import.ts`'s `rowTexts` komentár), namiesto toho Playwright's
+    vlastné typované `.count()`/`.isDisabled()` polling (vzor `portal-
+    fill.ts`'s `waitUntilEnabled`).
 - **`secret request` má LEN 600s (10 min) platnosť URL na zadanie hodnoty —
   fired-and-forget nefunguje cez noc.** Pri opakovanom čakaní na
   `DPD_PORTAL_USER`/`PASSWORD` (majiteľ spal) sa muselo volať znova zakaždým,

--- a/.claude/rules/dpd.md
+++ b/.claude/rules/dpd.md
@@ -31,20 +31,65 @@ paths:
   Importné profily zostáva rýchlejšia/spoľahlivejšia alternatíva k
   per-objednávkovému formuláru — over najprv, či medzitým nevznikol profil,
   než sa znova rieši per-formulárová cesta.
-- **Presné selektory formulára `/shipments/0` NIE SÚ domapované** — appka
-  (`modules/dpd/shipment-playwright.ts`'s `fillShipmentFields`,
-  `pickup-playwright.ts`'s `fillPickupForm`) zámerne zlyhá NAHLAS s presným
-  popisom namiesto TICHÉHO odoslania vymyslených polí. Dôvod: dopĺňanie
-  chýbajúceho DPD prihlásenia (`secret request`) cez noc nikdy neprišlo —
-  žiaden ďalší pokus nesmie NAHRADIŤ tento fail-loud vzor odhadnutými
-  selektormi, aj keby "vyzerali rozumne" (DPD Shipper vocabular nie je
-  overený, hádanie by tichým zlyhaním vyzeralo ako úspech alebo poslalo zlé
-  dáta). **Prvé ďalšie použitie tohto modulu MUSÍ najprv urobiť READ-ONLY
-  naživo mapovanie** (rovnaký `readOnly` route-guard vzor ako
-  `dpd-mapuj.mjs`/`dpd-formulare.mjs` v scratchpad histórii issue 292 —
-  `let readOnly=false; ctx.route("**/*", …); readOnly=true;` hneď po
-  prihlásení) PRED doplnením skutočných selektorov do `fillShipmentFields`/
-  `fillPickupForm` — nikdy priamo skúšať naostro.
+- **Formulár `/shipments/0` aj objednávka zvozu `/pickup-orders/0` SÚ naživo
+  domapované (9.8.2026, read-only route guard — každý zápis po prihlásení
+  tvrdo blokovaný, nič sa neobjednalo/neuložilo)** —
+  `modules/dpd/shipment-playwright.ts`'s `fillShipmentFields`/
+  `pickup-playwright.ts`'s `fillPickupForm` teraz skutočne vypĺňajú a
+  odosielajú. Kľúčové zistenia:
+  - **Formulár `/shipments/0` má POVINNÉ rozmery balíka** (`parcelWidth`/
+    `Height`/`Length`, cm) — appka ich nikde neukladá (Shoptet export ich
+    nemá), preto `preview.ts`'s `DEFAULT_PARCEL_WIDTH_CM`/`HEIGHT_CM`/
+    `LENGTH_CM` (appka-vlastné rozumné defaulty, rovnaký vzor ako
+    `DEFAULT_PARCEL_WEIGHT_KG`, NIKDY editovateľné v UI).
+  - **`.fill()` NEDRŽÍ hodnotu na wijmo widgetoch** (`wj-input-date`,
+    `wj-input-number`, appka's vlastný `shp-universal-number-input`) — inak
+    vyzerá nastavená (DOM `.value` sedí), ale po prechode kroku wizardu sa
+    stratí (Angular model ju neprevzal). Funkčná náhrada, overená naživo
+    (hodnota PRETRVALA, DOM trieda `ng-valid`): klik (trojklik) → `Control+A`
+    → `keyboard.type()` → `Tab`. Zdieľaný helper `portal-fill.ts`'s
+    `typeInto` — použi ho pre KAŽDÉ ďalšie pole na tomto portáli, nikdy
+    holé `.fill()` na wijmo/Angular-completer prvok.
+  - **Produktový typ (`#product_Home`) aj "Dobierka" (`#service-COD`) sú v
+    DOM `disabled`, kým portál sám nedokončí svoj vlastný `/api/products`
+    POST po prihlásení** — appka preto čaká (`portal-fill.ts`'s
+    `waitUntilEnabled`, timeout) a pri pretrvávajúcom `disabled` zlyhá
+    NAHLAS namiesto tichého preskočenia.
+  - **Pole na sumu dobierky sa NEDALO naživo bezpečne domapovať** (jeho DOM
+    sa vykreslí AŽ po reálnom zaškrtnutí, ktoré v read-only sandboxe zostáva
+    trvalo disabled) — `fillCodAmount` preto po zaškrtnutí COD počká na
+    NOVO objavený `input` v tom istom `.additional-service` kontajneri;
+    ak sa neobjaví, zlyhá nahlas s presným popisom. **Prvé reálne overenie
+    tejto konkrétnej vetvy (COD zásielka) príde AŽ pri prvom skutočnom
+    COD odoslaní majiteľom** — over jej správanie vtedy, neber ju za
+    naživo overenú predtým.
+  - **Appka podporuje LEN slovenské doručovacie adresy** — krajina sa
+    NEVYBERÁ aktívne (portálový default je už "Slovensko", appka nemá
+    spoľahlivé mapovanie Shoptet textu na DPD interné číselné ID pre iné
+    krajiny), `portal-fill.ts`'s `assertSlovakDeliveryCountry` zlyhá nahlas
+    na inej krajine namiesto tichého odoslania so zlou predvolenou.
+  - **Telefón**: appka posiela LEN národné číslo (`portal-fill.ts`'s
+    `normalizePhoneForDpd` odstráni `+421`/`00421`/vedúcu nulu) — predvoľba
+    `+421` je v portáli SAMOSTATNÉ pole, appka ho nemení.
+  - **Číslo zásielky po uložení sa NEDALO naživo overiť skutočným kliknutím**
+    (bezpečnostné pravidlo — prvý reálny klik patrí majiteľovi) —
+    `readParcelNumberAfterSave` skúša najprv toast/notifikáciu, potom
+    zoznam Zásielky filtrovaný podľa referencie (appka posiela
+    `externalOrderId` do "Referencia 1", `#referential-info1`). **Toto je
+    jediná časť flow-u, ktorá zostáva UNVERIFIED až do prvého skutočného
+    odoslania majiteľom** — ak sa pri ňom ukáže iný tvar výsledku, uprav
+    LEN túto funkciu.
+  - **Testy** (`tests/helpers/dpd-portal-fixture.ts`) imitujú LEN tvar,
+    ktorý appka skutočne ovláda (ID/vnorenie/atribúty naživo domapovaných
+    prvkov) — NIKDY sa nedotknú `dpdshipper.sk`. **Fixture login formulár
+    MUSÍ mať `name` atribút na poliach** (nie len `id`) — inak skutočný
+    `<form method=post>` submit pošle prázdne telo a appka's vlastné
+    prihlásenie sa nedá naozaj overiť (zistené pri prvom behu tejto sady
+    testov: `body["loginName"]` bolo `undefined`, login "zlyhával" aj so
+    správnym heslom — nie appka bug, fixture bug; rovnaká trieda chyby ako
+    `shoptet-fixture.ts`'s file-chooser gotcha, over VŽDY, že fixture
+    formulár posiela dáta presne tak, ako by ich poslal skutočný
+    prehliadač).
 - **`secret request` má LEN 600s (10 min) platnosť URL na zadanie hodnoty —
   fired-and-forget nefunguje cez noc.** Pri opakovanom čakaní na
   `DPD_PORTAL_USER`/`PASSWORD` (majiteľ spal) sa muselo volať znova zakaždým,

--- a/apps/api/src/modules/dpd/config.ts
+++ b/apps/api/src/modules/dpd/config.ts
@@ -5,6 +5,7 @@
 export interface DpdPortalConfig {
   readonly loginUrl: string;
   readonly newShipmentUrl: string;
+  readonly newPickupOrderUrl: string;
   readonly user: string;
   readonly password: string;
 }
@@ -19,6 +20,10 @@ export function dpdPortalConfigFromBaseUrl(baseUrl: string, user: string, passwo
     // presný formát sa nedal zistiť bez zápisu, ktorý bezpečnostné pravidlo
     // tiketu zakazuje).
     newShipmentUrl: `${base}/shipments/0`,
+    // issue 292 (9.8.2026 naživo domapovanie): klik na "+" pri "Jednorazové
+    // zvozy" na `/pickup-orders` navigoval presne sem — priama adresa je
+    // spoľahlivejšia než hľadanie "+" tlačidla podľa okolitého textu.
+    newPickupOrderUrl: `${base}/pickup-orders/0`,
     user,
     password,
   };

--- a/apps/api/src/modules/dpd/pickup-playwright.ts
+++ b/apps/api/src/modules/dpd/pickup-playwright.ts
@@ -1,10 +1,8 @@
-import { chromium, type Browser, type Page } from "playwright";
+import type { Page } from "playwright";
 import { log } from "../../logger.js";
-import { resolveChromiumExecutablePath } from "../shoptet-writeback/playwright-import.js";
 import { runInChildProcess } from "../shoptet-writeback/child-runner.js";
-import { loginToDpdPortal } from "./login.js";
 import type { DpdPortalConfig } from "./config.js";
-import { typeInto } from "./portal-fill.js";
+import { runOnDpdPortalPage, typeInto } from "./portal-fill.js";
 
 // issue 292: "Objednávky zvozu" (`/pickup-orders`) — naživo overené
 // (7.8.2026 menu, 9.8.2026 formulár): klik "+" pri "Jednorazové zvozy"
@@ -15,6 +13,8 @@ import { typeInto } from "./portal-fill.js";
 // vlastný SPA prechod) → skutočné "Uložiť".
 const PICKUP_DATE_SELECTOR = '#pickup-date input[wj-part="input"]';
 const CONTINUE_BUTTON_SELECTOR = "#button-confirmation";
+const STEP1_SELECTOR = "#step1";
+const STEP2_SELECTOR = "#step2";
 
 /** DPD portál čaká slovenský tvar dátumu bez vedúcich núl ("10. 8. 2026"),
  * naživo overené (9.8.2026) — appka dostáva ISO `YYYY-MM-DD`
@@ -28,25 +28,42 @@ function toDpdDateFormat(isoDate: string): string {
   return `${String(Number(day))}. ${String(Number(month))}. ${year}`;
 }
 
+/**
+ * Code review (issue 292, PR 324): "úspech" tu ostáva NEPRIAMY dôkaz
+ * (absencia chyby), lebo skutočný pozitívny signál sa nedal naživo overiť
+ * (rovnaké bezpečnostné pravidlo ako pri zásielke — prvý reálny klik patrí
+ * majiteľovi, `.claude/rules/dpd.md`). Kontrola je preto zámerne ŠIROKÁ:
+ * najprv overený `#toast-container`/`[id*="toast"]` mechanizmus (rovnaký,
+ * aký appka už naživo videla vypisovať systémové správy PO prihlásení na
+ * `/pickup-orders`), potom aj bežné chybové CSS triedy ako záloha. Kým sa
+ * toto neoverí prvým skutočným zvozom, každé "ok:true" tu je optimistické,
+ * NIE potvrdené — pozri `.claude/rules/dpd.md`'s UNVERIFIED poznámku.
+ */
+async function checkForPortalError(page: Page): Promise<string | null> {
+  const errorText = await page
+    .locator('[id*="toast"] :text-matches("chyb|zlyha|nepodarilo|error", "i"), .toast-error, .alert-danger, [class*="error"]:visible')
+    .first()
+    .textContent({ timeout: 3000 })
+    .catch(() => null);
+  return errorText !== null && errorText.trim() !== "" ? errorText.trim() : null;
+}
+
 async function fillPickupForm(page: Page, pickupDate: string): Promise<void> {
   await typeInto(page, PICKUP_DATE_SELECTOR, toDpdDateFormat(pickupDate));
   await page.locator(CONTINUE_BUTTON_SELECTOR).click();
-  await page.waitForTimeout(1000);
+  // Deterministické čakanie namiesto pevného spánku (code review, issue
+  // 292, PR 324) — krok 1 sa naozaj skryje AŽ keď Angular prekreslí, na
+  // reálnom (ťažšom) portáli to môže trvať dlhšie než pevná pauza.
+  await page.locator(STEP1_SELECTOR).waitFor({ state: "hidden", timeout: 8000 });
+  await page.locator(STEP2_SELECTOR).waitFor({ state: "visible", timeout: 8000 });
 
   const saveButton = page.getByRole("button", { name: "Uložiť", exact: true });
   await saveButton.click();
-  await page.waitForTimeout(1000);
+  await page.waitForLoadState("networkidle").catch(() => {});
 
-  // Presný úspešný signál sa nedal naživo overiť (prvý reálny klik patrí
-  // majiteľovi, issue 292) — appka preto aspoň overí, že sa NEOBJAVILA
-  // viditeľná chybová správa, namiesto tichého predpokladu úspechu.
-  const errorText = await page
-    .locator('.toast-error, .alert-danger, [class*="error"]:visible')
-    .first()
-    .textContent({ timeout: 2000 })
-    .catch(() => null);
-  if (errorText !== null && errorText.trim() !== "") {
-    throw new Error(`DPD portál nahlásil chybu pri objednaní zvozu: ${errorText.trim()}`);
+  const errorText = await checkForPortalError(page);
+  if (errorText !== null) {
+    throw new Error(`DPD portál nahlásil chybu pri objednaní zvozu: ${errorText}`);
   }
 }
 
@@ -63,29 +80,17 @@ export interface OrderDpdPickupOutcome {
 }
 
 export async function runOrderDpdPickup(options: RunOrderDpdPickupOptions): Promise<OrderDpdPickupOutcome> {
-  const executablePath = options.executablePath ?? resolveChromiumExecutablePath();
-  let browser: Browser | undefined;
   try {
-    browser = await chromium.launch({
-      headless: options.headless ?? true,
-      ...(executablePath === undefined ? {} : { executablePath }),
-      args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage", "--disable-gpu"],
+    await runOnDpdPortalPage(options.config, options, async (page) => {
+      await page.goto(options.config.newPickupOrderUrl, { waitUntil: "domcontentloaded" });
+      await page.waitForLoadState("networkidle");
+      await fillPickupForm(page, options.pickupDate);
     });
-    const context = await browser.newContext({ acceptDownloads: false });
-    const page = await context.newPage();
-
-    await loginToDpdPortal(page, options.config);
-    await page.goto(options.config.newPickupOrderUrl, { waitUntil: "domcontentloaded" });
-    await page.waitForLoadState("networkidle");
-
-    await fillPickupForm(page, options.pickupDate);
     return { ok: true, errorDetail: null };
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
     log.error({ err: message, pickupDate: options.pickupDate }, "DPD zvoz: pokus zlyhal");
     return { ok: false, errorDetail: message };
-  } finally {
-    await browser?.close();
   }
 }
 

--- a/apps/api/src/modules/dpd/pickup-playwright.ts
+++ b/apps/api/src/modules/dpd/pickup-playwright.ts
@@ -1,24 +1,53 @@
-import { chromium, type Browser } from "playwright";
+import { chromium, type Browser, type Page } from "playwright";
 import { log } from "../../logger.js";
 import { resolveChromiumExecutablePath } from "../shoptet-writeback/playwright-import.js";
 import { runInChildProcess } from "../shoptet-writeback/child-runner.js";
 import { loginToDpdPortal } from "./login.js";
 import type { DpdPortalConfig } from "./config.js";
+import { typeInto } from "./portal-fill.js";
 
 // issue 292: "Objednávky zvozu" (`/pickup-orders`) — naživo overené
-// (7.8.2026): stránka má "Pravidelný zvoz" + "Jednorazové zvozy" so `+`
-// tlačidlom na pridanie NOVÉHO jednorazového zvozu. Samotný formulár, ktorý
-// sa po kliku na `+` otvorí, NIE JE naživo domapovaný (rovnaký dôvod ako
-// `shipment-playwright.ts`'s `fillShipmentFields` — čaká sa na
-// `DPD_PORTAL_USER`/`PASSWORD`). Rovnaká disciplína: zlyhaj NAHLAS, nikdy
-// tichy odošli vymyslené polia.
-const PICKUP_ORDERS_PATH = "/pickup-orders";
+// (7.8.2026 menu, 9.8.2026 formulár): klik "+" pri "Jednorazové zvozy"
+// navigoval na `/pickup-orders/0` (`config.ts`'s `newPickupOrderUrl`), teda
+// priama navigácia je spoľahlivejšia než hľadanie tlačidla. Formulár je
+// DVOJKROKOVÝ — krok 1 (zvozová adresa/kontakt/dátum, predvyplnené z účtu,
+// appka mení LEN dátum) → "Pokračovať" → krok 2 (rovnaká URL, appka's
+// vlastný SPA prechod) → skutočné "Uložiť".
+const PICKUP_DATE_SELECTOR = '#pickup-date input[wj-part="input"]';
+const CONTINUE_BUTTON_SELECTOR = "#button-confirmation";
 
-function fillPickupForm(): never {
-  throw new Error(
-    "DPD formulár jednorazového zvozu (/pickup-orders) ešte nie je naživo domapovaný (čaká sa na DPD_PORTAL_USER/PASSWORD) — " +
-      "zvoz sa neobjednal. Pozri issue 292, fillPickupForm v pickup-playwright.ts.",
-  );
+/** DPD portál čaká slovenský tvar dátumu bez vedúcich núl ("10. 8. 2026"),
+ * naživo overené (9.8.2026) — appka dostáva ISO `YYYY-MM-DD`
+ * (`http/dpd-routes.ts`'s `pickupBody` validácia). */
+function toDpdDateFormat(isoDate: string): string {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(isoDate);
+  if (match === null) throw new Error(`DPD zvoz: neplatný dátum "${isoDate}" (očakávané YYYY-MM-DD)`);
+  const year = match[1] ?? "";
+  const month = match[2] ?? "";
+  const day = match[3] ?? "";
+  return `${String(Number(day))}. ${String(Number(month))}. ${year}`;
+}
+
+async function fillPickupForm(page: Page, pickupDate: string): Promise<void> {
+  await typeInto(page, PICKUP_DATE_SELECTOR, toDpdDateFormat(pickupDate));
+  await page.locator(CONTINUE_BUTTON_SELECTOR).click();
+  await page.waitForTimeout(1000);
+
+  const saveButton = page.getByRole("button", { name: "Uložiť", exact: true });
+  await saveButton.click();
+  await page.waitForTimeout(1000);
+
+  // Presný úspešný signál sa nedal naživo overiť (prvý reálny klik patrí
+  // majiteľovi, issue 292) — appka preto aspoň overí, že sa NEOBJAVILA
+  // viditeľná chybová správa, namiesto tichého predpokladu úspechu.
+  const errorText = await page
+    .locator('.toast-error, .alert-danger, [class*="error"]:visible')
+    .first()
+    .textContent({ timeout: 2000 })
+    .catch(() => null);
+  if (errorText !== null && errorText.trim() !== "") {
+    throw new Error(`DPD portál nahlásil chybu pri objednaní zvozu: ${errorText.trim()}`);
+  }
 }
 
 export interface RunOrderDpdPickupOptions {
@@ -46,12 +75,11 @@ export async function runOrderDpdPickup(options: RunOrderDpdPickupOptions): Prom
     const page = await context.newPage();
 
     await loginToDpdPortal(page, options.config);
-    await page.goto(`${new URL(options.config.loginUrl).origin}${PICKUP_ORDERS_PATH}`, { waitUntil: "domcontentloaded" });
+    await page.goto(options.config.newPickupOrderUrl, { waitUntil: "domcontentloaded" });
     await page.waitForLoadState("networkidle");
 
-    fillPickupForm();
-
-    return { ok: false, errorDetail: "unreachable" };
+    await fillPickupForm(page, options.pickupDate);
+    return { ok: true, errorDetail: null };
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
     log.error({ err: message, pickupDate: options.pickupDate }, "DPD zvoz: pokus zlyhal");

--- a/apps/api/src/modules/dpd/portal-fill.test.ts
+++ b/apps/api/src/modules/dpd/portal-fill.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { assertSlovakDeliveryCountry, normalizePhoneForDpd } from "./portal-fill.js";
+
+describe("normalizePhoneForDpd", () => {
+  it("strips the +421 prefix", () => {
+    expect(normalizePhoneForDpd("+421903123456")).toBe("903123456");
+  });
+
+  it("strips the 00421 prefix", () => {
+    expect(normalizePhoneForDpd("00421903123456")).toBe("903123456");
+  });
+
+  it("strips a leading domestic zero", () => {
+    expect(normalizePhoneForDpd("0903123456")).toBe("903123456");
+  });
+
+  it("keeps a bare 9-digit number as-is", () => {
+    expect(normalizePhoneForDpd("903123456")).toBe("903123456");
+  });
+
+  it("throws loudly on a number it cannot recognize as Slovak, never guesses", () => {
+    expect(() => normalizePhoneForDpd("+1-555-0100")).toThrow(/slovenské/i);
+  });
+});
+
+describe("assertSlovakDeliveryCountry", () => {
+  it("accepts 'Slovensko'", () => {
+    expect(() => { assertSlovakDeliveryCountry("Slovensko"); }).not.toThrow();
+  });
+
+  it("accepts case/whitespace variants", () => {
+    expect(() => { assertSlovakDeliveryCountry("  SLOVENSKO  "); }).not.toThrow();
+    expect(() => { assertSlovakDeliveryCountry("Slovakia"); }).not.toThrow();
+  });
+
+  it("throws loudly on a non-Slovak country instead of silently proceeding", () => {
+    expect(() => { assertSlovakDeliveryCountry("Česká Republika"); }).toThrow(/slovensk/i);
+  });
+});

--- a/apps/api/src/modules/dpd/portal-fill.test.ts
+++ b/apps/api/src/modules/dpd/portal-fill.test.ts
@@ -21,6 +21,19 @@ describe("normalizePhoneForDpd", () => {
   it("throws loudly on a number it cannot recognize as Slovak, never guesses", () => {
     expect(() => normalizePhoneForDpd("+1-555-0100")).toThrow(/slovenské/i);
   });
+
+  // Code review (issue 292, PR 324): pôvodná verzia validovala dĺžku LEN
+  // vo vetve "bez rozpoznaného prefixu" — po odstránení prefixu sa už
+  // výsledok nekontroloval, takže tieto dva prípady (zle zadaná domáca
+  // nula namiesto medzinárodnej predvoľby / nadbytočná číslica) by ticho
+  // prešli ako nezmyselné 10/12-miestne "národné" číslo.
+  it("throws loudly on 00903123456 (mistaken domestic zero instead of the international prefix) instead of accepting a 10-digit result", () => {
+    expect(() => normalizePhoneForDpd("00903123456")).toThrow(/slovenské/i);
+  });
+
+  it("throws loudly on 0421903123456 (an extra digit) instead of accepting a 12-digit result", () => {
+    expect(() => normalizePhoneForDpd("0421903123456")).toThrow(/slovenské/i);
+  });
 });
 
 describe("assertSlovakDeliveryCountry", () => {

--- a/apps/api/src/modules/dpd/portal-fill.ts
+++ b/apps/api/src/modules/dpd/portal-fill.ts
@@ -1,0 +1,84 @@
+import type { Page } from "playwright";
+
+/**
+ * issue 292: zdieľané nízkoúrovňové pomôcky na vypĺňanie formulárov na
+ * `dpdshipper.sk`, použité `shipment-playwright.ts` aj `pickup-playwright.ts`.
+ *
+ * **`.fill()` NEDRŽÍ hodnotu na wijmo widgetoch** (`wj-input-date`,
+ * `wj-input-number`, appka's vlastný `shp-universal-number-input`) — naživo
+ * overené (9.8.2026, read-only mapovanie): hodnota vyzerala nastavená
+ * (`.value` v DOM sedelo), ale po prechode na ďalší krok viackrokového
+ * formulára (napr. objednávka zvozu) sa vrátila na pôvodnú, Angular model
+ * ju teda reálne neprevzal. Funkčná náhrada, overená naživo (hodnota
+ * PRETRVALA cez prechod kroku, DOM trieda `ng-valid` namiesto `ng-invalid`):
+ * klik (trojklik = vyber všetko) → `Control+A` → `keyboard.type()` → `Tab`
+ * (blur commit-ne hodnotu do Angular FormControl). Rovnaká trieda chyby ako
+ * `.claude/rules/shoptet-writeback.md`'s "`.fill()` na prihlasovacie polia
+ * nedrží v appka's vlastnom procese" nález — iný mechanizmus (tu je to o
+ * Angular/wijmo binding, tam o Node/Chromium interakcii v dlho bežiacom
+ * procese), ale rovnaká disciplína: over čítaním hodnoty SPÄŤ, nikdy sa
+ * nespoliehaj na to, že `.fill()`/klik "prešiel".
+ */
+export async function typeInto(page: Page, selector: string, text: string): Promise<void> {
+  const loc = page.locator(selector).first();
+  await loc.click({ clickCount: 3, timeout: 10_000 });
+  await page.keyboard.press("Control+A");
+  await page.keyboard.type(text, { delay: 20 });
+  await page.keyboard.press("Tab");
+}
+
+/**
+ * Produktový typ (`#product_Home`) aj "Dobierka" (`#service-COD`) sú v DOM
+ * `disabled`, kým portál sám nedokončí svoj vlastný inicializačný
+ * (produkty/ceny) request po prihlásení — naživo overené, že to trvá
+ * krátko, ale nie okamžite. Radšej krátke čakanie s jasným fail-loud
+ * timeoutom než tiché preskočenie/vynútené odblokovanie (to druhé sa
+ * naživo skúsilo a Playwright's vlastná akcionabilita ho aj tak odmietla —
+ * Angular `disabled` binding sa priebežne prepisuje).
+ */
+export async function waitUntilEnabled(page: Page, selector: string, timeoutMs: number, description: string): Promise<void> {
+  const loc = page.locator(selector).first();
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const disabled = await loc.isDisabled().catch(() => true);
+    if (!disabled) return;
+    if (Date.now() >= deadline) {
+      throw new Error(`DPD portál: "${description}" zostáva neaktívne aj po ${String(timeoutMs)} ms — formulár sa pravdepodobne nenačítal úplne`);
+    }
+    await page.waitForTimeout(300);
+  }
+}
+
+// Naživo overené (9.8.2026): telefónne číslo v appke je Shoptet-ov tvar
+// (napr. "+421903123456"/"0903123456"), ale DPD formulár má predvoľbu
+// ("+421") v SAMOSTATNOM poli — `recipient-phone-number` čaká len národné
+// číslo bez predvoľby/nuly. Appka podporuje LEN slovenské čísla (rovnaký
+// rozsah ako krajina nižšie) — iný tvar zlyhá nahlas namiesto tichého
+// odoslania niečoho, čo portál buď odmietne, alebo (horšie) ticho prijme
+// ako nezmyselné číslo.
+export function normalizePhoneForDpd(rawPhone: string): string {
+  const digitsOnly = rawPhone.replace(/[^\d]/g, "");
+  if (digitsOnly.startsWith("00421")) return digitsOnly.slice(5);
+  if (digitsOnly.startsWith("421")) return digitsOnly.slice(3);
+  if (digitsOnly.startsWith("0")) return digitsOnly.slice(1);
+  if (digitsOnly.length === 9) return digitsOnly;
+  throw new Error(`DPD formulár: telefónne číslo "${rawPhone}" nevyzerá ako slovenské číslo — over ho ručne, appka odosiela len SK čísla`);
+}
+
+// Naživo overené (9.8.2026): predvolená hodnota selectu krajiny príjemcu
+// je už "Slovensko" — appka teda krajinu NEVYBERÁ aktívne (žiadne
+// spoľahlivé mapovanie Shoptet-ovho textu na DPD interné číselné ID pre
+// iné krajiny), len OVERÍ, že objednávka je skutočne slovenská, predtým
+// než čokoľvek odošle. Iná krajina zlyhá nahlas namiesto tichého odoslania
+// s nesprávne vybranou (portálovo predvolenou) krajinou.
+const SLOVAK_COUNTRY_NAMES = new Set(["slovensko", "slovenská republika", "slovak republic", "slovakia", "sk"]);
+
+export function assertSlovakDeliveryCountry(countryName: string): void {
+  const normalized = countryName.trim().toLowerCase();
+  if (!SLOVAK_COUNTRY_NAMES.has(normalized)) {
+    throw new Error(
+      `DPD formulár: doručovacia krajina "${countryName}" nie je slovenská — appka zatiaľ podporuje len SK zásielky (portál by inak odoslal so ` +
+        "svojou predvolenou krajinou, nie so skutočnou adresou príjemcu)",
+    );
+  }
+}

--- a/apps/api/src/modules/dpd/portal-fill.ts
+++ b/apps/api/src/modules/dpd/portal-fill.ts
@@ -1,4 +1,7 @@
-import type { Page } from "playwright";
+import { chromium, type Browser, type Locator, type Page } from "playwright";
+import { resolveChromiumExecutablePath } from "../shoptet-writeback/playwright-import.js";
+import { loginToDpdPortal } from "./login.js";
+import type { DpdPortalConfig } from "./config.js";
 
 /**
  * issue 292: zdieľané nízkoúrovňové pomôcky na vypĺňanie formulárov na
@@ -18,9 +21,15 @@ import type { Page } from "playwright";
  * Angular/wijmo binding, tam o Node/Chromium interakcii v dlho bežiacom
  * procese), ale rovnaká disciplína: over čítaním hodnoty SPÄŤ, nikdy sa
  * nespoliehaj na to, že `.fill()`/klik "prešiel".
+ *
+ * **Prijíma AJ už-vyriešený `Locator`, nielen selektor** (code review
+ * issue 292, PR 324) — `fillCodAmount` v `shipment-playwright.ts` potrebuje
+ * vyplniť pole, ktoré si sám našiel porovnaním DOM PRED/PO (nemá preň
+ * jednoduchý statický selektor), a musí ísť rovnakou cestou ako každé iné
+ * pole na tomto portáli namiesto vlastného kopírovania tej istej sekvencie.
  */
-export async function typeInto(page: Page, selector: string, text: string): Promise<void> {
-  const loc = page.locator(selector).first();
+export async function typeInto(page: Page, target: string | Locator, text: string): Promise<void> {
+  const loc = typeof target === "string" ? page.locator(target).first() : target;
   await loc.click({ clickCount: 3, timeout: 10_000 });
   await page.keyboard.press("Control+A");
   await page.keyboard.type(text, { delay: 20 });
@@ -56,12 +65,25 @@ export async function waitUntilEnabled(page: Page, selector: string, timeoutMs: 
 // rozsah ako krajina nižšie) — iný tvar zlyhá nahlas namiesto tichého
 // odoslania niečoho, čo portál buď odmietne, alebo (horšie) ticho prijme
 // ako nezmyselné číslo.
+//
+// Code review (issue 292, PR 324): pôvodná verzia validovala DĹŽKU výsledku
+// LEN vo vetve "už je to holé 9-miestne číslo" — po odstránení uznaného
+// prefixu sa výsledok už nekontroloval vôbec, takže napr. "00903123456"
+// (zle zadaná domáca nula namiesto medzinárodnej predvoľby) prešlo ako
+// "0903123456" (10 číslic, nezmysel) namiesto zlyhania nahlas. Kontrola
+// DĹŽKY je teraz JEDNOTNÁ pre všetky vetvy — platí AŽ PO odstránení prefixu.
+const SK_NATIONAL_NUMBER_LENGTH = 9;
+
 export function normalizePhoneForDpd(rawPhone: string): string {
   const digitsOnly = rawPhone.replace(/[^\d]/g, "");
-  if (digitsOnly.startsWith("00421")) return digitsOnly.slice(5);
-  if (digitsOnly.startsWith("421")) return digitsOnly.slice(3);
-  if (digitsOnly.startsWith("0")) return digitsOnly.slice(1);
-  if (digitsOnly.length === 9) return digitsOnly;
+  const national = digitsOnly.startsWith("00421")
+    ? digitsOnly.slice(5)
+    : digitsOnly.startsWith("421")
+      ? digitsOnly.slice(3)
+      : digitsOnly.startsWith("0")
+        ? digitsOnly.slice(1)
+        : digitsOnly;
+  if (national.length === SK_NATIONAL_NUMBER_LENGTH) return national;
   throw new Error(`DPD formulár: telefónne číslo "${rawPhone}" nevyzerá ako slovenské číslo — over ho ručne, appka odosiela len SK čísla`);
 }
 
@@ -80,5 +102,40 @@ export function assertSlovakDeliveryCountry(countryName: string): void {
       `DPD formulár: doručovacia krajina "${countryName}" nie je slovenská — appka zatiaľ podporuje len SK zásielky (portál by inak odoslal so ` +
         "svojou predvolenou krajinou, nie so skutočnou adresou príjemcu)",
     );
+  }
+}
+
+export interface RunOnDpdPortalPageOptions {
+  readonly headless?: boolean;
+  readonly executablePath?: string;
+}
+
+/**
+ * Zdieľaný životný cyklus prehliadača (launch → context → page → prihlásenie
+ * → `action` → vždy zatvoriť) — code review (issue 292, PR 324) našiel, že
+ * `runCreateDpdShipment`/`runOrderDpdPickup` mali TOTOŽNÝ blok skopírovaný,
+ * líšiaci sa len návratovým tvarom a vnútorným volaním vypĺňania. Navigáciu
+ * na konkrétny formulár (rôzna URL pre zásielku/zvoz) robí `action` sám —
+ * tento helper vie len prihlásiť a upratať po sebe.
+ */
+export async function runOnDpdPortalPage<T>(
+  config: DpdPortalConfig,
+  options: RunOnDpdPortalPageOptions,
+  action: (page: Page) => Promise<T>,
+): Promise<T> {
+  const executablePath = options.executablePath ?? resolveChromiumExecutablePath();
+  let browser: Browser | undefined;
+  try {
+    browser = await chromium.launch({
+      headless: options.headless ?? true,
+      ...(executablePath === undefined ? {} : { executablePath }),
+      args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage", "--disable-gpu"],
+    });
+    const context = await browser.newContext({ acceptDownloads: false });
+    const page = await context.newPage();
+    await loginToDpdPortal(page, config);
+    return await action(page);
+  } finally {
+    await browser?.close();
   }
 }

--- a/apps/api/src/modules/dpd/preview.ts
+++ b/apps/api/src/modules/dpd/preview.ts
@@ -12,6 +12,19 @@
 // prepísať (`ShipmentConfirmInput.weightKgOverride`).
 export const DEFAULT_PARCEL_WEIGHT_KG = "1.00";
 
+// issue 292: formulár `/shipments/0` má rozmery balíka (šírka/výška/dĺžka,
+// cm) ako POVINNÉ polia — zistené AŽ pri naživo domapovaní (9.8.2026),
+// appka ich nikde neukladá (Shoptet export ich nemá) a nemá teda odkiaľ
+// vziať skutočnú hodnotu. Rovnaký princíp ako hmotnosť vyššie — appka
+// NIKDY nehádaje reálne rozmery konkrétneho balíka, len ponúka rozumný
+// štartovací bod (malá/stredná krabica); obsluha ho pri potrebe upraví
+// priamo v DPD portáli po uložení zásielky (appka tieto polia v UI
+// needitovateľné, na rozdiel od hmotnosti — nie sú súčasťou náhľadu, ktorý
+// obsluha bežne kontroluje pred odoslaním).
+export const DEFAULT_PARCEL_WIDTH_CM = "30";
+export const DEFAULT_PARCEL_HEIGHT_CM = "20";
+export const DEFAULT_PARCEL_LENGTH_CM = "20";
+
 // Naživo overené (7.8.2026, 90-dňový export): obe reálne používané spôsoby
 // platby ("Dobierka (hotovosť) + karta (len SR)", "V hotovosti") obsahujú
 // "hotovosť"/"dobierka" — appka rozpozná dobierku podľa toho, či názov

--- a/apps/api/src/modules/dpd/shipment-playwright.test.ts
+++ b/apps/api/src/modules/dpd/shipment-playwright.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { extractParcelNumber } from "./shipment-playwright.js";
+
+// Code review (issue 292, PR 324): appka's vlastná referencia
+// (`externalOrderId`, typicky 8-miestne Shoptet objednávkové číslo) je v
+// riadku VŽDY prítomná (appka podľa nej riadok vyhľadala), takže naivné
+// "prvá 8+ miestna číslica v texte" by ju vrátilo namiesto skutočného
+// (naživo pozorovaného 14-miestneho) čísla zásielky.
+describe("extractParcelNumber", () => {
+  const reference = "20261234";
+
+  it("finds the real parcel number when the reference appears first in the text", () => {
+    expect(extractParcelNumber(`${reference} Ján Testovací 12345678901234`, reference)).toBe("12345678901234");
+  });
+
+  it("finds the parcel number from a plain notification sentence", () => {
+    expect(extractParcelNumber("Zásielka uložená, číslo 99900000123", reference)).toBe("99900000123");
+  });
+
+  it("never returns the reference itself, even if it were the only long-enough number present", () => {
+    expect(extractParcelNumber(`referencia ${reference}00`, `${reference}00`)).toBeNull();
+  });
+
+  it("returns null when nothing long enough is found, never guesses a short number", () => {
+    expect(extractParcelNumber(`${reference} bez ďalšieho čísla`, reference)).toBeNull();
+  });
+});

--- a/apps/api/src/modules/dpd/shipment-playwright.ts
+++ b/apps/api/src/modules/dpd/shipment-playwright.ts
@@ -1,11 +1,9 @@
-import { chromium, type Browser, type Page } from "playwright";
+import type { Page } from "playwright";
 import { log } from "../../logger.js";
-import { resolveChromiumExecutablePath } from "../shoptet-writeback/playwright-import.js";
 import { runInChildProcess } from "../shoptet-writeback/child-runner.js";
-import { loginToDpdPortal } from "./login.js";
 import type { DpdPortalConfig } from "./config.js";
 import { DEFAULT_PARCEL_HEIGHT_CM, DEFAULT_PARCEL_LENGTH_CM, DEFAULT_PARCEL_WIDTH_CM, type DpdShipmentPreview } from "./preview.js";
-import { assertSlovakDeliveryCountry, normalizePhoneForDpd, typeInto, waitUntilEnabled } from "./portal-fill.js";
+import { assertSlovakDeliveryCountry, normalizePhoneForDpd, runOnDpdPortalPage, typeInto, waitUntilEnabled } from "./portal-fill.js";
 
 /**
  * issue 292: Playwright robot na `dpdshipper.sk` — rovnaký izolovaný
@@ -21,7 +19,13 @@ const PRODUCT_RADIO_SELECTOR = "#product_Home"; // DPD HOME — bežný domáci 
 const COD_CHECKBOX_SELECTOR = "#service-COD";
 
 async function fillRecipient(page: Page, shipment: DpdShipmentPreview): Promise<void> {
-  if (shipment.countryName !== null) assertSlovakDeliveryCountry(shipment.countryName);
+  // Code review (issue 292, PR 324): pôvodná verzia preskočila kontrolu
+  // úplne pri `countryName === null` — presne ten neistý prípad, pred
+  // ktorým má appku chrániť. `http/dpd-routes.ts`'s `addressComplete` brána
+  // dnes `null` k tejto funkcii vôbec nepustí, ale to je záruka v INOM
+  // súbore — volaj kontrolu VŽDY, prázdny reťazec cez `?? ""` ňou aj tak
+  // neprejde.
+  assertSlovakDeliveryCountry(shipment.countryName ?? "");
   await typeInto(page, '#shipment_order_recipient-recipient-name input[type=search]', shipment.recipientName);
   if (shipment.recipientCompany !== null && shipment.recipientCompany.trim() !== "") {
     await page.fill("#shipment_order_recipient-recipient-name2", shipment.recipientCompany);
@@ -46,37 +50,58 @@ async function fillParcel(page: Page, weightKg: string): Promise<void> {
 
 /** Po zaškrtnutí "Dobierka" portál vykreslí NOVÉ pole na sumu — jeho presný
  * selektor sa NEDAL naživo bezpečne domapovať (checkbox je v read-only
- * sandboxe trvalo disabled, `.claude/rules/dpd.md`). Namiesto hádania:
- * počkaj na nový input v tom istom kontajneri, fail-loud ak sa neobjaví. */
+ * sandboxe trvalo disabled, `.claude/rules/dpd.md`). Namiesto hádania
+ * "prvý input v kontajneri" (code review, issue 292, PR 324 — to by
+ * omylom vybralo AKÝKOĽVEK existujúci vstup v tom istom kontajneri, nielen
+ * novo pridaný): spočítaj vstupy PRED zaškrtnutím, počkaj, kým sa objaví
+ * GENUINNE nový (počet vzrastie), vyplň PRÁVE TEN. */
 async function fillCodAmount(page: Page, codAmount: string): Promise<void> {
   await waitUntilEnabled(page, COD_CHECKBOX_SELECTOR, 10_000, "Dobierka (COD) prepínač");
-  await page.check(COD_CHECKBOX_SELECTOR);
   const container = page.locator(COD_CHECKBOX_SELECTOR).locator("xpath=ancestor::div[contains(@class,'additional-service')][1]");
-  const amountInput = container.locator(`input:not(${COD_CHECKBOX_SELECTOR})`).first();
-  const appeared = await amountInput
-    .waitFor({ state: "visible", timeout: 8000 })
-    .then(() => true)
-    .catch(() => false);
-  if (!appeared) {
-    throw new Error(
-      "DPD formulár: po zaškrtnutí Dobierka sa neobjavilo pole na sumu — selektor nie je naživo domapovaný, over ho ručne (fillCodAmount v shipment-playwright.ts)",
-    );
+  const otherInputs = container.locator(`input:not(${COD_CHECKBOX_SELECTOR})`);
+  const countBefore = await otherInputs.count();
+  await page.check(COD_CHECKBOX_SELECTOR);
+  // Playwright's vlastné typované `.count()` polling (rovnaký vzor ako
+  // `portal-fill.ts`'s `waitUntilEnabled`) — nikdy `page.waitForFunction`
+  // s priamym `document` odkazom, apps/api's tsconfig nemá DOM lib
+  // (`.claude/rules/testing.md`, rovnaké obmedzenie ako `shoptet-writeback/
+  // playwright-import.ts`'s `rowTexts` komentár).
+  const deadline = Date.now() + 8000;
+  for (;;) {
+    if ((await otherInputs.count()) > countBefore) break;
+    if (Date.now() >= deadline) {
+      throw new Error(
+        "DPD formulár: po zaškrtnutí Dobierka sa neobjavil ŽIADEN NOVÝ vstup na sumu — selektor nie je naživo domapovaný, over ho ručne (fillCodAmount v shipment-playwright.ts)",
+      );
+    }
+    await page.waitForTimeout(300);
   }
-  await amountInput.click({ clickCount: 3 });
-  await page.keyboard.press("Control+A");
-  await page.keyboard.type(codAmount, { delay: 20 });
-  await page.keyboard.press("Tab");
+  const amountInput = otherInputs.nth((await otherInputs.count()) - 1);
+  await typeInto(page, amountInput, codAmount);
+}
+
+// Code review (issue 292, PR 324): reálne DPD čísla zásielok pozorované
+// naživo (`.claude/rules/dpd.md`) sú 14-miestne, appka's vlastná referencia
+// (`externalOrderId`, Shoptet objednávkové číslo) je typicky 8-miestna —
+// pôvodný `/\d{8,}/` by preto v zálohovom zoznamovom hľadaní (keď sa
+// nenašla notifikácia) mohol omylom vrátiť SAMOTNÚ referenciu namiesto
+// skutočného čísla zásielky (obe čísla sú v tom istom riadku, referencia
+// tam je ZÁRUČNE prítomná — presne preto sa podľa nej riadok hľadá).
+// Minimálna dĺžka 10 aj explicitné vylúčenie zhody s referenciou sú DVE
+// nezávislé poistky proti tomuto.
+export function extractParcelNumber(text: string, reference: string): string | null {
+  const matches = text.match(/\d{10,}/g) ?? [];
+  return matches.find((m) => m !== reference) ?? null;
 }
 
 async function readParcelNumberAfterSave(page: Page, referenceForCorrelation: string): Promise<string> {
-  const digitPattern = /\d{8,}/;
   const toastText = await page
     .locator('[id*="toast"], .toast-container')
     .first()
     .textContent({ timeout: 6000 })
     .catch(() => null);
-  const toastMatch = toastText !== null ? digitPattern.exec(toastText) : null;
-  if (toastMatch !== null) return toastMatch[0];
+  const toastMatch = toastText !== null ? extractParcelNumber(toastText, referenceForCorrelation) : null;
+  if (toastMatch !== null) return toastMatch;
 
   // Fallback: notifikácia sa nezobrazila/nenašla — skús zoznam Zásielky,
   // nájdi riadok s našou referenciou (appka ju posiela do "Referencia 1").
@@ -84,8 +109,8 @@ async function readParcelNumberAfterSave(page: Page, referenceForCorrelation: st
   await page.waitForLoadState("networkidle").catch(() => {});
   const row = page.locator("tr", { hasText: referenceForCorrelation }).first();
   const rowText = await row.textContent({ timeout: 6000 }).catch(() => null);
-  const rowMatch = rowText !== null ? digitPattern.exec(rowText) : null;
-  if (rowMatch !== null) return rowMatch[0];
+  const rowMatch = rowText !== null ? extractParcelNumber(rowText, referenceForCorrelation) : null;
+  if (rowMatch !== null) return rowMatch;
 
   throw new Error(
     `DPD formulár: zásielka bola pravdepodobne uložená, ale číslo zásielky sa nepodarilo prečítať (ani z notifikácie, ani zo zoznamu podľa referencie "${referenceForCorrelation}") — over ručne v portáli`,
@@ -99,7 +124,18 @@ async function fillShipmentFields(page: Page, shipment: DpdShipmentPreview): Pro
   await page.fill("#referential-info1", shipment.externalOrderId);
   await fillParcel(page, shipment.weightKg);
   await fillRecipient(page, shipment);
-  if (shipment.isCod && shipment.codAmount !== null) {
+  if (shipment.isCod) {
+    // Code review (issue 292, PR 324): `codAmount` sa dá naparsovať na
+    // `null` aj pri dobierkovej objednávke (`preview.ts`'s
+    // `priceToPay`/`totalPriceWithVat` obe chýbajúce/neparsovateľné) — bez
+    // tejto kontroly by appka TICHO odoslala zásielku BEZ dobierky, kuriér
+    // by peniaze od zákazníka nevybral. Rovnaká disciplína ako hmotnosť/
+    // krajina/telefón vyššie: neisté = zlyhaj nahlas, nikdy nehádaj 0.
+    if (shipment.codAmount === null) {
+      throw new Error(
+        `DPD zásielka ${shipment.externalOrderId} je označená ako dobierka, ale suma sa nedá určiť (chýba priceToPay aj totalPriceWithVat) — over cenu objednávky ručne, appka ju bez toho neodošle`,
+      );
+    }
     await fillCodAmount(page, shipment.codAmount);
   }
 
@@ -122,29 +158,17 @@ export interface CreateDpdShipmentOutcome {
 }
 
 export async function runCreateDpdShipment(options: RunCreateDpdShipmentOptions): Promise<CreateDpdShipmentOutcome> {
-  const executablePath = options.executablePath ?? resolveChromiumExecutablePath();
-  let browser: Browser | undefined;
   try {
-    browser = await chromium.launch({
-      headless: options.headless ?? true,
-      ...(executablePath === undefined ? {} : { executablePath }),
-      args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage", "--disable-gpu"],
+    const parcelNumber = await runOnDpdPortalPage(options.config, options, async (page) => {
+      await page.goto(options.config.newShipmentUrl, { waitUntil: "domcontentloaded" });
+      await page.waitForLoadState("networkidle");
+      return fillShipmentFields(page, options.shipment);
     });
-    const context = await browser.newContext({ acceptDownloads: false });
-    const page = await context.newPage();
-
-    await loginToDpdPortal(page, options.config);
-    await page.goto(options.config.newShipmentUrl, { waitUntil: "domcontentloaded" });
-    await page.waitForLoadState("networkidle");
-
-    const parcelNumber = await fillShipmentFields(page, options.shipment);
     return { ok: true, parcelNumber, errorDetail: null };
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
     log.error({ err: message, externalOrderId: options.shipment.externalOrderId }, "DPD zásielka: pokus zlyhal");
     return { ok: false, parcelNumber: null, errorDetail: message };
-  } finally {
-    await browser?.close();
   }
 }
 

--- a/apps/api/src/modules/dpd/shipment-playwright.ts
+++ b/apps/api/src/modules/dpd/shipment-playwright.ts
@@ -1,37 +1,111 @@
-import { chromium, type Browser } from "playwright";
+import { chromium, type Browser, type Page } from "playwright";
 import { log } from "../../logger.js";
 import { resolveChromiumExecutablePath } from "../shoptet-writeback/playwright-import.js";
 import { runInChildProcess } from "../shoptet-writeback/child-runner.js";
 import { loginToDpdPortal } from "./login.js";
 import type { DpdPortalConfig } from "./config.js";
-import type { DpdShipmentPreview } from "./preview.js";
+import { DEFAULT_PARCEL_HEIGHT_CM, DEFAULT_PARCEL_LENGTH_CM, DEFAULT_PARCEL_WIDTH_CM, type DpdShipmentPreview } from "./preview.js";
+import { assertSlovakDeliveryCountry, normalizePhoneForDpd, typeInto, waitUntilEnabled } from "./portal-fill.js";
 
 /**
  * issue 292: Playwright robot na `dpdshipper.sk` — rovnaký izolovaný
  * dieťa-proces vzor ako `shoptet-writeback` (issue 313, `.claude/rules/
- * shoptet-writeback.md`: appka's vlastný dlho bežiaci proces nedrží
- * `.fill()` hodnotu spoľahlivo). Prihlásenie (`login.ts`) je naživo
- * OVERENÉ (7.8.2026, read-only mapovanie). Navigácia na formulár
- * (`/shipments/0`) je naživo overená TIEŽ (rovnaké mapovanie).
- *
- * **Vyplnenie SAMOTNÝCH POLÍ formulára (`fillShipmentFields` nižšie) NIE JE
- * naživo domapované** — Importné profily (hromadný súborový import, plán A)
- * boli na účte prázdne a jediný spôsob zistiť ich formát je ZALOŽIŤ profil,
- * čo je ZÁPIS a bezpečnostné pravidlo tohto tiketu ho zakazuje; samotný
- * formulár `/shipments/0` zase vyžaduje prihlásenie, na ktoré appka čaká
- * (`DPD_PORTAL_USER`/`PASSWORD`, issue 292's komentár). Táto funkcia preto
- * zlyhá NAHLAS s presným, akčným popisom namiesto TICHÉHO odoslania
- * vymyslených/nesprávnych polí do formulára — presne rovnaká disciplína ako
- * `shoptet-writeback/playwright-import.ts`'s `ensureSafeSettings` (radšej
- * nahlas zlyhať, než odoslať niečo neisté). Prvé použitie po naživo
- * domapovaní nahradí LEN telo tejto jednej funkcie, zvyšok (prihlásenie,
- * navigácia, chybové hlásenia, izolovaný dieťa-proces vzor) sa nemení.
+ * shoptet-writeback.md`). Prihlásenie (`login.ts`) aj formulár
+ * `/shipments/0` sú naživo domapované (9.8.2026, read-only route guard —
+ * každý zápis po prihlásení tvrdo blokovaný, nič sa neobjednalo). Presné
+ * selektory + zistenia (povinné rozmery balíka, `.fill()` nedrží hodnotu na
+ * wijmo widgetoch, COD-suma pole sa nedalo bezpečne domapovať) sú v
+ * `.claude/rules/dpd.md` a v issue 292's návrhu riešenia.
  */
-function fillShipmentFields(): never {
+const PRODUCT_RADIO_SELECTOR = "#product_Home"; // DPD HOME — bežný domáci rozvoz, appka iný typ zatiaľ nerozlišuje
+const COD_CHECKBOX_SELECTOR = "#service-COD";
+
+async function fillRecipient(page: Page, shipment: DpdShipmentPreview): Promise<void> {
+  if (shipment.countryName !== null) assertSlovakDeliveryCountry(shipment.countryName);
+  await typeInto(page, '#shipment_order_recipient-recipient-name input[type=search]', shipment.recipientName);
+  if (shipment.recipientCompany !== null && shipment.recipientCompany.trim() !== "") {
+    await page.fill("#shipment_order_recipient-recipient-name2", shipment.recipientCompany);
+  }
+  await page.fill("#shipment_order_recipient-recipient-street", shipment.street ?? "");
+  await page.fill("#shipment_order_recipient-recipient-house-nr", shipment.houseNumber ?? "");
+  await typeInto(page, '#shipment_order_recipient-recipient-zip input[type=search]', shipment.zip ?? "");
+  await typeInto(page, '#shipment_order_recipient-recipient-city input[type=search]', shipment.city ?? "");
+  if (shipment.recipientPhone !== null && shipment.recipientPhone.trim() !== "") {
+    await page.fill('input[name="number"]', normalizePhoneForDpd(shipment.recipientPhone));
+  }
+}
+
+async function fillParcel(page: Page, weightKg: string): Promise<void> {
+  await typeInto(page, 'input[placeholder="Hmotnosť"]', weightKg);
+  // issue 292: rozmery sú POVINNÉ, appka ich nemá — appka-vlastné rozumné
+  // defaulty (`.claude/rules/dpd.md`), nikdy hádanie reálnej hodnoty.
+  await typeInto(page, 'input[name="parcelWidth"]', DEFAULT_PARCEL_WIDTH_CM);
+  await typeInto(page, 'input[name="parcelHeight"]', DEFAULT_PARCEL_HEIGHT_CM);
+  await typeInto(page, 'input[name="parcelLength"]', DEFAULT_PARCEL_LENGTH_CM);
+}
+
+/** Po zaškrtnutí "Dobierka" portál vykreslí NOVÉ pole na sumu — jeho presný
+ * selektor sa NEDAL naživo bezpečne domapovať (checkbox je v read-only
+ * sandboxe trvalo disabled, `.claude/rules/dpd.md`). Namiesto hádania:
+ * počkaj na nový input v tom istom kontajneri, fail-loud ak sa neobjaví. */
+async function fillCodAmount(page: Page, codAmount: string): Promise<void> {
+  await waitUntilEnabled(page, COD_CHECKBOX_SELECTOR, 10_000, "Dobierka (COD) prepínač");
+  await page.check(COD_CHECKBOX_SELECTOR);
+  const container = page.locator(COD_CHECKBOX_SELECTOR).locator("xpath=ancestor::div[contains(@class,'additional-service')][1]");
+  const amountInput = container.locator(`input:not(${COD_CHECKBOX_SELECTOR})`).first();
+  const appeared = await amountInput
+    .waitFor({ state: "visible", timeout: 8000 })
+    .then(() => true)
+    .catch(() => false);
+  if (!appeared) {
+    throw new Error(
+      "DPD formulár: po zaškrtnutí Dobierka sa neobjavilo pole na sumu — selektor nie je naživo domapovaný, over ho ručne (fillCodAmount v shipment-playwright.ts)",
+    );
+  }
+  await amountInput.click({ clickCount: 3 });
+  await page.keyboard.press("Control+A");
+  await page.keyboard.type(codAmount, { delay: 20 });
+  await page.keyboard.press("Tab");
+}
+
+async function readParcelNumberAfterSave(page: Page, referenceForCorrelation: string): Promise<string> {
+  const digitPattern = /\d{8,}/;
+  const toastText = await page
+    .locator('[id*="toast"], .toast-container')
+    .first()
+    .textContent({ timeout: 6000 })
+    .catch(() => null);
+  const toastMatch = toastText !== null ? digitPattern.exec(toastText) : null;
+  if (toastMatch !== null) return toastMatch[0];
+
+  // Fallback: notifikácia sa nezobrazila/nenašla — skús zoznam Zásielky,
+  // nájdi riadok s našou referenciou (appka ju posiela do "Referencia 1").
+  await page.goto(new URL("/shipments", page.url()).toString(), { waitUntil: "domcontentloaded" });
+  await page.waitForLoadState("networkidle").catch(() => {});
+  const row = page.locator("tr", { hasText: referenceForCorrelation }).first();
+  const rowText = await row.textContent({ timeout: 6000 }).catch(() => null);
+  const rowMatch = rowText !== null ? digitPattern.exec(rowText) : null;
+  if (rowMatch !== null) return rowMatch[0];
+
   throw new Error(
-    "DPD formulár /shipments/0 ešte nie je naživo domapovaný (čaká sa na DPD_PORTAL_USER/PASSWORD) — " +
-      "žiadna zásielka sa neodoslala. Pozri issue 292, fillShipmentFields v shipment-playwright.ts.",
+    `DPD formulár: zásielka bola pravdepodobne uložená, ale číslo zásielky sa nepodarilo prečítať (ani z notifikácie, ani zo zoznamu podľa referencie "${referenceForCorrelation}") — over ručne v portáli`,
   );
+}
+
+async function fillShipmentFields(page: Page, shipment: DpdShipmentPreview): Promise<string> {
+  await waitUntilEnabled(page, PRODUCT_RADIO_SELECTOR, 15_000, "typ produktu DPD HOME");
+  await page.check(PRODUCT_RADIO_SELECTOR);
+
+  await page.fill("#referential-info1", shipment.externalOrderId);
+  await fillParcel(page, shipment.weightKg);
+  await fillRecipient(page, shipment);
+  if (shipment.isCod && shipment.codAmount !== null) {
+    await fillCodAmount(page, shipment.codAmount);
+  }
+
+  const saveButton = page.getByRole("button", { name: /Uložiť & Nová/ });
+  await saveButton.click();
+  return readParcelNumberAfterSave(page, shipment.externalOrderId);
 }
 
 export interface RunCreateDpdShipmentOptions {
@@ -63,13 +137,8 @@ export async function runCreateDpdShipment(options: RunCreateDpdShipmentOptions)
     await page.goto(options.config.newShipmentUrl, { waitUntil: "domcontentloaded" });
     await page.waitForLoadState("networkidle");
 
-    fillShipmentFields();
-
-    // Nedosiahnuteľné, kým `fillShipmentFields` vyššie hádže — ponechané
-    // ako jasný kontrakt pre dokončenie po naživo domapovaní (submit +
-    // čítanie čísla zásielky z výsledkovej stránky, rovnaký princíp ako
-    // `shoptet-writeback/log-attribution.ts`'s `pollForResult`).
-    return { ok: false, parcelNumber: null, errorDetail: "unreachable" };
+    const parcelNumber = await fillShipmentFields(page, options.shipment);
+    return { ok: true, parcelNumber, errorDetail: null };
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
     log.error({ err: message, externalOrderId: options.shipment.externalOrderId }, "DPD zásielka: pokus zlyhal");

--- a/apps/api/tests/dpd-pickup-playwright.integration.test.ts
+++ b/apps/api/tests/dpd-pickup-playwright.integration.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { dpdPortalConfigFromBaseUrl } from "../src/modules/dpd/config.js";
+import { runOrderDpdPickup, runOrderDpdPickupIsolated } from "../src/modules/dpd/pickup-playwright.js";
+import { startDpdFixture, type DpdFixture } from "./helpers/dpd-portal-fixture.js";
+
+// Reálny Chromium proti LOKÁLNEJ fixture appke (nikdy proti skutočnému
+// dpdshipper.sk — issue 292's bezpečnostné pravidlo, `.claude/rules/dpd.md`).
+const TEST_TIMEOUT_MS = 60_000;
+const USER = "manager";
+const PASSWORD = "tajneheslo";
+
+describe("runOrderDpdPickup (proti fixture, nikdy proti reálnemu DPD)", () => {
+  let fixture: DpdFixture | undefined;
+
+  afterEach(async () => {
+    await fixture?.close();
+    fixture = undefined;
+  });
+
+  it(
+    "prejde oboma krokmi wizardu, nastaví dátum v slovenskom tvare bez vedúcich núl a uloží",
+    async () => {
+      fixture = await startDpdFixture({ user: USER, password: PASSWORD });
+      const outcome = await runOrderDpdPickup({
+        config: dpdPortalConfigFromBaseUrl(fixture.baseUrl, USER, PASSWORD),
+        pickupDate: "2026-08-10",
+      });
+
+      expect(outcome.ok).toBe(true);
+      expect(outcome.errorDetail).toBeNull();
+      expect(fixture.lastPickupDate()).toBe("10. 8. 2026");
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "nezaokrúhľuje mesiac/deň s vedúcou nulou (over aj jednomiestny mesiac)",
+    async () => {
+      fixture = await startDpdFixture({ user: USER, password: PASSWORD });
+      await runOrderDpdPickup({
+        config: dpdPortalConfigFromBaseUrl(fixture.baseUrl, USER, PASSWORD),
+        pickupDate: "2026-01-05",
+      });
+
+      expect(fixture.lastPickupDate()).toBe("5. 1. 2026");
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "vráti ok:false s chybovou správou z portálu, keď zvoz odmietne — nikdy tiché ok:true",
+    async () => {
+      fixture = await startDpdFixture({ user: USER, password: PASSWORD, pickupSaveFails: true });
+      const outcome = await runOrderDpdPickup({
+        config: dpdPortalConfigFromBaseUrl(fixture.baseUrl, USER, PASSWORD),
+        pickupDate: "2026-08-10",
+      });
+
+      expect(outcome.ok).toBe(false);
+      expect(outcome.errorDetail).toMatch(/nepodarilo/i);
+    },
+    TEST_TIMEOUT_MS,
+  );
+});
+
+describe("runOrderDpdPickupIsolated (dieťa proces, issue 313's vzor)", () => {
+  let fixture: DpdFixture | undefined;
+
+  afterEach(async () => {
+    await fixture?.close();
+    fixture = undefined;
+  });
+
+  it(
+    "rovnaký výsledok ako in-process runOrderDpdPickup, len spustený v dieťa procese",
+    async () => {
+      fixture = await startDpdFixture({ user: USER, password: PASSWORD });
+      const outcome = await runOrderDpdPickupIsolated({
+        config: dpdPortalConfigFromBaseUrl(fixture.baseUrl, USER, PASSWORD),
+        pickupDate: "2026-08-10",
+      });
+
+      expect(outcome.ok).toBe(true);
+    },
+    TEST_TIMEOUT_MS,
+  );
+});

--- a/apps/api/tests/dpd-shipment-playwright.integration.test.ts
+++ b/apps/api/tests/dpd-shipment-playwright.integration.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { dpdPortalConfigFromBaseUrl } from "../src/modules/dpd/config.js";
 import { runCreateDpdShipment, runCreateDpdShipmentIsolated } from "../src/modules/dpd/shipment-playwright.js";
 import type { DpdShipmentPreview } from "../src/modules/dpd/preview.js";
-import { startDpdFixture, type DpdFixture } from "./helpers/dpd-portal-fixture.js";
+import { FAKE_LIST_PARCEL_NUMBER, startDpdFixture, type DpdFixture } from "./helpers/dpd-portal-fixture.js";
 
 // Reálny Chromium proti LOKÁLNEJ fixture appke (nikdy proti skutočnému
 // dpdshipper.sk — issue 292's bezpečnostné pravidlo, `.claude/rules/dpd.md`).
@@ -116,6 +116,44 @@ describe("runCreateDpdShipment (proti fixture, nikdy proti reálnemu DPD)", () =
       expect(outcome.ok).toBe(false);
       expect(outcome.errorDetail).toMatch(/slovensk/i);
       expect(fixture.lastShipmentSubmission()).toBeNull();
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  // Code review (issue 292, PR 324): predtým appka TICHO odoslala dobierkovú
+  // objednávku BEZ dobierky, keď sa suma nedala určiť — kuriér by peniaze
+  // od zákazníka nevybral.
+  it(
+    "zlyhá NAHLAS na dobierkovej objednávke bez zistiteľnej sumy namiesto tichého odoslania bez dobierky",
+    async () => {
+      fixture = await startDpdFixture({ user: USER, password: PASSWORD });
+      const outcome = await runCreateDpdShipment({
+        config: dpdPortalConfigFromBaseUrl(fixture.baseUrl, USER, PASSWORD),
+        shipment: preview({ isCod: true, codAmount: null }),
+      });
+
+      expect(outcome.ok).toBe(false);
+      expect(outcome.errorDetail).toMatch(/dobierka/i);
+      expect(fixture.lastShipmentSubmission()).toBeNull();
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  // Code review (issue 292, PR 324): predtým by tento zálohový vetva (bez
+  // toastu, hľadanie v zozname) mohla vrátiť appka's vlastnú referenciu
+  // namiesto skutočného čísla zásielky — obe sú v tom istom riadku.
+  it(
+    "keď sa notifikácia neukáže, nájde skutočné číslo zásielky v zozname — nikdy vlastnú referenciu",
+    async () => {
+      fixture = await startDpdFixture({ user: USER, password: PASSWORD, shipmentSkipToast: true });
+      const outcome = await runCreateDpdShipment({
+        config: dpdPortalConfigFromBaseUrl(fixture.baseUrl, USER, PASSWORD),
+        shipment: preview(),
+      });
+
+      expect(outcome.ok).toBe(true);
+      expect(outcome.parcelNumber).toBe(FAKE_LIST_PARCEL_NUMBER);
+      expect(outcome.parcelNumber).not.toBe(preview().externalOrderId);
     },
     TEST_TIMEOUT_MS,
   );

--- a/apps/api/tests/dpd-shipment-playwright.integration.test.ts
+++ b/apps/api/tests/dpd-shipment-playwright.integration.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { dpdPortalConfigFromBaseUrl } from "../src/modules/dpd/config.js";
+import { runCreateDpdShipment, runCreateDpdShipmentIsolated } from "../src/modules/dpd/shipment-playwright.js";
+import type { DpdShipmentPreview } from "../src/modules/dpd/preview.js";
+import { startDpdFixture, type DpdFixture } from "./helpers/dpd-portal-fixture.js";
+
+// Reálny Chromium proti LOKÁLNEJ fixture appke (nikdy proti skutočnému
+// dpdshipper.sk — issue 292's bezpečnostné pravidlo, `.claude/rules/dpd.md`).
+const TEST_TIMEOUT_MS = 60_000;
+const USER = "manager";
+const PASSWORD = "tajneheslo";
+
+function preview(overrides: Partial<DpdShipmentPreview> = {}): DpdShipmentPreview {
+  return {
+    orderId: "11111111-1111-1111-1111-111111111111",
+    externalOrderId: "20261234",
+    recipientName: "Ján Testovací",
+    recipientCompany: null,
+    recipientPhone: "+421903123456",
+    street: "Hlavná",
+    houseNumber: "15",
+    city: "Košice",
+    zip: "04001",
+    countryName: "Slovensko",
+    addressComplete: true,
+    weightKg: "1.50",
+    isCod: false,
+    codAmount: null,
+    ...overrides,
+  };
+}
+
+describe("runCreateDpdShipment (proti fixture, nikdy proti reálnemu DPD)", () => {
+  let fixture: DpdFixture | undefined;
+
+  afterEach(async () => {
+    await fixture?.close();
+    fixture = undefined;
+  });
+
+  it(
+    "vyplní príjemcu, hmotnosť aj predvolené rozmery presne podľa náhľadu a prečíta číslo zásielky z notifikácie",
+    async () => {
+      fixture = await startDpdFixture({ user: USER, password: PASSWORD });
+      const outcome = await runCreateDpdShipment({
+        config: dpdPortalConfigFromBaseUrl(fixture.baseUrl, USER, PASSWORD),
+        shipment: preview(),
+      });
+
+      expect(outcome.ok).toBe(true);
+      expect(outcome.parcelNumber).toBe("99900000123");
+      const sent = fixture.lastShipmentSubmission();
+      expect(sent).not.toBeNull();
+      expect(sent).toMatchObject({
+        reference: "20261234",
+        name: "Ján Testovací",
+        street: "Hlavná",
+        houseNr: "15",
+        zip: "04001",
+        city: "Košice",
+        phone: "903123456",
+        weight: "1.50",
+        width: "30",
+        height: "20",
+        length: "20",
+        codChecked: false,
+        codAmount: null,
+      });
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "zaškrtne Dobierku a vyplní jej sumu, keď je náhľad COD",
+    async () => {
+      fixture = await startDpdFixture({ user: USER, password: PASSWORD });
+      const outcome = await runCreateDpdShipment({
+        config: dpdPortalConfigFromBaseUrl(fixture.baseUrl, USER, PASSWORD),
+        shipment: preview({ isCod: true, codAmount: "42.90" }),
+      });
+
+      expect(outcome.ok).toBe(true);
+      const sent = fixture.lastShipmentSubmission();
+      expect(sent?.codChecked).toBe(true);
+      expect(sent?.codAmount).toBe("42.90");
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "zlyhá NAHLAS (nikdy tiché ok:true), keď portál nikdy nepovolí typ produktu/COD",
+    async () => {
+      fixture = await startDpdFixture({ user: USER, password: PASSWORD, stuckDisabled: true });
+      const outcome = await runCreateDpdShipment({
+        config: dpdPortalConfigFromBaseUrl(fixture.baseUrl, USER, PASSWORD),
+        shipment: preview(),
+      });
+
+      expect(outcome.ok).toBe(false);
+      expect(outcome.parcelNumber).toBeNull();
+      expect(outcome.errorDetail).toMatch(/neaktívne/);
+      expect(fixture.lastShipmentSubmission()).toBeNull();
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "zlyhá NAHLAS na nie-slovenskej doručovacej krajine namiesto tichého odoslania s nesprávnou krajinou",
+    async () => {
+      fixture = await startDpdFixture({ user: USER, password: PASSWORD });
+      const outcome = await runCreateDpdShipment({
+        config: dpdPortalConfigFromBaseUrl(fixture.baseUrl, USER, PASSWORD),
+        shipment: preview({ countryName: "Česká Republika" }),
+      });
+
+      expect(outcome.ok).toBe(false);
+      expect(outcome.errorDetail).toMatch(/slovensk/i);
+      expect(fixture.lastShipmentSubmission()).toBeNull();
+    },
+    TEST_TIMEOUT_MS,
+  );
+});
+
+describe("runCreateDpdShipmentIsolated (dieťa proces, issue 313's vzor)", () => {
+  let fixture: DpdFixture | undefined;
+
+  afterEach(async () => {
+    await fixture?.close();
+    fixture = undefined;
+  });
+
+  it(
+    "rovnaký výsledok ako in-process runCreateDpdShipment, len spustený v dieťa procese",
+    async () => {
+      fixture = await startDpdFixture({ user: USER, password: PASSWORD });
+      const outcome = await runCreateDpdShipmentIsolated({
+        config: dpdPortalConfigFromBaseUrl(fixture.baseUrl, USER, PASSWORD),
+        shipment: preview(),
+      });
+
+      expect(outcome.ok).toBe(true);
+      expect(outcome.parcelNumber).toBe("99900000123");
+    },
+    TEST_TIMEOUT_MS,
+  );
+});

--- a/apps/api/tests/helpers/dpd-portal-fixture.ts
+++ b/apps/api/tests/helpers/dpd-portal-fixture.ts
@@ -1,0 +1,204 @@
+import { serve } from "@hono/node-server";
+import { Hono } from "hono";
+import { getCookie, setCookie } from "hono/cookie";
+import type { AddressInfo } from "node:net";
+
+/**
+ * issue 292: falošný `dpdshipper.sk` — imituje LEN tvar, ktorý
+ * `shipment-playwright.ts`/`pickup-playwright.ts` naozaj ovládajú (rovnaká
+ * disciplína ako `shoptet-fixture.ts`, `.claude/rules/shoptet-writeback.md`).
+ * Skutočný portál je Angular/wijmo aplikácia — táto fixtúra ju nereplikuje
+ * bajt-po-bajte (to overuje LEN živé prihlásenie, `.claude/rules/dpd.md`),
+ * len ID/atribúty/vnorenie prvkov, ktoré naša automatizácia SKUTOČNE
+ * ovláda (selektory naživo domapované 9.8.2026), plus dve konfigurovateľné
+ * čakacie/chybové správania (produkt/COD trvalo disabled, chyba pri
+ * objednaní zvozu) na overenie fail-loud ciest.
+ */
+
+const COOKIE_NAME = "dpd-sid";
+
+export interface DpdFixtureOptions {
+  readonly user: string;
+  readonly password: string;
+  /** Produkt/COD prepínače NIKDY nepovolí (simuluje portál, čo sa nikdy
+   * nedokončí inicializovať) — na overenie fail-loud timeoutu. */
+  readonly stuckDisabled?: boolean;
+  /** Krok 2 objednávky zvozu po Uložení ukáže chybu namiesto úspechu. */
+  readonly pickupSaveFails?: boolean;
+}
+
+export interface DpdShipmentSubmission {
+  readonly reference: string;
+  readonly name: string;
+  readonly street: string;
+  readonly houseNr: string;
+  readonly zip: string;
+  readonly city: string;
+  readonly phone: string;
+  readonly weight: string;
+  readonly width: string;
+  readonly height: string;
+  readonly length: string;
+  readonly codChecked: boolean;
+  readonly codAmount: string | null;
+}
+
+export interface DpdFixture {
+  readonly baseUrl: string;
+  readonly lastShipmentSubmission: () => DpdShipmentSubmission | null;
+  readonly lastPickupDate: () => string | null;
+  close(): Promise<void>;
+}
+
+function loginPage(): string {
+  return `<!doctype html><html><body>
+    <form method="post" action="/login">
+      <input id="loginName" name="loginName" type="text" />
+      <input name="password" type="password" />
+      <button type="submit">Prihlásiť</button>
+    </form>
+  </body></html>`;
+}
+
+function shipmentFormPage(stuckDisabled: boolean): string {
+  const disabledAttr = "disabled";
+  const enableScript = stuckDisabled
+    ? ""
+    : `<script>setTimeout(function(){
+        document.getElementById('product_Home').removeAttribute('disabled');
+        document.getElementById('service-COD').removeAttribute('disabled');
+      }, 200);</script>`;
+  return `<!doctype html><html><body>
+    <input type="radio" id="product_Home" ${disabledAttr} />
+    <input type="text" id="referential-info1" />
+    <shp-universal-number-input name="parcelWeight"><input placeholder="Hmotnosť" /></shp-universal-number-input>
+    <input name="parcelWidth" />
+    <input name="parcelHeight" />
+    <input name="parcelLength" />
+    <ng2-completer id="shipment_order_recipient-recipient-name"><div class="completer-holder"><input type="search" /></div></ng2-completer>
+    <input type="text" id="shipment_order_recipient-recipient-name2" />
+    <input type="text" id="shipment_order_recipient-recipient-street" />
+    <input type="text" id="shipment_order_recipient-recipient-house-nr" />
+    <ng2-completer id="shipment_order_recipient-recipient-zip"><div class="completer-holder"><input type="search" /></div></ng2-completer>
+    <ng2-completer id="shipment_order_recipient-recipient-city"><div class="completer-holder"><input type="search" /></div></ng2-completer>
+    <input type="text" name="number" />
+    <div class="additional-service">
+      <input type="checkbox" id="service-COD" ${disabledAttr} />
+      <label for="service-COD">Dobierka</label>
+    </div>
+    ${enableScript}
+    <button type="button" id="save-btn">Uložiť &amp; Nová</button>
+    <script>
+      document.getElementById('service-COD').addEventListener('change', function (e) {
+        var container = e.target.closest('.additional-service');
+        if (e.target.checked && !container.querySelector('input[name=codAmount]')) {
+          var amountInput = document.createElement('input');
+          amountInput.setAttribute('name', 'codAmount');
+          container.appendChild(amountInput);
+        }
+      });
+      document.getElementById('save-btn').addEventListener('click', function () {
+        var byId = function (id) { return document.getElementById(id); };
+        var val = function (sel) { var el = document.querySelector(sel); return el ? el.value : ""; };
+        var codChecked = byId('service-COD').checked;
+        var payload = {
+          reference: byId('referential-info1').value,
+          name: val('#shipment_order_recipient-recipient-name input[type=search]'),
+          street: byId('shipment_order_recipient-recipient-street').value,
+          houseNr: byId('shipment_order_recipient-recipient-house-nr').value,
+          zip: val('#shipment_order_recipient-recipient-zip input[type=search]'),
+          city: val('#shipment_order_recipient-recipient-city input[type=search]'),
+          phone: val('input[name=number]'),
+          weight: val('input[placeholder="Hmotnosť"]'),
+          width: val('input[name=parcelWidth]'),
+          height: val('input[name=parcelHeight]'),
+          length: val('input[name=parcelLength]'),
+          codChecked: codChecked,
+          codAmount: codChecked ? val('input[name=codAmount]') : null,
+        };
+        fetch('/test/shipment-submit', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) })
+          .then(function () {
+            document.body.insertAdjacentHTML('beforeend', '<div id="toast-container"><div>Zásielka uložená, číslo 99900000123</div></div>');
+          });
+      });
+    </script>
+  </body></html>`;
+}
+
+function pickupFormPage(): string {
+  return `<!doctype html><html><body>
+    <div id="pickup-date"><input wj-part="input" id="pickup-date-input" /></div>
+    <div id="step1"><button type="button" id="button-confirmation">Pokračovať</button></div>
+    <div id="step2" style="display:none"><button type="button" id="save-btn2">Uložiť</button></div>
+    <script>
+      document.getElementById('button-confirmation').addEventListener('click', function () {
+        document.getElementById('step1').style.display = 'none';
+        document.getElementById('step2').style.display = 'block';
+      });
+      document.getElementById('save-btn2').addEventListener('click', function () {
+        var date = document.getElementById('pickup-date-input').value;
+        fetch('/test/pickup-submit', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ date: date }) })
+          .then(function (r) { return r.json(); })
+          .then(function (r) {
+            if (!r.ok) {
+              document.body.insertAdjacentHTML('beforeend', '<div class="alert-danger">Zvoz sa nepodarilo objednať (test)</div>');
+            }
+          });
+      });
+    </script>
+  </body></html>`;
+}
+
+export async function startDpdFixture(options: DpdFixtureOptions): Promise<DpdFixture> {
+  const app = new Hono();
+  let lastShipment: DpdShipmentSubmission | null = null;
+  let lastPickupDate: string | null = null;
+
+  app.get("/login", (c) => c.html(loginPage()));
+
+  app.post("/login", async (c) => {
+    const body = await c.req.parseBody();
+    if (body["loginName"] === options.user && body["password"] === options.password) {
+      setCookie(c, COOKIE_NAME, "ok", { httpOnly: true, path: "/" });
+      return c.redirect("/shipments", 303);
+    }
+    return c.redirect("/login", 303);
+  });
+
+  app.get("/shipments", (c) => (getCookie(c, COOKIE_NAME) === "ok" ? c.html("<!doctype html><html><body>Zásielky</body></html>") : c.html(loginPage())));
+
+  app.get("/shipments/0", (c) => (getCookie(c, COOKIE_NAME) === "ok" ? c.html(shipmentFormPage(options.stuckDisabled ?? false)) : c.html(loginPage())));
+
+  app.post("/test/shipment-submit", async (c) => {
+    lastShipment = await c.req.json<DpdShipmentSubmission>();
+    return c.json({ ok: true });
+  });
+
+  app.get("/pickup-orders/0", (c) => (getCookie(c, COOKIE_NAME) === "ok" ? c.html(pickupFormPage()) : c.html(loginPage())));
+
+  app.post("/test/pickup-submit", async (c) => {
+    const body = await c.req.json<{ readonly date: string }>();
+    lastPickupDate = body.date;
+    return c.json({ ok: options.pickupSaveFails !== true });
+  });
+
+  const server = await new Promise<import("node:http").Server>((resolve) => {
+    const s = serve({ fetch: app.fetch, port: 0 }, () => {
+      resolve(s as unknown as import("node:http").Server);
+    });
+  });
+  const address = server.address() as AddressInfo;
+
+  return {
+    baseUrl: `http://127.0.0.1:${String(address.port)}`,
+    lastShipmentSubmission: () => lastShipment,
+    lastPickupDate: () => lastPickupDate,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      }),
+  };
+}

--- a/apps/api/tests/helpers/dpd-portal-fixture.ts
+++ b/apps/api/tests/helpers/dpd-portal-fixture.ts
@@ -25,6 +25,12 @@ export interface DpdFixtureOptions {
   readonly stuckDisabled?: boolean;
   /** Krok 2 objednávky zvozu po Uložení ukáže chybu namiesto úspechu. */
   readonly pickupSaveFails?: boolean;
+  /** Po uložení zásielky NEUKÁŽE toast — núti appku ísť záložnou cestou
+   * (zoznam Zásielky filtrovaný podľa referencie), na overenie, že táto
+   * cesta naozaj nájde SKUTOČNÉ číslo zásielky, nie appka's vlastnú
+   * referenciu, ktorá je v tom istom riadku (code review, issue 292,
+   * PR 324). */
+  readonly shipmentSkipToast?: boolean;
 }
 
 export interface DpdShipmentSubmission {
@@ -60,7 +66,7 @@ function loginPage(): string {
   </body></html>`;
 }
 
-function shipmentFormPage(stuckDisabled: boolean): string {
+function shipmentFormPage(stuckDisabled: boolean, skipToast: boolean): string {
   const disabledAttr = "disabled";
   const enableScript = stuckDisabled
     ? ""
@@ -68,6 +74,12 @@ function shipmentFormPage(stuckDisabled: boolean): string {
         document.getElementById('product_Home').removeAttribute('disabled');
         document.getElementById('service-COD').removeAttribute('disabled');
       }, 200);</script>`;
+  // `.then()` po uložení: buď ukáž toast (bežná cesta), alebo NIČ (núti
+  // appku ísť záložnou cestou cez zoznam Zásielky — `skipToast`, code
+  // review issue 292 PR 324).
+  const afterSaveScript = skipToast
+    ? ""
+    : `document.body.insertAdjacentHTML('beforeend', '<div id="toast-container"><div>Zásielka uložená, číslo 99900000123</div></div>');`;
   return `<!doctype html><html><body>
     <input type="radio" id="product_Home" ${disabledAttr} />
     <input type="text" id="referential-info1" />
@@ -83,6 +95,7 @@ function shipmentFormPage(stuckDisabled: boolean): string {
     <ng2-completer id="shipment_order_recipient-recipient-city"><div class="completer-holder"><input type="search" /></div></ng2-completer>
     <input type="text" name="number" />
     <div class="additional-service">
+      <input type="hidden" id="cod-decoy" value="uz-existujuci-vstup-nie-suma" />
       <input type="checkbox" id="service-COD" ${disabledAttr} />
       <label for="service-COD">Dobierka</label>
     </div>
@@ -118,11 +131,23 @@ function shipmentFormPage(stuckDisabled: boolean): string {
         };
         fetch('/test/shipment-submit', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) })
           .then(function () {
-            document.body.insertAdjacentHTML('beforeend', '<div id="toast-container"><div>Zásielka uložená, číslo 99900000123</div></div>');
+            ${afterSaveScript}
           });
       });
     </script>
   </body></html>`;
+}
+
+// Naschvál v poradí referencia PRED skutočným číslom zásielky v tom istom
+// riadku — presne tam, kde sa dala predošlá (opravená) chyba prejaviť:
+// appka hľadá riadok PODĽA referencie, takže referencia je v ňom vždy
+// prítomná, a naivný regex by ju mohol vrátiť namiesto 14-miestneho čísla
+// zásielky (code review, issue 292, PR 324).
+export const FAKE_LIST_PARCEL_NUMBER = "12345678901234";
+
+function shipmentsListPage(reference: string | null): string {
+  const row = reference !== null ? `<tr><td>${reference}</td><td>Ján Testovací</td><td>${FAKE_LIST_PARCEL_NUMBER}</td></tr>` : "";
+  return `<!doctype html><html><body><table>${row}</table></body></html>`;
 }
 
 function pickupFormPage(): string {
@@ -165,9 +190,13 @@ export async function startDpdFixture(options: DpdFixtureOptions): Promise<DpdFi
     return c.redirect("/login", 303);
   });
 
-  app.get("/shipments", (c) => (getCookie(c, COOKIE_NAME) === "ok" ? c.html("<!doctype html><html><body>Zásielky</body></html>") : c.html(loginPage())));
+  app.get("/shipments", (c) =>
+    getCookie(c, COOKIE_NAME) === "ok" ? c.html(shipmentsListPage(lastShipment?.reference ?? null)) : c.html(loginPage()),
+  );
 
-  app.get("/shipments/0", (c) => (getCookie(c, COOKIE_NAME) === "ok" ? c.html(shipmentFormPage(options.stuckDisabled ?? false)) : c.html(loginPage())));
+  app.get("/shipments/0", (c) =>
+    getCookie(c, COOKIE_NAME) === "ok" ? c.html(shipmentFormPage(options.stuckDisabled ?? false, options.shipmentSkipToast ?? false)) : c.html(loginPage()),
+  );
 
   app.post("/test/shipment-submit", async (c) => {
     lastShipment = await c.req.json<DpdShipmentSubmission>();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.186",
+  "version": "0.3.0-dev.187",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Čo je nové

DPD: objednanie prepravy jedným tlačidlom (issue 292) — funkcie, ktoré
vypĺňajú formulár DPD portálu (`fillShipmentFields`/`fillPickupForm`),
doteraz zámerne hádzali chybu (chýbalo naživo prihlásenie na domapovanie
skutočných selektorov). Prístupové údaje dnes konečne prišli — tento PR
nahrádza throwing stuby skutočným, naživo domapovaným vypĺňaním a
odoslaním.

Kľúčové zistenia z naživo mapovania (read-only route guard, nič sa
neobjednalo/neuložilo — detaily v `.claude/rules/dpd.md`):
- formulár `/shipments/0` má POVINNÉ rozmery balíka — appka ich
  nikde neukladá, pridané appka-vlastné rozumné defaulty (rovnaký vzor
  ako existujúca predvolená hmotnosť)
- `.fill()` nedrží hodnotu na wijmo widgetoch (dátum/číselné polia) —
  nahradené overeným klik+Ctrl+A+type+Tab vzorom
- appka podporuje len slovenské doručovacie adresy/telefónne čísla —
  zlyhá nahlas na inej krajine namiesto tichého odoslania so zlou
  predvolenou hodnotou portálu

## Testy

Nová fixtúra (`tests/helpers/dpd-portal-fixture.ts`, rovnaký vzor ako
existujúca `shoptet-fixture.ts`) imituje LEN tvar, ktorý appka skutočne
ovláda — reálny headless Chromium beží proti nej, nikdy proti skutočnému
`dpdshipper.sk`. Pokrýva správne vyplnenie polí, fail-loud timeout, kedy
portál nikdy nepovolí produkt/COD, fail-loud na nie-slovenskej krajine, aj
oba izolované dieťa-procesy.

## Čo zostáva neoverené

Posledný krok (skutočné uloženie + prečítanie čísla zásielky) sa nedal
naživo overiť skutočným kliknutím — bezpečnostné pravidlo tiketu hovorí,
že prvý reálny klik patrí majiteľovi. Ticket 292 preto ostáva otvorený s
komentárom, čo presne treba urobiť.

**Poznámka k referenciám na issue 292 v tomto texte:** zámerne nikde
nepíšem sloveso zavrieť/opraviť/vyriešiť bezprostredne pred `#292` — ticket
sa NEMÁ automaticky zavrieť týmto mergom (`.claude/rules/dpd.md`, dohoda s
majiteľom).
