### PR TITLE
fix: wire DPD_PORTAL_* env vars into docker-compose.prod.yml (issue 292)

### DIFF
--- a/.claude/rules/deploy.md
+++ b/.claude/rules/deploy.md
@@ -47,6 +47,22 @@ paths:
   ssh newlevel@dev2 'docker exec forestshop-app-1 sh -c "env | grep -E \"<PREMENNA>\""'
   ```
   Prázdny výstup = chýbajúci riadok v compose, nie chyba v appke.
+  **Zopakovalo sa presne to isté (issue 292, PR 324/9.8.2026):**
+  `DPD_PORTAL_USER`/`DPD_PORTAL_PASSWORD`/`DPD_PORTAL_BASE_URL` boli v
+  `env.ts` `.optional()` už od F1 (schéma/UI nasadené skôr, kód čakal na
+  prihlasovacie údaje), ale riadok v `docker-compose.prod.yml` NIKDY
+  nepribudol — appka na `/srv/forestshop/.env`'s hodnoty čakala TÝŽDNE,
+  no do kontajnera sa nikdy nedostali. Odhalené AŽ pri prvom skutočnom
+  post-deploy overení ("Preprava DPD" stále hlásila nenakonfigurované, hoci
+  `.env` mal obe hodnoty). **Ponaučenie: `env.ts`'s `.optional()` premenná
+  bez sprievodnej `docker-compose.prod.yml` riadky je TICHÁ medzera, ktorá
+  môže prežiť VEĽA nasadení bez povšimnutia — kontrola vyššie patrí do
+  KAŽDÉHO PR-u, čo pridáva novú `env.ts` premennú, nie len do toho, čo ju
+  prvýkrát POUŽÍVA v kóde.** Táto konkrétna trieda YAML-konfiguračnej
+  medzery (žiadna appka logika, žiadny testovateľný kód) nemá v tomto repe
+  automatizovaný testovací postih — kontrola vyššie (`docker exec ... env |
+  grep`) JE regresným testom, robeným ručne pri KAŽDOM ďalšom pridaní
+  premennej.
 - **Nepovinná premenná v `environment:` bloku patrí bez `:?`, ako holý kľúč
   (`SHOPTET_EXPORT_URL:`, žiadna hodnota) — NIE `${VAR:?chyba}`.** Bare kľúč
   preberá hodnotu z `/srv/forestshop/.env`, keď tam je, a keď nie je, premenná

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -105,6 +105,20 @@ services:
       # údaje — nikdy natvrdo, nikdy do repa.
       SHOPTET_ADMIN_USER:
       SHOPTET_ADMIN_PASSWORD:
+      # issue 292: DPD portál (dpdshipper.sk) prihlásenie — rovnaká úvaha ako
+      # SHOPTET_ADMIN_USER/PASSWORD vyššie: `.optional()` v `env.ts`, bare
+      # kľúč preberá `/srv/forestshop/.env`, keď tam je; keď nie je, appka
+      # beží ďalej, "Preprava DPD" hlási nenakonfigurované namiesto pádu.
+      # Nájdené AŽ pri post-deploy overení PR 324 — tento riadok chýbal od
+      # F1 (schéma/UI bez neho nasadené skôr), rovnaká trieda medzery ako
+      # `.claude/rules/deploy.md`'s zdokumentovaný issue 198 nález
+      # (MAIL_BCC/NEDOSTUPNE_BCC_EMAIL).
+      DPD_PORTAL_USER:
+      DPD_PORTAL_PASSWORD:
+      # `env.ts` má rozumný `.default(...)` — bare kľúč tu je len na to, aby
+      # sa dala adresa portálu zmeniť BEZ nového deploy/buildu (rovnaký
+      # dôvod ako SHOPTET_ADMIN_BASE_URL vyššie).
+      DPD_PORTAL_BASE_URL:
       # Alpine (base image) nemá Playwright's vlastný stiahnutý Chromium —
       # `Dockerfile` inštaluje systémový `apk add chromium` a
       # `playwright-import.ts`'s `resolveChromiumExecutablePath` ho nájde

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.187",
+  "version": "0.3.0-dev.188",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Čo je nové

Nadväzuje na PR 324 (issue 292 — DPD naživo domapované vyplnenie
formulára). Pri post-deploy overení sa ukázalo, že appka na produkcii
stále hlásila "DPD preprava nie je nakonfigurovaná", hoci
`DPD_PORTAL_USER`/`PASSWORD` boli už zapísané do `/srv/forestshop/.env`
na dev2.

Príčina: `docker-compose.prod.yml`'s `app` service nikdy nedeklarovala
`DPD_PORTAL_USER`/`DPD_PORTAL_PASSWORD`/`DPD_PORTAL_BASE_URL` v
`environment:` bloku — presne rovnaká medzera, akú `.claude/rules/
deploy.md` už zdokumentoval pri issue 198 (`MAIL_BCC`/
`NEDOSTUPNE_BCC_EMAIL`). Bez riadku v compose sa hodnota z `.env` do
kontajnera NIKDY nedostane, appka ju vidí ako chýbajúcu bez ohľadu na to,
čo je v `.env`.

Tento PR pridáva chýbajúce tri riadky (rovnaký vzor ako
`SHOPTET_ADMIN_USER`/`PASSWORD`) a rozširuje playbook o poznámku, že táto
kontrola patrí do KAŽDÉHO PR-u pridávajúceho novú `env.ts` premennú.

**Poznámka k referenciám na issue 292:** zámerne nikde nepíšem sloveso
zavrieť/opraviť/vyriešiť bezprostredne pred `#292` — ticket ostáva
otvorený (majiteľov prvý reálny klik).
