### PR TITLE
Upozornenia: kompaktné karty, bez stavu Nevybavená, s mazaním (issue 327)

### DIFF
--- a/.claude/rules/upozornenia.md
+++ b/.claude/rules/upozornenia.md
@@ -54,12 +54,27 @@ paths:
   "mountedRef nastavený v tele efektu", `.claude/rules/frontend-design.md`),
   aby sa mark-seen spustil PRESNE RAZ za mount, nikdy znova pri zmene
   filtra "aj vybavené" (ten len refetchne `load()` bez mark-seen).
-- **`updateOwnNote`/`deleteOwnNote` server-side vynucujú `source ===
-  "vlastne"`** — karta zo zdroja "appka" nemá tlačidlá Upraviť/Zmazať vôbec
-  vo frontende, ale to nestačí (rovnaká past ako `.claude/rules/
-  nedostupne.md`'s povinný náhľad — front-end skrytie nie je vynútenie).
-  Server vráti `updated`/`removed: false` namiesto chyby pri pokuse o cudziu
-  kartu.
+- **`updateOwnNote` server-side vynucuje `source === "vlastne"`** — karta zo
+  zdroja "appka" nemá tlačidlo Upraviť vôbec vo frontende, ale to nestačí
+  (rovnaká past ako `.claude/rules/nedostupne.md`'s povinný náhľad —
+  front-end skrytie nie je vynútenie). Server vráti `updated: false`
+  namiesto chyby pri pokuse o cudziu kartu.
+  **AKTUALIZÁCIA (issue 327, 10. 8. 2026): `deleteOwnNote` UŽ NEEXISTUJE —
+  nahradila ho generická `deleteUpozornenie`, ktorá NEVYNUCUJE
+  `source === "vlastne"` (majiteľ chce vedieť odstrániť AKÚKOĽVEK kartu,
+  nielen vlastnú poznámku — tlačidlo "Odstrániť" je teraz v akčnom riadku
+  pre VŠETKY nevyriešené karty).** `deleteUpozornenie` NAOPAK vynucuje
+  `resolved_at IS NULL` (code review pred mergom): vyriešenú kartu zmazať
+  NEJDE, server vráti `removed: false` — nie kvôli zrkadleniu frontendu
+  (ten dnes aj tak nikdy nerenderuje "Odstrániť" pre vyriešenú kartu), ale
+  kvôli vynúteniu `vratenie` typu KONEČNOSTI (pozri nižšie v tomto súbore):
+  `return-upozornenia.ts`'s pre-check rozpoznáva "už bolo vybavené" podľa
+  TOHO, že pre `dedupKey` EXISTUJE aj vyriešený riadok — hard-delete
+  vyriešenej `vratenie` karty by ten riadok odstránil a ĎALŠÍ import tej
+  istej (stále aktívnej) vrátkovej objednávky by ju ticho znova založil ako
+  NOVÚ kartu. Test pri KAŽDOM ĎALŠOM rozšírení nejakej `source`/`resolved`
+  obmedzenej akcie v tomto module: server MUSÍ overiť podmienku SÁM, front-end
+  gate nikdy nestačí.
 - **Odložená karta bola živo nájdená ako NEVIDITEĽNÁ ÚPLNE VŽDY — žiadna
   hodnota žiadneho filtra ju neodkryla, a neexistovala akcia na jej
   vrátenie skôr, než sa vráti sama** (issue 267 follow-up, gap 2, nájdené

--- a/apps/api/src/http/upozornenia-routes.ts
+++ b/apps/api/src/http/upozornenia-routes.ts
@@ -7,7 +7,7 @@ import { countActionableUpozornenia, listResolvedUpozornenia, listUpozornenia, t
 import {
   cancelPostpone,
   createOwnNote,
-  deleteOwnNote,
+  deleteUpozornenie,
   markAllSeen,
   postponeUpozornenie,
   resolveUpozornenie,
@@ -118,12 +118,14 @@ export function registerUpozorneniaRoutes(app: Hono<AppBindings>, db: Database):
     },
   );
 
-  // Zmazanie — rovnaká disciplína ako `nedostupne-routes.ts`'s odkazy: neznáme/
-  // už zmazané id (dvojklik) je NEŠKODNÉ, vždy 200, nikdy 4xx.
+  // Zmazanie — issue 327: rozšírené na VŠETKY zdroje (predtým len vlastné
+  // poznámky, issue 267), `deleteUpozornenie` (`service.ts`) to komentuje
+  // podrobne. Rovnaká disciplína ako `nedostupne-routes.ts`'s odkazy:
+  // neznáme/už zmazané id (dvojklik) je NEŠKODNÉ, vždy 200, nikdy 4xx.
   app.delete("/api/upozornenia/:id", requireSameOrigin(), requireUser(db), requireRole("admin", "manazer"), zValidator("param", idParam), async (c) => {
     const { id } = c.req.valid("param");
     const user = c.get("user");
-    const removed = await deleteOwnNote(db, id);
+    const removed = await deleteUpozornenie(db, id);
     if (removed) {
       await record(db, { at: new Date(), actorUserId: user.userId, action: "upozornenie.deleted", entity: "upozornenie", entityId: id, data: { id } });
     }

--- a/apps/api/src/modules/orders/stuck-status.test.ts
+++ b/apps/api/src/modules/orders/stuck-status.test.ts
@@ -3,11 +3,19 @@ import { ORDER_STUCK_THRESHOLD_DAYS, daysStuck, isUnfinishedOrderStatus, stuckOr
 
 // issue 301: tretie automatické Upozornenie — objednávka, ktorá dlho visí v
 // NEVYBAVENOM stave. Naživo overené stavy (7. 8. 2026): "Vybavuje sa" (31
-// objednávok), "Nevybavená" (3 objednávky) — presne tieto dva, žiadny ďalší.
+// objednávok), "Nevybavená" (3 objednávky).
+//
+// AKTUALIZÁCIA (issue 327): majiteľ nechce kartu za "Nevybavená" vôbec —
+// zostáva len "Vybavuje sa" (`stuck-status.ts`'s vlastný komentár má plné
+// odôvodnenie, vrátane toho, prečo existujúce otvorené karty za tento stav
+// netreba manuálne mazať).
 describe("isUnfinishedOrderStatus", () => {
-  it("rozpozná oba naživo overené nevybavené stavy", () => {
+  it("rozpozná JEDINÝ zostávajúci nevybavený stav 'Vybavuje sa'", () => {
     expect(isUnfinishedOrderStatus("Vybavuje sa")).toBe(true);
-    expect(isUnfinishedOrderStatus("Nevybavená")).toBe(true);
+  });
+
+  it("issue 327: 'Nevybavená' už NIE JE nevybavený stav — karta sa zaň nemá zakladať", () => {
+    expect(isUnfinishedOrderStatus("Nevybavená")).toBe(false);
   });
 
   it("hotové/iné stavy vrátia false", () => {
@@ -20,7 +28,6 @@ describe("isUnfinishedOrderStatus", () => {
 
   it("normalizuje (NFC + orez) rovnako ako `order.status_name`, nikdy bajtovo presnú zhodu", () => {
     expect(isUnfinishedOrderStatus("  Vybavuje sa  ")).toBe(true);
-    expect(isUnfinishedOrderStatus("Nevybavená".normalize("NFD"))).toBe(true);
   });
 });
 

--- a/apps/api/src/modules/orders/stuck-status.ts
+++ b/apps/api/src/modules/orders/stuck-status.ts
@@ -4,21 +4,30 @@ import { normalizeStatusName } from "./parser.js";
 // NEVYBAVENOM stave (šéf: "objednávky, ktoré je potrebné riešiť"). Naživo
 // overené na produkcii (7. 8. 2026): 31 objednávok v stave "Vybavuje sa"
 // (najstaršia od 30. 4. 2026), 3 v stave "Nevybavená" (najstaršia od
-// 7. 5. 2026) — presne TIETO dva stavy, žiadny ďalší (rozšírenie zoznamu
-// vyžaduje ROVNAKÉ živé overenie proti produkčnej DB ako `return-status.ts`,
-// nikdy odhad).
+// 7. 5. 2026) — pôvodne oba tieto stavy zakladali kartu.
+//
+// AKTUALIZÁCIA (issue 327, 10. 8. 2026): majiteľ výslovne nechce kartu za
+// stav "Nevybavená" vôbec — "ten stav nevybavená — vôbec sem nedávať".
+// `UNFINISHED_ORDER_STATUS_NAMES` teraz obsahuje LEN "Vybavuje sa". Keďže
+// `objednavka_visi` je ZNOVA-OHLÁSITEĽNÁ kategória (nie KONEČNÁ, viď
+// `.claude/rules/upozornenia.md`'s zavedené rozhodnutie z #301,
+// `stuck-upozornenia.ts`), objednávka v stave "Nevybavená" teraz spadne do
+// `!isUnfinishedOrderStatus(...)` vetvy tej istej slučky — EXISTUJÚCE
+// otvorené karty za tento stav sa preto AUTOMATICKY ZATVORIA (`autoResolve
+// ByDedupKey`) pri najbližšom nočnom behu `ordersImportJob`, presne ten istý
+// mechanizmus, aký #297 použilo pre "Vybavená výmena"/"Vybavený Dobropis" —
+// ŽIADNA jednorazová migrácia potrebná (`.claude/rules/upozornenia.md`'s
+// #308 poučenie: over najprv, či nasledujúci naplánovaný beh prirodzene
+// dorieši existujúce riadky).
 //
 // ZÁMERNE NEZDIEĽANÉ s `open-statuses.ts`'s admin-nastaviteľným
 // `order_open_status` zoznamom (ten rozhoduje, čo appka ukáže na "Na
 // objednanie" a šéf ho sám edituje) — "visí príliš dlho" je NEZÁVISLÝ,
 // fixný pojem: aj keby šéf zajtra pridal/odobral stav zo zoznamu "Na
-// objednanie", toto upozornenie musí zostať naviazané na tie ISTÉ dva stavy,
-// ktoré naživo videl v dátach. Rovnaký princíp ako `return-status.ts`'s
+// objednanie", toto upozornenie musí zostať naviazané na TENTO pevný stav,
+// ktorý naživo videl v dátach. Rovnaký princíp ako `return-status.ts`'s
 // vlastný nezávislý zoznam vrátkových stavov.
-const UNFINISHED_ORDER_STATUS_NAMES: ReadonlySet<string> = new Set([
-  normalizeStatusName("Vybavuje sa"),
-  normalizeStatusName("Nevybavená"),
-]);
+const UNFINISHED_ORDER_STATUS_NAMES: ReadonlySet<string> = new Set([normalizeStatusName("Vybavuje sa")]);
 
 // Prečo 14 dní: appka už má KRATŠÍ vekový prah pre PRÍBUZNÚ, ale INÚ vec —
 // `order-reminder/constants.ts`'s `MIN_DAYS = 4` rozhoduje, kedy pripomenúť

--- a/apps/api/src/modules/upozornenia/service.ts
+++ b/apps/api/src/modules/upozornenia/service.ts
@@ -125,11 +125,21 @@ export async function updateOwnNote(db: UpozornenieExecutor, input: UpdateOwnNot
   return result.length > 0;
 }
 
-export async function deleteOwnNote(db: Database, id: string): Promise<boolean> {
-  const result = await db
-    .delete(upozornenie)
-    .where(and(eq(upozornenie.id, id), eq(upozornenie.source, "vlastne")))
-    .returning({ id: upozornenie.id });
+// issue 267 pôvodne obmedzilo mazanie len na `source === "vlastne"`
+// (`deleteOwnNote`) — issue 327 (majiteľ, zákres "Odstrániť" vedľa
+// "Odložiť" v akčnom riadku, ktorý sa renderuje pre VŠETKY nevyriešené
+// karty, plus generický text ticketu "upozornenie odstrániť") rozšírilo
+// mazanie na VŠETKY zdroje. Na rozdiel od "Upraviť" (editácia
+// titulku/textu, `updateOwnNote` nižšie — ostáva vlastníctvom LEN vlastných
+// poznámok, editovať generovaný text automatickej karty nedáva zmysel),
+// zmazanie CELÉHO riadku je zmysluplné pre AKÝKOĽVEK zdroj — majiteľ chce
+// vedieť trvalo odstrániť aj automaticky vygenerovanú kartu, ktorú už
+// nechce vidieť. Znova-ohlásiteľné typy (napr. `objednavka_visi`,
+// `.claude/rules/upozornenia.md`) sa jednoducho znova vytvoria pri ďalšom
+// behu, ak podmienka stále platí — rovnaké správanie ako keby karta nikdy
+// nevznikla.
+export async function deleteUpozornenie(db: Database, id: string): Promise<boolean> {
+  const result = await db.delete(upozornenie).where(eq(upozornenie.id, id)).returning({ id: upozornenie.id });
   return result.length > 0;
 }
 

--- a/apps/api/src/modules/upozornenia/service.ts
+++ b/apps/api/src/modules/upozornenia/service.ts
@@ -138,8 +138,27 @@ export async function updateOwnNote(db: UpozornenieExecutor, input: UpdateOwnNot
 // `.claude/rules/upozornenia.md`) sa jednoducho znova vytvoria pri ďalšom
 // behu, ak podmienka stále platí — rovnaké správanie ako keby karta nikdy
 // nevznikla.
+//
+// KRITICKÉ (code review pred mergom, issue 327): mazanie je obmedzené na
+// `resolved_at IS NULL` — VYRIEŠENÚ kartu zmazať NEJDE. Dôvod nie je len
+// zrkadlenie frontendu (ten dnes aj tak nikdy nerenderuje "Odstrániť" pre
+// vyriešenú kartu, `row.status !== "vybavene"` v `UpozornenieCard.tsx`) —
+// je to VYNÚTENIE `vratenie` typu KONEČNOSTI (`.claude/rules/
+// upozornenia.md`'s "vybavené je KONEČNÉ, nikdy sa nemá zopakovať"):
+// `return-upozornenia.ts`'s pre-check rozpoznáva "už bolo vybavené" podľa
+// TOHO, že PRE `dedupKey` EXISTUJE (aj vyriešený) riadok — hard-delete
+// vyriešenej `vratenie` karty by ten riadok úplne odstránil, pre-check by
+// nič nenašiel, a ĎALŠÍ import objednávky v tom istom (stále aktívnom)
+// vrátkovom stave by ju TICHO znova založil ako NOVÚ kartu — presne ten bug,
+// čo `return-upozornenia.ts` existuje riešiť. Front-end skrytie NIKDY nie je
+// vynútenie (`.claude/rules/upozornenia.md`'s vlastná disciplína pri
+// `updateOwnNote`/`deleteOwnNote`) — server to musí overiť sám, nezávisle od
+// toho, čo UI dnes ukazuje.
 export async function deleteUpozornenie(db: Database, id: string): Promise<boolean> {
-  const result = await db.delete(upozornenie).where(eq(upozornenie.id, id)).returning({ id: upozornenie.id });
+  const result = await db
+    .delete(upozornenie)
+    .where(and(eq(upozornenie.id, id), isNull(upozornenie.resolvedAt)))
+    .returning({ id: upozornenie.id });
   return result.length > 0;
 }
 

--- a/apps/api/tests/orders-ingest-stuck-upozornenie.integration.test.ts
+++ b/apps/api/tests/orders-ingest-stuck-upozornenie.integration.test.ts
@@ -92,7 +92,10 @@ it("objednávka NEVYBAVENÁ dlhšie než prah vyrobí kartu s číslom, dňami a
   expect(rows[0]?.resolvedAt).toBeNull();
 });
 
-it("Nevybavená (druhý naživo overený nevybavený stav) tiež vyrobí kartu po prekročení prahu", async () => {
+// issue 327: majiteľ nechce kartu za stav "Nevybavená" vôbec — na rozdiel
+// od predošlého správania (issue 301, kde OBA nevybavené stavy zakladali
+// kartu), tento test teraz overuje presný OPAK.
+it("issue 327: objednávka v stave 'Nevybavená' NEVYROBÍ kartu 'visí', hoci prekročila prah", async () => {
   const { db, dir } = await boot();
   await insertTestVariant(db, "40237/XL");
 
@@ -105,8 +108,43 @@ it("Nevybavená (druhý naživo overený nevybavený stav) tiež vyrobí kartu p
   });
 
   const rows = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "objednavka-visi:20700003"));
-  expect(rows).toHaveLength(1);
-  expect(rows[0]?.title).toContain("Nevybavená");
+  expect(rows).toHaveLength(0);
+});
+
+// issue 327: existujúca OTVORENÁ karta pre stav "Nevybavená" (založená pred
+// touto zmenou, keď ešte tento stav bol súčasťou "nevybavených") sa má
+// AUTOMATICKY zatvoriť pri najbližšom importe, žiadny manuálny cleanup
+// skript — rovnaký mechanizmus, aký `applyStuckUpozornenia` už používa pre
+// prechod do skutočne vybaveného stavu (test nižšie), len teraz spustený aj
+// pre "Nevybavená", lebo tá už NIE JE v `UNFINISHED_ORDER_STATUS_NAMES`.
+it("issue 327: existujúca otvorená karta 'Vybavuje sa' → 'Nevybavená' sa AUTOMATICKY zatvorí ďalším importom", async () => {
+  const { db, dir } = await boot();
+  await insertTestVariant(db, "40237/XL");
+
+  await ingestOrders(db, {
+    fetchExport: fetcherOf(buildCsv(HEADER, [rowOf("20700007", "Vybavuje sa", "2026-07-18 10:00:00")])),
+    now: NOW,
+    rawDir: dir,
+    windowStart: WINDOW_START,
+    windowEnd: WINDOW_END,
+  });
+  const before = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "objednavka-visi:20700007"));
+  expect(before).toHaveLength(1);
+  expect(before[0]?.resolvedAt).toBeNull();
+
+  await ingestOrders(db, {
+    fetchExport: fetcherOf(buildCsv(HEADER, [rowOf("20700007", "Nevybavená", "2026-07-18 10:00:00")])),
+    now: new Date("2026-08-08T10:00:00Z"),
+    rawDir: dir,
+    windowStart: WINDOW_START,
+    windowEnd: WINDOW_END,
+  });
+
+  const after = await db.select().from(upozornenie).where(eq(upozornenie.dedupKey, "objednavka-visi:20700007"));
+  expect(after).toHaveLength(1); // stále jedna karta, žiadna nová
+  expect(after[0]?.id).toBe(before[0]?.id);
+  expect(after[0]?.resolvedAt).not.toBeNull(); // AUTOMATICKY zatvorená
+  expect(after[0]?.resolvedByUserId).toBeNull(); // "vybavené systémom", nie ručne
 });
 
 it("opakovaný import tej istej stuck objednávky NEVYROBÍ druhú kartu, len obnoví počet dní", async () => {

--- a/apps/api/tests/upozornenia-http.integration.test.ts
+++ b/apps/api/tests/upozornenia-http.integration.test.ts
@@ -233,4 +233,21 @@ describe("PATCH/DELETE /api/upozornenia/:id", () => {
     expect(res.status).toBe(200);
     expect((await res.json()) as { ok: boolean; removed: boolean }).toEqual({ ok: true, removed: false });
   });
+
+  // issue 327: mazanie UŽ NIE JE obmedzené na vlastné poznámky (issue 267) —
+  // aj karta zo zdroja "appka" (automatický zdroj) sa dá cez túto trasu
+  // odstrániť.
+  it("issue 327: zmaže AJ kartu zo zdroja 'appka' (automatický zdroj)", async () => {
+    const { app, cookie, db } = await boot("manazer");
+    const now = new Date("2026-08-10T08:00:00Z");
+    const created = await upsertUpozornenie(db, { type: "objednavka_visi", source: "appka", title: "Objednávka 1 visí", dedupKey: "objednavka-visi:1", now });
+
+    const res = await app.request(`/api/upozornenia/${created.id}`, { method: "DELETE", headers: { cookie } });
+    expect(res.status).toBe(200);
+    expect((await res.json()) as { ok: boolean; removed: boolean }).toEqual({ ok: true, removed: true });
+
+    const list = await app.request("/api/upozornenia", { headers: { cookie } });
+    const body = (await list.json()) as { rows: readonly { id: string }[] };
+    expect(body.rows.some((r) => r.id === created.id)).toBe(false);
+  });
 });

--- a/apps/api/tests/upozornenia-http.integration.test.ts
+++ b/apps/api/tests/upozornenia-http.integration.test.ts
@@ -250,4 +250,23 @@ describe("PATCH/DELETE /api/upozornenia/:id", () => {
     const body = (await list.json()) as { rows: readonly { id: string }[] };
     expect(body.rows.some((r) => r.id === created.id)).toBe(false);
   });
+
+  // Code review pred mergom (issue 327): server-side vynútenie cez CELÚ
+  // HTTP trasu, nielen v `service.ts` — vyriešenú kartu tento endpoint
+  // NIKDY nezmaže (`.claude/rules/upozornenia.md`'s `vratenie` KONEČNOSŤ).
+  it("issue 327: NEZMAŽE vyriešenú kartu (removed:false, karta ostáva v zozname 'Vybavené')", async () => {
+    const { app, cookie, db } = await boot("manazer");
+    const now = new Date("2026-08-10T08:00:00Z");
+    const created = await upsertUpozornenie(db, { type: "vlastna_poznamka", source: "vlastne", title: "Vybavené", now });
+    const resolveRes = await app.request(`/api/upozornenia/${created.id}/resolve`, { method: "POST", headers: { cookie } });
+    expect(((await resolveRes.json()) as { resolved: boolean }).resolved).toBe(true);
+
+    const res = await app.request(`/api/upozornenia/${created.id}`, { method: "DELETE", headers: { cookie } });
+    expect(res.status).toBe(200);
+    expect((await res.json()) as { ok: boolean; removed: boolean }).toEqual({ ok: true, removed: false });
+
+    const resolvedList = await app.request("/api/upozornenia/resolved", { headers: { cookie } });
+    const resolvedBody = (await resolvedList.json()) as { rows: readonly { id: string }[] };
+    expect(resolvedBody.rows.some((r) => r.id === created.id)).toBe(true);
+  });
 });

--- a/apps/api/tests/upozornenia-service.integration.test.ts
+++ b/apps/api/tests/upozornenia-service.integration.test.ts
@@ -204,6 +204,25 @@ describe("deleteUpozornenie — všetky zdroje", () => {
     const { db } = await bootDb();
     expect(await deleteUpozornenie(db, "00000000-0000-0000-0000-000000000000")).toBe(false);
   });
+
+  // Code review pred mergom (issue 327): VYRIEŠENÚ kartu zmazať NEJDE —
+  // server-side vynútenie, nezávisle od toho, že dnešný frontend aj tak
+  // nikdy nerenderuje "Odstrániť" pre vyriešenú kartu. Dôvod: `vratenie`
+  // typu KONEČNOSŤ (`.claude/rules/upozornenia.md`) sa spolieha na to, že
+  // pre `dedupKey` EXISTUJE aj vyriešený riadok — hard-delete by ho
+  // odstránil a ĎALŠÍ import by tú istú (stále aktívnu) vrátkovú kartu
+  // ticho znova založil ako novú.
+  it("NEZMAŽE vyriešenú kartu (vracia false, riadok ostáva)", async () => {
+    const { db, userId } = await bootDb();
+    const now = new Date("2026-08-05T08:00:00Z");
+    const own = await createOwnNote(db, { title: "Vybavené — nezmazať", createdByUserId: userId, now });
+    expect(await resolveUpozornenie(db, { id: own.id, resolvedByUserId: userId, now })).toBe(true);
+
+    expect(await deleteUpozornenie(db, own.id)).toBe(false);
+    const rows = await db.select().from(upozornenie);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.id).toBe(own.id);
+  });
 });
 
 describe("resolveUpozornenie / postponeUpozornenie", () => {

--- a/apps/api/tests/upozornenia-service.integration.test.ts
+++ b/apps/api/tests/upozornenia-service.integration.test.ts
@@ -5,7 +5,7 @@ import { hashPassword } from "../src/modules/auth/passwords.js";
 import {
   cancelPostpone,
   createOwnNote,
-  deleteOwnNote,
+  deleteUpozornenie,
   markAllSeen,
   postponeUpozornenie,
   resolveUpozornenie,
@@ -144,7 +144,7 @@ describe("upsertUpozornenie — súbežnosť (issue 272)", () => {
   });
 });
 
-describe("updateOwnNote / deleteOwnNote — len zdroj 'vlastne'", () => {
+describe("updateOwnNote — len zdroj 'vlastne'", () => {
   it("upraví vlastnú poznámku", async () => {
     const { db, userId } = await bootDb();
     const now = new Date("2026-08-05T08:00:00Z");
@@ -165,22 +165,44 @@ describe("updateOwnNote / deleteOwnNote — len zdroj 'vlastne'", () => {
     const [row] = await db.select().from(upozornenie);
     expect(row?.title).toBe("Automatická karta");
   });
+});
 
-  it("zmaže vlastnú poznámku, ale NIE kartu zo zdroja 'appka'", async () => {
+// issue 327: mazanie UŽ NIE JE obmedzené na `source === "vlastne"` (predtým
+// `deleteOwnNote`, issue 267) — `deleteUpozornenie` maže KTORÚKOĽVEK kartu
+// bez ohľadu na zdroj, viď `service.ts`'s odôvodnenie.
+describe("deleteUpozornenie — všetky zdroje", () => {
+  it("zmaže vlastnú poznámku", async () => {
     const { db, userId } = await bootDb();
     const now = new Date("2026-08-05T08:00:00Z");
     const own = await createOwnNote(db, { title: "Zmazať ma", createdByUserId: userId, now });
-    const appka = await upsertUpozornenie(db, { type: "vlastna_poznamka", source: "appka", title: "Nezmazať", dedupKey: "posta:W", now });
-    expect(await deleteOwnNote(db, own.id)).toBe(true);
-    expect(await deleteOwnNote(db, appka.id)).toBe(false);
+    expect(await deleteUpozornenie(db, own.id)).toBe(true);
+    const rows = await db.select().from(upozornenie);
+    expect(rows).toHaveLength(0);
+  });
+
+  it("zmaže AJ kartu zo zdroja 'appka' (automatický zdroj)", async () => {
+    const { db } = await bootDb();
+    const now = new Date("2026-08-05T08:00:00Z");
+    const appka = await upsertUpozornenie(db, { type: "vlastna_poznamka", source: "appka", title: "Automatická karta", dedupKey: "posta:W", now });
+    expect(await deleteUpozornenie(db, appka.id)).toBe(true);
+    const rows = await db.select().from(upozornenie);
+    expect(rows).toHaveLength(0);
+  });
+
+  it("nezmaže INÚ kartu, len tú so zhodným id", async () => {
+    const { db, userId } = await bootDb();
+    const now = new Date("2026-08-05T08:00:00Z");
+    const own = await createOwnNote(db, { title: "Zmazať ma", createdByUserId: userId, now });
+    const other = await createOwnNote(db, { title: "Nezmazať", createdByUserId: userId, now });
+    expect(await deleteUpozornenie(db, own.id)).toBe(true);
     const rows = await db.select().from(upozornenie);
     expect(rows).toHaveLength(1);
-    expect(rows[0]?.title).toBe("Nezmazať");
+    expect(rows[0]?.id).toBe(other.id);
   });
 
   it("zmazanie neznámeho/už zmazaného id je neškodné (vracia false, nikdy nevyhodí)", async () => {
     const { db } = await bootDb();
-    expect(await deleteOwnNote(db, "00000000-0000-0000-0000-000000000000")).toBe(false);
+    expect(await deleteUpozornenie(db, "00000000-0000-0000-0000-000000000000")).toBe(false);
   });
 });
 

--- a/apps/web/src/components/UpozorneniaSection.test.tsx
+++ b/apps/web/src/components/UpozorneniaSection.test.tsx
@@ -2,12 +2,12 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 import { afterEach, expect, it, vi } from "vitest";
 import { UpozorneniaSection } from "./UpozorneniaSection.js";
 
-const { fetchUpozornenia, markUpozorneniaSeen, createOwnNote, updateOwnNote, deleteOwnNote, resolveUpozornenie, postponeUpozornenie } = vi.hoisted(() => ({
+const { fetchUpozornenia, markUpozorneniaSeen, createOwnNote, updateOwnNote, deleteUpozornenie, resolveUpozornenie, postponeUpozornenie } = vi.hoisted(() => ({
   fetchUpozornenia: vi.fn(),
   markUpozorneniaSeen: vi.fn(),
   createOwnNote: vi.fn(),
   updateOwnNote: vi.fn(),
-  deleteOwnNote: vi.fn(),
+  deleteUpozornenie: vi.fn(),
   resolveUpozornenie: vi.fn(),
   postponeUpozornenie: vi.fn(),
 }));
@@ -16,7 +16,7 @@ const { fetchUpozornenia, markUpozorneniaSeen, createOwnNote, updateOwnNote, del
 // `NedostupneSection.test.tsx` — `instanceof` v komponente musí fungovať).
 vi.mock("../upozorneniaApi.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../upozorneniaApi.js")>();
-  return { ...actual, fetchUpozornenia, markUpozorneniaSeen, createOwnNote, updateOwnNote, deleteOwnNote, resolveUpozornenie, postponeUpozornenie };
+  return { ...actual, fetchUpozornenia, markUpozorneniaSeen, createOwnNote, updateOwnNote, deleteUpozornenie, resolveUpozornenie, postponeUpozornenie };
 });
 
 const VLASTNA_KARTA = {
@@ -115,30 +115,37 @@ afterEach(() => {
   vi.resetAllMocks();
 });
 
-it("karta s odkazom (automatický zdroj) zobrazí štítok 'Otvoriť objednávku v Shoptete' a otvára sa v novom okne", async () => {
+// issue 327: nadpis SAMOTNÝ sa stal klikateľným odkazom (predtým samostatný
+// riadok s `LINK_LABELS`'ovým textom) — ten text teraz nesie `aria-label`/
+// `title` (prístupnosť + hover), nie viditeľný `textContent`.
+it("karta s odkazom (automatický zdroj): nadpis JE odkaz, aria-label nesie štítok 'Otvoriť objednávku v Shoptete', otvára sa v novom okne", async () => {
   markUpozorneniaSeen.mockResolvedValue(undefined);
   fetchUpozornenia.mockResolvedValue([VRATENIE_KARTA]);
   render(<UpozorneniaSection role="manazer" onSessionExpired={vi.fn()} />);
   await screen.findByTestId("upozornenie-vratenie-1");
 
   const link = screen.getByTestId<HTMLAnchorElement>("upozornenie-link-vratenie-1");
-  expect(link.textContent).toBe("Otvoriť objednávku v Shoptete");
+  expect(link.textContent).toBe(VRATENIE_KARTA.title);
+  expect(link.getAttribute("aria-label")).toBe(`Otvoriť objednávku v Shoptete — ${VRATENIE_KARTA.title}`);
+  expect(link.getAttribute("title")).toBe("Otvoriť objednávku v Shoptete");
   expect(link.getAttribute("href")).toBe(VRATENIE_KARTA.link);
   expect(link.getAttribute("target")).toBe("_blank");
   expect(link.getAttribute("rel")).toBe("noreferrer");
 });
 
-it("issue 298: karta 'Nevyzdvihnutá zásielka' zobrazí štítok 'Sledovať zásielku na Pošte' s odkazom na Poštu SK, aj termín vyzdvihnutia v details", async () => {
+it("issue 298/327: karta 'Nevyzdvihnutá zásielka' — nadpis je odkaz so štítkom 'Sledovať zásielku na Pošte', prvý riadok details (Zákazník) je vedľa nadpisu, zvyšok (vrátane termínu vyzdvihnutia) ostáva pod kartou", async () => {
   markUpozorneniaSeen.mockResolvedValue(undefined);
   fetchUpozornenia.mockResolvedValue([NEVYZDVIHNUTA_KARTA]);
   render(<UpozorneniaSection role="manazer" onSessionExpired={vi.fn()} />);
   await screen.findByTestId("upozornenie-posta-1");
 
   const link = screen.getByTestId<HTMLAnchorElement>("upozornenie-link-posta-1");
-  expect(link.textContent).toBe("Sledovať zásielku na Pošte");
+  expect(link.textContent).toBe(NEVYZDVIHNUTA_KARTA.title);
+  expect(link.getAttribute("aria-label")).toBe(`Sledovať zásielku na Pošte — ${NEVYZDVIHNUTA_KARTA.title}`);
   expect(link.getAttribute("href")).toBe(NEVYZDVIHNUTA_KARTA.link);
   expect(link.getAttribute("target")).toBe("_blank");
   expect(link.getAttribute("rel")).toBe("noreferrer");
+  expect(screen.getByTestId("upozornenie-meta-posta-1").textContent).toContain("Zákazník: Ján Novák");
   expect(screen.getByText(/Vyzdvihnutie do: 2026-08-15/)).toBeTruthy();
 });
 
@@ -150,13 +157,14 @@ it("issue 299: karta 'Vrátená zásielka' zobrazí vlastný typový štítok a 
 
   expect(screen.getByTestId("upozornenie-type-posta-vratena-1").textContent).toBe("Vrátená zásielka");
   const link = screen.getByTestId<HTMLAnchorElement>("upozornenie-link-posta-vratena-1");
-  expect(link.textContent).toBe("Sledovať zásielku na Pošte");
+  expect(link.textContent).toBe(VRATENA_ZASIELKA_KARTA.title);
+  expect(link.getAttribute("aria-label")).toBe(`Sledovať zásielku na Pošte — ${VRATENA_ZASIELKA_KARTA.title}`);
   expect(link.getAttribute("href")).toBe(VRATENA_ZASIELKA_KARTA.link);
   expect(link.getAttribute("target")).toBe("_blank");
   expect(link.getAttribute("rel")).toBe("noreferrer");
 });
 
-it("issue 301: karta 'Objednávka visí' zobrazí vlastný typový štítok a odkaz do Shoptet administrácie", async () => {
+it("issue 301: karta 'Objednávka visí' zobrazí vlastný typový štítok, nadpis je odkaz do Shoptet administrácie, zákazník je vedľa nadpisu", async () => {
   markUpozorneniaSeen.mockResolvedValue(undefined);
   fetchUpozornenia.mockResolvedValue([OBJEDNAVKA_VISI_KARTA]);
   render(<UpozorneniaSection role="manazer" onSessionExpired={vi.fn()} />);
@@ -164,8 +172,10 @@ it("issue 301: karta 'Objednávka visí' zobrazí vlastný typový štítok a od
 
   expect(screen.getByTestId("upozornenie-type-visi-1").textContent).toBe("Objednávka visí");
   const link = screen.getByTestId<HTMLAnchorElement>("upozornenie-link-visi-1");
-  expect(link.textContent).toBe("Otvoriť objednávku v Shoptete");
+  expect(link.textContent).toBe(OBJEDNAVKA_VISI_KARTA.title);
+  expect(link.getAttribute("aria-label")).toBe(`Otvoriť objednávku v Shoptete — ${OBJEDNAVKA_VISI_KARTA.title}`);
   expect(link.getAttribute("href")).toBe(OBJEDNAVKA_VISI_KARTA.link);
+  expect(screen.getByTestId("upozornenie-meta-visi-1").textContent).toContain("Zákazník: Ján Novák");
 });
 
 it("prázdny zoznam zobrazí informačnú vetu (po označení videných)", async () => {
@@ -185,7 +195,9 @@ it("zobrazí kartu s 'Nové' štítkom pre nevidenú kartu", async () => {
   await screen.findByTestId("upozornenie-own-1");
   expect(screen.getByTestId("upozornenie-nove-own-1").textContent).toBe("Nové");
   expect(screen.getByText("Schôdzka v stredu")).toBeTruthy();
-  expect(screen.getByText("o 10:00")).toBeTruthy();
+  // issue 327: vlastná poznámka (žiadny `\n` v `details`) sa celá presunie
+  // VEDĽA nadpisu — už nie je vlastný samostatný `<p>` element.
+  expect(screen.getByTestId("upozornenie-meta-own-1").textContent).toContain("o 10:00");
 });
 
 it("rola 'citanie' vidí zoznam, ale NEVIDÍ žiadne akčné tlačidlá ani formulár", async () => {
@@ -198,14 +210,19 @@ it("rola 'citanie' vidí zoznam, ale NEVIDÍ žiadne akčné tlačidlá ani form
   expect(screen.queryByTestId("upozornenie-edit-own-1")).toBeNull();
 });
 
-it("karta zo zdroja 'appka' nemá Upraviť/Zmazať, len Vybavené/Odložiť", async () => {
+// issue 327: mazanie sa rozšírilo na VŠETKY zdroje (predtým len vlastné
+// poznámky) — karta zo zdroja "appka" má teraz Vybavené/Odložiť/Odstrániť,
+// ale STÁLE nemá Upraviť (editácia generovaného textu automatickej karty
+// nedáva zmysel, ticket ju ani nežiada).
+it("karta zo zdroja 'appka' nemá Upraviť, ale MÁ Odstrániť (spolu s Vybavené/Odložiť)", async () => {
   markUpozorneniaSeen.mockResolvedValue(undefined);
   fetchUpozornenia.mockResolvedValue([{ ...VLASTNA_KARTA, id: "appka-1", source: "appka" as const }]);
   render(<UpozorneniaSection role="manazer" onSessionExpired={vi.fn()} />);
   await screen.findByTestId("upozornenie-appka-1");
   expect(screen.getByTestId("upozornenie-resolve-appka-1")).toBeTruthy();
+  expect(screen.getByTestId("upozornenie-postpone-appka-1")).toBeTruthy();
+  expect(screen.getByTestId("upozornenie-delete-appka-1")).toBeTruthy();
   expect(screen.queryByTestId("upozornenie-edit-appka-1")).toBeNull();
-  expect(screen.queryByTestId("upozornenie-delete-appka-1")).toBeNull();
 });
 
 it("'+ Nové upozornenie' otvorí formulár, uloženie zavolá createOwnNote a znova načíta zoznam", async () => {
@@ -252,18 +269,37 @@ it("Upraviť predvyplní formulár existujúcimi hodnotami vlastnej poznámky", 
   expect(screen.getByTestId<HTMLTextAreaElement>("upozornenie-form-details").value).toBe("o 10:00");
 });
 
-it("Zmazať zavolá deleteOwnNote a znova načíta zoznam", async () => {
+it("Odstrániť zavolá deleteUpozornenie a znova načíta zoznam (vlastná poznámka)", async () => {
   markUpozorneniaSeen.mockResolvedValue(undefined);
   // Tretie `[]` je issue 267 follow-up gap 3's doplnkový najširší dopyt,
   // ktorý `load()` spraví, keď je zoznam prázdny (tu: po zmazaní).
   fetchUpozornenia.mockResolvedValueOnce([VLASTNA_KARTA]).mockResolvedValueOnce([]).mockResolvedValueOnce([]);
-  deleteOwnNote.mockResolvedValue(undefined);
+  deleteUpozornenie.mockResolvedValue(undefined);
   render(<UpozorneniaSection role="manazer" onSessionExpired={vi.fn()} />);
   await screen.findByTestId("upozornenie-own-1");
 
   fireEvent.click(screen.getByTestId("upozornenie-delete-own-1"));
   await waitFor(() => {
-    expect(deleteOwnNote).toHaveBeenCalledWith("own-1");
+    expect(deleteUpozornenie).toHaveBeenCalledWith("own-1");
+  });
+  await screen.findByTestId("upozornenia-empty");
+});
+
+// issue 327: mazanie sa rozšírilo na VŠETKY zdroje — over aj priamo pre
+// kartu zo zdroja "appka" (automatický zdroj), nielen vlastnú poznámku.
+it("issue 327: Odstrániť zavolá deleteUpozornenie AJ pre kartu zo zdroja 'appka'", async () => {
+  markUpozorneniaSeen.mockResolvedValue(undefined);
+  fetchUpozornenia
+    .mockResolvedValueOnce([{ ...VLASTNA_KARTA, id: "appka-1", source: "appka" as const }])
+    .mockResolvedValueOnce([])
+    .mockResolvedValueOnce([]);
+  deleteUpozornenie.mockResolvedValue(undefined);
+  render(<UpozorneniaSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("upozornenie-appka-1");
+
+  fireEvent.click(screen.getByTestId("upozornenie-delete-appka-1"));
+  await waitFor(() => {
+    expect(deleteUpozornenie).toHaveBeenCalledWith("appka-1");
   });
   await screen.findByTestId("upozornenia-empty");
 });

--- a/apps/web/src/components/UpozorneniaSection.tsx
+++ b/apps/web/src/components/UpozorneniaSection.tsx
@@ -7,7 +7,7 @@ import { UpozorneniaResolvedList } from "./UpozorneniaResolvedList.js";
 import {
   cancelPostponeUpozornenie,
   createOwnNote,
-  deleteOwnNote,
+  deleteUpozornenie,
   fetchUpozornenia,
   markUpozorneniaSeen,
   postponeUpozornenie,
@@ -373,7 +373,7 @@ export function UpozorneniaSection({ role, onSessionExpired }: { readonly role: 
                 setDraft({ id: row.id, title: row.title, details: row.details, dueAt: row.dueAt === null ? "" : row.dueAt.slice(0, 10) });
               }}
               onDelete={() => {
-                withBusy(row.id, () => deleteOwnNote(row.id));
+                withBusy(row.id, () => deleteUpozornenie(row.id));
               }}
             />
           ))}

--- a/apps/web/src/components/UpozornenieCard.splitDetailLines.test.ts
+++ b/apps/web/src/components/UpozornenieCard.splitDetailLines.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { splitDetailLines } from "./UpozornenieCard.js";
+
+// issue 327 (code review pred mergom, finding 5): tabuľkový test na hraničné
+// prípady `splitDetailLines`, ktoré `UpozorneniaSection.test.tsx`'s
+// renderovacie testy pokrývajú len nepriamo (cez konkrétne fixtúry). Toto je
+// ŠTRUKTURÁLNY split (prvý riadok / zvyšok podľa `\n`), nikdy parsovanie
+// "Zákazník:" reťazca — pozri `UpozornenieCard.tsx`'s vlastný komentár.
+describe("splitDetailLines", () => {
+  it("prázdny reťazec: žiadny prvý riadok, prázdny zvyšok", () => {
+    expect(splitDetailLines("")).toEqual({ first: null, rest: "" });
+  });
+
+  it("jeden riadok bez `\\n` (typický vlastný poznámkový text): celý sa stane 'prvým riadkom'", () => {
+    expect(splitDetailLines("o 10:00 s dodávateľom")).toEqual({ first: "o 10:00 s dodávateľom", rest: "" });
+  });
+
+  it("dva riadky (typický automatický zdroj, 'Zákazník: X\\n...'): prvý oddelene, zvyšok bez neho", () => {
+    expect(splitDetailLines("Zákazník: Ján Novák\nStav objednávky: Vratený tovar")).toEqual({
+      first: "Zákazník: Ján Novák",
+      rest: "Stav objednávky: Vratený tovar",
+    });
+  });
+
+  it("viac riadkov: zvyšok zostáva spojený `\\n`, nie len posledný riadok", () => {
+    expect(splitDetailLines("A\nB\nC")).toEqual({ first: "A", rest: "B\nC" });
+  });
+
+  it("reťazec je iba jeden `\\n`: prvý riadok je prázdny reťazec (nie null), zvyšok tiež prázdny", () => {
+    expect(splitDetailLines("\n")).toEqual({ first: "", rest: "" });
+  });
+
+  it("prázdny prvý riadok pred skutočným obsahom: prvý je '' (volajúci ho vynechá, nikdy '· '), zvyšok nesie obsah", () => {
+    expect(splitDetailLines("\nSkutočný obsah")).toEqual({ first: "", rest: "Skutočný obsah" });
+  });
+});

--- a/apps/web/src/components/UpozornenieCard.tsx
+++ b/apps/web/src/components/UpozornenieCard.tsx
@@ -21,7 +21,11 @@ import type { UpozornenieRow } from "../upozorneniaApi.js";
 // zvyčajne bez `\n` vôbec, takže CELÝ text sa jednoducho presunie vedľa
 // nadpisu) aj pre AKÝKOĽVEK budúci automatický zdroj bez väzby na presnú
 // formuláciu backendového textu.
-function splitDetailLines(details: string): { readonly first: string | null; readonly rest: string } {
+// Exportovaná KVÔLI testovateľnosti (code review pred mergom, issue 327) —
+// vlastný jednotkový test na hraničné prípady (`UpozornenieCard.
+// splitDetailLines.test.ts`), nezávisle od renderovacích testov, ktoré ju
+// pokrývajú len nepriamo.
+export function splitDetailLines(details: string): { readonly first: string | null; readonly rest: string } {
   if (details === "") return { first: null, rest: "" };
   const lines = details.split("\n");
   return { first: lines[0] ?? null, rest: lines.slice(1).join("\n") };

--- a/apps/web/src/components/UpozornenieCard.tsx
+++ b/apps/web/src/components/UpozornenieCard.tsx
@@ -11,6 +11,22 @@ import type { UpozornenieRow } from "../upozorneniaApi.js";
 // `UpozorneniaSection.tsx`, ktorý je jediný, čo ho potrebuje zdieľať naprieč
 // viacerými kartami naraz.
 
+// issue 327 (majiteľ, zákresy nad appkou v0.3.0-dev.174: "Datum dať vedľa",
+// "Alebo to dať všetko vedľa"): PRVÝ riadok `details` (v praxi takmer vždy
+// "Zákazník: X" — `posta-uncollected/run.ts`/`orders/return-upozornenia.ts`/
+// `orders/stuck-upozornenia.ts` ho VŽDY píšu ako prvý riadok) sa presúva na
+// riadok s nadpisom, spolu s "Vzniklo .../vybaviť do ...". Toto je
+// ŠTRUKTURÁLNY split (prvý riadok / zvyšok podľa `\n`), nikdy parsovanie
+// "Zákazník:" reťazca — funguje rovnako pre vlastné poznámky (voľný text,
+// zvyčajne bez `\n` vôbec, takže CELÝ text sa jednoducho presunie vedľa
+// nadpisu) aj pre AKÝKOĽVEK budúci automatický zdroj bez väzby na presnú
+// formuláciu backendového textu.
+function splitDetailLines(details: string): { readonly first: string | null; readonly rest: string } {
+  if (details === "") return { first: null, rest: "" };
+  const lines = details.split("\n");
+  return { first: lines[0] ?? null, rest: lines.slice(1).join("\n") };
+}
+
 // Otvorený zoznam typov — budúci ďalší automatický zdroj pridá svoj štítok
 // sem, keď pridá svoju `pgEnum` hodnotu.
 const TYPE_LABELS: Readonly<Record<UpozornenieRow["type"], string>> = {
@@ -86,6 +102,8 @@ export function UpozornenieCard({
   onDelete,
 }: UpozornenieCardProps): JSX.Element {
   const isOwn = row.source === "vlastne";
+  const { first: firstDetailLine, rest: restDetailLines } = splitDetailLines(row.details);
+  const linkLabel = LINK_LABELS[row.type] ?? DEFAULT_LINK_LABEL;
   return (
     <div className={"card upozornenie-card" + (row.status === "nove" ? " upozornenie-nove" : "")} data-testid={`upozornenie-${row.id}`}>
       <div className="upozornenie-head">
@@ -99,17 +117,34 @@ export function UpozornenieCard({
           </span>
         )}
       </div>
-      <p className="upozornenie-title">{row.title}</p>
-      {row.details !== "" && <p className="upozornenie-details">{row.details}</p>}
-      <p className="upozornenie-meta">
-        Vzniklo {formatSkDate(row.createdAt)}
-        {row.dueAt !== null && <> · vybaviť do {formatSkDate(row.dueAt)}</>}
-      </p>
-      {row.link !== null && (
-        <a href={row.link} target="_blank" rel="noreferrer" data-testid={`upozornenie-link-${row.id}`}>
-          {LINK_LABELS[row.type] ?? DEFAULT_LINK_LABEL}
-        </a>
-      )}
+      {/* issue 327: nadpis + "zákazník"/dátum na JEDNOM riadku ("Datum dať
+          vedľa"). Keď karta má odkaz, nadpis SAMOTNÝ sa stane klikateľným
+          odkazom (`LINK_LABELS`'ov text ostáva ako aria-label/title —
+          prístupnosť + hover, keďže vizuálne ho nahradila samotná titulka) —
+          samostatný odkazový riadok pod kartou zmizol. */}
+      <div className="upozornenie-title-row">
+        {row.link !== null ? (
+          <a
+            className="upozornenie-title"
+            href={row.link}
+            target="_blank"
+            rel="noreferrer"
+            aria-label={`${linkLabel} — ${row.title}`}
+            title={linkLabel}
+            data-testid={`upozornenie-link-${row.id}`}
+          >
+            {row.title}
+          </a>
+        ) : (
+          <p className="upozornenie-title">{row.title}</p>
+        )}
+        <span className="upozornenie-inline-meta" data-testid={`upozornenie-meta-${row.id}`}>
+          {firstDetailLine !== null && firstDetailLine !== "" && <>{firstDetailLine} · </>}
+          Vzniklo {formatSkDate(row.createdAt)}
+          {row.dueAt !== null && <> · vybaviť do {formatSkDate(row.dueAt)}</>}
+        </span>
+      </div>
+      {restDetailLines !== "" && <p className="upozornenie-details">{restDetailLines}</p>}
       {canControl && row.status !== "vybavene" && (
         <div className="upozornenie-actions">
           <button type="button" className="btn sm good" disabled={busy} onClick={onResolve} data-testid={`upozornenie-resolve-${row.id}`}>
@@ -128,6 +163,16 @@ export function UpozornenieCard({
           <button type="button" className="btn sm ghost" disabled={busy || postponeDraftValue === ""} onClick={onPostpone} data-testid={`upozornenie-postpone-${row.id}`}>
             Odložiť
           </button>
+          {/* issue 327 (majiteľ, zákres "Odstrániť" vedľa "Odložiť"): mazanie
+              UŽ NIE JE obmedzené len na vlastné poznámky (issue 267) —
+              generický text ticketu ("upozornenie odstrániť") aj umiestnenie
+              v akčnom riadku (renderovanom pre VŠETKY nevyriešené karty)
+              ukazujú na VŠETKY typy, nielen `isOwn`. "Upraviť" (editácia
+              titulku/textu) OSTÁVA len pre vlastné poznámky nižšie — editovať
+              generovaný text automatickej karty nedáva zmysel. */}
+          <button type="button" className="btn sm ghost" disabled={busy} onClick={onDelete} data-testid={`upozornenie-delete-${row.id}`}>
+            Odstrániť
+          </button>
           {row.status === "odlozene" && (
             // issue 267 (živé overenie, gap 2): jediný spôsob, ako vrátiť
             // odloženú kartu SKÔR, než sa vráti sama (napr. majiteľ sa
@@ -137,14 +182,9 @@ export function UpozornenieCard({
             </button>
           )}
           {isOwn && (
-            <>
-              <button type="button" className="btn sm ghost" disabled={busy} onClick={onEdit} data-testid={`upozornenie-edit-${row.id}`}>
-                Upraviť
-              </button>
-              <button type="button" className="btn sm ghost" disabled={busy} onClick={onDelete} data-testid={`upozornenie-delete-${row.id}`}>
-                ✕ Zmazať
-              </button>
-            </>
+            <button type="button" className="btn sm ghost" disabled={busy} onClick={onEdit} data-testid={`upozornenie-edit-${row.id}`}>
+              Upraviť
+            </button>
           )}
         </div>
       )}

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2081,10 +2081,41 @@ tr:last-child td {
   gap: var(--fs-space-3);
   flex-wrap: wrap;
 }
+/* issue 327 (majiteľ: "Datum dať vedľa", "Alebo to dať všetko vedľa" —
+   kompaktné karty, do dĺžky nie výšky): nadpis + prvý riadok `details`
+   ("Zákazník: X") + dátum vzniku/vybaviť do na JEDNOM riadku namiesto troch
+   samostatných stohovaných `<p>` elementov. `align-items: baseline` drží
+   nadpis (väčšie písmo) a meta (menšie písmo) na spoločnej textovej línii;
+   `flex-wrap: wrap` je poistka pre úzku obrazovku/dlhší nadpis. */
+.upozornenie-title-row {
+  display: flex;
+  align-items: baseline;
+  gap: var(--fs-space-2);
+  flex-wrap: wrap;
+}
 .upozornenie-title {
   font-size: var(--fs-text-md);
   font-weight: var(--fs-weight-semibold);
   margin: 0;
+}
+/* Nadpis ako odkaz (karta má `link`) — TRVALÉ podčiarknutie (rovnaký
+   vizuálny jazyk ako `.ord-admin-link`), nie len pri hoveri: keď nadpis
+   VIZUÁLNE nahradil predošlý samostatný odkazový riadok "Otvoriť
+   objednávku v Shoptete", musí byť SÁM OSEBE rozoznateľný ako klikateľný,
+   bez potreby najazdiť naň myšou (živo overené — bez podčiarknutia
+   nebolo vidieť žiadny rozdiel od obyčajného textového nadpisu). */
+a.upozornenie-title {
+  color: var(--fs-ink);
+  text-decoration: underline;
+  text-decoration-color: var(--fs-border);
+}
+a.upozornenie-title:hover {
+  color: var(--fs-brand);
+  text-decoration-color: currentColor;
+}
+.upozornenie-inline-meta {
+  font-size: var(--fs-text-sm);
+  color: var(--fs-ink-faint);
 }
 .upozornenie-details {
   margin: 0;
@@ -2103,6 +2134,17 @@ tr:last-child td {
   flex-wrap: wrap;
   margin-top: var(--fs-space-2);
 }
+/* issue 327 (majiteľ: "tlačidlá a pole s dátumom aspoň o 25 % nižšie —
+   tieto obdĺžniky"): zmerané naživo cez Playwright proti lokálnemu dev
+   serveru (rovnaká metodika ako issue 105/107/111/127/171/204/214/258/303)
+   — pôvodný jednoriadkový pás akcií mal ~35.6px (issue 303's vlastný
+   nameraný údaj); nižšie paddingy + o stupeň menšie písmo na tlačidlách
+   znižujú výšku o zmeraných ≥25 %, bez zmeny šírky/textu tlačidiel. */
+.upozornenie-actions .btn {
+  padding-top: 1px;
+  padding-bottom: 1px;
+  font-size: var(--fs-text-xs);
+}
 /* issue 303: the global `input:not([type="hidden"]) { width: 100% }` reset
    (app.css §1) stretched the "odložiť do" date field to the FULL width of
    this flex row (measured live: 1491px at 1600px desktop) — same trap as
@@ -2117,6 +2159,11 @@ tr:last-child td {
   width: auto;
   min-width: 9.5rem;
   flex: 0 0 auto;
+  /* issue 327: rovnaká ≥25 % nižšia disciplína ako `.upozornenie-actions
+     .btn` vyššie — padding znížený z predvoleného `--fs-space-2`
+     (8px)/strana na 1px/strana. */
+  padding-top: 1px;
+  padding-bottom: 1px;
 }
 .upozornenie-form {
   display: flex;

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2139,7 +2139,14 @@ a.upozornenie-title:hover {
    serveru (rovnaká metodika ako issue 105/107/111/127/171/204/214/258/303)
    — pôvodný jednoriadkový pás akcií mal ~35.6px (issue 303's vlastný
    nameraný údaj); nižšie paddingy + o stupeň menšie písmo na tlačidlách
-   znižujú výšku o zmeraných ≥25 %, bez zmeny šírky/textu tlačidiel. */
+   znižujú výšku o zmeraných ≥25 %, bez zmeny šírky/textu tlačidiel.
+   Code review: táto trieda (`.upozornenie-actions .btn`) VEDOME zasahuje aj
+   do záložky "Vybavené" (`UpozorneniaResolvedList.tsx` znovupoužíva rovnaké
+   `.upozornenie-actions`/`.btn.sm.ghost` pre "↩ Vrátiť medzi otvorené") —
+   živo overené, že tlačidlo ostáva čitateľné/klikateľné, len o niečo
+   kompaktnejšie. Zámerné zdieľanie triedy naprieč OBOMA záložkami, rovnaký
+   princíp ako issue 303's centrálna zmena tokenov namiesto lokálnych
+   výnimiek (`.claude/rules/frontend-design.md`). */
 .upozornenie-actions .btn {
   padding-top: 1px;
   padding-bottom: 1px;

--- a/apps/web/src/upozorneniaApi.ts
+++ b/apps/web/src/upozorneniaApi.ts
@@ -104,9 +104,12 @@ export async function updateOwnNote(id: string, input: OwnNoteInput): Promise<bo
   return body.updated;
 }
 
-export async function deleteOwnNote(id: string): Promise<void> {
+// issue 327: mazanie už NIE JE obmedzené na vlastné poznámky (predtým
+// `deleteOwnNote`, issue 267) — akákoľvek karta s `canControl` sa dá
+// odstrániť, viď `service.ts`'s `deleteUpozornenie` pre plné odôvodnenie.
+export async function deleteUpozornenie(id: string): Promise<void> {
   const response = await fetch(`/api/upozornenia/${encodeURIComponent(id)}`, { method: "DELETE" });
-  await readJson(response, "Upozornenie sa nepodarilo zmazať");
+  await readJson(response, "Upozornenie sa nepodarilo odstrániť");
 }
 
 export async function resolveUpozornenie(id: string): Promise<void> {

--- a/apps/web/tests/e2e/upozornenia.spec.ts
+++ b/apps/web/tests/e2e/upozornenia.spec.ts
@@ -148,7 +148,17 @@ test("vlastná poznámka — vytvorenie, 'Nové' zmizne po znovuotvorení, úpra
 // dátumové pole "odložiť do" naťahovalo na CELÚ šírku pásu (naživo namerané:
 // 1491px pri 1600px okne), takže tri ovládacie prvky (✓ Vybavené / dátum /
 // Odložiť) sa zalomili na tri samostatné riadky namiesto jedného.
-test("desktop (1600px): pás akcií karty je jednoriadkový, nie zalomený na viac riadkov (issue 303)", async ({ page }) => {
+//
+// AKTUALIZÁCIA (issue 327, majiteľ: "aspoň o 25 % nižšie — tie obdĺžniky",
+// "jedna poznámka ≈ polovica dnešnej výšky alebo menej"): issue 303's
+// vlastný nameraný jednoriadkový pás akcií (35.59px) je tu DOKUMENTOVANÝ
+// baseline — nový strop (26px) je z neho ≥25 % nižší
+// (35.59 × 0.75 ≈ 26.7px). Samostatná asercia overuje aj CELÚ výšku karty
+// (predtým 269px pre 5-riadkový obsah, `.claude/rules/upozornenia.md`'s
+// vlastný "~150 bodov" odkaz na plnšiu automatickú kartu) — nová karta s
+// nadpisom+meta na jednom riadku a bez samostatného odkazového riadku musí
+// byť výrazne nižšia.
+test("desktop (1600px): pás akcií karty je ≥25 % nižší než issue 303's baseline, karta samotná výrazne kompaktnejšia (issue 327)", async ({ page }) => {
   const chyby: string[] = [];
   page.on("console", (m) => {
     if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
@@ -166,20 +176,25 @@ test("desktop (1600px): pás akcií karty je jednoriadkový, nie zalomený na vi
 
   await page.getByTestId("upozornenie-new").click();
   await page.getByTestId("upozornenie-form-title").fill("Hustota — pás akcií na jednom riadku");
+  await page.getByTestId("upozornenie-form-details").fill("o 10:00 s dodávateľom");
   await page.getByTestId("upozornenie-form-save").click();
   await expect(page.getByTestId("upozornenie-form")).toBeHidden();
 
   const card = kartaSNadpisom(page, "Hustota — pás akcií na jednom riadku");
   await expect(card).toBeVisible();
 
-  // Strop 50px necháva malú rezervu nad nameraným jednoriadkovým 35.59px
-  // (dátumové pole je vyššie než tlačidlá, takže ono určuje výšku riadku) bez
-  // toho, aby maskoval skutočné zalomenie späť na viac riadkov (namerané
-  // zalomené: 104px — ďaleko nad 50px stropom).
   const actionsHeight = await card.evaluate((el) => el.querySelector(".upozornenie-actions")?.getBoundingClientRect().height ?? 0);
-  expect(actionsHeight, "pás akcií karty musí byť jednoriadkový (<=50px), nie zalomený na viac riadkov").toBeLessThanOrEqual(50);
+  expect(actionsHeight, "pás akcií karty musí byť ≥25 % nižší než issue 303's nameraný 35.59px baseline (≤26.7px)").toBeLessThanOrEqual(27);
 
-  await card.getByRole("button", { name: "Zmazať", exact: false }).click(); // upratanie po teste
+  const cardHeight = await card.evaluate((el) => el.getBoundingClientRect().height);
+  expect(cardHeight, "celá karta musí byť výrazne nižšia než issue 303's nameraný 269px pre 5-riadkový obsah").toBeLessThanOrEqual(140);
+
+  // "zákazník"/detaily vedľa nadpisu na SPOLOČNOM riadku — samostatný
+  // stohovaný riadok (staré správanie) tu neexistuje.
+  await expect(card.getByTestId(/^upozornenie-meta-/)).toContainText("o 10:00 s dodávateľom");
+  await expect(card.getByTestId(/^upozornenie-meta-/)).toContainText("Vzniklo");
+
+  await card.getByRole("button", { name: "Odstrániť", exact: true }).click(); // upratanie po teste
 
   expect(chyby).toEqual([]);
 });

--- a/apps/web/tests/e2e/upozornenia.spec.ts
+++ b/apps/web/tests/e2e/upozornenia.spec.ts
@@ -184,7 +184,10 @@ test("desktop (1600px): pás akcií karty je ≥25 % nižší než issue 303's b
   await expect(card).toBeVisible();
 
   const actionsHeight = await card.evaluate((el) => el.querySelector(".upozornenie-actions")?.getBoundingClientRect().height ?? 0);
-  expect(actionsHeight, "pás akcií karty musí byť ≥25 % nižší než issue 303's nameraný 35.59px baseline (≤26.7px)").toBeLessThanOrEqual(27);
+  // Code review: 35.59 × 0.75 = 26.69px presne — strop musí byť TENTO
+  // reťazec, nie zaokrúhlené 27 (to by pustilo cez ~24.4 % zníženie ako
+  // "≥25 %").
+  expect(actionsHeight, "pás akcií karty musí byť ≥25 % nižší než issue 303's nameraný 35.59px baseline (≤26.69px)").toBeLessThanOrEqual(26.69);
 
   const cardHeight = await card.evaluate((el) => el.getBoundingClientRect().height);
   expect(cardHeight, "celá karta musí byť výrazne nižšia než issue 303's nameraný 269px pre 5-riadkový obsah").toBeLessThanOrEqual(140);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.189",
+  "version": "0.3.0-dev.190",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.188",
+  "version": "0.3.0-dev.189",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
issue 327 — Upozornenia: kompaktné karty (do dĺžky, nie výšky), bez stavu Nevybavená, s mazaním.

## Čo sa mení

1. **Kompaktné karty** — nadpis + prvý riadok `details` (typicky "Zákazník: X")
   + "Vzniklo .../vybaviť do ..." teraz na JEDNOM riadku (štrukturálny
   split, nikdy parsovanie "Zákazník:" reťazca). Odkaz karty ("Otvoriť
   objednávku v Shoptete" a pod.) je teraz PRIAMO na nadpise — nadpis sa
   stane klikateľným (starý text ostáva ako `aria-label`/`title`). Akčný
   riadok (tlačidlá + dátumové pole) o ≥25 % nižší, živo zmerané cez
   Playwright proti issue 303's dokumentovanému baseline (35.59px →
   25.59px, −28 %). Paired pred/po meranie tej istej karty: 149.58px →
   115.58px / 175.17px → 115.58px pri 1600px šírke.
2. **Stav "Nevybavená" sa už nezakladá** — `UNFINISHED_ORDER_STATUS_NAMES`
   teraz obsahuje len "Vybavuje sa". Existujúce otvorené karty sa NEMIGRUJÚ
   jednorazovo — automaticky sa zatvoria pri najbližšom nočnom
   `ordersImportJob` behu (rovnaký mechanizmus ako issue 297).
3. **Mazanie rozšírené na VŠETKY karty** — "Odstrániť" je teraz v akčnom
   riadku vedľa "Odložiť" pre KAŽDÚ nevyriešenú kartu (predtým len vlastné
   poznámky). Vyriešenú kartu zmazať NEJDE (server-side vynútenie —
   chráni `vratenie` typu konečnosť).

## Overenie

- `pnpm lint` / `pnpm typecheck` čisté.
- `pnpm --filter @forestshop/web test`: 74/74 súborov, 539 testov.
- `pnpm --filter @forestshop/api test`: 51/51 súborov, 690 testov.
- `pnpm --filter @forestshop/api test:integration`: 84/84 súborov, 629 testov.
- `pnpm --filter @forestshop/web e2e`: 51/51 testov.
- Dispatchovaný code review (0 🔴, 2 Important + 3 Minor, všetky opravené
  pred pushom — pozri komentár na issue 327).

## Poznámka k mergu

Toto issue má akceptačnú podmienku, ktorá sa dá overiť AŽ po nasadení
(naživo zmerať výšku karty, potvrdiť 0 chýb v konzole) — telo PR preto
zámerne NEOBSAHUJE zatváracie slovo pre issue 327 (viď CLAUDE.md). Ticket
sa zavrie ručne po živom overení.
