### PR TITLE
Vypredané → Skladom: odkaz na náš produkt v Prepnutých produktoch (issue 329)

### DIFF
--- a/.claude/rules/local-dev.md
+++ b/.claude/rules/local-dev.md
@@ -31,6 +31,22 @@ paths:
 - Bežný lokálny cyklus: `docker compose up -d postgres` (port 5433) →
   `pnpm --filter @forestshop/api db:migrate` → `pnpm test` /
   `pnpm test:integration` / `pnpm --filter @forestshop/web e2e`.
+- **Ručne bežiaci `pnpm --filter @forestshop/api start`/`web dev` (napr. pre
+  naživo Playwright meranie proti lokálnemu devu, `.claude/rules/frontend-
+  design.md`'s metodika) zdieľa TÚ ISTÚ lokálnu Postgres inštanciu (port
+  5433) ako `pnpm --filter @forestshop/api test:integration`.** `test:
+  integration`'s `withCleanDb()` TRUNCATE-uje `users`/`sessions` pri KAŽDOM
+  teste (`.claude/rules/testing.md`) — ak spustíš celú integračnú sadu
+  MEDZI vlastným manuálnym prihlásením a ďalšou akciou, tvoja relácia aj
+  účet ticho zmiznú. Prejaví sa to ZAVÁDZAJÚCO: appka vráti "Nesprávny
+  e-mail alebo heslo" (issue 327, živé overenie) — vyzerá to ako zlé heslo
+  alebo vyčerpaný `login-rate-limit.ts`, v skutočnosti `users` tabuľka je
+  úplne prázdna. Over `SELECT email FROM users` PRED podozrievaním hesla/
+  rate limitu; fix je jednoducho znova spustiť `pnpm exec tsx scripts/
+  e2e-setup.ts` (reseeduje `e2e-*@forestshop.sk` účty) a prihlásiť sa
+  odznova. Nespúšťaj automatizovanú testovaciu sadu (unit test beží bez DB
+  a je bezpečný, ale `test:integration`/`e2e` NIE) medzi krokmi manuálneho
+  naživo overovania na tej istej lokálnej DB.
 - **Vzor pre "priečinok mimo hlavného `tsc -b` composite grafu, ale chcem naň
   plnú prísnu kontrolu typov"** (najprv `scripts/`, potom `apps/api/tests/`
   — issue #4): nový SAMOSTATNÝ, nekompozitný tsconfig (`extends` spoločný

--- a/apps/api/src/http/restock-routes.ts
+++ b/apps/api/src/http/restock-routes.ts
@@ -1,14 +1,14 @@
 import { zValidator } from "@hono/zod-validator";
-import { desc, eq } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import type { Hono } from "hono";
 import { z } from "zod";
 import type { Database } from "../db/client.js";
-import { jobRuns, restockEvents } from "../db/schema.js";
+import { jobRuns } from "../db/schema.js";
 import { log } from "../logger.js";
 import { record } from "../modules/audit/service.js";
 import { findFeedStateConflicts } from "../modules/catalog/feed-cross-check.js";
 import { MAX_PER_RUN, RESTOCK_JOB_NAME } from "../modules/restock/constants.js";
-import { listRestockWaiting, selectRestockCandidates } from "../modules/restock/queries.js";
+import { listRestockEvents, listRestockWaiting, selectRestockCandidates } from "../modules/restock/queries.js";
 import type { RestockRunResult, RunRestockOptions } from "../modules/restock/run.js";
 import { isRestockEnabled, runRestock, setRestockEnabled } from "../modules/restock/run.js";
 import { getLatestJobRun } from "../modules/scheduler/queries.js";
@@ -68,7 +68,7 @@ export function registerRestockRoutes(app: Hono<AppBindings>, db: Database, deps
       isRestockEnabled(db),
       getLatestJobRun(db, RESTOCK_JOB_NAME),
       selectRestockCandidates(db, now),
-      db.select().from(restockEvents).orderBy(desc(restockEvents.at)).limit(200),
+      listRestockEvents(db, 200),
       // issue 226: krížová kontrola nášho stavu proti Shoptetovmu feedu —
       // varovanie s číslom a zoznamom priamo na tejto obrazovke, nikdy len
       // tichý zápis do logu.

--- a/apps/api/src/modules/restock/queries.ts
+++ b/apps/api/src/modules/restock/queries.ts
@@ -4,9 +4,9 @@
 // e-shope produkt, ktorý majiteľ vedome vypol. Preto sa každá podmienka
 // kontroluje pozitívne (musí platiť), nikdy sa nič nepredpokladá.
 
-import { and, asc, eq, isNull, ne, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, isNull, ne, or, sql } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
-import { products, shopProductUrl, supplierStock, variants } from "../../db/schema.js";
+import { products, restockEvents, shopProductUrl, supplierStock, variants } from "../../db/schema.js";
 import { FEED_IN_STOCK } from "../catalog/feed-cross-check.js";
 import {
   CONFIRMATION_MAX_AGE_HOURS,
@@ -201,4 +201,50 @@ export async function listRestockWaiting(
     rows: filtered.slice(options.offset, options.offset + options.limit),
     suppliers,
   };
+}
+
+export interface RestockEventWithLink {
+  readonly id: string;
+  readonly at: Date;
+  readonly variantCode: string;
+  readonly pairCode: string | null;
+  readonly productName: string;
+  readonly supplier: string | null;
+  readonly supplierLink: string;
+  readonly supplierAvailabilityText: string;
+  readonly supplierPrice: string | null;
+  readonly confirmedAt: Date;
+  /**
+   * Priama adresa detailu NÁŠHO produktu z feedu pre porovnávače (issue 329),
+   * alebo `null`, keď kód vo feede nie je (rovnaký LEFT JOIN dôvod ako
+   * `RestockCandidate.ourUrl` vyššie — chýbajúci riadok nesmie históriu
+   * prepnutí zahodiť).
+   */
+  readonly ourUrl: string | null;
+}
+
+/**
+ * História UŽ vykonaných prepnutí (issue 213), teraz aj s odkazom na náš
+ * produkt (issue 329) — majiteľ tak vie jedným klikom overiť, či konkrétne
+ * prepnutie naozaj sedí, nielen dostať sa k stránke dodávateľa.
+ */
+export async function listRestockEvents(db: Database, limit: number): Promise<readonly RestockEventWithLink[]> {
+  return db
+    .select({
+      id: restockEvents.id,
+      at: restockEvents.at,
+      variantCode: restockEvents.variantCode,
+      pairCode: restockEvents.pairCode,
+      productName: restockEvents.productName,
+      supplier: restockEvents.supplier,
+      supplierLink: restockEvents.supplierLink,
+      supplierAvailabilityText: restockEvents.supplierAvailabilityText,
+      supplierPrice: restockEvents.supplierPrice,
+      confirmedAt: restockEvents.confirmedAt,
+      ourUrl: shopProductUrl.url,
+    })
+    .from(restockEvents)
+    .leftJoin(shopProductUrl, eq(shopProductUrl.code, restockEvents.variantCode))
+    .orderBy(desc(restockEvents.at))
+    .limit(limit);
 }

--- a/apps/api/tests/restock-run.integration.test.ts
+++ b/apps/api/tests/restock-run.integration.test.ts
@@ -4,7 +4,7 @@ import type { Database } from "../src/db/client.js";
 import { products, restockEvents, shopProductUrl, supplierStock, variants } from "../src/db/schema.js";
 import type { ShoptetImportConfig } from "../src/modules/shoptet-writeback/config.js";
 import { runRestock, setRestockEnabled } from "../src/modules/restock/run.js";
-import { listRestockWaiting, selectRestockCandidates } from "../src/modules/restock/queries.js";
+import { listRestockEvents, listRestockWaiting, selectRestockCandidates } from "../src/modules/restock/queries.js";
 import { insertTestSnapshot } from "./helpers/catalog.js";
 import { withCleanDb } from "./helpers/db.js";
 
@@ -326,5 +326,21 @@ describe("prepínanie Vypredané → Skladom", () => {
     await seedVariant("Z3");
 
     expect((await selectRestockCandidates(db, NOW)).picked.map((c) => c.variantCode)).toEqual(["Z3"]);
+  });
+
+  // issue 329 — história prepnutí teraz nesie aj odkaz na náš produkt z
+  // feedu, chýbajúci feed riadok sa nesmie zamlčať výnimkou/pádom.
+  it("história prepnutí nesie priamu adresu z feedu a bez nej riadok nezahodí", async () => {
+    await seedSupplierStock();
+    await seedVariant("V1");
+    await seedVariant("V2");
+    await db.insert(shopProductUrl).values({ code: "V1", url: "https://www.forestshop.sk/v1/", fetchedAt: NOW });
+
+    await runRestock({ db, now: NOW, config: CONFIG, importToShoptet: okImport });
+
+    const udalosti = await listRestockEvents(db, 200);
+    expect(
+      Object.fromEntries(udalosti.map((u) => [u.variantCode, u.ourUrl])),
+    ).toEqual({ V1: "https://www.forestshop.sk/v1/", V2: null });
   });
 });

--- a/apps/web/src/components/RestockSection.test.tsx
+++ b/apps/web/src/components/RestockSection.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { RestockSection } from "./RestockSection.js";
 
@@ -70,6 +70,23 @@ const STATUS = {
       supplierAvailabilityText: "skladom",
       supplierPrice: "59.90",
       confirmedAt: "2026-08-04T04:20:00.000Z",
+      ourUrl: "https://www.forestshop.sk/nohavice-forest/?variantId=9001",
+    },
+    {
+      // issue 329: kód, ktorý vo feede pre porovnávače nie je — odkaz na náš
+      // produkt sa nesmie zobraziť vôbec (žiadny fallback na vyhľadávanie,
+      // na rozdiel od "Pripravené na prepnutie" vyššie).
+      id: "e2",
+      at: "2026-08-03T09:00:00.000Z",
+      variantCode: "9002",
+      pairCode: null,
+      productName: "Bunda bez adresy z feedu",
+      supplier: "Huntingshop",
+      supplierLink: "https://huntingshop.eu/bunda-bez-feedu",
+      supplierAvailabilityText: "skladom",
+      supplierPrice: "39.00",
+      confirmedAt: "2026-08-03T08:00:00.000Z",
+      ourUrl: null,
     },
   ],
   lastRun: {
@@ -100,9 +117,25 @@ it("ukáže, ktoré produkty automatizácia prepla", async () => {
   const riadok = await screen.findByTestId("restock-event-40237/L");
   expect(riadok.textContent).toContain("Nohavice FOREST");
   expect(riadok.textContent).toContain("Huntingshop");
-  expect(screen.getByRole("link", { name: "skladom" }).getAttribute("href")).toBe(
+  expect(within(riadok).getByRole("link", { name: "skladom" }).getAttribute("href")).toBe(
     "https://huntingshop.eu/nohavice",
   );
+
+  // issue 329: odkaz na náš produkt priamo z feedu, otvárajúci sa v novej karte.
+  const nasOdkaz = [...riadok.querySelectorAll("a")].find((a) => a.textContent === "náš ↗");
+  expect(nasOdkaz?.getAttribute("href")).toBe("https://www.forestshop.sk/nohavice-forest/?variantId=9001");
+  expect(nasOdkaz?.getAttribute("target")).toBe("_blank");
+});
+
+// issue 329: majiteľ výslovne žiadal, aby chýbajúca adresa z feedu
+// nezobrazila mŕtvy odkaz — riadok sa vykreslí bez chyby a bez odkazu.
+it("prepnutý produkt bez adresy z feedu sa zobrazí bez odkazu na náš produkt a bez chyby", async () => {
+  fetchRestockStatus.mockResolvedValue(STATUS);
+  render(<RestockSection role="admin" onSessionExpired={vi.fn()} />);
+
+  const riadok = await screen.findByTestId("restock-event-9002");
+  expect(riadok.textContent).toContain("Bunda bez adresy z feedu");
+  expect([...riadok.querySelectorAll("a")].some((a) => a.textContent === "náš ↗")).toBe(false);
 });
 
 it("ukáže, koľko produktov čaká na najbližší beh", async () => {

--- a/apps/web/src/components/RestockSection.tsx
+++ b/apps/web/src/components/RestockSection.tsx
@@ -10,7 +10,7 @@ import {
   type RestockStatus,
   type RestockWaitingPage,
 } from "../restockApi.js";
-import { ourProductLink } from "../shopLinks.js";
+import { feedOnlyProductLink, ourProductLink } from "../shopLinks.js";
 
 // Majiteľ si chce vzorku preklikať po stovkách („potváram si zo sto a overím"),
 // takže stránka je 100 riadkov, nie tradičných 20.
@@ -243,23 +243,36 @@ export function RestockSection({
                   <th scope="col">Kód</th>
                   <th scope="col">Názov</th>
                   <th scope="col">Dodávateľ</th>
+                  <th scope="col">Náš produkt</th>
                   <th scope="col">Čo dodávateľ hlásil</th>
                 </tr>
               </thead>
               <tbody>
-                {events.map((event) => (
-                  <tr key={event.id} data-testid={`restock-event-${event.variantCode}`}>
-                    <td>{formatSkDateTime(event.at)}</td>
-                    <td>{event.variantCode}</td>
-                    <td>{event.productName}</td>
-                    <td>{event.supplier ?? "—"}</td>
-                    <td>
-                      <a href={event.supplierLink} target="_blank" rel="noreferrer noopener">
-                        {event.supplierAvailabilityText === "" ? "skladom" : event.supplierAvailabilityText}
-                      </a>
-                    </td>
-                  </tr>
-                ))}
+                {events.map((event) => {
+                  const nasOdkaz = feedOnlyProductLink(event.ourUrl);
+                  return (
+                    <tr key={event.id} data-testid={`restock-event-${event.variantCode}`}>
+                      <td>{formatSkDateTime(event.at)}</td>
+                      <td>{event.variantCode}</td>
+                      <td>{event.productName}</td>
+                      <td>{event.supplier ?? "—"}</td>
+                      <td>
+                        {nasOdkaz === null ? (
+                          "—"
+                        ) : (
+                          <a href={nasOdkaz} target="_blank" rel="noreferrer noopener">
+                            náš ↗
+                          </a>
+                        )}
+                      </td>
+                      <td>
+                        <a href={event.supplierLink} target="_blank" rel="noreferrer noopener">
+                          {event.supplierAvailabilityText === "" ? "skladom" : event.supplierAvailabilityText}
+                        </a>
+                      </td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>

--- a/apps/web/src/restockApi.ts
+++ b/apps/web/src/restockApi.ts
@@ -14,6 +14,10 @@ const eventSchema = z.object({
   supplierAvailabilityText: z.string(),
   supplierPrice: z.string().nullable(),
   confirmedAt: z.string(),
+  // Priama adresa detailu z feedu (issue 329). `null` = kód vo feede nie je
+  // — odkaz sa v tomto zozname nezobrazí vôbec (žiadny fallback na
+  // vyhľadávanie, na rozdiel od "Pripravené na prepnutie" nižšie).
+  ourUrl: z.string().nullable(),
 });
 export type RestockEvent = z.infer<typeof eventSchema>;
 

--- a/apps/web/src/shopLinks.test.ts
+++ b/apps/web/src/shopLinks.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { ourProductLink, ourProductUrl } from "./shopLinks.js";
+import { feedOnlyProductLink, ourProductLink, ourProductUrl } from "./shopLinks.js";
 
 describe("ourProductLink (issue 220)", () => {
   it("uprednostní priamu adresu z feedu aj s výberom veľkosti", () => {
@@ -14,5 +14,21 @@ describe("ourProductLink (issue 220)", () => {
 
   it("prázdny reťazec sa berie rovnako ako chýbajúca adresa", () => {
     expect(ourProductLink("15314", "")).toBe(ourProductUrl("15314"));
+  });
+});
+
+describe("feedOnlyProductLink (issue 329)", () => {
+  it("vráti priamu adresu z feedu, keď je k dispozícii", () => {
+    expect(feedOnlyProductLink("https://www.forestshop.sk/bunda/?variantId=4211")).toBe(
+      "https://www.forestshop.sk/bunda/?variantId=4211",
+    );
+  });
+
+  it("chýbajúca adresa (null) sa nenahradí — vráti null, nikdy vyhľadávanie", () => {
+    expect(feedOnlyProductLink(null)).toBeNull();
+  });
+
+  it("prázdny reťazec sa berie rovnako ako chýbajúca adresa", () => {
+    expect(feedOnlyProductLink("")).toBeNull();
   });
 });

--- a/apps/web/src/shopLinks.ts
+++ b/apps/web/src/shopLinks.ts
@@ -24,3 +24,14 @@ export function ourProductUrl(code: string): string {
 export function ourProductLink(code: string, feedUrl: string | null): string {
   return feedUrl === null || feedUrl === "" ? ourProductUrl(code) : feedUrl;
 }
+
+/**
+ * Odkaz na náš produkt VÝHRADNE z feedu, bez dohadu (issue 329 — história
+ * "Prepnuté produkty"). Na rozdiel od `ourProductLink` vyššie (padá na
+ * vyhľadávanie podľa kódu) tu sa pri chýbajúcej adrese odkaz jednoducho
+ * NEZOBRAZÍ — presne to majiteľ pre tento zoznam žiadal ("odkaz sa proste
+ * nezobrazí"), nikdy náhradný/mŕtvy odkaz.
+ */
+export function feedOnlyProductLink(feedUrl: string | null): string | null {
+  return feedUrl === null || feedUrl === "" ? null : feedUrl;
+}

--- a/apps/web/tests/e2e/restock-events.spec.ts
+++ b/apps/web/tests/e2e/restock-events.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "@playwright/test";
+
+const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
+const E2E_PREPINANIE_EMAIL = "e2e-prepinanie@forestshop.sk"; // musí sa zhodovať s hodnotou v scripts/e2e-setup.ts
+
+// issue 329 — majiteľ: "chcem mať aj link na naše produkty, nech si to viem
+// overiť", konkrétne pre UŽ prepnuté produkty ("Prepnuté produkty" — dnes sa
+// vie dostať len na stránku dodávateľa). Test overuje presne to: odkaz na náš
+// produkt, do novej karty, a že chýbajúca adresa z feedu sa NEVYKRESLÍ ako
+// mŕtvy odkaz.
+test("história prepnutí ponúkne odkaz na náš produkt z feedu, bez neho sa nič nerozbije; konzola je čistá", async ({
+  page,
+}) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/");
+  await page.getByLabel("E-mail").fill(E2E_PREPINANIE_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+
+  await page.getByRole("button", { name: "Vypredané → Skladom", exact: true }).click();
+
+  // Seedovaná udalosť S adresou z feedu (`scripts/e2e-fixtures-restock-events.ts`).
+  const sOdkazom = page.getByTestId("restock-event-PREP-EVT-1");
+  await expect(sOdkazom).toBeVisible();
+  const nasOdkaz = sOdkazom.getByRole("link", { name: "náš ↗" });
+  await expect(nasOdkaz).toHaveAttribute("href", "https://www.forestshop.sk/e2e-prepnuta-1/");
+  await expect(nasOdkaz).toHaveAttribute("target", "_blank");
+  const riadokVyska = await sOdkazom.evaluate((el) => el.getBoundingClientRect().height);
+
+  // Seedovaná udalosť BEZ adresy z feedu — odkaz sa nesmie zobraziť vôbec,
+  // riadok sa vykreslí bez chyby (majiteľ: "odkaz sa proste nezobrazí").
+  const bezOdkazu = page.getByTestId("restock-event-PREP-EVT-2");
+  await expect(bezOdkazu).toBeVisible();
+  await expect(bezOdkazu.getByRole("link", { name: "náš ↗" })).toHaveCount(0);
+  await expect(bezOdkazu).toContainText("E2E Bunda Prepnutá Bez Odkazu");
+
+  // Kompaktnosť (issues 303/327): riadok bez odkazu nesmie byť VYŠŠÍ než
+  // riadok s odkazom — nový stĺpec nesmie zväčšiť výšku riadku.
+  const bezOdkazuVyska = await bezOdkazu.evaluate((el) => el.getBoundingClientRect().height);
+  expect(bezOdkazuVyska).toBeLessThanOrEqual(riadokVyska + 1);
+
+  expect(chyby).toEqual([]);
+});

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -3253,3 +3253,35 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   `Closes #309` anywhere in the PR body or any commit message (this repo
   merges via merge commits, so commit messages reach `main` intact and
   would auto-close too).
+
+## Issue 327 (10. 8. 2026) — Upozornenia: kompaktné karty, bez stavu Nevybavená, s mazaním
+
+- Verzia 0.3.0-dev.189 → 0.3.0-dev.190 (`c59f8c7`).
+- Commity: `0bbbeec` [red] test na `isUnfinishedOrderStatus("Nevybavená")
+  === false`, `b6c7861` [green] `UNFINISHED_ORDER_STATUS_NAMES` → len
+  "Vybavuje sa" (existujúce otvorené karty sa AUTOMATICKY zatvoria
+  ďalším `ordersImportJob` behom, žiadna migrácia), `dacff9f`
+  `deleteOwnNote` → generická `deleteUpozornenie` (VŠETKY zdroje),
+  `d359fdb` kompaktné karty (nadpis+meta na jednom riadku, nadpis =
+  odkaz, akčný riadok ≥25 % nižší — živo zmerané 35.59px→25.59px),
+  `3378a1d` code-review fixy (`deleteUpozornenie` teraz odmieta
+  vyriešené karty — chráni `vratenie`'s KONEČNOSŤ; playbook update;
+  e2e strop sprísnený na 26.69px; `splitDetailLines` exportovaná +
+  vlastný test).
+- Dispatchovaný Senior Code Reviewer subagent (rozsah `c59f8c7..d359fdb`):
+  0 🔴, 2 Important + 3 Minor, všetky opravené pred pushom.
+- Testy: web unit 74/74 súborov (539 testov), api unit 51/51 (690
+  testov), api integration 84/84 (629 testov), e2e 51/51 (52 spec
+  súborov) — zero console errors.
+- PR #328 merged (`123b769`) do `main`; main CI + Deploy oba zelené.
+  Deployed image `ghcr.io/zbynekdrlik/forestshop-app:0.3.0-dev.190`
+  potvrdený na dev2.
+- Post-deploy naživo overené (Playwright, prihlásený ako majiteľ
+  Zbyněk/admin): karta 115.58px (predtým 149.58–175.17px podľa
+  obsahu), akčný riadok 25.59px; nadpis je funkčný odkaz s
+  aria-label; ručne spustené "Stiahnuť teraz" (Objednávky) na
+  produkcii AUTOMATICKY zatvorilo obe existujúce otvorené "Nevybavená"
+  karty (žiadny manuálny DB zásah); tlačidlo "Odstrániť" funkčne
+  overené vytvorením + zmazaním testovacej vlastnej poznámky; 0 chýb v
+  konzole počas celého overenia.
+- Issue 327 zavretý s dôkazovým komentárom po živom overení.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.190",
+  "version": "0.3.0-dev.191",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.191",
+  "version": "0.3.0-dev.192",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-fixtures-restock-events.ts
+++ b/scripts/e2e-fixtures-restock-events.ts
@@ -1,0 +1,41 @@
+// issue 329: história "Prepnuté produkty" na "Vypredané → Skladom" teraz nesie
+// aj odkaz na náš produkt z feedu pre porovnávače — vyčlenené z `e2e-setup.ts`
+// (eslint `max-lines: 400`, `.claude/rules/testing.md`), rovnaký vzor ako
+// existujúci `e2e-fixtures-restock-links.ts`. `restock_event` je plochá
+// história bez FK na `variant`/`product` (`schema-restock.ts`), takže tu
+// netreba seedovať ani jedno z nich — len samotné udalosti (a pre jednu z nich
+// zodpovedajúci `shop_product_url` riadok).
+import type { Database } from "../apps/api/src/db/client.js";
+import { restockEvents, shopProductUrl } from "../apps/api/src/db/schema.js";
+
+export async function seedRestockEventsFixtures(db: Database, teraz: Date): Promise<void> {
+  await db.insert(restockEvents).values({
+    at: teraz,
+    variantCode: "PREP-EVT-1",
+    productName: "E2E Bunda Prepnutá S Odkazom",
+    supplier: "DODAVATEL-PREPINANIE",
+    supplierLink: "https://huntingshop.eu/e2e-prepnuta-1",
+    supplierAvailabilityText: "skladom",
+    supplierPrice: "44.90",
+    confirmedAt: teraz,
+  });
+  await db.insert(shopProductUrl).values({
+    code: "PREP-EVT-1",
+    url: "https://www.forestshop.sk/e2e-prepnuta-1/",
+    fetchedAt: teraz,
+  });
+
+  // issue 329: kód, ktorý vo feede pre porovnávače nie je — dôkaz, že riadok
+  // histórie sa vykreslí bez odkazu (a bez chyby), nikdy s náhradným/mŕtvym
+  // odkazom.
+  await db.insert(restockEvents).values({
+    at: teraz,
+    variantCode: "PREP-EVT-2",
+    productName: "E2E Bunda Prepnutá Bez Odkazu",
+    supplier: "DODAVATEL-PREPINANIE",
+    supplierLink: "https://huntingshop.eu/e2e-prepnuta-2",
+    supplierAvailabilityText: "skladom",
+    supplierPrice: "34.90",
+    confirmedAt: teraz,
+  });
+}

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -20,6 +20,7 @@ import { ORDER_REMINDER_SETTINGS_ID } from "../apps/api/src/modules/order-remind
 import { seedDpdFixtures } from "./e2e-fixtures-dpd.js";
 import { seedOrderFlagsFixtures } from "./e2e-fixtures-order-flags.js";
 import { seedProductLinksFixtures } from "./e2e-fixtures-product-links.js";
+import { seedRestockEventsFixtures } from "./e2e-fixtures-restock-events.js";
 import { seedRestockLinksFixtures } from "./e2e-fixtures-restock-links.js";
 import { seedSearchFixtures } from "./e2e-fixtures-search.js";
 
@@ -800,5 +801,8 @@ await seedRestockLinksFixtures(db, teraz, snapshotPrepinanie, E2E_HESLO);
 
 // issue 292: fixtúra vyčlenená do vlastného súboru, rovnaký dôvod ako vyššie.
 await seedDpdFixtures(db, E2E_HESLO);
+
+// issue 329: fixtúra vyčlenená do vlastného súboru, rovnaký dôvod ako vyššie.
+await seedRestockEventsFixtures(db, teraz);
 
 await pool.end();


### PR DESCRIPTION
issue 329

## Čo sa mení

"Prepnuté produkty" na obrazovke "Vypredané → Skladom" doteraz odkazovalo
len na stránku dodávateľa — majiteľ chce aj druhú stranu porovnania
("aby si overil, či prepnutie sedí"), priamo z existujúceho feedu pre
porovnávače (google.xml, issue 220), nikdy s vymysleným/mŕtvym odkazom.

- Backend: `listRestockEvents()` (nová funkcia v `restock/queries.ts`) —
  LEFT JOIN `restock_event` → `shop_product_url` podľa kódu variantu,
  rovnaký vzor ako existujúci `allRestockCandidates`'s `ourUrl`.
- Frontend: nový stĺpec "Náš produkt" v tabuľke "Prepnuté produkty", nový
  `feedOnlyProductLink()` helper (na rozdiel od `ourProductLink` NEPADÁ na
  vyhľadávanie — chýbajúca adresa = žiadny odkaz, žiadna chyba).
- Testy: unit (URL rozlíšenie vrátane chýbajúceho prípadu), integračný
  (LEFT JOIN zachová históriu bez feed riadku), Playwright e2e (odkaz,
  nová karta, forestshop.sk doména, chýbajúci prípad bez chyby, výška
  riadku sa nemení, 0 chýb v konzole).

## Overenie

Lokálne: typecheck, lint, `pnpm test` (API aj web), `test:integration`
(84/84 súborov), plný e2e balík (52/52) — všetko zelené. Nezávislý code
review (subagent): 0 🔴 0 🟡, 1 🔵 informačná (nesúvisiaca s touto zmenou).

**Ticket NEuzatváram týmto PR** (žiadny `Closes`) — akceptačná podmienka
vyžaduje naživo overiť odkazy na nasadenej appke (aspoň 3 riadky, správny
produkt v e-shope), čo príde AŽ PO nasadení. Ticket zavriem ručne po tomto
overení.
