### PR TITLE
fix: doména bez pravidla nikdy neprepne na 'available' len z JSON-LD (issue 330)

### DIFF
--- a/apps/api/src/modules/supplier-stock/availability-domain-rules.ts
+++ b/apps/api/src/modules/supplier-stock/availability-domain-rules.ts
@@ -314,16 +314,22 @@ export function visibleAvailabilityFor(url: string, html: string): VisibleAvaila
  * `true`, keď doména (alebo jej poddoména) MÁ vlastné pravidlo — viditeľné
  * (`VISIBLE_AVAILABILITY_RULES`) ALEBO textové (`TEXT_AVAILABILITY_RULES`) —
  * teda keď sa preň niekedy spravila AKÁKOĽVEK overovacia práca (issue 330).
- * Používa `parsePage` (`parse.ts`): doména BEZ AKÉHOKOĽVEK pravidla
- * (presne prípad `roy.sk` — nie je ani v jednom zo zoznamov) nesmie dostať
+ * Volá ju `parsePage` (`parse.ts`): doména BEZ AKÉHOKOĽVEK pravidla (presne
+ * prípad `roy.sk` — nie je ani v jednom zo zoznamov) nesmie dostať
  * `available` len zo strojového JSON-LD/meta údaju bez druhej kontroly —
  * fail-closed predvolený stav (`unknown`) namiesto dôvery naslepo. Domény
  * UŽ pokryté jedným z týchto pravidiel sa touto kontrolou nemenia — ich
  * správanie ostáva presné, aké je dnes (rozhodnutie zapísané na ticket-e).
+ *
+ * Textová polovica zámerne znovu POUŽÍVA `textAvailabilityRuleFor` (čistá,
+ * len na `url` závislá funkcia) namiesto vlastného porovnávania — viditeľná
+ * polovica to urobiť NEMÔŽE (`visibleAvailabilityFor` závisí aj na `html` a
+ * vracia `null` aj keď doména pravidlo MÁ, len sa na TEJTO konkrétnej
+ * stránke nenašla zhoda — to by tu znamenalo mylné "doména bez pravidla").
  */
 export function hasKnownAvailabilityRule(url: string): boolean {
+  if (textAvailabilityRuleFor(url) !== null) return true;
   const host = hostOf(url);
   if (host === "") return false;
-  const matches = (ruleHost: string): boolean => host === ruleHost || host.endsWith(`.${ruleHost}`);
-  return TEXT_AVAILABILITY_RULES.some((rule) => matches(rule.host)) || VISIBLE_AVAILABILITY_RULES.some((rule) => matches(rule.host));
+  return VISIBLE_AVAILABILITY_RULES.some((rule) => host === rule.host || host.endsWith(`.${rule.host}`));
 }

--- a/apps/api/src/modules/supplier-stock/availability-domain-rules.ts
+++ b/apps/api/src/modules/supplier-stock/availability-domain-rules.ts
@@ -309,3 +309,21 @@ export function visibleAvailabilityFor(url: string, html: string): VisibleAvaila
   const rule = VISIBLE_AVAILABILITY_RULES.find((r) => host === r.host || host.endsWith(`.${r.host}`));
   return rule === undefined ? null : rule.read(html);
 }
+
+/**
+ * `true`, keď doména (alebo jej poddoména) MÁ vlastné pravidlo — viditeľné
+ * (`VISIBLE_AVAILABILITY_RULES`) ALEBO textové (`TEXT_AVAILABILITY_RULES`) —
+ * teda keď sa preň niekedy spravila AKÁKOĽVEK overovacia práca (issue 330).
+ * Používa `parsePage` (`parse.ts`): doména BEZ AKÉHOKOĽVEK pravidla
+ * (presne prípad `roy.sk` — nie je ani v jednom zo zoznamov) nesmie dostať
+ * `available` len zo strojového JSON-LD/meta údaju bez druhej kontroly —
+ * fail-closed predvolený stav (`unknown`) namiesto dôvery naslepo. Domény
+ * UŽ pokryté jedným z týchto pravidiel sa touto kontrolou nemenia — ich
+ * správanie ostáva presné, aké je dnes (rozhodnutie zapísané na ticket-e).
+ */
+export function hasKnownAvailabilityRule(url: string): boolean {
+  const host = hostOf(url);
+  if (host === "") return false;
+  const matches = (ruleHost: string): boolean => host === ruleHost || host.endsWith(`.${ruleHost}`);
+  return TEXT_AVAILABILITY_RULES.some((rule) => matches(rule.host)) || VISIBLE_AVAILABILITY_RULES.some((rule) => matches(rule.host));
+}

--- a/apps/api/src/modules/supplier-stock/parse-issue330.test.ts
+++ b/apps/api/src/modules/supplier-stock/parse-issue330.test.ts
@@ -9,6 +9,7 @@
 // eslint max-lines: 400 (`.claude/rules/testing.md`) — rovnaký vzor ako
 // existujúci parse-issue307.test.ts split.
 import { describe, expect, it } from "vitest";
+import { hasKnownAvailabilityRule } from "./availability-domain-rules.js";
 import { parsePage } from "./parse.js";
 
 const ROY_JSON_LD_INSTOCK = `<html><head>
@@ -18,6 +19,30 @@ const ROY_JSON_LD_INSTOCK = `<html><head>
  "availability":"https://schema.org/InStock"}}
 </script>
 </head><body><p>Popis produktu.</p></body></html>`;
+
+describe("hasKnownAvailabilityRule — issue 330", () => {
+  it("doména BEZ textového ani viditeľného pravidla nemá známe pravidlo", () => {
+    expect(hasKnownAvailabilityRule("https://www.roy.sk/p-3238/wachman-alfa")).toBe(false);
+    expect(hasKnownAvailabilityRule("https://www.grube.de/nieco")).toBe(false);
+  });
+
+  it("doména s textovým pravidlom (huntingshop.eu) MÁ známe pravidlo, aj jej poddoména", () => {
+    expect(hasKnownAvailabilityRule("https://www.huntingshop.eu/p/1")).toBe(true);
+    expect(hasKnownAvailabilityRule("https://shop.huntingshop.eu/p/1")).toBe(true);
+  });
+
+  it("doména s viditeľným pravidlom (odimon.sk) MÁ známe pravidlo", () => {
+    expect(hasKnownAvailabilityRule("https://www.odimon.sk/p/1")).toBe(true);
+  });
+
+  it("cudzia doména s rovnakým koncom sa nezhoduje (huntingshop.eu vs. nothuntingshop.eu)", () => {
+    expect(hasKnownAvailabilityRule("https://nothuntingshop.eu/p/1")).toBe(false);
+  });
+
+  it("neplatná URL nemá známe pravidlo", () => {
+    expect(hasKnownAvailabilityRule("toto nie je url")).toBe(false);
+  });
+});
 
 describe("parsePage — issue 330: doména bez akéhokoľvek pravidla nikdy neprepne na 'available' zo samotného JSON-LD", () => {
   it("roy.sk s JSON-LD 'InStock' je unknown, NIKDY available (žiadna druhá kontrola pre túto doménu neexistuje)", () => {

--- a/apps/api/src/modules/supplier-stock/parse-issue330.test.ts
+++ b/apps/api/src/modules/supplier-stock/parse-issue330.test.ts
@@ -1,0 +1,49 @@
+// issue 330: doména BEZ akéhokoľvek pravidla (ani TEXT_AVAILABILITY_RULES,
+// ani VISIBLE_AVAILABILITY_RULES — teda žiadna overovacia práca sa preň
+// nikdy nespravila) nesmie dostať `available` len zo strojového JSON-LD/meta
+// údaju bez druhej kontroly. Živý dôkaz: roy.sk (997/S543, restock_event
+// 9. 8. 2026) sa prepol výhradne na `"https://schema.org/InStock"`, hoci
+// roy.sk v žiadnom zo zoznamov v `availability-domain-rules.ts` nie je.
+//
+// Vlastný súbor (nie parse.test.ts), aby ani jeden zo súborov neprerástol
+// eslint max-lines: 400 (`.claude/rules/testing.md`) — rovnaký vzor ako
+// existujúci parse-issue307.test.ts split.
+import { describe, expect, it } from "vitest";
+import { parsePage } from "./parse.js";
+
+const ROY_JSON_LD_INSTOCK = `<html><head>
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"Product","name":"Wachman Alfa",
+ "offers":{"@type":"Offer","price":"49,90","priceCurrency":"EUR",
+ "availability":"https://schema.org/InStock"}}
+</script>
+</head><body><p>Popis produktu.</p></body></html>`;
+
+describe("parsePage — issue 330: doména bez akéhokoľvek pravidla nikdy neprepne na 'available' zo samotného JSON-LD", () => {
+  it("roy.sk s JSON-LD 'InStock' je unknown, NIKDY available (žiadna druhá kontrola pre túto doménu neexistuje)", () => {
+    const result = parsePage(ROY_JSON_LD_INSTOCK, "https://www.roy.sk/p-3238/wachman-alfa");
+    expect(result.availability).toBe("unknown");
+    expect(result.availability).not.toBe("available");
+    expect(result.source).toBe("none");
+  });
+
+  it("rovnaký JSON-LD 'OutOfStock' na doméne bez pravidla sa BERIE ako doteraz (unavailable nikdy neprepne skladom, nič sa nemení)", () => {
+    const html = ROY_JSON_LD_INSTOCK.replace("InStock", "OutOfStock");
+    const result = parsePage(html, "https://www.roy.sk/p-3238/wachman-alfa");
+    expect(result.availability).toBe("unavailable");
+    expect(result.source).toBe("json_ld");
+  });
+
+  it("rovnaký JSON-LD 'InStock' na doméne S OVERENÝM pravidlom (huntingshop.eu) ostáva available bez zmeny — existujúce domény sa touto opravou nedotýkajú", () => {
+    const result = parsePage(ROY_JSON_LD_INSTOCK, "https://www.huntingshop.eu/p/1");
+    expect(result.availability).toBe("available");
+    expect(result.source).toBe("json_ld");
+  });
+
+  it("meta znacky (product:availability) na doméne bez pravidla su rovnako fail-closed, nikdy sa neprepnu na available", () => {
+    const html = `<meta property="product:availability" content="instock"><body>Popis</body>`;
+    const result = parsePage(html, "https://www.roy.sk/p-9999/nieco");
+    expect(result.availability).toBe("unknown");
+    expect(result.source).toBe("none");
+  });
+});

--- a/apps/api/src/modules/supplier-stock/parse.ts
+++ b/apps/api/src/modules/supplier-stock/parse.ts
@@ -24,7 +24,7 @@
 // Čokoľvek, čo neprejde ani jednou úrovňou, je `unknown` — a `unknown` nikdy
 // neprepne produkt (issue 213).
 
-import { textAvailabilityRuleFor, visibleAvailabilityFor } from "./availability-domain-rules.js";
+import { hasKnownAvailabilityRule, textAvailabilityRuleFor, visibleAvailabilityFor } from "./availability-domain-rules.js";
 import { availabilityFromText, hostOf, type SupplierAvailability } from "./availability-primitives.js";
 
 export type { SupplierAvailability };
@@ -357,7 +357,18 @@ export function parsePage(html: string, url: string): ParsedPage {
     };
   }
 
+  // issue 330: doména bez AKÉHOKOĽVEK pravidla (ani visible, ani text — teda
+  // sa preň nikdy nespravila žiadna overovacia práca, presne prípad roy.sk)
+  // sa nesmie spoliehať na strojový JSON-LD/meta `available` bez druhej
+  // kontroly — fail-closed, `unknown` namiesto dôvery naslepo. Domény S
+  // pravidlom (text alebo visible) sa nemenia, ich `available` ostáva ako
+  // doteraz.
+  const knownDomain = hasKnownAvailabilityRule(url);
+
   if (jsonLd !== null) {
+    if (jsonLd.availability === "available" && !knownDomain) {
+      return { availability: "unknown", availabilityText: "", price: null, source: "none" };
+    }
     return {
       availability: jsonLd.availability,
       availabilityText: jsonLd.token,
@@ -368,6 +379,9 @@ export function parsePage(html: string, url: string): ParsedPage {
 
   const meta = fromMetaTags(html);
   if (meta !== null) {
+    if (meta.availability === "available" && !knownDomain) {
+      return { availability: "unknown", availabilityText: "", price: null, source: "none" };
+    }
     return {
       availability: meta.availability,
       availabilityText: meta.token,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.194",
+  "version": "0.3.0-dev.195",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Čo sa opravuje

Doména BEZ akéhokoľvek pravidla (ani `VISIBLE_AVAILABILITY_RULES`, ani
`TEXT_AVAILABILITY_RULES` v `availability-domain-rules.ts`) vedela prepnúť
produkt z "Vypredané" na "Skladom" len na základe strojového JSON-LD/meta
údaju zo stránky dodávateľa, bez akejkoľvek druhej kontroly. Živý dôkaz:
`roy.sk` (kód 997/S543) sa takto prepol 9. 8. 2026 výhradne na
`"https://schema.org/InStock"`.

**Systémová oprava** (rozhodnutie + dôvody na tikete): doména bez
AKÉHOKOĽVEK pravidla teraz dostane `unknown` namiesto dôvery naslepo —
fail-closed. Domény, ktoré UŽ majú vlastné pravidlo (text alebo visible,
napr. `huntingshop.eu`, `odimon.sk`), sa touto zmenou nemenia.

Cena zúženého rozsahu, zmeraná priamo na produkcii (read-only SQL, rovnaké
podmienky ako `allRestockCandidates`): 2 aktuálni kandidáti (`grube.de`)
by sa touto zmenou presunuli z "automaticky prepnúť" na "neznáme, čaká na
človeka" — zanedbateľná cena oproti odstráneniu celej triedy chyby.

## Audit ostatných 5 doteraz prepnutých produktov

4× `huntingshop.eu` (TEXT pravidlo), 1× `odimon.sk` (VISIBLE pravidlo) —
oba domény majú vlastné pravidlo, potvrdené priamo v kóde. Jediný z 6 bez
akéhokoľvek pravidla bol `roy.sk`.

## Testy

- `[red]`/`[green]` regresný pár:
  `apps/api/src/modules/supplier-stock/parse-issue330.test.ts` — reprodukuje
  prepnutie na doméne bez pravidla, potvrdzuje, že existujúce domény s
  pravidlom sa nemenia (`unavailable` cesta, meta-tag cesta).
- Nezávislý code review (general-purpose subagent) + moja vlastná kontrola —
  0 kritických/dôležitých nálezov, kozmetické nálezy opravené v tej istej
  vetve (viď komentár na issue 330).

## Overené lokálne

- `pnpm typecheck` čisté
- `pnpm lint` čisté
- `pnpm --filter @forestshop/api test` — 699/699 zelených
- `pnpm --filter @forestshop/web test` — 543/543 zelených
- `pnpm --filter @forestshop/api test:integration` — 630/630 zelených (84 súborov)
- `pnpm --filter @forestshop/web e2e` — 52/52 zelených

## Odporúčanie k 997/S543 (mimo rozsahu tohto PR)

Variant je v appke stále `state=sellable`, hoci `roy.sk` teraz (10. 8.)
hlási `OutOfStock`. Odporúčam ho ručne vrátiť na `out_of_stock` — NEROBÍM
to v tomto PR, čaká na potvrdenie majiteľa/supervízora.

issue 330
