### PR TITLE
Vypredané → Skladom: odznak chýbajúcich odkazov + jednoklikové potvrdenie návrhu

### DIFF
--- a/apps/api/tests/restock-links-http.integration.test.ts
+++ b/apps/api/tests/restock-links-http.integration.test.ts
@@ -260,3 +260,21 @@ it("vráti najviac 3 kandidátov aj keď rovnako skórovaných vyhovuje viac", a
   // Rovnaké skóre pre všetky 4 → tie-break podľa mena, abecedne.
   expect(item?.candidates.map((c) => c.productKey)).toEqual(["RL-STROP-A1", "RL-STROP-B2", "RL-STROP-C3"]);
 });
+
+// issue 331: odznak v ľavom menu (`App.tsx`) čítava TENTO endpoint s
+// `pageSize=1` (lacný dopyt na samotný počet, `restockLinksApi.ts`'s
+// `fetchRestockLinksMissingCount`) — `total` sa MUSÍ počítať nad CELOU
+// odfiltrovanou množinou nezávisle od `pageSize`, inak by odznak
+// zobrazoval len "1" namiesto skutočného počtu. Doteraz žiadny test
+// nepoužil `pageSize` iný než predvolený, tento overuje presne ten
+// predpoklad, na ktorom odznak stojí.
+it("total sa počíta nad CELOU množinou nezávisle od pageSize — odznak v menu na tomto stojí", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedVariant(db, snapshotId, "RL-BADGE-1", "RL-BADGE-1/1", { name: "Bez linky Prvý", state: "out_of_stock" });
+  await seedVariant(db, snapshotId, "RL-BADGE-2", "RL-BADGE-2/1", { name: "Bez linky Druhý", state: "out_of_stock" });
+
+  const telo = (await (await app.request("/api/restock-links?q=RL-BADGE&page=1&pageSize=1", { headers: { cookie } })).json()) as Telo;
+  expect(telo.total).toBe(2);
+  expect(telo.items).toHaveLength(1);
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -12,6 +12,8 @@ import { OrderFlagsBadgeRefreshContext } from "./orderFlagsBadgeContext.js";
 import { fetchOrderReminderStatus } from "./orderReminderApi.js";
 import { OrdersRemainingCountContext } from "./ordersRemainingCountContext.js";
 import { fetchPostaUncollectedStatus } from "./postaUncollectedApi.js";
+import { fetchRestockLinksMissingCount } from "./restockLinksApi.js";
+import { RestockLinksBadgeRefreshContext } from "./restockLinksBadgeContext.js";
 import { fetchThemeColors } from "./themeColorsApi.js";
 import { fetchUpozorneniaCount } from "./upozorneniaApi.js";
 import { UpozorneniaBadgeRefreshContext } from "./upozorneniaBadgeContext.js";
@@ -78,6 +80,34 @@ export function App(): JSX.Element {
     };
   }, [me, activeTabId, upozorneniaRefreshNonce]);
 
+  // issue 331: odznak "Vypredané → Skladom: návrhy odkazov" — TEN ISTÝ
+  // priamy vzor ako `upozorneniaCount` vyššie (musí byť známy hneď po
+  // prihlásení, nikdy len po prvom otvorení záložky). Diagnostika #331
+  // zistila, že táto obrazovka síce ukazuje "Nájdených: N", ale majiteľ sa
+  // na ňu nikdy sám od seba nedostane — odznak v menu (priečinok
+  // "Automatizácie" je predvolene rozbalený) rieši presne to, bez toho,
+  // aby na záložku vôbec klikol.
+  const [restockLinksMissingCount, setRestockLinksMissingCount] = useState<number | null>(null);
+  const [restockLinksRefreshNonce, setRestockLinksRefreshNonce] = useState(0);
+  const restockLinksBadgeRefresh = useCallback(() => {
+    setRestockLinksRefreshNonce((n) => n + 1);
+  }, []);
+  const restockLinksBadgeContextValue = useMemo(() => ({ refresh: restockLinksBadgeRefresh }), [restockLinksBadgeRefresh]);
+  useEffect(() => {
+    if (me === null) return;
+    let cancelled = false;
+    fetchRestockLinksMissingCount()
+      .then((count) => {
+        if (!cancelled) setRestockLinksMissingCount(count);
+      })
+      .catch(() => {
+        // Sieťový výpadok — odznak zostane na poslednej známej hodnote.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [me, activeTabId, restockLinksRefreshNonce]);
+
   // issue 290: odznaky "Výmena tovaru"/"Vrátený tovar"/"Reklamácie" — rovnaký
   // priamy vzor ako `upozorneniaCount` vyššie (JEDEN endpoint, `App.tsx` si
   // ho volá sám, počty musia byť známe hneď po prihlásení). Na rozdiel od
@@ -115,6 +145,11 @@ export function App(): JSX.Element {
     const counts: Record<string, number> = {};
     if (ordersRemainingCount !== null) counts["orders"] = ordersRemainingCount;
     if (upozorneniaCount !== null) counts["upozornenia"] = upozorneniaCount;
+    // issue 331: rovnaký princíp ako "orders"/"upozornenia" vyššie — odznak
+    // sa ukazuje AJ pri nule (appka tým hovorí "toto číslo poznám, je 0" —
+    // presne to majiteľovi chýbalo, keď číslo poznal len z ručného SQL
+    // dopytu).
+    if (restockLinksMissingCount !== null) counts["restock-links"] = restockLinksMissingCount;
     // issue 290: na rozdiel od "orders"/"upozornenia" vyššie (odznak sa
     // ukazuje AJ pri nule — appka tým hovorí "toto číslo poznám, je 0")
     // tieto tri odznaky sa VÔBEC nezobrazujú pri nule (ticket: "shown only
@@ -131,7 +166,7 @@ export function App(): JSX.Element {
     // istý tvar bugu ako `UpozorneniaSection.tsx`'s `withBusy`), takže lint
     // to nezachytí a stará hodnota (chýbajúce odznaky hneď po prihlásení,
     // kým sa nespustí NEJAKÝ INÝ trigger) prežije bez varovania.
-  }, [ordersRemainingCount, upozorneniaCount, orderFlagCounts]);
+  }, [ordersRemainingCount, upozorneniaCount, restockLinksMissingCount, orderFlagCounts]);
 
   // issue 185: stav zapnuté/vypnuté pre "Automatizácie" priečinok v menu.
   // Na rozdiel od `ordersRemainingCount` vyššie (publikované OBRAZOVKOU
@@ -252,36 +287,38 @@ export function App(): JSX.Element {
   return (
     <OrdersRemainingCountContext.Provider value={ordersRemainingCountContextValue}>
       <UpozorneniaBadgeRefreshContext.Provider value={upozorneniaBadgeContextValue}>
-        <OrderFlagsBadgeRefreshContext.Provider value={orderFlagsBadgeContextValue}>
-          <div className="app-shell">
-            <Sidebar
-              folders={NAV}
-              activeTabId={activeTabId}
-              onSelectTab={selectTab}
-              badgeCounts={badgeCounts}
-              badgeStatus={automationStatus}
-            />
-            <div className="main">
-              <Topbar
-                title={isVisibleTabId(activeTabId) ? (tab?.label ?? null) : null}
-                greeting={`Prihlásený: ${me.displayName} (${me.role})`}
-                role={me.role}
-                onSessionExpired={reload}
-                onLogout={logout}
-                passwordPanelOpen={passwordPanelOpen}
-                onTogglePasswordPanel={() => {
-                  setPasswordPanelOpen((open) => !open);
-                }}
-              >
-                <ChangePasswordForm email={me.email} onSessionExpired={reload} />
-              </Topbar>
-              <main className={tab?.wide === true ? "main-wide" : undefined}>
-                {logoutError !== "" && <p role="alert">{logoutError}</p>}
-                {ActiveComponent !== null && <ActiveComponent role={me.role} onSessionExpired={reload} />}
-              </main>
+        <RestockLinksBadgeRefreshContext.Provider value={restockLinksBadgeContextValue}>
+          <OrderFlagsBadgeRefreshContext.Provider value={orderFlagsBadgeContextValue}>
+            <div className="app-shell">
+              <Sidebar
+                folders={NAV}
+                activeTabId={activeTabId}
+                onSelectTab={selectTab}
+                badgeCounts={badgeCounts}
+                badgeStatus={automationStatus}
+              />
+              <div className="main">
+                <Topbar
+                  title={isVisibleTabId(activeTabId) ? (tab?.label ?? null) : null}
+                  greeting={`Prihlásený: ${me.displayName} (${me.role})`}
+                  role={me.role}
+                  onSessionExpired={reload}
+                  onLogout={logout}
+                  passwordPanelOpen={passwordPanelOpen}
+                  onTogglePasswordPanel={() => {
+                    setPasswordPanelOpen((open) => !open);
+                  }}
+                >
+                  <ChangePasswordForm email={me.email} onSessionExpired={reload} />
+                </Topbar>
+                <main className={tab?.wide === true ? "main-wide" : undefined}>
+                  {logoutError !== "" && <p role="alert">{logoutError}</p>}
+                  {ActiveComponent !== null && <ActiveComponent role={me.role} onSessionExpired={reload} />}
+                </main>
+              </div>
             </div>
-          </div>
-        </OrderFlagsBadgeRefreshContext.Provider>
+          </OrderFlagsBadgeRefreshContext.Provider>
+        </RestockLinksBadgeRefreshContext.Provider>
       </UpozorneniaBadgeRefreshContext.Provider>
     </OrdersRemainingCountContext.Provider>
   );

--- a/apps/web/src/components/RestockLinkSuggestionsSection.test.tsx
+++ b/apps/web/src/components/RestockLinkSuggestionsSection.test.tsx
@@ -67,35 +67,44 @@ it("pri 401 zavolá onSessionExpired namiesto zobrazenia všeobecnej chyby", asy
   });
 });
 
-it("rola citanie nevidí stĺpec Akcie ani tlačidlo 'Použiť návrh'", async () => {
+it("rola citanie nevidí stĺpec Akcie ani tlačidlo 'Potvrdiť'", async () => {
   searchRestockLinkSuggestions.mockResolvedValue({ total: 1, items: [S_NAVRHOM] });
 
   render(<RestockLinkSuggestionsSection role="citanie" onSessionExpired={() => {}} />);
 
   await screen.findByTestId("restock-link-row-RL-2");
   expect(screen.queryByTestId("restock-link-edit-toggle-RL-2")).toBeNull();
-  expect(screen.queryByTestId("restock-link-use-candidate-RL-2-RL-CAND")).toBeNull();
+  expect(screen.queryByTestId("restock-link-confirm-RL-2-RL-CAND")).toBeNull();
 });
 
-it("rola manazer klikne na návrh — vyplní vstup, NEULOŽÍ automaticky, potom potvrdí uložením", async () => {
+// issue 331: samotné NAČÍTANIE zoznamu nikdy nič neuloží — `saveProductLink`
+// sa smie zavolať LEN po výslovnom ľudskom klik na konkrétny návrh.
+it("samotné zobrazenie zoznamu s návrhom NEULOŽÍ nič automaticky", async () => {
+  searchRestockLinkSuggestions.mockResolvedValue({ total: 1, items: [S_NAVRHOM] });
+
+  render(<RestockLinkSuggestionsSection role="manazer" onSessionExpired={() => {}} />);
+
+  await screen.findByTestId("restock-link-confirm-RL-2-RL-CAND");
+  expect(saveProductLink).not.toHaveBeenCalled();
+});
+
+it("rola manazer klikne na 'Potvrdiť' pri návrhu — jeden klik rovno uloží presne tento kandidát", async () => {
   searchRestockLinkSuggestions.mockResolvedValueOnce({ total: 1, items: [S_NAVRHOM] });
   searchRestockLinkSuggestions.mockResolvedValueOnce({ total: 0, items: [] });
   saveProductLink.mockResolvedValue(undefined);
 
   render(<RestockLinkSuggestionsSection role="manazer" onSessionExpired={() => {}} />);
 
-  fireEvent.click(await screen.findByTestId("restock-link-use-candidate-RL-2-RL-CAND"));
-  const vstup = screen.getByTestId<HTMLInputElement>("restock-link-edit-input-RL-2");
-  expect(vstup.value).toBe("https://dodavatel.example.com/rl-cand");
-  // Kliknutie na návrh SAMO OSEBE nič neuloží — potvrdenie je až explicitné
-  // kliknutie na Uložiť (ticketova podmienka "nikdy automaticky priradiť").
-  expect(saveProductLink).not.toHaveBeenCalled();
+  fireEvent.click(await screen.findByTestId("restock-link-confirm-RL-2-RL-CAND"));
 
-  fireEvent.click(screen.getByTestId("restock-link-save-RL-2"));
   await waitFor(() => {
     expect(saveProductLink).toHaveBeenCalledWith("RL-2", "https://dodavatel.example.com/rl-cand");
   });
+  expect(saveProductLink).toHaveBeenCalledTimes(1);
   expect(searchRestockLinkSuggestions).toHaveBeenCalledTimes(2);
+  // Produkt teraz MÁ linku — zmizne zo zoznamu (skutočný, nie optimistický
+  // dôkaz, refetch po uložení).
+  await screen.findByTestId("restock-links-empty");
 });
 
 it("rola manazer doplní VLASTNÝ odkaz (bez návrhu) cez tlačidlo Doplniť", async () => {

--- a/apps/web/src/components/RestockLinkSuggestionsSection.tsx
+++ b/apps/web/src/components/RestockLinkSuggestionsSection.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useRef, useState, type SyntheticEvent, type JSX } from "react";
+import { useCallback, useContext, useEffect, useRef, useState, type SyntheticEvent, type JSX } from "react";
 import type { Me } from "../api.js";
 import { validateSupplierLinkUrl } from "../ordersApi.js";
+import { RestockLinksBadgeRefreshContext } from "../restockLinksBadgeContext.js";
 import { saveProductLink, SupplierLinksUnauthorizedError } from "../supplierLinksApi.js";
 import {
   RestockLinksUnauthorizedError,
@@ -14,6 +15,11 @@ import {
 // restock-links.md`) a s NAVRHOVANÝM kandidátom (odvodený zo zhody mena +
 // dodávateľa s produktmi, čo UŽ linku majú). Zápis potvrdenia ide cez UŽ
 // existujúcu `saveProductLink` (#239) — žiadna nová zapisovacia trasa.
+// issue 331: klik na kandidáta odteraz UKLADÁ PRIAMO (jeden klik, meno aj
+// URL sú na tlačidle vidno PRED kliknutím — stále výslovné ľudské
+// potvrdenie NA KONKRÉTNOM návrhu, nikdy automatické priradenie) namiesto
+// pôvodného dvojklikového "predvyplň → Uložiť". "✏️ Doplniť" (ručný/opravný
+// vstup) ostáva bezo zmeny pre korekciu/vlastnú adresu.
 const CAN_EDIT_ROLES: ReadonlySet<Me["role"]> = new Set(["admin", "manazer"]);
 
 export function RestockLinkSuggestionsSection({
@@ -34,6 +40,11 @@ export function RestockLinkSuggestionsSection({
   const [editingKey, setEditingKey] = useState<string | null>(null);
   const [urlDraft, setUrlDraft] = useState("");
   const [busyKey, setBusyKey] = useState<string | null>(null);
+
+  // issue 331: odznak v ľavom menu (`App.tsx`) sa musí prepočítať po
+  // KAŽDOM úspešnom potvrdení (jednoklikovom aj cez ✏️ Doplniť) — inak by
+  // číslo v menu zaostávalo za tým, čo obrazovka práve zapísala.
+  const restockLinksBadge = useContext(RestockLinksBadgeRefreshContext);
 
   // Len najnovšia požiadavka smie zapísať výsledok (rovnaký dôvod ako
   // `SupplierLinksSection.tsx`'s `searchSeq`).
@@ -121,6 +132,7 @@ export function RestockLinkSuggestionsSection({
         .then(() => {
           if (editingKeyRef.current === productKey) setEditingKey(null);
           refetch();
+          restockLinksBadge.refresh();
         })
         .catch((err: unknown) => {
           if (err instanceof SupplierLinksUnauthorizedError) {
@@ -133,7 +145,36 @@ export function RestockLinkSuggestionsSection({
           setBusyKey(null);
         });
     },
-    [refetch, onSessionExpired, urlDraft],
+    [refetch, onSessionExpired, urlDraft, restockLinksBadge],
+  );
+
+  // issue 331: jednoklikové potvrdenie kandidáta — na rozdiel od `save()`
+  // vyššie (ktorý ukladá `urlDraft` z otvoreného editora) tento ukladá
+  // PRIAMO URL konkrétneho, na tlačidle viditeľne popísaného kandidáta bez
+  // otvárania editora. Stále výslovný ľudský klik na KONKRÉTNY návrh —
+  // nikdy automatické priradenie bez klik.
+  const confirmCandidate = useCallback(
+    (productKey: string, url: string) => {
+      setActionError("");
+      setBusyKey(productKey);
+      saveProductLink(productKey, url)
+        .then(() => {
+          if (editingKeyRef.current === productKey) setEditingKey(null);
+          refetch();
+          restockLinksBadge.refresh();
+        })
+        .catch((err: unknown) => {
+          if (err instanceof SupplierLinksUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setActionError(err instanceof Error ? err.message : "Uloženie odkazu sa nepodarilo.");
+        })
+        .finally(() => {
+          setBusyKey(null);
+        });
+    },
+    [refetch, onSessionExpired, restockLinksBadge],
   );
 
   return (
@@ -141,8 +182,8 @@ export function RestockLinkSuggestionsSection({
       <p>
         Vypredané produkty, ktoré nemajú VÔBEC žiadny odkaz na dodávateľa — automatika „Vypredané →
         Skladom“ ich preto nikdy neposúdi. Appka podľa názvu a dodávateľa navrhne najpodobnejší
-        produkt, čo linku už má — návrh nikdy nič neuloží sám, len predvyplní vstup, ktorý potvrdíš
-        alebo prepíšeš vlastnou adresou.
+        produkt, čo linku už má — klik na „✅ Potvrdiť“ pri návrhu ho rovno uloží (meno aj adresa sú
+        na tlačidle vidno pred kliknutím). Vlastnú alebo opravenú adresu vlož cez „✏️ Doplniť“.
       </p>
 
       <form onSubmit={submit}>
@@ -195,16 +236,15 @@ export function RestockLinkSuggestionsSection({
                             {canEdit ? (
                               <button
                                 type="button"
-                                className="btn sm ghost"
-                                data-testid={`restock-link-use-candidate-${item.productKey}-${candidate.productKey}`}
-                                aria-label={`Použiť návrh — ${candidate.productName} (${candidate.url})`}
+                                className="btn sm good"
+                                data-testid={`restock-link-confirm-${item.productKey}-${candidate.productKey}`}
+                                aria-label={`Potvrdiť odkaz — ${candidate.productName} (${candidate.url})`}
+                                disabled={busyHere}
                                 onClick={() => {
-                                  setEditingKey(item.productKey);
-                                  setUrlDraft(candidate.url);
-                                  setActionError("");
+                                  confirmCandidate(item.productKey, candidate.url);
                                 }}
                               >
-                                💡 {candidate.productName}: {candidate.url}
+                                ✅ {candidate.productName}: {candidate.url}
                               </button>
                             ) : (
                               <span>
@@ -277,6 +317,7 @@ export function RestockLinkSuggestionsSection({
                             className="btn sm ghost"
                             data-testid={`restock-link-edit-toggle-${item.productKey}`}
                             aria-label={`Doplniť odkaz na dodávateľa — ${item.productName} (${item.productKey})`}
+                            disabled={busyHere}
                             onClick={() => {
                               startEdit(item);
                             }}

--- a/apps/web/src/restockLinksApi.ts
+++ b/apps/web/src/restockLinksApi.ts
@@ -58,3 +58,23 @@ export async function searchRestockLinkSuggestions(input: {
   const response = await fetch(`/api/restock-links?${query.toString()}`);
   return searchSchema.parse(await readJson(response, "Zoznam vypredaných produktov bez linky sa nepodarilo načítať"));
 }
+
+const countSchema = z.object({ total: z.number() });
+
+// issue 331: odznak v ľavom menu (`App.tsx`, rovnaký vzor ako
+// `fetchUpozorneniaCount`) — musí byť známy HNEĎ po prihlásení, nikdy až
+// po otvorení tejto záložky. Znovupoužíva TEN ISTÝ `GET /api/restock-links`
+// endpoint s `pageSize: 1` — `total` sa v `listRestockLinkSuggestions`
+// počíta nad CELOU odfiltrovanou množinou nezávisle od `pageSize` (len
+// samotní `candidates` sa počítajú iba pre vrátenú stranu), takže je to
+// lacný dopyt, žiadna nová trasa. Chyba (401/sieť) sa nikdy nehádže —
+// odznak jednoducho ostane na poslednej známej hodnote, rovnaký vzor ako
+// `fetchUpozorneniaCount`.
+export async function fetchRestockLinksMissingCount(): Promise<number> {
+  const query = new URLSearchParams({ q: "", page: "1", pageSize: "1" });
+  const response = await fetch(`/api/restock-links?${query.toString()}`);
+  if (response.status === 401) return 0;
+  if (!response.ok) return 0;
+  const parsed = countSchema.safeParse(await response.json());
+  return parsed.success ? parsed.data.total : 0;
+}

--- a/apps/web/src/restockLinksBadgeContext.ts
+++ b/apps/web/src/restockLinksBadgeContext.ts
@@ -1,0 +1,18 @@
+import { createContext } from "react";
+
+// issue 331: most medzi `RestockLinkSuggestionsSection` (mutuje dáta —
+// potvrdenie kandidáta) a `App.tsx` (vlastní odznak v ľavom menu,
+// `badgeCounts`) — presne rovnaký vzor a dôvod ako `UpozorneniaBadgeRefreshContext`
+// (issue 267, gap 1). `App.tsx` si count naďalej načítava a vlastní SÁM
+// (musí byť známy hneď po prihlásení, nie až po prvom otvorení tejto
+// záložky), tento context nesie LEN účinok "niečo sa práve zmenilo".
+export interface RestockLinksBadgeRefreshContextValue {
+  readonly refresh: () => void;
+}
+
+export const RestockLinksBadgeRefreshContext = createContext<RestockLinksBadgeRefreshContextValue>({
+  refresh: () => {
+    // Predvolená hodnota mimo Provider-a (napr. test, čo rendruje
+    // RestockLinkSuggestionsSection samostatne bez App.tsx) — bezpečné no-op.
+  },
+});

--- a/apps/web/tests/e2e/restock-links.spec.ts
+++ b/apps/web/tests/e2e/restock-links.spec.ts
@@ -16,8 +16,40 @@ const E2E_NAVRHY_ODKAZOV_EMAIL = "e2e-navrhy-odkazov@forestshop.sk";
 // zhody). Potvrdenie ide cez ROVNAKÚ `product_supplier_link_override`
 // tabuľku ako "Párovanie produktov" (#239) — druhá polovica testu to
 // overuje NA TEJ DRUHEJ obrazovke, dôkaz zdieľanej zápisovej cesty.
+// issue 331: klik na návrh odteraz UKLADÁ PRIAMO (jeden klik, nie
+// predvyplň-a-potom-Uložiť) — a odznak v ľavom menu (rovnaký generický
+// mechanizmus ako issue 147/267) je vidno HNEĎ po prihlásení, bez toho, aby
+// sa na túto záložku vôbec kliklo.
 
-test("vypredaný produkt bez linky ponúkne návrh podľa zhody mena + dodávateľa, potvrdenie sa zapíše a zdieľa sa s Párovaním produktov; konzola je čistá", async ({
+test("odznak v menu ukazuje počet chýbajúcich odkazov HNEĎ po prihlásení, bez otvorenia záložky; konzola je čistá", async ({
+  page,
+}) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/");
+  await page.getByLabel("E-mail").fill(E2E_NAVRHY_ODKAZOV_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+
+  // Predvolená landing obrazovka je "Na objednanie" (issue 302) — odznak
+  // musí byť vidno TU, bez toho, aby sa na "Vypredané → Skladom: návrhy
+  // odkazov" vôbec kliklo. Presné číslo je zdieľaný fixtúrový stav (iné
+  // spec súbory môžu bežať súbežne) — over PLATNÝ tvar, nie presnú
+  // hodnotu, rovnaký princíp ako `nav.spec.ts`'s `nav-badge-orders`.
+  const odznak = page.getByTestId("nav-badge-restock-links");
+  await expect(odznak).toBeVisible();
+  await expect(odznak).toHaveText(/^\d+$/);
+
+  expect(chyby).toEqual([]);
+});
+
+test("vypredaný produkt bez linky ponúkne návrh podľa zhody mena + dodávateľa, jeden klik ho rovno potvrdí a zdieľa sa s Párovaním produktov; konzola je čistá", async ({
   page,
 }) => {
   const chyby: string[] = [];
@@ -44,23 +76,27 @@ test("vypredaný produkt bez linky ponúkne návrh podľa zhody mena + dodávate
   await expect(riadok).toContainText("E2E Bunda Alfa Vypredaná");
 
   // Návrh (kandidát z rovnakého dodávateľa + prekrývajúceho sa mena) je
-  // VIDITEĽNÝ, ale NIČ sa nikdy neuloží samo — len klik na "Použiť" ho
-  // predvyplní do vstupu.
-  const navrhTlacidlo = riadok.getByTestId("restock-link-use-candidate-E2E-RL-CHYBA-E2E-RL-NAVRH");
-  await expect(navrhTlacidlo).toContainText("https://e2e-dodavatel.example.com/bunda-alfa-navrh");
+  // VIDITEĽNÝ, meno aj adresa sú na tlačidle vidno PRED kliknutím — ale
+  // NIČ sa nikdy neuloží samo, len explicitný klik na "✅ Potvrdiť" uloží
+  // TOHTO KONKRÉTNEHO kandidáta.
+  const potvrdTlacidlo = riadok.getByTestId("restock-link-confirm-E2E-RL-CHYBA-E2E-RL-NAVRH");
+  await expect(potvrdTlacidlo).toContainText("https://e2e-dodavatel.example.com/bunda-alfa-navrh");
   // Nesúvisiaci produkt sa v návrhu NIKDY neobjaví.
   await expect(riadok).not.toContainText("E2E Šál Zeta Cudzí");
 
-  await navrhTlacidlo.click();
-  const vstup = page.getByTestId("restock-link-edit-input-E2E-RL-CHYBA");
-  await expect(vstup).toHaveValue("https://e2e-dodavatel.example.com/bunda-alfa-navrh");
-
-  await page.getByTestId("restock-link-save-E2E-RL-CHYBA").click();
+  await potvrdTlacidlo.click();
 
   // Produkt teraz MÁ linku — táto obrazovka zobrazuje LEN produkty BEZ nej,
   // takže po uložení riadok zmizne (skutočný, nie len optimistický dôkaz
   // uloženia — refetch to potvrdzuje).
   await expect(page.getByTestId("restock-links-empty")).toBeVisible();
+
+  // Odznak v menu sa po potvrdení sám prepočíta — číslo je ZDIEĽANÝ globálny
+  // stav (počíta VŠETKY vypredané produkty v celej e2e DB, nielen tie z
+  // tohto účtu), iné súbežne bežiace spec súbory ho môžu meniť naraz, preto
+  // sa overuje len PLATNÝ TVAR (rovnaký princíp ako `nav.spec.ts`'s
+  // `nav-badge-orders`), nikdy presná hodnota.
+  await expect(page.getByTestId("nav-badge-restock-links")).toHaveText(/^\d+$/);
 
   // Zdieľaná zápisová cesta (#239's `product_supplier_link_override`) — tá
   // istá hodnota je vidno aj na "Párovanie produktov", úplne INEJ

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.195",
+  "version": "0.3.0-dev.196",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
issue 331

## Prečo prepínanie postihuje málo produktov

Diagnostika na živej produkcii: kandidáti sa generujú SPRÁVNE pre
100 % dnes chýbajúcich odkazov (mechanizmus z issue 311 funguje), obrazovka
JE v ľavom menu — ale odznak "Nájdených: N" bol vidno LEN po vyslovnom
otvorení tejto jednej obrazovky, a od nasadenia #311 pribudlo presne 0
nových potvrdení. Detaily v komentároch na ticket-e.

## Čo pribudlo

1. Odznak počtu chýbajúcich odkazov v ľavom menu (rovnaký generický
   mechanizmus ako "Na objednanie"/"Upozornenia") — viditeľný HNEĎ po
   prihlásení, bez otvorenia záložky.
2. Jednoklikové "✅ Potvrdiť" tlačidlo pri každom navrhnutom kandidátovi —
   meno aj URL sú na tlačidle vidno PRED kliknutím, stále výslovný ľudský
   klik na KONKRÉTNY návrh (nikdy automatické priradenie). "✏️ Doplniť"
   (ručný/opravný vstup) beze zmeny.

## Overenie

- `pnpm typecheck` / `pnpm lint` — čisté
- `pnpm --filter @forestshop/web test` — 544/544
- `pnpm --filter @forestshop/api test` — 699/699
- `pnpm --filter @forestshop/api test:integration` — 631/631
- `pnpm --filter @forestshop/web e2e` — 53/53 (jeden izolovaný beh mal
  nesúvisiace `pairing.spec.ts` zlyhanie na preťaženom zdieľanom boxe —
  izolovaný re-beh 6/6 aj plný balík znova 53/53 potvrdili flake)
- Nezávislý code-review subagent: 0 🔴 0 🟡, Ready to merge — Yes

Naživo overenie na nasadenej appke (odznak, jeden reálny klik na
potvrdenie, 0 chýb v konzole) prebehne po deployi — post-deploy krok.

Nadväzuje na #212/#213 (prepínanie) a #311 (návrhy odkazov). Súvisiaci
systémový nález (page=1/pageSize=50 bez ďalšej strany naprieč viacerými
obrazovkami) je zapísaný samostatne ako #337, tu sa nerieši.
