### PR TITLE
feat: "Load more" na 4 obrazovkách, ktoré predtým limitovali na prvých 50 (issue 337)

### DIFF
--- a/apps/web/src/components/CatalogPage.loadMore.test.tsx
+++ b/apps/web/src/components/CatalogPage.loadMore.test.tsx
@@ -80,3 +80,26 @@ it("keď sú zobrazené všetky varianty, tlačidlo 'Načítať ďalšie' sa vô
   await screen.findByTestId("variant-A");
   expect(screen.queryByTestId("load-more")).toBeNull();
 });
+
+// requesting-code-review finding (issue 337): "Load more" musí žiadať
+// ďalšiu stranu DOPYTU, ktorý naozaj vyprodukoval zobrazené `items`/`total`
+// — NIE dopyt práve rozpísaný (ešte NEODOSLANÝ) vo vstupnom poli. Bez tejto
+// ochrany by rozpísanie nového textu PO zobrazení výsledkov a klik na
+// "Načítať ďalšie" ticho vyžiadal DRUHÚ stranu úplne INÉHO (neodoslaného)
+// dopytu, hoci `total`/`items` na obrazovke ešte patria pôvodnému.
+it("po rozpísaní NEODOSLANÉHO nového dopytu žiada 'Načítať ďalšie' ďalej stranu PÔVODNÉHO (naposledy odoslaného) dopytu", async () => {
+  fetchCatalogStats.mockResolvedValue(null);
+  searchCatalogVariants.mockResolvedValueOnce({ total: 2, items: [variant("A")] }); // úvodné "" vyhľadanie
+  searchCatalogVariants.mockResolvedValueOnce({ total: 2, items: [variant("B")] }); // load-more, strana 2
+
+  render(<CatalogPage role="citanie" onSessionExpired={() => {}} />);
+  await screen.findByTestId("variant-A");
+
+  // Rozpíš nový text, ale NEODOŠLI ho (žiadny klik na "Hľadať").
+  fireEvent.change(screen.getByLabelText("Kód alebo názov"), { target: { value: "nieco-ine" } });
+
+  fireEvent.click(await screen.findByTestId("load-more"));
+  await screen.findByTestId("variant-B");
+
+  expect(searchCatalogVariants).toHaveBeenLastCalledWith({ q: "", state: "all", page: 2 });
+});

--- a/apps/web/src/components/CatalogPage.loadMore.test.tsx
+++ b/apps/web/src/components/CatalogPage.loadMore.test.tsx
@@ -1,0 +1,82 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { CatalogPage } from "./CatalogPage.js";
+
+const { fetchCatalogStats, searchCatalogVariants } = vi.hoisted(() => ({
+  fetchCatalogStats: vi.fn(),
+  searchCatalogVariants: vi.fn(),
+}));
+vi.mock("../catalogApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../catalogApi.js")>();
+  return { ...actual, fetchCatalogStats, searchCatalogVariants };
+});
+
+function variant(code: string): {
+  code: string;
+  productKey: string;
+  sizeLabel: string | null;
+  name: string;
+  state: "sellable";
+  stock: number;
+  price: string | null;
+  currency: string | null;
+  availabilityText: string;
+  missingSince: string | null;
+} {
+  return {
+    code,
+    productKey: code,
+    sizeLabel: null,
+    name: `Test variant ${code}`,
+    state: "sellable",
+    stock: 1,
+    price: null,
+    currency: null,
+    availabilityText: "Skladom",
+    missingSince: null,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+// issue 337: bez tlačidla "Načítať ďalšie" boli varianty nad `PAGE_SIZE = 50`
+// natrvalo nedosiahnuteľné, hoci server ich vie vrátiť.
+it("keď je total väčší než počet zobrazených variantov, ukáže tlačidlo 'Načítať ďalšie' s počtom zvyšných", async () => {
+  fetchCatalogStats.mockResolvedValue(null);
+  searchCatalogVariants.mockResolvedValue({ total: 60, items: [variant("A")] });
+
+  render(<CatalogPage role="citanie" onSessionExpired={() => {}} />);
+
+  const button = await screen.findByTestId("load-more");
+  expect(button.textContent).toBe("Načítať ďalšie (50)"); // min(PAGE_SIZE, 60 - 1)
+});
+
+it("klik na 'Načítať ďalšie' zavolá search s DRUHOU stranou a pripojí výsledok k existujúcim variantom", async () => {
+  fetchCatalogStats.mockResolvedValue(null);
+  searchCatalogVariants.mockResolvedValueOnce({ total: 2, items: [variant("A")] });
+  searchCatalogVariants.mockResolvedValueOnce({ total: 2, items: [variant("B")] });
+
+  render(<CatalogPage role="citanie" onSessionExpired={() => {}} />);
+
+  fireEvent.click(await screen.findByTestId("load-more"));
+
+  await screen.findByTestId("variant-B");
+  expect(screen.getByTestId("variant-A")).toBeTruthy();
+  expect(searchCatalogVariants).toHaveBeenLastCalledWith({ q: "", state: "all", page: 2 });
+  await waitFor(() => {
+    expect(screen.queryByTestId("load-more")).toBeNull();
+  });
+});
+
+it("keď sú zobrazené všetky varianty, tlačidlo 'Načítať ďalšie' sa vôbec nevykreslí", async () => {
+  fetchCatalogStats.mockResolvedValue(null);
+  searchCatalogVariants.mockResolvedValue({ total: 1, items: [variant("A")] });
+
+  render(<CatalogPage role="citanie" onSessionExpired={() => {}} />);
+
+  await screen.findByTestId("variant-A");
+  expect(screen.queryByTestId("load-more")).toBeNull();
+});

--- a/apps/web/src/components/CatalogPage.tsx
+++ b/apps/web/src/components/CatalogPage.tsx
@@ -6,11 +6,13 @@ import {
   fetchCatalogStats,
   searchCatalogVariants,
   triggerCatalogIngest,
+  PAGE_SIZE,
   type CatalogIngestOutcome,
   type CatalogState,
   type CatalogStats,
   type VariantSummary,
 } from "../catalogApi.js";
+import { useLoadMore } from "../useLoadMore.js";
 
 const STATE_LABELS: Record<VariantSummary["state"], string> = {
   sellable: "Skladom",
@@ -153,10 +155,26 @@ export function CatalogPage({
       });
   }, [onSessionExpired]);
 
+  // issue 337: zdieľaný "Načítať ďalšie" mechanizmus (`useLoadMore.ts`) —
+  // `reset()` sa volá na ZAČIATKU KAŽDÉHO nového vyhľadávania (nižšie), aby
+  // sa zahodila prípadná ešte nedoručená odpoveď na "load more" patriaca
+  // STARÉMU dopytu/filtru.
+  const loadMoreState = useLoadMore<VariantSummary>({
+    mountedRef,
+    onAppend: (newItems, newTotal) => {
+      setItems((prev) => [...prev, ...newItems]);
+      setTotal(newTotal);
+    },
+    onError: () => {
+      setSearchError("Načítanie ďalších položiek zlyhalo.");
+    },
+  });
+
   const search = useCallback(
     (q: string, s: CatalogState) => {
       const seq = (searchSeq.current += 1);
       setSearchError("");
+      loadMoreState.reset();
       searchCatalogVariants({ q, state: s, page: 1 })
         .then((result) => {
           if (!mountedRef.current) return; // odmountované skôr, než odpoveď doletela
@@ -322,6 +340,21 @@ export function CatalogPage({
             </tbody>
           </table>
         </div>
+      )}
+
+      {items.length < total && (
+        <button
+          type="button"
+          data-testid="load-more"
+          disabled={loadMoreState.loadingMore}
+          onClick={() => {
+            loadMoreState.loadMore((page) => searchCatalogVariants({ q: query, state, page }));
+          }}
+        >
+          {loadMoreState.loadingMore
+            ? "Načítavam…"
+            : `Načítať ďalšie (${String(Math.min(PAGE_SIZE, total - items.length))})`}
+        </button>
       )}
     </section>
   );

--- a/apps/web/src/components/CatalogPage.tsx
+++ b/apps/web/src/components/CatalogPage.tsx
@@ -170,10 +170,26 @@ export function CatalogPage({
     },
   });
 
+  // requesting-code-review finding (issue 337): the "Load more" button MUST
+  // fetch the next page of the filter that actually produced the CURRENT
+  // `items`/`total` — NOT whatever `query`/`state` currently hold, which
+  // track every keystroke/select-change independent of whether `search()`
+  // has actually run for them. Without this, typing a new (unsubmitted)
+  // query after a search renders, then clicking "Load more", silently
+  // fetches page 2 of the NEW query while `total` still reflects the OLD
+  // one — set synchronously inside `search()` itself (same "sync in the
+  // function that owns the value, not via useEffect" discipline as
+  // `queryRef`/`stateRef` above, since `search()` already receives the
+  // exact q/s that will produce the results these refs must describe).
+  const searchedQueryRef = useRef(query);
+  const searchedStateRef = useRef(state);
+
   const search = useCallback(
     (q: string, s: CatalogState) => {
       const seq = (searchSeq.current += 1);
       setSearchError("");
+      searchedQueryRef.current = q;
+      searchedStateRef.current = s;
       loadMoreState.reset();
       searchCatalogVariants({ q, state: s, page: 1 })
         .then((result) => {
@@ -348,7 +364,9 @@ export function CatalogPage({
           data-testid="load-more"
           disabled={loadMoreState.loadingMore}
           onClick={() => {
-            loadMoreState.loadMore((page) => searchCatalogVariants({ q: query, state, page }));
+            loadMoreState.loadMore((page) =>
+              searchCatalogVariants({ q: searchedQueryRef.current, state: searchedStateRef.current, page }),
+            );
           }}
         >
           {loadMoreState.loadingMore

--- a/apps/web/src/components/PairingSection.loadMore.test.tsx
+++ b/apps/web/src/components/PairingSection.loadMore.test.tsx
@@ -77,3 +77,21 @@ it("keď sú zobrazené všetky varianty, tlačidlo 'Načítať ďalšie' sa vô
   await screen.findByTestId("pairing-A");
   expect(screen.queryByTestId("load-more")).toBeNull();
 });
+
+// requesting-code-review finding (issue 337, rovnaký nález ako
+// `CatalogPage.loadMore.test.tsx`): "Load more" musí žiadať ďalšiu stranu
+// naposledy ODOSLANÉHO dopytu, nie práve rozpísaný (neodoslaný) text.
+it("po rozpísaní NEODOSLANÉHO nového dopytu žiada 'Načítať ďalšie' ďalej stranu PÔVODNÉHO (naposledy odoslaného) dopytu", async () => {
+  searchPairings.mockResolvedValueOnce({ total: 2, items: [item("A")] });
+  searchPairings.mockResolvedValueOnce({ total: 2, items: [item("B")] });
+
+  render(<PairingSection role="manazer" onSessionExpired={() => {}} />);
+  await screen.findByTestId("pairing-A");
+
+  fireEvent.change(screen.getByLabelText("Kód variantu alebo produktu"), { target: { value: "nieco-ine" } });
+
+  fireEvent.click(await screen.findByTestId("load-more"));
+  await screen.findByTestId("pairing-B");
+
+  expect(searchPairings).toHaveBeenLastCalledWith({ q: "", state: "all", page: 2 });
+});

--- a/apps/web/src/components/PairingSection.loadMore.test.tsx
+++ b/apps/web/src/components/PairingSection.loadMore.test.tsx
@@ -1,0 +1,79 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { PairingSection } from "./PairingSection.js";
+
+const { searchPairings } = vi.hoisted(() => ({ searchPairings: vi.fn() }));
+vi.mock("../pairingApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../pairingApi.js")>();
+  return { ...actual, searchPairings };
+});
+
+// Jednovariantné produkty (`productKey === variantCode`) — rovnaký vzor ako
+// `PairingSection.test.tsx`'s `NAVRHNUTY`/`POTVRDENY`, aby `renderGroup`
+// zobral jednoduchú (nezoskupenú) vetvu.
+function item(code: string): {
+  variantCode: string;
+  variantName: string;
+  sizeLabel: string | null;
+  productKey: string;
+  productName: string;
+  productSupplier: string | null;
+  supplierUrl: string | null;
+  state: "navrhnute";
+  confirmedByName: string | null;
+  confirmedAt: string | null;
+} {
+  return {
+    variantCode: code,
+    variantName: `Test variant ${code}`,
+    sizeLabel: null,
+    productKey: code,
+    productName: `Test variant ${code}`,
+    productSupplier: "Test dodávateľ",
+    supplierUrl: "https://dodavatel.example.com/x",
+    state: "navrhnute",
+    confirmedByName: null,
+    confirmedAt: null,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+// issue 337: bez tlačidla "Načítať ďalšie" boli varianty nad `PAGE_SIZE = 50`
+// natrvalo nedosiahnuteľné, hoci server ich vie vrátiť.
+it("keď je total väčší než počet zobrazených variantov, ukáže tlačidlo 'Načítať ďalšie' s počtom zvyšných", async () => {
+  searchPairings.mockResolvedValue({ total: 51, items: [item("A")] });
+
+  render(<PairingSection role="manazer" onSessionExpired={() => {}} />);
+
+  const button = await screen.findByTestId("load-more");
+  expect(button.textContent).toBe("Načítať ďalšie (50)"); // min(PAGE_SIZE, 51 - 1)
+});
+
+it("klik na 'Načítať ďalšie' zavolá search s DRUHOU stranou a pripojí výsledok k existujúcim variantom", async () => {
+  searchPairings.mockResolvedValueOnce({ total: 2, items: [item("A")] });
+  searchPairings.mockResolvedValueOnce({ total: 2, items: [item("B")] });
+
+  render(<PairingSection role="manazer" onSessionExpired={() => {}} />);
+
+  fireEvent.click(await screen.findByTestId("load-more"));
+
+  await screen.findByTestId("pairing-B");
+  expect(screen.getByTestId("pairing-A")).toBeTruthy();
+  expect(searchPairings).toHaveBeenLastCalledWith({ q: "", state: "all", page: 2 });
+  await waitFor(() => {
+    expect(screen.queryByTestId("load-more")).toBeNull();
+  });
+});
+
+it("keď sú zobrazené všetky varianty, tlačidlo 'Načítať ďalšie' sa vôbec nevykreslí", async () => {
+  searchPairings.mockResolvedValue({ total: 1, items: [item("A")] });
+
+  render(<PairingSection role="manazer" onSessionExpired={() => {}} />);
+
+  await screen.findByTestId("pairing-A");
+  expect(screen.queryByTestId("load-more")).toBeNull();
+});

--- a/apps/web/src/components/PairingSection.tsx
+++ b/apps/web/src/components/PairingSection.tsx
@@ -4,9 +4,11 @@ import {
   confirmPairing,
   searchPairings,
   PairingUnauthorizedError,
+  PAGE_SIZE,
   type PairingItem,
   type PairingState,
 } from "../pairingApi.js";
+import { useLoadMore } from "../useLoadMore.js";
 import {
   assertBulkConfirmSucceeded,
   groupPairingItems,
@@ -73,10 +75,23 @@ export function PairingSection({
     };
   }, []);
 
+  // issue 337: zdieľaný "Načítať ďalšie" mechanizmus, `useLoadMore.ts`.
+  const loadMoreState = useLoadMore<PairingItem>({
+    mountedRef,
+    onAppend: (newItems, newTotal) => {
+      setItems((prev) => [...prev, ...newItems]);
+      setTotal(newTotal);
+    },
+    onError: () => {
+      setSearchError("Načítanie ďalších položiek zlyhalo.");
+    },
+  });
+
   const search = useCallback(
     (q: string, s: PairingState) => {
       const seq = (searchSeq.current += 1);
       setSearchError("");
+      loadMoreState.reset();
       searchPairings({ q, state: s, page: 1 })
         .then((result) => {
           if (!mountedRef.current) return; // odmountované skôr, než odpoveď doletela
@@ -470,6 +485,21 @@ export function PairingSection({
             </tbody>
           </table>
         </div>
+      )}
+
+      {items.length < total && (
+        <button
+          type="button"
+          data-testid="load-more"
+          disabled={loadMoreState.loadingMore}
+          onClick={() => {
+            loadMoreState.loadMore((page) => searchPairings({ q: query, state, page }));
+          }}
+        >
+          {loadMoreState.loadingMore
+            ? "Načítavam…"
+            : `Načítať ďalšie (${String(Math.min(PAGE_SIZE, total - items.length))})`}
+        </button>
       )}
     </section>
   );

--- a/apps/web/src/components/PairingSection.tsx
+++ b/apps/web/src/components/PairingSection.tsx
@@ -87,10 +87,21 @@ export function PairingSection({
     },
   });
 
+  // requesting-code-review finding (issue 337, same fix as `CatalogPage
+  // .tsx`): "Load more" must fetch the next page of the filter that
+  // produced the CURRENT `items`/`total`, not whatever `query`/`state`
+  // currently hold (tracks every keystroke, independent of submit) — set
+  // synchronously inside `search()` itself, which already receives the
+  // exact q/s that will produce the results.
+  const searchedQueryRef = useRef(query);
+  const searchedStateRef = useRef(state);
+
   const search = useCallback(
     (q: string, s: PairingState) => {
       const seq = (searchSeq.current += 1);
       setSearchError("");
+      searchedQueryRef.current = q;
+      searchedStateRef.current = s;
       loadMoreState.reset();
       searchPairings({ q, state: s, page: 1 })
         .then((result) => {
@@ -493,7 +504,9 @@ export function PairingSection({
           data-testid="load-more"
           disabled={loadMoreState.loadingMore}
           onClick={() => {
-            loadMoreState.loadMore((page) => searchPairings({ q: query, state, page }));
+            loadMoreState.loadMore((page) =>
+              searchPairings({ q: searchedQueryRef.current, state: searchedStateRef.current, page }),
+            );
           }}
         >
           {loadMoreState.loadingMore

--- a/apps/web/src/components/RestockLinkSuggestionsSection.loadMore.test.tsx
+++ b/apps/web/src/components/RestockLinkSuggestionsSection.loadMore.test.tsx
@@ -80,3 +80,23 @@ it("nové vyhľadávanie (zmena dopytu) resetuje stranu späť na 1 — ďalší
     expect(searchRestockLinkSuggestions).toHaveBeenLastCalledWith({ q: "iny", page: 2 });
   });
 });
+
+// requesting-code-review finding (issue 337, rovnaký nález ako
+// `CatalogPage.loadMore.test.tsx`): "Load more" musí žiadať ďalšiu stranu
+// naposledy ODOSLANÉHO dopytu, nie práve rozpísaný (neodoslaný) text —
+// na rozdiel od testu vyššie, tu sa nový dopyt NIKDY neodošle (žiadny klik
+// na "Zobraziť").
+it("po rozpísaní NEODOSLANÉHO nového dopytu žiada 'Načítať ďalšie' ďalej stranu PÔVODNÉHO (naposledy odoslaného) dopytu", async () => {
+  searchRestockLinkSuggestions.mockResolvedValueOnce({ total: 2, items: [item("RL-1")] });
+  searchRestockLinkSuggestions.mockResolvedValueOnce({ total: 2, items: [item("RL-2")] });
+
+  render(<RestockLinkSuggestionsSection role="manazer" onSessionExpired={() => {}} />);
+  await screen.findByTestId("restock-link-row-RL-1");
+
+  fireEvent.change(screen.getByLabelText("Hľadať produkt (kód alebo názov)"), { target: { value: "nieco-ine" } });
+
+  fireEvent.click(await screen.findByTestId("load-more"));
+  await screen.findByTestId("restock-link-row-RL-2");
+
+  expect(searchRestockLinkSuggestions).toHaveBeenLastCalledWith({ q: "", page: 2 });
+});

--- a/apps/web/src/components/RestockLinkSuggestionsSection.loadMore.test.tsx
+++ b/apps/web/src/components/RestockLinkSuggestionsSection.loadMore.test.tsx
@@ -1,0 +1,82 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { RestockLinkSuggestionsSection } from "./RestockLinkSuggestionsSection.js";
+
+const { searchRestockLinkSuggestions } = vi.hoisted(() => ({ searchRestockLinkSuggestions: vi.fn() }));
+vi.mock("../restockLinksApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../restockLinksApi.js")>();
+  return { ...actual, searchRestockLinkSuggestions };
+});
+
+function item(key: string): {
+  productKey: string;
+  productName: string;
+  supplier: string | null;
+  candidates: never[];
+} {
+  return { productKey: key, productName: `Test bunda ${key}`, supplier: "Test dodávateľ", candidates: [] };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+// issue 337: tlačidlo "Načítať ďalšie" je JEDINÝ spôsob, ako sa dostať k
+// položkám nad prvú stranu (`PAGE_SIZE = 50`) — bez neho by boli natrvalo
+// nedosiahnuteľné, hoci server ich vie vrátiť.
+it("keď je total väčší než počet zobrazených položiek, ukáže tlačidlo 'Načítať ďalšie' s počtom zvyšných", async () => {
+  searchRestockLinkSuggestions.mockResolvedValue({ total: 55, items: [item("RL-1")] });
+
+  render(<RestockLinkSuggestionsSection role="manazer" onSessionExpired={() => {}} />);
+
+  const button = await screen.findByTestId("load-more");
+  expect(button.textContent).toBe("Načítať ďalšie (50)"); // min(PAGE_SIZE, 55 - 1)
+});
+
+it("klik na 'Načítať ďalšie' zavolá search s DRUHOU stranou a pripojí výsledok k existujúcim položkám", async () => {
+  searchRestockLinkSuggestions.mockResolvedValueOnce({ total: 2, items: [item("RL-1")] });
+  searchRestockLinkSuggestions.mockResolvedValueOnce({ total: 2, items: [item("RL-2")] });
+
+  render(<RestockLinkSuggestionsSection role="manazer" onSessionExpired={() => {}} />);
+
+  fireEvent.click(await screen.findByTestId("load-more"));
+
+  await screen.findByTestId("restock-link-row-RL-2");
+  // Pôvodná položka ostáva viditeľná — DRUHÁ strana sa PRIPOJILA, nenahradila.
+  expect(screen.getByTestId("restock-link-row-RL-1")).toBeTruthy();
+  expect(searchRestockLinkSuggestions).toHaveBeenLastCalledWith({ q: "", page: 2 });
+  await waitFor(() => {
+    expect(screen.queryByTestId("load-more")).toBeNull(); // 2/2 zobrazených — tlačidlo zmizne
+  });
+});
+
+it("keď sú zobrazené všetky položky, tlačidlo 'Načítať ďalšie' sa vôbec nevykreslí", async () => {
+  searchRestockLinkSuggestions.mockResolvedValue({ total: 1, items: [item("RL-1")] });
+
+  render(<RestockLinkSuggestionsSection role="manazer" onSessionExpired={() => {}} />);
+
+  await screen.findByTestId("restock-link-row-RL-1");
+  expect(screen.queryByTestId("load-more")).toBeNull();
+});
+
+it("nové vyhľadávanie (zmena dopytu) resetuje stranu späť na 1 — ďalší klik na 'Načítať ďalšie' žiada znova stranu 2", async () => {
+  searchRestockLinkSuggestions.mockResolvedValueOnce({ total: 2, items: [item("RL-1")] });
+  searchRestockLinkSuggestions.mockResolvedValueOnce({ total: 2, items: [item("RL-2")] });
+
+  render(<RestockLinkSuggestionsSection role="manazer" onSessionExpired={() => {}} />);
+  fireEvent.click(await screen.findByTestId("load-more"));
+  await screen.findByTestId("restock-link-row-RL-2");
+
+  searchRestockLinkSuggestions.mockResolvedValueOnce({ total: 3, items: [item("RL-3")] });
+  fireEvent.change(screen.getByLabelText("Hľadať produkt (kód alebo názov)"), { target: { value: "iny" } });
+  fireEvent.click(screen.getByRole("button", { name: "Zobraziť" }));
+  await screen.findByTestId("restock-link-row-RL-3");
+
+  searchRestockLinkSuggestions.mockResolvedValueOnce({ total: 3, items: [item("RL-4")] });
+  fireEvent.click(await screen.findByTestId("load-more"));
+
+  await waitFor(() => {
+    expect(searchRestockLinkSuggestions).toHaveBeenLastCalledWith({ q: "iny", page: 2 });
+  });
+});

--- a/apps/web/src/components/RestockLinkSuggestionsSection.tsx
+++ b/apps/web/src/components/RestockLinkSuggestionsSection.tsx
@@ -6,8 +6,10 @@ import { saveProductLink, SupplierLinksUnauthorizedError } from "../supplierLink
 import {
   RestockLinksUnauthorizedError,
   searchRestockLinkSuggestions,
+  PAGE_SIZE,
   type RestockLinkMissingItem,
 } from "../restockLinksApi.js";
+import { useLoadMore } from "../useLoadMore.js";
 
 // issue 311: "Vypredané → Skladom: návrhy odkazov" — priamy náprotivok
 // `SupplierLinksSection.tsx` (#239), len ZÚŽENÝ na populáciu vypredaných
@@ -59,9 +61,22 @@ export function RestockLinkSuggestionsSection({
     };
   }, []);
 
+  // issue 337: zdieľaný "Načítať ďalšie" mechanizmus, `useLoadMore.ts`.
+  const loadMoreState = useLoadMore<RestockLinkMissingItem>({
+    mountedRef,
+    onAppend: (newItems, newTotal) => {
+      setItems((prev) => [...prev, ...newItems]);
+      setTotal(newTotal);
+    },
+    onError: () => {
+      setSearchError("Načítanie ďalších položiek zlyhalo.");
+    },
+  });
+
   const search = useCallback((q: string) => {
     const seq = (searchSeq.current += 1);
     setSearchError("");
+    loadMoreState.reset();
     searchRestockLinkSuggestions({ q, page: 1 })
       .then((result) => {
         if (!mountedRef.current) return;
@@ -177,6 +192,11 @@ export function RestockLinkSuggestionsSection({
     [refetch, onSessionExpired, restockLinksBadge],
   );
 
+  // issue 337: rovnaká "zobrazených prvých M" poznámka ako `CatalogPage.tsx`/
+  // `PairingSection.tsx`/`SupplierLinksSection.tsx` — predtým chýbala, holé
+  // "Nájdených: N" neukazovalo, že za prvou stranou môže byť ešte viac.
+  const showingAll = total === 0 || items.length >= total;
+
   return (
     <section data-testid="restock-links-section">
       <p>
@@ -201,7 +221,11 @@ export function RestockLinkSuggestionsSection({
 
       {searchError !== "" && <p role="alert">{searchError}</p>}
       {actionError !== "" && <p role="alert">{actionError}</p>}
-      <p data-testid="restock-links-total">Nájdených: {total}</p>
+      <p data-testid="restock-links-total">
+        {showingAll
+          ? `Nájdených: ${String(total)}`
+          : `Nájdených: ${String(total)} (zobrazených prvých ${String(items.length)})`}
+      </p>
 
       {searchLoaded && total === 0 ? (
         <p data-testid="restock-links-empty">Žiadny vypredaný produkt bez linky sa nenašiel.</p>
@@ -333,6 +357,21 @@ export function RestockLinkSuggestionsSection({
             </tbody>
           </table>
         </div>
+      )}
+
+      {items.length < total && (
+        <button
+          type="button"
+          data-testid="load-more"
+          disabled={loadMoreState.loadingMore}
+          onClick={() => {
+            loadMoreState.loadMore((page) => searchRestockLinkSuggestions({ q: query, page }));
+          }}
+        >
+          {loadMoreState.loadingMore
+            ? "Načítavam…"
+            : `Načítať ďalšie (${String(Math.min(PAGE_SIZE, total - items.length))})`}
+        </button>
       )}
     </section>
   );

--- a/apps/web/src/components/RestockLinkSuggestionsSection.tsx
+++ b/apps/web/src/components/RestockLinkSuggestionsSection.tsx
@@ -73,9 +73,17 @@ export function RestockLinkSuggestionsSection({
     },
   });
 
+  // requesting-code-review finding (issue 337, same fix as `CatalogPage
+  // .tsx`/`PairingSection.tsx`/`SupplierLinksSection.tsx`): "Load more"
+  // must fetch the next page of the query that produced the CURRENT
+  // `items`/`total`, not whatever `query` currently holds — set
+  // synchronously inside `search()` itself.
+  const searchedQueryRef = useRef(query);
+
   const search = useCallback((q: string) => {
     const seq = (searchSeq.current += 1);
     setSearchError("");
+    searchedQueryRef.current = q;
     loadMoreState.reset();
     searchRestockLinkSuggestions({ q, page: 1 })
       .then((result) => {
@@ -365,7 +373,7 @@ export function RestockLinkSuggestionsSection({
           data-testid="load-more"
           disabled={loadMoreState.loadingMore}
           onClick={() => {
-            loadMoreState.loadMore((page) => searchRestockLinkSuggestions({ q: query, page }));
+            loadMoreState.loadMore((page) => searchRestockLinkSuggestions({ q: searchedQueryRef.current, page }));
           }}
         >
           {loadMoreState.loadingMore

--- a/apps/web/src/components/SupplierLinksSection.loadMore.test.tsx
+++ b/apps/web/src/components/SupplierLinksSection.loadMore.test.tsx
@@ -1,0 +1,70 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { SupplierLinksSection } from "./SupplierLinksSection.js";
+
+const { searchProductLinks } = vi.hoisted(() => ({ searchProductLinks: vi.fn() }));
+vi.mock("../supplierLinksApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../supplierLinksApi.js")>();
+  return { ...actual, searchProductLinks };
+});
+
+function item(key: string): {
+  productKey: string;
+  productName: string;
+  supplier: string | null;
+  variantCount: number;
+  url: string | null;
+  updatedAt: string | null;
+  syncedAt: string | null;
+} {
+  return {
+    productKey: key,
+    productName: `Test produkt ${key}`,
+    supplier: "Test dodávateľ",
+    variantCount: 1,
+    url: null,
+    updatedAt: null,
+    syncedAt: null,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+// issue 337: bez tlačidla "Načítať ďalšie" boli položky nad `PAGE_SIZE = 50`
+// natrvalo nedosiahnuteľné (aj keď server má koľko chceš stránok).
+it("keď je total väčší než počet zobrazených položiek, ukáže tlačidlo 'Načítať ďalšie' s počtom zvyšných", async () => {
+  searchProductLinks.mockResolvedValue({ total: 52, missingTotal: 52, items: [item("PL-1")] });
+
+  render(<SupplierLinksSection role="manazer" onSessionExpired={() => {}} />);
+
+  const button = await screen.findByTestId("load-more");
+  expect(button.textContent).toBe("Načítať ďalšie (50)"); // min(PAGE_SIZE, 52 - 1)
+});
+
+it("klik na 'Načítať ďalšie' zavolá search s DRUHOU stranou (rovnaký filter/dopyt) a pripojí výsledok", async () => {
+  searchProductLinks.mockResolvedValueOnce({ total: 2, missingTotal: 2, items: [item("PL-1")] });
+  searchProductLinks.mockResolvedValueOnce({ total: 2, missingTotal: 2, items: [item("PL-2")] });
+
+  render(<SupplierLinksSection role="manazer" onSessionExpired={() => {}} />);
+
+  fireEvent.click(await screen.findByTestId("load-more"));
+
+  await screen.findByTestId("product-link-row-PL-2");
+  expect(screen.getByTestId("product-link-row-PL-1")).toBeTruthy(); // pripojené, nie nahradené
+  expect(searchProductLinks).toHaveBeenLastCalledWith({ q: "", state: "missing", page: 2 });
+  await waitFor(() => {
+    expect(screen.queryByTestId("load-more")).toBeNull();
+  });
+});
+
+it("keď sú zobrazené všetky položky, tlačidlo 'Načítať ďalšie' sa vôbec nevykreslí", async () => {
+  searchProductLinks.mockResolvedValue({ total: 1, missingTotal: 1, items: [item("PL-1")] });
+
+  render(<SupplierLinksSection role="manazer" onSessionExpired={() => {}} />);
+
+  await screen.findByTestId("product-link-row-PL-1");
+  expect(screen.queryByTestId("load-more")).toBeNull();
+});

--- a/apps/web/src/components/SupplierLinksSection.loadMore.test.tsx
+++ b/apps/web/src/components/SupplierLinksSection.loadMore.test.tsx
@@ -68,3 +68,21 @@ it("keď sú zobrazené všetky položky, tlačidlo 'Načítať ďalšie' sa vô
   await screen.findByTestId("product-link-row-PL-1");
   expect(screen.queryByTestId("load-more")).toBeNull();
 });
+
+// requesting-code-review finding (issue 337, rovnaký nález ako
+// `CatalogPage.loadMore.test.tsx`): "Load more" musí žiadať ďalšiu stranu
+// naposledy ODOSLANÉHO dopytu, nie práve rozpísaný (neodoslaný) text.
+it("po rozpísaní NEODOSLANÉHO nového dopytu žiada 'Načítať ďalšie' ďalej stranu PÔVODNÉHO (naposledy odoslaného) dopytu", async () => {
+  searchProductLinks.mockResolvedValueOnce({ total: 2, missingTotal: 2, items: [item("PL-1")] });
+  searchProductLinks.mockResolvedValueOnce({ total: 2, missingTotal: 2, items: [item("PL-2")] });
+
+  render(<SupplierLinksSection role="manazer" onSessionExpired={() => {}} />);
+  await screen.findByTestId("product-link-row-PL-1");
+
+  fireEvent.change(screen.getByLabelText("Hľadať produkt (kód alebo názov)"), { target: { value: "nieco-ine" } });
+
+  fireEvent.click(await screen.findByTestId("load-more"));
+  await screen.findByTestId("product-link-row-PL-2");
+
+  expect(searchProductLinks).toHaveBeenLastCalledWith({ q: "", state: "missing", page: 2 });
+});

--- a/apps/web/src/components/SupplierLinksSection.tsx
+++ b/apps/web/src/components/SupplierLinksSection.tsx
@@ -6,9 +6,11 @@ import {
   saveProductLink,
   searchProductLinks,
   SupplierLinksUnauthorizedError,
+  PAGE_SIZE,
   type ProductLinkItem,
   type ProductLinkState,
 } from "../supplierLinksApi.js";
+import { useLoadMore } from "../useLoadMore.js";
 
 // issue 239: "Eshop → Párovanie produktov" — priamy náprotivok
 // `PairingSection.tsx`, ale kľúčovaný PRODUKTOM (nie variantom): jeden riadok
@@ -76,10 +78,23 @@ export function SupplierLinksSection({
     };
   }, []);
 
+  // issue 337: zdieľaný "Načítať ďalšie" mechanizmus, `useLoadMore.ts`.
+  const loadMoreState = useLoadMore<ProductLinkItem>({
+    mountedRef,
+    onAppend: (newItems, newTotal) => {
+      setItems((prev) => [...prev, ...newItems]);
+      setTotal(newTotal);
+    },
+    onError: () => {
+      setSearchError("Načítanie ďalších položiek zlyhalo.");
+    },
+  });
+
   const search = useCallback(
     (q: string, s: ProductLinkState) => {
       const seq = (searchSeq.current += 1);
       setSearchError("");
+      loadMoreState.reset();
       searchProductLinks({ q, state: s, page: 1 })
         .then((result) => {
           if (!mountedRef.current) return; // odmountované skôr, než odpoveď doletela
@@ -381,6 +396,21 @@ export function SupplierLinksSection({
           </tbody>
         </table>
         </div>
+      )}
+
+      {items.length < total && (
+        <button
+          type="button"
+          data-testid="load-more"
+          disabled={loadMoreState.loadingMore}
+          onClick={() => {
+            loadMoreState.loadMore((page) => searchProductLinks({ q: query, state, page }));
+          }}
+        >
+          {loadMoreState.loadingMore
+            ? "Načítavam…"
+            : `Načítať ďalšie (${String(Math.min(PAGE_SIZE, total - items.length))})`}
+        </button>
       )}
     </section>
   );

--- a/apps/web/src/components/SupplierLinksSection.tsx
+++ b/apps/web/src/components/SupplierLinksSection.tsx
@@ -90,10 +90,20 @@ export function SupplierLinksSection({
     },
   });
 
+  // requesting-code-review finding (issue 337, same fix as `CatalogPage
+  // .tsx`/`PairingSection.tsx`): "Load more" must fetch the next page of
+  // the filter that produced the CURRENT `items`/`total`, not whatever
+  // `query`/`state` currently hold — set synchronously inside `search()`
+  // itself, which already receives the exact q/s that produce the results.
+  const searchedQueryRef = useRef(query);
+  const searchedStateRef = useRef(state);
+
   const search = useCallback(
     (q: string, s: ProductLinkState) => {
       const seq = (searchSeq.current += 1);
       setSearchError("");
+      searchedQueryRef.current = q;
+      searchedStateRef.current = s;
       loadMoreState.reset();
       searchProductLinks({ q, state: s, page: 1 })
         .then((result) => {
@@ -404,7 +414,9 @@ export function SupplierLinksSection({
           data-testid="load-more"
           disabled={loadMoreState.loadingMore}
           onClick={() => {
-            loadMoreState.loadMore((page) => searchProductLinks({ q: query, state, page }));
+            loadMoreState.loadMore((page) =>
+              searchProductLinks({ q: searchedQueryRef.current, state: searchedStateRef.current, page }),
+            );
           }}
         >
           {loadMoreState.loadingMore

--- a/apps/web/src/useLoadMore.test.ts
+++ b/apps/web/src/useLoadMore.test.ts
@@ -95,10 +95,17 @@ it("odpoveď na load-more požiadavku vyslanú PRED reset()-om sa po doručení 
   act(() => {
     result.current.loadMore(staleFetch);
   });
+  expect(result.current.loadingMore).toBe(true);
 
   act(() => {
     result.current.reset();
   });
+
+  // requesting-code-review finding (issue 337): the stale request's own
+  // `.finally()` is skipped entirely (generation mismatch), so WITHOUT
+  // `reset()` itself clearing `loadingMore`, nothing else ever would —
+  // the button would stay stuck `disabled`/"Načítavam…" forever.
+  expect(result.current.loadingMore).toBe(false);
 
   await act(async () => {
     resolveStale?.({ items: ["stale"], total: 99 });
@@ -108,6 +115,7 @@ it("odpoveď na load-more požiadavku vyslanú PRED reset()-om sa po doručení 
 
   expect(onAppend).not.toHaveBeenCalled();
   expect(onError).not.toHaveBeenCalled();
+  expect(result.current.loadingMore).toBe(false); // stale response must not flip it back on
 });
 
 it("keď fetchNextPage zlyhá, zavolá sa onError a loadingMore sa vráti na false", async () => {

--- a/apps/web/src/useLoadMore.test.ts
+++ b/apps/web/src/useLoadMore.test.ts
@@ -1,0 +1,149 @@
+import { act, renderHook } from "@testing-library/react";
+import { expect, it, vi } from "vitest";
+import { useLoadMore } from "./useLoadMore.js";
+
+function mountedRef(value = true): { readonly current: boolean } {
+  return { current: value };
+}
+
+it("loadMore zavolá fetchNextPage so stranou 2 a pripojí výsledok cez onAppend", async () => {
+  const onAppend = vi.fn();
+  const onError = vi.fn();
+  const { result } = renderHook(() => useLoadMore<string>({ mountedRef: mountedRef(), onAppend, onError }));
+
+  const fetchNextPage = vi.fn().mockResolvedValue({ items: ["b"], total: 3 });
+  await act(async () => {
+    result.current.loadMore(fetchNextPage);
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+  expect(fetchNextPage).toHaveBeenCalledWith(2);
+  expect(onAppend).toHaveBeenCalledWith(["b"], 3);
+  expect(onError).not.toHaveBeenCalled();
+  expect(result.current.loadingMore).toBe(false);
+});
+
+it("druhé loadMore po úspešnom prvom žiada stranu 3, nie znova stranu 2", async () => {
+  const onAppend = vi.fn();
+  const { result } = renderHook(() =>
+    useLoadMore<string>({ mountedRef: mountedRef(), onAppend, onError: vi.fn() }),
+  );
+
+  const fetchPage2 = vi.fn().mockResolvedValue({ items: ["b"], total: 5 });
+  await act(async () => {
+    result.current.loadMore(fetchPage2);
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+  const fetchPage3 = vi.fn().mockResolvedValue({ items: ["c"], total: 5 });
+  await act(async () => {
+    result.current.loadMore(fetchPage3);
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+  expect(fetchPage3).toHaveBeenCalledWith(3);
+});
+
+it("reset() vráti stranu späť na 1 — ĎALŠIE loadMore znova žiada stranu 2", async () => {
+  const { result } = renderHook(() =>
+    useLoadMore<string>({ mountedRef: mountedRef(), onAppend: vi.fn(), onError: vi.fn() }),
+  );
+
+  const fetchPage2 = vi.fn().mockResolvedValue({ items: ["b"], total: 5 });
+  await act(async () => {
+    result.current.loadMore(fetchPage2);
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+  act(() => {
+    result.current.reset();
+  });
+
+  const fetchAfterReset = vi.fn().mockResolvedValue({ items: ["x"], total: 2 });
+  await act(async () => {
+    result.current.loadMore(fetchAfterReset);
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+  expect(fetchAfterReset).toHaveBeenCalledWith(2);
+});
+
+// issue 337: `reset()` volaný ZATIAĽ ČO staršie "load more" volanie ešte
+// čaká na odpoveď (napr. užívateľ zmenil dopyt/filter kým predchádzajúca
+// strana ešte doletovala) MUSÍ zahodiť tú neskoro doručenú, k STARÉMU
+// dopytu patriacu odpoveď — inak by `onAppend` pripojil položky z INÉHO
+// vyhľadávania k práve nahradenému zoznamu (rovnaká trieda race ako
+// `.claude/rules/frontend-design.md`'s "latest ref"/`searchSeq` nálezy).
+it("odpoveď na load-more požiadavku vyslanú PRED reset()-om sa po doručení zahodí (generation guard)", async () => {
+  const onAppend = vi.fn();
+  const onError = vi.fn();
+  const { result } = renderHook(() => useLoadMore<string>({ mountedRef: mountedRef(), onAppend, onError }));
+
+  let resolveStale: ((page: { items: string[]; total: number }) => void) | undefined;
+  const staleFetch = vi.fn(
+    () =>
+      new Promise<{ items: string[]; total: number }>((resolve) => {
+        resolveStale = resolve;
+      }),
+  );
+
+  act(() => {
+    result.current.loadMore(staleFetch);
+  });
+
+  act(() => {
+    result.current.reset();
+  });
+
+  await act(async () => {
+    resolveStale?.({ items: ["stale"], total: 99 });
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+  expect(onAppend).not.toHaveBeenCalled();
+  expect(onError).not.toHaveBeenCalled();
+});
+
+it("keď fetchNextPage zlyhá, zavolá sa onError a loadingMore sa vráti na false", async () => {
+  const onAppend = vi.fn();
+  const onError = vi.fn();
+  const { result } = renderHook(() => useLoadMore<string>({ mountedRef: mountedRef(), onAppend, onError }));
+
+  const failing = vi.fn().mockRejectedValue(new Error("network"));
+  await act(async () => {
+    result.current.loadMore(failing);
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+  expect(onError).toHaveBeenCalledTimes(1);
+  expect(onAppend).not.toHaveBeenCalled();
+  expect(result.current.loadingMore).toBe(false);
+});
+
+it("keď komponent už nie je mountnutý (mountedRef.current === false), onAppend/onError sa nezavolajú", async () => {
+  const ref = mountedRef(true);
+  const onAppend = vi.fn();
+  const onError = vi.fn();
+  const { result } = renderHook(() => useLoadMore<string>({ mountedRef: ref, onAppend, onError }));
+
+  const fetchNextPage = vi.fn().mockResolvedValue({ items: ["b"], total: 3 });
+  act(() => {
+    result.current.loadMore(fetchNextPage);
+  });
+  (ref as { current: boolean }).current = false;
+
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+  expect(onAppend).not.toHaveBeenCalled();
+  expect(onError).not.toHaveBeenCalled();
+});

--- a/apps/web/src/useLoadMore.ts
+++ b/apps/web/src/useLoadMore.ts
@@ -36,9 +36,18 @@ export function useLoadMore<T>(params: {
   const [loadingMore, setLoadingMore] = useState(false);
   const { mountedRef, onAppend, onError } = params;
 
+  // requesting-code-review finding (issue 337): `reset()` bumps the
+  // generation so a stale in-flight `loadMore()`'s `.finally()` skips its
+  // own `setLoadingMore(false)` (the `gen === genRef.current` guard is now
+  // false) — WITHOUT this line nothing else ever clears it, so the button
+  // is stuck showing "Načítavam…"/`disabled` for the rest of the component
+  // instance's life the moment a new search starts while a "load more"
+  // request is still in flight (an entirely ordinary sequence: click "Load
+  // more", then submit a new search before page 2 lands).
   const reset = useCallback(() => {
     pageRef.current = 1;
     genRef.current += 1;
+    setLoadingMore(false);
   }, []);
 
   const loadMore = useCallback(

--- a/apps/web/src/useLoadMore.ts
+++ b/apps/web/src/useLoadMore.ts
@@ -1,0 +1,67 @@
+import { useCallback, useRef, useState, type RefObject } from "react";
+
+// issue 337: "Načítať ďalšie" — zdieľaný mechanizmus pre KAŽDÚ stránkovanú
+// vyhľadávaciu obrazovku (Katalóg/Kontrola párovania/Eshop → Párovanie
+// produktov/Vypredané → Skladom: návrhy odkazov). Backend `page`/`pageSize`
+// už podporuje plnohodnotne (viď `.claude/rules` per-modul poznámky) — chýbal
+// len spôsob, ako sa z frontendu dostať za prvú stranu. Rieši VÝHRADNE
+// "načítaj ĎALŠIU stranu a pripoj k existujúcim položkám" — samotné NOVÉ
+// vyhľadávanie (zmena dopytu/filtra) ostáva vo `search()` každej obrazovky
+// nezmenené (nahrádza `items` a strana sa vracia na 1), volajúci na jeho
+// ZAČIATKU zavolá `reset()`.
+export interface LoadMorePage<T> {
+  readonly items: readonly T[];
+  readonly total: number;
+}
+
+/**
+ * `reset()` zvýši generáciu — akákoľvek ODPOVEĎ na "load more" požiadavku
+ * vyslanú PRED resetom (teda patriacu STARÉMU dopytu/filtru) sa pri doručení
+ * zahodí, rovnaký "latest generation" princíp ako existujúci `searchSeq`
+ * vzor v týchto komponentoch (`.claude/rules/frontend-design.md`'s "latest
+ * ref" záznamy), len o úroveň vyššie (pre CELÚ load-more sekvenciu, nie pre
+ * jedno volanie).
+ */
+export function useLoadMore<T>(params: {
+  readonly mountedRef: RefObject<boolean>;
+  readonly onAppend: (items: readonly T[], total: number) => void;
+  readonly onError: () => void;
+}): {
+  readonly loadMore: (fetchNextPage: (page: number) => Promise<LoadMorePage<T>>) => void;
+  readonly loadingMore: boolean;
+  readonly reset: () => void;
+} {
+  const pageRef = useRef(1);
+  const genRef = useRef(0);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const { mountedRef, onAppend, onError } = params;
+
+  const reset = useCallback(() => {
+    pageRef.current = 1;
+    genRef.current += 1;
+  }, []);
+
+  const loadMore = useCallback(
+    (fetchNextPage: (page: number) => Promise<LoadMorePage<T>>) => {
+      const gen = genRef.current;
+      const nextPage = pageRef.current + 1;
+      setLoadingMore(true);
+      fetchNextPage(nextPage)
+        .then((result) => {
+          if (!mountedRef.current || gen !== genRef.current) return;
+          pageRef.current = nextPage;
+          onAppend(result.items, result.total);
+        })
+        .catch(() => {
+          if (!mountedRef.current || gen !== genRef.current) return;
+          onError();
+        })
+        .finally(() => {
+          if (mountedRef.current && gen === genRef.current) setLoadingMore(false);
+        });
+    },
+    [mountedRef, onAppend, onError],
+  );
+
+  return { loadMore, loadingMore, reset };
+}

--- a/apps/web/tests/e2e/catalog.spec.ts
+++ b/apps/web/tests/e2e/catalog.spec.ts
@@ -36,13 +36,16 @@ test("manažér vidí stav katalógu, vyhľadá variant a konzola je čistá", a
   // + 1 seedovaný produkt pre "Vyhľadať" ("E2E-SEARCH-1", issue 240,
   // `scripts/e2e-fixtures-search.ts`) + 3 seedované produkty pre "Vypredané →
   // Skladom: návrhy odkazov" ("E2E-RL-CHYBA"/"E2E-RL-NAVRH"/"E2E-RL-CUDZI",
-  // issue 311, `scripts/e2e-fixtures-restock-links.ts`).
+  // issue 311, `scripts/e2e-fixtures-restock-links.ts`)
+  // + 60 seedovaných produktov pre "Načítať ďalšie" (issue 337, "E2E-PAGE-
+  // 001".."E2E-PAGE-060", `scripts/e2e-fixtures-pagination.ts`) = 103.
   // Prví dvaja (PREP-1/PREP-2) aj "E2E-RL-CHYBA" sú `out_of_stock` (nemenia
-  // "sellable"/"missing" nižšie), zvyšných 5 sú `sellable` (posúvajú filter
-  // "sellable" 7→12 nižšie), "missing"(1) sa nemení ani jedným z nich.
+  // "sellable"/"missing" nižšie), zvyšných 5 aj všetkých 60 "E2E-PAGE-*" sú
+  // `sellable` (posúvajú filter "sellable" 7→72 nižšie), "missing"(1) sa
+  // nemení ani jedným z nich.
   await expect(page.getByTestId("snapshot")).toContainText("Posledný import: prijatý");
-  await expect(page.getByTestId("counts")).toContainText("Variantov v katalógu (vrátane chýbajúcich): 43");
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 43");
+  await expect(page.getByTestId("counts")).toContainText("Variantov v katalógu (vrátane chýbajúcich): 103");
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 103 (zobrazených prvých 50)");
 
   await page.getByLabel("Kód alebo názov").fill("40237/3XL");
   await page.getByRole("button", { name: "Hľadať", exact: true }).click();
@@ -62,16 +65,17 @@ test("filter podľa stavu zúži zoznam na predajné varianty", async ({ page })
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 43");
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 103 (zobrazených prvých 50)");
   await page.getByLabel("Stav", { exact: true }).selectOption("sellable");
   await page.getByRole("button", { name: "Hľadať", exact: true }).click();
 
-  // 12 = 7 od issue 219 (variant "40237/L" má oba texty dostupnosti prázdne,
+  // 72 = 7 od issue 219 (variant "40237/L" má oba texty dostupnosti prázdne,
   // čo znamená predvolenú dostupnosť Shoptetu — "Skladom", nie vypredané) +
   // 2 sellable produkty issue 239's fixtúry ("E2E-PL-CHYBA"/"E2E-PL-OPRAVA")
   // + 1 sellable produkt issue 240's fixtúry ("E2E-SEARCH-1") + 2 sellable
-  // produkty issue 311's fixtúry ("E2E-RL-NAVRH"/"E2E-RL-CUDZI").
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 12");
+  // produkty issue 311's fixtúry ("E2E-RL-NAVRH"/"E2E-RL-CUDZI") + 60 sellable
+  // produktov issue 337's fixtúry ("E2E-PAGE-001".."E2E-PAGE-060").
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 72 (zobrazených prvých 50)");
   await expect(page.getByTestId("variant-40237/M")).toBeVisible();
 });
 
@@ -83,7 +87,7 @@ test("filter 'Chýbajúce' nájde presne označený variant a riadok ukazuje, od
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 43");
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 103 (zobrazených prvých 50)");
   await page.getByLabel("Stav", { exact: true }).selectOption("missing");
   await page.getByRole("button", { name: "Hľadať", exact: true }).click();
 
@@ -140,7 +144,7 @@ test("import (ešte prebiehajúci) nesmie prepísať MEDZITÝM zmenený filter z
   await page.getByLabel("E-mail").fill(E2E_RACE_EMAIL);
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 43");
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 103 (zobrazených prvých 50)");
 
   await page.getByRole("button", { name: "Stiahnuť a naimportovať export" }).click();
 

--- a/apps/web/tests/e2e/supplier-links.spec.ts
+++ b/apps/web/tests/e2e/supplier-links.spec.ts
@@ -275,3 +275,56 @@ test("uloženie riadku A (ešte čakajúce na odpoveď) nesmie zavrieť editor r
 
   expect(chyby).toEqual([]);
 });
+
+// issue 337: bez tlačidla "Načítať ďalšie" boli položky NAD prvou stranou
+// (`PAGE_SIZE = 50`) NEDOSIAHNUTEĽNÉ, hoci server ich vie vrátiť — presne to
+// je akceptačný dôkaz, ktorý ticket žiada. 60 fixtúrových produktov
+// "E2E-PAGE-001".."E2E-PAGE-060" (`e2e-fixtures-pagination.ts`), dopyt
+// scoped na spoločný prefix "E2E-PAGE-" tak, aby `total` bol nezávislý od
+// zvyšku databázy/ostatných fixtúr.
+test("položka nad hranicou 50 je po kliknutí na 'Načítať ďalšie' skutočne dosiahnuteľná, s viditeľným celkovým počtom", async ({
+  page,
+}) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/?tab=supplier-links");
+  await page.getByLabel("E-mail").fill(E2E_PAROVANIE_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await expect(page.getByRole("heading", { name: "Párovanie produktov" })).toBeVisible();
+
+  // Predvolený filter je "Bez linky" — všetkých 60 fixtúrových produktov
+  // (žiadny nemá `internalNote`) tam patrí.
+  await page.getByLabel("Hľadať produkt (kód alebo názov)").fill("E2E-PAGE-");
+  await page.getByRole("button", { name: "Zobraziť" }).click();
+
+  await expect(page.getByTestId("product-link-row-E2E-PAGE-001")).toBeVisible();
+  // Prvá strana = 50 položiek — položka #51 zatiaľ NIE JE v DOM-e vôbec.
+  await expect(page.getByTestId("product-link-row-E2E-PAGE-051")).toHaveCount(0);
+
+  const tlacidlo = page.getByTestId("load-more");
+  await expect(tlacidlo).toHaveText("Načítať ďalšie (10)"); // min(PAGE_SIZE, 60 - 50)
+  // Celkový počet je viditeľný UŽ na prvej strane — presne to bolo pôvodne
+  // neviditeľné ("Nájdených: N" bez poznámky by nikto nevedel, že za
+  // stranou je ešte viac).
+  await expect(page.getByTestId("product-links-total")).toContainText("Nájdených: 60 (zobrazených prvých 50)");
+  await tlacidlo.click();
+
+  // Druhá strana sa PRIPOJILA — položka #51 je teraz dosiahnuteľná a #1
+  // ostáva viditeľná (nič sa nenahradilo).
+  await expect(page.getByTestId("product-link-row-E2E-PAGE-051")).toBeVisible();
+  await expect(page.getByTestId("product-link-row-E2E-PAGE-001")).toBeVisible();
+  await expect(page.getByTestId("product-link-row-E2E-PAGE-060")).toBeVisible();
+
+  // Všetkých 60 je teraz zobrazených — tlačidlo zmizne, viac stránok niet.
+  await expect(page.getByTestId("load-more")).toHaveCount(0);
+  await expect(page.getByTestId("product-links-total")).toHaveText("Nájdených: 60");
+
+  expect(chyby).toEqual([]);
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.199",
+  "version": "0.3.0-dev.200",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-fixtures-pagination.ts
+++ b/scripts/e2e-fixtures-pagination.ts
@@ -1,0 +1,24 @@
+// issue 337: "Načítať ďalšie" — Playwright e2e dôkaz, že položka NAD prvou
+// stranou (`PAGE_SIZE = 50`) je po kliknutí na "Načítať ďalšie" skutočne
+// dosiahnuteľná, na obrazovke "Eshop → Párovanie produktov" (#239). 60
+// VLASTNÝCH, dovtedy nepoužitých jednovariantných produktov so SPOLOČNÝM
+// prefixom kódu ("E2E-PAGE-"), aby dopyt scoped na tento prefix mal `total`
+// NEZÁVISLÝ od zvyšku databázy (iné fixtúry/produkty z predošlých issue).
+// Bez efektívnej linky (žiadny `internalNote`) — spadajú do predvoleného
+// filtra "Bez linky", presne ako `E2E-PL-CHYBA` (`e2e-fixtures-product-
+// links.ts`). Žiadny vlastný e2e účet — beží pod `E2E_PAROVANIE_EMAIL`
+// (rovnaká obrazovka, čisto ČÍTACÍ dopyt, žiadna mutácia zdieľaného stavu),
+// rovnaký mechanizmus ako existujúce testy v `supplier-links.spec.ts`.
+import type { Database } from "../apps/api/src/db/client.js";
+import { products, variants } from "../apps/api/src/db/schema.js";
+
+export const E2E_PAGE_PREFIX = "E2E-PAGE-";
+export const E2E_PAGE_COUNT = 60;
+
+export async function seedPaginationFixtures(db: Database, teraz: Date, snapshotId: string): Promise<void> {
+  for (let i = 1; i <= E2E_PAGE_COUNT; i += 1) {
+    const key = `${E2E_PAGE_PREFIX}${String(i).padStart(3, "0")}`;
+    await db.insert(products).values({ key, name: `E2E Stránkovanie ${key}`, supplier: "E2E Dodávateľ Stránkovanie", internalNote: null, firstSeenAt: teraz, lastSeenAt: teraz, lastSeenSnapshotId: snapshotId });
+    await db.insert(variants).values({ code: key, productKey: key, guid: key, name: `E2E Stránkovanie ${key}`, stock: 5, availabilityInStockText: "Skladom", availabilityOutOfStockText: "Vypredané", availabilityText: "Skladom", productVisibility: "visible", state: "sellable", firstSeenAt: teraz, lastSeenAt: teraz, lastSeenSnapshotId: snapshotId });
+  }
+}

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -19,6 +19,7 @@ import { POSTA_UNCOLLECTED_SETTINGS_ID } from "../apps/api/src/modules/posta-unc
 import { ORDER_REMINDER_SETTINGS_ID } from "../apps/api/src/modules/order-reminder/settings.js";
 import { seedDpdFixtures } from "./e2e-fixtures-dpd.js";
 import { seedOrderFlagsFixtures } from "./e2e-fixtures-order-flags.js";
+import { seedPaginationFixtures } from "./e2e-fixtures-pagination.js";
 import { seedProductLinksFixtures } from "./e2e-fixtures-product-links.js";
 import { seedRestockEventsFixtures } from "./e2e-fixtures-restock-events.js";
 import { seedRestockLinksFixtures } from "./e2e-fixtures-restock-links.js";
@@ -804,5 +805,8 @@ await seedDpdFixtures(db, E2E_HESLO);
 
 // issue 329: fixtúra vyčlenená do vlastného súboru, rovnaký dôvod ako vyššie.
 await seedRestockEventsFixtures(db, teraz);
+
+// issue 337: fixtúra vyčlenená do vlastného súboru, rovnaký dôvod ako vyššie.
+await seedPaginationFixtures(db, teraz, snapshotPrepinanie);
 
 await pool.end();


### PR DESCRIPTION
## Čo bolo zlé

Viacero obrazoviek (Katalóg, Kontrola párovania, Eshop → Párovanie
produktov, Vypredané → Skladom: návrhy odkazov) volalo svoj vyhľadávací
endpoint VŽDY s `page: 1`/pevným `pageSize: 50`, bez akéhokoľvek spôsobu,
ako sa dostať k položkám nad limit — hoci backend `page`/`pageSize`
podporuje plnohodnotne. Položky nad prvou stranou boli natrvalo
nedosiahnuteľné.

## Riešenie

Jeden zdieľaný `useLoadMore` hook (page-tracking + append + generation-
counter ochrana pred zastaraným výsledkom po resete), zapojený identicky
na všetkých štyroch obrazovkách. Pod tabuľkou pribudlo tlačidlo "Načítať
ďalšie (N)", viditeľné keď `items.length < total`; klik pripojí ďalšiu
stranu k existujúcim položkám (žiadny reset scrollu). Celkový počet je
vždy viditeľný ("Nájdených: N (zobrazených prvých M)") — predtým to
chýbalo na "Vypredané → Skladom" obrazovke, dorovnané na rovnaký vzor ako
ostatné tri. Backend sa nemení.

## Testy

Unit test hooku (append/reset/race-guard) + po jednom teste na tlačidlo
pre každú zo 4 obrazoviek + Playwright e2e (60 fixtúrových produktov,
scoped dopyt), ktorý dokazuje, že položka za hranicou 50 je po kliknutí
skutočne dosiahnuteľná. `catalog.spec.ts`'s existujúce pevné počty
dorovnané o nové fixtúrové varianty (dokumentovaný gotcha).

issue 337
