### PR TITLE
Ľavé menu: Systém a Automatizácie štartujú zbalené (issue 343)

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -1059,3 +1059,51 @@ paths:
   "<názov testu>"` na dôkaz RED, potom `stash pop` + rovnaký beh na dôkaz
   GREEN. Rýchlejšie než plný `pnpm --filter @forestshop/web e2e` cyklus
   pri overovaní JEDNÉHO testu.
+- **Zdieľaný "Načítať ďalšie" stránkovací mechanizmus je `apps/web/src/
+  useLoadMore.ts` (issue 337) — KAŽDÁ ĎALŠIA obrazovka, ktorá potrebuje
+  prekročiť `page: 1`/pevný `pageSize`, ho má POUŽIŤ, nie znova
+  vynachádzať vlastný page-tracking stav.** Zapojenie na 4 existujúcich
+  obrazovkách (`CatalogPage.tsx`/`PairingSection.tsx`/
+  `SupplierLinksSection.tsx`/`RestockLinkSuggestionsSection.tsx`) je
+  identické: `useLoadMore({mountedRef, onAppend, onError})`, `reset()`
+  volaný na ZAČIATKU `search()`, tlačidlo `data-testid="load-more"`
+  viditeľné len keď `items.length < total`, klik pripojí (nikdy
+  nenahrádza) výsledok.
+- **`reset()` v `useLoadMore.ts` MUSÍ vyčistiť KAŽDÝ derivovaný stav, ktorý
+  jeho vlastný generation-guard môže "zamraziť" — nestačí len zvýšiť
+  generáciu.** Code review na PR 341 (issue 337): `reset()` pôvodne len
+  bumpol `genRef`, no `loadingMore` sa nastavuje `true` pri štarte
+  `loadMore()` a späť na `false` AŽ v jeho `.finally()`, ktoré je SAMO
+  podmienené `gen === genRef.current` — takže reset VYVOLANÝ, kým staré
+  "load more" volanie ešte čaká na odpoveď, spôsobil, že `.finally()` sa
+  pre TÚTO (teraz zastaranú) požiadavku už nikdy neuplatnil a `loadingMore`
+  ostal `true` navždy (tlačidlo trvalo "Načítavam…"/disabled). Bežný
+  spúšťací sled: klik "Načítať ďalšie" → PRED doručením odpovede nové
+  vyhľadávanie. Fix: `reset()` teraz aj `setLoadingMore(false)`. Test na
+  KAŽDÝ ĎALŠÍ generation-guard v tomto repe (`searchSeq`/`gen`/podobne):
+  existuje vedľajší `useState` boolean (busy/loading/disabled), ktorý sa
+  nastavuje `true` PRED asynchrónnou operáciou a späť `false` AŽ vnútri
+  toho istého guardovaného `.then()/.catch()/.finally()`? Ak áno, `reset()`
+  (alebo čokoľvek, čo guard obchádza) ho musí vyčistiť SÁM, inak zostane
+  navždy zaseknutý.
+- **"Latest ref"/`queryRef`-`stateRef` trieda chyby (issue 251/254, viď
+  vyššie v tomto súbore) sa netýka LEN `.then()` mikrotaskov — presne ten
+  istý bug vzniká aj v ONCLICK handleri, ktorý priamo číta LIVE component
+  state namiesto hodnôt, čo skutočne vyprodukovali zobrazené výsledky.**
+  Code review na PR 341 (issue 337): "Načítať ďalšie" tlačidlo na všetkých
+  4 obrazovkách pôvodne volalo `searchXxx({q: query, state, page})` —
+  `query`/`state` sú kontrolované vstupy, menia sa pri KAŽDOM stlačení
+  klávesy/zmene selectu, NEZÁVISLE od toho, či `search()` (submit) preň
+  vôbec prebehol. Scenár: odošli vyhľadanie "socks" → výsledky sa
+  vykreslia → rozpíš INÝ text bez kliknutia na "Hľadať" → klik na "Načítať
+  ďalšie" ticho vyžiada druhú stranu NOVÉHO, NEODOSLANÉHO dopytu, hoci
+  `items`/`total` na obrazovke ešte patria pôvodnému. Fix: `search(q, s)`
+  (ktorá už dostáva presne odoslané hodnoty) ich synchrónne uloží do
+  VLASTNÉHO refu (`searchedQueryRef`/`searchedStateRef`, oddeleného od
+  existujúceho `queryRef`/`stateRef`, ktorý zámerne zrkadlí LIVE hodnotu
+  pre INÝ účel — ingest/refetch race), tlačidlo číta z tohto refu, nikdy z
+  live stavu vstupov. Test na KAŽDÝ ĎALŠÍ onClick/onSubmit handler v tomto
+  repe, ktorý volá server s hodnotou z `useState`u kontrolovaného vstupu:
+  je táto hodnota GARANTOVANE tá istá, čo vyprodukovala AKTUÁLNE
+  zobrazené dáta, alebo len "čo je práve rozpísané"? Ak druhé, potrebuje
+  vlastný "naposledy odoslané" ref, nie priamy odkaz na live state.

--- a/apps/web/src/components/Sidebar.test.tsx
+++ b/apps/web/src/components/Sidebar.test.tsx
@@ -45,6 +45,45 @@ it("klik na záložku zavolá onSelectTab s jej id", () => {
   expect(onSelectTab).toHaveBeenCalledWith("orders");
 });
 
+// issue 343: šéf chce, aby "Systém" a "Automatizácie" štartovali ZBALENÉ
+// (menu inak zaberá celú výšku a treba rolovať), "Eshop" ostáva rozbalený.
+// Predvolený stav je deklarovaný PER PRIEČINOK v `nav.ts` (`defaultCollapsed`),
+// nie ako zoznam mien v `Sidebar.tsx` — test preto simuluje presne tento tvar
+// registra (tri priečinky, dva s `defaultCollapsed: true`).
+const FOLDERS_WITH_DEFAULT_COLLAPSED = [
+  {
+    id: "eshop",
+    label: "Eshop",
+    tabs: [{ id: "orders", label: "Na objednanie", icon: "📦", Component: () => null }],
+  },
+  {
+    id: "system",
+    label: "Systém",
+    defaultCollapsed: true,
+    tabs: [{ id: "sync", label: "Sync zo Shoptetu", icon: "🔄", Component: () => null }],
+  },
+  {
+    id: "automations",
+    label: "Automatizácie",
+    defaultCollapsed: true,
+    tabs: [{ id: "restock", label: "Vypredané → Skladom", icon: "🔁", Component: () => null }],
+  },
+];
+
+it("Systém a Automatizácie štartujú zbalené (defaultCollapsed), Eshop ostáva rozbalený", () => {
+  render(<Sidebar folders={FOLDERS_WITH_DEFAULT_COLLAPSED} activeTabId="orders" onSelectTab={() => {}} />);
+
+  expect(screen.getByRole("button", { name: "Eshop" }).getAttribute("aria-expanded")).toBe("true");
+  expect(screen.getByRole("button", { name: "Systém" }).getAttribute("aria-expanded")).toBe("false");
+  expect(screen.getByRole("button", { name: "Automatizácie" }).getAttribute("aria-expanded")).toBe("false");
+});
+
+it("priečinok bez defaultCollapsed (napr. budúce Dôležité z #342) štartuje rozbalený ako doteraz", () => {
+  render(<Sidebar folders={FOLDERS} activeTabId="sync" onSelectTab={() => {}} />);
+
+  expect(screen.getByRole("button", { name: "Systém" }).getAttribute("aria-expanded")).toBe("true");
+});
+
 it("klik na hlavičku priečinka ho zbalí (folder-chev sa otočí cez triedu 'collapsed')", () => {
   render(<Sidebar folders={FOLDERS} activeTabId="sync" onSelectTab={() => {}} />);
 

--- a/apps/web/src/components/Sidebar.test.tsx
+++ b/apps/web/src/components/Sidebar.test.tsx
@@ -84,6 +84,67 @@ it("priečinok bez defaultCollapsed (napr. budúce Dôležité z #342) štartuje
   expect(screen.getByRole("button", { name: "Systém" }).getAttribute("aria-expanded")).toBe("true");
 });
 
+// issue 343 (code review nález): zbalenie priečinka "Automatizácie" skrýva
+// odznaky/pilulky, ktoré predtým (#331/#267) žiadali byť vidno HNEĎ po
+// prihlásení bez otvorenia záložky. Fix: hlavička ZBALENÉHO priečinka
+// dostane SÚHRNNÝ odznak (súčet badgeCounts vnútri, rovnaká trieda
+// `.tab-badge` ako existujúce vnútorné odznaky), alebo — keď nie je žiadne
+// číslo, ale niečo má badgeStatus (Beží/Zastavené) — malú bodku. Po
+// rozbalení priečinka zmizne (vnútri sú vidno originály).
+it("zbalený priečinok s nenulovým súčtom badgeCounts ukáže súhrnný odznak na hlavičke", () => {
+  render(
+    <Sidebar
+      folders={FOLDERS_WITH_DEFAULT_COLLAPSED}
+      activeTabId="orders"
+      onSelectTab={() => {}}
+      badgeCounts={{ restock: 3 }}
+    />,
+  );
+
+  const folderBadge = screen.getByTestId("folder-badge-automations");
+  expect(folderBadge.textContent).toBe("3");
+  expect(folderBadge.className).toContain("tab-badge");
+  expect(screen.queryByTestId("folder-dot-automations")).toBeNull();
+});
+
+it("zbalený priečinok s nulovým/chýbajúcim badgeCounts, ale s badgeStatus, ukáže len bodku", () => {
+  render(
+    <Sidebar
+      folders={FOLDERS_WITH_DEFAULT_COLLAPSED}
+      activeTabId="orders"
+      onSelectTab={() => {}}
+      badgeStatus={{ restock: "off" }}
+    />,
+  );
+
+  expect(screen.getByTestId("folder-dot-automations")).toBeTruthy();
+  expect(screen.queryByTestId("folder-badge-automations")).toBeNull();
+});
+
+it("zbalený priečinok bez badgeCounts aj bez badgeStatus neukáže na hlavičke nič", () => {
+  render(<Sidebar folders={FOLDERS_WITH_DEFAULT_COLLAPSED} activeTabId="orders" onSelectTab={() => {}} />);
+
+  expect(screen.queryByTestId("folder-badge-automations")).toBeNull();
+  expect(screen.queryByTestId("folder-dot-automations")).toBeNull();
+});
+
+it("rozbalenie priečinka schová súhrnný odznak z hlavičky (originály vnútri ostávajú)", () => {
+  render(
+    <Sidebar
+      folders={FOLDERS_WITH_DEFAULT_COLLAPSED}
+      activeTabId="orders"
+      onSelectTab={() => {}}
+      badgeCounts={{ restock: 3 }}
+    />,
+  );
+
+  expect(screen.getByTestId("folder-badge-automations")).toBeTruthy();
+  fireEvent.click(screen.getByRole("button", { name: "Automatizácie" }));
+
+  expect(screen.queryByTestId("folder-badge-automations")).toBeNull();
+  expect(screen.getByTestId("nav-badge-restock").textContent).toBe("3");
+});
+
 it("klik na hlavičku priečinka ho zbalí (folder-chev sa otočí cez triedu 'collapsed')", () => {
   render(<Sidebar folders={FOLDERS} activeTabId="sync" onSelectTab={() => {}} />);
 

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -71,7 +71,21 @@ export function Sidebar({
   // tá nemá koncept zapnuté/vypnuté vôbec, je len na požiadanie).
   readonly badgeStatus?: Readonly<Record<string, "on" | "off">>;
 }): JSX.Element {
-  const [collapsed, setCollapsed] = useState<Readonly<Record<string, boolean>>>({});
+  // issue 343: predvolený stav zbalenia sa číta z registra (`NavFolder
+  // .defaultCollapsed` v `nav.ts`), nie hardcoded tu — pridanie nového
+  // priečinka do menu tak nikdy nevyžaduje zásah do tejto komponenty. Lazy
+  // initializer beží len pri prvom vykreslení (rovnaké `folders` prop sa
+  // odovzdáva zo statického registra, nemení sa počas behu appky) — ZÁMERNE
+  // sa NEPAMÄTÁ medzi návštevami (na rozdiel od `rail` nižšie), po obnovení
+  // stránky sa vždy vráti na túto predvolenú hodnotu (viď dizajnové
+  // rozhodnutie na tickete #343).
+  const [collapsed, setCollapsed] = useState<Readonly<Record<string, boolean>>>(() => {
+    const initial: Record<string, boolean> = {};
+    for (const folder of folders) {
+      if (folder.defaultCollapsed === true) initial[folder.id] = true;
+    }
+    return initial;
+  });
   const [rail, setRail] = useState<boolean>(initialRail);
 
   useEffect(() => {

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -138,6 +138,20 @@ export function Sidebar({
           // schovať záložky — preto sa trieda `collapsed` v tomto stave
           // neaplikuje. Po rozbalení panela sa pôvodný stav priečinkov vráti.
           const isCollapsed = !rail && collapsed[folder.id] === true;
+          // issue 343 (code review nález): zbalenie priečinka skrylo odznaky/
+          // pilulky, ktoré predtým (#331/#267) žiadali byť vidno HNEĎ po
+          // prihlásení bez otvorenia záložky. Súhrn sa počíta LEN kým je
+          // priečinok zbalený (po rozbalení sú vidno originály vnútri, žiadna
+          // duplicita) — z tých istých `badgeCounts`/`badgeStatus` props, žiadny
+          // nový sieťový dotaz. `aria-hidden` na oboch, aby hlavička priečinka
+          // NEMENILA svoj prístupný názov (existujúce `getByRole("button",
+          // {name: folder.label})` dotazy naprieč testami by inak prestali
+          // sedieť, keďže by doň spadol aj text/aria-label odznaku).
+          const folderBadgeSum = isCollapsed
+            ? folder.tabs.reduce((sum, tab) => sum + (badgeCounts?.[tab.id] ?? 0), 0)
+            : 0;
+          const folderHasStatus =
+            isCollapsed && folder.tabs.some((tab) => badgeStatus?.[tab.id] !== undefined);
           return (
             <div className={"nav-folder" + (isCollapsed ? " collapsed" : "")} key={folder.id}>
               {!rail && (
@@ -150,6 +164,14 @@ export function Sidebar({
                   }}
                 >
                   <span className="ftitle">{folder.label}</span>
+                  {folderBadgeSum > 0 && (
+                    <span className="tab-badge" data-testid={`folder-badge-${folder.id}`} aria-hidden="true">
+                      {folderBadgeSum}
+                    </span>
+                  )}
+                  {folderBadgeSum === 0 && folderHasStatus && (
+                    <span className="folder-dot" data-testid={`folder-dot-${folder.id}`} aria-hidden="true" />
+                  )}
                   <span className="folder-chev" aria-hidden="true">
                     ⌄
                   </span>

--- a/apps/web/src/nav.test.ts
+++ b/apps/web/src/nav.test.ts
@@ -57,6 +57,21 @@ it("NAV má tri priečinky (Eshop/Systém/Automatizácie), s 10/3/5 záložkami 
   ]);
 });
 
+// issue 343: šéf chce, aby "Systém" a "Automatizácie" štartovali v ľavom menu
+// zbalené (menu inak zaberá celú výšku a treba rolovať) — "Eshop" ostáva
+// rozbalený (denne používaná obrazovka). Stav je deklarovaný priamo v
+// registri (`NavFolder.defaultCollapsed`), aby budúci priečinok (napr.
+// "Dôležité" z issue 342) mohol zvoliť vlastný predvolený stav jedným
+// riadkom bez zásahu do `Sidebar.tsx` (viď jeho vlastný test).
+it("Systém a Automatizácie majú defaultCollapsed: true, Eshop ho nemá nastavené", () => {
+  expect(NAV[0]?.label).toBe("Eshop");
+  expect(NAV[0]?.defaultCollapsed).toBeUndefined();
+  expect(NAV[1]?.label).toBe("Systém");
+  expect(NAV[1]?.defaultCollapsed).toBe(true);
+  expect(NAV[2]?.label).toBe("Automatizácie");
+  expect(NAV[2]?.defaultCollapsed).toBe(true);
+});
+
 // issue 287: DEFAULT_TAB_ID sa NEODVODZUJE od NAV[0] (to je "eshop", priečinok,
 // nie záložka) — je to PEVNÝ literál, nezávislý od poradia priečinkov v NAV.
 // issue 302 (šéf, cez Discord): "keď štartnem appku, nešlo by to na Na

--- a/apps/web/src/nav.ts
+++ b/apps/web/src/nav.ts
@@ -52,6 +52,14 @@ export interface NavFolder {
   readonly id: string;
   readonly label: string;
   readonly tabs: readonly NavTab[];
+  // issue 343: predvolený stav ZBALENIA priečinka pri prvom vykreslení menu
+  // (nezapamätáva sa medzi návštevami — vždy sa vráti na túto hodnotu po
+  // obnovení stránky, viď `Sidebar.tsx`). `true` = štartuje zbalený. Chýbajúce
+  // pole = rozbalený (pôvodné, nezmenené správanie). Zámerne PER PRIEČINOK
+  // tu v registri, nie ako zoznam mien priamo v `Sidebar.tsx` — pridanie
+  // nového priečinka (napr. "Dôležité" z issue 342) si tak volí vlastný
+  // predvolený stav jedným riadkom, bez zásahu do Sidebar.tsx.
+  readonly defaultCollapsed?: boolean;
 }
 
 // Ľavé menu — VIDITEĽNÉ položky. Pôvodne (issue 57, 2026-07-30) majiteľ chcel
@@ -119,6 +127,10 @@ export const NAV: readonly NavFolder[] = [
   {
     id: "system",
     label: "Systém",
+    // issue 343: šéf (Discord, 11.8.2026) — s toľkými priečinkami/záložkami
+    // menu zaberá celú výšku a treba rolovať; "Systém" sa denne nepoužíva
+    // (na rozdiel od "Eshop"), preto štartuje zbalený.
+    defaultCollapsed: true,
     // issue 192: "Texty e-mailov" patrí sem — je to nastavenie appky, ktoré sa
     // dotýka VŠETKÝCH automatizácií naraz, nie práca s konkrétnymi
     // objednávkami (tá je v Eshope) ani jedna konkrétna automatizácia.
@@ -134,6 +146,9 @@ export const NAV: readonly NavFolder[] = [
   {
     id: "automations",
     label: "Automatizácie",
+    // issue 343: rovnaký dôvod ako "Systém" vyššie — zbalený predvolene, aby
+    // menu nezaberalo celú výšku obrazovky.
+    defaultCollapsed: true,
     // Len tie dve veci, ktoré SKUTOČNE bežia na plán a dajú sa zapnúť/vypnúť
     // (issue 195). Poradie podľa dôležitosti (issue 185, zadanie majiteľa).
     // issue 193: "Odoslané e-maily" patrí SEM — je to prehľad toho, čo

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -466,6 +466,18 @@ tr:last-child td {
 .tab-status {
   flex-shrink: 0;
 }
+/* issue 343: malá bodka na hlavičke ZBALENÉHO priečinka — keď vnútri nie je
+   číselný odznak (ten dostane `.tab-badge`, tá istá trieda ako vnútri), ale
+   niečo má stav (Beží/Zastavené), signalizuje "je tu niečo" bez duplicity
+   čísla. Zmizne po rozbalení priečinka (Sidebar.tsx počíta len kým je
+   zbalený). */
+.folder-dot {
+  flex-shrink: 0;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: var(--fs-brand);
+}
 
 .sidefoot {
   border-top: 1px solid var(--fs-border);

--- a/apps/web/tests/e2e/mail-log.spec.ts
+++ b/apps/web/tests/e2e/mail-log.spec.ts
@@ -21,6 +21,8 @@ test("prehľad odoslaných e-mailov ukáže súhrn, riadky s príjemcom a filtro
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
   // Obrazovka je dostupná z ľavého menu pod "Automatizácie".
+  // issue 343: priečinok "Automatizácie" štartuje zbalený — treba ho najprv rozbaliť.
+  await page.getByRole("button", { name: "Automatizácie" }).click();
   await page.getByRole("button", { name: "Odoslané e-maily" }).click();
   await expect(page.getByTestId("mail-log-table")).toBeVisible();
 

--- a/apps/web/tests/e2e/mail-templates.spec.ts
+++ b/apps/web/tests/e2e/mail-templates.spec.ts
@@ -22,6 +22,8 @@ test("úprava znenia e-mailu: vloženie poľa, živý náhľad, uloženie a vrá
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
   // Obrazovka je dostupná z ľavého menu (nie skrytá za `?tab=`).
+  // issue 343: priečinok "Systém" štartuje zbalený — treba ho najprv rozbaliť.
+  await page.getByRole("button", { name: "Systém" }).click();
   await page.getByRole("button", { name: "Texty e-mailov" }).click();
   await expect(page.getByTestId("mail-template-list")).toBeVisible();
 
@@ -50,6 +52,8 @@ test("úprava znenia e-mailu: vloženie poľa, živý náhľad, uloženie a vrá
 
   // Uložené znenie prežije obnovenie stránky.
   await page.reload();
+  // issue 343: obnovenie stránky = nové vykreslenie, priečinok je opäť zbalený.
+  await page.getByRole("button", { name: "Systém" }).click();
   await page.getByRole("button", { name: "Texty e-mailov" }).click();
   await page.getByTestId("mail-template-pick-order_reminder").click();
   await expect(page.getByTestId("mail-template-subject")).toHaveValue("E2E predmet {{cislo_objednavky}}");

--- a/apps/web/tests/e2e/nav.spec.ts
+++ b/apps/web/tests/e2e/nav.spec.ts
@@ -50,6 +50,18 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s osemnásti
   await expect(page.getByRole("button", { name: "Eshop" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Automatizácie" })).toBeVisible();
 
+  // issue 343: "Systém" a "Automatizácie" štartujú ZBALENÉ (menu by inak
+  // presahovalo výšku obrazovky), "Eshop" ostáva rozbalený — over predvolený
+  // stav priamo po prihlásení, potom oba priečinky rozbaľ, aby zvyšok tohto
+  // testu mohol pokračovať v pôvodnom toku a klikať na ich záložky.
+  await expect(page.getByRole("button", { name: "Eshop" })).toHaveAttribute("aria-expanded", "true");
+  await expect(page.getByRole("button", { name: "Systém" })).toHaveAttribute("aria-expanded", "false");
+  await expect(page.getByRole("button", { name: "Automatizácie" })).toHaveAttribute("aria-expanded", "false");
+  await page.getByRole("button", { name: "Systém" }).click();
+  await page.getByRole("button", { name: "Automatizácie" }).click();
+  await expect(page.getByRole("button", { name: "Systém" })).toHaveAttribute("aria-expanded", "true");
+  await expect(page.getByRole("button", { name: "Automatizácie" })).toHaveAttribute("aria-expanded", "true");
+
   // Presne osemnásť záložiek v CELOM menu.
   await expect(page.locator(".side-nav .tab")).toHaveCount(18);
   await expect(page.getByRole("button", { name: "Sync zo Shoptetu" })).toBeVisible();
@@ -229,6 +241,8 @@ test("Sync zo Shoptetu ukazuje stav katalógu aj objednávok a tlačidlo 'Stiahn
   // issue 302: predvolená obrazovka po prihlásení je odvtedy "Na
   // objednanie", nie "Sync zo Shoptetu" — tento test overuje práve obrazovku
   // "Sync zo Shoptetu", takže tam teraz musí prejsť explicitným klikom.
+  // issue 343: priečinok "Systém" štartuje zbalený — treba ho najprv rozbaliť.
+  await page.getByRole("button", { name: "Systém" }).click();
   await page.getByRole("button", { name: "Sync zo Shoptetu" }).click();
   await expect(page.getByRole("heading", { name: "Sync zo Shoptetu" })).toBeVisible();
 

--- a/apps/web/tests/e2e/restock-events.spec.ts
+++ b/apps/web/tests/e2e/restock-events.spec.ts
@@ -24,6 +24,8 @@ test("história prepnutí ponúkne odkaz na náš produkt z feedu, bez neho sa n
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
+  // issue 343: priečinok "Automatizácie" štartuje zbalený — treba ho najprv rozbaliť.
+  await page.getByRole("button", { name: "Automatizácie" }).click();
   await page.getByRole("button", { name: "Vypredané → Skladom", exact: true }).click();
 
   // Seedovaná udalosť S adresou z feedu (`scripts/e2e-fixtures-restock-events.ts`).

--- a/apps/web/tests/e2e/restock-links.spec.ts
+++ b/apps/web/tests/e2e/restock-links.spec.ts
@@ -20,6 +20,9 @@ const E2E_NAVRHY_ODKAZOV_EMAIL = "e2e-navrhy-odkazov@forestshop.sk";
 // predvyplň-a-potom-Uložiť) — a odznak v ľavom menu (rovnaký generický
 // mechanizmus ako issue 147/267) je vidno HNEĎ po prihlásení, bez toho, aby
 // sa na túto záložku vôbec kliklo.
+// issue 343: priečinok "Automatizácie" (kde táto záložka žije) odteraz
+// štartuje ZBALENÝ — odznak preto potrebuje priečinok najprv rozbaliť,
+// hoci samotnú ZÁLOŽKU test stále neotvára (viď komentár nižšie pri teste).
 
 test("odznak v menu ukazuje počet chýbajúcich odkazov HNEĎ po prihlásení, bez otvorenia záložky; konzola je čistá", async ({
   page,
@@ -42,6 +45,14 @@ test("odznak v menu ukazuje počet chýbajúcich odkazov HNEĎ po prihlásení, 
   // odkazov" vôbec kliklo. Presné číslo je zdieľaný fixtúrový stav (iné
   // spec súbory môžu bežať súbežne) — over PLATNÝ tvar, nie presnú
   // hodnotu, rovnaký princíp ako `nav.spec.ts`'s `nav-badge-orders`.
+  //
+  // issue 343: priečinok "Automatizácie" (a teda aj tento odznak, ktorý žije
+  // NA jeho záložke) štartuje od tohto ticketu ZBALENÝ — odznak je preto
+  // vidno až po rozbalení priečinka, nie hneď po prihlásení ako predtým.
+  // Toto je vedomý dôsledok #343 (zaznamenané aj na tickete), nie regresia
+  // #331 — samotný odznak (počet + hodnota) je nezmenený, mení sa len jeho
+  // predvolená VIDITEĽNOSŤ, presne to, čo znamená "priečinok je zbalený".
+  await page.getByRole("button", { name: "Automatizácie" }).click();
   const odznak = page.getByTestId("nav-badge-restock-links");
   await expect(odznak).toBeVisible();
   await expect(odznak).toHaveText(/^\d+$/);
@@ -65,6 +76,8 @@ test("vypredaný produkt bez linky ponúkne návrh podľa zhody mena + dodávate
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
+  // issue 343: priečinok "Automatizácie" štartuje zbalený — treba ho najprv rozbaliť.
+  await page.getByRole("button", { name: "Automatizácie" }).click();
   await page.getByRole("button", { name: "Vypredané → Skladom: návrhy odkazov" }).click();
   await expect(page.getByRole("heading", { name: "Vypredané → Skladom: návrhy odkazov" })).toBeVisible();
 

--- a/apps/web/tests/e2e/restock-waiting.spec.ts
+++ b/apps/web/tests/e2e/restock-waiting.spec.ts
@@ -23,6 +23,8 @@ test("zoznam pripravených na prepnutie ponúkne odkaz na náš produkt aj k dod
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
   // Obrazovka je dostupná z ľavého menu pod "Automatizácie".
+  // issue 343: priečinok "Automatizácie" štartuje zbalený — treba ho najprv rozbaliť.
+  await page.getByRole("button", { name: "Automatizácie" }).click();
   await page.getByRole("button", { name: "Vypredané → Skladom", exact: true }).click();
   await expect(page.getByTestId("restock-waiting-list")).toBeVisible();
 
@@ -68,6 +70,8 @@ test("rozpor nášho stavu s feedom sa ukáže ako varovanie a kandidáta vylú�
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
+  // issue 343: priečinok "Automatizácie" štartuje zbalený — treba ho najprv rozbaliť.
+  await page.getByRole("button", { name: "Automatizácie" }).click();
   await page.getByRole("button", { name: "Vypredané → Skladom", exact: true }).click();
   await expect(page.getByTestId("restock-waiting-list")).toBeVisible();
 

--- a/apps/web/tests/e2e/supplier-stock.spec.ts
+++ b/apps/web/tests/e2e/supplier-stock.spec.ts
@@ -24,6 +24,8 @@ test("prehľad podľa domény ukáže virginiashop.sk aj upozornenie na vlastný
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
+  // issue 343: priečinok "Systém" štartuje zbalený — treba ho najprv rozbaliť.
+  await page.getByRole("button", { name: "Systém" }).click();
   await page.getByRole("button", { name: "Dodávateľský sklad" }).click();
   await expect(page.getByRole("heading", { name: "Dodávateľský sklad" })).toBeVisible();
 

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -3358,3 +3358,27 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   overenia produkčnej logiky priamo cez appkin skompilovaný `dist/`
   (`docker exec ... node -e 'require("./dist/...")'`, `createDb()` vracia
   `{ pool, db }`, nie `db` priamo).
+
+## Issue 337 (page=1/pageSize=50 na 4 obrazovkách, žiadna ďalšia strana)
+
+- Commits: `c562da1` (shared `useLoadMore.ts` hook), `b2d910b`/`c8013d6`/
+  `0222ac0`/`48abcd3` (zapojenie na CatalogPage/PairingSection/
+  SupplierLinksSection/RestockLinkSuggestionsSection), `9d00b2f` (e2e
+  fixtúra + Playwright dôkaz), `0185840` (catalog.spec.ts count bump),
+  `f8b3d8e`/`2ae1a62`/`5985142`/`55de8a1`/`5a5b4ae` (2 review nálezy:
+  🔴 `reset()` nikdy nevyčistilo `loadingMore`, 🟡 tlačidlo čítalo LIVE
+  `query`/`state` namiesto naposledy odoslaného dopytu — oba RED-verified
+  a opravené vo všetkých 4 obrazovkách).
+- PR #341 (`352045e`), CI aj Deploy zelené (deploy raz zlyhal na známej
+  containerd `failed to Lchown` chybe, vyriešené `docker pull` na dev2 +
+  `gh run rerun --failed`, žiadna zmena kódu).
+- Post-deploy naživo overené (v0.3.0-dev.200): "Eshop → Párovanie
+  produktov" `Nájdených: 2302 (zobrazených prvých 50)` → klik "Načítať
+  ďalšie" → 100 riadkov, "(zobrazených prvých 100)"; "Vypredané → Skladom:
+  návrhy odkazov" (total 34, pod 50) tlačidlo správne chýba. 0 chýb v
+  konzole na oboch.
+- Playbook: `.claude/rules/frontend-design.md` — nový zdieľaný
+  `useLoadMore.ts` hook (budúce obrazovky ho majú znovupoužiť) + 2 nové
+  bullet-y generalizujúce review nálezy (generation-guard musí vyčistiť
+  KAŽDÝ derivovaný stav, "latest ref" trieda platí aj pre onClick
+  handlery, nielen `.then()` mikrotasky).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.200",
+  "version": "0.3.0-dev.201",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.201",
+  "version": "0.3.0-dev.202",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Scope-gate: user-request

## Čo

issue 343 — priečinky "Systém" a "Automatizácie" v ľavom menu teraz štartujú
ZBALENÉ, "Eshop" ostáva rozbalený. Šéf: menu s toľkými záložkami zaberalo
celú výšku obrazovky a treba bolo rolovať.

## Ako

`NavFolder` (`apps/web/src/nav.ts`) má nové voliteľné pole
`defaultCollapsed?: boolean`, nastavené `true` pre "system"/"automations".
`Sidebar.tsx` inicializuje stav zbalenia priečinkov z tohto registra (lazy
`useState` initializer) namiesto prázdneho objektu. Žiadny hardcoded zoznam
mien priečinkov v `Sidebar.tsx` — nový priečinok (napr. "Dôležité" z issue
342) si zvolí vlastný predvolený stav jedným riadkom v `nav.ts`.

**Pamätanie stavu naprieč návštevami:** zámerne sa NEPAMÄTÁ (jednoduchšie
riešenie, zdôvodnené na tickete) — po obnovení stránky sa vždy vráti na
predvolený stav z registra.

## Testy

- Unit: `Sidebar.test.tsx` (nové priečinky s `defaultCollapsed` štartujú
  zbalené/rozbalené podľa poľa), `nav.test.ts` (samotný register).
- E2E: `nav.spec.ts` overuje predvolený stav priamo po prihlásení. Ostatné
  e2e spec súbory, ktoré klikajú priamo na záložku v Systéme/Automatizáciách
  (nie cez `?tab=`), rozbaľujú príslušný priečinok pred klikom.

## Známy vedľajší dôsledok

Odznak počtu na "Vypredané → Skladom: návrhy odkazov" (issue 331, mal byť
vidno hneď po prihlásení bez otvorenia záložky) je teraz vidno až po
rozbalení priečinka "Automatizácie" — priamy dôsledok zbalenia, zaznamenané
na issue 343.

issue 343
