### PR TITLE
E-maily zákazníkom: hlavička/pätička so skutočnými kontaktami, produktová karta s obrázkom namiesto holej adresy (issue 347)

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -1107,3 +1107,44 @@ paths:
   je táto hodnota GARANTOVANE tá istá, čo vyprodukovala AKTUÁLNE
   zobrazené dáta, alebo len "čo je práve rozpísané"? Ak druhé, potrebuje
   vlastný "naposledy odoslané" ref, nie priamy odkaz na live state.
+- **Predvolený stav (zbalené/rozbalené, viditeľné/skryté, ...) per PRIEČINOK/
+  ZÁLOŽKA v ľavom menu patrí do REGISTRA (`nav.ts`), nikdy ako hardcoded
+  zoznam mien/id v `Sidebar.tsx`.** Issue 343 (šéf: "Systém"/"Automatizácie"
+  majú štartovať zbalené) pridalo `NavFolder.defaultCollapsed?: boolean` —
+  `Sidebar.tsx`'s `collapsed` `useState` sa inicializuje LAZY initializerom,
+  ktorý prejde `folders` prop a nastaví `true` len tam, kde je pole
+  nastavené. Žiadna zmena `Sidebar.tsx` pri pridaní ĎALŠIEHO priečinka s
+  vlastným predvoleným stavom (napr. budúce "Dôležité" z issue 342) — presne
+  ten istý princíp ako existujúci `NavTab.wide`/`icon`. Stav sa NEPAMÄTÁ cez
+  `localStorage` (na rozdiel od `rail`, issue 190) — to bolo výslovné
+  rozhodnutie na tickete (šéf žiadal len predvolený stav, nie pamätanie),
+  nie technické obmedzenie; ak by niekedy chcel pamätanie, je to jasne
+  ohraničené samostatné rozšírenie toho istého `useState`.
+- **Pridanie ĽUBOVOĽNÉHO nového viditeľného prvku (text, odznak, pilulka)
+  DOVNÚTRA tlačidla/hlavičky, ktoré existujúce testy vyhľadávajú cez
+  `getByRole("button", {name: "presný text"})`, potrebuje `aria-hidden="true"`
+  na tom novom prvku, INAK sa zmení PRÍSTUPNÝ NÁZOV tlačidla a všetky
+  exact-name dotazy naprieč testami (unit aj e2e) prestanú sedieť.** Issue
+  343 (code review nález, PR 348): pridanie súhrnného odznaku "34" priamo do
+  `.folder-head` tlačidla "Automatizácie" (súčet `badgeCounts` vnútri, keď je
+  priečinok zbalený — rovnaká `.tab-badge` trieda ako existujúce vnútorné
+  odznaky, `.folder-dot` malá bodka keď je súčet 0 ale niečo má
+  `badgeStatus`) by BEZ `aria-hidden` zmenilo accessible name tlačidla z
+  `"Automatizácie"` na niečo ako `"Automatizácie 34"` — rozbilo by to
+  DESIATKY existujúcich `page.getByRole("button", {name: "Automatizácie"})`
+  klikov naprieč e2e sadou. `aria-hidden` na dekoratívnom doplnku ponecháva
+  názov tlačidla presne taký, aký bol; obsah je stále VIZUÁLNE prítomný, len
+  sa nepočíta do accname algoritmu. Overené `getByTestId`, nikdy `getByRole`
+  dotazom, na nový doplnkový prvok samotný. Akýkoľvek FUTURE "pridaj malý
+  vizuálny indikátor do existujúceho pomenovaného tlačidla" potrebuje rovnakú
+  kontrolu: nezmenilo sa accessible name? (over `getByRole` dotazom
+  s PÔVODNÝM textom, nie novým).
+- **Súhrnný ukazovateľ (odznak/bodka) na hlavičke ZBALENÉHO kontajnera sa
+  počíta z TÝCH ISTÝCH props, čo už vykresľujú originály vnútri — žiadny
+  nový sieťový dotaz, žiadny nový stav navyše.** Issue 343: `folderBadgeSum`/
+  `folderHasStatus` v `Sidebar.tsx` sú odvodené priamo z `badgeCounts`/
+  `badgeStatus`, ktoré komponenta už dostáva ako props (issue 147/185) —
+  počítajú sa LEN kým `isCollapsed` (po rozbalení sú vidno originály, žiadna
+  duplicita). Prioritné poradie (číslo > bodka > nič) je explicitné
+  zadanie na tickete, nie odvodené — pri podobnom "súhrn na zbalenom
+  kontajneri" v budúcnosti si vyžiadaj/over presné poradie, nepredpokladaj ho.

--- a/apps/api/drizzle/0045_narrow_leper_queen.sql
+++ b/apps/api/drizzle/0045_narrow_leper_queen.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "shop_product_url" ADD COLUMN "image_url" text;

--- a/apps/api/drizzle/meta/0045_snapshot.json
+++ b/apps/api/drizzle/meta/0045_snapshot.json
@@ -1,0 +1,3037 @@
+{
+  "id": "7df95f74-c44c-4ed4-b0d3-dfc3c13fe617",
+  "prevId": "74eaaf58-9a21-409c-991d-6b25d7d2422a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_code": {
+          "name": "external_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_open_status": {
+      "name": "order_open_status",
+      "schema": "",
+      "columns": {
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Vybavuje sa'"
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop_remark": {
+          "name": "shop_remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shoptet_order_id": {
+          "name": "shoptet_order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_updated_at": {
+          "name": "comment_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_synced_at": {
+          "name": "comment_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_carrier_name": {
+          "name": "shipping_carrier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_price_with_vat": {
+          "name": "total_price_with_vat",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_marked_at": {
+          "name": "claim_marked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_note": {
+          "name": "claim_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_full_name": {
+          "name": "delivery_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_company": {
+          "name": "delivery_company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_street": {
+          "name": "delivery_street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_house_number": {
+          "name": "delivery_house_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_city": {
+          "name": "delivery_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_zip": {
+          "name": "delivery_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_country_name": {
+          "name": "delivery_country_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_name": {
+          "name": "payment_method_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_to_pay": {
+          "name": "price_to_pay",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_link_override": {
+      "name": "product_supplier_link_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_link_override_product_key_product_key_fk": {
+          "name": "product_supplier_link_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_link_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_override": {
+      "name": "product_supplier_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_override_product_key_product_key_fk": {
+          "name": "product_supplier_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing": {
+      "name": "pairing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_url": {
+          "name": "supplier_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "pairing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'navrhnute'"
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pairing_state_idx": {
+          "name": "pairing_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_confirmed_by_idx": {
+          "name": "pairing_confirmed_by_idx",
+          "columns": [
+            {
+              "expression": "confirmed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_variant_code_variant_code_fk": {
+          "name": "pairing_variant_code_variant_code_fk",
+          "tableFrom": "pairing",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pairing_confirmed_by_users_id_fk": {
+          "name": "pairing_confirmed_by_users_id_fk",
+          "tableFrom": "pairing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pairing_variant_code_unique": {
+          "name": "pairing_variant_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pairing_confirmation_ck": {
+          "name": "pairing_confirmation_ck",
+          "value": "(\"pairing\".\"state\" = 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)\n        OR (\"pairing\".\"state\" != 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NULL AND \"pairing\".\"confirmed_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier": {
+      "name": "supplier",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wholesale_base_url": {
+          "name": "wholesale_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_key": {
+          "name": "adapter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_settings": {
+      "name": "posta_uncollected_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_state": {
+      "name": "posta_uncollected_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notify_count": {
+          "name": "notify_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_state": {
+          "name": "terminal_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_settings": {
+      "name": "order_reminder_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_state": {
+      "name": "order_reminder_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_replacement_link": {
+      "name": "nedostupne_replacement_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nedostupne_replacement_link_variant_idx": {
+          "name": "nedostupne_replacement_link_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_state": {
+      "name": "nedostupne_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "nedostupne_email_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nedostupne_state_order_variant_type_uq": {
+          "name": "nedostupne_state_order_variant_type_uq",
+          "columns": [
+            {
+              "expression": "order_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template_history": {
+      "name": "mail_template_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "mail_template_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_template_history_key_idx": {
+          "name": "mail_template_history_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_template_history_changed_by_user_id_users_id_fk": {
+          "name": "mail_template_history_changed_by_user_id_users_id_fk",
+          "tableFrom": "mail_template_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template": {
+      "name": "mail_template",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail_template_updated_by_user_id_users_id_fk": {
+          "name": "mail_template_updated_by_user_id_users_id_fk",
+          "tableFrom": "mail_template",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_log": {
+      "name": "mail_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "mail_log_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_log_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "mail_log_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_log_created_idx": {
+          "name": "mail_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_log_source_created_idx": {
+          "name": "mail_log_source_created_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_log_actor_user_id_users_id_fk": {
+          "name": "mail_log_actor_user_id_users_id_fk",
+          "tableFrom": "mail_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_stock": {
+      "name": "supplier_stock",
+      "schema": "",
+      "columns": {
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "supplier_availability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "supplier_stock_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "supplier_stock_host_idx": {
+          "name": "supplier_stock_host_idx",
+          "columns": [
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "supplier_stock_avail_idx": {
+          "name": "supplier_stock_avail_idx",
+          "columns": [
+            {
+              "expression": "availability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "supplier_stock_link_size_label_pk": {
+          "name": "supplier_stock_link_size_label_pk",
+          "columns": [
+            "link",
+            "size_label"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_event": {
+      "name": "restock_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_link": {
+          "name": "supplier_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_availability_text": {
+          "name": "supplier_availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "supplier_price": {
+          "name": "supplier_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "restock_event_at_idx": {
+          "name": "restock_event_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "restock_event_variant_idx": {
+          "name": "restock_event_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_settings": {
+      "name": "restock_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shop_product_url": {
+      "name": "shop_product_url",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.theme_color": {
+      "name": "theme_color",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "theme_color_updated_by_user_id_users_id_fk": {
+          "name": "theme_color_updated_by_user_id_users_id_fk",
+          "tableFrom": "theme_color",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upozornenie": {
+      "name": "upozornenie",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "upozornenie_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "upozornenie_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedup_key": {
+          "name": "dedup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postponed_until": {
+          "name": "postponed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seen_at": {
+          "name": "seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "upozornenie_dedup_key_uq": {
+          "name": "upozornenie_dedup_key_uq",
+          "columns": [
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "resolved_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upozornenie_resolved_at_idx": {
+          "name": "upozornenie_resolved_at_idx",
+          "columns": [
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upozornenie_dedup_key_idx": {
+          "name": "upozornenie_dedup_key_idx",
+          "columns": [
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upozornenie_resolved_by_user_id_users_id_fk": {
+          "name": "upozornenie_resolved_by_user_id_users_id_fk",
+          "tableFrom": "upozornenie",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "upozornenie_created_by_user_id_users_id_fk": {
+          "name": "upozornenie_created_by_user_id_users_id_fk",
+          "tableFrom": "upozornenie",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dpd_pickup_request": {
+      "name": "dpd_pickup_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "pickup_date": {
+          "name": "pickup_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "dpd_operation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dpd_shipment": {
+      "name": "dpd_shipment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "dpd_operation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parcel_number": {
+          "name": "parcel_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cod_amount": {
+          "name": "cod_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dpd_shipment_order_uq": {
+          "name": "dpd_shipment_order_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dpd_shipment_order_id_order_id_fk": {
+          "name": "dpd_shipment_order_id_order_id_fk",
+          "tableFrom": "dpd_shipment",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne"
+      ]
+    },
+    "public.pairing_state": {
+      "name": "pairing_state",
+      "schema": "public",
+      "values": [
+        "navrhnute",
+        "potvrdene"
+      ]
+    },
+    "public.nedostupne_email_type": {
+      "name": "nedostupne_email_type",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "alternativa"
+      ]
+    },
+    "public.mail_template_action": {
+      "name": "mail_template_action",
+      "schema": "public",
+      "values": [
+        "save",
+        "reset"
+      ]
+    },
+    "public.mail_log_source": {
+      "name": "mail_log_source",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "posta_uncollected",
+        "order_reminder",
+        "supplier_order",
+        "order_merge"
+      ]
+    },
+    "public.mail_log_status": {
+      "name": "mail_log_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.mail_log_trigger": {
+      "name": "mail_log_trigger",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "manual"
+      ]
+    },
+    "public.supplier_availability": {
+      "name": "supplier_availability",
+      "schema": "public",
+      "values": [
+        "available",
+        "unavailable",
+        "unknown"
+      ]
+    },
+    "public.supplier_stock_source": {
+      "name": "supplier_stock_source",
+      "schema": "public",
+      "values": [
+        "json_ld",
+        "meta",
+        "text",
+        "size_list",
+        "none"
+      ]
+    },
+    "public.upozornenie_source": {
+      "name": "upozornenie_source",
+      "schema": "public",
+      "values": [
+        "vlastne",
+        "appka"
+      ]
+    },
+    "public.upozornenie_type": {
+      "name": "upozornenie_type",
+      "schema": "public",
+      "values": [
+        "vlastna_poznamka",
+        "nevyzdvihnuta_zasielka",
+        "vratenie",
+        "vratena_zasielka",
+        "objednavka_visi"
+      ]
+    },
+    "public.dpd_operation_status": {
+      "name": "dpd_operation_status",
+      "schema": "public",
+      "values": [
+        "submitted",
+        "failed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -316,6 +316,13 @@
       "when": 1786139744428,
       "tag": "0044_lovely_franklin_storm",
       "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "7",
+      "when": 1786452370306,
+      "tag": "0045_narrow_leper_queen",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema-shop-feed.ts
+++ b/apps/api/src/db/schema-shop-feed.ts
@@ -22,4 +22,9 @@ export const shopProductUrl = pgTable("shop_product_url", {
   // Čas behu, ktorý riadok naposledy potvrdil — keď feed na strane Shoptetu
   // zamrzne, na obrazovke je vidieť, že mapa starne.
   fetchedAt: timestamp("fetched_at", { withTimezone: true }).notNull(),
+  // issue 347: obrázok produktu (`<g:image_link>`) — appka ho potrebuje na
+  // vykreslenie produktovej karty v e-maile "alternatívy k nedostupnému
+  // tovaru" (`nedostupne/resolve-products.ts`). Nullable rovnako ako
+  // `availability` vyššie — nie každá položka feedu obrázok nesie.
+  imageUrl: text("image_url"),
 });

--- a/apps/api/src/modules/mail-templates/layout.ts
+++ b/apps/api/src/modules/mail-templates/layout.ts
@@ -1,0 +1,45 @@
+import { KONTAKT_EMAIL, KONTAKT_TELEFON, WEB_FORESTSHOP } from "./context.js";
+
+// issue 347 — majiteľ: e-maily zákazníkom vyzerali "hrozne" (holá adresa ako
+// text odkazu, žiadny obrázok, telefón/e-mail stratené vo vete). Táto jedna
+// zdieľaná kostra (hlavička + pätička s KONTAKTAMI oddelenými od tela) sa
+// vkladá okolo obsahu KAŽDEJ šablóny — šablóny (`registry.ts`) do nej vkladajú
+// len svoj obsah, kostra sa needituje. Volaná z DVOCH vykresľovacích miest
+// (`assembleHtml` cez `renderTemplate`, `renderEditedBody`), takže platí pre
+// každý e-mail appky bez toho, aby si to musel pamätať každý odosielateľ.
+// `orders/mail.ts`'s `supplier_order` (jediný ČISTO TEXTOVÝ e-mail,
+// `.claude/rules/mail-templates.md`) sem nikdy nepríde — posiela výhradne
+// `.text`, `assembleHtml`/`wrapEmailHtml` sa naň nikdy nepozerá.
+//
+// `KONTAKT_TELEFON`/`KONTAKT_EMAIL`/`WEB_FORESTSHOP` sú TIE ISTÉ hodnoty, aké
+// dostanú `{{kontakt_telefon}}`/`{{kontakt_email}}`/`{{web_forestshop}}` v
+// tele šablóny (`context.ts`) — pätička nikdy nemôže obsahovať iný telefón/
+// e-mail, než aký appka ponúka ako zástupné pole.
+
+const BRAND = "#2f5233";
+const TEL_HREF = `tel:${KONTAKT_TELEFON.replaceAll(" ", "")}`;
+
+export function wrapEmailHtml(bodyHtml: string): string {
+  return [
+    "<!DOCTYPE html>",
+    "<html>",
+    '  <body style="margin:0;padding:24px 12px;background:#f4f1ec;font-family: Arial, sans-serif;">',
+    '    <table role="presentation" width="100%" cellpadding="0" cellspacing="0"><tr><td align="center">',
+    '    <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="width:100%;max-width:600px;background:#ffffff;border-radius:8px;overflow:hidden;">',
+    `      <tr><td style="padding:18px 32px;background:${BRAND};">`,
+    `        <a href="${WEB_FORESTSHOP}" style="font-size:20px;font-weight:bold;color:#ffffff;text-decoration:none;">Forestshop.sk</a>`,
+    "      </td></tr>",
+    '      <tr><td style="padding:28px 32px;font-size:16px;color:#333;">',
+    bodyHtml,
+    "      </td></tr>",
+    '      <tr><td style="padding:20px 32px;border-top:1px solid #e5e0d8;font-size:13px;color:#666;">',
+    `        <div style="margin-bottom:4px;">Tel.: <a href="${TEL_HREF}" style="color:${BRAND};text-decoration:none;">${KONTAKT_TELEFON}</a></div>`,
+    `        <div style="margin-bottom:4px;">E-mail: <a href="mailto:${KONTAKT_EMAIL}" style="color:${BRAND};text-decoration:none;">${KONTAKT_EMAIL}</a></div>`,
+    `        <div><a href="${WEB_FORESTSHOP}" style="color:${BRAND};text-decoration:none;">www.forestshop.sk</a></div>`,
+    "      </td></tr>",
+    "    </table>",
+    "    </td></tr></table>",
+    "  </body>",
+    "</html>",
+  ].join("\n");
+}

--- a/apps/api/src/modules/mail-templates/render.test.ts
+++ b/apps/api/src/modules/mail-templates/render.test.ts
@@ -11,6 +11,16 @@ const CTX: TemplateContext = {
   odkaz_sledovanie: { kind: "link", url: "https://tandt.posta.sk/x", label: "https://tandt.posta.sk/x" },
   zoznam_nahrad: { kind: "list", textPrefix: "- ", items: [{ label: "Podkolienky BOBR", url: "https://e.sk/bobr" }] },
   prazdny_zoznam: { kind: "list", items: [] },
+  // issue 347: zoznam s produktovou kartou — jeden prvok má obrázok+cenu,
+  // druhý (nedohľadaný odkaz) ich nemá, aby test overil aj miešaný zoznam.
+  zoznam_karta: {
+    kind: "list",
+    textPrefix: "- ",
+    items: [
+      { label: "Nohavice FOREST 1003", url: "https://e.sk/nohavice", imageUrl: "https://cdn.e.sk/nohavice.jpg", priceText: "64,90 €" },
+      { label: "https://e.sk/nedohladany", url: "https://e.sk/nedohladany" },
+    ],
+  },
 };
 
 const ALLOWED = new Set(Object.keys(CTX));
@@ -82,15 +92,77 @@ describe("renderTemplate — podmienky", () => {
 });
 
 describe("renderTemplate — zoznam", () => {
-  it("v HTML je odrážkový zoznam s odkazmi, v texte riadky s predponou", () => {
+  it("v HTML je odrážkový zoznam s odkazmi (bez obrázka — nezmenené správanie)", () => {
     const out = renderTemplate({ subject: "x", body: "Náhrady:\n{{zoznam_nahrad}}" }, CTX);
     expect(out.html).toContain('<li><a href="https://e.sk/bobr" target="_blank">Podkolienky BOBR</a></li>');
-    expect(out.text).toBe("Náhrady:\n- Podkolienky BOBR (https://e.sk/bobr)");
+  });
+
+  // issue 347: názov a adresa idú na SAMOSTATNÉ riadky — nikdy "názov (url)",
+  // aby text v poštovom klientovi nikdy neukázal adresu zdvojenú v zátvorke.
+  it("v texte idú názov a adresa na samostatné riadky, nikdy adresa v zátvorke", () => {
+    const out = renderTemplate({ subject: "x", body: "Náhrady:\n{{zoznam_nahrad}}" }, CTX);
+    expect(out.text).toBe("Náhrady:\n- Podkolienky BOBR\nhttps://e.sk/bobr");
+    expect(out.text).not.toContain("(https://e.sk/bobr)");
   });
 
   it("prázdny zoznam nevyrobí prázdny <ul>", () => {
     const out = renderTemplate({ subject: "x", body: "A\n{{prazdny_zoznam}}" }, CTX);
     expect(out.html).not.toContain("<ul>");
+  });
+});
+
+// issue 347: majiteľov nahlásený bug — odkaz v e-maile mal ako text celú
+// adresu (zdvojenú), žiadny obrázok produktu, kontakty stratené vo vete.
+describe("renderTemplate — produktová karta v zozname (issue 347)", () => {
+  it("prvok s obrázkom sa vykreslí ako karta (obrázok + klikací NÁZOV, nikdy holá adresa ako text odkazu)", () => {
+    const out = renderTemplate({ subject: "x", body: "Ponúkame:\n{{zoznam_karta}}" }, CTX);
+    expect(out.html).toContain('<img src="https://cdn.e.sk/nohavice.jpg"');
+    expect(out.html).toContain('<a href="https://e.sk/nohavice"');
+    expect(out.html).toContain(">Nohavice FOREST 1003<");
+    expect(out.html).toContain("64,90");
+    // odkaz na produkt sa nesmie ukázať ako holý text URL (pôvodný bug)
+    expect(out.html).not.toContain(">https://e.sk/nohavice<");
+  });
+
+  it('karta má tlačidlo "Zobraziť produkt"', () => {
+    const out = renderTemplate({ subject: "x", body: "{{zoznam_karta}}" }, CTX);
+    expect(out.html).toContain("Zobraziť produkt");
+  });
+
+  it("prvok BEZ obrázka (nedohľadaný odkaz) v tom istom zozname sa vykreslí bez <img>, ale nezhodí zvyšok karty", () => {
+    const out = renderTemplate({ subject: "x", body: "{{zoznam_karta}}" }, CTX);
+    // druhý prvok nemá imageUrl — nesmie vyrobiť <img src="undefined">
+    expect(out.html).not.toContain("undefined");
+  });
+
+  it("zoznam s obrázkom sa v HTML nevykreslí ako <ul><li> (karta nahrádza zoznam)", () => {
+    const out = renderTemplate({ subject: "x", body: "{{zoznam_karta}}" }, CTX);
+    expect(out.html).not.toContain("<li>");
+  });
+
+  it("v texte je pri prvku s cenou aj cena, adresa vždy na vlastnom riadku", () => {
+    const out = renderTemplate({ subject: "x", body: "{{zoznam_karta}}" }, CTX);
+    expect(out.text).toContain("Nohavice FOREST 1003");
+    expect(out.text).toContain("64,90");
+    expect(out.text).toContain("https://e.sk/nohavice");
+    expect(out.text).not.toContain("(https://e.sk/nohavice)");
+  });
+});
+
+// issue 347: spoločná kostra — hlavička + pätička s kontaktami, na VŠETKÝCH
+// e-mailoch appky (kontakty dnes vedeli byť stratené vo vete).
+describe("renderTemplate — spoločná HTML kostra (issue 347)", () => {
+  it("HTML má hlavičku s odkazom na Forestshop.sk", () => {
+    const out = renderTemplate({ subject: "x", body: "Ahoj." }, CTX);
+    expect(out.html).toContain(">Forestshop.sk<");
+    expect(out.html).toContain('href="https://www.forestshop.sk"');
+  });
+
+  it("HTML má oddelenú pätičku s klikacím telefónom, e-mailom a webom — nezávisle od obsahu tela šablóny", () => {
+    const out = renderTemplate({ subject: "x", body: "Text bez akejkoľvek zmienky o kontaktoch." }, CTX);
+    expect(out.html).toContain('href="tel:+421903670766"');
+    expect(out.html).toContain('href="mailto:eshop@forestshop.sk"');
+    expect(out.html).toContain("+421 903 670 766");
   });
 });
 
@@ -144,6 +216,16 @@ describe("renderEditedBody — jednorazová ručná úprava (issue 277)", () => 
     expect(out.html).toContain("<p>Dobrý deň,<br>\n      ešte dopĺňam vetu.</p>");
     expect(out.html).toContain("<p>S pozdravom,<br>\n      obchod</p>");
     expect(out.text).toBe("Dobrý deň,\nešte dopĺňam vetu.\n\nS pozdravom,\nobchod");
+  });
+
+  // issue 347: ručne upravený text (okno náhľadu pred odoslaním) dostane
+  // TÚ ISTÚ spoločnú kostru (hlavička/pätička) ako šablónou vygenerovaný
+  // e-mail — kostra sa aplikuje na oboch vykresľovacích cestách.
+  it("dostane rovnakú hlavičku/pätičku ako šablónou vygenerovaný e-mail (issue 347)", () => {
+    const out = renderEditedBody("Ahoj.");
+    expect(out.html).toContain(">Forestshop.sk<");
+    expect(out.html).toContain('href="tel:+421903670766"');
+    expect(out.html).toContain('href="mailto:eshop@forestshop.sk"');
   });
 
   it("HTML napísané obsluhou sa ESCAPUJE, nikdy sa nestane surovou značkou", () => {

--- a/apps/api/src/modules/mail-templates/render.ts
+++ b/apps/api/src/modules/mail-templates/render.ts
@@ -10,9 +10,21 @@
 //   **tučné**
 //   prázdny riadok = nový odstavec, jednoduchý riadok = zalomenie
 
+import { wrapEmailHtml } from "./layout.js";
+
 export interface TemplateListItem {
   readonly label: string;
   readonly url?: string;
+  // issue 347: keď je prítomný, `assembleHtml` vykreslí CELÝ zoznam (nie len
+  // tento prvok) ako produktovú kartu namiesto <ul><li> — obrázok produktu z
+  // feedu pre porovnávače (`shop-feed/parse.ts`'s `<g:image_link>`). Bez
+  // neho sa správanie zoznamu NEMENÍ (napr. `orders/mail.ts`'s
+  // `zoznam_poloziek`, ktorý obrázok nikdy nemá).
+  readonly imageUrl?: string;
+  // issue 347: voliteľná, už NAFORMÁTOVANÁ cena ("64,90 €") — appka tu
+  // nikdy nepočíta menu/desatinné miesta, len zobrazí to, čo jej dal
+  // volajúci (`nedostupne/resolve-products.ts`).
+  readonly priceText?: string;
 }
 
 export type TemplateValue =
@@ -173,6 +185,42 @@ function toPieces(nodes: readonly Node[], ctx: TemplateContext, mode: Mode): Pie
   return out;
 }
 
+// issue 347: zoznam, kde AKÝKOĽVEK prvok nesie `imageUrl` (produktová
+// náhrada s obrázkom z feedu), sa v HTML vykreslí ako "karta" namiesto
+// obyčajného <ul><li> — obrázok, klikací NÁZOV (nikdy holá adresa ako text
+// odkazu), voliteľná cena a tlačidlo. Prvok BEZ obrázka v tom istom zozname
+// (nedohľadaný odkaz) dostane rovnaký rám bez <img>, nikdy sa nezalomí.
+function productCardHtml(item: TemplateListItem): string {
+  const label = htmlEscape(item.label);
+  const hasUrl = item.url !== undefined && item.url !== "";
+  const url = hasUrl ? htmlEscape(item.url as string) : undefined;
+  const nameHtml =
+    url === undefined
+      ? label
+      : `<a href="${url}" target="_blank" style="color:#2f5233;text-decoration:none;font-weight:bold;">${label}</a>`;
+  const priceHtml =
+    item.priceText !== undefined && item.priceText !== ""
+      ? `<div style="margin-top:4px;color:#555;">${htmlEscape(item.priceText)}</div>`
+      : "";
+  const hasImage = item.imageUrl !== undefined && item.imageUrl !== "";
+  const imageCell = hasImage
+    ? `        <td width="88" style="padding:12px;vertical-align:top;"><img src="${htmlEscape(item.imageUrl as string)}" width="72" height="72" style="display:block;border-radius:4px;object-fit:cover;" alt="${label}"></td>\n`
+    : "";
+  const buttonHtml =
+    url === undefined
+      ? ""
+      : `<div style="margin-top:10px;"><a href="${url}" target="_blank" style="display:inline-block;padding:6px 14px;background:#2f5233;color:#ffffff;border-radius:4px;text-decoration:none;font-size:13px;">Zobraziť produkt →</a></div>`;
+  return [
+    '    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin:10px 0;border:1px solid #e5e0d8;border-radius:6px;">',
+    "      <tr>",
+    imageCell + `        <td style="padding:12px 16px;vertical-align:top;font-size:15px;">`,
+    `          ${nameHtml}${priceHtml}${buttonHtml}`,
+    "        </td>",
+    "      </tr>",
+    "    </table>",
+  ].join("\n");
+}
+
 function assembleHtml(pieces: readonly Piece[]): string {
   const blocks: string[] = [];
   let current: string[] = [];
@@ -197,25 +245,34 @@ function assembleHtml(pieces: readonly Piece[]): string {
     else if (piece.p === "par") flush();
     else {
       flush();
-      const items = piece.items
-        .map((i) => {
-          const label = htmlEscape(i.label);
-          const shown = i.url === undefined || i.url === "" ? label : `<a href="${htmlEscape(i.url)}" target="_blank">${label}</a>`;
-          return `      <li>${shown}</li>`;
-        })
-        .join("\n");
-      if (items !== "") blocks.push(`    <ul>\n${items}\n    </ul>`);
+      const hasCards = piece.items.some((i) => i.imageUrl !== undefined && i.imageUrl !== "");
+      if (hasCards) {
+        const cards = piece.items.map((i) => productCardHtml(i)).join("\n");
+        if (cards !== "") blocks.push(cards);
+      } else {
+        const items = piece.items
+          .map((i) => {
+            const label = htmlEscape(i.label);
+            const shown = i.url === undefined || i.url === "" ? label : `<a href="${htmlEscape(i.url)}" target="_blank">${label}</a>`;
+            return `      <li>${shown}</li>`;
+          })
+          .join("\n");
+        if (items !== "") blocks.push(`    <ul>\n${items}\n    </ul>`);
+      }
     }
   }
   flush();
-  return [
-    "<!DOCTYPE html>",
-    "<html>",
-    '  <body style="font-family: Arial, sans-serif; font-size: 16px; color: #333;">',
-    ...blocks,
-    "  </body>",
-    "</html>",
-  ].join("\n");
+  return wrapEmailHtml(blocks.join("\n"));
+}
+
+// issue 347: keď prvok nesie `url`, jeho adresa ide na SAMOSTATNÝ riadok pod
+// názvom (nikdy "názov (url)") — majiteľov nahlásený bug ("odkaz má ako text
+// celú adresu... zdvojene"). Cena (`priceText`), ak je prítomná, sa pripojí
+// za názov na tom istom riadku.
+function textListItemLine(item: TemplateListItem, prefix: string): string {
+  const priceSuffix = item.priceText !== undefined && item.priceText !== "" ? ` — ${item.priceText}` : "";
+  const head = `${prefix}${item.label}${priceSuffix}`;
+  return item.url === undefined || item.url === "" ? head : `${head}\n${item.url}`;
 }
 
 function assembleText(pieces: readonly Piece[]): string {
@@ -232,9 +289,12 @@ function assembleText(pieces: readonly Piece[]): string {
     else if (piece.p === "br") current.push("\n");
     else if (piece.p === "par") flush();
     else {
-      const lines = piece.items
-        .map((i) => `${piece.textPrefix}${i.label}${i.url === undefined || i.url === "" ? "" : ` (${i.url})`}`)
-        .join("\n");
+      // Prvok s adresou dostane vlastný dvojriadok (názov + adresa) — medzi
+      // TAKÝMITO prvkami je prázdny riadok navyše čitateľnejší; obyčajný
+      // jednoriadkový zoznam (napr. `orders/mail.ts`'s `zoznam_poloziek`,
+      // žiadny prvok nemá `url`) ostáva PRESNE ako predtým.
+      const hasAnyUrl = piece.items.some((i) => i.url !== undefined && i.url !== "");
+      const lines = piece.items.map((i) => textListItemLine(i, piece.textPrefix)).join(hasAnyUrl ? "\n\n" : "\n");
       if (lines !== "") current.push(lines);
     }
   }
@@ -286,14 +346,7 @@ export function renderEditedBody(text: string): RenderedEditedBody {
     .map((p) => p.trim())
     .filter((p) => p !== "");
   const htmlParagraphs = paragraphs.map((p) => `    <p>${htmlEscape(p).replaceAll("\n", "<br>\n      ")}</p>`);
-  const html = [
-    "<!DOCTYPE html>",
-    "<html>",
-    '  <body style="font-family: Arial, sans-serif; font-size: 16px; color: #333;">',
-    ...htmlParagraphs,
-    "  </body>",
-    "</html>",
-  ].join("\n");
+  const html = wrapEmailHtml(htmlParagraphs.join("\n"));
   return { html, text: paragraphs.join("\n\n") };
 }
 

--- a/apps/api/src/modules/mail-templates/render.ts
+++ b/apps/api/src/modules/mail-templates/render.ts
@@ -193,7 +193,7 @@ function toPieces(nodes: readonly Node[], ctx: TemplateContext, mode: Mode): Pie
 function productCardHtml(item: TemplateListItem): string {
   const label = htmlEscape(item.label);
   const hasUrl = item.url !== undefined && item.url !== "";
-  const url = hasUrl ? htmlEscape(item.url as string) : undefined;
+  const url = hasUrl ? htmlEscape(item.url) : undefined;
   const nameHtml =
     url === undefined
       ? label
@@ -204,7 +204,7 @@ function productCardHtml(item: TemplateListItem): string {
       : "";
   const hasImage = item.imageUrl !== undefined && item.imageUrl !== "";
   const imageCell = hasImage
-    ? `        <td width="88" style="padding:12px;vertical-align:top;"><img src="${htmlEscape(item.imageUrl as string)}" width="72" height="72" style="display:block;border-radius:4px;object-fit:cover;" alt="${label}"></td>\n`
+    ? `        <td width="88" style="padding:12px;vertical-align:top;"><img src="${htmlEscape(item.imageUrl)}" width="72" height="72" style="display:block;border-radius:4px;object-fit:cover;" alt="${label}"></td>\n`
     : "";
   const buttonHtml =
     url === undefined

--- a/apps/api/src/modules/mail-templates/samples.ts
+++ b/apps/api/src/modules/mail-templates/samples.ts
@@ -3,6 +3,7 @@ import type { Database } from "../../db/client.js";
 import { orders, products, variants } from "../../db/schema.js";
 import { log } from "../../logger.js";
 import { listReplacementLinksByVariant } from "../nedostupne/replacement-links.js";
+import { resolveReplacementProducts, type ResolvedReplacementProduct } from "../nedostupne/resolve-products.js";
 import { itemsWord } from "../orders/pluralize.js";
 import { trackingLink } from "../posta-uncollected/constants.js";
 import { textValue } from "./context.js";
@@ -43,10 +44,13 @@ async function productSample(db: Database): Promise<{ name: string; code: string
 // issue 238: vzorka pre "zoznam_nahrad" teraz vychádza z majiteľových
 // RUČNE vložených odkazov (`nedostupne_replacement_link`), nie z pôvodného
 // automatického `product.relatedCodes` návrhu — ten istý variant, ktorého
-// meno použije `nazov_tovaru` vyššie.
-async function replacementLinkSample(db: Database, variantCode: string): Promise<readonly string[]> {
+// meno použije `nazov_tovaru` vyššie. issue 347: náhľad dostáva TÚ ISTÚ
+// dohľadanú kartu (názov/obrázok/cena), akú uvidí zákazník — inak by náhľad
+// v editore šablóny ukazoval holé odkazy, kým skutočný e-mail už karty.
+async function replacementProductSample(db: Database, variantCode: string): Promise<readonly ResolvedReplacementProduct[]> {
   const map = await listReplacementLinksByVariant(db, [variantCode]);
-  return (map.get(variantCode) ?? []).map((link) => link.url);
+  const urls = (map.get(variantCode) ?? []).map((link) => link.url);
+  return resolveReplacementProducts(db, urls);
 }
 
 async function supplierSample(db: Database): Promise<string | null> {
@@ -73,12 +77,17 @@ export async function previewContext(db: Database, key: MailTemplateKey): Promis
         const product = await productSample(db);
         if (product !== null) {
           ctx["nazov_tovaru"] = textValue(product.name);
-          const links = await replacementLinkSample(db, product.code);
-          if (links.length > 0) {
+          const products = await replacementProductSample(db, product.code);
+          if (products.length > 0) {
             ctx["zoznam_nahrad"] = {
               kind: "list",
               textPrefix: "- ",
-              items: links.map((url) => ({ label: url, url })),
+              items: products.map((p) => ({
+                label: p.label,
+                url: p.url,
+                ...(p.imageUrl !== undefined ? { imageUrl: p.imageUrl } : {}),
+                ...(p.priceText !== undefined ? { priceText: p.priceText } : {}),
+              })),
             };
           }
         }

--- a/apps/api/src/modules/nedostupne/logic.test.ts
+++ b/apps/api/src/modules/nedostupne/logic.test.ts
@@ -30,13 +30,15 @@ describe("buildUnavailableEmail", () => {
 });
 
 // issue 238: automatický návrh (`product.relatedCodes` → `buildAlternatives`)
-// je preč — `buildAlternativeEmail` teraz dostáva PRIAMO majiteľove ručne
-// vložené odkazy (holé URL, appka k nim nepozná žiadny názov/kód), preto sa
-// v e-maile zobrazí samotný odkaz ako klikateľný text (`label === url`).
+// je preč — `buildAlternativeEmail` dostáva odkazy DOHĽADANÉ proti katalógu
+// (`resolve-products.ts`'s `ResolvedReplacementProduct` — `send.ts` volá
+// `resolveReplacementProducts` PRED touto funkciou). Keď sa zhoda nenašla,
+// dohľadávanie samo vráti `label === url` (appka nepozná názov) — presne to
+// isté, čo tu simulujú prvé testy priamym zadaním takého tvaru.
 describe("buildAlternativeEmail", () => {
-  it("s ručnými odkazmi vypíše KAŽDÝ z nich (label je samotná URL, appka nepozná názov)", () => {
+  it("nedohľadaný odkaz (label === url, appka nepozná názov) vypíše samotnú URL ako klikateľný text", () => {
     const built = buildAlternativeEmail(ALTERNATIVA, "Ján Zákazník", "Nohavice FOREST 1003", [
-      "https://www.forestshop.sk/nahradny-produkt/",
+      { url: "https://www.forestshop.sk/nahradny-produkt/", label: "https://www.forestshop.sk/nahradny-produkt/" },
     ]);
     expect(built.subject).toBe("Alternatívy k vášmu tovaru — Forestshop.sk");
     expect(built.html).toContain("Nohavice FOREST 1003");
@@ -44,10 +46,30 @@ describe("buildAlternativeEmail", () => {
     expect(built.text).toContain("https://www.forestshop.sk/nahradny-produkt/");
   });
 
+  // issue 347: DOHĽADANÝ odkaz nesie skutočný NÁZOV, cenu a obrázok — v
+  // HTML sa smie ukázať názov ako klikací text, NIKDY holá adresa (majiteľov
+  // nahlásený bug).
+  it("dohľadaný odkaz vypíše NÁZOV produktu ako klikací text, nikdy holú adresu; ukáže aj cenu a obrázok", () => {
+    const built = buildAlternativeEmail(ALTERNATIVA, "Ján Zákazník", "Nohavice FOREST 1003", [
+      {
+        url: "https://www.forestshop.sk/nahradny-produkt/",
+        label: "Podkolienky BOBR",
+        imageUrl: "https://cdn.example.sk/bobr.jpg",
+        priceText: "12,50 €",
+      },
+    ]);
+    expect(built.html).toContain(">Podkolienky BOBR<");
+    expect(built.html).not.toContain(">https://www.forestshop.sk/nahradny-produkt/<");
+    expect(built.html).toContain('<img src="https://cdn.example.sk/bobr.jpg"');
+    expect(built.html).toContain("12,50");
+    expect(built.text).toContain("Podkolienky BOBR");
+    expect(built.text).toContain("https://www.forestshop.sk/nahradny-produkt/");
+  });
+
   it("viac odkazov naraz — každý dostane svoju položku v zozname", () => {
     const built = buildAlternativeEmail(ALTERNATIVA, "Ján", "Bunda", [
-      "https://www.forestshop.sk/a/",
-      "https://www.forestshop.sk/b/",
+      { url: "https://www.forestshop.sk/a/", label: "https://www.forestshop.sk/a/" },
+      { url: "https://www.forestshop.sk/b/", label: "https://www.forestshop.sk/b/" },
     ]);
     expect(built.html).toContain("https://www.forestshop.sk/a/");
     expect(built.html).toContain("https://www.forestshop.sk/b/");
@@ -60,7 +82,9 @@ describe("buildAlternativeEmail", () => {
   });
 
   it("HTML-escapuje názov produktu (odkazy samotné sú validované ako http(s) URL na HTTP hranici, nie voľný text)", () => {
-    const built = buildAlternativeEmail(ALTERNATIVA, "Ján", "<i>Prod</i>", ["https://www.forestshop.sk/x/"]);
+    const built = buildAlternativeEmail(ALTERNATIVA, "Ján", "<i>Prod</i>", [
+      { url: "https://www.forestshop.sk/x/", label: "https://www.forestshop.sk/x/" },
+    ]);
     expect(built.html).not.toContain("<i>Prod</i>");
     expect(built.html).toContain("&lt;i&gt;Prod&lt;/i&gt;");
   });

--- a/apps/api/src/modules/nedostupne/logic.ts
+++ b/apps/api/src/modules/nedostupne/logic.ts
@@ -1,5 +1,6 @@
 import { globalContext, textValue } from "../mail-templates/context.js";
 import { renderTemplate, type MailTemplateText, type RenderedEmail } from "../mail-templates/render.js";
+import type { ResolvedReplacementProduct } from "./resolve-products.js";
 
 // Čistá logika (žiadna DB, žiadna sieť). Znenie e-mailu už NIE je natvrdo tu —
 // issue 192 ho presunulo do upraviteľných šablón (`mail-templates/registry.ts`
@@ -23,15 +24,18 @@ export function buildUnavailableEmail(template: MailTemplateText, customerName: 
 /** E-mail s návrhom náhrady — produkt je nedostupný + majiteľove RUČNE
  * vložené odkazy na náhradné produkty (issue 238 — nahrádza pôvodný
  * automatický návrh z `product.relatedCodes`, ktorý majiteľ zamietol ako
- * "súvisiace produkty, nie náhrady"). Appka k ručne vloženému odkazu nepozná
- * žiadny názov/kód, preto je `label` samotná URL (klikateľný text = presne
- * to, čo majiteľ vložil). Prázdny zoznam náhrad je v šablóne podmienka
+ * "súvisiace produkty, nie náhrady"). Volajúci (`send.ts`) ich PRED touto
+ * funkciou dohľadá proti katalógu (`resolve-products.ts`'s
+ * `resolveReplacementProducts`, issue 347) — keď sa zhoda nenájde, dohľadanie
+ * samo vráti `label === url` (appka nepozná názov), táto funkcia to
+ * nerozlišuje, len prenesie `label`/`url`/`imageUrl`/`priceText` do
+ * šablóny. Prázdny zoznam náhrad je v šablóne podmienka
  * (`{{#ak zoznam_nahrad}}`), nie osobitná vetva v kóde. */
 export function buildAlternativeEmail(
   template: MailTemplateText,
   customerName: string,
   itemName: string,
-  replacementUrls: readonly string[],
+  replacementProducts: readonly ResolvedReplacementProduct[],
 ): BuiltNedostupneEmail {
   return renderTemplate(template, {
     ...globalContext(),
@@ -40,7 +44,12 @@ export function buildAlternativeEmail(
     zoznam_nahrad: {
       kind: "list",
       textPrefix: "- ",
-      items: replacementUrls.map((url) => ({ label: url, url })),
+      items: replacementProducts.map((p) => ({
+        label: p.label,
+        url: p.url,
+        ...(p.imageUrl !== undefined ? { imageUrl: p.imageUrl } : {}),
+        ...(p.priceText !== undefined ? { priceText: p.priceText } : {}),
+      })),
     },
   });
 }

--- a/apps/api/src/modules/nedostupne/resolve-products.ts
+++ b/apps/api/src/modules/nedostupne/resolve-products.ts
@@ -1,0 +1,101 @@
+import { eq, sql } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { shopProductUrl, variants } from "../../db/schema.js";
+
+// issue 347: majiteľove RUČNE vložené odkazy náhrad (`replacement-links.ts`)
+// nesú LEN url — appka k nim nepozná názov/kód (issue 238's zámerné
+// rozhodnutie). E-mailová karta ("Radi by sme vám ponúkli tieto alternatívne
+// produkty") ale potrebuje NÁZOV, OBRÁZOK a CENU. Namiesto duplikovania
+// týchto dát (majiteľ by ich musel zadávať ručne pri KAŽDOM vloženom odkaze)
+// appka spätne dohľadá zhodu proti tomu, čo UŽ MÁ — `shop_product_url`
+// (adresa + obrázok z feedu pre porovnávače) a `variants` (názov + cena z
+// katalógu). Keď sa zhoda nenájde, padá sa PRESNE na pôvodné správanie
+// (`label = url`, žiadny obrázok/cena) — nikdy sa nič nedohaduje/nefabrikuje,
+// rovnaká disciplína ako `nedostupne.md`'s "nikdy nevyrábať adresu odhadom".
+
+export interface ResolvedReplacementProduct {
+  readonly url: string;
+  readonly label: string;
+  readonly imageUrl?: string;
+  readonly priceText?: string;
+}
+
+/** Adresa BEZ query stringu — majiteľ zvyčajne vloží bázovú adresu produktu
+ * (bez `?variantId=`), feed ju nesie S `?variantId=…`. Porovnanie na tejto
+ * úrovni nájde zhodu bez ohľadu na to, ktorá strana query string nesie. */
+function basePath(url: string): string {
+  const qIdx = url.indexOf("?");
+  return (qIdx === -1 ? url : url.slice(0, qIdx)).trim();
+}
+
+/** Appka nikdy nepočíta menu/desatinné miesta pre zákazníka inak, než ako ich
+ * ukazuje katalóg — `variant.price` je `numeric` stĺpec (string, 2 desatinné
+ * miesta, `.claude/rules/database.md`). `null` = cenu nemáme, karta ju
+ * jednoducho vynechá (nikdy neukáže "0,00 €" ani odhad). */
+function formatPriceText(price: string | null, currency: string | null): string | undefined {
+  if (price === null) return undefined;
+  const amount = Number(price);
+  if (!Number.isFinite(amount)) return undefined;
+  const formatted = amount.toFixed(2).replace(".", ",");
+  return currency === null || currency === "" || currency === "EUR" ? `${formatted} €` : `${formatted} ${currency}`;
+}
+
+async function findMatchingCode(db: Pick<Database, "select">, trimmedUrl: string): Promise<{ code: string; imageUrl: string | null } | null> {
+  const [exact] = await db
+    .select({ code: shopProductUrl.code, imageUrl: shopProductUrl.imageUrl })
+    .from(shopProductUrl)
+    .where(eq(shopProductUrl.url, trimmedUrl))
+    .limit(1);
+  if (exact !== undefined) return exact;
+
+  // Žiadna PRESNÁ zhoda — skús zhodu podľa CESTY (bez query stringu), keď
+  // majiteľ vložil/feed nesie inú variáciu tej istej adresy (napr. iná
+  // veľkosť produktu — rovnaký produkt, iný `?variantId=`). Determinizmus
+  // pri viacerých zhodách: najmenší kód.
+  const base = basePath(trimmedUrl);
+  if (base === "") return null;
+  const [byPath] = await db
+    .select({ code: shopProductUrl.code, imageUrl: shopProductUrl.imageUrl })
+    .from(shopProductUrl)
+    .where(sql`split_part(${shopProductUrl.url}, '?', 1) = ${base}`)
+    .orderBy(shopProductUrl.code)
+    .limit(1);
+  return byPath ?? null;
+}
+
+async function resolveOne(db: Pick<Database, "select">, url: string): Promise<ResolvedReplacementProduct> {
+  const trimmed = url.trim();
+  if (trimmed === "") return { url, label: url };
+
+  const match = await findMatchingCode(db, trimmed);
+  if (match === null) return { url, label: url };
+
+  const [variant] = await db
+    .select({ name: variants.name, price: variants.price, currency: variants.currency })
+    .from(variants)
+    .where(eq(variants.code, match.code))
+    .limit(1);
+  // Adresu vo feede sme našli, ale variant medzičasom zmizol z katalógu
+  // (zriedkavé, ale nie nemožné) — padni na pôvodné správanie, nikdy
+  // nevyrábaj kartu bez názvu.
+  if (variant === undefined) return { url, label: url };
+
+  const priceText = formatPriceText(variant.price, variant.currency);
+  return {
+    url,
+    label: variant.name,
+    ...(match.imageUrl !== null ? { imageUrl: match.imageUrl } : {}),
+    ...(priceText !== undefined ? { priceText } : {}),
+  };
+}
+
+/** Zachováva PORADIE vstupu (rovnaké poradie, v akom majiteľ odkazy vložil,
+ * `replacement-links.ts`'s `listReplacementLinksForVariant`). */
+export async function resolveReplacementProducts(
+  db: Pick<Database, "select">,
+  urls: readonly string[],
+): Promise<readonly ResolvedReplacementProduct[]> {
+  const out: ResolvedReplacementProduct[] = [];
+  for (const url of urls) out.push(await resolveOne(db, url));
+  return out;
+}

--- a/apps/api/src/modules/nedostupne/send.ts
+++ b/apps/api/src/modules/nedostupne/send.ts
@@ -11,6 +11,7 @@ import { NEDOSTUPNE_SEND_LOCK_KEY, TYPE_ALTERNATIVE, type NedostupneEmailType } 
 import { renderEditedBody } from "../mail-templates/render.js";
 import { buildAlternativeEmail, buildUnavailableEmail, type BuiltNedostupneEmail } from "./logic.js";
 import { listReplacementLinksForVariant } from "./replacement-links.js";
+import { resolveReplacementProducts } from "./resolve-products.js";
 import { hasSentNedostupne, markSentNedostupne } from "./state.js";
 
 export interface NedostupneEmailContext {
@@ -69,7 +70,11 @@ export async function findNedostupneContext(db: Database, orderCode: string, var
 export async function buildEmailForType(db: Database, ctx: NedostupneEmailContext, type: NedostupneEmailType): Promise<BuiltNedostupneEmail> {
   if (type === TYPE_ALTERNATIVE) {
     const template = await resolveTemplate(db, "nedostupne_alternativa");
-    return buildAlternativeEmail(template, ctx.customerName, ctx.itemName, ctx.replacementUrls);
+    // issue 347: dohľadanie názvu/obrázka/ceny proti katalógu PRED
+    // vyrenderovaním — rovnaká cesta pre náhľad aj skutočné odoslanie
+    // (táto funkcia je volaná z OBOCH, `.claude/rules/mail-templates.md`).
+    const products = await resolveReplacementProducts(db, ctx.replacementUrls);
+    return buildAlternativeEmail(template, ctx.customerName, ctx.itemName, products);
   }
   return buildUnavailableEmail(await resolveTemplate(db, "nedostupne"), ctx.customerName);
 }

--- a/apps/api/src/modules/shop-feed/fixtures/feed-sample.xml
+++ b/apps/api/src/modules/shop-feed/fixtures/feed-sample.xml
@@ -8,12 +8,14 @@
 	<g:id>40237/M</g:id>
 	<title>Nohavice FOREST 1003 Veľkosť: M</title>
 	<link>https://www.forestshop.sk/polovnicke-nohavice-forest-1003/?variantId=106</link>
+	<g:image_link>https://cdn.myshoptet.com/usr/www.forestshop.sk/user/shop/orig/nohavice-forest-1003.jpg</g:image_link>
 	<g:availability>in stock</g:availability>
 	<g:price>64.9 EUR</g:price>
 </entry><entry>
 	<g:id>15314</g:id>
 	<title>Poľovnícky ruksak HART SPEAN 25</title>
 	<link>https://www.forestshop.sk/polovnicky-ruksak-hart-spean-25/</link>
+	<g:image_link></g:image_link>
 	<g:availability>out of stock</g:availability>
 </entry><entry>
 	<g:id>10125/41</g:id>

--- a/apps/api/src/modules/shop-feed/parse.test.ts
+++ b/apps/api/src/modules/shop-feed/parse.test.ts
@@ -15,11 +15,14 @@ describe("parseShopFeed", () => {
         code: "40237/M",
         url: "https://www.forestshop.sk/polovnicke-nohavice-forest-1003/?variantId=106",
         availability: "in stock",
+        imageUrl: "https://cdn.myshoptet.com/usr/www.forestshop.sk/user/shop/orig/nohavice-forest-1003.jpg",
       },
       {
         code: "15314",
         url: "https://www.forestshop.sk/polovnicky-ruksak-hart-spean-25/",
         availability: "out of stock",
+        // <g:image_link></g:image_link> prázdna → null, nikdy prázdny reťazec.
+        imageUrl: null,
       },
       {
         code: "10125/41",
@@ -28,8 +31,20 @@ describe("parseShopFeed", () => {
         // prázdny reťazec — chýbajúci signál sa nesmie dať zameniť s
         // hodnotou, ktorá by sa dala porovnávať proti "in stock"/"out of stock".
         availability: null,
+        // issue 347: chýbajúca značka <g:image_link> úplne (nie len prázdna) → null.
+        imageUrl: null,
       },
     ]);
+  });
+
+  // issue 347: obrázok produktu — appka ho potrebuje pre kartu v e-maile
+  // "alternatívy k nedostupnému tovaru".
+  it("vyparsuje <g:image_link> ku každej položke", () => {
+    const rows = parseShopFeed(sample);
+    expect(rows.find((r) => r.code === "40237/M")?.imageUrl).toBe(
+      "https://cdn.myshoptet.com/usr/www.forestshop.sk/user/shop/orig/nohavice-forest-1003.jpg",
+    );
+    expect(rows.find((r) => r.code === "15314")?.imageUrl).toBeNull();
   });
 
   // issue 226: krížová kontrola nášho stavu proti feedu potrebuje aj
@@ -44,7 +59,7 @@ describe("parseShopFeed", () => {
     // "99999" v fixtúre má <g:availability>in stock</g:availability> ale bez
     // <link> — preskočí sa celá. Preto pre tento prípad vlastný vstup.
     const xml = "<feed><entry><g:id>ABC</g:id><link>https://x.sk/p/</link></entry></feed>";
-    expect(parseShopFeed(xml)).toEqual([{ code: "ABC", url: "https://x.sk/p/", availability: null }]);
+    expect(parseShopFeed(xml)).toEqual([{ code: "ABC", url: "https://x.sk/p/", availability: null, imageUrl: null }]);
   });
 
   it("nepoužije hlavičkový <link href=…> feedu ako adresu produktu", () => {

--- a/apps/api/src/modules/shop-feed/parse.ts
+++ b/apps/api/src/modules/shop-feed/parse.ts
@@ -18,6 +18,11 @@ export interface ShopFeedEntry {
   // celkom. Chýbajúci signál sa NIKDY nezamieňa s prázdnym reťazcom — obe
   // musia byť rovnako "žiadny rozpor", nikdy porovnateľná hodnota.
   readonly availability: string | null;
+  // issue 347: obrázok produktu (`<g:image_link>`) — appka ho potrebuje na
+  // vykreslenie produktovej karty v e-maile "alternatívy k nedostupnému
+  // tovaru". `null` keď feed značku nemá/je prázdna, rovnaká disciplína ako
+  // `availability` vyššie (chýbajúci signál ≠ prázdny reťazec).
+  readonly imageUrl: string | null;
 }
 
 const ENTRY = /<entry>([\s\S]*?)<\/entry>/g;
@@ -26,6 +31,7 @@ const CODE = /<g:id>([\s\S]*?)<\/g:id>/;
 // (samostatne uzavretý, adresa vzorového webu), ktorý sa takto nikdy nechytí.
 const URL_TAG = /<link>([\s\S]*?)<\/link>/;
 const AVAILABILITY_TAG = /<g:availability>([\s\S]*?)<\/g:availability>/;
+const IMAGE_LINK_TAG = /<g:image_link>([\s\S]*?)<\/g:image_link>/;
 
 const ENTITIES: Readonly<Record<string, string>> = {
   "&amp;": "&",
@@ -59,7 +65,13 @@ export function parseShopFeed(xml: string): readonly ShopFeedEntry[] {
     if (seen.has(code)) continue;
     seen.add(code);
     const rawAvailability = decode(AVAILABILITY_TAG.exec(entry)?.[1] ?? "");
-    rows.push({ code, url, availability: rawAvailability === "" ? null : rawAvailability });
+    const rawImageUrl = decode(IMAGE_LINK_TAG.exec(entry)?.[1] ?? "");
+    rows.push({
+      code,
+      url,
+      availability: rawAvailability === "" ? null : rawAvailability,
+      imageUrl: rawImageUrl === "" ? null : rawImageUrl,
+    });
   }
 
   return rows;

--- a/apps/api/src/modules/shop-feed/run.ts
+++ b/apps/api/src/modules/shop-feed/run.ts
@@ -52,6 +52,10 @@ export async function runShopFeed(options: RunShopFeedOptions): Promise<ShopFeed
           // stará hodnota z predošlého behu tíško prežívala a krížová
           // kontrola by porovnávala proti zastaranému signálu.
           availability: sql`excluded.availability`,
+          // issue 347: obrázok sa PREPÍŠE na aktuálnu hodnotu z tohto behu
+          // (vrátane NULL), rovnaká disciplína ako `availability` vyššie —
+          // inak by stará adresa obrázka z predošlého behu ticho prežívala.
+          imageUrl: sql`excluded.image_url`,
           fetchedAt: sql`excluded.fetched_at`,
         },
       });

--- a/apps/api/tests/nedostupne-resolve-products.integration.test.ts
+++ b/apps/api/tests/nedostupne-resolve-products.integration.test.ts
@@ -1,0 +1,107 @@
+// issue 347: majiteľove RUČNE vložené odkazy náhrad (issue 238) nesú len URL
+// — appka spätne dohľadá názov/obrázok/cenu proti tomu, čo UŽ MÁ
+// (shop_product_url + variants), aby e-mailová karta mala čo ukázať.
+
+import { eq } from "drizzle-orm";
+import { afterEach, expect, it } from "vitest";
+import { shopProductUrl, variants } from "../src/db/schema.js";
+import { resolveReplacementProducts } from "../src/modules/nedostupne/resolve-products.js";
+import { insertTestVariant } from "./helpers/orders.js";
+import { withCleanDb } from "./helpers/db.js";
+
+let close: (() => Promise<void>) | undefined;
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+});
+
+async function boot() {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  return ctx.db;
+}
+
+it("PRESNÁ zhoda url → vráti názov, obrázok aj naformátovanú cenu", async () => {
+  const db = await boot();
+  await insertTestVariant(db, "P347A", "Test dodávateľ");
+  await db.insert(shopProductUrl).values({
+    code: "P347A",
+    url: "https://www.forestshop.sk/p347a/?variantId=1",
+    fetchedAt: new Date("2026-08-11T00:00:00Z"),
+    imageUrl: "https://cdn.example.sk/p347a.jpg",
+  });
+
+  const [resolved] = await resolveReplacementProducts(db, ["https://www.forestshop.sk/p347a/?variantId=1"]);
+  expect(resolved).toEqual({
+    url: "https://www.forestshop.sk/p347a/?variantId=1",
+    label: "Test produkt P347A",
+    imageUrl: "https://cdn.example.sk/p347a.jpg",
+    priceText: "10,00 €",
+  });
+});
+
+it("zhoda podľa CESTY (majiteľ vložil adresu bez ?variantId=, feed ju nesie S ním)", async () => {
+  const db = await boot();
+  await insertTestVariant(db, "P347B", "Test dodávateľ");
+  await db.insert(shopProductUrl).values({
+    code: "P347B",
+    url: "https://www.forestshop.sk/p347b/?variantId=9",
+    fetchedAt: new Date("2026-08-11T00:00:00Z"),
+    imageUrl: "https://cdn.example.sk/p347b.jpg",
+  });
+
+  const [resolved] = await resolveReplacementProducts(db, ["https://www.forestshop.sk/p347b/"]);
+  expect(resolved?.label).toBe("Test produkt P347B");
+  expect(resolved?.imageUrl).toBe("https://cdn.example.sk/p347b.jpg");
+});
+
+it("žiadna zhoda → padne PRESNE na pôvodné správanie (label = url, žiadny obrázok/cena)", async () => {
+  const db = await boot();
+  const [resolved] = await resolveReplacementProducts(db, ["https://www.forestshop.sk/nikdy-nevidane/"]);
+  expect(resolved).toEqual({ url: "https://www.forestshop.sk/nikdy-nevidane/", label: "https://www.forestshop.sk/nikdy-nevidane/" });
+});
+
+it("variant bez ceny → priceText chýba, ale názov/obrázok ostávajú", async () => {
+  const db = await boot();
+  await insertTestVariant(db, "P347C", "Test dodávateľ");
+  await db.update(variants).set({ price: null, currency: null }).where(eq(variants.code, "P347C"));
+  await db.insert(shopProductUrl).values({
+    code: "P347C",
+    url: "https://www.forestshop.sk/p347c/",
+    fetchedAt: new Date("2026-08-11T00:00:00Z"),
+    imageUrl: "https://cdn.example.sk/p347c.jpg",
+  });
+
+  const [resolved] = await resolveReplacementProducts(db, ["https://www.forestshop.sk/p347c/"]);
+  expect(resolved).toEqual({
+    url: "https://www.forestshop.sk/p347c/",
+    label: "Test produkt P347C",
+    imageUrl: "https://cdn.example.sk/p347c.jpg",
+  });
+});
+
+it("feed bez obrázka → imageUrl chýba, názov/cena ostávajú", async () => {
+  const db = await boot();
+  await insertTestVariant(db, "P347D", "Test dodávateľ");
+  await db.insert(shopProductUrl).values({
+    code: "P347D",
+    url: "https://www.forestshop.sk/p347d/",
+    fetchedAt: new Date("2026-08-11T00:00:00Z"),
+  });
+
+  const [resolved] = await resolveReplacementProducts(db, ["https://www.forestshop.sk/p347d/"]);
+  expect(resolved).toEqual({ url: "https://www.forestshop.sk/p347d/", label: "Test produkt P347D", priceText: "10,00 €" });
+});
+
+it("zachová poradie vstupu pri viacerých url naraz", async () => {
+  const db = await boot();
+  await insertTestVariant(db, "P347E1", "Test dodávateľ");
+  await insertTestVariant(db, "P347E2", "Test dodávateľ");
+  await db.insert(shopProductUrl).values([
+    { code: "P347E1", url: "https://www.forestshop.sk/e1/", fetchedAt: new Date("2026-08-11T00:00:00Z") },
+    { code: "P347E2", url: "https://www.forestshop.sk/e2/", fetchedAt: new Date("2026-08-11T00:00:00Z") },
+  ]);
+
+  const resolved = await resolveReplacementProducts(db, ["https://www.forestshop.sk/e2/", "https://www.forestshop.sk/e1/"]);
+  expect(resolved.map((r) => r.label)).toEqual(["Test produkt P347E2", "Test produkt P347E1"]);
+});

--- a/apps/api/tests/shop-feed-run.integration.test.ts
+++ b/apps/api/tests/shop-feed-run.integration.test.ts
@@ -105,3 +105,70 @@ describe("runShopFeed — ukladanie dostupnosti (issue 226)", () => {
     expect(row?.availability).toBeNull();
   });
 });
+
+// issue 347: `runShopFeed` musí uložiť aj `g:image_link` — appka ho potrebuje
+// na vykreslenie produktovej karty v e-maile "alternatívy k nedostupnému
+// tovaru" (`nedostupne/resolve-products.ts`).
+describe("runShopFeed — ukladanie obrázka produktu (issue 347)", () => {
+  let db: Database;
+  let close: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ db, close } = await withCleanDb());
+  });
+  afterEach(async () => {
+    await close();
+  });
+
+  function feedWithImage(rows: readonly { code: string; imageUrl: string | null }[]): string {
+    const entries = rows
+      .map(
+        (r) =>
+          `<entry><g:id>${r.code}</g:id><link>https://www.forestshop.sk/${r.code}/</link>${
+            r.imageUrl === null ? "" : `<g:image_link>${r.imageUrl}</g:image_link>`
+          }</entry>`,
+      )
+      .join("");
+    const filler = Array.from(
+      { length: 1_000 },
+      (_unused, i) => `<entry><g:id>IMG${String(i)}</g:id><link>https://www.forestshop.sk/img${String(i)}/</link></entry>`,
+    ).join("");
+    return `<feed>${entries}${filler}</feed>`;
+  }
+
+  it("uloží g:image_link spolu s kódom a adresou", async () => {
+    await runShopFeed({
+      db,
+      now: NOW,
+      fetchFeed: () =>
+        Promise.resolve(
+          feedWithImage([{ code: "I1", imageUrl: "https://cdn.example.sk/i1.jpg" }, { code: "I2", imageUrl: null }]),
+        ),
+    });
+
+    const rows = await db
+      .select({ code: shopProductUrl.code, imageUrl: shopProductUrl.imageUrl })
+      .from(shopProductUrl)
+      .where(inArray(shopProductUrl.code, ["I1", "I2"]))
+      .orderBy(asc(shopProductUrl.code));
+
+    expect(rows).toEqual([
+      { code: "I1", imageUrl: "https://cdn.example.sk/i1.jpg" },
+      { code: "I2", imageUrl: null },
+    ]);
+  });
+
+  it("pri opakovanom behu PREPÍŠE starší obrázok novým (UPSERT), aj keď feed značku STRATÍ (prepíše na null)", async () => {
+    const runOnce = (imageUrl: string | null) =>
+      runShopFeed({ db, now: NOW, fetchFeed: () => Promise.resolve(feedWithImage([{ code: "J1", imageUrl }])) });
+
+    await runOnce("https://cdn.example.sk/stary.jpg");
+    await runOnce("https://cdn.example.sk/novy.jpg");
+    let [row] = await db.select({ imageUrl: shopProductUrl.imageUrl }).from(shopProductUrl).where(eq(shopProductUrl.code, "J1"));
+    expect(row?.imageUrl).toBe("https://cdn.example.sk/novy.jpg");
+
+    await runOnce(null);
+    [row] = await db.select({ imageUrl: shopProductUrl.imageUrl }).from(shopProductUrl).where(eq(shopProductUrl.code, "J1"));
+    expect(row?.imageUrl).toBeNull();
+  });
+});

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -3382,3 +3382,30 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   bullet-y generalizujúce review nálezy (generation-guard musí vyčistiť
   KAŽDÝ derivovaný stav, "latest ref" trieda platí aj pre onClick
   handlery, nielen `.then()` mikrotasky).
+
+## Issue 343 (ľavé menu: Systém a Automatizácie zbalené predvolene)
+
+- Commits: `af06d5a` [red] test (Sidebar defaultCollapsed), `14ea1e7`
+  [green] `NavFolder.defaultCollapsed` + lazy `useState` initializer v
+  `Sidebar.tsx`, `74428ff` súhrnný odznak/bodka na hlavičke zbaleného
+  priečinka (code review nález na PR 348 — issue 331/267's odznaky boli
+  predtým vidno hneď po prihlásení, zbalenie priečinka ich skrylo; fix
+  pridáva agregát z tých istých `badgeCounts`/`badgeStatus` props,
+  `aria-hidden` aby nezmenil accessible name tlačidla — RED-verified cez
+  `git stash push --keep-index` na implementáciu).
+- PR #348 (`f995d85d`), CI aj Deploy na main zelené na PRVÝ pokus (žiadna
+  containerd flaka tentoraz). 8 e2e spec súborov aktualizovaných (klikajú
+  priamo na záložku v Systéme/Automatizáciách, treba najprv rozbaliť
+  priečinok) — grep celého `tests/e2e/` adresára potvrdil úplnosť.
+- Rozhodnutie na tickete: stav zbalenia sa NEPAMÄTÁ medzi návštevami
+  (šéf žiadal len predvolený stav).
+- Post-deploy naživo overené (v0.3.0-dev.202): Eshop rozbalený, Systém aj
+  Automatizácie zbalené, Automatizácie ukazuje "34" na hlavičke (súčet
+  `restock-links` odznaku), po rozbalení zmizne a originály vnútri sú
+  nezmenené. 0 chýb/varovaní v konzole.
+- Playbook: `.claude/rules/frontend-design.md` — 3 nové bullety: per-
+  priečinok `defaultCollapsed` v registri (nie hardcoded v Sidebar.tsx),
+  `aria-hidden` gotcha pri pridávaní vizuálneho doplnku do pomenovaného
+  tlačidla (inak sa zmení accessible name a rozbijú sa `getByRole`
+  dotazy), a súhrnný ukazovateľ na zbalenom kontajneri sa počíta z
+  existujúcich props bez nového fetchu.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.203",
+  "version": "0.3.0-dev.204",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.202",
+  "version": "0.3.0-dev.203",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
issue 347

## Čo bolo zle

Majiteľ (11. 8. 2026): e-maily zákazníkom vyzerali "hrozne" — odkaz na
náhradný produkt mal ako klikací text celú adresu (zdvojenú: "URL (URL)"),
žiadny obrázok produktu, telefón/e-mail stratené vo vete tela namiesto
oddelenej pätičky.

## Čo sa mení

- Jedna zdieľaná HTML kostra (`mail-templates/layout.ts`) — hlavička
  (Forestshop.sk) + oddelená pätička (telefón ako `tel:`, e-mail ako
  `mailto:`, odkaz na web) — aplikuje sa na VŠETKY e-maily appky
  (`assembleHtml` aj `renderEditedBody`), nie len na alternatívy. Objednávka
  dodávateľovi (jediný čisto textový e-mail) ostáva bajt na bajt nedotknutá.
- `shop_product_url` dostáva nový stĺpec `image_url` (additive migrácia),
  plnený z feedu `<g:image_link>` (rovnaká disciplína ako `availability`).
- Nová `nedostupne/resolve-products.ts` spätne dohľadá majiteľov ručne
  vložený odkaz náhrady (URL) proti `shop_product_url`+`variants`, aby
  e-mail mohol ukázať skutočný NÁZOV, OBRÁZOK a CENU namiesto holej adresy.
  Bez zhody sa správanie NEMENÍ (rovnaký fallback ako doteraz).
- Zoznam s obrázkom sa v HTML vykreslí ako produktová karta (obrázok,
  klikací názov, cena, tlačidlo "Zobraziť produkt") namiesto `<ul><li>`.
  Text-verzia dáva názov (+cenu) a adresu na samostatné riadky — nikdy
  "názov (url)".

## Prečo nie `Closes #347`

Ticket žiada naživo overiť vyrenderovaný e-mail (obrázok, odkaz, pätička) —
`.claude/rules` tohto repa: `Closes #N` v PR zatvorí ticket AUTOMATICKY v
momente mergu, ešte pred post-deploy naživo overením. Ticket sa zavrie
ručne AŽ po overení na https://forestshop-novy.newlevel.media.
