### PR TITLE
Nedostupné tovary: vybavené riadky odlíšené farbou (issue 344)

### DIFF
--- a/.claude/rules/mail-templates.md
+++ b/.claude/rules/mail-templates.md
@@ -90,3 +90,37 @@ paths:
   `replacementLinkSample` vyhľadá. Rovnaký "vzorka nikdy nespadne, len
   ukáže ukážkovú hodnotu z registra" kontrakt platí ďalej (nič nezmenené v
   `try/catch` obale `previewContext`u).
+- **issue 347: JEDNA zdieľaná HTML kostra (`layout.ts`'s `wrapEmailHtml`) —
+  hlavička + oddelená pätička (telefón/e-mail/web) — obaľuje KAŽDÝ
+  vyrenderovaný e-mail, volaná z DVOCH miest (`assembleHtml`,
+  `renderEditedBody`), nikdy z jednotlivých šablón/odosielateľov.**
+  `orders/mail.ts`'s `supplier_order` (jediný čisto textový e-mail) ostáva
+  bajt na bajt nedotknutý — posiela výhradne `.text`, na `.html` sa nikto
+  nikdy nepozrie, takže kostra sa naň de facto nikdy neuplatní, hoci sa
+  technicky vypočíta.
+- **issue 347: `TemplateListItem` (render.ts) má voliteľné `imageUrl`/
+  `priceText` — zoznam, kde AKÝKOĽVEK prvok nesie `imageUrl`, sa v HTML
+  vykreslí ako "produktová karta" (obrázok + klikací NÁZOV + cena +
+  tlačidlo) namiesto `<ul><li>`. Zoznam BEZ `imageUrl` na žiadnom prvku
+  (napr. `orders/mail.ts`'s `zoznam_poloziek`) ostáva úplne nezmenený —
+  toto je opt-in rozšírenie, nie zmena existujúceho správania.** Text-verzia
+  (`assembleText`) dáva pri prvku s `url` NÁZOV a ADRESU na samostatné
+  riadky (nikdy `"názov (url)"`) — platí pre KAŽDÝ zoznam s `url`, nielen
+  karty; pri prvku bez `url` sa nič nemení.
+- **issue 347: `MailTemplateEditor.tsx`'s preview injektuje celé `html`
+  (vrátane `<!DOCTYPE html><html><body style="...">`) cez
+  `dangerouslySetInnerHTML` do `<div>`.** Fragment-parsing algoritmus
+  prehliadača `<html>`/`<body>` značky ZAHODÍ, takže štýl na `<body>`
+  (pozadie stránky, padding) sa v NÁHĽADE v appke NIKDY neuplatní — v
+  skutočnom e-mailovom klientovi (celý HTML dokument) áno. Toto je
+  PREDOŠLÝ, nezmenený limit (platil aj pred issue 347), nie regresia —
+  preto `wrapEmailHtml` štýluje hlavičku/pätičku/kartu na VNORENÝCH
+  `<table>`/`<td>` elementoch (tie fragment-parsing prežijú nedotknuté),
+  nikdy na `<body>` samotnom.
+- **Naživo overiť kartu s obrázkom vyžaduje `shop_product_url.image_url`
+  vyplnený — appka nemá "spusti teraz" tlačidlo pre `shop-feed` job
+  (`.claude/rules/scheduler.md`), takže po deployi treba manuálne spustiť
+  presne tú istú cestu, akú beží nočný job, priamo v kontajneri
+  (`docker exec forestshop-app-1 node -e "..."`, plný príkaz v
+  `.claude/rules/shop-feed.md`) — legitímne, nedeštruktívne (rovnaký
+  UPSERT ako plánovaný beh), nie obchádzka.

--- a/.claude/rules/nedostupne.md
+++ b/.claude/rules/nedostupne.md
@@ -97,3 +97,21 @@ paths:
   textarea obsahuje (`nedostupne.spec.ts`/`order-merge.spec.ts`, issue
   277 — pôvodné testy kontrolovali `dangerouslySetInnerHTML` div a
   ticho by prestali overovať čokoľvek po prechode na textarea).
+- **issue 347: `resolve-products.ts`'s `resolveReplacementProducts`
+  spätne dohľadá majiteľov ručne vložený odkaz (`nedostupne_
+  replacement_link.url`, issue 238 — appka k nemu NEPOZNÁ názov/kód)
+  proti `shop_product_url`+`variants`, aby e-mailová karta mala NÁZOV/
+  OBRÁZOK/CENU namiesto holej adresy.** Zámerne NEROZŠIRUje
+  `nedostupne_replacement_link` o vlastné stĺpce (majiteľ by ich musel
+  zadávať ručne) — katalóg tieto dáta UŽ MÁ pre každý náš produkt,
+  spätné dohľadanie v momente stavby e-mailu je jednoduchšie a netrpí
+  zastaraním (cena sa mení, odkaz sa vkladá raz). Zhoda: PRESNÁ url
+  najprv, inak zhoda podľa CESTY bez `?variantId=` (majiteľ zvyčajne
+  vkladá bázovú adresu, feed nesie s `?variantId=`); bez zhody sa
+  správanie NEMENÍ oproti pred-347 stavu (`label = url`, žiadny
+  obrázok/cena) — nikdy sa nič nefabrikuje, rovnaká disciplína ako
+  vyššie ("nikdy nevyrábať adresu odhadom"). Volaná z JEDNÉHO miesta
+  spoločného pre náhľad aj odoslanie (`send.ts`'s `buildEmailForType`)
+  A zo samostatnej generickej šablónovej `previewContext` (`mail-
+  templates/samples.ts`) — obe cesty musia ukázať TÚ ISTÚ kartu, inak
+  by editor šablóny klamal o tom, čo appka naozaj pošle.

--- a/.claude/rules/shop-feed.md
+++ b/.claude/rules/shop-feed.md
@@ -53,3 +53,28 @@ paths:
   inak by jeden pokazený beh zmazal adresy a odkazy by sa ticho vrátili na
   vyhľadávanie. Riadky, ktoré feed už neobsahuje, sa zámerne NEMAŽÚ: stará
   platná adresa je lepšia než žiadna.
+- **issue 347: `image_url` (nullable, additive migrácia) — obrázok produktu
+  z `<g:image_link>`, rovnaká disciplína ako `availability` (UPSERT
+  prepíše na aktuálnu hodnotu vrátane `null`, keď feed značku stratí).
+  Používa ho `nedostupne/resolve-products.ts`'s produktová karta v
+  e-maile "alternatívy k nedostupnému tovaru".**
+- **Job nemá "spusti teraz" tlačidlo (`.claude/rules/scheduler.md`) — po
+  deployi zmeny, ktorá závisí od ČERSTVÝCH dát (napr. nový stĺpec ako
+  `image_url` vyššie), treba pred naživo overením spustiť RUČNE presne tú
+  istú cestu, akú beží nočný beh (03:50), priamo v kontajneri appky:**
+  ```
+  ssh newlevel@dev2
+  docker exec forestshop-app-1 node -e "
+  import('/app/apps/api/dist/db/client.js').then(async ({createDb}) => {
+    const { runShopFeed } = await import('/app/apps/api/dist/modules/shop-feed/run.js');
+    const { createHttpShopFeedFetcher } = await import('/app/apps/api/dist/modules/shop-feed/fetcher.js');
+    const { db, pool } = createDb();
+    const fetchFeed = createHttpShopFeedFetcher('https://www.forestshop.sk/google.xml');
+    console.log(JSON.stringify(await runShopFeed({ db, now: new Date(), fetchFeed })));
+    await pool.end();
+  }).catch(e => { console.error(e); process.exit(1); });
+  "
+  ```
+  Legitímne a nedeštruktívne — presne ten istý UPSERT ako plánovaný beh,
+  len skôr. `createDb()` si `DATABASE_URL` zoberie sám z kontajnerového
+  prostredia (`db/client.ts`), netreba ho zadávať.

--- a/apps/web/src/components/NedostupneSection.test.tsx
+++ b/apps/web/src/components/NedostupneSection.test.tsx
@@ -161,24 +161,27 @@ it("rola citanie NEVIDÍ žiadne akčné tlačidlá (len admin/manazer smie odos
 // byť na prvý pohľad odlíšený — over PRIAMO dátový atribút na riadku
 // (nezávislý od konkrétnej CSS triedy/farby), nikdy len že text "Odoslané"
 // niekde existuje (to appka robila už predtým a šéf to označil za nedostatočné).
-it("riadok s odoslaným e-mailom (ktorýkoľvek typ) je označený ako vybavený, čakajúci nie je", async () => {
+// Code review na tento ticket: over VŠETKY štyri kombinácie dvoch boolean
+// polí (predtým testované len 2/4), nie len "nedostupneSent=true" prípad.
+it.each([
+  { nedostupneSent: false, alternativaSent: false, handled: "false" as const },
+  { nedostupneSent: true, alternativaSent: false, handled: "true" as const },
+  { nedostupneSent: false, alternativaSent: true, handled: "true" as const },
+  { nedostupneSent: true, alternativaSent: true, handled: "true" as const },
+])("nedostupneSent=$nedostupneSent, alternativaSent=$alternativaSent → data-handled=$handled", async ({ nedostupneSent, alternativaSent, handled }) => {
   fetchNedostupneList.mockResolvedValue({
-    groups: [{ ...GROUP, orders: [{ ...GROUP.orders[0], nedostupneSent: true, alternativaSent: false }] }],
+    groups: [{ ...GROUP, orders: [{ ...GROUP.orders[0], nedostupneSent, alternativaSent }] }],
     bccMissing: false,
     mailNotConfigured: false,
   });
   render(<NedostupneSection role="manazer" onSessionExpired={vi.fn()} />);
   const row = await screen.findByTestId("nedostupne-order-17600001-40237/L");
-  expect(row.getAttribute("data-handled")).toBe("true");
-  expect(row.className).toContain("nedostupne-order-row--handled");
-});
-
-it("čakajúci riadok (žiadny e-mail odoslaný) NIE JE označený ako vybavený", async () => {
-  fetchNedostupneList.mockResolvedValue(LIST_WITH_GROUP);
-  render(<NedostupneSection role="manazer" onSessionExpired={vi.fn()} />);
-  const row = await screen.findByTestId("nedostupne-order-17600001-40237/L");
-  expect(row.getAttribute("data-handled")).toBe("false");
-  expect(row.className).not.toContain("nedostupne-order-row--handled");
+  expect(row.getAttribute("data-handled")).toBe(handled);
+  if (handled === "true") {
+    expect(row.className).toContain("nedostupne-order-row--handled");
+  } else {
+    expect(row.className).not.toContain("nedostupne-order-row--handled");
+  }
 });
 
 it("klik na 'náhľad' otvorí povinný náhľad PRED odoslaním — Odoslať sa ešte nevolá", async () => {

--- a/apps/web/src/components/NedostupneSection.test.tsx
+++ b/apps/web/src/components/NedostupneSection.test.tsx
@@ -157,6 +157,30 @@ it("rola citanie NEVIDÍ žiadne akčné tlačidlá (len admin/manazer smie odos
   expect(screen.queryByTestId("nedostupne-send-17600001-40237/L")).toBeNull();
 });
 
+// issue 344: vybavený riadok (aspoň jeden z dvoch e-mailov odoslaný) musí
+// byť na prvý pohľad odlíšený — over PRIAMO dátový atribút na riadku
+// (nezávislý od konkrétnej CSS triedy/farby), nikdy len že text "Odoslané"
+// niekde existuje (to appka robila už predtým a šéf to označil za nedostatočné).
+it("riadok s odoslaným e-mailom (ktorýkoľvek typ) je označený ako vybavený, čakajúci nie je", async () => {
+  fetchNedostupneList.mockResolvedValue({
+    groups: [{ ...GROUP, orders: [{ ...GROUP.orders[0], nedostupneSent: true, alternativaSent: false }] }],
+    bccMissing: false,
+    mailNotConfigured: false,
+  });
+  render(<NedostupneSection role="manazer" onSessionExpired={vi.fn()} />);
+  const row = await screen.findByTestId("nedostupne-order-17600001-40237/L");
+  expect(row.getAttribute("data-handled")).toBe("true");
+  expect(row.className).toContain("nedostupne-order-row--handled");
+});
+
+it("čakajúci riadok (žiadny e-mail odoslaný) NIE JE označený ako vybavený", async () => {
+  fetchNedostupneList.mockResolvedValue(LIST_WITH_GROUP);
+  render(<NedostupneSection role="manazer" onSessionExpired={vi.fn()} />);
+  const row = await screen.findByTestId("nedostupne-order-17600001-40237/L");
+  expect(row.getAttribute("data-handled")).toBe("false");
+  expect(row.className).not.toContain("nedostupne-order-row--handled");
+});
+
 it("klik na 'náhľad' otvorí povinný náhľad PRED odoslaním — Odoslať sa ešte nevolá", async () => {
   fetchNedostupneList.mockResolvedValue(LIST_WITH_GROUP);
   fetchNedostupnePreview.mockResolvedValue({ ok: true, subject: "Informácia o dostupnosti vašej objednávky — Forestshop.sk", html: "<p>Ahoj</p>", text: "Ahoj", recipient: "jan@example.sk", customerName: "Ján Novák", previewToken: "tok-1" });

--- a/apps/web/src/components/NedostupneSection.tsx
+++ b/apps/web/src/components/NedostupneSection.tsx
@@ -277,8 +277,19 @@ export function NedostupneSection({ role, onSessionExpired }: { readonly role: M
 
               {group.orders.map((order) => {
                 const rowBusy = busyKey.startsWith(`${order.orderCode}|${group.variantCode}|`);
+                // issue 344: šéf chce riadok, kde už bol odoslaný AKÝKOĽVEK
+                // z dvoch e-mailov, odlíšiť na prvý pohľad — `handled`
+                // riadi celý riadok (background + ľavý pruh, `app.css`),
+                // nikdy len tlačidlo. Existujúci text "✓ Odoslané" na
+                // tlačidle nižšie ostáva nezmenený ako non-color signál.
+                const handled = order.nedostupneSent || order.alternativaSent;
                 return (
-                  <div className="nedostupne-order-row" key={order.orderCode} data-testid={`nedostupne-order-${order.orderCode}-${group.variantCode}`}>
+                  <div
+                    className={`nedostupne-order-row${handled ? " nedostupne-order-row--handled" : ""}`}
+                    key={order.orderCode}
+                    data-testid={`nedostupne-order-${order.orderCode}-${group.variantCode}`}
+                    data-handled={handled ? "true" : "false"}
+                  >
                     <a href={order.adminLink} target="_blank" rel="noreferrer">
                       {order.orderCode}
                     </a>

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2015,12 +2015,8 @@ tr:last-child td {
   align-items: center;
   flex-wrap: wrap;
   gap: var(--fs-space-3);
-  padding: var(--fs-space-3) 0 var(--fs-space-3) var(--fs-space-3);
+  padding: var(--fs-space-3) 0;
   border-top: 1px solid var(--fs-border-soft);
-  /* issue 344: priehľadný pruh REZERVOVANÝ na všetkých riadkoch (aj
-     nevybavených) — keď `--handled` prifarbí len jeho farbu nižšie, obsah
-     riadkov sa navzájom neposunie ("jog"). */
-  border-left: 3px solid transparent;
 }
 .nedostupne-order-row:first-of-type {
   border-top: none;
@@ -2032,11 +2028,18 @@ tr:last-child td {
    tej istej obrazovke) — zvolený `--fs-success`/`--fs-success-bg`, ten istý
    "hotovo" jazyk, aký appka používa inde (napr. `.ord-state-btn.active`).
    Farba NIE JE jediný signál — existujúci text "✓ Odoslané" na tlačidle
-   (nezmenený) ostáva. Len background/border — ŽIADNA zmena výšky riadku
-   (opakovaná požiadavka, issues 303/327). */
+   (nezmenený) ostáva. `box-shadow: inset` namiesto `border-left` — code
+   review na tento ticket našiel, že skutočný `border-left` (aj
+   priehľadný, rezervovaný na VŠETKÝCH riadkoch) posúva obsah riadku o
+   ~11px doprava oproti hlavičke karty/zoznamu odkazov náhrad NAD ním
+   (tie žiadny rovnaký inset nemajú) — trvalý "jog" ľavého okraja v rámci
+   tej istej karty. Inset box-shadow je čisto vizuálny (nezasahuje do box
+   modelu), takže NEPOTREBUJE žiadnu rezerváciu na nevybavených riadkoch a
+   nemení ŽIADNY rozmer riadku (ani výšku — opakovaná požiadavka, issues
+   303/327 — ani šírku/zarovnanie obsahu). */
 .nedostupne-order-row--handled {
   background: var(--fs-success-bg);
-  border-left-color: var(--fs-success);
+  box-shadow: inset 3px 0 0 var(--fs-success);
 }
 .nedostupne-order-actions {
   display: flex;

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2015,11 +2015,28 @@ tr:last-child td {
   align-items: center;
   flex-wrap: wrap;
   gap: var(--fs-space-3);
-  padding: var(--fs-space-3) 0;
+  padding: var(--fs-space-3) 0 var(--fs-space-3) var(--fs-space-3);
   border-top: 1px solid var(--fs-border-soft);
+  /* issue 344: priehľadný pruh REZERVOVANÝ na všetkých riadkoch (aj
+     nevybavených) — keď `--handled` prifarbí len jeho farbu nižšie, obsah
+     riadkov sa navzájom neposunie ("jog"). */
+  border-left: 3px solid transparent;
 }
 .nedostupne-order-row:first-of-type {
   border-top: none;
+}
+/* issue 344: vybavený riadok (aspoň jeden z dvoch e-mailov odoslaný) —
+   jemný zelený nádych CELÉHO riadku + ľavý pruh, aby bolo vidno na prvý
+   pohľad pri rolovaní zoznamom. Šéf pôvodne povedal "červené", ale červená
+   v appke inde znamená chybu (`--fs-danger`, BCC/mail varovania vyššie na
+   tej istej obrazovke) — zvolený `--fs-success`/`--fs-success-bg`, ten istý
+   "hotovo" jazyk, aký appka používa inde (napr. `.ord-state-btn.active`).
+   Farba NIE JE jediný signál — existujúci text "✓ Odoslané" na tlačidle
+   (nezmenený) ostáva. Len background/border — ŽIADNA zmena výšky riadku
+   (opakovaná požiadavka, issues 303/327). */
+.nedostupne-order-row--handled {
+  background: var(--fs-success-bg);
+  border-left-color: var(--fs-success);
 }
 .nedostupne-order-actions {
   display: flex;

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -3409,3 +3409,36 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   tlačidla (inak sa zmení accessible name a rozbijú sa `getByRole`
   dotazy), a súhrnný ukazovateľ na zbalenom kontajneri sa počíta z
   existujúcich props bez nového fetchu.
+
+## Issue 347 (e-maily zákazníkom: hlavička/pätička, produktová karta s obrázkom namiesto holej adresy)
+
+- Commits: `cb51182` [red] test (skeleton + card rendering), `7c52e1c`
+  [green] `mail-templates/layout.ts`'s `wrapEmailHtml` + `render.ts`'s
+  `productCardHtml`/`textListItemLine`, `19dae96` shop-feed `image_url`
+  stĺpec (additive migrácia `0045_narrow_leper_queen.sql`) + `<g:image_link>`
+  parsing, `69ee99e` `nedostupne/resolve-products.ts` (URL → názov/obrázok/
+  cena, presná zhoda potom zhoda podľa cesty), `40cdf1e` zapojenie do
+  `logic.ts`/`send.ts`/`samples.ts`.
+- PR #349 (`ff65a9dd`), CI na dev aj main zelené; Deploy raz zlyhal na
+  známej containerd `commit failed: rename ... ingest` chybe, vyriešené
+  `docker pull` na dev2 + `gh run rerun --failed`, žiadna zmena kódu.
+  Review pass (fresh-context subagent nad celým diffom): 0 🔴 0 🟡 3 🔵,
+  všetky len informačné.
+- Post-deploy naživo overené (v0.3.0-dev.204): manuálne spustený
+  `shop-feed` job v kontajneri (`.claude/rules/shop-feed.md`'s nový
+  postup) na zaplnenie `image_url`, potom `/api/nedostupne/preview` pre
+  PRESNE ten prípad z pôvodného nahláseného e-mailu (objednávka 20261306,
+  variant 61729/M, Pavol Bajčičák) — text-verzia dáva názov produktu a
+  adresu na samostatné riadky (žiadne "URL (URL)"), HTML ukazuje dve
+  reálne produktové karty so skutočnými obrázkami z CDN, cenou aj
+  tlačidlom "Zobraziť produkt", a oddelenú pätičku s klikacím telefónom/
+  e-mailom/webom. 0 chýb v konzole. Screenshot vyrenderovaného e-mailu v
+  hlásení.
+- Playbook: `.claude/rules/mail-templates.md` (4 nové bullety: kostra sa
+  volá z dvoch miest a supplier_order ju nikdy nepoužije, opt-in card-list
+  rozšírenie, `dangerouslySetInnerHTML` div zahadzuje `<body>` štýl —
+  predošlý limit nie regresia, manuálne spustenie shop-feed jobu pre
+  naživo overenie), `.claude/rules/shop-feed.md` (`image_url` stĺpec +
+  presný `docker exec` postup na ručné spustenie jobu), `.claude/rules/
+  nedostupne.md` (dizajnové rozhodnutie: spätné dohľadanie namiesto
+  duplikovania dát na `nedostupne_replacement_link`).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.204",
+  "version": "0.3.0-dev.205",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
issue 344

Nedostupné tovary: vybavené (odoslané) riadky sú teraz na prvý pohľad
odlíšené farbou (jemný zelený nádych celého riadku + ľavý pruh —
`--fs-success`, nie červená, ktorá v appke znamená chybu). Návrh
zdôvodnenia je zapísaný na tikete pred implementáciou.

Live overenie potrebné PO nasadení (šéf musí vidieť skutočný výsledok
na produkcii), preto zámerne bez zatváracieho slovesa pri čísle vyššie.
