### PR TITLE
Nový adresár Dôležité + obrazovka Úlohy na dnes (issue 342)

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -1148,3 +1148,25 @@ paths:
   duplicita). Prioritné poradie (číslo > bodka > nič) je explicitné
   zadanie na tickete, nie odvodené — pri podobnom "súhrn na zbalenom
   kontajneri" v budúcnosti si vyžiadaj/over presné poradie, nepredpokladaj ho.
+- **A per-row visual "state accent" (left border/stripe on SOME rows of a
+  list, not all) needs `box-shadow: inset <x> 0 0 <color>`, NEVER a real
+  `border-left`, even a "transparent-reserved on every row" one.** Issue
+  344 (Nedostupné tovary — vybavené riadky odlíšené farbou): the first
+  attempt reserved a 3px `border-left: solid transparent` on EVERY row so
+  the state-coloured rows wouldn't "jog" relative to pending ones — but a
+  real border still consumes box-model space, and NOTHING else in the same
+  card (the group header, the replacement-links list above the rows) got
+  the same reservation, so every row ended up ~11px right of the text
+  directly above it in the same card (found by code review, not by any
+  existing test — this app has NO layout-shift test for horizontal
+  alignment, only for row HEIGHT per issues 303/327). Fix: `box-shadow:
+  inset 3px 0 0 var(--fs-success)` on the state class ONLY — inset
+  box-shadow is purely visual (paints inside the border box, never
+  resizes/repositions it), so pending rows need ZERO reservation and there
+  is no jog possible, by construction, not by careful measurement. Verified
+  live (production DOM read): identical `getBoundingClientRect().left` and
+  `.height` for a handled vs. a pending row. **Any future per-row/per-card
+  state accent in this app (colour band, status stripe) should default to
+  inset `box-shadow`, not `border`,** given how many prior tickets in this
+  playbook (105/107/111/127/163/204/214/291/303/327) already fought pixel
+  alignment/row-height regressions the hard way.

--- a/.claude/rules/nedostupne.md
+++ b/.claude/rules/nedostupne.md
@@ -115,3 +115,15 @@ paths:
   A zo samostatnej generickej šablónovej `previewContext` (`mail-
   templates/samples.ts`) — obe cesty musia ukázať TÚ ISTÚ kartu, inak
   by editor šablóny klamal o tom, čo appka naozaj pošle.
+- **issue 344: riadok je "vybavený" keď `order.nedostupneSent ||
+  order.alternativaSent` — buď typ e-mailu stačí, appka nikdy nevynucuje
+  oba.** Šéf pôvodne pýtal "červené" pre vizuálne odlíšenie vybavených
+  riadkov, ale červená v appke inde znamená CHYBU (`--fs-danger`, BCC/mail
+  varovania na tej istej obrazovke) — použitý `--fs-success`/
+  `--fs-success-bg` namiesto toho (zdôvodnené priamo na tikete), rovnaký
+  "hotovo" jazyk ako `.ord-state-btn.active` inde v appke. Implementácia
+  (CSS technika `box-shadow: inset`, nie `border`) je popísaná v
+  `.claude/rules/frontend-design.md`. Keď šéf inde v appke znova povie
+  konkrétnu farbu ("červené"/"zelené"), over najprv, či tá farba už v
+  appke nemá iný, kolidujúci význam, než ju rovno použiješ — a zdôvodnenie
+  zapíš na ticket, nech to vie posúdiť.

--- a/apps/api/drizzle/0046_third_master_mold.sql
+++ b/apps/api/drizzle/0046_third_master_mold.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "daily_task" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"text" text NOT NULL,
+	"emoji" text,
+	"done_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "daily_task" ADD CONSTRAINT "daily_task_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "daily_task_user_id_created_at_idx" ON "daily_task" USING btree ("user_id","created_at");

--- a/apps/api/drizzle/meta/0046_snapshot.json
+++ b/apps/api/drizzle/meta/0046_snapshot.json
@@ -1,0 +1,3131 @@
+{
+  "id": "ef8c57c1-5648-4c6b-890b-8a9124745b67",
+  "prevId": "7df95f74-c44c-4ed4-b0d3-dfc3c13fe617",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_code": {
+          "name": "external_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_open_status": {
+      "name": "order_open_status",
+      "schema": "",
+      "columns": {
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Vybavuje sa'"
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop_remark": {
+          "name": "shop_remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shoptet_order_id": {
+          "name": "shoptet_order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_updated_at": {
+          "name": "comment_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_synced_at": {
+          "name": "comment_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_carrier_name": {
+          "name": "shipping_carrier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_price_with_vat": {
+          "name": "total_price_with_vat",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_marked_at": {
+          "name": "claim_marked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_note": {
+          "name": "claim_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_full_name": {
+          "name": "delivery_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_company": {
+          "name": "delivery_company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_street": {
+          "name": "delivery_street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_house_number": {
+          "name": "delivery_house_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_city": {
+          "name": "delivery_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_zip": {
+          "name": "delivery_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_country_name": {
+          "name": "delivery_country_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_name": {
+          "name": "payment_method_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_to_pay": {
+          "name": "price_to_pay",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_link_override": {
+      "name": "product_supplier_link_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_link_override_product_key_product_key_fk": {
+          "name": "product_supplier_link_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_link_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_override": {
+      "name": "product_supplier_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_override_product_key_product_key_fk": {
+          "name": "product_supplier_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing": {
+      "name": "pairing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_url": {
+          "name": "supplier_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "pairing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'navrhnute'"
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pairing_state_idx": {
+          "name": "pairing_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_confirmed_by_idx": {
+          "name": "pairing_confirmed_by_idx",
+          "columns": [
+            {
+              "expression": "confirmed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_variant_code_variant_code_fk": {
+          "name": "pairing_variant_code_variant_code_fk",
+          "tableFrom": "pairing",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pairing_confirmed_by_users_id_fk": {
+          "name": "pairing_confirmed_by_users_id_fk",
+          "tableFrom": "pairing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pairing_variant_code_unique": {
+          "name": "pairing_variant_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pairing_confirmation_ck": {
+          "name": "pairing_confirmation_ck",
+          "value": "(\"pairing\".\"state\" = 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)\n        OR (\"pairing\".\"state\" != 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NULL AND \"pairing\".\"confirmed_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier": {
+      "name": "supplier",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wholesale_base_url": {
+          "name": "wholesale_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_key": {
+          "name": "adapter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_settings": {
+      "name": "posta_uncollected_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_state": {
+      "name": "posta_uncollected_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notify_count": {
+          "name": "notify_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_state": {
+          "name": "terminal_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_settings": {
+      "name": "order_reminder_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_state": {
+      "name": "order_reminder_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_replacement_link": {
+      "name": "nedostupne_replacement_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nedostupne_replacement_link_variant_idx": {
+          "name": "nedostupne_replacement_link_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_state": {
+      "name": "nedostupne_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "nedostupne_email_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nedostupne_state_order_variant_type_uq": {
+          "name": "nedostupne_state_order_variant_type_uq",
+          "columns": [
+            {
+              "expression": "order_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template_history": {
+      "name": "mail_template_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "mail_template_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_template_history_key_idx": {
+          "name": "mail_template_history_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_template_history_changed_by_user_id_users_id_fk": {
+          "name": "mail_template_history_changed_by_user_id_users_id_fk",
+          "tableFrom": "mail_template_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template": {
+      "name": "mail_template",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail_template_updated_by_user_id_users_id_fk": {
+          "name": "mail_template_updated_by_user_id_users_id_fk",
+          "tableFrom": "mail_template",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_log": {
+      "name": "mail_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "mail_log_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_log_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "mail_log_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_log_created_idx": {
+          "name": "mail_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_log_source_created_idx": {
+          "name": "mail_log_source_created_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_log_actor_user_id_users_id_fk": {
+          "name": "mail_log_actor_user_id_users_id_fk",
+          "tableFrom": "mail_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_stock": {
+      "name": "supplier_stock",
+      "schema": "",
+      "columns": {
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "supplier_availability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "supplier_stock_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "supplier_stock_host_idx": {
+          "name": "supplier_stock_host_idx",
+          "columns": [
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "supplier_stock_avail_idx": {
+          "name": "supplier_stock_avail_idx",
+          "columns": [
+            {
+              "expression": "availability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "supplier_stock_link_size_label_pk": {
+          "name": "supplier_stock_link_size_label_pk",
+          "columns": [
+            "link",
+            "size_label"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_event": {
+      "name": "restock_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_link": {
+          "name": "supplier_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_availability_text": {
+          "name": "supplier_availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "supplier_price": {
+          "name": "supplier_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "restock_event_at_idx": {
+          "name": "restock_event_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "restock_event_variant_idx": {
+          "name": "restock_event_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_settings": {
+      "name": "restock_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shop_product_url": {
+      "name": "shop_product_url",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.theme_color": {
+      "name": "theme_color",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "theme_color_updated_by_user_id_users_id_fk": {
+          "name": "theme_color_updated_by_user_id_users_id_fk",
+          "tableFrom": "theme_color",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upozornenie": {
+      "name": "upozornenie",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "upozornenie_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "upozornenie_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedup_key": {
+          "name": "dedup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postponed_until": {
+          "name": "postponed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seen_at": {
+          "name": "seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "upozornenie_dedup_key_uq": {
+          "name": "upozornenie_dedup_key_uq",
+          "columns": [
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "resolved_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upozornenie_resolved_at_idx": {
+          "name": "upozornenie_resolved_at_idx",
+          "columns": [
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upozornenie_dedup_key_idx": {
+          "name": "upozornenie_dedup_key_idx",
+          "columns": [
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upozornenie_resolved_by_user_id_users_id_fk": {
+          "name": "upozornenie_resolved_by_user_id_users_id_fk",
+          "tableFrom": "upozornenie",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "upozornenie_created_by_user_id_users_id_fk": {
+          "name": "upozornenie_created_by_user_id_users_id_fk",
+          "tableFrom": "upozornenie",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dpd_pickup_request": {
+      "name": "dpd_pickup_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "pickup_date": {
+          "name": "pickup_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "dpd_operation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dpd_shipment": {
+      "name": "dpd_shipment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "dpd_operation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parcel_number": {
+          "name": "parcel_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cod_amount": {
+          "name": "cod_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dpd_shipment_order_uq": {
+          "name": "dpd_shipment_order_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dpd_shipment_order_id_order_id_fk": {
+          "name": "dpd_shipment_order_id_order_id_fk",
+          "tableFrom": "dpd_shipment",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_task": {
+      "name": "daily_task",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "done_at": {
+          "name": "done_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "daily_task_user_id_created_at_idx": {
+          "name": "daily_task_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_task_user_id_users_id_fk": {
+          "name": "daily_task_user_id_users_id_fk",
+          "tableFrom": "daily_task",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne"
+      ]
+    },
+    "public.pairing_state": {
+      "name": "pairing_state",
+      "schema": "public",
+      "values": [
+        "navrhnute",
+        "potvrdene"
+      ]
+    },
+    "public.nedostupne_email_type": {
+      "name": "nedostupne_email_type",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "alternativa"
+      ]
+    },
+    "public.mail_template_action": {
+      "name": "mail_template_action",
+      "schema": "public",
+      "values": [
+        "save",
+        "reset"
+      ]
+    },
+    "public.mail_log_source": {
+      "name": "mail_log_source",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "posta_uncollected",
+        "order_reminder",
+        "supplier_order",
+        "order_merge"
+      ]
+    },
+    "public.mail_log_status": {
+      "name": "mail_log_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.mail_log_trigger": {
+      "name": "mail_log_trigger",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "manual"
+      ]
+    },
+    "public.supplier_availability": {
+      "name": "supplier_availability",
+      "schema": "public",
+      "values": [
+        "available",
+        "unavailable",
+        "unknown"
+      ]
+    },
+    "public.supplier_stock_source": {
+      "name": "supplier_stock_source",
+      "schema": "public",
+      "values": [
+        "json_ld",
+        "meta",
+        "text",
+        "size_list",
+        "none"
+      ]
+    },
+    "public.upozornenie_source": {
+      "name": "upozornenie_source",
+      "schema": "public",
+      "values": [
+        "vlastne",
+        "appka"
+      ]
+    },
+    "public.upozornenie_type": {
+      "name": "upozornenie_type",
+      "schema": "public",
+      "values": [
+        "vlastna_poznamka",
+        "nevyzdvihnuta_zasielka",
+        "vratenie",
+        "vratena_zasielka",
+        "objednavka_visi"
+      ]
+    },
+    "public.dpd_operation_status": {
+      "name": "dpd_operation_status",
+      "schema": "public",
+      "values": [
+        "submitted",
+        "failed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -323,6 +323,13 @@
       "when": 1786452370306,
       "tag": "0045_narrow_leper_queen",
       "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "7",
+      "when": 1786464616133,
+      "tag": "0046_third_master_mold",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema-daily-tasks.ts
+++ b/apps/api/src/db/schema-daily-tasks.ts
@@ -1,0 +1,40 @@
+import { index, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { users } from "./schema-users.js";
+
+// issue 342: "Úlohy na dnes" — nahrádza šéfove poznámky písané do Discord
+// kanála #úlohy-na-dnes. ÚPLNE osobný zoznam, viazaný na `user_id` — každý
+// prihlásený používateľ vidí a upravuje LEN svoje vlastné riadky, server to
+// vynucuje na každom endpointe (`modules/daily-tasks/service.ts`), nikdy len
+// frontend. Zámerne SAMOSTATNÁ tabuľka, nie nová `upozornenie.type` hodnota —
+// plné odôvodnenie na tickete (design komentár pred prvým commitom kódu):
+// Upozornenia sú zdieľaná firemná queue s postpone/resolve/dedupKey
+// sémantikou a odznakom pre VŠETKÝCH zamestnancov, tento zoznam je súkromný
+// poznámkový blok bez toho všetkého.
+export const dailyTask = pgTable(
+  "daily_task",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    text: text("text").notNull(),
+    // Nepovinné — majiteľ ho pridáva/mení AŽ PO vytvorení úlohy, samostatnou
+    // akciou (design komentár na tickete: "písať jedno za druhým", emoji nie
+    // je súčasť rýchleho vytvorenia). Obyčajný text stĺpec — appka nevynucuje,
+    // že ide o skutočný emoji znak, spolieha sa na to, čo používateľ napíše
+    // cez systémový/klávesnicový výber (rozhodnutie na tickete: žiadny
+    // vlastný emoji-picker).
+    emoji: text("emoji"),
+    // `null` = ešte nevybavené. Nastavuje/ruší sa cez jeden atomický UPDATE
+    // (`setDailyTaskDone`), nikdy sa nemaže riadok len kvôli prepnutiu stavu.
+    doneAt: timestamp("done_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    // Zoznam sa vždy číta zoradený "najnovšie hore" A vždy filtrovaný na
+    // JEDNÉHO používateľa naraz (`.claude/rules/database.md` — index podľa
+    // toho, ako sa dáta SKUTOČNE čítajú).
+    index("daily_task_user_id_created_at_idx").on(t.userId, t.createdAt),
+  ],
+);

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -14,3 +14,4 @@ export * from "./schema-shop-feed.js";
 export * from "./schema-theme-colors.js";
 export * from "./schema-upozornenia.js";
 export * from "./schema-dpd.js";
+export * from "./schema-daily-tasks.js";

--- a/apps/api/src/http/app.ts
+++ b/apps/api/src/http/app.ts
@@ -12,6 +12,7 @@ import { appVersion } from "../version.js";
 import { registerCalendarRoutes } from "./calendar-routes.js";
 import type { NextEventService } from "../modules/calendar/service.js";
 import { registerCatalogRoutes, type RunIngest } from "./catalog-routes.js";
+import { registerDailyTasksRoutes } from "./daily-tasks-routes.js";
 import { registerDpdRoutes, type DpdRunDeps } from "./dpd-routes.js";
 import { checkLoginRateLimit, clientIp } from "./login-rate-limit.js";
 import { SESSION_COOKIE, requireUser, type AppBindings } from "./middleware.js";
@@ -313,6 +314,7 @@ export function createApp(
   // dependency (na rozdiel od nedostupne/orderReminder vyššie) — táto
   // obrazovka neposiela mail ani nekontaktuje tretiu stranu.
   registerUpozorneniaRoutes(app, db);
+  registerDailyTasksRoutes(app, db);
   // issue 309: rovnaká nástenka, ale NEZÁVISLÝ modul (žiadny dedupKey/
   // resolve/postpone — `upozornenia.md`'s návrhový komentár na tickete).
   registerCalendarRoutes(app, db, options.nextEvent);

--- a/apps/api/src/http/daily-tasks-routes.ts
+++ b/apps/api/src/http/daily-tasks-routes.ts
@@ -15,7 +15,11 @@ import { requireUser, type AppBindings } from "./middleware.js";
 // zamestnancovi s rolou "citanie" mať VLASTNÝ súkromný zoznam bez dôvodu.
 const createBody = z.object({ text: z.string().trim().min(1).max(300) });
 const updateTextBody = z.object({ text: z.string().trim().min(1).max(300) });
-const updateEmojiBody = z.object({ emoji: z.string().trim().max(16).nullable() });
+// Code review: 16 znakov by odmietlo legitímnu VIACPRVKOVÚ emoji sekvenciu
+// (rodinné/kožný odtieň kombinácie spájané ZWJ znakom môžu ľahko presiahnuť
+// 16 UTF-16 jednotiek) — 32 dáva dosť priestoru aj pre takú sekvenciu a stále
+// bráni zjavnému zneužitiu poľa na dlhý text.
+const updateEmojiBody = z.object({ emoji: z.string().trim().max(32).nullable() });
 const doneBody = z.object({ done: z.boolean() });
 const idParam = z.object({ id: z.string().uuid() });
 

--- a/apps/api/src/http/daily-tasks-routes.ts
+++ b/apps/api/src/http/daily-tasks-routes.ts
@@ -1,0 +1,66 @@
+import { zValidator } from "@hono/zod-validator";
+import type { Hono } from "hono";
+import { z } from "zod";
+import type { Database } from "../db/client.js";
+import { createDailyTask, deleteDailyTask, setDailyTaskDone, updateDailyTaskEmoji, updateDailyTaskText } from "../modules/daily-tasks/service.js";
+import { listDailyTasks } from "../modules/daily-tasks/queries.js";
+import { requireSameOrigin } from "./origin-check.js";
+import { requireUser, type AppBindings } from "./middleware.js";
+
+// issue 342: "Úlohy na dnes" — súkromný zoznam, viazaný na prihláseného
+// používateľa. Na rozdiel od zvyšku appky (zápis vyžaduje `requireRole
+// ("admin", "manazer")`) tu STAČÍ `requireUser` na KAŽDÚ akciu vrátane
+// zápisu — server aj tak vynucuje `userId` na každom dopyte, takže žiadna
+// rola nedostane prístup k CUDZÍM úlohám; obmedzenie roly by tu len bránilo
+// zamestnancovi s rolou "citanie" mať VLASTNÝ súkromný zoznam bez dôvodu.
+const createBody = z.object({ text: z.string().trim().min(1).max(300) });
+const updateTextBody = z.object({ text: z.string().trim().min(1).max(300) });
+const updateEmojiBody = z.object({ emoji: z.string().trim().max(16).nullable() });
+const doneBody = z.object({ done: z.boolean() });
+const idParam = z.object({ id: z.string().uuid() });
+
+export function registerDailyTasksRoutes(app: Hono<AppBindings>, db: Database): void {
+  app.get("/api/daily-tasks", requireUser(db), async (c) => {
+    const user = c.get("user");
+    const rows = await listDailyTasks(db, user.userId);
+    return c.json({ rows });
+  });
+
+  app.post("/api/daily-tasks", requireSameOrigin(), requireUser(db), zValidator("json", createBody), async (c) => {
+    const { text } = c.req.valid("json");
+    const user = c.get("user");
+    const created = await createDailyTask(db, { userId: user.userId, text, now: new Date() });
+    return c.json({ ok: true as const, id: created.id });
+  });
+
+  app.patch("/api/daily-tasks/:id/text", requireSameOrigin(), requireUser(db), zValidator("param", idParam), zValidator("json", updateTextBody), async (c) => {
+    const { id } = c.req.valid("param");
+    const { text } = c.req.valid("json");
+    const user = c.get("user");
+    const updated = await updateDailyTaskText(db, { id, userId: user.userId, text, now: new Date() });
+    return c.json({ ok: true as const, updated });
+  });
+
+  app.patch("/api/daily-tasks/:id/emoji", requireSameOrigin(), requireUser(db), zValidator("param", idParam), zValidator("json", updateEmojiBody), async (c) => {
+    const { id } = c.req.valid("param");
+    const { emoji } = c.req.valid("json");
+    const user = c.get("user");
+    const updated = await updateDailyTaskEmoji(db, { id, userId: user.userId, emoji: emoji === "" ? null : emoji, now: new Date() });
+    return c.json({ ok: true as const, updated });
+  });
+
+  app.post("/api/daily-tasks/:id/done", requireSameOrigin(), requireUser(db), zValidator("param", idParam), zValidator("json", doneBody), async (c) => {
+    const { id } = c.req.valid("param");
+    const { done } = c.req.valid("json");
+    const user = c.get("user");
+    const updated = await setDailyTaskDone(db, { id, userId: user.userId, done, now: new Date() });
+    return c.json({ ok: true as const, updated });
+  });
+
+  app.delete("/api/daily-tasks/:id", requireSameOrigin(), requireUser(db), zValidator("param", idParam), async (c) => {
+    const { id } = c.req.valid("param");
+    const user = c.get("user");
+    const removed = await deleteDailyTask(db, { id, userId: user.userId });
+    return c.json({ ok: true as const, removed });
+  });
+}

--- a/apps/api/src/modules/daily-tasks/queries.ts
+++ b/apps/api/src/modules/daily-tasks/queries.ts
@@ -1,0 +1,30 @@
+import { desc, eq } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { dailyTask } from "../../db/schema.js";
+
+export interface DailyTaskRow {
+  readonly id: string;
+  readonly text: string;
+  readonly emoji: string | null;
+  readonly doneAt: Date | null;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+}
+
+// Vždy filtrované na JEDNÉHO používateľa (nikdy zdieľané, viď design komentár
+// na issue 342) a zoradené "najnovšie hore" — jediná os triedenia, vybavené
+// úlohy ostávajú na svojom mieste (frontend ich len vizuálne stlmí).
+export async function listDailyTasks(db: Database, userId: string): Promise<readonly DailyTaskRow[]> {
+  return db
+    .select({
+      id: dailyTask.id,
+      text: dailyTask.text,
+      emoji: dailyTask.emoji,
+      doneAt: dailyTask.doneAt,
+      createdAt: dailyTask.createdAt,
+      updatedAt: dailyTask.updatedAt,
+    })
+    .from(dailyTask)
+    .where(eq(dailyTask.userId, userId))
+    .orderBy(desc(dailyTask.createdAt));
+}

--- a/apps/api/src/modules/daily-tasks/service.ts
+++ b/apps/api/src/modules/daily-tasks/service.ts
@@ -1,0 +1,97 @@
+import { and, eq } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { dailyTask } from "../../db/schema.js";
+
+export interface CreateDailyTaskInput {
+  readonly userId: string;
+  readonly text: string;
+  readonly now: Date;
+}
+
+export interface DailyTaskWriteResult {
+  readonly id: string;
+}
+
+// Jediná zapisovacia cesta pre NOVÚ úlohu — rovnaký princíp ako
+// `.claude/rules/mail-log.md`/`upozornenia`'s "jediná zapisovacia cesta".
+export async function createDailyTask(db: Database, input: CreateDailyTaskInput): Promise<DailyTaskWriteResult> {
+  const [row] = await db
+    .insert(dailyTask)
+    .values({ userId: input.userId, text: input.text, createdAt: input.now, updatedAt: input.now })
+    .returning({ id: dailyTask.id });
+  if (row === undefined) throw new Error("Vloženie úlohy zlyhalo bez chyby");
+  return { id: row.id };
+}
+
+export interface UpdateDailyTaskTextInput {
+  readonly id: string;
+  readonly userId: string;
+  readonly text: string;
+  readonly now: Date;
+}
+
+// Vlastníctvo (`user_id`) sa vynucuje TU, nie len vo frontende — rovnaká
+// disciplína ako `upozornenia/service.ts`'s `updateOwnNote` (`source ===
+// "vlastne"`). Cudziu/neznámu/už zmazanú úlohu vráti ako `false`, nikdy 4xx
+// (rovnaký "neškodné no-op" princíp ako zvyšok appky).
+//
+// Text a emoji sú ZÁMERNE dve samostatné funkcie/endpointy, nie jeden
+// partial-update — zrkadlí to dve samostatné akcie v UI ("upraviť text" /
+// "pridať emoji", design komentár na tickete) a vyhýba sa dvojznačnosti
+// "kľúč nezadaný vs. zadaný ako null" (`.claude/rules/testing.md`'s vlastná
+// past pri `??` defaultoch v testových helperoch — rovnaký princíp, len na
+// úrovni HTTP body namiesto testovej funkcie).
+export async function updateDailyTaskText(db: Database, input: UpdateDailyTaskTextInput): Promise<boolean> {
+  const result = await db
+    .update(dailyTask)
+    .set({ text: input.text, updatedAt: input.now })
+    .where(and(eq(dailyTask.id, input.id), eq(dailyTask.userId, input.userId)))
+    .returning({ id: dailyTask.id });
+  return result.length > 0;
+}
+
+export interface UpdateDailyTaskEmojiInput {
+  readonly id: string;
+  readonly userId: string;
+  // `null` = zmazať emoji (späť na "žiadne").
+  readonly emoji: string | null;
+  readonly now: Date;
+}
+
+export async function updateDailyTaskEmoji(db: Database, input: UpdateDailyTaskEmojiInput): Promise<boolean> {
+  const result = await db
+    .update(dailyTask)
+    .set({ emoji: input.emoji, updatedAt: input.now })
+    .where(and(eq(dailyTask.id, input.id), eq(dailyTask.userId, input.userId)))
+    .returning({ id: dailyTask.id });
+  return result.length > 0;
+}
+
+export interface SetDailyTaskDoneInput {
+  readonly id: string;
+  readonly userId: string;
+  readonly done: boolean;
+  readonly now: Date;
+}
+
+export async function setDailyTaskDone(db: Database, input: SetDailyTaskDoneInput): Promise<boolean> {
+  const result = await db
+    .update(dailyTask)
+    .set({ doneAt: input.done ? input.now : null, updatedAt: input.now })
+    .where(and(eq(dailyTask.id, input.id), eq(dailyTask.userId, input.userId)))
+    .returning({ id: dailyTask.id });
+  return result.length > 0;
+}
+
+export interface DeleteDailyTaskInput {
+  readonly id: string;
+  readonly userId: string;
+}
+
+export async function deleteDailyTask(db: Database, input: DeleteDailyTaskInput): Promise<boolean> {
+  const result = await db
+    .delete(dailyTask)
+    .where(and(eq(dailyTask.id, input.id), eq(dailyTask.userId, input.userId)))
+    .returning({ id: dailyTask.id });
+  return result.length > 0;
+}

--- a/apps/api/tests/daily-tasks-http.integration.test.ts
+++ b/apps/api/tests/daily-tasks-http.integration.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { users } from "../src/db/schema.js";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import type { UserRole } from "../src/modules/auth/service.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 342: "Dôležité → Úlohy na dnes" — súkromný, per-používateľský zoznam.
+const HESLO = "test-heslo-abc";
+
+let close: (() => Promise<void>) | undefined;
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  resetLoginRateLimit();
+});
+
+async function bootUser(email: string, role: UserRole) {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await ctx.db.insert(users).values({ email, passwordHash: await hashPassword(HESLO), displayName: email, role });
+  const app = createApp(ctx.db, { cookieSecure: false });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email, password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie, db: ctx.db };
+}
+
+// Druhý používateľ v TEJ ISTEJ (už čistej) DB — `withCleanDb()` TRUNCATE-uje
+// `users` len raz na začiatku testu, druhé prihlásenie sa preto len PRIDÁ do
+// existujúceho pripojenia (rovnaký princíp ako `.claude/rules/testing.md`'s
+// "DVA `boot()`-štýl helpery sa navzájom prepíšu" — tu sa preto NEVOLÁ
+// `withCleanDb()` druhýkrát, len ďalší insert + login na tej istej `app`).
+async function secondLogin(app: ReturnType<typeof createApp>, db: Awaited<ReturnType<typeof withCleanDb>>["db"], email: string, role: UserRole) {
+  await db.insert(users).values({ email, passwordHash: await hashPassword(HESLO), displayName: email, role });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email, password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { cookie };
+}
+
+describe("GET /api/daily-tasks", () => {
+  it("bez prihlásenia vráti 401", async () => {
+    const { app } = await bootUser("sef@forestshop.sk", "admin");
+    const res = await app.request("/api/daily-tasks");
+    expect(res.status).toBe(401);
+  });
+
+  it("čerstvý používateľ má prázdny zoznam", async () => {
+    const { app, cookie } = await bootUser("sef@forestshop.sk", "admin");
+    const res = await app.request("/api/daily-tasks", { headers: { cookie } });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { rows: readonly unknown[] };
+    expect(body.rows).toEqual([]);
+  });
+
+  it("zoznam je zoradený najnovšie hore", async () => {
+    const { app, cookie } = await bootUser("sef@forestshop.sk", "admin");
+    await app.request("/api/daily-tasks", { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ text: "poslať DPD" }) });
+    await app.request("/api/daily-tasks", { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ text: "Nemáme sáčky" }) });
+
+    const res = await app.request("/api/daily-tasks", { headers: { cookie } });
+    const body = (await res.json()) as { rows: readonly { text: string }[] };
+    expect(body.rows.map((r) => r.text)).toEqual(["Nemáme sáčky", "poslať DPD"]);
+  });
+
+  it("úlohy sú OSOBNÉ — druhý používateľ ich v zozname nevidí", async () => {
+    const { app, cookie, db } = await bootUser("sef@forestshop.sk", "admin");
+    await app.request("/api/daily-tasks", { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ text: "šéfova súkromná úloha" }) });
+
+    const other = await secondLogin(app, db, "zamestnanec@forestshop.sk", "manazer");
+    const res = await app.request("/api/daily-tasks", { headers: { cookie: other.cookie } });
+    const body = (await res.json()) as { rows: readonly unknown[] };
+    expect(body.rows).toEqual([]);
+  });
+});
+
+describe("POST /api/daily-tasks", () => {
+  it("vytvorí úlohu len s textom, žiadne ďalšie pole nie je povinné", async () => {
+    const { app, cookie } = await bootUser("sef@forestshop.sk", "admin");
+    const res = await app.request("/api/daily-tasks", { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ text: "Záhorecký volať" }) });
+    expect(res.status).toBe(200);
+    const created = (await res.json()) as { ok: boolean; id: string };
+    expect(created.ok).toBe(true);
+
+    const list = await app.request("/api/daily-tasks", { headers: { cookie } });
+    const body = (await list.json()) as { rows: readonly { id: string; text: string; emoji: string | null; doneAt: string | null }[] };
+    expect(body.rows).toHaveLength(1);
+    expect(body.rows[0]).toMatchObject({ id: created.id, text: "Záhorecký volať", emoji: null, doneAt: null });
+  });
+
+  it("prázdny text je odmietnutý (400)", async () => {
+    const { app, cookie } = await bootUser("sef@forestshop.sk", "admin");
+    const res = await app.request("/api/daily-tasks", { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ text: "  " }) });
+    expect(res.status).toBe(400);
+  });
+
+  it("rola 'citanie' SMIE vytvoriť vlastnú úlohu — je to jej vlastný súkromný zoznam", async () => {
+    const { app, cookie } = await bootUser("zamestnanec@forestshop.sk", "citanie");
+    const res = await app.request("/api/daily-tasks", { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ text: "moja poznámka" }) });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("PATCH /api/daily-tasks/:id/text", () => {
+  it("upraví text vlastnej úlohy", async () => {
+    const { app, cookie } = await bootUser("sef@forestshop.sk", "admin");
+    const create = await app.request("/api/daily-tasks", { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ text: "Pôvodná" }) });
+    const { id } = (await create.json()) as { id: string };
+
+    const patch = await app.request(`/api/daily-tasks/${id}/text`, { method: "PATCH", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ text: "Upravená" }) });
+    expect((await patch.json()) as { ok: boolean; updated: boolean }).toEqual({ ok: true, updated: true });
+
+    const list = await app.request("/api/daily-tasks", { headers: { cookie } });
+    const body = (await list.json()) as { rows: readonly { text: string }[] };
+    expect(body.rows[0]?.text).toBe("Upravená");
+  });
+
+  it("CUDZIU úlohu neupraví (updated:false), text ostane pôvodný", async () => {
+    const { app, cookie, db } = await bootUser("sef@forestshop.sk", "admin");
+    const create = await app.request("/api/daily-tasks", { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ text: "Šéfova úloha" }) });
+    const { id } = (await create.json()) as { id: string };
+
+    const other = await secondLogin(app, db, "zamestnanec@forestshop.sk", "manazer");
+    const patch = await app.request(`/api/daily-tasks/${id}/text`, { method: "PATCH", headers: { cookie: other.cookie, "content-type": "application/json" }, body: JSON.stringify({ text: "Prepísané cudzím" }) });
+    expect((await patch.json()) as { ok: boolean; updated: boolean }).toEqual({ ok: true, updated: false });
+
+    const list = await app.request("/api/daily-tasks", { headers: { cookie } });
+    const body = (await list.json()) as { rows: readonly { text: string }[] };
+    expect(body.rows[0]?.text).toBe("Šéfova úloha");
+  });
+});
+
+describe("PATCH /api/daily-tasks/:id/emoji", () => {
+  it("pridá a potom zmaže emoji (null)", async () => {
+    const { app, cookie } = await bootUser("sef@forestshop.sk", "admin");
+    const create = await app.request("/api/daily-tasks", { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ text: "Úloha" }) });
+    const { id } = (await create.json()) as { id: string };
+
+    const setEmoji = await app.request(`/api/daily-tasks/${id}/emoji`, { method: "PATCH", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ emoji: "🚚" }) });
+    expect((await setEmoji.json()) as { updated: boolean }).toEqual({ ok: true, updated: true });
+    const afterSet = await app.request("/api/daily-tasks", { headers: { cookie } });
+    expect(((await afterSet.json()) as { rows: readonly { emoji: string | null }[] }).rows[0]?.emoji).toBe("🚚");
+
+    const clearEmoji = await app.request(`/api/daily-tasks/${id}/emoji`, { method: "PATCH", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ emoji: null }) });
+    expect((await clearEmoji.json()) as { updated: boolean }).toEqual({ ok: true, updated: true });
+    const afterClear = await app.request("/api/daily-tasks", { headers: { cookie } });
+    expect(((await afterClear.json()) as { rows: readonly { emoji: string | null }[] }).rows[0]?.emoji).toBeNull();
+  });
+});
+
+describe("POST /api/daily-tasks/:id/done", () => {
+  it("označí ako vybavené a späť ako nevybavené (doneAt sa nastaví/zruší)", async () => {
+    const { app, cookie } = await bootUser("sef@forestshop.sk", "admin");
+    const create = await app.request("/api/daily-tasks", { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ text: "Úloha" }) });
+    const { id } = (await create.json()) as { id: string };
+
+    const markDone = await app.request(`/api/daily-tasks/${id}/done`, { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ done: true }) });
+    expect((await markDone.json()) as { updated: boolean }).toEqual({ ok: true, updated: true });
+    const afterDone = await app.request("/api/daily-tasks", { headers: { cookie } });
+    expect(((await afterDone.json()) as { rows: readonly { doneAt: string | null }[] }).rows[0]?.doneAt).not.toBeNull();
+
+    const markUndone = await app.request(`/api/daily-tasks/${id}/done`, { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ done: false }) });
+    expect((await markUndone.json()) as { updated: boolean }).toEqual({ ok: true, updated: true });
+    const afterUndone = await app.request("/api/daily-tasks", { headers: { cookie } });
+    expect(((await afterUndone.json()) as { rows: readonly { doneAt: string | null }[] }).rows[0]?.doneAt).toBeNull();
+  });
+});
+
+describe("DELETE /api/daily-tasks/:id", () => {
+  it("okamžite odstráni vlastnú úlohu", async () => {
+    const { app, cookie } = await bootUser("sef@forestshop.sk", "admin");
+    const create = await app.request("/api/daily-tasks", { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ text: "Na zmazanie" }) });
+    const { id } = (await create.json()) as { id: string };
+
+    const del = await app.request(`/api/daily-tasks/${id}`, { method: "DELETE", headers: { cookie } });
+    expect((await del.json()) as { removed: boolean }).toEqual({ ok: true, removed: true });
+
+    const list = await app.request("/api/daily-tasks", { headers: { cookie } });
+    expect(((await list.json()) as { rows: readonly unknown[] }).rows).toEqual([]);
+  });
+
+  it("neznáme id vráti 200 {removed:false}, nikdy chybu", async () => {
+    const { app, cookie } = await bootUser("sef@forestshop.sk", "admin");
+    const res = await app.request("/api/daily-tasks/00000000-0000-0000-0000-000000000000", { method: "DELETE", headers: { cookie } });
+    expect(res.status).toBe(200);
+    expect((await res.json()) as { ok: boolean; removed: boolean }).toEqual({ ok: true, removed: false });
+  });
+
+  it("CUDZIU úlohu nezmaže (removed:false), ostáva v zozname vlastníka", async () => {
+    const { app, cookie, db } = await bootUser("sef@forestshop.sk", "admin");
+    const create = await app.request("/api/daily-tasks", { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ text: "Šéfova úloha" }) });
+    const { id } = (await create.json()) as { id: string };
+
+    const other = await secondLogin(app, db, "zamestnanec@forestshop.sk", "manazer");
+    const del = await app.request(`/api/daily-tasks/${id}`, { method: "DELETE", headers: { cookie: other.cookie } });
+    expect((await del.json()) as { removed: boolean }).toEqual({ ok: true, removed: false });
+
+    const list = await app.request("/api/daily-tasks", { headers: { cookie } });
+    expect(((await list.json()) as { rows: readonly { id: string }[] }).rows.map((r) => r.id)).toEqual([id]);
+  });
+});

--- a/apps/api/tests/daily-tasks-http.integration.test.ts
+++ b/apps/api/tests/daily-tasks-http.integration.test.ts
@@ -154,6 +154,24 @@ describe("PATCH /api/daily-tasks/:id/emoji", () => {
     const afterClear = await app.request("/api/daily-tasks", { headers: { cookie } });
     expect(((await afterClear.json()) as { rows: readonly { emoji: string | null }[] }).rows[0]?.emoji).toBeNull();
   });
+
+  // Code review: symetrické pokrytie s "PATCH .../text"'s a "DELETE"'s
+  // rovnaké IDOR testy nižšie — implementácia je identická (`and(eq(id),
+  // eq(userId))`), ale bez PRIAMEHO testu by táto cesta ostala pokrytá len
+  // nepriamo.
+  it("CUDZIU úlohu neupraví emoji (updated:false), emoji ostane pôvodné", async () => {
+    const { app, cookie, db } = await bootUser("sef@forestshop.sk", "admin");
+    const create = await app.request("/api/daily-tasks", { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ text: "Šéfova úloha" }) });
+    const { id } = (await create.json()) as { id: string };
+
+    const other = await secondLogin(app, db, "zamestnanec@forestshop.sk", "manazer");
+    const patch = await app.request(`/api/daily-tasks/${id}/emoji`, { method: "PATCH", headers: { cookie: other.cookie, "content-type": "application/json" }, body: JSON.stringify({ emoji: "🚚" }) });
+    expect((await patch.json()) as { ok: boolean; updated: boolean }).toEqual({ ok: true, updated: false });
+
+    const list = await app.request("/api/daily-tasks", { headers: { cookie } });
+    const body = (await list.json()) as { rows: readonly { emoji: string | null }[] };
+    expect(body.rows[0]?.emoji).toBeNull();
+  });
 });
 
 describe("POST /api/daily-tasks/:id/done", () => {
@@ -171,6 +189,21 @@ describe("POST /api/daily-tasks/:id/done", () => {
     expect((await markUndone.json()) as { updated: boolean }).toEqual({ ok: true, updated: true });
     const afterUndone = await app.request("/api/daily-tasks", { headers: { cookie } });
     expect(((await afterUndone.json()) as { rows: readonly { doneAt: string | null }[] }).rows[0]?.doneAt).toBeNull();
+  });
+
+  // Code review: rovnaké symetrické IDOR pokrytie ako "PATCH .../emoji" vyššie.
+  it("CUDZIU úlohu neoznačí ako vybavenú (updated:false), doneAt ostane null", async () => {
+    const { app, cookie, db } = await bootUser("sef@forestshop.sk", "admin");
+    const create = await app.request("/api/daily-tasks", { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ text: "Šéfova úloha" }) });
+    const { id } = (await create.json()) as { id: string };
+
+    const other = await secondLogin(app, db, "zamestnanec@forestshop.sk", "manazer");
+    const markDone = await app.request(`/api/daily-tasks/${id}/done`, { method: "POST", headers: { cookie: other.cookie, "content-type": "application/json" }, body: JSON.stringify({ done: true }) });
+    expect((await markDone.json()) as { ok: boolean; updated: boolean }).toEqual({ ok: true, updated: false });
+
+    const list = await app.request("/api/daily-tasks", { headers: { cookie } });
+    const body = (await list.json()) as { rows: readonly { doneAt: string | null }[] };
+    expect(body.rows[0]?.doneAt).toBeNull();
   });
 });
 

--- a/apps/web/src/components/DailyTasksSection.test.tsx
+++ b/apps/web/src/components/DailyTasksSection.test.tsx
@@ -153,3 +153,52 @@ it("pri 401 (session vypršala) zavolá onSessionExpired", async () => {
     expect(onSessionExpired).toHaveBeenCalled();
   });
 });
+
+// Code review: rovnaký nález ako issue 251's `SupplierLinksSection.tsx`/
+// `PairingSection.tsx` — bez "latest ref" guardu by uloženie riadku A (ešte
+// čakajúce na odpoveď) zavrelo editor riadku B, otvorený medzitým.
+it("uloženie textu riadku A (ešte čakajúce na odpoveď) nesmie zavrieť editor riadku B otvorený medzitým", async () => {
+  fetchDailyTasks.mockResolvedValue([ROW_B, ROW_A]);
+  let resolveA: (v: boolean) => void = () => {};
+  updateDailyTaskText.mockImplementationOnce(
+    () =>
+      new Promise<boolean>((resolve) => {
+        resolveA = resolve;
+      }),
+  );
+  render(<DailyTasksSection onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("uloha-row-task-a");
+
+  // Otvoriť editor riadku A a uložiť — odpoveď zatiaľ NEDORAZILA.
+  fireEvent.click(screen.getByTestId("uloha-edit-task-a"));
+  fireEvent.click(screen.getByTestId("uloha-edit-save-task-a"));
+  await waitFor(() => {
+    expect(updateDailyTaskText).toHaveBeenCalledWith("task-a", "poslať DPD");
+  });
+
+  // Kým A čaká, otvoriť editor riadku B (appka dovolí len JEDEN naraz).
+  fireEvent.click(screen.getByTestId("uloha-edit-task-b"));
+  expect(screen.getByTestId("uloha-edit-input-task-b")).toBeTruthy();
+
+  // Teraz nech odpoveď A dorazí — editor riadku B musí OSTAŤ otvorený.
+  resolveA(true);
+  await waitFor(() => {
+    expect(fetchDailyTasks).toHaveBeenCalledTimes(2); // mount + po uložení A
+  });
+  expect(screen.getByTestId("uloha-edit-input-task-b")).toBeTruthy();
+});
+
+it("pri 401 POČAS mutácie (nielen počiatočného načítania) tiež zavolá onSessionExpired", async () => {
+  const { DailyTasksUnauthorizedError } = await import("../dailyTasksApi.js");
+  fetchDailyTasks.mockResolvedValueOnce([ROW_A]);
+  setDailyTaskDone.mockRejectedValueOnce(new DailyTasksUnauthorizedError());
+  const onSessionExpired = vi.fn();
+  render(<DailyTasksSection onSessionExpired={onSessionExpired} />);
+  await screen.findByTestId("uloha-row-task-a");
+
+  fireEvent.click(screen.getByTestId("uloha-done-task-a"));
+
+  await waitFor(() => {
+    expect(onSessionExpired).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/DailyTasksSection.test.tsx
+++ b/apps/web/src/components/DailyTasksSection.test.tsx
@@ -1,0 +1,155 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { DailyTasksSection } from "./DailyTasksSection.js";
+
+const { fetchDailyTasks, createDailyTask, updateDailyTaskText, updateDailyTaskEmoji, setDailyTaskDone, deleteDailyTask } = vi.hoisted(() => ({
+  fetchDailyTasks: vi.fn(),
+  createDailyTask: vi.fn(),
+  updateDailyTaskText: vi.fn(),
+  updateDailyTaskEmoji: vi.fn(),
+  setDailyTaskDone: vi.fn(),
+  deleteDailyTask: vi.fn(),
+}));
+
+// `DailyTasksUnauthorizedError` ostáva SKUTOČNÁ trieda (rovnaký dôvod ako
+// `UpozorneniaSection.test.tsx`/`NedostupneSection.test.tsx` — `instanceof`
+// v komponente musí fungovať).
+vi.mock("../dailyTasksApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../dailyTasksApi.js")>();
+  return { ...actual, fetchDailyTasks, createDailyTask, updateDailyTaskText, updateDailyTaskEmoji, setDailyTaskDone, deleteDailyTask };
+});
+
+const ROW_A = { id: "task-a", text: "poslať DPD", emoji: null, doneAt: null, createdAt: "2026-08-11T08:00:00.000Z", updatedAt: "2026-08-11T08:00:00.000Z" };
+const ROW_B = { id: "task-b", text: "Nemáme sáčky", emoji: "🛍️", doneAt: null, createdAt: "2026-08-11T09:00:00.000Z", updatedAt: "2026-08-11T09:00:00.000Z" };
+const ROW_DONE = { id: "task-done", text: "Vybavená úloha", emoji: null, doneAt: "2026-08-11T10:00:00.000Z", createdAt: "2026-08-11T07:00:00.000Z", updatedAt: "2026-08-11T10:00:00.000Z" };
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+it("zobrazí zoznam úloh z fetchDailyTasks", async () => {
+  fetchDailyTasks.mockResolvedValueOnce([ROW_B, ROW_A]);
+  render(<DailyTasksSection onSessionExpired={vi.fn()} />);
+
+  await screen.findByTestId("uloha-row-task-a");
+  expect(screen.getByTestId("uloha-text-task-a").textContent).toBe("poslať DPD");
+  expect(screen.getByTestId("uloha-text-task-b").textContent).toBe("Nemáme sáčky");
+});
+
+it("prázdny zoznam ukáže výzvu, nie chybu", async () => {
+  fetchDailyTasks.mockResolvedValueOnce([]);
+  render(<DailyTasksSection onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("ulohy-empty");
+});
+
+it("Enter v novom vstupe vytvorí úlohu a vyčistí pole, žiadny formulár/dialóg", async () => {
+  fetchDailyTasks.mockResolvedValueOnce([]).mockResolvedValueOnce([ROW_A]);
+  createDailyTask.mockResolvedValueOnce(undefined);
+  render(<DailyTasksSection onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("ulohy-empty");
+
+  const input = screen.getByTestId<HTMLInputElement>("uloha-new-input");
+  fireEvent.change(input, { target: { value: "poslať DPD" } });
+  fireEvent.keyDown(input, { key: "Enter" });
+
+  await waitFor(() => {
+    expect(createDailyTask).toHaveBeenCalledWith("poslať DPD");
+  });
+  await screen.findByTestId("uloha-row-task-a");
+  expect(input.value).toBe("");
+});
+
+it("prázdny text sa neodošle (tlačidlo Pridať je disabled, Enter nič nespraví)", async () => {
+  fetchDailyTasks.mockResolvedValueOnce([]);
+  render(<DailyTasksSection onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("ulohy-empty");
+
+  const input = screen.getByTestId<HTMLInputElement>("uloha-new-input");
+  expect(screen.getByTestId<HTMLButtonElement>("uloha-new-add").disabled).toBe(true);
+  fireEvent.keyDown(input, { key: "Enter" });
+  expect(createDailyTask).not.toHaveBeenCalled();
+});
+
+it("upraví text úlohy cez inline ✏️ toggle", async () => {
+  fetchDailyTasks.mockResolvedValueOnce([ROW_A]).mockResolvedValueOnce([{ ...ROW_A, text: "poslať DPD zajtra" }]);
+  updateDailyTaskText.mockResolvedValueOnce(true);
+  render(<DailyTasksSection onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("uloha-row-task-a");
+
+  fireEvent.click(screen.getByTestId("uloha-edit-task-a"));
+  const editInput = screen.getByTestId<HTMLInputElement>("uloha-edit-input-task-a");
+  fireEvent.change(editInput, { target: { value: "poslať DPD zajtra" } });
+  fireEvent.click(screen.getByTestId("uloha-edit-save-task-a"));
+
+  await waitFor(() => {
+    expect(updateDailyTaskText).toHaveBeenCalledWith("task-a", "poslať DPD zajtra");
+  });
+  await waitFor(() => {
+    expect(screen.getByTestId("uloha-text-task-a").textContent).toBe("poslať DPD zajtra");
+  });
+});
+
+it("pridá emoji cez inline 😊 toggle", async () => {
+  fetchDailyTasks.mockResolvedValueOnce([ROW_A]).mockResolvedValueOnce([{ ...ROW_A, emoji: "🚚" }]);
+  updateDailyTaskEmoji.mockResolvedValueOnce(true);
+  render(<DailyTasksSection onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("uloha-row-task-a");
+
+  fireEvent.click(screen.getByTestId("uloha-emoji-task-a"));
+  const emojiInput = screen.getByTestId<HTMLInputElement>("uloha-emoji-input-task-a");
+  fireEvent.change(emojiInput, { target: { value: "🚚" } });
+  fireEvent.click(screen.getByTestId("uloha-emoji-save-task-a"));
+
+  await waitFor(() => {
+    expect(updateDailyTaskEmoji).toHaveBeenCalledWith("task-a", "🚚");
+  });
+});
+
+it("označí úlohu ako vybavenú — riadok dostane triedu 'done'", async () => {
+  fetchDailyTasks.mockResolvedValueOnce([ROW_A]).mockResolvedValueOnce([{ ...ROW_A, doneAt: "2026-08-11T12:00:00.000Z" }]);
+  setDailyTaskDone.mockResolvedValueOnce(true);
+  render(<DailyTasksSection onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("uloha-row-task-a");
+
+  fireEvent.click(screen.getByTestId("uloha-done-task-a"));
+
+  await waitFor(() => {
+    expect(setDailyTaskDone).toHaveBeenCalledWith("task-a", true);
+  });
+  await waitFor(() => {
+    expect(screen.getByTestId("uloha-row-task-a").className).toContain("done");
+  });
+});
+
+it("vybavená úloha OSTÁVA v zozname (nezmizne), len je stlmená", async () => {
+  fetchDailyTasks.mockResolvedValueOnce([ROW_DONE]);
+  render(<DailyTasksSection onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("uloha-row-task-done");
+  expect(screen.getByTestId("uloha-row-task-done").className).toContain("done");
+});
+
+it("odstráni úlohu okamžite, bez potvrdzovacieho dialógu", async () => {
+  fetchDailyTasks.mockResolvedValueOnce([ROW_A]).mockResolvedValueOnce([]);
+  deleteDailyTask.mockResolvedValueOnce(undefined);
+  render(<DailyTasksSection onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("uloha-row-task-a");
+
+  fireEvent.click(screen.getByTestId("uloha-delete-task-a"));
+
+  await waitFor(() => {
+    expect(deleteDailyTask).toHaveBeenCalledWith("task-a");
+  });
+  await screen.findByTestId("ulohy-empty");
+});
+
+it("pri 401 (session vypršala) zavolá onSessionExpired", async () => {
+  const { DailyTasksUnauthorizedError } = await import("../dailyTasksApi.js");
+  fetchDailyTasks.mockRejectedValueOnce(new DailyTasksUnauthorizedError());
+  const onSessionExpired = vi.fn();
+  render(<DailyTasksSection onSessionExpired={onSessionExpired} />);
+
+  await waitFor(() => {
+    expect(onSessionExpired).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/DailyTasksSection.tsx
+++ b/apps/web/src/components/DailyTasksSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, type JSX } from "react";
+import { useCallback, useEffect, useRef, useState, type JSX } from "react";
 import {
   createDailyTask,
   DailyTasksUnauthorizedError,
@@ -32,6 +32,18 @@ export function DailyTasksSection({ onSessionExpired }: { readonly onSessionExpi
   const [editingEmojiId, setEditingEmojiId] = useState<string | null>(null);
   const [emojiDraft, setEmojiDraft] = useState<Record<string, string>>({});
 
+  // Code review (rovnaký nález ako issue 251's `SupplierLinksSection.tsx`/
+  // `PairingSection.tsx`): `saveText`/`saveEmoji`'s `.then()` musí vedieť,
+  // KTORÝ riadok je PRÁVE editovaný V OKAMIHU, keď odpoveď doletí — nie ten,
+  // čo bol editovaný v momente kliknutia na Uložiť. Bez tohto by uloženie
+  // riadku A (ešte čakajúce na odpoveď) mohlo zavrieť editor riadku B,
+  // otvorený medzitým. "Latest ref" vzor — synchrónne priamo v tele
+  // komponentu, nie cez `useEffect`.
+  const editingTextIdRef = useRef(editingTextId);
+  editingTextIdRef.current = editingTextId;
+  const editingEmojiIdRef = useRef(editingEmojiId);
+  editingEmojiIdRef.current = editingEmojiId;
+
   const load = useCallback(() => {
     fetchDailyTasks()
       .then((data) => {
@@ -50,6 +62,22 @@ export function DailyTasksSection({ onSessionExpired }: { readonly onSessionExpi
     load();
   }, [load]);
 
+  // Code review: KAŽDÁ mutácia (nielen počiatočný `load()`) musí rozlíšiť
+  // vypršanú reláciu (401) od bežného zlyhania — inak po vypršaní počas
+  // akcie appka len opakovane hlási všeobecnú chybu bez cesty späť na
+  // prihlásenie. Rovnaký vzor ako `NedostupneSection.tsx`'s každý mutačný
+  // `.catch()`.
+  const handleActionError = useCallback(
+    (err: unknown, fallback: string) => {
+      if (err instanceof DailyTasksUnauthorizedError) {
+        onSessionExpired();
+        return;
+      }
+      setError(fallback);
+    },
+    [onSessionExpired],
+  );
+
   const addTask = useCallback(() => {
     const text = newText.trim();
     if (text === "" || creating) return;
@@ -60,13 +88,13 @@ export function DailyTasksSection({ onSessionExpired }: { readonly onSessionExpi
         setNewText("");
         load();
       })
-      .catch(() => {
-        setError("Úlohu sa nepodarilo pridať — skúste to znova.");
+      .catch((err: unknown) => {
+        handleActionError(err, "Úlohu sa nepodarilo pridať — skúste to znova.");
       })
       .finally(() => {
         setCreating(false);
       });
-  }, [newText, creating, load]);
+  }, [newText, creating, load, handleActionError]);
 
   const toggleDone = useCallback(
     (row: DailyTaskRow) => {
@@ -76,14 +104,14 @@ export function DailyTasksSection({ onSessionExpired }: { readonly onSessionExpi
         .then(() => {
           load();
         })
-        .catch(() => {
-          setError("Akcia zlyhala — skúste to znova.");
+        .catch((err: unknown) => {
+          handleActionError(err, "Akcia zlyhala — skúste to znova.");
         })
         .finally(() => {
           setBusyId("");
         });
     },
-    [load],
+    [load, handleActionError],
   );
 
   const saveText = useCallback(
@@ -94,17 +122,21 @@ export function DailyTasksSection({ onSessionExpired }: { readonly onSessionExpi
       setError("");
       updateDailyTaskText(id, text)
         .then(() => {
-          setEditingTextId(null);
+          // Code review: kým táto odpoveď čakala, používateľ mohol otvoriť
+          // INÝ riadok na úpravu textu (`editingTextId` sa presunul naň) —
+          // vtedy toto zatvorenie NESMIE prebehnúť, inak by ticho zavrelo
+          // CUDZÍ, práve rozpísaný editor.
+          if (editingTextIdRef.current === id) setEditingTextId(null);
           load();
         })
-        .catch(() => {
-          setError("Text sa nepodarilo uložiť — skúste to znova.");
+        .catch((err: unknown) => {
+          handleActionError(err, "Text sa nepodarilo uložiť — skúste to znova.");
         })
         .finally(() => {
           setBusyId("");
         });
     },
-    [textDraft, load],
+    [textDraft, load, handleActionError],
   );
 
   const saveEmoji = useCallback(
@@ -114,17 +146,19 @@ export function DailyTasksSection({ onSessionExpired }: { readonly onSessionExpi
       setError("");
       updateDailyTaskEmoji(id, emoji === "" ? null : emoji)
         .then(() => {
-          setEditingEmojiId(null);
+          // Rovnaký dôvod ako `saveText` vyššie — nezavrieť CUDZÍ, medzitým
+          // otvorený emoji editor.
+          if (editingEmojiIdRef.current === id) setEditingEmojiId(null);
           load();
         })
-        .catch(() => {
-          setError("Emoji sa nepodarilo uložiť — skúste to znova.");
+        .catch((err: unknown) => {
+          handleActionError(err, "Emoji sa nepodarilo uložiť — skúste to znova.");
         })
         .finally(() => {
           setBusyId("");
         });
     },
-    [emojiDraft, load],
+    [emojiDraft, load, handleActionError],
   );
 
   const removeTask = useCallback(
@@ -135,14 +169,14 @@ export function DailyTasksSection({ onSessionExpired }: { readonly onSessionExpi
         .then(() => {
           load();
         })
-        .catch(() => {
-          setError("Úlohu sa nepodarilo odstrániť — skúste to znova.");
+        .catch((err: unknown) => {
+          handleActionError(err, "Úlohu sa nepodarilo odstrániť — skúste to znova.");
         })
         .finally(() => {
           setBusyId("");
         });
     },
-    [load],
+    [load, handleActionError],
   );
 
   const intro = <p>Osobný zoznam úloh — nahrádza poznámky písané do Discordu. Vidíš len svoje vlastné úlohy.</p>;

--- a/apps/web/src/components/DailyTasksSection.tsx
+++ b/apps/web/src/components/DailyTasksSection.tsx
@@ -1,0 +1,355 @@
+import { useCallback, useEffect, useState, type JSX } from "react";
+import {
+  createDailyTask,
+  DailyTasksUnauthorizedError,
+  deleteDailyTask,
+  fetchDailyTasks,
+  setDailyTaskDone,
+  updateDailyTaskEmoji,
+  updateDailyTaskText,
+  type DailyTaskRow,
+} from "../dailyTasksApi.js";
+
+// issue 342: "Dôležité → Úlohy na dnes" — nahrádza šéfove poznámky písané do
+// Discord kanála #úlohy-na-dnes. Na rozdiel od zvyšku appky (viď
+// `UpozorneniaSection.tsx`'s `CONTROL_ROLES`) tu NIE JE žiadne
+// role-podmienené ovládanie — úlohy sú súkromné pre KAŽDÉHO prihláseného
+// používateľa nezávisle od role (server to vynucuje cez `user_id`,
+// `daily-tasks-routes.ts`), takže neexistuje dôvod niekomu brániť mať
+// vlastný súkromný zoznam. Preto komponent prijíma len `onSessionExpired`,
+// nie celý `SectionProps` — TypeScript-ovo je to stále kompatibilné s
+// `ComponentType<SectionProps>` (`nav.ts`), lebo objekt s VIAC poľami (role
+// navyše) sa dá vždy odovzdať tam, kde sa čaká len podmnožina.
+
+export function DailyTasksSection({ onSessionExpired }: { readonly onSessionExpired: () => void }): JSX.Element {
+  const [rows, setRows] = useState<readonly DailyTaskRow[] | null>(null);
+  const [error, setError] = useState("");
+  const [newText, setNewText] = useState("");
+  const [busyId, setBusyId] = useState("");
+  const [creating, setCreating] = useState(false);
+  const [editingTextId, setEditingTextId] = useState<string | null>(null);
+  const [textDraft, setTextDraft] = useState<Record<string, string>>({});
+  const [editingEmojiId, setEditingEmojiId] = useState<string | null>(null);
+  const [emojiDraft, setEmojiDraft] = useState<Record<string, string>>({});
+
+  const load = useCallback(() => {
+    fetchDailyTasks()
+      .then((data) => {
+        setRows(data);
+      })
+      .catch((err: unknown) => {
+        if (err instanceof DailyTasksUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setError("Úlohy sa nepodarilo načítať.");
+      });
+  }, [onSessionExpired]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const addTask = useCallback(() => {
+    const text = newText.trim();
+    if (text === "" || creating) return;
+    setCreating(true);
+    setError("");
+    createDailyTask(text)
+      .then(() => {
+        setNewText("");
+        load();
+      })
+      .catch(() => {
+        setError("Úlohu sa nepodarilo pridať — skúste to znova.");
+      })
+      .finally(() => {
+        setCreating(false);
+      });
+  }, [newText, creating, load]);
+
+  const toggleDone = useCallback(
+    (row: DailyTaskRow) => {
+      setBusyId(row.id);
+      setError("");
+      setDailyTaskDone(row.id, row.doneAt === null)
+        .then(() => {
+          load();
+        })
+        .catch(() => {
+          setError("Akcia zlyhala — skúste to znova.");
+        })
+        .finally(() => {
+          setBusyId("");
+        });
+    },
+    [load],
+  );
+
+  const saveText = useCallback(
+    (id: string) => {
+      const text = (textDraft[id] ?? "").trim();
+      if (text === "") return;
+      setBusyId(id);
+      setError("");
+      updateDailyTaskText(id, text)
+        .then(() => {
+          setEditingTextId(null);
+          load();
+        })
+        .catch(() => {
+          setError("Text sa nepodarilo uložiť — skúste to znova.");
+        })
+        .finally(() => {
+          setBusyId("");
+        });
+    },
+    [textDraft, load],
+  );
+
+  const saveEmoji = useCallback(
+    (id: string) => {
+      const emoji = (emojiDraft[id] ?? "").trim();
+      setBusyId(id);
+      setError("");
+      updateDailyTaskEmoji(id, emoji === "" ? null : emoji)
+        .then(() => {
+          setEditingEmojiId(null);
+          load();
+        })
+        .catch(() => {
+          setError("Emoji sa nepodarilo uložiť — skúste to znova.");
+        })
+        .finally(() => {
+          setBusyId("");
+        });
+    },
+    [emojiDraft, load],
+  );
+
+  const removeTask = useCallback(
+    (id: string) => {
+      setBusyId(id);
+      setError("");
+      deleteDailyTask(id)
+        .then(() => {
+          load();
+        })
+        .catch(() => {
+          setError("Úlohu sa nepodarilo odstrániť — skúste to znova.");
+        })
+        .finally(() => {
+          setBusyId("");
+        });
+    },
+    [load],
+  );
+
+  const intro = <p>Osobný zoznam úloh — nahrádza poznámky písané do Discordu. Vidíš len svoje vlastné úlohy.</p>;
+
+  const addRow = (
+    <div className="ulohy-add-row">
+      <input
+        value={newText}
+        onChange={(e) => {
+          setNewText(e.target.value);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            addTask();
+          }
+        }}
+        aria-label="Nová úloha"
+        placeholder="Napíš úlohu a stlač Enter…"
+        data-testid="uloha-new-input"
+        disabled={creating}
+      />
+      <button type="button" className="btn good sm" onClick={addTask} disabled={newText.trim() === "" || creating} data-testid="uloha-new-add">
+        + Pridať
+      </button>
+    </div>
+  );
+
+  if (error !== "" && rows === null) {
+    return (
+      <section>
+        {intro}
+        {addRow}
+        <p role="alert">{error}</p>
+      </section>
+    );
+  }
+  if (rows === null) {
+    return (
+      <section>
+        {intro}
+        {addRow}
+        <p>Načítavam…</p>
+      </section>
+    );
+  }
+
+  return (
+    <section>
+      {intro}
+      {addRow}
+      {error !== "" && <p role="alert">{error}</p>}
+
+      {rows.length === 0 ? (
+        <p data-testid="ulohy-empty">Žiadne úlohy — napíš prvú vyššie.</p>
+      ) : (
+        <div className="ulohy-list" data-testid="ulohy-list">
+          {rows.map((row) => {
+            const isDone = row.doneAt !== null;
+            const busy = busyId === row.id;
+            return (
+              <div className={"uloha-row" + (isDone ? " done" : "")} key={row.id} data-testid={`uloha-row-${row.id}`}>
+                <button
+                  type="button"
+                  className="uloha-done-toggle"
+                  aria-pressed={isDone}
+                  aria-label={isDone ? "Označiť ako nevybavené" : "Označiť ako vybavené"}
+                  title={isDone ? "Označiť ako nevybavené" : "Označiť ako vybavené"}
+                  disabled={busy}
+                  onClick={() => {
+                    toggleDone(row);
+                  }}
+                  data-testid={`uloha-done-${row.id}`}
+                >
+                  {isDone ? "☑" : "☐"}
+                </button>
+
+                {row.emoji !== null && editingEmojiId !== row.id && (
+                  <span className="uloha-emoji" aria-hidden="true">
+                    {row.emoji}
+                  </span>
+                )}
+
+                {editingTextId === row.id ? (
+                  <>
+                    <input
+                      className="uloha-edit-input"
+                      value={textDraft[row.id] ?? row.text}
+                      onChange={(e) => {
+                        const value = e.target.value;
+                        setTextDraft((d) => ({ ...d, [row.id]: value }));
+                      }}
+                      aria-label="Upraviť text úlohy"
+                      data-testid={`uloha-edit-input-${row.id}`}
+                      autoFocus
+                    />
+                    <button
+                      type="button"
+                      className="uloha-icon-btn"
+                      disabled={busy}
+                      onClick={() => {
+                        saveText(row.id);
+                      }}
+                      title="Uložiť"
+                      aria-label="Uložiť text"
+                      data-testid={`uloha-edit-save-${row.id}`}
+                    >
+                      💾
+                    </button>
+                    <button
+                      type="button"
+                      className="uloha-icon-btn"
+                      onClick={() => {
+                        setEditingTextId(null);
+                      }}
+                      title="Zrušiť"
+                      aria-label="Zrušiť úpravu textu"
+                    >
+                      ✕
+                    </button>
+                  </>
+                ) : (
+                  <span className="uloha-text" data-testid={`uloha-text-${row.id}`}>
+                    {row.text}
+                  </span>
+                )}
+
+                {editingEmojiId === row.id && (
+                  <>
+                    <input
+                      className="uloha-emoji-input-field"
+                      value={emojiDraft[row.id] ?? row.emoji ?? ""}
+                      onChange={(e) => {
+                        const value = e.target.value;
+                        setEmojiDraft((d) => ({ ...d, [row.id]: value }));
+                      }}
+                      aria-label="Emoji úlohy"
+                      placeholder="😊"
+                      data-testid={`uloha-emoji-input-${row.id}`}
+                      autoFocus
+                    />
+                    <button
+                      type="button"
+                      className="uloha-icon-btn"
+                      disabled={busy}
+                      onClick={() => {
+                        saveEmoji(row.id);
+                      }}
+                      title="Uložiť emoji"
+                      aria-label="Uložiť emoji"
+                      data-testid={`uloha-emoji-save-${row.id}`}
+                    >
+                      💾
+                    </button>
+                  </>
+                )}
+
+                {editingTextId !== row.id && (
+                  <div className="uloha-actions">
+                    <button
+                      type="button"
+                      className="uloha-icon-btn"
+                      onClick={() => {
+                        setTextDraft((d) => ({ ...d, [row.id]: row.text }));
+                        setEditingTextId(row.id);
+                      }}
+                      title="Upraviť text"
+                      aria-label={`Upraviť text úlohy ${row.text}`}
+                      data-testid={`uloha-edit-${row.id}`}
+                    >
+                      ✏️
+                    </button>
+                    {editingEmojiId !== row.id && (
+                      <button
+                        type="button"
+                        className="uloha-icon-btn"
+                        onClick={() => {
+                          setEmojiDraft((d) => ({ ...d, [row.id]: row.emoji ?? "" }));
+                          setEditingEmojiId(row.id);
+                        }}
+                        title="Pridať/zmeniť emoji"
+                        aria-label={`Pridať/zmeniť emoji úlohy ${row.text}`}
+                        data-testid={`uloha-emoji-${row.id}`}
+                      >
+                        😊
+                      </button>
+                    )}
+                    <button
+                      type="button"
+                      className="uloha-icon-btn"
+                      disabled={busy}
+                      onClick={() => {
+                        removeTask(row.id);
+                      }}
+                      title="Odstrániť"
+                      aria-label={`Odstrániť úlohu ${row.text}`}
+                      data-testid={`uloha-delete-${row.id}`}
+                    >
+                      🗑
+                    </button>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/dailyTasksApi.ts
+++ b/apps/web/src/dailyTasksApi.ts
@@ -1,0 +1,89 @@
+import { z } from "zod";
+
+// issue 342: "Dôležité → Úlohy na dnes" — zrkadlí `DailyTaskRow`
+// (`apps/api/src/modules/daily-tasks/queries.ts`).
+
+const rowSchema = z.object({
+  id: z.string(),
+  text: z.string(),
+  emoji: z.string().nullable(),
+  doneAt: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+export type DailyTaskRow = z.infer<typeof rowSchema>;
+
+const listSchema = z.object({ rows: z.array(rowSchema) });
+
+export class DailyTasksUnauthorizedError extends Error {
+  constructor() {
+    super("Neprihlásený");
+  }
+}
+
+const errorBodySchema = z.object({ error: z.string() });
+
+async function serverErrorMessage(response: Response, fallback: string): Promise<string> {
+  try {
+    const parsed = errorBodySchema.safeParse(await response.json());
+    if (parsed.success) return parsed.data.error;
+  } catch {
+    // telo nie je platný JSON — použi všeobecnú hlášku
+  }
+  return fallback;
+}
+
+async function readJson(response: Response, fallback: string): Promise<unknown> {
+  if (response.status === 401) throw new DailyTasksUnauthorizedError();
+  if (!response.ok) throw new Error(await serverErrorMessage(response, fallback));
+  return await response.json();
+}
+
+export async function fetchDailyTasks(): Promise<readonly DailyTaskRow[]> {
+  const response = await fetch("/api/daily-tasks");
+  return listSchema.parse(await readJson(response, "Úlohy sa nepodarilo načítať")).rows;
+}
+
+export async function createDailyTask(text: string): Promise<void> {
+  const response = await fetch("/api/daily-tasks", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ text }),
+  });
+  await readJson(response, "Úlohu sa nepodarilo pridať");
+}
+
+export async function updateDailyTaskText(id: string, text: string): Promise<boolean> {
+  const response = await fetch(`/api/daily-tasks/${encodeURIComponent(id)}/text`, {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ text }),
+  });
+  const body = (await readJson(response, "Text sa nepodarilo upraviť")) as { readonly updated: boolean };
+  return body.updated;
+}
+
+export async function updateDailyTaskEmoji(id: string, emoji: string | null): Promise<boolean> {
+  const response = await fetch(`/api/daily-tasks/${encodeURIComponent(id)}/emoji`, {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ emoji }),
+  });
+  const body = (await readJson(response, "Emoji sa nepodarilo uložiť")) as { readonly updated: boolean };
+  return body.updated;
+}
+
+export async function setDailyTaskDone(id: string, done: boolean): Promise<boolean> {
+  const response = await fetch(`/api/daily-tasks/${encodeURIComponent(id)}/done`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ done }),
+  });
+  const body = (await readJson(response, "Označenie zlyhalo")) as { readonly updated: boolean };
+  return body.updated;
+}
+
+export async function deleteDailyTask(id: string): Promise<void> {
+  const response = await fetch(`/api/daily-tasks/${encodeURIComponent(id)}`, { method: "DELETE" });
+  await readJson(response, "Úlohu sa nepodarilo odstrániť");
+}

--- a/apps/web/src/nav.test.ts
+++ b/apps/web/src/nav.test.ts
@@ -23,14 +23,18 @@ import { DEFAULT_TAB_ID, HIDDEN_TABS, NAV, findTab, isVisibleTabId } from "./nav
 // Automatizáciách (rovnaká automatizácia, doplnenie chýbajúcich odkazov,
 // ktoré ju živia). Issue 292 pridalo "Preprava DPD" na koniec priečinka
 // "Eshop" (majiteľovo zadanie, jedno tlačidlo na objednanie prepravy).
+// Issue 342 pridalo ŠTVRTÝ priečinok "Dôležité" (PRED "Eshop"), presunulo
+// "Upozornenia" doňho a pridalo novú záložku "Úlohy na dnes".
 // Tento test je najbližšie k tomu, čo strojovo overiť dá (registrácia, nie DOM).
-it("NAV má tri priečinky (Eshop/Systém/Automatizácie), s 10/3/5 záložkami v poradí podľa dôležitosti", () => {
-  expect(NAV).toHaveLength(3);
-  expect(NAV.map((f) => f.label)).toEqual(["Eshop", "Systém", "Automatizácie"]);
-  expect(NAV[0]?.tabs).toHaveLength(10);
-  expect(NAV[1]?.tabs).toHaveLength(3);
-  expect(NAV[2]?.tabs).toHaveLength(5);
-  expect(NAV[0]?.tabs.map((t) => t.label)).toEqual([
+it("NAV má štyri priečinky (Dôležité/Eshop/Systém/Automatizácie), s 2/9/3/5 záložkami v poradí podľa dôležitosti", () => {
+  expect(NAV).toHaveLength(4);
+  expect(NAV.map((f) => f.label)).toEqual(["Dôležité", "Eshop", "Systém", "Automatizácie"]);
+  expect(NAV[0]?.tabs).toHaveLength(2);
+  expect(NAV[1]?.tabs).toHaveLength(9);
+  expect(NAV[2]?.tabs).toHaveLength(3);
+  expect(NAV[3]?.tabs).toHaveLength(5);
+  expect(NAV[0]?.tabs.map((t) => t.label)).toEqual(["Upozornenia", "Úlohy na dnes"]);
+  expect(NAV[1]?.tabs.map((t) => t.label)).toEqual([
     "Na objednanie",
     "Nedostupné tovary",
     "Výmena tovaru",
@@ -39,14 +43,13 @@ it("NAV má tri priečinky (Eshop/Systém/Automatizácie), s 10/3/5 záložkami 
     "Párovanie produktov",
     "Vyhľadať",
     "Zlúčenie objednávok",
-    "Upozornenia",
     "Preprava DPD",
   ]);
   // issue 212: "Dodávateľský sklad" — scraper dostupnosti u dodávateľa;
   // patrí do Systému (zadanie majiteľa), nie medzi Automatizácie.
-  expect(NAV[1]?.tabs.map((t) => t.label)).toEqual(["Sync zo Shoptetu", "Texty e-mailov", "Dodávateľský sklad"]);
+  expect(NAV[2]?.tabs.map((t) => t.label)).toEqual(["Sync zo Shoptetu", "Texty e-mailov", "Dodávateľský sklad"]);
   // issue 193: "Odoslané e-maily" — prehľad toho, čo automatizácie poslali.
-  expect(NAV[2]?.tabs.map((t) => t.label)).toEqual([
+  expect(NAV[3]?.tabs.map((t) => t.label)).toEqual([
     // issue 213: prepínanie vypredaných produktov späť na skladom.
     "Vypredané → Skladom",
     // issue 311: návrh dodávateľského odkazu pre vypredané produkty bez neho.
@@ -60,16 +63,20 @@ it("NAV má tri priečinky (Eshop/Systém/Automatizácie), s 10/3/5 záložkami 
 // issue 343: šéf chce, aby "Systém" a "Automatizácie" štartovali v ľavom menu
 // zbalené (menu inak zaberá celú výšku a treba rolovať) — "Eshop" ostáva
 // rozbalený (denne používaná obrazovka). Stav je deklarovaný priamo v
-// registri (`NavFolder.defaultCollapsed`), aby budúci priečinok (napr.
-// "Dôležité" z issue 342) mohol zvoliť vlastný predvolený stav jedným
-// riadkom bez zásahu do `Sidebar.tsx` (viď jeho vlastný test).
-it("Systém a Automatizácie majú defaultCollapsed: true, Eshop ho nemá nastavené", () => {
-  expect(NAV[0]?.label).toBe("Eshop");
+// registri (`NavFolder.defaultCollapsed`), aby budúci priečinok mohol zvoliť
+// vlastný predvolený stav jedným riadkom bez zásahu do `Sidebar.tsx` (viď
+// jeho vlastný test). Issue 342: "Dôležité" (nový, PRVÝ priečinok) ostáva
+// tiež rozbalený — rovnaký dôvod ako "Eshop" (dennodenne používaná
+// obrazovka).
+it("Dôležité a Eshop nemajú defaultCollapsed nastavené, Systém a Automatizácie majú true", () => {
+  expect(NAV[0]?.label).toBe("Dôležité");
   expect(NAV[0]?.defaultCollapsed).toBeUndefined();
-  expect(NAV[1]?.label).toBe("Systém");
-  expect(NAV[1]?.defaultCollapsed).toBe(true);
-  expect(NAV[2]?.label).toBe("Automatizácie");
+  expect(NAV[1]?.label).toBe("Eshop");
+  expect(NAV[1]?.defaultCollapsed).toBeUndefined();
+  expect(NAV[2]?.label).toBe("Systém");
   expect(NAV[2]?.defaultCollapsed).toBe(true);
+  expect(NAV[3]?.label).toBe("Automatizácie");
+  expect(NAV[3]?.defaultCollapsed).toBe(true);
 });
 
 // issue 287: DEFAULT_TAB_ID sa NEODVODZUJE od NAV[0] (to je "eshop", priečinok,
@@ -94,6 +101,8 @@ it("findTab nájde viditeľnú aj skrytú záložku podľa id, neznáme id vrát
   expect(findTab("returned")?.label).toBe("Vrátený tovar");
   expect(findTab("claims")?.label).toBe("Reklamácie");
   expect(findTab("restock-links")?.label).toBe("Vypredané → Skladom: návrhy odkazov");
+  expect(findTab("upozornenia")?.label).toBe("Upozornenia");
+  expect(findTab("ulohy")?.label).toBe("Úlohy na dnes");
   expect(findTab("neexistuje")).toBeUndefined();
 });
 
@@ -112,6 +121,8 @@ it("isVisibleTabId rozlíši viditeľné (NAV) od skrytých (HIDDEN_TABS)", () =
   expect(isVisibleTabId("claims")).toBe(true);
   // issue 311: nová viditeľná záložka "Vypredané → Skladom: návrhy odkazov".
   expect(isVisibleTabId("restock-links")).toBe(true);
+  // issue 342: nová viditeľná záložka "Úlohy na dnes" (v priečinku "Dôležité").
+  expect(isVisibleTabId("ulohy")).toBe(true);
   for (const hiddenId of Object.keys(HIDDEN_TABS)) {
     expect(isVisibleTabId(hiddenId)).toBe(false);
   }

--- a/apps/web/src/nav.ts
+++ b/apps/web/src/nav.ts
@@ -2,6 +2,7 @@ import type { ComponentType } from "react";
 import type { Me } from "./api.js";
 import { CatalogPage } from "./components/CatalogPage.js";
 import { ClaimOrdersSection } from "./components/ClaimOrdersSection.js";
+import { DailyTasksSection } from "./components/DailyTasksSection.js";
 import { DpdSection } from "./components/DpdSection.js";
 import { ExchangeOrdersSection } from "./components/ExchangeOrdersSection.js";
 import { MailLogSection } from "./components/MailLogSection.js";
@@ -72,6 +73,27 @@ export interface NavFolder {
 // App.tsx/Sidebar.tsx.
 export const NAV: readonly NavFolder[] = [
   {
+    id: "dolezite",
+    label: "Dôležité",
+    // issue 342: šéfovo zadanie (Discord, 11.8.2026) — nahrádza jeho poznámky
+    // písané do Discord kanála #úlohy-na-dnes. Priečinok je zámerne PRED
+    // "Eshop" (poradie prvkov = poradie vykreslenia, rovnaký princíp ako
+    // issue 287's presun "Eshop" na prvé miesto) a `defaultCollapsed`
+    // NENASTAVENÉ (teda rozbalený, na rozdiel od "Systém"/"Automatizácie" z
+    // issue 343) — je to dennodenne používaná obrazovka, má byť vidno hneď
+    // bez extra kliku.
+    tabs: [
+      // Presunuté z priečinka "eshop" (predtým riadok tam nižšie) — žiadna
+      // zmena `UpozorneniaSection.tsx`/routes/schémy, len iné miesto v menu
+      // (`isVisibleTabId`/`findTab` fungujú z REGISTRA, nie z priečinka).
+      { id: "upozornenia", label: "Upozornenia", icon: "🔔", Component: UpozorneniaSection, wide: true },
+      // issue 342: nová obrazovka — kompaktný, chronologický osobný zoznam
+      // úloh (najnovšie hore). `wide` sa NENASTAVUJE — je to jednoduchý
+      // stĺpec riadkov, nie hustá viacstĺpcová tabuľka, čitacia šírka stačí.
+      { id: "ulohy", label: "Úlohy na dnes", icon: "📝", Component: DailyTasksSection },
+    ],
+  },
+  {
     id: "eshop",
     label: "Eshop",
     // issue 287: majiteľ, "adresár Eshop dať uplne ako prvý... Eshop je to,
@@ -111,11 +133,6 @@ export const NAV: readonly NavFolder[] = [
       // z rovnakého dôvodu ako "Párovanie produktov"/"Vyhľadať" vyššie
       // (obsluha na nej pracuje, žiadny plán/zapnuté-vypnuté koncept).
       { id: "order-merge", label: "Zlúčenie objednávok", icon: "🔀", Component: OrderMergeSection, wide: true },
-      // issue 267: "Upozornenia" — nástenka vecí, ktoré majiteľ musí vybaviť
-      // (vlastné poznámky + budúce automatické zdroje #268/#269). Patrí sem
-      // (nie do Automatizácie) z rovnakého dôvodu ako "Na objednanie" —
-      // obsluha na nej pracuje, žiadny plán/zapnuté-vypnuté koncept.
-      { id: "upozornenia", label: "Upozornenia", icon: "🔔", Component: UpozorneniaSection, wide: true },
       // issue 292: majiteľ (Discord, 6.8.2026) — jedno tlačidlo na objednanie
       // prepravy DPD. Patrí sem (nie do Automatizácie) z rovnakého dôvodu ako
       // "Na objednanie"/"Zlúčenie objednávok" — obsluha na nej pracuje ručne

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2260,6 +2260,107 @@ a.upozornenie-title:hover {
   color: var(--fs-ink-faint);
 }
 
+/* ---------------- 18. DÔLEŽITÉ → ÚLOHY NA DNES (issue 342) ----------------
+   Majiteľova požiadavka: "space-effective", "nieže dám 4 na stranu" — riadky
+   sú preto ÚZKE (žiadne karty s tieňom/rámikom ako Upozornenia, len tenká
+   deliaca čiara), aby sa na obrazovku zmestilo veľa úloh naraz. */
+.ulohy-add-row {
+  display: flex;
+  gap: var(--fs-space-2);
+  margin-bottom: var(--fs-space-4);
+}
+/* issue 303's globálny `input:not([type="hidden"]) { width: 100% }` reset by
+   inak natiahol vstup na celú šírku a zrazil tlačidlo "+ Pridať" na ďalší
+   riadok pri užšej obrazovke — `flex: 1 1 0%` (issue 105's flex-basis vzor)
+   necháva vstup rásť, tlačidlo ostáva `flex: 0 0 auto` vo `.btn` predvolene. */
+.ulohy-add-row input {
+  flex: 1 1 0%;
+  min-width: 8rem;
+  width: auto;
+}
+.ulohy-list {
+  display: flex;
+  flex-direction: column;
+}
+.uloha-row {
+  display: flex;
+  align-items: center;
+  gap: var(--fs-space-2);
+  padding: var(--fs-space-1) var(--fs-space-2);
+  border-bottom: 1px solid var(--fs-border-soft);
+  font-size: var(--fs-text-sm);
+}
+.uloha-row:first-child {
+  border-top: 1px solid var(--fs-border-soft);
+}
+/* Vybavené úlohy OSTÁVAJÚ v zozname (design rozhodnutie na tickete — poradie
+   je čisto chronologické), len vizuálne stlmené: prečiarknutý text + nižší
+   kontrast, žiadna druhá farba/ikona navyše (rovnaký "jeden jasný signál"
+   princíp ako `.upozornenie-nove`). */
+.uloha-row.done {
+  opacity: 0.6;
+}
+.uloha-row.done .uloha-text {
+  text-decoration: line-through;
+}
+.uloha-done-toggle {
+  flex: 0 0 auto;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: var(--fs-text-md);
+  line-height: 1;
+  padding: 0;
+}
+.uloha-done-toggle:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.uloha-emoji {
+  flex: 0 0 auto;
+}
+.uloha-text {
+  flex: 1 1 auto;
+  overflow-wrap: break-word;
+  min-width: 0;
+}
+.uloha-edit-input {
+  flex: 1 1 0%;
+  min-width: 6rem;
+  width: auto;
+  padding: var(--fs-space-1) var(--fs-space-2);
+}
+.uloha-emoji-input-field {
+  flex: 0 0 auto;
+  width: 4rem;
+  padding: var(--fs-space-1) var(--fs-space-2);
+}
+.uloha-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--fs-space-1);
+  flex: 0 0 auto;
+  margin-left: auto;
+}
+/* Ikonové tlačidlá bez textu — kompaktné, žiadne `.btn` paddingy/pozadie
+   (tie by na riadok pridali výšku, presný opak "space-effective" žiadosti). */
+.uloha-icon-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: var(--fs-text-sm);
+  line-height: 1;
+  padding: var(--fs-space-1);
+}
+.uloha-icon-btn:hover {
+  background: var(--fs-surface-alt);
+  border-radius: var(--fs-radius-sm);
+}
+.uloha-icon-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 /* ---------------- MODÁLNY DIALÓG (issue 191) ----------------
    Náhľad e-mailu pred odoslaním sa už nerozbaľuje na spodku stránky —
    otvorí sa cez obrazovku, takže je okamžite v zornom poli. `z-index`

--- a/apps/web/tests/e2e/daily-tasks.spec.ts
+++ b/apps/web/tests/e2e/daily-tasks.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from "@playwright/test";
+
+const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
+const E2E_ULOHY_EMAIL = "e2e-ulohy@forestshop.sk"; // musí sa zhodovať s hodnotou v scripts/e2e-setup.ts
+
+// issue 342: "Dôležité → Úlohy na dnes" — nahrádza šéfove poznámky písané do
+// Discordu. Reálny prehliadač cez celý cyklus: napísať + Enter (žiadny
+// formulár), upraviť text, pridať emoji, označiť vybavené (ostáva v
+// zozname, len stlmené), odstrániť. Konzola musí zostať čistá
+// (`.claude/rules/testing.md`). Účet má rolu "citanie" — server (a teda aj
+// appka) nemá pre tento súkromný zoznam žiadne role-podmienené obmedzenie.
+test("napísať jedno za druhým, upraviť, pridať emoji, vybaviť (ostáva vidno), odstrániť — konzola je čistá", async ({ page }) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/?tab=ulohy");
+  await page.getByLabel("E-mail").fill(E2E_ULOHY_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await expect(page.getByRole("heading", { name: "Úlohy na dnes" })).toBeVisible();
+  await expect(page.getByTestId("ulohy-empty")).toBeVisible();
+
+  // "Písať jedno za druhým" — napísať + Enter, žiadny formulár/dialóg.
+  const novyVstup = page.getByTestId("uloha-new-input");
+  await novyVstup.fill("Nemáme sáčky");
+  await novyVstup.press("Enter");
+  await expect(page.getByTestId("ulohy-list").getByText("Nemáme sáčky")).toBeVisible();
+  await expect(novyVstup).toHaveValue("");
+
+  await novyVstup.fill("Záhorecký volať");
+  await novyVstup.press("Enter");
+  await expect(page.getByTestId("ulohy-list").getByText("Záhorecký volať")).toBeVisible();
+
+  // "Najnovšia hore" — druhá pridaná úloha ("Záhorecký volať") je PRVÝ riadok.
+  const riadky = page.locator(".uloha-row");
+  await expect(riadky).toHaveCount(2);
+  await expect(riadky.nth(0)).toContainText("Záhorecký volať");
+  await expect(riadky.nth(1)).toContainText("Nemáme sáčky");
+
+  // Nájsť konkrétny riadok podľa aktuálneho textu (rovnaký vzor ako
+  // `upozornenia.spec.ts`'s `kartaSNadpisom`, len cez `.uloha-row`).
+  const sackyRiadok = page.locator(".uloha-row").filter({ hasText: "Nemáme sáčky" });
+
+  // Upraviť text inline. Kým je riadok v editačnom móde, jeho pôvodný text
+  // už NIE JE textovým uzlom v DOM-e (je len hodnotou <input>u), takže
+  // `sackyRiadok`'s `hasText` filter by sa prestal zhodovať s KAŽDÝM ĎALŠÍM
+  // (lazy) vyhodnotením — vstup/tlačidlo sa preto vyhľadáva GLOBÁLNE cez ich
+  // pevný (nie per-riadok interpolovaný) `aria-label`, bezpečné, lebo appka
+  // dovolí najviac JEDEN riadok v editácii textu naraz.
+  await sackyRiadok.getByRole("button", { name: "Upraviť text" }).click();
+  const editInput = page.locator("input.uloha-edit-input");
+  await editInput.fill("Nemáme sáčky — objednať zajtra");
+  await page.getByRole("button", { name: "Uložiť text" }).click();
+  const upravenyRiadok = page.locator(".uloha-row").filter({ hasText: "Nemáme sáčky — objednať zajtra" });
+  await expect(upravenyRiadok).toBeVisible();
+
+  // Pridať emoji (samostatná akcia od úpravy textu).
+  await upravenyRiadok.getByRole("button", { name: "Pridať/zmeniť emoji" }).click();
+  await upravenyRiadok.locator('input[placeholder="😊"]').fill("🛍️");
+  await upravenyRiadok.getByRole("button", { name: "Uložiť emoji" }).click();
+  await expect(upravenyRiadok.locator(".uloha-emoji")).toHaveText("🛍️");
+
+  // Označiť ako vybavené — úloha OSTÁVA v zozname (nezmizne), len stlmená.
+  await upravenyRiadok.getByRole("button", { name: "Označiť ako vybavené" }).click();
+  await expect(upravenyRiadok).toHaveClass(/done/);
+  await expect(riadky).toHaveCount(2); // stále obe, žiadna nezmizla
+
+  // Odstránenie druhej úlohy — okamžite, bez potvrdzovacieho dialógu.
+  const zaharecKyRiadok = page.locator(".uloha-row").filter({ hasText: "Záhorecký volať" });
+  await zaharecKyRiadok.getByRole("button", { name: "Odstrániť" }).click();
+  await expect(page.locator(".uloha-row")).toHaveCount(1);
+  await expect(page.getByText("Záhorecký volať")).toHaveCount(0);
+
+  // Upratanie po teste — druhý (vybavený) riadok tiež zmazať.
+  await upravenyRiadok.getByRole("button", { name: "Odstrániť" }).click();
+  await expect(page.getByTestId("ulohy-empty")).toBeVisible();
+
+  expect(chyby).toEqual([]);
+});

--- a/apps/web/tests/e2e/nav.spec.ts
+++ b/apps/web/tests/e2e/nav.spec.ts
@@ -28,8 +28,13 @@ const E2E_NAV_EMAIL = "e2e-nav@forestshop.sk";
 // Skladom" — sedemnásta záložka celkovo (funkčný test v samostatnom
 // `restock-links.spec.ts`, rovnaký vzor). Issue 292 (2026-08-08) pridáva
 // "Preprava DPD" NA KONIEC priečinka "Eshop" — osemnásta záložka celkovo
-// (funkčný test v samostatnom `dpd.spec.ts`, rovnaký vzor).
-test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s osemnástimi záložkami, klik prepne obrazovku, panel sa zbalí do lišty a stav si pamätá, konzola je čistá", async ({
+// (funkčný test v samostatnom `dpd.spec.ts`, rovnaký vzor). Issue 342
+// (2026-08-11) pridáva ŠTVRTÝ priečinok "Dôležité" (PRED "Eshop" — hlavný
+// login screen odteraz vidí menu v poradí Dôležité/Eshop/Systém/
+// Automatizácie), presúva "Upozornenia" doňho (z priečinka "Eshop") a pridáva
+// novú záložku "Úlohy na dnes" — devätnásta záložka celkovo (funkčný test v
+// samostatnom `daily-tasks.spec.ts`, rovnaký vzor).
+test("ľavé menu má štyri priečinky (Dôležité/Eshop/Systém/Automatizácie) s devätnástimi záložkami, klik prepne obrazovku, panel sa zbalí do lišty a stav si pamätá, konzola je čistá", async ({
   page,
 }) => {
   const chyby: string[] = [];
@@ -45,7 +50,8 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s osemnásti
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
-  // Presne tri priečinky.
+  // Presne štyri priečinky.
+  await expect(page.getByRole("button", { name: "Dôležité" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Systém" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Eshop" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Automatizácie" })).toBeVisible();
@@ -53,7 +59,10 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s osemnásti
   // issue 343: "Systém" a "Automatizácie" štartujú ZBALENÉ (menu by inak
   // presahovalo výšku obrazovky), "Eshop" ostáva rozbalený — over predvolený
   // stav priamo po prihlásení, potom oba priečinky rozbaľ, aby zvyšok tohto
-  // testu mohol pokračovať v pôvodnom toku a klikať na ich záložky.
+  // testu mohol pokračovať v pôvodnom toku a klikať na ich záložky. Issue 342:
+  // "Dôležité" štartuje ROZBALENÝ (dennodenne používaná obrazovka, rovnaký
+  // dôvod ako "Eshop").
+  await expect(page.getByRole("button", { name: "Dôležité" })).toHaveAttribute("aria-expanded", "true");
   await expect(page.getByRole("button", { name: "Eshop" })).toHaveAttribute("aria-expanded", "true");
   await expect(page.getByRole("button", { name: "Systém" })).toHaveAttribute("aria-expanded", "false");
   await expect(page.getByRole("button", { name: "Automatizácie" })).toHaveAttribute("aria-expanded", "false");
@@ -62,8 +71,8 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s osemnásti
   await expect(page.getByRole("button", { name: "Systém" })).toHaveAttribute("aria-expanded", "true");
   await expect(page.getByRole("button", { name: "Automatizácie" })).toHaveAttribute("aria-expanded", "true");
 
-  // Presne osemnásť záložiek v CELOM menu.
-  await expect(page.locator(".side-nav .tab")).toHaveCount(18);
+  // Presne devätnásť záložiek v CELOM menu.
+  await expect(page.locator(".side-nav .tab")).toHaveCount(19);
   await expect(page.getByRole("button", { name: "Sync zo Shoptetu" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Texty e-mailov" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Na objednanie" })).toBeVisible();
@@ -78,6 +87,7 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s osemnásti
   await expect(page.getByRole("button", { name: "Zlúčenie objednávok" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Upozornenia" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Preprava DPD" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Úlohy na dnes" })).toBeVisible();
 
   // issue 302: predvolená obrazovka (bez kliknutia) je odvtedy "Na
   // objednanie", nie "Sync zo Shoptetu". `scripts/e2e-setup.ts` vždy seeduje
@@ -174,6 +184,13 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s osemnásti
   await expect(page.getByRole("heading", { name: "Upozornenia" })).toBeVisible();
   await expect(page.getByTestId("nav-status-upozornenia")).toHaveCount(0);
 
+  // issue 342: rovnaký dôvod ako "Upozornenia" vyššie — žiadny plán/zapnuté-
+  // vypnuté koncept, teda žiadny stavový odznak v menu. Obrazovka je teraz
+  // súčasťou priečinka "Dôležité" (rozbalený predvolene, žiadny extra klik).
+  await page.getByRole("button", { name: "Úlohy na dnes" }).click();
+  await expect(page.getByRole("heading", { name: "Úlohy na dnes" })).toBeVisible();
+  await expect(page.getByTestId("nav-status-ulohy")).toHaveCount(0);
+
   // issue 190: zbalenie panela do úzkej lišty. Zámerne je to SÚČASŤ tohto
   // testu, nie samostatný test — každý ďalší test v tomto súbore by znamenal
   // ďalšie prihlásenie na zdieľanom `MAX_ATTEMPTS=10` rozpočte
@@ -196,7 +213,7 @@ test("ľavé menu má tri priečinky (Systém/Eshop/Automatizácie) s osemnásti
 
   // Hlavičky priečinkov zmiznú, ikony všetkých modulov ostanú.
   await expect(page.getByRole("button", { name: "Systém" })).toHaveCount(0);
-  await expect(page.locator(".side-nav .tab")).toHaveCount(18);
+  await expect(page.locator(".side-nav .tab")).toHaveCount(19);
   // Názov sa v lište ukáže bublinou pri prejdení myšou.
   await expect(page.getByRole("button", { name: "Na objednanie" })).toHaveAttribute(
     "title",

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -3442,3 +3442,51 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   presný `docker exec` postup na ručné spustenie jobu), `.claude/rules/
   nedostupne.md` (dizajnové rozhodnutie: spätné dohľadanie namiesto
   duplikovania dát na `nedostupne_replacement_link`).
+
+## 2026-08-11 — #344 (Nedostupné tovary — vybavené riadky odlíšené farbou)
+
+- Solo ticket, owner-requested via Discord (boss, 11.8.2026 — "žiaden
+  autopilot-skip", scope-gate `user-request`).
+- Version already strictly above main (0.3.0-dev.205 > main's .204) —
+  no bump commit needed.
+- Design comment BEFORE first code commit:
+  https://github.com/zbynekdrlik/forestshop-app/issues/344#issuecomment-5254401764
+  — signal: `order.nedostupneSent || order.alternativaSent`; colour:
+  `--fs-success`/`--fs-success-bg` (NOT the boss's literal "červené" —
+  red already means error on this same screen, explained on the ticket);
+  whole row (background + accent), not just the button; accessibility
+  floor satisfied by the EXISTING unchanged "✓ Odoslané" button text.
+  Rejected alternative: copying issue 259→263's row-coloring rejection
+  from the Orders screen — different screen, this ticket explicitly asks
+  for row-level distinction here.
+- RED `d4066df` (unit test: data-handled attribute + modifier class,
+  fails against unmodified component) → GREEN `5219f6c` (feat: border-left
+  reservation + CSS).
+- Review pass (fresh-context general-purpose subagent, PR #350, commit
+  range `d4066df^..5219f6c`): 1 🟡 0 🔴 2 🔵 — 🟡 the transparent
+  border-left reservation on every row shifted content ~11px right of
+  the group header/replacement-links above it (no matching inset there);
+  🔵 test coverage only 2/4 boolean combinations; 🔵 comment overclaimed
+  "no layout change" (only height was proven). Fixed same branch, commit
+  `3e9afef`: switched to `box-shadow: inset 3px 0 0 var(--fs-success)`
+  (zero box-model impact, no reservation needed anywhere), `it.each`
+  covering all 4 combinations, comment tightened.
+- Main CI's `integration` job failed once on a single unrelated test
+  (`order-note-playwright.integration.test.ts`, 60s timeout — shoptet
+  writeback/Chromium, nothing this PR touches; same suite had already
+  passed twice on dev's own CI). One `gh run rerun --failed` on run
+  31507330187 came back green — treated as a transient CI-runner flake,
+  not a regression (per `ci-monitoring.md`: one rerun to rule out a
+  transient is acceptable).
+- Merged `fb80ed3`, deployed + verified v0.3.0-dev.205 live on
+  https://forestshop-novy.newlevel.media/?tab=nedostupne: two REAL
+  already-sent orders (20261338/61634, 20261306/61729-M) render
+  `data-handled="true"` with the green tint + accent, `getBoundingClientRect()`
+  identical height/left vs. a pending row (no jog), 0 console
+  errors/warnings, screenshot in the run.
+- Playbook: `.claude/rules/frontend-design.md` (new bullet — per-row
+  state accents must use inset `box-shadow`, never a reserved
+  `border-left`, to avoid the alignment-jog class of bug this ticket's
+  own review caught), `.claude/rules/nedostupne.md` (handled predicate +
+  the "boss says a colour, check it doesn't already mean something else
+  in this app" precedent).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.205",
+  "version": "0.3.0-dev.206",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.206",
+  "version": "0.3.0-dev.207",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -209,6 +209,12 @@ const E2E_UPOZORNENIA_EMAIL = "e2e-upozornenia@forestshop.sk"; // musí sa zhodo
 // posúvania stránky na telefónnej šírke) dostáva VLASTNÝ izolovaný účet.
 const E2E_MOBIL_EMAIL = "e2e-mobil@forestshop.sk"; // musí sa zhodovať s hodnotou v mobile-responsive.spec.ts
 
+// issue 342: rovnaký mechanizmus a dôvod ako `E2E_MOBIL_EMAIL` vyššie — nový
+// spec súbor (`daily-tasks.spec.ts` — "Dôležité → Úlohy na dnes") dostáva
+// VLASTNÝ izolovaný účet. Rola "citanie" (zámerne — `daily-tasks-routes.ts`
+// nevyžaduje admin/manazer, úlohy sú súkromné pre KAŽDÚ rolu, test to overuje).
+const E2E_ULOHY_EMAIL = "e2e-ulohy@forestshop.sk"; // musí sa zhodovať s hodnotou v daily-tasks.spec.ts
+
 const { db, pool } = createDb();
 // Konštantný literál bez interpolácie — obyčajný reťazec je tu rovnako bezpečný
 // ako `sql` tagovaná šablóna (tú používa ekvivalentný apps/api/tests/helpers/db.ts),
@@ -374,6 +380,7 @@ await db.insert(users).values({ email: E2E_ZLUCENIE_EMAIL, passwordHash: await h
 await db.insert(users).values({ email: E2E_FARBY_EMAIL, passwordHash: await hashPassword(E2E_HESLO), displayName: "E2E Manažér", role: "manazer" });
 await db.insert(users).values({ email: E2E_UPOZORNENIA_EMAIL, passwordHash: await hashPassword(E2E_HESLO), displayName: "E2E Manažér", role: "manazer" });
 await db.insert(users).values({ email: E2E_MOBIL_EMAIL, passwordHash: await hashPassword(E2E_HESLO), displayName: "E2E Manažér", role: "manazer" });
+await db.insert(users).values({ email: E2E_ULOHY_EMAIL, passwordHash: await hashPassword(E2E_HESLO), displayName: "E2E Čitateľ", role: "citanie" });
 
 // Katalóg pre E2E: tá istá commitnutá fixtúra ako v jednotkových testoch, cez tú istú
 // službu importu — E2E tak overuje skutočnú cestu dát, nie ručne nasypané riadky.
@@ -622,11 +629,7 @@ await db.insert(shopProductUrl).values({
   url: "https://www.forestshop.sk/e2e-nedostupne-40287/",
   fetchedAt: new Date("2026-07-27T09:00:00Z"),
 });
-await db.insert(productSupplierLinkOverrides).values({
-  productKey: "d63e07c9-3c48-11e6-8a3b-0cc47a6c92bc",
-  url: "https://dodavatel.example/e2e-nedostupne-40287",
-  updatedAt: new Date("2026-07-27T09:00:00Z"),
-});
+await db.insert(productSupplierLinkOverrides).values({ productKey: "d63e07c9-3c48-11e6-8a3b-0cc47a6c92bc", url: "https://dodavatel.example/e2e-nedostupne-40287", updatedAt: new Date("2026-07-27T09:00:00Z") });
 
 // F4 (#45): jeden UŽ NAVRHNUTÝ (nepotvrdený) pairing kandidát — simuluje to,
 // čo by inak vložilo #46 (automatické hľadanie kandidátov, ešte


### PR DESCRIPTION
issue 342

## Čo pridáva

Nový nav priečinok **„Dôležité"** (pred „Eshop", rozbalený predvolene),
presúva doňho existujúcu záložku „Upozornenia" a pridáva novú obrazovku
**„Úlohy na dnes"** — nahrádza šéfove poznámky písané do Discord kanála
`#úlohy-na-dnes`.

- Súkromný, per-používateľský zoznam (`daily_task` tabuľka, `user_id` FK,
  ownership vynútený na serveri, žiadna rola nevidí cudzie úlohy).
- Písanie „jedno za druhým" — text + Enter, žiadny formulár/dialóg.
- Kompaktné riadky (najnovšie hore), inline ✏️ upraviť text / 😊 pridať
  emoji (dve samostatné akcie) / ☑ vybaviť (ostáva vidno, len stlmené) /
  🗑 odstrániť (okamžite).
- Design rozhodnutia (emoji = obyčajný text vstup, vybavené ostáva v
  zozname, vlastníctvo per-user) zapísané na tickete PRED kódom.

## Overenie

- `pnpm typecheck` / `pnpm lint` — čisté
- `pnpm --filter @forestshop/api test` — 716/716
- `pnpm --filter @forestshop/web test` — 588/588
- `pnpm --filter @forestshop/api test:integration` — 653/653 (86 súborov)
- `pnpm --filter @forestshop/web e2e` — 55/55
