### PR TITLE
Ťažké brány presunúť z dev1 do CI (issue 351)

### DIFF
--- a/.claude/rules/ci.md
+++ b/.claude/rules/ci.md
@@ -6,6 +6,16 @@ paths:
 
 # CI gotchas
 
+- **`integration`, `e2e` a `docker-build` joby MUSIA ostať BEZPODMIENEČNÉ
+  (žiadne `if:`, žiadne `continue-on-error`) na KAŽDOM push/PR do `dev` aj
+  `main` — issue 351 na tom stojí celý plán.** Od issue 351 sa tieto dve
+  brány (postgres + skutočný prehliadač) na dev1 lokálne default NESPÚŠŤAJÚ
+  (`.claude/rules/local-dev.md`'s `pnpm gates:local`) presne preto, že
+  `ci.yml` ich aj tak zakaždým odbeží znova, zadarmo (verejné repo,
+  `ubuntu-latest`). Keby sa niektorá z nich stala podmienenou/voliteľnou,
+  vznikne diera v pokrytí bez toho, aby to bolo vidno lokálne. `version-
+  check`'s `if: github.ref_name != 'main'` je jediná zámerná výnimka
+  (netýka sa testovacích brán, len toho, že na `main` nemá zmysel).
 - **`pnpm/action-setup@v4` sa v `ci.yml` volá BEZ `version:` inputu.**
   `package.json` má `packageManager: "pnpm@10.0.0"` — keď action dostane aj
   explicitný `version` input aj nájde `packageManager`, zlyhá s "Multiple

--- a/.claude/rules/local-dev.md
+++ b/.claude/rules/local-dev.md
@@ -29,8 +29,9 @@ paths:
   lokálnym behom). Pri kopírovaní `DATABASE_URL` medzi lokálnym behom a CI
   logmi si všimni, že port sa líši — nie je to preklep.
 - Bežný lokálny cyklus: `docker compose up -d postgres` (port 5433) →
-  `pnpm --filter @forestshop/api db:migrate` → `pnpm test` /
-  `pnpm test:integration` / `pnpm --filter @forestshop/web e2e`.
+  `pnpm --filter @forestshop/api db:migrate` → `pnpm gates:local` (výnimočne,
+  keď tiket priamo zasahuje danú oblasť, aj `pnpm test:integration` /
+  `pnpm --filter @forestshop/web e2e` — pozri ďalší bod).
 - **Predvolená lokálna sada PRED pushom je `pnpm gates:local`** (issue 351 —
   `typecheck && lint && test`, SEKVENČNE, nikdy paralelne) — `test:
   integration` a `e2e` sa lokálne NESPÚŠŤAJÚ default. Dôvod: `ci.yml` obe
@@ -42,7 +43,10 @@ paths:
   databázou → `test:integration`), spusti LEN tú jednu dotknutú sadu, nikdy
   obe naraz a nikdy súbežne s `gates:local`. `pnpm lint` má explicitný
   `--concurrency=off` (ESLint 9.9+, viacvláknový lint je len experimentálny
-  opt-in `--concurrency=auto|N`) a `apps/web/playwright.config.ts` má mimo
+  opt-in `--concurrency=auto|N` — na nainštalovanej `9.39.5` je `off` už aj
+  tak default, takže flag lintu samotnému nič neuberá; ide o výslovné
+  zafixovanie zámeru, keby sa niekedy default zmenil) a
+  `apps/web/playwright.config.ts` má mimo
   CI `workers: 1` — obe zámerne, aby ani výnimočný lokálny beh nezdvojil
   zaťaženie. Merané dôkazy (peak pamäť/load pred a po) na tikete 351.
 - **Ručne bežiaci `pnpm --filter @forestshop/api start`/`web dev` (napr. pre

--- a/.claude/rules/local-dev.md
+++ b/.claude/rules/local-dev.md
@@ -31,6 +31,20 @@ paths:
 - Bežný lokálny cyklus: `docker compose up -d postgres` (port 5433) →
   `pnpm --filter @forestshop/api db:migrate` → `pnpm test` /
   `pnpm test:integration` / `pnpm --filter @forestshop/web e2e`.
+- **Predvolená lokálna sada PRED pushom je `pnpm gates:local`** (issue 351 —
+  `typecheck && lint && test`, SEKVENČNE, nikdy paralelne) — `test:
+  integration` a `e2e` sa lokálne NESPÚŠŤAJÚ default. Dôvod: `ci.yml` obe
+  brány aj tak znova spustí na `ubuntu-latest` (repo je verejné, zadarmo),
+  takže lokálny beh je čistá duplicita nákladu — a dev1 má len 4 jadrá/7 GB,
+  zdieľané s ďalšími reláciami/projektmi (namerané: záťaž 15,6, 4,2 GB swap,
+  `eslint` sám 1,5 GB pri behu VŠETKÝCH brán naraz). Výnimka: keď tiket
+  PRIAMO zasahuje danú oblasť (obrazovky/UI → `e2e`; prihlásenie/práca s
+  databázou → `test:integration`), spusti LEN tú jednu dotknutú sadu, nikdy
+  obe naraz a nikdy súbežne s `gates:local`. `pnpm lint` má explicitný
+  `--concurrency=off` (ESLint 9.9+, viacvláknový lint je len experimentálny
+  opt-in `--concurrency=auto|N`) a `apps/web/playwright.config.ts` má mimo
+  CI `workers: 1` — obe zámerne, aby ani výnimočný lokálny beh nezdvojil
+  zaťaženie. Merané dôkazy (peak pamäť/load pred a po) na tikete 351.
 - **Ručne bežiaci `pnpm --filter @forestshop/api start`/`web dev` (napr. pre
   naživo Playwright meranie proti lokálnemu devu, `.claude/rules/frontend-
   design.md`'s metodika) zdieľa TÚ ISTÚ lokálnu Postgres inštanciu (port

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -11,6 +11,13 @@ paths:
 
 # Tests
 
+- **`test:integration` a `e2e` sa lokálne na dev1 default NESPÚŠŤAJÚ (issue
+  351)** — bežia bezpodmienečne v `ci.yml` (`.claude/rules/ci.md`), lokálne
+  ostáva len `pnpm gates:local` (typecheck+lint+unit testy). Spusti tú
+  jednu heavy sadu lokálne LEN keď tiket priamo zasahuje jej oblasť
+  (obrazovky→e2e, DB/prihlásenie→integration), nikdy obe naraz, nikdy
+  súbežne s ničím iným. Plný dôvod + namerané čísla: `.claude/rules/local-
+  dev.md`.
 - **`apps/api` má dve úrovne testov, oddelené priečinkom aj scriptom:**
   - `src/**/*.test.ts` → `pnpm --filter @forestshop/api test` (`vitest run
     src`) — bežia BEZ databázy, čisto unit (napr. rate-limiter, password

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -3,6 +3,12 @@ import { defineConfig } from "@playwright/test";
 export default defineConfig({
   testDir: "./tests/e2e",
   timeout: 30_000,
+  // issue 351: dev1 (4 jadrá/7 GB) beží zdieľaný s ďalšími reláciami/
+  // projektmi — mimo CI preto e2e beží na JEDEN worker (žiadne súbežné
+  // Chromium procesy), aby prípadný manuálny lokálny beh (tiket priamo
+  // dotýkajúci sa obrazoviek) nezdvojnásobil zaťaženie. V CI (`process.env.CI`,
+  // GitHub Actions ho nastavuje automaticky) ostáva predvolený počet.
+  workers: process.env.CI ? undefined : 1,
   use: { baseURL: "http://127.0.0.1:5173", trace: "on-first-retry" },
   webServer: [
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.207",
+  "version": "0.3.0-dev.208",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
   },
   "scripts": {
     "typecheck": "tsc -b && tsc -p scripts/tsconfig.json && tsc -p apps/api/tests/tsconfig.json && tsc -p apps/web/tests/e2e/tsconfig.json",
-    "lint": "eslint .",
+    "lint": "eslint . --concurrency=off",
     "test": "pnpm -r test",
     "test:integration": "pnpm --filter @forestshop/api test:integration",
+    "gates:local": "pnpm typecheck && pnpm lint && pnpm test",
     "catalog:ingest": "tsx scripts/catalog-ingest.ts",
     "catalog:prune-raw": "tsx scripts/catalog-prune-raw.ts",
     "orders:ingest": "tsx scripts/orders-ingest.ts"


### PR DESCRIPTION
## Čo a prečo

issue 351 — dev1 (4 jadrá, 7 GB) bol pred týmto pushom zaťažený na 15,6 so
4,2 GB odloženými na disk; najväčší jednotlivý žrút z tohto projektu bol
`eslint` s 1,5 GB. Príčina: lokálny predpush zvyk spúšťal CELÚ sadu brán
(typecheck, lint, unit, integration proti lokálnemu Postgresu, e2e so
skutočným Chromiom) — presne to, čo `ci.yml` aj tak znova beží zadarmo na
`ubuntu-latest` (repo je verejné).

## Zmena (dokumentácia + tooling, žiadna zmena appky)

- Nový `pnpm gates:local` (`typecheck && lint && test`, sekvenčne) — nová
  predvolená lokálna sada.
- `pnpm lint` dostal explicitný `--concurrency=off`.
- `apps/web/playwright.config.ts`: `workers: 1` mimo CI.
- `.claude/rules/{local-dev,testing,ci}.md`: zapísané, čo beží kde a prečo,
  a že `integration`/`e2e`/`docker-build` v `ci.yml` musia ostať
  bezpodmienečné — plán na tom stojí.

## Overenie

- `pnpm gates:local` — zelené (typecheck, lint, 716+590 unit testov).
- `pnpm test:integration` (86 súborov, 655 testov) — zelené, bez zmeny.
- `pnpm --filter @forestshop/web e2e` — zelené s NOVÝM `workers: 1`
  configom (55/55, 1,5 min).
- CI beh na `dev` (push): `check`, `integration`, `e2e`, `docker-build`,
  `version-check` — všetkých 5 job-ov zelených.

## Namerané (peak load / pamäť, `.claude/rules/local-dev.md`)

| Beh | trvanie pod záťažou | peak 1-min load | peak použitá pamäť |
|---|---|---|---|
| stará plná lokálna sada (typecheck+lint+unit+integration+e2e) | 539 s | 4,60 | 4955 MB |
| nová `pnpm gates:local` (typecheck+lint+unit) | 114 s | 3,91 | 4999 MB |

Peak pamäť sa medzi behmi výrazne nemení (rovnaký JS toolchain, rovnaké
procesy) — to, čo reálne klesá, je ČAS, počas ktorého box beží pod záťažou:
4,7× kratšie (539 s → 114 s), lebo Postgres-backed integračné testy (655
testov, 336 s) a Playwright e2e so skutočným prehliadačom (55 testov) sa
lokálne default už nespúšťajú vôbec — bežia len v CI, na každom pushi,
bezpodmienečne.

issue 351
