### PR TITLE
feat: "Objednávky predajňa" — nová obrazovka pre predajňové objednávky (issue 345)

### DIFF
--- a/.claude/rules/orders.md
+++ b/.claude/rules/orders.md
@@ -595,3 +595,25 @@ paths:
   cp1250 cez zdieľané `helpers/orders-return-csv.ts`) je v
   `orders-ingest-stuck-upozornenie.integration.test.ts` — rovnaký dôvod na
   cp1250 ako vyššie (stav "Nevybavená" nesie diakritiku).
+- **Issue 345: "Eshop → Objednávky predajňa" — predajňové objednávky sa
+  rozlišujú cez `order.shipping_carrier_name ILIKE '%Osobný odber%'`
+  (PODREŤAZEC, nikdy presná veta s výkričníkom — Shoptet ju môže kedykoľvek
+  preformulovať, `floor-orders-queries.ts`). Zistené naživo na produkcii
+  (ticket, komentár 11.8.2026): `shipping_carrier_name` = "Osobný odber -
+  len na predajni v POPRADE!" (30→32 objednávok), sedí aj s
+  `payment_method_name` = "V hotovosti", ale TÚTO druhú koreláciu appka
+  zámerne NEVYUŽÍVA ako filter (nespoľahlivá, len doplnková zhoda z
+  komentára na tickete). Táto obrazovka je jednotabuľkový WHERE+ORDER BY
+  bez per-riadkového odvodenia — na rozdiel od `order-flags-queries.ts`
+  (load-everything + JS filter, lebo potrebuje `unresolved`) tu je preto
+  správne skutočné SQL `LIMIT`/`OFFSET` + `COUNT(*)`, rovnaký vzor ako
+  `catalog/queries.ts`'s `searchVariants`. `PAGE_SIZE = 10` (zámerne malé,
+  nie zvyčajných 50) — produkcia má len ~30 zodpovedajúcich objednávok,
+  malá strana robí "Načítať ďalšie" reálne overiteľné aj naživo. Review
+  finding: `ORDER BY placed_at DESC` SAMOTNÉ je nedeterministické pri
+  dvoch objednávkach v tej istej minúte (Shoptet `date` má len minútovú
+  presnosť) — `.orderBy(desc(orders.placedAt), desc(orders.id))` je
+  tie-breaker, rovnaký vzor ako `catalog/queries.ts`'s
+  `desc(fetchedAt), desc(id)`. Test na KAŽDÝ ĎALŠÍ nový `ORDER BY placedAt`
+  dopyt s LIMIT/OFFSET: pridaj rovnaký tie-breaker, inak stránkovanie môže
+  riadok zopakovať alebo stratiť pri zhode timestampu.

--- a/apps/api/src/http/app.ts
+++ b/apps/api/src/http/app.ts
@@ -14,6 +14,7 @@ import type { NextEventService } from "../modules/calendar/service.js";
 import { registerCatalogRoutes, type RunIngest } from "./catalog-routes.js";
 import { registerDailyTasksRoutes } from "./daily-tasks-routes.js";
 import { registerDpdRoutes, type DpdRunDeps } from "./dpd-routes.js";
+import { registerFloorOrdersRoutes } from "./floor-orders-routes.js";
 import { checkLoginRateLimit, clientIp } from "./login-rate-limit.js";
 import { SESSION_COOKIE, requireUser, type AppBindings } from "./middleware.js";
 import { registerOrdersRoutes, type RunOrdersIngest } from "./orders-routes.js";
@@ -322,6 +323,9 @@ export function createApp(
   // READ-ONLY pohľady + appkina vlastná reklamácia-značka. Žiadny voliteľný
   // dependency (rovnaký dôvod ako `upozornenia` vyššie).
   registerOrderFlagsRoutes(app, db, options.adminBaseUrl ?? "https://www.forestshop.sk");
+  // issue 345: "Eshop → Objednávky predajňa" — LEN čítanie, rovnaká rodina
+  // ako `registerOrderFlagsRoutes` vyššie, žiadna nová zapisovacia cesta.
+  registerFloorOrdersRoutes(app, db, options.adminBaseUrl ?? "https://www.forestshop.sk");
   // issue 292: "Eshop → Preprava DPD" — bez dodanej konfigurácie sa do DPD
   // NEODOSIELA vôbec (fail-closed, rovnaký princíp ako `restock`/
   // `nedostupne` vyššie): akcie vrátia 503 "nenakonfigurované".

--- a/apps/api/src/http/floor-orders-routes.ts
+++ b/apps/api/src/http/floor-orders-routes.ts
@@ -1,0 +1,26 @@
+import { zValidator } from "@hono/zod-validator";
+import type { Hono } from "hono";
+import { z } from "zod";
+import type { Database } from "../db/client.js";
+import { listFloorOrders } from "../modules/orders/floor-orders-queries.js";
+import { requireUser, type AppBindings } from "./middleware.js";
+
+// issue 345: "Eshop → Objednávky predajňa" — LEN čítanie, rovnaké
+// oprávnenie ako ostatné zoznamy objednávok (`requireUser`, žiadne
+// obmedzenie roly). Prázdna hodnota (`page=`) sa má správať ako neprítomný
+// parameter — rovnaký vzor ako `restock-links-routes.ts`'s `pageParam`.
+const pageParam = z.preprocess(
+  (value) => (value === "" ? undefined : value),
+  z.coerce.number().int().min(1).max(100_000).default(1),
+);
+
+const floorOrdersQuery = z.object({
+  page: pageParam,
+  pageSize: z.coerce.number().int().min(1).max(200).default(10),
+});
+
+export function registerFloorOrdersRoutes(app: Hono<AppBindings>, db: Database, adminBaseUrl: string): void {
+  app.get("/api/floor-orders", requireUser(db), zValidator("query", floorOrdersQuery), async (c) =>
+    c.json(await listFloorOrders(db, adminBaseUrl, c.req.valid("query"))),
+  );
+}

--- a/apps/api/src/http/floor-orders-routes.ts
+++ b/apps/api/src/http/floor-orders-routes.ts
@@ -7,16 +7,21 @@ import { requireUser, type AppBindings } from "./middleware.js";
 
 // issue 345: "Eshop → Objednávky predajňa" — LEN čítanie, rovnaké
 // oprávnenie ako ostatné zoznamy objednávok (`requireUser`, žiadne
-// obmedzenie roly). Prázdna hodnota (`page=`) sa má správať ako neprítomný
-// parameter — rovnaký vzor ako `restock-links-routes.ts`'s `pageParam`.
-const pageParam = z.preprocess(
-  (value) => (value === "" ? undefined : value),
-  z.coerce.number().int().min(1).max(100_000).default(1),
-);
+// obmedzenie roly). Prázdna hodnota (`page=`/`pageSize=`) sa má správať ako
+// neprítomný parameter — rovnaký vzor ako `restock-links-routes.ts`'s
+// `pageParam` (review finding, issue 345: pôvodne mal len `page` tento
+// `z.preprocess`, `pageSize=` bez neho skončí ako `0` → 400, hoci `page=`
+// je tolerované — teraz zdieľajú TÚ ISTÚ funkciu).
+function emptyToUndefined(value: unknown): unknown {
+  return value === "" ? undefined : value;
+}
+
+const pageParam = z.preprocess(emptyToUndefined, z.coerce.number().int().min(1).max(100_000).default(1));
+const pageSizeParam = z.preprocess(emptyToUndefined, z.coerce.number().int().min(1).max(200).default(10));
 
 const floorOrdersQuery = z.object({
   page: pageParam,
-  pageSize: z.coerce.number().int().min(1).max(200).default(10),
+  pageSize: pageSizeParam,
 });
 
 export function registerFloorOrdersRoutes(app: Hono<AppBindings>, db: Database, adminBaseUrl: string): void {

--- a/apps/api/src/modules/orders/floor-orders-queries.ts
+++ b/apps/api/src/modules/orders/floor-orders-queries.ts
@@ -65,8 +65,15 @@ export async function listFloorOrders(
     })
     .from(orders)
     .where(where)
-    // Najnovšie hore — zadanie tiketu.
-    .orderBy(desc(orders.placedAt))
+    // Najnovšie hore — zadanie tiketu. `desc(orders.id)` je tu tie-breaker
+    // (review finding, issue 345): `placedAt` je len minútová presnosť
+    // (Shoptet export) — bez druhého, jednoznačného kľúča by LIMIT/OFFSET
+    // pri dvoch objednávkach v tej istej minúte mohol byť nedeterministický
+    // (riadok sa zopakuje na ďalšej strane = duplicitný React `key`, alebo
+    // sa celkom stratí). Rovnaký vzor ako `catalog/queries.ts`'s
+    // `desc(fetchedAt), desc(id)` / `orders/queries.ts`'s
+    // `desc(placedAt), desc(orderLines.id)`.
+    .orderBy(desc(orders.placedAt), desc(orders.id))
     .limit(input.pageSize)
     .offset((input.page - 1) * input.pageSize);
 

--- a/apps/api/src/modules/orders/floor-orders-queries.ts
+++ b/apps/api/src/modules/orders/floor-orders-queries.ts
@@ -1,0 +1,84 @@
+import { desc, sql } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { orders } from "../../db/schema.js";
+import { buildShoptetAdminOrderUrl } from "./queries.js";
+
+// issue 345: "Eshop → Objednávky predajňa" — READ-ONLY zoznam objednávok,
+// ktoré nevznikli v e-shope, ale na kamennej predajni. Priznak je overený
+// NAŽIVO na produkcii (ticket, komentár 11.8.2026 + STEP 0 re-overenie
+// pred implementáciou): `shipping_carrier_name` obsahuje podreťazec
+// "Osobný odber" (`Osobný odber - len na predajni v POPRADE!`, 30→32
+// objednávok). ILIKE na PODREŤAZEC (nikdy presnú vetu s výkričníkom) —
+// prežije zmenu textu v Shoptete, rozhodnuté na tickete.
+//
+// Na rozdiel od `order-flags-queries.ts` (načíta VŠETKO a filtruje/
+// stránkuje v JS, lebo potrebuje per-riadkový odvodený `unresolved` stav)
+// je toto čistý jednotabuľkový WHERE+ORDER BY bez per-riadkového odvodenia
+// — skutočné SQL `LIMIT`/`OFFSET` + `COUNT(*)` je tu správnejšie, presne
+// vzor `catalog/queries.ts`'s `searchVariants`/`restock-links-routes.ts`.
+// Ticket výslovne žiada zdieľaný `useLoadMore` hook (#337) — ten doteraz
+// vždy sedel na skutočnom `page`/`pageSize`/`total` kontrakte, nikdy na
+// load-everything vzore.
+const FLOOR_ORDER_SHIPPING_PATTERN = "%Osobný odber%";
+
+export interface FloorOrderRow {
+  readonly id: string;
+  readonly externalOrderId: string;
+  readonly customerName: string;
+  readonly statusName: string;
+  readonly placedAt: string;
+  readonly totalPriceWithVat: string | null;
+  readonly adminUrl: string;
+}
+
+export interface FloorOrdersSearchInput {
+  readonly page: number;
+  readonly pageSize: number;
+}
+
+export interface FloorOrdersSearchResult {
+  readonly total: number;
+  readonly items: readonly FloorOrderRow[];
+}
+
+export async function listFloorOrders(
+  db: Database,
+  adminBaseUrl: string,
+  input: FloorOrdersSearchInput,
+): Promise<FloorOrdersSearchResult> {
+  const where = sql`${orders.shippingCarrierName} ILIKE ${FLOOR_ORDER_SHIPPING_PATTERN}`;
+
+  const [totals] = await db
+    .select({ total: sql<number>`count(*)`.mapWith(Number) })
+    .from(orders)
+    .where(where);
+
+  const rows = await db
+    .select({
+      id: orders.id,
+      externalOrderId: orders.externalOrderId,
+      customerName: orders.customerName,
+      statusName: orders.statusName,
+      placedAt: orders.placedAt,
+      totalPriceWithVat: orders.totalPriceWithVat,
+      shoptetOrderId: orders.shoptetOrderId,
+    })
+    .from(orders)
+    .where(where)
+    // Najnovšie hore — zadanie tiketu.
+    .orderBy(desc(orders.placedAt))
+    .limit(input.pageSize)
+    .offset((input.page - 1) * input.pageSize);
+
+  const items: FloorOrderRow[] = rows.map((row) => ({
+    id: row.id,
+    externalOrderId: row.externalOrderId,
+    customerName: row.customerName,
+    statusName: row.statusName,
+    placedAt: row.placedAt.toISOString(),
+    totalPriceWithVat: row.totalPriceWithVat,
+    adminUrl: buildShoptetAdminOrderUrl(adminBaseUrl, row.externalOrderId, row.shoptetOrderId),
+  }));
+
+  return { total: totals?.total ?? 0, items };
+}

--- a/apps/api/tests/floor-orders-http.integration.test.ts
+++ b/apps/api/tests/floor-orders-http.integration.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { orders, users } from "../src/db/schema.js";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import type { UserRole } from "../src/modules/auth/service.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 345: HTTP vrstva pre "Eshop → Objednávky predajňa" — vlastný súbor
+// (rovnaký dôvod ako `order-flags-http.integration.test.ts`, eslint
+// `max-lines: 400`).
+const HESLO = "test-heslo-abc"; // testovacie údaje, nie tajomstvo
+
+let close: (() => Promise<void>) | undefined;
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  resetLoginRateLimit();
+});
+
+async function boot(role: UserRole) {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const [pouzivatel] = await ctx.db
+    .insert(users)
+    .values({ email: "pouzivatel@forestshop.sk", passwordHash: await hashPassword(HESLO), displayName: "Test", role })
+    .returning({ id: users.id });
+  if (pouzivatel === undefined) throw new Error("testovací používateľ sa nepodarilo vložiť");
+  const app = createApp(ctx.db, { cookieSecure: false });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "pouzivatel@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie, db: ctx.db };
+}
+
+let poradie = 0;
+async function insertOrder(
+  db: Awaited<ReturnType<typeof boot>>["db"],
+  options: {
+    readonly shippingCarrierName?: string | null;
+    readonly placedAt?: Date;
+    readonly customerName?: string;
+  } = {},
+): Promise<{ id: string; externalOrderId: string }> {
+  poradie += 1;
+  const externalOrderId = `8${String(poradie).padStart(5, "0")}`;
+  // `??` by prepadol cez explicitný `null` na default (JS past — `null ?? x`
+  // vráti `x`, nie `null`), preto `"shippingCarrierName" in options`
+  // namiesto `?? default`, aby test "bez dopravy" naozaj vložil `null`.
+  const shippingCarrierName =
+    "shippingCarrierName" in options ? (options.shippingCarrierName ?? null) : "Osobný odber - len na predajni v POPRADE!";
+  const [order] = await db
+    .insert(orders)
+    .values({
+      externalOrderId,
+      customerName: options.customerName ?? "Zákazník testovaný",
+      statusName: "Vybavená",
+      shippingCarrierName,
+      placedAt: options.placedAt ?? new Date("2026-07-20T00:00:00Z"),
+      totalPriceWithVat: "42.00",
+    })
+    .returning({ id: orders.id, externalOrderId: orders.externalOrderId });
+  if (order === undefined) throw new Error("insert objednávky zlyhal");
+  return order;
+}
+
+describe("GET /api/floor-orders", () => {
+  it("vráti len objednávky s 'Osobný odber' v spôsobe dopravy, podreťazcovo a case-insensitive", async () => {
+    const { app, cookie, db } = await boot("citanie");
+    const predajna = await insertOrder(db, { shippingCarrierName: "OSOBNÝ ODBER" });
+    await insertOrder(db, { shippingCarrierName: "Kuriér" }); // iná doprava — nesmie sa objaviť
+    await insertOrder(db, { shippingCarrierName: null }); // bez dopravy — nesmie sa objaviť
+
+    const res = await app.request("/api/floor-orders", { headers: { cookie } });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { total: number; items: readonly Record<string, unknown>[] };
+    expect(body.total).toBe(1);
+    expect(body.items).toHaveLength(1);
+    expect(body.items[0]?.["externalOrderId"]).toBe(predajna.externalOrderId);
+  });
+
+  it("prežije zmenu textu v Shoptete — hľadá sa podreťazec, nie presná veta", async () => {
+    const { app, cookie, db } = await boot("citanie");
+    await insertOrder(db, { shippingCarrierName: "Osobný odber - úplne iný text ako predtým" });
+
+    const res = await app.request("/api/floor-orders", { headers: { cookie } });
+    const body = (await res.json()) as { total: number };
+    expect(body.total).toBe(1);
+  });
+
+  it("zoradí najnovšie hore", async () => {
+    const { app, cookie, db } = await boot("citanie");
+    const starsia = await insertOrder(db, { placedAt: new Date("2026-07-01T00:00:00Z") });
+    const novsia = await insertOrder(db, { placedAt: new Date("2026-07-10T00:00:00Z") });
+
+    const res = await app.request("/api/floor-orders", { headers: { cookie } });
+    const body = (await res.json()) as { items: readonly Record<string, unknown>[] };
+    expect(body.items.map((i) => i["externalOrderId"])).toEqual([novsia.externalOrderId, starsia.externalOrderId]);
+  });
+
+  it("stránkuje podľa page/pageSize, total počíta CELÚ odfiltrovanú množinu", async () => {
+    const { app, cookie, db } = await boot("citanie");
+    for (let i = 0; i < 5; i += 1) {
+      await insertOrder(db, { placedAt: new Date(2026, 6, 1 + i) });
+    }
+
+    const prva = await app.request("/api/floor-orders?page=1&pageSize=2", { headers: { cookie } });
+    const prvaBody = (await prva.json()) as { total: number; items: readonly unknown[] };
+    expect(prvaBody.total).toBe(5);
+    expect(prvaBody.items).toHaveLength(2);
+
+    const druha = await app.request("/api/floor-orders?page=2&pageSize=2", { headers: { cookie } });
+    const druhaBody = (await druha.json()) as { total: number; items: readonly unknown[] };
+    expect(druhaBody.items).toHaveLength(2);
+
+    const tretia = await app.request("/api/floor-orders?page=3&pageSize=2", { headers: { cookie } });
+    const tretiaBody = (await tretia.json()) as { total: number; items: readonly unknown[] };
+    expect(tretiaBody.items).toHaveLength(1);
+  });
+
+  it("obsahuje odkaz do Shoptet administrácie", async () => {
+    const { app, cookie, db } = await boot("citanie");
+    const objednavka = await insertOrder(db);
+
+    const res = await app.request("/api/floor-orders", { headers: { cookie } });
+    const body = (await res.json()) as { items: readonly Record<string, unknown>[] };
+    expect(body.items[0]?.["adminUrl"]).toContain(objednavka.externalOrderId);
+  });
+
+  it("bez prihlásenia vráti 401", async () => {
+    const { app } = await boot("manazer");
+    const res = await app.request("/api/floor-orders");
+    expect(res.status).toBe(401);
+  });
+});

--- a/apps/api/tests/floor-orders-http.integration.test.ts
+++ b/apps/api/tests/floor-orders-http.integration.test.ts
@@ -101,6 +101,25 @@ describe("GET /api/floor-orders", () => {
     expect(body.items.map((i) => i["externalOrderId"])).toEqual([novsia.externalOrderId, starsia.externalOrderId]);
   });
 
+  // review finding (issue 345): `placedAt` má len minútovú presnosť
+  // (Shoptet export) — bez tie-breakera (`desc(orders.id)`) by LIMIT/OFFSET
+  // pri dvoch objednávkach v TEJ ISTEJ minúte mohol byť nedeterministický
+  // (riadok sa zopakuje na druhej strane, alebo sa stratí).
+  it("dve objednávky s presne rovnakým 'placedAt' sa pri stránkovaní po jednej nikdy nezopakujú ani nestratia", async () => {
+    const { app, cookie, db } = await boot("citanie");
+    const rovnakyCas = new Date("2026-07-15T09:00:00Z");
+    const a = await insertOrder(db, { placedAt: rovnakyCas });
+    const b = await insertOrder(db, { placedAt: rovnakyCas });
+
+    const prva = await app.request("/api/floor-orders?page=1&pageSize=1", { headers: { cookie } });
+    const prvaBody = (await prva.json()) as { items: readonly Record<string, unknown>[] };
+    const druha = await app.request("/api/floor-orders?page=2&pageSize=1", { headers: { cookie } });
+    const druhaBody = (await druha.json()) as { items: readonly Record<string, unknown>[] };
+
+    const videneIds = [prvaBody.items[0]?.["externalOrderId"], druhaBody.items[0]?.["externalOrderId"]];
+    expect(videneIds.sort()).toEqual([a.externalOrderId, b.externalOrderId].sort());
+  });
+
   it("stránkuje podľa page/pageSize, total počíta CELÚ odfiltrovanú množinu", async () => {
     const { app, cookie, db } = await boot("citanie");
     for (let i = 0; i < 5; i += 1) {

--- a/apps/web/src/components/FloorOrdersSection.test.tsx
+++ b/apps/web/src/components/FloorOrdersSection.test.tsx
@@ -1,0 +1,110 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { FloorOrdersSection } from "./FloorOrdersSection.js";
+
+const { fetchFloorOrders } = vi.hoisted(() => ({ fetchFloorOrders: vi.fn() }));
+vi.mock("../floorOrdersApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../floorOrdersApi.js")>();
+  return { ...actual, fetchFloorOrders };
+});
+
+const { FloorOrdersUnauthorizedError } = await import("../floorOrdersApi.js");
+
+function row(externalOrderId: string): {
+  id: string;
+  externalOrderId: string;
+  customerName: string;
+  statusName: string;
+  placedAt: string;
+  totalPriceWithVat: string | null;
+  adminUrl: string;
+} {
+  return {
+    id: `order-${externalOrderId}`,
+    externalOrderId,
+    customerName: "Zákazník testovaný",
+    statusName: "Vybavená",
+    placedAt: "2026-08-01T10:00:00.000Z",
+    totalPriceWithVat: "42.00",
+    adminUrl: `https://www.forestshop.sk/admin/objednavky-detail/?id=${externalOrderId}`,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+it("prázdny zoznam zobrazí informačnú vetu", async () => {
+  fetchFloorOrders.mockResolvedValue({ total: 0, items: [] });
+  render(<FloorOrdersSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("floor-orders-empty");
+});
+
+it("zobrazí riadok objednávky s odkazom do Shoptetu", async () => {
+  fetchFloorOrders.mockResolvedValue({ total: 1, items: [row("93001")] });
+  render(<FloorOrdersSection role="manazer" onSessionExpired={vi.fn()} />);
+  const r = await screen.findByTestId("floor-order-row-93001");
+  expect(r.textContent).toContain("93001");
+  expect(r.textContent).toContain("42.00 €");
+  expect(screen.getByTestId("floor-order-admin-link-93001").getAttribute("href")).toBe(
+    "https://www.forestshop.sk/admin/objednavky-detail/?id=93001",
+  );
+});
+
+// review finding (issue 345): keď POČIATOČNÉ načítanie zlyhá, `total` je
+// tiež 0 — bez `error === ""` gate by sa "žiadna objednávka" zobrazilo
+// popri chybovej hláške, hoci v skutočnosti sa nič nenačítalo.
+it("keď počiatočné načítanie zlyhá, ukáže chybu, NIKDY prázdny stav 'žiadna objednávka'", async () => {
+  fetchFloorOrders.mockRejectedValue(new Error("boom"));
+  render(<FloorOrdersSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByRole("alert");
+  expect(screen.queryByTestId("floor-orders-empty")).toBeNull();
+});
+
+it("401 (Unauthorized) volá onSessionExpired namiesto zobrazenia chyby", async () => {
+  fetchFloorOrders.mockRejectedValue(new FloorOrdersUnauthorizedError());
+  const onSessionExpired = vi.fn();
+  render(<FloorOrdersSection role="manazer" onSessionExpired={onSessionExpired} />);
+  await waitFor(() => {
+    expect(onSessionExpired).toHaveBeenCalled();
+  });
+});
+
+it("keď je total väčší než počet zobrazených položiek, ukáže tlačidlo 'Načítať ďalšie' s počtom zvyšných", async () => {
+  fetchFloorOrders.mockResolvedValue({ total: 11, items: [row("93001")] });
+  render(<FloorOrdersSection role="manazer" onSessionExpired={vi.fn()} />);
+  const button = await screen.findByTestId("load-more");
+  expect(button.textContent).toBe("Načítať ďalšie (10)"); // min(PAGE_SIZE, 11 - 1)
+});
+
+it("klik na 'Načítať ďalšie' pripojí druhú stranu k existujúcim položkám, tlačidlo zmizne keď je zobrazené všetko", async () => {
+  fetchFloorOrders.mockResolvedValueOnce({ total: 2, items: [row("93001")] });
+  fetchFloorOrders.mockResolvedValueOnce({ total: 2, items: [row("93002")] });
+
+  render(<FloorOrdersSection role="manazer" onSessionExpired={vi.fn()} />);
+  fireEvent.click(await screen.findByTestId("load-more"));
+
+  await screen.findByTestId("floor-order-row-93002");
+  // Pôvodná položka ostáva viditeľná — DRUHÁ strana sa PRIPOJILA, nenahradila.
+  expect(screen.getByTestId("floor-order-row-93001")).toBeTruthy();
+  expect(fetchFloorOrders).toHaveBeenLastCalledWith({ page: 2 });
+  await waitFor(() => {
+    expect(screen.queryByTestId("load-more")).toBeNull();
+  });
+});
+
+// review finding (issue 345): chyba pri "Načítať ďalšie" (na rozdiel od
+// počiatočného načítania) NESMIE zhodiť už zobrazenú tabuľku — `items`/
+// `total` sa pri nej vôbec nemenia (`useLoadMore`'s `onError`).
+it("chyba pri 'Načítať ďalšie' ukáže hlášku, ale existujúce riadky ostanú viditeľné", async () => {
+  fetchFloorOrders.mockResolvedValueOnce({ total: 2, items: [row("93001")] });
+  fetchFloorOrders.mockRejectedValueOnce(new Error("boom"));
+
+  render(<FloorOrdersSection role="manazer" onSessionExpired={vi.fn()} />);
+  fireEvent.click(await screen.findByTestId("load-more"));
+
+  await screen.findByRole("alert");
+  expect(screen.getByTestId("floor-order-row-93001")).toBeTruthy();
+  expect(screen.queryByTestId("floor-orders-empty")).toBeNull();
+});

--- a/apps/web/src/components/FloorOrdersSection.tsx
+++ b/apps/web/src/components/FloorOrdersSection.tsx
@@ -1,0 +1,144 @@
+import { useCallback, useEffect, useRef, useState, type JSX } from "react";
+import type { Me } from "../api.js";
+import { formatSkDate } from "../formatDate.js";
+import { fetchFloorOrders, FloorOrdersUnauthorizedError, PAGE_SIZE, type FloorOrderRow } from "../floorOrdersApi.js";
+import { useLoadMore } from "../useLoadMore.js";
+
+// issue 345: "Eshop → Objednávky predajňa" — READ-ONLY zoznam objednávok,
+// ktoré nevznikli v e-shope, ale na kamennej predajni (`shipping_carrier_
+// name` obsahuje "Osobný odber", `apps/api/src/modules/orders/floor-orders-
+// queries.ts`). Vlastná malá tabuľka namiesto zdieľanej `OrderFlagTable.tsx`
+// — tá nesie stĺpec "Poznámka" a štítok "nevybavené", ktoré zadanie tiketu
+// nežiada (návrhový komentár na tickete). `useLoadMore` (#337) — rovnaký
+// vzor ako `RestockLinkSuggestionsSection.tsx`.
+export function FloorOrdersSection({ onSessionExpired }: { readonly role: Me["role"]; readonly onSessionExpired: () => void }): JSX.Element {
+  const [items, setItems] = useState<readonly FloorOrderRow[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState("");
+
+  // Rovnaký dôvod ako `RestockLinkSuggestionsSection.tsx`/`SupplierLinksSection.tsx`
+  // (issue 251, StrictMode double-mount past — `.claude/rules/frontend-design.md`).
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const loadMoreState = useLoadMore<FloorOrderRow>({
+    mountedRef,
+    onAppend: (newItems, newTotal) => {
+      setItems((prev) => [...prev, ...newItems]);
+      setTotal(newTotal);
+    },
+    onError: () => {
+      setError("Načítanie ďalších objednávok zlyhalo.");
+    },
+  });
+
+  const load = useCallback(() => {
+    setError("");
+    loadMoreState.reset();
+    fetchFloorOrders({ page: 1 })
+      .then((result) => {
+        if (!mountedRef.current) return;
+        setItems(result.items);
+        setTotal(result.total);
+        setLoaded(true);
+      })
+      .catch((err: unknown) => {
+        if (!mountedRef.current) return;
+        setLoaded(true);
+        if (err instanceof FloorOrdersUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setItems([]);
+        setTotal(0);
+        setError("Zoznam objednávok predajne sa nepodarilo načítať.");
+      });
+  }, [onSessionExpired]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const showingAll = total === 0 || items.length >= total;
+
+  return (
+    <section data-testid="floor-orders-section">
+      <p>
+        Objednávky, ktoré Shoptet eviduje s dopravou „Osobný odber“ — teda vznikli priamo na predajni,
+        nie v e-shope.
+      </p>
+
+      {error !== "" && <p role="alert">{error}</p>}
+
+      {!loaded ? (
+        <p>Načítavam…</p>
+      ) : total === 0 ? (
+        <p data-testid="floor-orders-empty">Momentálne žiadna objednávka z predajne nie je evidovaná.</p>
+      ) : (
+        <>
+          <p data-testid="floor-orders-total">
+            {showingAll
+              ? `Nájdených: ${String(total)}`
+              : `Nájdených: ${String(total)} (zobrazených prvých ${String(items.length)})`}
+          </p>
+          <div className="fs-table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Číslo</th>
+                  <th>Dátum</th>
+                  <th>Zákazník</th>
+                  <th>Stav</th>
+                  <th>Suma</th>
+                  <th />
+                </tr>
+              </thead>
+              <tbody>
+                {items.map((row) => (
+                  <tr key={row.id} data-testid={`floor-order-row-${row.externalOrderId}`}>
+                    <td>{row.externalOrderId}</td>
+                    <td>{formatSkDate(row.placedAt)}</td>
+                    <td>{row.customerName}</td>
+                    <td>{row.statusName}</td>
+                    <td>{row.totalPriceWithVat === null ? "—" : `${row.totalPriceWithVat} €`}</td>
+                    <td>
+                      <a
+                        href={row.adminUrl}
+                        target="_blank"
+                        rel="noreferrer noopener"
+                        data-testid={`floor-order-admin-link-${row.externalOrderId}`}
+                      >
+                        Otvoriť v Shoptete
+                      </a>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+
+      {items.length < total && (
+        <button
+          type="button"
+          data-testid="load-more"
+          disabled={loadMoreState.loadingMore}
+          onClick={() => {
+            loadMoreState.loadMore((page) => fetchFloorOrders({ page }));
+          }}
+        >
+          {loadMoreState.loadingMore
+            ? "Načítavam…"
+            : `Načítať ďalšie (${String(Math.min(PAGE_SIZE, total - items.length))})`}
+        </button>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/FloorOrdersSection.tsx
+++ b/apps/web/src/components/FloorOrdersSection.tsx
@@ -38,18 +38,28 @@ export function FloorOrdersSection({ onSessionExpired }: { readonly role: Me["ro
     },
   });
 
+  // "Latest generation" vzor (review finding, issue 345 — rovnaký dôvod ako
+  // `SupplierLinksSection.tsx`/`RestockLinkSuggestionsSection.tsx`'s
+  // `searchSeq`): bez neho by neskoro doručená (napr. StrictMode double-
+  // mount) odpoveď TEJTO funkcie mohla prepísať `items` SPÄŤ na prvú stranu
+  // PO tom, čo už používateľ klikol "Načítať ďalšie" — `useLoadMore`'s
+  // interný `pageRef` by pritom ostal na strane 2, takže ďalší klik by
+  // preskočil rovno na stranu 3 a stratil riadky strany 2.
+  const loadSeq = useRef(0);
+
   const load = useCallback(() => {
+    const seq = (loadSeq.current += 1);
     setError("");
     loadMoreState.reset();
     fetchFloorOrders({ page: 1 })
       .then((result) => {
-        if (!mountedRef.current) return;
+        if (!mountedRef.current || seq !== loadSeq.current) return;
         setItems(result.items);
         setTotal(result.total);
         setLoaded(true);
       })
       .catch((err: unknown) => {
-        if (!mountedRef.current) return;
+        if (!mountedRef.current || seq !== loadSeq.current) return;
         setLoaded(true);
         if (err instanceof FloorOrdersUnauthorizedError) {
           onSessionExpired();
@@ -79,7 +89,13 @@ export function FloorOrdersSection({ onSessionExpired }: { readonly role: Me["ro
       {!loaded ? (
         <p>Načítavam…</p>
       ) : total === 0 ? (
-        <p data-testid="floor-orders-empty">Momentálne žiadna objednávka z predajne nie je evidovaná.</p>
+        // review finding (issue 345): keď POČIATOČNÉ načítanie zlyhá, `total`
+        // je tiež `0` — bez `error === ""` by táto obrazovka klamlivo tvrdila
+        // "žiadna objednávka" popri chybovej hláške vyššie. Chyba pri "Načítať
+        // ďalšie" sem nikdy nespadne (`total`/`items` sa vtedy nemenia, viď
+        // `useLoadMore`'s `onError`), takže tabuľka nižšie ostáva viditeľná aj
+        // pri takej chybe — rovnaké správanie ako `RestockLinkSuggestionsSection.tsx`.
+        error === "" && <p data-testid="floor-orders-empty">Momentálne žiadna objednávka z predajne nie je evidovaná.</p>
       ) : (
         <>
           <p data-testid="floor-orders-total">

--- a/apps/web/src/floorOrdersApi.ts
+++ b/apps/web/src/floorOrdersApi.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+
+// issue 345: "Eshop → Objednávky predajňa" — zrkadlí `GET /api/floor-orders`
+// (`apps/api/src/http/floor-orders-routes.ts`). LEN čítanie, žiadna
+// zapisovacia funkcia v tomto súbore.
+
+const floorOrderRowSchema = z.object({
+  id: z.string(),
+  externalOrderId: z.string(),
+  customerName: z.string(),
+  statusName: z.string(),
+  placedAt: z.string(),
+  totalPriceWithVat: z.string().nullable(),
+  adminUrl: z.string(),
+});
+export type FloorOrderRow = z.infer<typeof floorOrderRowSchema>;
+
+const searchSchema = z.object({ total: z.number(), items: z.array(floorOrderRowSchema) });
+
+// Zámerne malé (nie 50 ako `restock-links`/katalóg) — produkcia má dnes len
+// ~30 zodpovedajúcich objednávok, malá strana robí "Načítať ďalšie" reálne
+// overiteľné aj naživo na skutočných dátach (rozhodnuté na tickete).
+export const PAGE_SIZE = 10;
+
+/** Relácia medzitým vypršala (401) — rovnaký vzor ako ostatné `*ApiError` triedy. */
+export class FloorOrdersUnauthorizedError extends Error {
+  constructor() {
+    super("Neprihlásený");
+  }
+}
+
+const errorBodySchema = z.object({ error: z.string() });
+
+async function serverErrorMessage(response: Response, fallback: string): Promise<string> {
+  try {
+    const parsed = errorBodySchema.safeParse(await response.json());
+    if (parsed.success) return parsed.data.error;
+  } catch {
+    // telo nie je platný JSON — použi všeobecnú hlášku
+  }
+  return fallback;
+}
+
+async function readJson(response: Response, fallback: string): Promise<unknown> {
+  if (response.status === 401) throw new FloorOrdersUnauthorizedError();
+  if (!response.ok) throw new Error(await serverErrorMessage(response, fallback));
+  return await response.json();
+}
+
+export async function fetchFloorOrders(input: { readonly page: number }): Promise<z.infer<typeof searchSchema>> {
+  const query = new URLSearchParams({ page: String(input.page), pageSize: String(PAGE_SIZE) });
+  const response = await fetch(`/api/floor-orders?${query.toString()}`);
+  return searchSchema.parse(await readJson(response, "Zoznam objednávok predajne sa nepodarilo načítať"));
+}

--- a/apps/web/src/nav.test.ts
+++ b/apps/web/src/nav.test.ts
@@ -25,17 +25,20 @@ import { DEFAULT_TAB_ID, HIDDEN_TABS, NAV, findTab, isVisibleTabId } from "./nav
 // "Eshop" (majiteľovo zadanie, jedno tlačidlo na objednanie prepravy).
 // Issue 342 pridalo ŠTVRTÝ priečinok "Dôležité" (PRED "Eshop"), presunulo
 // "Upozornenia" doňho a pridalo novú záložku "Úlohy na dnes".
+// Issue 345 pridalo "Objednávky predajňa" hneď za "Na objednanie" (obe sú
+// "zoznam objednávok" obrazovky).
 // Tento test je najbližšie k tomu, čo strojovo overiť dá (registrácia, nie DOM).
-it("NAV má štyri priečinky (Dôležité/Eshop/Systém/Automatizácie), s 2/9/3/5 záložkami v poradí podľa dôležitosti", () => {
+it("NAV má štyri priečinky (Dôležité/Eshop/Systém/Automatizácie), s 2/10/3/5 záložkami v poradí podľa dôležitosti", () => {
   expect(NAV).toHaveLength(4);
   expect(NAV.map((f) => f.label)).toEqual(["Dôležité", "Eshop", "Systém", "Automatizácie"]);
   expect(NAV[0]?.tabs).toHaveLength(2);
-  expect(NAV[1]?.tabs).toHaveLength(9);
+  expect(NAV[1]?.tabs).toHaveLength(10);
   expect(NAV[2]?.tabs).toHaveLength(3);
   expect(NAV[3]?.tabs).toHaveLength(5);
   expect(NAV[0]?.tabs.map((t) => t.label)).toEqual(["Upozornenia", "Úlohy na dnes"]);
   expect(NAV[1]?.tabs.map((t) => t.label)).toEqual([
     "Na objednanie",
+    "Objednávky predajňa",
     "Nedostupné tovary",
     "Výmena tovaru",
     "Vrátený tovar",

--- a/apps/web/src/nav.ts
+++ b/apps/web/src/nav.ts
@@ -5,6 +5,7 @@ import { ClaimOrdersSection } from "./components/ClaimOrdersSection.js";
 import { DailyTasksSection } from "./components/DailyTasksSection.js";
 import { DpdSection } from "./components/DpdSection.js";
 import { ExchangeOrdersSection } from "./components/ExchangeOrdersSection.js";
+import { FloorOrdersSection } from "./components/FloorOrdersSection.js";
 import { MailLogSection } from "./components/MailLogSection.js";
 import { MailTemplatesSection } from "./components/MailTemplatesSection.js";
 import { NedostupneSection } from "./components/NedostupneSection.js";
@@ -108,6 +109,12 @@ export const NAV: readonly NavFolder[] = [
     // okna, viď `NavTab.wide` vyššie).
     tabs: [
       { id: "orders", label: "Na objednanie", icon: "📦", Component: OrdersSection, wide: true },
+      // issue 345: šéfovo zadanie (Discord, 11.8.2026) — READ-ONLY zoznam
+      // objednávok, ktoré nevznikli v e-shope, ale na kamennej predajni
+      // (`shipping_carrier_name` obsahuje "Osobný odber", návrhový komentár
+      // na tickete). Patrí hneď za "Na objednanie" — obe sú "zoznam
+      // objednávok" obrazovky, najprirodzenejšie susedné.
+      { id: "floor-orders", label: "Objednávky predajňa", icon: "🏬", Component: FloorOrdersSection, wide: true },
       { id: "nedostupne", label: "Nedostupné tovary", icon: "🚫", Component: NedostupneSection, wide: true },
       // issue 290: šéfovo zadanie (Discord, 6.8.2026) — tri nové položky
       // "hneď pod Nedostupné tovary". READ-ONLY pohľady nad `order.status_

--- a/apps/web/tests/e2e/floor-orders.spec.ts
+++ b/apps/web/tests/e2e/floor-orders.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "@playwright/test";
+
+const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
+const E2E_OBJEDNAVKY_PREDAJNA_EMAIL = "e2e-predajna@forestshop.sk"; // musí sa zhodovať s hodnotou v scripts/e2e-fixtures-floor-orders.ts
+
+// issue 345: "Eshop → Objednávky predajňa" — nová viditeľná záložka
+// (`nav.ts`, priečinok Eshop, hneď za "Na objednanie"). Fixtúrové
+// objednávky "93001"–"93011" (11 kusov, PAGE_SIZE + 1 = 10 + 1) + "93999"
+// (INÁ doprava, nesmie sa nikdy objaviť) patria VÝHRADNE tomuto spec
+// súboru (`scripts/e2e-fixtures-floor-orders.ts`).
+test("zobrazí objednávky predajne najnovšie hore, odkaz do Shoptetu funguje, Načítať ďalšie odhalí zvyšok; konzola je čistá", async ({
+  page,
+}) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/");
+  await page.getByLabel("E-mail").fill(E2E_OBJEDNAVKY_PREDAJNA_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await expect(page.getByRole("heading", { name: "Na objednanie" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Objednávky predajňa" }).click();
+  await expect(page.getByRole("heading", { name: "Objednávky predajňa" })).toBeVisible();
+
+  // Nájdených: 11 (fixtúra), zobrazených prvých 10 (PAGE_SIZE) — dôkaz, že
+  // stránkovanie/total naozaj funguje pred akýmkoľvek klikom.
+  await expect(page.getByTestId("floor-orders-total")).toHaveText("Nájdených: 11 (zobrazených prvých 10)");
+
+  // Najnovšia (93011, i=11 → najneskorší dátum vo fixtúre) je PRVÁ.
+  const riadky = page.locator('[data-testid^="floor-order-row-"]');
+  await expect(riadky.first()).toHaveAttribute("data-testid", "floor-order-row-93011");
+
+  const riadok = page.getByTestId("floor-order-row-93011");
+  await expect(riadok).toContainText("E2E Zákazník Predajňa 11");
+  await expect(riadok).toContainText("21.00 €");
+
+  // Iná doprava (93999, "Kuriér") sa nesmie nikdy objaviť.
+  await expect(page.getByTestId("floor-order-row-93999")).toHaveCount(0);
+
+  // Odkaz do Shoptet administrácie nesie číslo objednávky.
+  await expect(page.getByTestId("floor-order-admin-link-93011")).toHaveAttribute("href", /93011/);
+
+  // Najstaršia (93001) je zatiaľ MIMO prvej strany.
+  await expect(page.getByTestId("floor-order-row-93001")).toHaveCount(0);
+
+  await page.getByTestId("load-more").click();
+  await expect(page.getByTestId("floor-orders-total")).toHaveText("Nájdených: 11");
+  await expect(page.getByTestId("floor-order-row-93001")).toBeVisible();
+
+  expect(chyby).toEqual([]);
+});

--- a/apps/web/tests/e2e/nav.spec.ts
+++ b/apps/web/tests/e2e/nav.spec.ts
@@ -33,8 +33,10 @@ const E2E_NAV_EMAIL = "e2e-nav@forestshop.sk";
 // login screen odteraz vidí menu v poradí Dôležité/Eshop/Systém/
 // Automatizácie), presúva "Upozornenia" doňho (z priečinka "Eshop") a pridáva
 // novú záložku "Úlohy na dnes" — devätnásta záložka celkovo (funkčný test v
-// samostatnom `daily-tasks.spec.ts`, rovnaký vzor).
-test("ľavé menu má štyri priečinky (Dôležité/Eshop/Systém/Automatizácie) s devätnástimi záložkami, klik prepne obrazovku, panel sa zbalí do lišty a stav si pamätá, konzola je čistá", async ({
+// samostatnom `daily-tasks.spec.ts`, rovnaký vzor). Issue 345 (2026-08-11)
+// pridáva "Objednávky predajňa" HNEĎ ZA "Na objednanie" — dvadsiata záložka
+// celkovo (funkčný test v samostatnom `floor-orders.spec.ts`, rovnaký vzor).
+test("ľavé menu má štyri priečinky (Dôležité/Eshop/Systém/Automatizácie) s dvadsiatimi záložkami, klik prepne obrazovku, panel sa zbalí do lišty a stav si pamätá, konzola je čistá", async ({
   page,
 }) => {
   const chyby: string[] = [];
@@ -71,11 +73,12 @@ test("ľavé menu má štyri priečinky (Dôležité/Eshop/Systém/Automatizáci
   await expect(page.getByRole("button", { name: "Systém" })).toHaveAttribute("aria-expanded", "true");
   await expect(page.getByRole("button", { name: "Automatizácie" })).toHaveAttribute("aria-expanded", "true");
 
-  // Presne devätnásť záložiek v CELOM menu.
-  await expect(page.locator(".side-nav .tab")).toHaveCount(19);
+  // Presne dvadsať záložiek v CELOM menu.
+  await expect(page.locator(".side-nav .tab")).toHaveCount(20);
   await expect(page.getByRole("button", { name: "Sync zo Shoptetu" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Texty e-mailov" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Na objednanie" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Objednávky predajňa" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Nevyzdvihnuté zásielky" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Pripomienky objednávok" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Nedostupné tovary" })).toBeVisible();
@@ -213,7 +216,7 @@ test("ľavé menu má štyri priečinky (Dôležité/Eshop/Systém/Automatizáci
 
   // Hlavičky priečinkov zmiznú, ikony všetkých modulov ostanú.
   await expect(page.getByRole("button", { name: "Systém" })).toHaveCount(0);
-  await expect(page.locator(".side-nav .tab")).toHaveCount(19);
+  await expect(page.locator(".side-nav .tab")).toHaveCount(20);
   // Názov sa v lište ukáže bublinou pri prejdení myšou.
   await expect(page.getByRole("button", { name: "Na objednanie" })).toHaveAttribute(
     "title",

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -3490,3 +3490,26 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   own review caught), `.claude/rules/nedostupne.md` (handled predicate +
   the "boss says a colour, check it doesn't already mean something else
   in this app" precedent).
+
+## Issue 351 — tazke brany presunut z dev1 do CI
+
+- Root cause: lokalny predpush zvyk spustal CELU sadu bran (typecheck,
+  lint, unit, integration proti lokalnemu Postgresu, e2e so skutocnym
+  Chromiom) — duplicitu toho, co ci.yml aj tak zadarmo znova bezi na
+  ubuntu-latest. Namerane: zataz 15,6, 4,2 GB swap, eslint sam 1,5 GB.
+  Design comment: issuecomment-5256903352.
+- Commits: 50ea1f1 (version bump 0.3.0-dev.208), 080449f (gates:local +
+  --concurrency=off + playwright workers:1 + playbook), 632cad8 (review
+  fix — stale local-dev.md cyklus + eslint concurrency caveat).
+- PR opened from dev to main, merged 79325b4, main CI + Deploy oboje
+  zelene (vsetkych 5 jobov v CI vratane integration/e2e).
+- Namerane pred/po (jeden reprezentativny beh): stara plna sada 539 s pod
+  zatazou, peak load 4,60; nova gates:local 114 s, peak load 3,91 — 4,7x
+  kratsi cas pod zatazou (integration 655 testov/336 s + e2e 55 testov uz
+  lokalne default nebezia, len v CI).
+- Post-deploy: /api/version + Playwright DOM zhodne s 0.3.0-dev.208 a
+  merge SHA 79325b40, 0 console error/warning.
+- Playbook: .claude/rules/local-dev.md (nova predvolena lokalna sada +
+  namerane cisla), .claude/rules/testing.md (pointer na heavy-gates-CI-
+  only), .claude/rules/ci.md (integration/e2e/docker-build musia ostat
+  bezpodmienecne — plan na tom stoji).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.209",
+  "version": "0.3.0-dev.210",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.208",
+  "version": "0.3.0-dev.209",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-fixtures-floor-orders.ts
+++ b/scripts/e2e-fixtures-floor-orders.ts
@@ -1,0 +1,53 @@
+// issue 345: "Eshop → Objednávky predajňa" — vyčlenené do VLASTNÉHO súboru
+// (rovnaký dôvod ako `e2e-fixtures-order-flags.ts`, eslint `max-lines: 400`,
+// `.claude/rules/testing.md`). VLASTNÝ izolovaný E2E účet (zdieľaný
+// `e2e@forestshop.sk` je už na hranici `MAX_ATTEMPTS`) + 11 VLASTNÝCH
+// objednávok s dopravou "Osobný odber" (PAGE_SIZE + 1 = 11, aby
+// "Načítať ďalšie" malo čo reálne odhaliť na druhej strane) + 1 objednávka
+// s INOU dopravou (nesmie sa nikdy objaviť — dôkaz, že filter naozaj
+// filtruje). `placedAt` je zámerne PEVNÝ dátum HLBOKO V MINULOSTI (rovnaký
+// dôvod ako `e2e-fixtures-order-flags.ts`) — NIE `teraz`, aby tieto
+// objednávky neposunuli iné presné "objednávky dnes" počty.
+import type { Database } from "../apps/api/src/db/client.js";
+import { orders, users } from "../apps/api/src/db/schema.js";
+import { hashPassword } from "../apps/api/src/modules/auth/passwords.js";
+
+// Musí sa zhodovať s hodnotou v `apps/web/tests/e2e/floor-orders.spec.ts`.
+export const E2E_OBJEDNAVKY_PREDAJNA_EMAIL = "e2e-predajna@forestshop.sk";
+
+// PAGE_SIZE z `floorOrdersApi.ts` (10) + 1, aby prvá strana bola PLNÁ a
+// druhá strana mala presne JEDEN riadok navyše — jednoznačný dôkaz, že
+// "Načítať ďalšie" naozaj siahlo za prvú stranu.
+const POCET_PREDAJNA = 11;
+
+export async function seedFloorOrdersFixtures(db: Database, heslo: string): Promise<void> {
+  await db.insert(users).values({
+    email: E2E_OBJEDNAVKY_PREDAJNA_EMAIL,
+    passwordHash: await hashPassword(heslo),
+    displayName: "E2E Manažér Predajňa",
+    role: "manazer",
+  });
+
+  for (let i = 1; i <= POCET_PREDAJNA; i += 1) {
+    await db.insert(orders).values({
+      externalOrderId: `93${String(i).padStart(3, "0")}`,
+      customerName: `E2E Zákazník Predajňa ${String(i).padStart(2, "0")}`,
+      statusName: "Vybavená",
+      shippingCarrierName: "Osobný odber - len na predajni v POPRADE!",
+      // Rastúci dátum → posledná vložená (i = 11) je NAJNOVŠIA, musí byť
+      // prvá na obrazovke ("Najnovšie hore" — zadanie tiketu).
+      placedAt: new Date(2026, 5, i, 9, 0, 0),
+      totalPriceWithVat: `${String(10 + i)}.00`,
+    });
+  }
+
+  // INÁ doprava — nesmie sa nikdy objaviť na "Objednávky predajňa".
+  await db.insert(orders).values({
+    externalOrderId: "93999",
+    customerName: "E2E Zákazník Kuriér",
+    statusName: "Vybavená",
+    shippingCarrierName: "Kuriér",
+    placedAt: new Date("2026-06-20T09:00:00Z"),
+    totalPriceWithVat: "99.00",
+  });
+}

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -18,6 +18,7 @@ import { DEFAULT_ORDER_OPEN_STATUS } from "../apps/api/src/modules/orders/open-s
 import { POSTA_UNCOLLECTED_SETTINGS_ID } from "../apps/api/src/modules/posta-uncollected/settings.js";
 import { ORDER_REMINDER_SETTINGS_ID } from "../apps/api/src/modules/order-reminder/settings.js";
 import { seedDpdFixtures } from "./e2e-fixtures-dpd.js";
+import { seedFloorOrdersFixtures } from "./e2e-fixtures-floor-orders.js";
 import { seedOrderFlagsFixtures } from "./e2e-fixtures-order-flags.js";
 import { seedPaginationFixtures } from "./e2e-fixtures-pagination.js";
 import { seedProductLinksFixtures } from "./e2e-fixtures-product-links.js";
@@ -811,5 +812,8 @@ await seedRestockEventsFixtures(db, teraz);
 
 // issue 337: fixtúra vyčlenená do vlastného súboru, rovnaký dôvod ako vyššie.
 await seedPaginationFixtures(db, teraz, snapshotPrepinanie);
+
+// issue 345: fixtúra vyčlenená do vlastného súboru, rovnaký dôvod ako vyššie.
+await seedFloorOrdersFixtures(db, E2E_HESLO);
 
 await pool.end();


### PR DESCRIPTION
## Súhrn

Nová viditeľná záložka "Objednávky predajňa" v priečinku Eshop (hneď za
"Na objednanie") — read-only zoznam objednávok, ktoré nevznikli v
e-shope, ale na kamennej predajni. Rozlišujúci znak zistený naživo na
produkcii a zaznamenaný na tickete: `order.shipping_carrier_name`
obsahuje podreťazec „Osobný odber" (case-insensitive, prežije zmenu
textu v Shoptete).

- Nová `GET /api/floor-orders?page=&pageSize=` (SQL-stránkovaná,
  `LIMIT`/`OFFSET` + `COUNT(*)`, `ORDER BY placedAt DESC, id DESC`).
- Nová `FloorOrdersSection.tsx` používajúca zdieľaný `useLoadMore` hook
  (#337), `PAGE_SIZE = 10` (zámerne malé — produkcia má len ~30
  zodpovedajúcich objednávok, dá sa naživo overiť aj samotné "Načítať
  ďalšie").
- Integračný test (`floor-orders-http.integration.test.ts`), komponentový
  test (`FloorOrdersSection.test.tsx`), e2e spec s vlastnými fixtúrami
  (`floor-orders.spec.ts` + `e2e-fixtures-floor-orders.ts`).
- `nav.ts`/`nav.test.ts`/`nav.spec.ts` upravené na novú (dvadsiatu)
  záložku.
- Playbook zápis v `.claude/rules/orders.md`.

Návrhový komentár (root cause + zvolený prístup + zavrhnutá alternatíva)
a review komentár (0 🔴, 3 🟡, 4 🔵 — všetko opravené) sú na tickete.

Táto vetva rieši issue 345, ale zámerne bez `Closes` slova v tomto texte
— GitHub-ova detekcia zatváracích kľúčových slov nemá vypínač na
negáciu, takže akékoľvek `Closes`/`Fixes` by ticket zavrelo automaticky
pri merge. Ticket zatváram ručne, PO naživo overení na
https://forestshop-novy.newlevel.media (`.claude/rules/sensitive-values.md`'s
sesterský playbook postup, issue 120/66/127/132).

Vzťahuje sa k issue 345.
