### PR TITLE
docs: playbook entry — jest-dom matcher gotcha in web tests (issue 345)

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -4,6 +4,8 @@ paths:
   - "apps/api/src/**/*.test.ts"
   - "apps/api/vitest.config.ts"
   - "apps/web/vitest.config.ts"
+  - "apps/web/src/**/*.test.ts"
+  - "apps/web/src/**/*.test.tsx"
   - "apps/web/tests/e2e/**"
   - "apps/web/playwright.config.ts"
   - "scripts/e2e-setup.ts"
@@ -611,3 +613,11 @@ paths:
   akéhokoľvek ďalšieho výstupu skús izolovaný re-beh AKO PRVÉ, nie
   predlžovanie timeoutu (`no-timeout-band-aids.md`) ani hľadanie bugu v
   `e2e-setup.ts`/`playwright.config.ts`.
+- **Komponentové testy (`apps/web/src/components/*.test.tsx`) NEMAJÚ
+  `@testing-library/jest-dom` matchery — `expect(el).toHaveAttribute(...)`
+  padne na `tsc` s "Property 'toHaveAttribute' does not exist"** (issue
+  345, živo nájdené). Repo dôsledne používa holé vitest/RTL API:
+  `expect(el.getAttribute("href")).toBe(...)` namiesto jest-dom matcherov
+  (`toHaveAttribute`/`toBeVisible`/`toBeInTheDocument`) — over existujúci
+  sesterský test (napr. `NedostupneSection.test.tsx`) pred písaním nového,
+  nikdy nepredpokladaj, že jest-dom je nainštalovaný.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.210",
+  "version": "0.3.0-dev.211",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Playbook zápis z post-ticket review pre issue 345 (Eshop: nová obrazovka
Objednávky predajňa, PR #354, už zmergnuté) — čisto dokumentačná zmena,
žiadny funkčný kód. Verzia bumpnutá, lebo dev == main po merge #354.

Zisk: komponentové testy v `apps/web/src/components/*.test.tsx` NEMAJÚ
`@testing-library/jest-dom` matchery (`toHaveAttribute` a pod.) — repo
používa holé `expect(el.getAttribute(...)).toBe(...)`. Zaznamenané v
`.claude/rules/testing.md` + rozšírené `paths:` frontmatter, aby sa
pravidlo naozaj auto-loadovalo aj pri práci na web komponentových testoch.

Vzťahuje sa k issue 345.
