### PR TITLE
fix: cloudflared http2 + external uptime monitor (issue 357)

### DIFF
--- a/.claude/rules/deploy.md
+++ b/.claude/rules/deploy.md
@@ -10,6 +10,44 @@ paths:
 
 # Deployment (dev2)
 
+- **Cloudflare Error 1033 / HTTP 530 na oboch verejných adresách = tunel bez
+  živého spojenia, NIE appka (issue 357, výpadok 12. 8. 2026 ráno).**
+  `cloudflared` sa predvolene pripája protokolom QUIC (UDP 7844); keď QUIC
+  handshake na sieti dev2 prestane prechádzať (`ERR Failed to dial a quic
+  connection error="failed to dial to edge with quic: timeout: handshake
+  did not complete in time"` na všetkých štyroch spojeniach naraz), appka aj
+  DB bežia ďalej v poriadku (lokálne `HTTP 200` na dev2), len Cloudflare
+  nemá kam smerovať požiadavky. Diagnostika: `docker logs
+  forestshop-cloudflared-1` (hľadaj `quic`), `docker inspect
+  forestshop-cloudflared-1 --format '{{json .Config.Cmd}}'` (over aktuálny
+  príkaz). Oprava: `--protocol http2` v `cloudflared`'s `command:` v
+  `docker-compose.prod.yml` — vynúti TCP 443 namiesto UDP, bezpečná voľba
+  bez ohľadu na to, či bol QUIC výpadok dočasný alebo trvalý (mierne
+  pomalšie, zanedbateľne). **Táto zmena MUSÍ byť v repozitárovom
+  `docker-compose.prod.yml`, nie len ručne na dev2** — `deploy.yml`'s
+  `cp "$GITHUB_WORKSPACE/docker-compose.prod.yml" .` krok pri KAŽDOM
+  nasadení kompletne prepíše `/srv/forestshop/docker-compose.prod.yml`
+  súborom z repa; ranná ručná oprava priamo na serveri by prvým ďalším
+  nasadením potichu zmizla a výpadok by sa zopakoval.
+- **Vonkajšie sledovanie dostupnosti (issue 357):** appka predtým nemala nič,
+  čo by z VONKU kontrolovalo, či verejná adresa žije — výpadok objavil
+  majiteľ, nie automatika. `scripts/uptime-check.sh` (v tomto repe) beží cez
+  systemd `--user` timer **na dev1** (zámerne NIE na dev2 — monitor na tom
+  istom stroji, čo sleduje, by zomrel spolu s tým, čo má hlásiť; rovnaký
+  vzor ako `api-watchdog.timer`/`imag-obs-alert-watchdog.timer`), kontroluje
+  obe verejné adresy (`forestshop.newlevel.media`,
+  `forestshop-novy.newlevel.media`) každých 5 minút, alertuje až po 2
+  zlyhaniach za sebou (~10 min súvislého výpadku, nie jeden blik) cez
+  `~/devel/airuleset/airuleset.py notify --body ... --owner-name marek`,
+  opakovaný alert pre TÚ ISTÚ prebiehajúcu udalosť najviac raz za ~1h
+  (throttle) + jedna správa pri zotavení. **Systemd `.timer`/`.service`
+  súbory sa NEVERZUJÚ do repa** (`~/.config/systemd/user/uptime-check.
+  {timer,service}` na dev1, rovnaký vzor ako `parovanie-backup.timer`) —
+  repo drží len skript, inštalácia je ručný jednorazový krok. Stavový súbor
+  (potvrdzovací počítadlo + throttle) je v `${XDG_RUNTIME_DIR:-/tmp}` —
+  netreba ho zálohovať, monitor sa po reštarte dev1 sám znovu rozbehne od
+  nuly (najhorší prípad: jeden alert navyše, nikdy tichý výpadok).
+
 - **Kontajner beží v `TZ=Europe/Bratislava` (issue 293) — nastavené DVAKRÁT,
   zámerne.** `Dockerfile`'s `ENV TZ=Europe/Bratislava` (runtime štádium) je
   baked-in predvolená hodnota v samotnom obraze; `docker-compose.prod.yml`'s

--- a/.claude/rules/deploy.md
+++ b/.claude/rules/deploy.md
@@ -30,6 +30,14 @@ paths:
   nasadení kompletne prepíše `/srv/forestshop/docker-compose.prod.yml`
   súborom z repa; ranná ručná oprava priamo na serveri by prvým ďalším
   nasadením potichu zmizla a výpadok by sa zopakoval.
+  **`--protocol http2` je od `cloudflared` 2026.7.3 nezdokumentovaný —
+  funguje (overené naživo proti bežiacemu `cloudflared:latest`), ale vo
+  vlastnom `cloudflared tunnel --help` výstupe už nie je uvedený.** Keď po
+  najbližšom zdvihnutí verzie obrazu (`docker-compose.prod.yml`'s
+  `cloudflare/cloudflared:latest`) tunel znovu spadne, over NAJPRV, či
+  prepínač nebol pri tej príležitosti (napr. pri čítaní `--help`) omylom
+  odstránený ako "neexistujúci" — nepredpokladaj automaticky, že ide o ten
+  istý QUIC problém.
 - **Vonkajšie sledovanie dostupnosti (issue 357):** appka predtým nemala nič,
   čo by z VONKU kontrolovalo, či verejná adresa žije — výpadok objavil
   majiteľ, nie automatika. `scripts/uptime-check.sh` (v tomto repe) beží cez

--- a/.claude/rules/deploy.md
+++ b/.claude/rules/deploy.md
@@ -6,6 +6,7 @@ paths:
   - ".dockerignore"
   - "apps/api/src/cli/**"
   - "scripts/*.ts"
+  - "scripts/*.sh"
 ---
 
 # Deployment (dev2)

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -184,7 +184,16 @@ services:
   cloudflared:
     image: cloudflare/cloudflared:latest
     restart: unless-stopped
-    command: tunnel --no-autoupdate run --token ${CF_TUNNEL_TOKEN:?chyba CF_TUNNEL_TOKEN}
+    # issue 357: cloudflared sa predvolene pripája protokolom QUIC (UDP 7844).
+    # Na sieti dev2 QUIC handshake prestal prechádzať ("failed to dial to edge
+    # with quic: timeout") na VŠETKÝCH štyroch spojeniach súčasne -> tunel
+    # nemal ani jedno živé spojenie -> Cloudflare Error 1033 / HTTP 530 na
+    # oboch verejných adresách (výpadok 12. 8. 2026 ráno). `--protocol http2`
+    # núti tunel ísť po TCP 443 namiesto UDP — bezpečná voľba bez ohľadu na
+    # to, či bol QUIC výpadok dočasný alebo trvalý. Bez tohto riadku by
+    # KAŽDÉ ďalšie nasadenie (deploy.yml kopíruje tento súbor na dev2)
+    # potichu vrátilo QUIC a výpadok sa zopakuje.
+    command: tunnel --no-autoupdate --protocol http2 run --token ${CF_TUNNEL_TOKEN:?chyba CF_TUNNEL_TOKEN}
     depends_on: [app]
     logging: *default-logging
 

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -3547,3 +3547,25 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   (žiadny jest-dom v komponentových testoch — `getAttribute` namiesto
   `toHaveAttribute`, + rozšírené `paths:` na `apps/web/src/**/*.test.tsx`).
 - Issue 345 zavretý s dôkazom (issuecomment-5258524496).
+
+## Issue 357 — Výpadok: Cloudflare tunel QUIC handshake timeout (Error 1033)
+
+- Commits: `c91b2aa` (version bump 0.3.0-dev.213), `6074931` (fix + monitor).
+- Root cause: `cloudflared` predvolene ide QUIC (UDP 7844); handshake na sieti
+  dev2 prestal prechádzať na všetkých 4 spojeniach naraz -> tunel bez živého
+  spojenia -> Cloudflare 1033. Appka aj DB boli celý čas OK.
+- Ranná ručná oprava (`--protocol http2` priamo na dev2) teraz aj v repe
+  (`docker-compose.prod.yml`) — `deploy.yml` inak prepíše server súbor pri
+  ďalšom nasadení a výpadok by sa vrátil.
+- Nový `scripts/uptime-check.sh` — vonkajší monitor oboch verejných adries,
+  systemd `--user` timer NA DEV1 (`forestshop-uptime-check.timer`, 5 min
+  cadence, nainštalovaný ručne mimo repa — rovnaký vzor ako
+  `parovanie-backup.timer`). Confirm-threshold 2, throttle 12 prechodov
+  (~1h), + recovery správa. Alert cez `airuleset.py notify --body ...
+  --owner-name marek`.
+- Naživo overené VŠETKY vetvy rozhodovacej logiky (below-threshold,
+  confirm+skutočný alert doručený — `notify-delivery.log` `sent`,
+  throttle-suppress, recovery) — pozri PR popis / issue komentár.
+- Playbook: `.claude/rules/deploy.md` (nová sekcia — Error 1033 diagnostika +
+  oprava + monitor).
+- Issue 357 zavretý s dôkazom po merge/nasadení.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.212",
+  "version": "0.3.0-dev.213",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/uptime-check.sh
+++ b/scripts/uptime-check.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# airuleset:script-ok watchdog must survive every per-pass failure and keep polling on the
+# next timer tick — same convention as camera-box/scripts/imag-obs-alert-watchdog.sh
+# (set -uo pipefail, not -e: a single curl failure must not kill the whole pass).
+#
+# scripts/uptime-check.sh — issue 357, external public-URL availability monitor.
+#
+# WHY: nič doteraz z VONKU nekontrolovalo, či `forestshop.newlevel.media` /
+# `forestshop-novy.newlevel.media` žijú — 12. 8. 2026 objavil výpadok (Cloudflare
+# Error 1033, pozri .claude/rules/deploy.md) majiteľ, nie automatika. Beží NA
+# DEV1, zámerne NIE na dev2 (kde bežia appka aj tunel) — monitor na tom istom
+# stroji, čo sleduje, by zomrel presne v momente výpadku, ktorý má hlásiť.
+# Rovnaká "measure -> decide -> alert" topológia ako
+# camera-box/scripts/imag-obs-alert-watchdog.sh a `api-watchdog.timer` (systemd
+# --user timer na dev1 s hotovým Discord kanálom).
+#
+# Perióda (systemd timer) 5 min. Potvrdenie po 2 zlyhaniach OKAMIHU za sebou
+# (~10 min súvislého výpadku) — jeden jednorazový blik (krátky sieťový hik) sa
+# nealertuje. Alert pre TÚ ISTÚ prebiehajúcu udalosť sa neopakuje častejšie než
+# raz za ALERT_THROTTLE_PASSES prechodov (predvolene 12 = ~1h pri 5min cadence)
+# — žiadny spam pre jeden trvajúci výpadok. Pri zotavení (URL, čo bolo predtým
+# potvrdene dole, teraz vráti 200) sa pošle JEDNA správa o zotavení a stav sa
+# vyčistí.
+#
+# Usage:
+#   scripts/uptime-check.sh            # one pass: measure -> decide -> alert
+#   scripts/uptime-check.sh --dry-run  # measure + decide + LOG only; never alert
+#   scripts/uptime-check.sh --help
+set -uo pipefail
+
+case "${1:-}" in
+  --dry-run) DRY_RUN=1 ;;
+  --help|-h)
+    sed -n '3,26p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    exit 0
+    ;;
+  "") DRY_RUN=0 ;;
+  *) echo "uptime-check: unknown arg '$1' (try --help)" >&2; exit 2 ;;
+esac
+
+# ── config (all env-overridable) ─────────────────────────────────────────────
+# Bez trailing lomky — curl aj štítky nižšie sa opierajú o presne tento tvar.
+URLS="${UPTIME_CHECK_URLS:-https://forestshop.newlevel.media https://forestshop-novy.newlevel.media}"
+CONFIRM_THRESHOLD="${UPTIME_CHECK_CONFIRM_THRESHOLD:-2}"
+ALERT_THROTTLE_PASSES="${UPTIME_CHECK_ALERT_THROTTLE_PASSES:-12}"   # ~1h at the 5-min cadence
+CURL_TIMEOUT="${UPTIME_CHECK_CURL_TIMEOUT:-10}"
+
+NOTIFY="${AIRULESET_NOTIFY:-$HOME/devel/airuleset/airuleset.py}"
+OWNER_NAME="${UPTIME_CHECK_OWNER:-marek}"
+REPO_SLUG="${UPTIME_CHECK_REPO:-zbynekdrlik/forestshop-app}"
+
+STATE_DIR="${UPTIME_CHECK_STATE_DIR:-${XDG_RUNTIME_DIR:-/tmp}}"
+STATE_FILE="${UPTIME_CHECK_STATE_FILE:-$STATE_DIR/forestshop-app-uptime-check.state}"
+
+log() { printf '%s [uptime-check] %s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$*" >&2; }
+
+# ── measure: HTTP status code for one URL (empty on curl-level failure, e.g.
+# DNS/timeout/refused — that IS a down signal here, unlike a remote SSH probe
+# whose failure could mean "can't reach the probe box", not "target is down":
+# a curl failure against a PUBLIC internet URL from dev1 has no such ambiguity) ─
+probe_one() {
+  curl -s -o /dev/null -w '%{http_code}' --max-time "$CURL_TIMEOUT" "$1" 2>/dev/null || true
+}
+
+# ── read / write persisted per-URL state ────────────────────────────────────
+# Key namespaced by a sanitized URL so both endpoints get independent
+# confirm/throttle tracking (one down, one up must not mask each other).
+sanitize_key() { printf '%s' "$1" | tr -c 'A-Za-z0-9' '_'; }
+
+read_state_field() {
+  local key="$1" default="$2"
+  [ -f "$STATE_FILE" ] || { printf '%s' "$default"; return 0; }
+  local v
+  v="$(sed -n "s/^${key}=//p" "$STATE_FILE" 2>/dev/null | tail -1)"
+  printf '%s' "${v:-$default}"
+}
+write_state_field() {
+  local key="$1" val="$2" tmp
+  mkdir -p "$(dirname "$STATE_FILE")" 2>/dev/null || true
+  tmp="$(mktemp "${STATE_FILE}.XXXXXX" 2>/dev/null || echo "$STATE_FILE")"
+  { [ -f "$STATE_FILE" ] && grep -v "^${key}=" "$STATE_FILE"; printf '%s=%s\n' "$key" "$val"; } \
+    > "$tmp" 2>/dev/null || true
+  mv -f "$tmp" "$STATE_FILE" 2>/dev/null || true
+}
+
+send_alert() {
+  local body="$1"
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "[dry-run] WOULD alert: $body"
+    return 0
+  fi
+  log "ALERT: firing Discord notification"
+  python3 "$NOTIFY" notify --body "$body" --owner-name "$OWNER_NAME" \
+    >/dev/null 2>&1 || log "ALERT: airuleset.py notify failed (non-fatal)"
+}
+
+# ── one URL: measure -> confirm -> throttle -> alert/recover ───────────────
+check_url() {
+  local url="$1" key code down prev_confirm confirm
+  key="$(sanitize_key "$url")"
+
+  code="$(probe_one "$url")"
+  down=0
+  [ "$code" = "200" ] || down=1
+  log "url=$url code='${code:-<none>}' down=$down"
+
+  prev_confirm="$(read_state_field "${key}_confirm" 0)"
+  if [ "$down" -eq 1 ]; then
+    confirm=$((prev_confirm + 1))
+  else
+    confirm=0
+  fi
+  write_state_field "${key}_confirm" "$confirm"
+  log "url=$url confirm=$prev_confirm -> $confirm (threshold=$CONFIRM_THRESHOLD)"
+
+  # Recovered (was previously CONFIRMED down, now healthy) -> one recovery
+  # message, then clear the alert dedup so a FUTURE fresh outage always alerts.
+  local was_alerted
+  was_alerted="$(read_state_field "${key}_alerted" 0)"
+  if [ "$down" -eq 0 ]; then
+    if [ "$was_alerted" = "1" ]; then
+      send_alert "✅ uptime-check ($REPO_SLUG): $url je opäť dostupná (HTTP $code)."
+    fi
+    write_state_field "${key}_alerted" 0
+    write_state_field "${key}_throttle_passes" 0
+    return 0
+  fi
+
+  if [ "$confirm" -lt "$CONFIRM_THRESHOLD" ]; then
+    log "url=$url not yet confirmed down (below threshold) — no alert this pass"
+    return 0
+  fi
+
+  # Confirmed down. Throttle repeat alerts for the SAME ongoing outage.
+  local prior_passes
+  if [ "$was_alerted" = "1" ]; then
+    prior_passes="$(read_state_field "${key}_throttle_passes" 0)"
+    prior_passes=$((prior_passes + 1))
+    if [ "$prior_passes" -lt "$ALERT_THROTTLE_PASSES" ]; then
+      write_state_field "${key}_throttle_passes" "$prior_passes"
+      log "url=$url already alerted, suppressed by throttle (pass ${prior_passes}/${ALERT_THROTTLE_PASSES})"
+      return 0
+    fi
+    log "url=$url still down after throttle window — re-alerting"
+  fi
+
+  write_state_field "${key}_alerted" 1
+  write_state_field "${key}_throttle_passes" 0
+  send_alert "🚨 uptime-check ($REPO_SLUG): $url NEODPOVEDÁ (HTTP ${code:-<žiadna odpoveď>}) už ${CONFIRM_THRESHOLD}+ prechodov za sebou."
+}
+
+main() {
+  log "pass start (dry_run=$DRY_RUN, threshold=$CONFIRM_THRESHOLD, throttle=$ALERT_THROTTLE_PASSES)"
+  for url in $URLS; do
+    check_url "$url"
+  done
+  log "pass end"
+}
+
+# Run only when EXECUTED (systemd/CLI). Sourcing (tests) only defines the functions above.
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main
+fi

--- a/scripts/uptime-check.sh
+++ b/scripts/uptime-check.sh
@@ -5,6 +5,7 @@
 #
 # scripts/uptime-check.sh — issue 357, external public-URL availability monitor.
 #
+# HELP-BEGIN
 # WHY: nič doteraz z VONKU nekontrolovalo, či `forestshop.newlevel.media` /
 # `forestshop-novy.newlevel.media` žijú — 12. 8. 2026 objavil výpadok (Cloudflare
 # Error 1033, pozri .claude/rules/deploy.md) majiteľ, nie automatika. Beží NA
@@ -26,12 +27,25 @@
 #   scripts/uptime-check.sh            # one pass: measure -> decide -> alert
 #   scripts/uptime-check.sh --dry-run  # measure + decide + LOG only; never alert
 #   scripts/uptime-check.sh --help
+# HELP-END
 set -uo pipefail
+
+# Prints everything between the HELP-BEGIN/HELP-END marker comments above,
+# stripped of the leading "# " — a marker range instead of hard-coded line
+# numbers, so editing the header comment can never silently desync --help
+# from its actual content (review finding, issue 357).
+print_help() {
+  awk '
+    /^# HELP-BEGIN/ { on=1; next }
+    /^# HELP-END/   { on=0 }
+    on              { sub(/^# ?/, ""); print }
+  ' "${BASH_SOURCE[0]}"
+}
 
 case "${1:-}" in
   --dry-run) DRY_RUN=1 ;;
   --help|-h)
-    sed -n '3,26p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    print_help
     exit 0
     ;;
   "") DRY_RUN=0 ;;
@@ -40,7 +54,10 @@ esac
 
 # ── config (all env-overridable) ─────────────────────────────────────────────
 # Bez trailing lomky — curl aj štítky nižšie sa opierajú o presne tento tvar.
-URLS="${UPTIME_CHECK_URLS:-https://forestshop.newlevel.media https://forestshop-novy.newlevel.media}"
+# Pole, nie reťazec + `for url in $URLS` — review finding, issue 357: neúvodzovkovaná
+# expanzia reťazca sa spolieha na delenie slov (funguje, ale je krehké); pole je
+# odolnejšie a jasnejšie vyjadruje zámer (viacero nezávislých URL).
+read -ra URLS <<< "${UPTIME_CHECK_URLS:-https://forestshop.newlevel.media https://forestshop-novy.newlevel.media}"
 CONFIRM_THRESHOLD="${UPTIME_CHECK_CONFIRM_THRESHOLD:-2}"
 ALERT_THROTTLE_PASSES="${UPTIME_CHECK_ALERT_THROTTLE_PASSES:-12}"   # ~1h at the 5-min cadence
 CURL_TIMEOUT="${UPTIME_CHECK_CURL_TIMEOUT:-10}"
@@ -151,7 +168,7 @@ check_url() {
 
 main() {
   log "pass start (dry_run=$DRY_RUN, threshold=$CONFIRM_THRESHOLD, throttle=$ALERT_THROTTLE_PASSES)"
-  for url in $URLS; do
+  for url in "${URLS[@]}"; do
     check_url "$url"
   done
   log "pass end"


### PR DESCRIPTION
## issue 357 — výpadok: cloudflared QUIC handshake timeout (Error 1033)

Ráno (12. 8. 2026) appka aj DB bežali celý čas v poriadku, ale Cloudflare
vracalo 1033 / HTTP 530 na oboch verejných adresách — `cloudflared` sa
predvolene pripája cez QUIC (UDP 7844), ktorý na sieti dev2 prestal
prechádzať (handshake timeout na všetkých 4 spojeniach naraz). Ranná ručná
oprava (`--protocol http2` priamo na dev2) opravila výpadok okamžite, ale
existovala LEN na serveri.

### Čo je v tomto PR

1. **Zosúladenie repa so serverom** — `docker-compose.prod.yml` má teraz ten
   istý `--protocol http2` prepínač. Bez tejto zmeny by ho najbližšie
   nasadenie (`deploy.yml` kopíruje tento súbor na dev2 pri KAŽDOM push do
   main) ticho zmazalo a výpadok by sa zopakoval.
2. **Vonkajšie sledovanie dostupnosti** — nový `scripts/uptime-check.sh`,
   spúšťaný cez systemd `--user` timer NA DEV1 (nainštalovaný, beží — pozri
   overenie nižšie), 5min perióda. Kontroluje obe verejné adresy, alertuje
   po 2 zlyhaniach za sebou (~10 min súvislého výpadku, nie jeden blik),
   neopakuje alert pre tú istú prebiehajúcu udalosť častejšie než raz za
   ~1h, a pošle jednu správu pri zotavení. Cez existujúci
   `airuleset.py notify` kanál — žiadny nový.
3. `.claude/rules/deploy.md` — príčina + oprava + monitor zdokumentované pre
   budúcu podobnú situáciu.

### Naživo overené (pred otvorením PR)

- `docker inspect forestshop-cloudflared-1` na dev2: bežiaci príkaz má
  `--protocol http2`; obe verejné adresy vracajú 200.
- `scripts/uptime-check.sh` — všetky vetvy rozhodovacej logiky spustené
  naozaj (nie len prečítané):
  - proti oboch reálnym produkčným URL — `down=0`, žiadny alert.
  - proti zámerne nedosiahnuteľnému cieľu (`http://127.0.0.1:1`): 1. prechod
    pod prahom (žiadny alert), 2. prechod potvrdí výpadok a POŠLE reálny
    Discord alert — overené `~/.claude/notify-delivery.log` (`sent`, presný
    časový odtlačok).
  - 3. prechod (stále dole): throttle potlačí opakovaný alert (`suppressed
    by throttle`).
  - simulované zotavenie (predtým alertovaný stav, teraz 200): pošle presne
    JEDNU správu o zotavení, stav sa vyčistí.
- Systemd timer nainštalovaný a beží na dev1
  (`~/.config/systemd/user/forestshop-uptime-check.timer`, enable+now,
  `linger=yes` prežije reboot) — prvý reálny beh cez timer už prebehol
  (`journalctl --user -u forestshop-uptime-check.service`).

### Poznámka k `[no-test: ...]`

Táto zmena je docker-compose konfiguračný prepínač (žiadna appka logika) +
nový ops watchdog shell skript. Tento repozitár nemá bash/shell testovací
rámec (bats a pod.) a žiadny z existujúcich ops skriptov
(`scripts/backup-db.sh`, `scripts/restore-drill.sh`) nemá automatizované
testy. Namiesto toho bola CELÁ rozhodovacia logika (confirm-threshold,
throttle, recovery) naživo spustená a overená reálnymi príkazmi — vrátane
skutočného doručenia Discord alertu — pozri sekciu vyššie.
