### PR TITLE
feat: move sidebar collapse toggle into header as icon-only button (issue 359)

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -1184,3 +1184,24 @@ paths:
   ONLY when the screen genuinely has no role distinction (server enforces
   ownership/permission some OTHER way); if any role check exists, take the
   full `SectionProps` like every other screen in `nav.ts`.
+- **`gap` on a `display:flex` parent is a MINIMUM spacing floor that
+  `justify-content: space-between` cannot shrink below — it adds on top of
+  the children's own widths even when the parent is nearly full.** Issue
+  359 (sidebar collapse toggle moved from a standalone full-width row
+  INTO `.brand`, as an icon sibling of the logo): `.sidebar-rail .brand` is
+  only 72px wide, and after its own padding the content box is 64px — the
+  logo (32px, fixed) + the new icon button (28px, fixed) sum to exactly
+  60px, which LOOKS like it fits with 4px to spare. It did not: `.brand`'s
+  inherited `gap: var(--fs-space-2)` (6px) is enforced as a MINIMUM gap
+  between the two flex items regardless of `justify-content`, pushing the
+  real required width to 66px — a ~2px overflow invisible by inspection,
+  caught only by an independent review dispatch and confirmed by a live
+  `element.scrollWidth > element.clientWidth` check (`.claude/rules/
+  frontend-design.md`'s own established measurement pattern, issues
+  105/107/111/127/161/214). Fix: `.sidebar-rail .brand { gap: 0; }` — the
+  remaining slack is distributed by `space-between` alone, no minimum gap
+  fighting it. **Any FUTURE flex row that mixes a real `gap` with
+  `justify-content: space-between`/`space-around` in a TIGHT (near-zero-slack)
+  container:** the true minimum width is `Σ(children widths) + gap ×
+  (children − 1)`, not just `Σ(children widths)` — measure or compute
+  that explicitly before trusting `space-between` to "make it fit".

--- a/apps/web/src/components/Sidebar.test.tsx
+++ b/apps/web/src/components/Sidebar.test.tsx
@@ -301,3 +301,29 @@ it("uložená voľba (užívateľ predtým panel ručne rozbalil) vyhráva aj na
 
   expect(screen.getByTestId("sidebar-rail-toggle").getAttribute("aria-expanded")).toBe("true");
 });
+
+// issue 359: šéf zrušil samostatný celoširoký obdĺžnik "« Zbaliť menu" pod
+// hlavičkou — prepínač je teraz VŽDY len ikona (bez viditeľného textu) žijúca
+// v hlavičke (`.brand`) vedľa loga/názvu appky, nikdy samostatný riadok pod
+// ňou. Funkcia (zbalenie/rozbalenie) ostáva bit-identická — overuje ju
+// existujúca sada vyššie; tento test overuje LEN tvar/polohu prepínača.
+it("prepínač zbalenia je vždy len ikona (bez viditeľného textu 'Zbaliť menu'), žijúca v hlavičke vedľa loga", () => {
+  const { container } = render(<Sidebar folders={FOLDERS} activeTabId="sync" onSelectTab={() => {}} />);
+
+  // Starý viditeľný text zmizol úplne — v žiadnom stave sa nevykresľuje.
+  expect(screen.queryByText("Zbaliť menu")).toBeNull();
+
+  const toggle = screen.getByTestId("sidebar-rail-toggle");
+  // Prepínač je DIEŤA `.brand` hlavičky (rovnaký kontajner ako logo/názov),
+  // nie samostatný súrodenec `<aside>`-u ako predtým issue 190.
+  expect(toggle.closest(".brand")).not.toBeNull();
+  expect(container.querySelector(".brand > .rail-toggle")).toBe(toggle);
+
+  // Prístupný názov aj bublina myšou ostávajú, aj keď viditeľný text nie je.
+  expect(toggle.getAttribute("aria-label")).toBe("Zbaliť bočné menu");
+  expect(toggle.getAttribute("title")).toBe("Zbaliť bočné menu");
+
+  fireEvent.click(toggle);
+  expect(screen.queryByText("Zbaliť menu")).toBeNull();
+  expect(toggle.getAttribute("aria-label")).toBe("Rozbaliť bočné menu");
+});

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -102,35 +102,40 @@ export function Sidebar({
   return (
     <aside className={"sidebar" + (rail ? " sidebar-rail" : "")}>
       <div className="brand">
-        <span className="logo" aria-hidden="true">
-          🌲
-        </span>
-        {!rail && (
-          <span className="brandtxt">
-            Forestshop
-            <small>Firemný systém</small>
+        <div className="brand-id">
+          <span className="logo" aria-hidden="true">
+            🌲
           </span>
-        )}
+          {!rail && (
+            <span className="brandtxt">
+              Forestshop
+              <small>Firemný systém</small>
+            </span>
+          )}
+        </div>
+        {/* issue 359: prepínač bol samostatný celoširoký obdĺžnik pod hlavičkou
+            (issue 190) — šéf ho výslovne zakázal a chce len ikonu so šípkami v
+            hlavičke, vpravo hore, vedľa názvu appky. Rovnaký `data-testid`/
+            `aria-label`/`aria-expanded`/`onClick`/`localStorage` správanie,
+            len iná poloha a vizuál (bez rámu/textu). Prístupný názov (`aria-
+            label`) aj bublina myšou (`title`) ostávajú VŽDY rovnaké, aj keď je
+            teraz vždy len ikona bez viditeľného textu. */}
+        <button
+          type="button"
+          className="rail-toggle"
+          data-testid="sidebar-rail-toggle"
+          aria-expanded={!rail}
+          aria-label={railToggleLabel}
+          title={railToggleLabel}
+          onClick={() => {
+            setRail((r) => !r);
+          }}
+        >
+          <span className="rail-toggle-icon" aria-hidden="true">
+            {rail ? "»" : "«"}
+          </span>
+        </button>
       </div>
-      {/* issue 190: prepínač má VŽDY rovnaký prístupný názov (`aria-label`),
-          aj keď je jeho text v zbalenom stave skrytý — inak by sa tlačidlo v
-          lište stalo bezmenným. `title` dáva ten istý text ako bublinu myšou. */}
-      <button
-        type="button"
-        className="rail-toggle"
-        data-testid="sidebar-rail-toggle"
-        aria-expanded={!rail}
-        aria-label={railToggleLabel}
-        title={railToggleLabel}
-        onClick={() => {
-          setRail((r) => !r);
-        }}
-      >
-        <span className="rail-toggle-icon" aria-hidden="true">
-          {rail ? "»" : "«"}
-        </span>
-        {!rail && <span className="rail-toggle-label">Zbaliť menu</span>}
-      </button>
       <nav className="side-nav">
         {folders.map((folder) => {
           // V zbalenej lište sa hlavičky priečinkov nevykresľujú vôbec (nemajú

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -82,9 +82,9 @@
      sú dnes tesné) — každý ĎALŠÍ token je centrálne zmenšený, takže sa to
      prejaví naprieč VŠETKÝMI obrazovkami/tabuľkami/formulármi naraz (tie
      používajú tokeny, nie vlastné px hodnoty — `.claude/rules/
-     frontend-design.md`). Klikacie plochy s VLASTNÝM pevným `min-width`/
-     `min-height` (36×36px "veľké tlačidlá", `.rail-toggle`'s 40px, …) tento
-     posun NEZMENŠUJE — tie rozmery nie sú odvodené z tejto škály. */
+     frontend-design.md`). Klikacie plochy s VLASTNÝM pevným `width`/`height`
+     (36×36px "veľké tlačidlá", `.rail-toggle`'s 28×28px, …) tento posun
+     NEZMENŠUJE — tie rozmery nie sú odvodené z tejto škály. */
   --fs-space-1: 0.25rem;
   --fs-space-2: 0.375rem;
   --fs-space-3: 0.5rem;
@@ -261,41 +261,49 @@ tr:last-child td {
   flex: 0 0 var(--fs-sidebar-rail-width);
 }
 .sidebar-rail .brand {
-  justify-content: center;
-  padding: var(--fs-space-4) 0 var(--fs-space-2);
+  padding: var(--fs-space-4) var(--fs-space-1) var(--fs-space-2);
 }
+/* issue 359: prepínač zbalenia žil predtým ako samostatný celoširoký
+   obdĺžnik s rámom + textom pod hlavičkou (issue 190) — šéf ho výslovne
+   zakázal ("ten obdlžnik prosím ťa zruš") a chce len ikonu so šípkami v
+   hlavičke, vpravo hore, vedľa loga/názvu appky ("tak ako je to u
+   všetkých programov"). Teraz je vždy len 28×28px ikona bez rámu/textu —
+   `.brand`'s `justify-content: space-between` ju posunie na pravý okraj. */
 .rail-toggle {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: var(--fs-space-2);
-  min-height: 40px;
-  margin: 0 var(--fs-space-3) var(--fs-space-2);
-  border: 1px solid var(--fs-border);
+  width: 28px;
+  height: 28px;
+  flex: 0 0 28px;
+  padding: 0;
+  border: 0;
   border-radius: var(--fs-radius-sm);
   background: none;
   cursor: pointer;
   color: var(--fs-ink-muted);
-  font-size: var(--fs-text-sm);
-  font-weight: var(--fs-weight-medium);
 }
 .rail-toggle:hover {
   background: var(--fs-surface-alt);
-  border-color: var(--fs-ink-faint);
+  color: var(--fs-ink);
 }
 .rail-toggle-icon {
   font-size: var(--fs-text-md);
   line-height: 1;
 }
-.sidebar-rail .rail-toggle {
-  margin: 0 var(--fs-space-2) var(--fs-space-2);
-}
 
 .brand {
   display: flex;
   align-items: center;
-  gap: var(--fs-space-3);
+  justify-content: space-between;
+  gap: var(--fs-space-2);
   padding: var(--fs-space-5) var(--fs-space-4) var(--fs-space-4);
+}
+.brand-id {
+  display: flex;
+  align-items: center;
+  gap: var(--fs-space-3);
+  min-width: 0;
 }
 .brand .logo {
   width: 32px;

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -262,6 +262,12 @@ tr:last-child td {
 }
 .sidebar-rail .brand {
   padding: var(--fs-space-4) var(--fs-space-1) var(--fs-space-2);
+  /* Rail je len 72px široká — logo (32px) + ikona (28px) = 60px, čo sa do
+     zvyšných 64px (72 − 2×4px odsadenie) zmestí len s NULOVOU medzerou.
+     Bez tohto prepísania by zdedená `.brand`'s `gap: var(--fs-space-2)`
+     (6px, vynucovaná ako minimum aj pri `justify-content: space-between`)
+     vyžadovala 66px a o ~2px pretiekla. */
+  gap: 0;
 }
 /* issue 359: prepínač zbalenia žil predtým ako samostatný celoširoký
    obdĺžnik s rámom + textom pod hlavičkou (issue 190) — šéf ho výslovne

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -3569,3 +3569,30 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
 - Playbook: `.claude/rules/deploy.md` (nová sekcia — Error 1033 diagnostika +
   oprava + monitor).
 - Issue 357 zavretý s dôkazom po merge/nasadení.
+
+## issue 359 — Zrušiť obdĺžnik „Zbaliť menu“, presunúť na šípky vpravo hore v hlavičke menu
+
+- `a15c17b` chore: bump verzie na 0.3.0-dev.215 (0.3.0-dev.214 obsadené
+  neschváleným issue 358 + stash-om).
+- `ab2327f` feat: prepínač zbalenia presunutý zo samostatného celoširokého
+  obdĺžnika pod hlavičkou dovnútra `.brand`, ako 28×28px ikona bez rámu/
+  textu vpravo hore vedľa loga/názvu appky (`.brand`'s `justify-content:
+  space-between`); logo+text zabalené do nového `.brand-id`. Funkcia
+  (localStorage, `aria-expanded`, klik, auto-zbalenie na úzkej obrazovke)
+  bit-identická — overené existujúcou sadou bezo zmeny.
+  RED->GREEN regresný test: `Sidebar.test.tsx` "prepínač zbalenia je vždy
+  len ikona (bez viditeľného textu 'Zbaliť menu'), žijúca v hlavičke vedľa
+  loga" — padal proti pôvodnému kódu (span s textom "Zbaliť menu" nájdený),
+  prešiel proti `ab2327f`.
+- `0596e4d` review: nezávislý review dispatch našiel 1 zistenie (rail móde
+  72px `.brand` by pretiekol o ~2px kvôli zdedenému `gap` fungujúcemu ako
+  minimum aj pod `space-between`) — opravené `gap: 0` v rail móde, naživo
+  premerané (`scrollWidth === clientWidth`).
+- `9cfc204` docs: playbook zápis (`.claude/rules/frontend-design.md`) — gap
+  ako minimálna medzera pod `space-between`.
+- Pull request do vetvy dev (branch issue-359-collapse-icon), CI zelené
+  (5/5 SUCCESS), mergeable, mergeStateStatus CLEAN.
+- ZAMERNE NEZLUCENE, NENASADENE, tiket ostava otvoreny — nasadenie je
+  zmrazene kvoli issue 366 (produkcia presunuta z dev2 neautorizovanym
+  agentom, CI deploy job stale mieri na dev2). Merge/nasadenie/zavretie
+  tiketu caka na rozhodnutie majitela o issue 366.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.213",
+  "version": "0.3.0-dev.215",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Čo a prečo

issue 359 — šéf v Discorde zakázal samostatný celoširoký obdĺžnik "« Zbaliť
menu" pod hlavičkou bočného menu ("ten obdlžnik prosím ťa zruš") a chcel tú
istú funkciu (zbalenie panela do úzkej lišty, issue 190) presunutú do
hlavičky ako ikonu so šípkami, vpravo hore, vedľa loga/názvu appky — presne
tak, ako to majú väčšina programov. Uvoľnené miesto po odstránenom bloku
automaticky pripadlo priečinku "Dôležité" (issue 342), keďže ide o čisto
DOM-ové odstránenie predchádzajúceho súrodenca.

Design + validity + review komentáre na tickete (v poradí, ako vznikli):
https://github.com/zbynekdrlik/forestshop-app/issues/359#issuecomment-5267005459
https://github.com/zbynekdrlik/forestshop-app/issues/359#issuecomment-5267014035
https://github.com/zbynekdrlik/forestshop-app/issues/359#issuecomment-5267590514

## Rozsah

Zmenené súbory: `apps/web/src/components/Sidebar.tsx`,
`apps/web/src/components/Sidebar.test.tsx`, `apps/web/src/styles/app.css`,
`package.json` (verzia). Nič iné sa nemení — žiadne prefarbovanie,
prerozdeľovanie ani úpravy iných obrazoviek, presne podľa výslovného
zákazu svojvoľných zmien vzhľadu na tickete.

## Overenie

- `pnpm gates:local` (typecheck + lint + unit) čisté, vrátane nového
  regresného testu (RED proti pôvodnému kódu, GREEN proti novému).
- Existujúca `nav.spec.ts`/`mobile-responsive.spec.ts` e2e sada prešla
  bezo zmeny (spustená lokálne, keďže tiket priamo zasahuje obrazovku
  bočného menu) — funkcia zbalenia/rozbalenia je bit-identická.
- Naživo (Playwright proti lokálnemu dev serveru) pri 1600px aj 375px:
  obdĺžnik preč, ikona funguje klikom aj klávesnicou v oboch smeroch,
  `aria-expanded` sa mení správne, klávesový fokus funguje, 0 konzolových
  chýb, žiadne pretečenie zbalenej 72px lišty (`scrollWidth === clientWidth`).

## Nasadenie zámerne NEPREBEHLO

Nasadenie je momentálne zmrazené z dôvodu nesúvisiaceho s týmto tiketom —
produkcia bola presunutá z dev2 na iný box neautorizovaným agentom a
CI deploy job stále mieri na dev2, takže merge do `main` by nasadil appku
tam, kde ju nikto nevidí (sledované ako issue 366, čaká na rozhodnutie
majiteľa). Tento PR preto zámerne NIE JE mergnutý — čaká sa na zelené CI
a na rozhodnutie o nasadení.

issue 359
