### PR TITLE
fix: point deploy at forestshop-dev VPS instead of dev2 (issue 366)

### DIFF
--- a/.claude/rules/backups.md
+++ b/.claude/rules/backups.md
@@ -1,6 +1,7 @@
 ---
 paths:
   - "scripts/backup-db.sh"
+  - "scripts/backup-db-local.sh"
   - "scripts/restore-drill.sh"
 ---
 
@@ -44,3 +45,20 @@ paths:
   kontajner toho istého mena.
 - Žiadne heslo/passphrase/token sa v repe (ani v tomto rule súbore) nevypisuje
   ako hodnota — len cesty k súborom a názvy premenných.
+- **`scripts/backup-db-local.sh` (pridané do repa pri issue 366) je LOKÁLNA
+  varianta pre `forestshop-dev` (178.105.89.168).** `backup-db.sh` po
+  zálohovaní sám AKTÍVNE PUSHUJE dump + zašifrovaný `.env` na dev1 cez
+  `BACKUP_HOST=newlevel@100.104.8.125` (Tailscale) — `forestshop-dev` nemá
+  do dev1 žiadnu sieťovú cestu (žiadny tailscale klient), takže ten istý
+  push by tam vždy zlyhal timeoutom PRED zašifrovaním `.env`/mazaním podľa
+  retencie. `backup-db-local.sh` preto robí LEN lokálnu časť (dump, over
+  `pg_restore --list`, zašifruj `.env`, zmaž staršie ako 14 dní) — súbory si
+  odtiaľ STIAHNE dev1 vlastným pull cronom (`~/backups/
+  pull-forestshop-dev-backup.sh`, mimo tohto repa). Cron na `forestshop-dev`:
+  `15 2 * * *` (`backup-db.sh` na dev2 beží v rovnakom čase, teraz už len
+  ako záložná kópia záložnej kópie — dev2's postgres tam ostáva bežať ako
+  rollback dáta, appka tam nebeží). **Prečo je tento súbor teraz v repe:**
+  `deploy.yml`'s deploy krok robí `rsync -a --delete` z repového `scripts/`
+  do `/srv/forestshop/scripts/` na cieľovom stroji — súbor, ktorý existuje
+  len na serveri a nie v repe, by prvým ďalším nasadením na `forestshop-dev`
+  tichým zmazaním prišiel o nočné zálohovanie.

--- a/.claude/rules/deploy.md
+++ b/.claude/rules/deploy.md
@@ -9,7 +9,7 @@ paths:
   - "scripts/*.sh"
 ---
 
-# Deployment (dev2)
+# Deployment (forestshop-dev — presunuté z dev2, issue 366)
 
 - **Cloudflare Error 1033 / HTTP 530 na oboch verejných adresách = tunel bez
   živého spojenia, NIE appka (issue 357, výpadok 12. 8. 2026 ráno).**
@@ -41,9 +41,10 @@ paths:
 - **Vonkajšie sledovanie dostupnosti (issue 357):** appka predtým nemala nič,
   čo by z VONKU kontrolovalo, či verejná adresa žije — výpadok objavil
   majiteľ, nie automatika. `scripts/uptime-check.sh` (v tomto repe) beží cez
-  systemd `--user` timer **na dev1** (zámerne NIE na dev2 — monitor na tom
-  istom stroji, čo sleduje, by zomrel spolu s tým, čo má hlásiť; rovnaký
-  vzor ako `api-watchdog.timer`/`imag-obs-alert-watchdog.timer`), kontroluje
+  systemd `--user` timer **na dev1** (zámerne NIE na tom istom stroji, čo
+  beží appka — monitor na tom istom stroji, čo sleduje, by zomrel spolu s
+  tým, čo má hlásiť; rovnaký vzor ako
+  `api-watchdog.timer`/`imag-obs-alert-watchdog.timer`), kontroluje
   obe verejné adresy (`forestshop.newlevel.media`,
   `forestshop-novy.newlevel.media`) každých 5 minút, alertuje až po 2
   zlyhaniach za sebou (~10 min súvislého výpadku, nie jeden blik) cez
@@ -91,7 +92,7 @@ paths:
   (rob ju pri KAŽDOM pridaní premennej do `env.ts`, ešte pred hľadaním chyby v
   kóde):
   ```bash
-  ssh newlevel@dev2 'docker exec forestshop-app-1 sh -c "env | grep -E \"<PREMENNA>\""'
+  ssh admin@forestshop-dev.newlevel.media 'docker exec forestshop-app-1 sh -c "env | grep -E \"<PREMENNA>\""'
   ```
   Prázdny výstup = chýbajúci riadok v compose, nie chyba v appke.
   **Zopakovalo sa presne to isté (issue 292, PR 324/9.8.2026):**
@@ -123,18 +124,31 @@ paths:
   bare kľúč — to premennú v kontajneri NASTAVÍ na `""`, čo `z.string().url()`
   v `env.ts` odmietne a appku pri štarte zhodí, hoci samotná premenná je
   deklarovaná ako nepovinná.
-- **Kam sa nasadzuje:** `/srv/forestshop` na dev2 (vlastník `newlevel`).
+- **Kam sa nasadzuje (od 12. 8. 2026 — presunuté z dev2, issue 366):**
+  `/srv/forestshop` na vyhradenom Hetzner VPS **`forestshop-dev`**
+  (`forestshop-dev.newlevel.media`, `178.105.89.168`, nbg1; 2 CPU / 4 GB RAM
+  / 38 GB disk), vlastník `admin` (predtým `newlevel` — ten účet na tomto
+  stroji už neexistuje). Druhý, od appky nezávislý Linux účet `stepan` má na
+  tom istom stroji vlastný izolovaný klon repa — obidva účty môžu bežať
+  vlastné Claude relácie bez vzájomného rušenia. SSH: `ssh
+  admin@forestshop-dev.newlevel.media` (alebo priamo IP).
   Obsahuje `.env` (mode 600 — `POSTGRES_PASSWORD`, `CF_TUNNEL_TOKEN`),
   `docker-compose.prod.yml` (kopírovaný z repa pri každom deploy) a
   `scripts/` (synchronizovaný `rsync -a --delete` z repa pri každom deploy —
   predtým tam ležala ručne položená kópia, ktorá by sa tichým opomenutím
-  rozišla od gitu naveky; teraz je vynútené, že dev2 má vždy presne to, čo je
-  v repe).
-- **Self-hosted runner:** `dev2-forestshop`, labels
-  `self-hosted,Linux,X64,dev2`, beží ako systemd služba
-  `actions.runner.zbynekdrlik-forestshop-app.dev2-forestshop.service`
-  (enabled, prežije reboot). `deploy` job cieli `runs-on: [self-hosted,
-  dev2]`.
+  rozišla od gitu naveky; teraz je vynútené, že server má vždy presne to, čo
+  je v repe).
+  **Na dev2 ostáva `forestshop-postgres-1` bežať ďalej ako záložná kópia dát**
+  (majiteľove rozhodnutie, ticket 366) — appka a cloudflared tam boli pri
+  presune odstránené, dev2 sa už NIKDY nemá stať cieľom nasadenia znova.
+- **Self-hosted runner:** `forestshop-dev-runner`, label `forestshop-dev`,
+  beží ako systemd služba `actions.runner.zbynekdrlik-forestshop-app.
+  forestshop-dev-runner.service` na `forestshop-dev` (enabled, prežije
+  reboot). `deploy` job cieli `runs-on: [self-hosted, forestshop-dev]`.
+  **Starý `dev2-forestshop` runner (label `dev2`) ostáva zaregistrovaný, ale
+  nečinný** — žiadny workflow naň už necieli; ponechaný ako rollback cesta.
+  Zoznam runnerov repa: `gh api repos/zbynekdrlik/forestshop-app/actions/
+  runners`.
 - **Tag obrazu tečie z build jobu do deploy jobu cez `needs.build.outputs`,
   NIE cez `:latest`.** `build` job nastaví `outputs.version` (verzia z
   `package.json`), `deploy` job ho číta do `env.IMAGE_TAG` a použije ho pri
@@ -153,51 +167,32 @@ paths:
   (`**/node_modules`, `**/dist`, `**/*.tsbuildinfo`, `**/playwright-report`,
   `**/test-results`) — Docker ignore semantika bez `**/` matchuje len bare
   názvy v koreni kontextu, nie v podadresároch typu `apps/api/dist`.
-- **Verejný hostname `forestshop.newlevel.media` je zdieľaný problém, nie
-  technický detail.** V čase F0 ho živo obsluhoval iný projekt
-  (`parovanie_produktov`, rozhodnutie z 2026-07-22, issue #120 v tamojšom
-  repe) — presmerovanie DNS na nový systém by ho ticho odpojilo. Cloudflare
-  tunnel pre tento projekt (`forestshop-app`, samostatný od súrodenca) je
-  pripravený a pripojený.
-  **Rozhodnuté majiteľom 2026-07-29: hlavné meno prevezme tento systém až vo
-  fáze F6**, keď sa stará appka vypína — dovtedy sa `forestshop.newlevel.media`
-  nechá starému projektu (issue #5 je teraz úloha pre F6, nie otvorená otázka).
-
-- **Dočasný verejný hostname (do fázy F6, issue #5):
-  `forestshop-novy.newlevel.media`.** Beží na samostatnom tunneli
-  `forestshop-app` (id `e0cdc5bf-fbc8-45de-b1f7-f4c0b2a9b0dc`), ingress
-  `forestshop-novy.newlevel.media` → `http://app:3000` (popri pôvodnom
-  `forestshop.newlevel.media` ingress pravidle na tom istom tuneli — obe
-  smerujú na tú istú appku, líšia sa len menom). CNAME záznam vytvorený v
-  zóne `newlevel.media` (`b9019ca...`), `proxied: true`.
-  - **Prečo nie `novy.forestshop.newlevel.media` (pôvodne zamýšľaný tvar)?**
-    Cloudflare Universal SSL certifikát tejto zóny pokrýva len
-    `newlevel.media` + `*.newlevel.media` (jedna úroveň wildcard) — overené
-    `openssl s_client` + SAN výpisom certifikátu. Hostname o dve úrovne pod
-    apexom preto pri TLS handshake padá (`sslv3 alert handshake failure`).
-    Riešenie by vyžadovalo Cloudflare Total TLS / Advanced Certificate Manager
-    (samostatné oprávnenie `SSL and Certificates:Edit` na API tokene — token
-    použitý v F0 má len Tunnel Write + DNS Write + Zone Read + Account
-    Settings Read a na `/acm/total_tls` aj `/ssl/certificate_packs` vracia
-    autorizačnú chybu). Namiesto rozširovania oprávnení tokenu pre dočasný
-    hostname bol zvolený tvar o jednu úroveň nižšie (`forestshop-novy.` priamo
-    pod `newlevel.media`), ktorý sedí do existujúceho wildcard certifikátu bez
-    ďalších zásahov.
-  - **Prepnutie na finálny hostname po rozhodnutí issue #5:**
-    1. Zmeniť `LIVE_HOSTNAME` v `.github/workflows/deploy.yml` (jeden riadok).
-    2. Ak finálny hostname má byť opäť `forestshop.newlevel.media` (t.j. tento
-       projekt preberie meno): zmazať/presmerovať pôvodný záznam u súrodenca
-       (mimo tohto repa) a v CNAME zázname tejto appky prepísať `name` na
-       `forestshop.newlevel.media` (alebo pridať nový záznam a zmazať dočasný
-       `forestshop-novy`).
-    3. Ak finálny hostname zostáva iný ale je jednoúrovňový pod
-       `newlevel.media` → žiadny certifikátový problém, len DNS CNAME + ingress
-       hostname update cez Cloudflare API (rovnaký postup ako vyššie).
-    4. Ak sa má použiť viacúrovňový tvar ako pôvodne zamýšľaný
-       `novy.forestshop.newlevel.media` → najprv treba na Cloudflare API tokene
-       doplniť oprávnenie `SSL and Certificates:Edit` a zapnúť Total TLS
-       (`PATCH /zones/{zone}/acm/total_tls`) alebo objednať Advanced
-       Certificate, inak TLS handshake opäť zlyhá.
+- **Verejný hostname `forestshop.newlevel.media` odteraz patrí tejto appke —
+  VYRIEŠENÉ, issue #5, uzavreté 3. 8. 2026 (znovu overené 12. 8. 2026 pri
+  issue 366, nezávisle od presunu na `forestshop-dev`).** V čase F0 ho živo
+  obsluhoval súrodenský projekt `parovanie_produktov`; majiteľ 3. 8. 2026
+  výslovne schválil prepnutie ("chcem prejst na novu, staru vypinam"), starú
+  appku vypol sám a prepnutie bolo naživo overené (login screen, verzia v
+  pätičke). Nezávislé overenie z 12. 8. 2026: Cloudflare tunnel `forestshop-app`
+  (`e0cdc5bf-...`) má ingress pre `forestshop.newlevel.media` → `http://app:3000`
+  už od 29. 7. 2026; DNS CNAME v zóne `newlevel.media` naň ukazuje od 3. 8. 2026
+  (Cloudflare-ov vlastný `modified_on` + komentár na zázname "prepnute na novu
+  appku (issue 5)"); `curl https://forestshop.newlevel.media/api/version` aj
+  `curl https://forestshop-novy.newlevel.media/api/version` vracajú v tej istej
+  chvíli identickú verziu — obe mená obsluhuje TÁTO appka.
+- **`forestshop-novy.newlevel.media` zostáva funkčná záložná adresa** na tom
+  istom tuneli/kontajneri — netreba ju mazať, `deploy.yml` overuje verziu
+  proti `LIVE_HOSTNAME` (`forestshop.newlevel.media`), ale obe URL vždy
+  smerujú na rovnaký bežiaci `app` kontajner.
+  - **Prečo nie `novy.forestshop.newlevel.media` (pôvodne zamýšľaný tvar pre
+    `forestshop-novy`)?** Cloudflare Universal SSL certifikát zóny pokrýva
+    len `newlevel.media` + `*.newlevel.media` (jedna úroveň wildcard) —
+    overené `openssl s_client` + SAN výpisom certifikátu; hostname o dve
+    úrovne pod apexom pri TLS handshake padá (`sslv3 alert handshake
+    failure`). Preto bol zvolený jednoúrovňový tvar `forestshop-novy.` priamo
+    pod `newlevel.media`. Relevantné len ak v budúcnosti pribudne ďalší
+    viacúrovňový hostname — vyžadovalo by to na API tokene navyše oprávnenie
+    `SSL and Certificates:Edit` + zapnutý Total TLS.
 
 - **Docker inicializuje ČERSTVÝ named volume kopírovaním obsahu (aj
   vlastníctva) z toho, čo v obraze UŽ existuje na tej istej ceste v momente
@@ -225,7 +220,7 @@ paths:
 - **Retencia surových súborov (`.claude/rules/catalog.md`'s `pruneRawSnapshots`) beží
   PRIAMO v produkčnom obraze — nie cez `scripts/`.** `scripts/catalog-ingest.ts` a
   `scripts/catalog-prune-raw.ts` (spúšťané cez `pnpm catalog:*`, `tsx`) potrebujú
-  celý monorepo `node_modules` — na dev2 sú `scripts/` len ako `rsync`-nutá kópia
+  celý monorepo `node_modules` — na serveri sú `scripts/` len ako `rsync`-nutá kópia
   BEZ `node_modules` (final-wave-b, položka 2: prvý reálny produkčný import zapísal
   surový súbor a nemal ho čo niekedy zmazať, zväzok `catalog-raw` by rástol
   donekonečna). Kanonická implementácia preto žije v `apps/api/src/cli/
@@ -236,7 +231,7 @@ paths:
   `apps/api/dist`) — žiadna zmena Dockerfile nebola potrebná. Príkaz na produkcii:
 
   ```bash
-  ssh newlevel@dev2 'cd /srv/forestshop && docker compose -f docker-compose.prod.yml exec app node apps/api/dist/cli/catalog-prune-raw.js'
+  ssh admin@forestshop-dev.newlevel.media 'cd /srv/forestshop && docker compose -f docker-compose.prod.yml exec app node apps/api/dist/cli/catalog-prune-raw.js'
   ```
 
   Vypíše jednu ľudskú vetu aj JSON riadok (`{"removed": N}`) — bezpečné spustiť
@@ -247,7 +242,7 @@ paths:
   procese appky), takže `scripts/catalog-ingest.ts` zostáva len pohodlný LOKÁLNY/CI
   vstupný bod, nie produkčná nutnosť.
 
-- **`deploy` job (self-hosted dev2) môže raz za čas zlyhať na `failed to
+- **`deploy` job (self-hosted runner) môže raz za čas zlyhať na `failed to
   extract layer ... link ... no such file or directory` počas `docker
   compose pull app`** (pozorované 2026-07-29, PR #16 — žiadna zmena
   závislostí v tom PR, čiže nešlo o obsah image, ale o lokálny
@@ -258,11 +253,11 @@ paths:
   (`/root/.local/share/pnpm/store/v10/...`) do TEJ ISTEJ vrstvy ako
   `node_modules` — ak sa pri sťahovaní/extrakcii na dev2 poškodí/vynechá
   jeden blob v containerd content-store, hardlink naň zlyhá.
-  **Diagnostika (bez zásahu do bežiacich kontajnerov iných projektov na
-  zdieľanom dev2):**
+  **Diagnostika (bez zásahu do bežiacich kontajnerov iných účtov na tom
+  istom serveri):**
   ```bash
-  ssh newlevel@dev2 "sudo ctr --address /run/containerd/containerd.sock -n moby snapshots ls | grep <snapshot-id z chybovej hlášky>"
-  ssh newlevel@dev2 "sudo ctr --address /run/containerd/containerd.sock -n moby content ls | grep <chýbajúci sha256 prefix z chybovej hlášky>"
+  ssh admin@forestshop-dev.newlevel.media "sudo ctr --address /run/containerd/containerd.sock -n moby snapshots ls | grep <snapshot-id z chybovej hlášky>"
+  ssh admin@forestshop-dev.newlevel.media "sudo ctr --address /run/containerd/containerd.sock -n moby content ls | grep <chýbajúci sha256 prefix z chybovej hlášky>"
   ```
   (`ctr` bez `--address`/`-n moby` sa pripája na iný — prázdny — namespace a
   nič neukáže; docker's vlastný containerd socket je `/run/containerd/
@@ -273,13 +268,15 @@ paths:
   bežných "unused images"). V tomto prípade stačí `gh run rerun <run-id>
   --failed` — čerstvý pull znova stiahne vrstvu od nuly. Ak sa to isté zopakuje
   DRUHÝKRÁT za sebou, už to nie je transientný jav — over `docker system df`
-  (miesto na disku) a zváž reštart `containerd`/`docker` služby na dev2.
-  **Ďalší pozorovaný spúšťač TEJ ISTEJ triedy (issue 169, 2026-08-01): SÚBEŽNÝ
-  CI job na tom istom self-hosted dev2 runneri, ktorý si sám ťahá/spúšťa
-  Docker image (integration/e2e job's efemérne `postgres` service kontajnery)
-  presne v okamihu, keď `deploy` job extrahuje appkin image.** Potvrdené
-  koreláciou časových pečiatok — `ssh newlevel@dev2 "journalctl -u docker
-  --since '10 min ago'"` ukázal `image pulled ... postgres:16` tesne PRED aj
+  (miesto na disku) a zváž reštart `containerd`/`docker` služby na serveri.
+  **Ďalší pozorovaný spúšťač TEJ ISTEJ triedy (issue 169, 2026-08-01, vtedy
+  na dev2): SÚBEŽNÝ CI job na tom istom self-hosted runneri, ktorý si sám
+  ťahá/spúšťa Docker image (integration/e2e job's efemérne `postgres`
+  service kontajnery) presne v okamihu, keď `deploy` job extrahuje appkin
+  image.** Potvrdené koreláciou časových pečiatok — `ssh
+  admin@forestshop-dev.newlevel.media "journalctl -u docker --since '10 min
+  ago'"` (vtedy `ssh newlevel@dev2 ...`) ukázal `image pulled ...
+  postgres:16` tesne PRED aj
   PO zlyhanom `deploy`'s `failed to Lchown ...` v tej istej sekunde, a
   `gh run list --json databaseId,name,event,createdAt` potvrdil, že `CI`
   (push na `main`) a `Deploy` (push na `main`) z toho istého merge commitu
@@ -345,7 +342,7 @@ paths:
   `docker compose -f docker-compose.prod.yml exec` cieli na kontajner
   bežiaci PRIAMO Postgres, appka sama nemá `psql` nainštalované:
   ```
-  ssh newlevel@dev2
+  ssh admin@forestshop-dev.newlevel.media
   cd /srv/forestshop
   docker compose -f docker-compose.prod.yml exec -T postgres \
     psql -U forestshop -d forestshop -t -c \
@@ -381,7 +378,7 @@ paths:
   zatvorenie klientskeho spojenia (žiadny `req.on("close")`/abort-signal na
   tejto ceste), takže Cloudflare-ov 524 NIE JE zlyhanie behu — je to len
   strata KLIENTSKEJ odpovede. Overenie, či beh naozaj pokračuje/dobehol, ide
-  MIMO tunela, priamo cez SSH na dev2 (`.claude/rules/database.md`'s
+  MIMO tunela, priamo cez SSH na server (`.claude/rules/database.md`'s
   `postgres` service dopyt) — `pg_locks` filtrovaný na konkrétny advisory
   kľúč (`SELECT count(*) FROM pg_locks WHERE locktype='advisory' AND
   ((classid::bigint << 32) | objid::bigint) = <kľúč>;`, `1` = stále beží,

--- a/.claude/rules/deploy.md
+++ b/.claude/rules/deploy.md
@@ -142,13 +142,14 @@ paths:
   (majiteľove rozhodnutie, ticket 366) — appka a cloudflared tam boli pri
   presune odstránené, dev2 sa už NIKDY nemá stať cieľom nasadenia znova.
 - **Self-hosted runner:** `forestshop-dev-runner`, label `forestshop-dev`,
-  beží ako systemd služba `actions.runner.zbynekdrlik-forestshop-app.
-  forestshop-dev-runner.service` na `forestshop-dev` (enabled, prežije
-  reboot). `deploy` job cieli `runs-on: [self-hosted, forestshop-dev]`.
+  beží ako systemd služba
+  `actions.runner.zbynekdrlik-forestshop-app.forestshop-dev-runner.service`
+  na `forestshop-dev` (enabled, prežije reboot). `deploy` job cieli
+  `runs-on: [self-hosted, forestshop-dev]`.
   **Starý `dev2-forestshop` runner (label `dev2`) ostáva zaregistrovaný, ale
   nečinný** — žiadny workflow naň už necieli; ponechaný ako rollback cesta.
-  Zoznam runnerov repa: `gh api repos/zbynekdrlik/forestshop-app/actions/
-  runners`.
+  Zoznam runnerov repa:
+  `gh api repos/zbynekdrlik/forestshop-app/actions/runners`.
 - **Tag obrazu tečie z build jobu do deploy jobu cez `needs.build.outputs`,
   NIE cez `:latest`.** `build` job nastaví `outputs.version` (verzia z
   `package.json`), `deploy` job ho číta do `env.IMAGE_TAG` a použije ho pri

--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -1170,3 +1170,17 @@ paths:
   inset `box-shadow`, not `border`,** given how many prior tickets in this
   playbook (105/107/111/127/163/204/214/291/303/327) already fought pixel
   alignment/row-height regressions the hard way.
+- **A registered `NAV`/`HIDDEN_TABS` screen that does NOT need role-based
+  gating can declare its own props type NARROWER than the shared
+  `SectionProps` (`{role, onSessionExpired}`) — TypeScript still accepts
+  it as `ComponentType<SectionProps>` because `App.tsx` passes a real
+  `SectionProps` OBJECT VARIABLE (`<ActiveComponent role={me.role}
+  onSessionExpired={reload} />`), and excess-property checking only
+  fires on object LITERALS, never on a wider-typed value flowing into a
+  narrower parameter.** Issue 342's `DailyTasksSection` takes only
+  `{onSessionExpired}` (its data is scoped by `user_id` server-side, so no
+  `CONTROL_ROLES`-style role check exists anywhere in the component) — no
+  cast, no `as SectionProps`, `pnpm typecheck` passes clean. Reach for this
+  ONLY when the screen genuinely has no role distinction (server enforces
+  ownership/permission some OTHER way); if any role check exists, take the
+  full `SectionProps` like every other screen in `nav.ts`.

--- a/.claude/rules/sensitive-values.md
+++ b/.claude/rules/sensitive-values.md
@@ -18,7 +18,8 @@ pred zverejnením repa odhalil audit).
   overovaní na živom systéme, použi zástupný text `<heslo — mimo repozitára>`
   namiesto skutočnej hodnoty.
 - Skutočné hodnoty žijú len:
-  - v `/srv/forestshop/.env` (mode 600) na dev2, alebo
+  - v `/srv/forestshop/.env` (mode 600) na `forestshop-dev`
+    (`forestshop-dev.newlevel.media` — presunuté z dev2, issue 366), alebo
   - v lokálnej pamäti relácie (Claude memory), nikdy commitované.
 - Pred pushom vždy skontroluj diff (`git diff --cached` / `git show`) na
   prítomnosť akejkoľvek reálnej citlivej hodnoty — najmä keď si práve

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -621,3 +621,35 @@ paths:
   (`toHaveAttribute`/`toBeVisible`/`toBeInTheDocument`) — over existujúci
   sesterský test (napr. `NedostupneSection.test.tsx`) pred písaním nového,
   nikdy nepredpokladaj, že jest-dom je nainštalovaný.
+- **Playwright's `.filter({ hasText })` re-vyhodnocuje sa PRI KAŽDOM ĎALŠOM
+  použití locatora — ak akcia PREPÍŠE riadok tak, že jeho pôvodný text už
+  NIE JE textovým uzlom (napr. inline-edit prepne `<span>text</span>` na
+  `<input value="text">`), ten istý `hasText` filter prestane nachádzať
+  ČOKOĽVEK a ďalší krok (`.locator("input")` na ňom) timeoutne bez chyby o
+  tom, PREČO.** Issue 342 (`daily-tasks.spec.ts`): `<input>`'s `value`
+  atribút sa NEPOČÍTA do textového obsahu, na rozdiel od `<span>`. Fix pre
+  KROKY vnútri takto prepísaného stavu: nájsť vstup/tlačidlo GLOBÁLNE cez
+  jeho PEVNÝ (nie per-riadok interpolovaný) `aria-label`/CSS triedu, bezpečné
+  len keď appka dovolí najviac JEDEN riadok v tomto stave naraz (over to v
+  komponente pred spoliehaním sa naň). Pred/po tomto prepnutí (keď text
+  OSTÁVA viditeľný ako `<span>`) `hasText` funguje ďalej bez problémov —
+  past sa týka LEN krokov PROBIEHAJÚCICH počas prepnutia.
+- **`withCleanDb()`'s advisory zámok (`TEST_DB_ISOLATION_LOCK_KEY`) sa môže
+  natrvalo ZASEKNÚŤ, keď ho držiaci klient nikdy nezavolá `close()`
+  (zomrelý/killnutý proces, nie len preťažený box) — výsledný symptóm je
+  RASTÚCA fronta `pg_advisory_lock` čakateľov (jeden pribudne pri KAŽDOM
+  ĎALŠOM súbore vitestu, ~30s odstup = `testTimeout`), nie len pomalý beh.**
+  Issue 342: plný `test:integration` beh (predtým spustený a KILLNUTÝ inak,
+  nie `Ctrl+C`/graceful) nechal PRVÉHO držiteľa zámku v stave `idle`
+  (`pg_stat_activity`), takže KAŽDÝ ĎALŠÍ súbor v novom behu čakal navždy.
+  Diagnostika: `docker exec <postgres-kontajner> psql -U forestshop -d
+  forestshop -c "select pid, state, wait_event_type, query_start, left
+  (query,60) from pg_stat_activity where datname='forestshop' order by
+  query_start;"` — prvý riadok v stave `idle` s dávno starým `query_start`
+  DRŽÍ zámok, zvyšok ČAKÁ naň. Fix: `pg_terminate_backend(<ten prvý pid>)`
+  (bezpečné na LOKÁLNEJ dev DB, nikdy na produkcii), potom `ps aux | grep
+  vitest` + `kill -9` na osirelé OS procesy, potom nový beh. Príznak, čo to
+  odlišuje od bežného "preťažený box" (vyššie v tomto súbore): ten sa
+  prejaví POMALOSŤOU/timeoutmi na NÁHODNÝCH testoch, toto sa prejaví
+  ÚPLNÝM zamrznutím KAŽDÉHO ĎALŠIEHO integračného súboru bez jediného
+  riadku výstupu, kým sa nezabije držiaci proces.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,7 +85,7 @@ jobs:
           docker compose -f docker-compose.prod.yml pull app
           docker compose -f docker-compose.prod.yml up -d
       - name: Upratať staršie obrazy TEJTO appky
-        # issue 206: dev2 je zdieľaný stroj a bol na 100 % disku — jeden náš
+        # issue 206: dev2 (vtedajší cieľ nasadenia) bol zdieľaný stroj a bol na 100 % disku — jeden náš
         # obraz má ~1,4 GB, takže každé nasadenie doteraz nechalo po sebe
         # ďalší. Maže sa VÝHRADNE `ghcr.io/<repo>` (naše vlastné obrazy) a
         # nikdy ten práve nasadený — cudzie projekty na tom istom stroji sa

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,17 +6,22 @@ on:
 
 # Two quick merges to main can otherwise run two deploy jobs concurrently, and a
 # `docker compose pull` + `up -d` from the OLDER run finishing last would overwrite
-# the newer image on dev2. Never cancel a deploy mid-flight (cancel-in-progress:
-# false) — queue instead, so every push still gets fully deployed, in order.
+# the newer image on the target server. Never cancel a deploy mid-flight
+# (cancel-in-progress: false) — queue instead, so every push still gets fully
+# deployed, in order.
 concurrency:
   group: deploy
   cancel-in-progress: false
 
 env:
-  # Temporary public hostname while forestshop.newlevel.media still serves the
-  # older sibling project (parovanie_produktov) — decision pending issue #5.
-  # Switching to the final hostname later is a one-line change here.
-  LIVE_HOSTNAME: forestshop-novy.newlevel.media
+  # issue #5 (closed 2026-08-03): parovanie_produktov, the older sibling
+  # project that used to serve this hostname, was retired by its owner and
+  # forestshop.newlevel.media now belongs to this app — verified live
+  # (Cloudflare tunnel ingress + DNS CNAME both point here). See issue 366
+  # for the re-verification done when the deploy target moved off dev2.
+  # forestshop-novy.newlevel.media still resolves to the same app on the
+  # same tunnel and is kept working as a fallback address.
+  LIVE_HOSTNAME: forestshop.newlevel.media
 
 jobs:
   build:
@@ -56,7 +61,13 @@ jobs:
 
   deploy:
     needs: build
-    runs-on: [self-hosted, dev2]
+    # issue 366 (2026-08-12): production moved off dev2 onto a dedicated
+    # Hetzner VPS (`forestshop-dev`, forestshop-dev.newlevel.media). Runner
+    # `forestshop-dev-runner` is registered there (label `forestshop-dev`),
+    # enabled as a systemd service so it survives a reboot. dev2's old
+    # runner (`dev2-forestshop`, label `dev2`) is left registered but idle
+    # as a rollback path — no workflow targets it anymore.
+    runs-on: [self-hosted, forestshop-dev]
     env:
       # Pin pull + up to the version THIS run just built — never the mutable
       # `:latest` tag, which a second, faster deploy could repoint mid-flight.
@@ -67,7 +78,7 @@ jobs:
         working-directory: /srv/forestshop
         run: |
           cp "$GITHUB_WORKSPACE/docker-compose.prod.yml" .
-          # scripts/ (zálohovanie, obnovovací drill) musí byť na dev2 vždy presne to,
+          # scripts/ (zálohovanie, obnovovací drill) musí byť na serveri vždy presne to,
           # čo je v repozitári — inak sa tichým opomenutím rozíde od gitu naveky.
           mkdir -p scripts
           rsync -a --delete "$GITHUB_WORKSPACE/scripts/" scripts/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,10 @@ other's session.
 Repo: `zbynekdrlik/forestshop-app` (public). Two-branch flow — `main`
 (production) + `dev` (work). Fáza F0 (základ) je hotová: pnpm workspace
 `apps/api` (Hono + Drizzle + PostgreSQL) a `apps/web` (React + Vite),
-nasadenie na dev2 cez GHCR a Cloudflare tunel.
+nasadenie cez GHCR a Cloudflare tunel. **Od 12. 8. 2026 nasadzuje CI na
+vyhradený Hetzner VPS `forestshop-dev` (`forestshop-dev.newlevel.media`),
+NIE na dev2** — pozri `.claude/rules/deploy.md`'s "Kam sa nasadzuje" pre
+plné detaily (issue 366).
 
 **`gh issue view <N>` (bez `--json`) na tomto repe padá** (`GraphQL: Projects
 (classic) is being deprecated…`) — použi `gh issue view <N> --json
@@ -82,7 +85,7 @@ Per-area rules live in `.claude/rules/<area>.md` with `paths:` frontmatter.
 - database / Docker (Postgres 18 PGDATA, migrations) → `.claude/rules/database.md`
 - tests (unit vs integration split, e2e setup) → `.claude/rules/testing.md`
 - CI gotchas (pnpm action, Vite host binding) → `.claude/rules/ci.md`
-- deployment on dev2 → `.claude/rules/deploy.md`
+- deployment (forestshop-dev VPS, since 12.8.2026) → `.claude/rules/deploy.md`
 - backups / restore → `.claude/rules/backups.md`
 - katalóg zo Shoptetu (import, snapshoty, dostupnosť) → `.claude/rules/catalog.md`
 - plánovač úloh (F2 — nočné joby, job_run, advisory zámok) → `.claude/rules/scheduler.md`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.213",
+  "version": "0.3.0-dev.216",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/backup-db-local.sh
+++ b/scripts/backup-db-local.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Nočná záloha na forestshop-dev (178.105.89.168) — LOKÁLNA varianta
+# scripts/backup-db.sh z repozitára zbynekdrlik/forestshop-app.
+#
+# Prečo existuje samostatne: pôvodný scripts/backup-db.sh (dev2) po dumpe a
+# šifrovaní .env sám AKTÍVNE PUSHUJE oba súbory na dev1 cez
+# BACKUP_HOST=newlevel@100.104.8.125 (Tailscale IP). Táto škatuľka
+# (forestshop-dev) nemá do dev1 žiadnu sieťovú cestu — nemá nainštalovaný
+# tailscale klient a dev1 nemá verejnú adresu — takže ten istý push by tu
+# vždy zlyhal (timeout) a skript by skončil na `exit 1` PRED tým, než by
+# vôbec zašifroval .env alebo zmazal staré zálohy podľa retencie.
+#
+# Riešenie: smer sa obrátil. Táto škatuľka robí LEN lokálnu časť (dump,
+# over pg_restore --list, zašifruj .env, zmaž staršie ako 14 dní) a súbory
+# si odtiaľto STIAHNE dev1 vlastným pull cronom
+# (~/backups/pull-forestshop-dev-backup.sh, beží 02:25 — 10 min po tomto
+# skripte). Heslo v /srv/forestshop/.backup-passphrase sem bolo nakopírované
+# RUČNE, jednorazovo, z existujúcej kópie na dev1 (rovnaké heslo ako pri
+# dev2 — SHA-256 overené) — tento skript ho preto len POUŽÍVA, nikdy
+# negeneruje ani nepushuje (na rozdiel od dev2 varianty).
+
+STAMP=$(date +%Y%m%dT%H%M%S)
+DIR=/srv/forestshop/backups
+COMPOSE="docker compose -f /srv/forestshop/docker-compose.prod.yml"
+mkdir -p "$DIR"
+
+ENV_SRC=/srv/forestshop/.env
+PASS_FILE=/srv/forestshop/.backup-passphrase
+
+if [ -f "$ENV_SRC" ]; then
+  command -v gpg > /dev/null 2>&1 || {
+    echo "chyba: 'gpg' nie je nainštalované — zálohovanie $ENV_SRC by zlyhalo" >&2
+    exit 1
+  }
+  [ -s "$PASS_FILE" ] || {
+    echo "chyba: $PASS_FILE chýba alebo je prázdny — bez neho sa .env nedá zašifrovať (a dev1 pull by ho nemal ako rozšifrovať)" >&2
+    exit 1
+  }
+fi
+
+DUMP="$DIR/forestshop-$STAMP.dump"
+$COMPOSE exec -T postgres pg_dump -U forestshop -Fc forestshop > "$DUMP"
+
+# Over, že dump je čitateľný PRED zašifrovaním .env aj pred mazaním starých
+# záloh — poškodený/prázdny dump zastaví skript hneď, nikdy sa neoznačí za
+# platnú zálohu ani kvôli nemu nezmažú ešte platné staršie zálohy.
+if ! $COMPOSE exec -T postgres pg_restore --list < "$DUMP" > /dev/null; then
+  echo "záloha zlyhala — dump $DUMP nie je čitateľný pg_restore --list" >&2
+  exit 1
+fi
+
+if [ -f "$ENV_SRC" ]; then
+  gpg --batch --yes --symmetric --cipher-algo AES256 --passphrase-file "$PASS_FILE" \
+    --output "$DIR/forestshop-$STAMP.env.gpg" "$ENV_SRC"
+else
+  echo "upozornenie: $ENV_SRC neexistuje, zálohuje sa iba databáza" >&2
+fi
+
+find "$DIR" -name 'forestshop-*.dump' -mtime +14 -delete
+find "$DIR" -name 'forestshop-*.env.gpg' -mtime +14 -delete
+echo "záloha hotová: forestshop-$STAMP.dump"


### PR DESCRIPTION
## Čo a prečo

Produkcia sa 12. 8. 2026 presunula z dev2 na nový Hetzner VPS `forestshop-dev`
(neschválený agent, mimo bežného PR procesu). Deploy pipeline ale stále
mierila na dev2 (`runs-on: [self-hosted, dev2]`, overovací `LIVE_HOSTNAME`
na dočasnú adresu z F0) — ďalší merge do `main` by nasadil do prázdna.

Majiteľ rozhodol (issue 366, komentár): appka aj vývoj natrvalo ostávajú na
`forestshop-dev.newlevel.media`, späť na dev2 sa nič nevracia.

## Zmeny

- `.github/workflows/deploy.yml`: `runs-on` → `[self-hosted, forestshop-dev]`
  (runner tam už bol zaregistrovaný a beží, overené naživo); `LIVE_HOSTNAME`
  → `forestshop.newlevel.media` (issue #5 bolo nezávisle znovu overené ako
  skutočne vyriešené už 3. 8. 2026, dávno pred dnešným presunom — pozri
  komentáre na issue 366).
- `.claude/rules/deploy.md`: prepísaná sekcia "Kam sa nasadzuje" len s
  overenými faktami, opravená zastaraná F0-éra hostname sekcia, prepnuté
  operačné SSH príkazy (kontrola env premenných, catalog prune, read-only
  DB dopyt, containerd diagnostika) na nový stroj.
- `CLAUDE.md` + `.claude/rules/sensitive-values.md`: opravené zvyšné
  zmienky o dev2 ako aktuálnom nasadzovacom cieli / mieste tajomstiev.
- `package.json`: verzia → `0.3.0-dev.216`.

Dva stashe ponechané neschváleným agentom (`agent-migracia`,
`agent-migracia 2`) boli prehliadnuté riadok po riadku a zahodené — všetko
vyššie je nezávisle odvodené a overené, nie prevzaté naslepo. Vedľajší nález
(osirelý dev postgres kontajner + zvyškové dump súbory na novom stroji)
založený samostatne ako issue 369.

## Overenie

- `pnpm gates:local` (typecheck + lint + test) zelené lokálne.
- Cloudflare tunnel ingress + DNS CNAME pre `forestshop.newlevel.media`
  nezávisle overené cez API — patrí tejto appke od 3. 8. 2026.
- Po merge: CI na `main` sleduje sa do terminálneho stavu, deploy job beží
  na novom runneri, `/api/version` na živej adrese overený proti tejto
  verzii.

issue 366
