### PR TITLE
docs: zálohovanie a playbook po presune na forestshop-dev (issues 367, 372, 371)

### DIFF
--- a/.claude/rules/backups.md
+++ b/.claude/rules/backups.md
@@ -36,12 +36,21 @@ Smer je preto obrátený:
   `/srv/forestshop/backups/forestshop-<STAMP>.dump` + `.env.gpg`.
 - **dev1 si súbory STIAHNE vlastným pull cronom** —
   `~/backups/pull-forestshop-dev-backup.sh` (žije len na dev1, mimo tohto
-  repa), cron `30 4 * * *` **Bratislava-local** (zámerne o vyše 2h neskôr
-  než `forestshop-dev`'s 02:15 UTC beh — udržiava kladný odstup medzi
-  zdrojovým behom a pull-om naprieč CEST aj CET, keďže obe škatuľky bežia v
-  rôznych časových pásmach). Cieľ na dev1: **`~/backups/forestshop-dev/`**
-  — samostatný adresár, ODDELENE od dev2's `~/backups/forestshop/`
-  (nižšie), aby sa dve nezávislé zálohovacie histórie nikdy nepomiešali.
+  repa). **Presný čas má DVA nezhodné zdroje, ani jeden overiteľný z tohto
+  stroja:** `backup-db-local.sh`'s vlastný hlavičkový komentár (už v repe,
+  napísaný pri issue 366 — pravdepodobne s priamym prístupom na dev1 v tom
+  čase) hovorí "beží 02:25 — 10 min po tomto skripte" (teda ~02:25 UTC, len
+  10 min odstup od zdrojového behu); issue 367's zadanie namiesto toho
+  tvrdí cron `30 4 * * *` **Bratislava-local**, čo v CEST vychádza na
+  ~02:30 UTC (15 min odstup) a v CET na ~03:30 UTC (1h15 odstup) — v OBOCH
+  prípadoch výrazne menej než "kladný odstup naprieč oboma pásmami" by
+  malo znamenať, a navyše nesedí s "10 min po tomto skripte". Túto
+  nezhodu NERIEŠIM sám (vyžaduje priamy pohľad na dev1's skutočný
+  crontab, `forestshop-dev` k dev1 nemá sieťovú cestu) — over `crontab -l`
+  priamo na dev1 pri najbližšej príležitosti a zapíš sem skutočný riadok.
+  Cieľ na dev1: **`~/backups/forestshop-dev/`** — samostatný adresár,
+  ODDELENE od dev2's `~/backups/forestshop/` (nižšie), aby sa dve
+  nezávislé zálohovacie histórie nikdy nepomiešali.
 - **Prístup je READ-ONLY a scopovaný na jeden adresár.** Dedikovaný SSH
   kľúč `~/.ssh/forestshop_dev_backup_pull` na dev1, na strane
   `forestshop-dev` reštrikovaný v `authorized_keys` cez

--- a/.claude/rules/backups.md
+++ b/.claude/rules/backups.md
@@ -7,24 +7,91 @@ paths:
 
 # Backups
 
+**Primárne zálohovanie živých dát je odteraz na `forestshop-dev`** (issue
+366/367, 12. 8. 2026) — appka aj Postgres so živými dátami tam odvtedy
+bežia. **dev2 ostáva bežať ďalej, ale už len ako STATICKÁ rollback kópia**
+(appka a cloudflared tam boli pri presune odstránené, `forestshop-postgres-1`
+tam beží ďalej podľa výslovného rozhodnutia majiteľa a jeho dáta sa už
+nemenia) — mechanizmus nižšie v sekcii "dev2" je nezmenený a stále beží
+presne tak, ako je zdokumentovaný, len prestal byť zdrojom aktuálnych dát.
+
+## Primárne zálohovanie — forestshop-dev (živé dáta)
+
+**Smer je PULL, nie PUSH** — `forestshop-dev` (178.105.89.168) nemá žiadnu
+sieťovú cestu k dev1 (žiadny tailscale klient, dev1 nemá verejnú adresu), a
+teda dev2's PUSH prístup (pozri "dev2" nižšie) by tu vždy zlyhal timeoutom.
+Smer je preto obrátený:
+
+- **`/srv/forestshop/scripts/backup-db-local.sh`** (pridané do repa pri
+  issue 366 — inak by ho `deploy.yml`'s `rsync -a --delete` z repového
+  `scripts/` pri najbližšom nasadení potichu zmazal, keďže by existoval len
+  na serveri) beží cez cron `15 2 * * *`, **box-lokálny čas = UTC**
+  (`forestshop-dev`'s systémový čas je `Etc/UTC`, overené priamo
+  `timedatectl`). Robí LEN lokálnu časť: `pg_dump -Fc` databázy → over
+  `pg_restore --list` PRED čímkoľvek ďalším (poškodený/prázdny dump zastaví
+  skript hneď, `exit 1`, nikdy sa neoznačí za platný) → zašifruje `.env`
+  (`gpg --symmetric`, heslo v `/srv/forestshop/.backup-passphrase`, mode
+  600 — nakopírované jednorazovo RUČNE z existujúcej kópie na dev1, rovnaké
+  heslo ako dev2, SHA-256 overené) → zmaže staršie ako 14 dní. Výstup:
+  `/srv/forestshop/backups/forestshop-<STAMP>.dump` + `.env.gpg`.
+- **dev1 si súbory STIAHNE vlastným pull cronom** —
+  `~/backups/pull-forestshop-dev-backup.sh` (žije len na dev1, mimo tohto
+  repa), cron `30 4 * * *` **Bratislava-local** (zámerne o vyše 2h neskôr
+  než `forestshop-dev`'s 02:15 UTC beh — udržiava kladný odstup medzi
+  zdrojovým behom a pull-om naprieč CEST aj CET, keďže obe škatuľky bežia v
+  rôznych časových pásmach). Cieľ na dev1: **`~/backups/forestshop-dev/`**
+  — samostatný adresár, ODDELENE od dev2's `~/backups/forestshop/`
+  (nižšie), aby sa dve nezávislé zálohovacie histórie nikdy nepomiešali.
+- **Prístup je READ-ONLY a scopovaný na jeden adresár.** Dedikovaný SSH
+  kľúč `~/.ssh/forestshop_dev_backup_pull` na dev1, na strane
+  `forestshop-dev` reštrikovaný v `authorized_keys` cez
+  `command="/usr/bin/rrsync -ro /srv/forestshop/backups/",restrict` — žiadny
+  shell, žiadny zápis, žiadny prístup mimo `backups/`. Živo overené priamo
+  na `forestshop-dev`: presne tento riadok je v `~/.ssh/authorized_keys`.
+- **Retencia:** 14 dní na zdroji (`forestshop-dev` — rovnaká politika ako
+  dev2, pozri `backup-db-local.sh`'s `find ... -mtime +14 -delete`), na
+  dev1 sa nemaže (rovnaká politika ako dev2's archív nižšie).
+- **Obnova na úplne novom stroji** postupuje rovnakými krokmi ako dev2's
+  postup nižšie (nájdi posledný STAMP → stiahni dump + `.env.gpg` +
+  heslo → rozšifruj → over `pg_restore --list` → obnov cez
+  `restore-drill.sh`/priamym `pg_restore` → nasaď `.env` → `docker compose
+  up -d`) — jediný rozdiel je zdrojový adresár na dev1
+  (`~/backups/forestshop-dev/` namiesto `~/backups/forestshop/`). Presný
+  skriptovaný postup (scp príkazy, ssh cieľ) je zdokumentovaný len pre
+  dev2's `backup-db.sh` (hlavičkový komentár, pozri nižšie) — pre
+  `forestshop-dev` treba scp/ssh príkazy z toho istého postupu prepísať na
+  `~/backups/forestshop-dev/` ako zdrojový adresár.
+
+**Čo bolo overené naživo a čo nie:** Táto relácia beží priamo na
+`forestshop-dev`, takže box's vlastná strana (crontab, obsah skriptu,
+`authorized_keys`, reálne súbory v `/srv/forestshop/backups/` — napr.
+`forestshop-20260812T130301.dump` + `.env.gpg` z behu 12. 8. 2026) je overená
+priamym čítaním, nie len z textu tiketu. **dev1-strana** (pull skript, jeho
+vlastný crontab, obsah `~/backups/forestshop-dev/`) **nebola overená naživo
+z tohto stroja** — `forestshop-dev` nemá k dev1 žiadnu sieťovú cestu (`ssh
+dev1`/`ssh 100.104.8.125` obe zlyhali, presne z dôvodu popísaného vyššie) —
+tá časť je zdokumentovaná z pôvodného zadania issue 367.
+
+## dev2 (statická rollback kópia)
+
 - **Nočný beh (`scripts/backup-db.sh`, cron na dev2, `15 2 * * *`) robí DVE
   veci:** `pg_dump -Fc` databázy a šifrovanú kópiu `/srv/forestshop/.env`
   (obsahuje `POSTGRES_PASSWORD` + `CF_TUNNEL_TOKEN` — bez nich by obnovený
-  dump bol na nič, nová inštancia by sa nevedela pripojiť ani spustiť tunel).
-  Šifrovanie: `age -R <recipients>` ak je nastavený
-  `/srv/forestshop/.backup-age-recipients` (operátor drží súkromný kľúč MIMO
-  dev2), inak `gpg --symmetric` s heslom v
+  dump bol na nič, nová inštancia by sa nevedela pripojiť ani spustiť
+  tunel). Šifrovanie: `age -R <recipients>` ak je nastavený
+  `/srv/forestshop/.backup-age-recipients` (operátor drží súkromný kľúč
+  MIMO dev2), inak `gpg --symmetric` s heslom v
   `/srv/forestshop/.backup-passphrase` (mode 600, auto-generované pri prvom
   behu). K 2026-07-29 dev2 nemá `age` nastavené — beží gpg vetva.
-- **Dump aj šifrovaný `.env` (a pri gpg-vetve aj samotné heslo) sa kopírujú na
-  dev1** (`newlevel@100.104.8.125` — Tailscale IP, NIE bare hostname `dev1`;
-  MagicDNS je tenantovo zapnuté, ale `tailscale0` na dev2 nemá nastavený
-  žiadny DNS scope, takže bare meno sa odtiaľ nedá vyriešiť). Cieľ na dev1:
-  `~/backups/forestshop/`.
+- **Dump aj šifrovaný `.env` (a pri gpg-vetve aj samotné heslo) sa kopírujú
+  na dev1** (`newlevel@100.104.8.125` — Tailscale IP, NIE bare hostname
+  `dev1`; MagicDNS je tenantovo zapnuté, ale `tailscale0` na dev2 nemá
+  nastavený žiadny DNS scope, takže bare meno sa odtiaľ nedá vyriešiť).
+  Cieľ na dev1: `~/backups/forestshop/`.
 - **Dump sa validuje `pg_restore --list` PRED kopírovaním na dev1 a PRED
-  mazaním starých záloh** (`find ... -mtime +14 -delete`, 14 dní retencia) —
-  poškodený/prázdny dump zastaví skript hneď (`exit 1`), nikdy sa nekopíruje
-  ani sa kvôli nemu nezmažú ešte platné staršie zálohy.
+  mazaním starých záloh** (`find ... -mtime +14 -delete`, 14 dní retencia)
+  — poškodený/prázdny dump zastaví skript hneď (`exit 1`), nikdy sa
+  nekopíruje ani sa kvôli nemu nezmažú ešte platné staršie zálohy.
 - **Heslo na dešifrovanie sa pri KAŽDOM behu (nielen pri prvom) overí, že
   existuje a je neprázdne na dev1** (`ssh ... test -s`), a ak sa kópia nedá
   spraviť/overiť, skript zlyhá nahlas namiesto tichého vytvorenia zálohy,
@@ -45,20 +112,3 @@ paths:
   kontajner toho istého mena.
 - Žiadne heslo/passphrase/token sa v repe (ani v tomto rule súbore) nevypisuje
   ako hodnota — len cesty k súborom a názvy premenných.
-- **`scripts/backup-db-local.sh` (pridané do repa pri issue 366) je LOKÁLNA
-  varianta pre `forestshop-dev` (178.105.89.168).** `backup-db.sh` po
-  zálohovaní sám AKTÍVNE PUSHUJE dump + zašifrovaný `.env` na dev1 cez
-  `BACKUP_HOST=newlevel@100.104.8.125` (Tailscale) — `forestshop-dev` nemá
-  do dev1 žiadnu sieťovú cestu (žiadny tailscale klient), takže ten istý
-  push by tam vždy zlyhal timeoutom PRED zašifrovaním `.env`/mazaním podľa
-  retencie. `backup-db-local.sh` preto robí LEN lokálnu časť (dump, over
-  `pg_restore --list`, zašifruj `.env`, zmaž staršie ako 14 dní) — súbory si
-  odtiaľ STIAHNE dev1 vlastným pull cronom (`~/backups/
-  pull-forestshop-dev-backup.sh`, mimo tohto repa). Cron na `forestshop-dev`:
-  `15 2 * * *` (`backup-db.sh` na dev2 beží v rovnakom čase, teraz už len
-  ako záložná kópia záložnej kópie — dev2's postgres tam ostáva bežať ako
-  rollback dáta, appka tam nebeží). **Prečo je tento súbor teraz v repe:**
-  `deploy.yml`'s deploy krok robí `rsync -a --delete` z repového `scripts/`
-  do `/srv/forestshop/scripts/` na cieľovom stroji — súbor, ktorý existuje
-  len na serveri a nie v repe, by prvým ďalším nasadením na `forestshop-dev`
-  tichým zmazaním prišiel o nočné zálohovanie.

--- a/.claude/rules/catalog.md
+++ b/.claude/rules/catalog.md
@@ -147,8 +147,10 @@ paths:
   transakciou) zostali navždy bez záznamu, čo by naň ukazoval (review task-5-fix-1).
 - **Variant, ktorý zmizne z exportu, sa NEMAŽE** — nastaví sa `missing_since`. Keď sa
   vráti, `missing_since` sa vynuluje v tom istom UPSERTe.
-- **Surové bajty nie sú v Postgrese.** Ležia gzipnuté v `CATALOG_RAW_DIR` (na dev2
-  docker zväzok `catalog-raw`), v databáze je len `raw_path` + `content_sha256`.
+- **Surové bajty nie sú v Postgrese.** Ležia gzipnuté v `CATALOG_RAW_DIR` (od
+  presunu appky — issue 366 — na `forestshop-dev` docker zväzok `catalog-raw`,
+  živo overené `docker volume ls`/`docker inspect` 12. 8. 2026, issue 371:
+  `forestshop_catalog-raw`), v databáze je len `raw_path` + `content_sha256`.
   `pg_dump` ich teda NEZAHŔŇA — a nemusí, odvodený katalóg je celý v databáze.
   Retencia (`pnpm catalog:prune-raw`): prijaté staršie než 14 dní (skrátené z 30
   v issue 184 súčasne s prechodom importu na hodinovú kadenciu — viac
@@ -184,8 +186,11 @@ paths:
   `scripts/catalog-ingest.ts` zostáva len pohodlný LOKÁLNY/CI vstupný bod.
 - **`SHOPTET_EXPORT_URL` je tajomstvo** (prihlasovací `hash` je v query parametri). Do
   databázy ani do logov nesmie ísť celá — vždy cez `redactUrl`. V repe nikdy nie je.
-  Na dev2 zatiaľ nie je nastavené (issue #8) — appka bez neho beží ďalej (premenná je
-  v `env.ts` `.optional()`), len ručný import vráti 503.
+  Pôvodne na dev2 nebolo nastavené (issue #8) — appka bez neho beží ďalej (premenná je
+  v `env.ts` `.optional()`), len ručný import vráti 503. **Na `forestshop-dev` JE
+  nastavené** (živo overené priamo v bežiacom kontajneri 12. 8. 2026, issue 371 —
+  premenná je prítomná, hodnota sa neoveruje/nevypisuje, per
+  `.claude/rules/sensitive-values.md`).
 - **`redactUrl` (`fetcher.ts`) prekrýva ALLOWLISTOM, nie denylistom** (review
   final-wave-a, položka 2) — prekryje HODNOTU KAŽDÉHO query parametra okrem
   malého zoznamu známych neškodných (`patternId`, `partnerId`); pôvodne to

--- a/.claude/rules/deploy.md
+++ b/.claude/rules/deploy.md
@@ -131,7 +131,12 @@ paths:
   stroji už neexistuje). Druhý, od appky nezávislý Linux účet `stepan` má na
   tom istom stroji vlastný izolovaný klon repa — obidva účty môžu bežať
   vlastné Claude relácie bez vzájomného rušenia. SSH: `ssh
-  admin@forestshop-dev.newlevel.media` (alebo priamo IP).
+  admin@forestshop-dev.newlevel.media` (alebo priamo IP). **Playbook
+  príkazy s týmto `ssh` prefixom sú písané pre reláciu bežiacu na dev1** —
+  Claude relácia, ktorá už beží PRIAMO na `forestshop-dev` (napr. `stepan`'s
+  vlastný klon, alebo self-hosted runner), rovnaké príkazy spúšťa lokálne,
+  bez `ssh` prefixu (over `hostname` pri pochybnosti, ktorý prípad práve
+  platí — issue 371, 12. 8. 2026).
   Obsahuje `.env` (mode 600 — `POSTGRES_PASSWORD`, `CF_TUNNEL_TOKEN`),
   `docker-compose.prod.yml` (kopírovaný z repa pri každom deploy) a
   `scripts/` (synchronizovaný `rsync -a --delete` z repa pri každom deploy —

--- a/.claude/rules/orders.md
+++ b/.claude/rules/orders.md
@@ -136,10 +136,13 @@ paths:
   druhom kliku na "Odoslať". Pri manuálnom/Playwright overovaní na živom
   systéme na to netreba zabudnúť (#38, 2026-07-30) — jeden klik ešte nič
   neodošle.
-- **`MAIL_HOST/PORT/USER/PASS/FROM` na dev2 sú od #38 (2026-07-30) reálne
-  nastavené** — appka odosiela cez ROVNAKÚ SMTP schránku ako stará appka
-  (`parovanie_produktov`, majiteľovo rozhodnutie), hodnoty prevzaté z jej
-  gitignorovaného `data/.mail_env`. Overené end-to-end reálnym mailom cez
+- **`MAIL_HOST/PORT/USER/PASS/FROM` sú reálne nastavené od #38 (2026-07-30,
+  vtedy na dev2 — od presunu appky, issue 366, sú rovnaké premenné v
+  `/srv/forestshop/.env` na `forestshop-dev`, živo overené priamo v
+  bežiacom kontajneri 12. 8. 2026, issue 371)** — appka odosiela cez
+  ROVNAKÚ SMTP schránku ako stará appka (`parovanie_produktov`, majiteľovo
+  rozhodnutie), hodnoty prevzaté z jej gitignorovaného `data/.mail_env`.
+  Overené end-to-end reálnym mailom cez
   dočasný `supplier_contact` kontakt nastavený na majiteľovu vlastnú
   adresu, po overení znova odstránený. `MAIL_BCC` (BCC-vždy konvencia
   starej appky) táto appka zatiaľ NEPODPORUJE vôbec (nie je v `env.ts` ani

--- a/.claude/rules/shop-feed.md
+++ b/.claude/rules/shop-feed.md
@@ -63,7 +63,7 @@ paths:
   `image_url` vyššie), treba pred naživo overením spustiť RUČNE presne tú
   istú cestu, akú beží nočný beh (03:50), priamo v kontajneri appky:**
   ```
-  ssh newlevel@dev2
+  ssh admin@forestshop-dev.newlevel.media
   docker exec forestshop-app-1 node -e "
   import('/app/apps/api/dist/db/client.js').then(async ({createDb}) => {
     const { runShopFeed } = await import('/app/apps/api/dist/modules/shop-feed/run.js');

--- a/.claude/rules/shoptet-writeback.md
+++ b/.claude/rules/shoptet-writeback.md
@@ -166,9 +166,9 @@ paths:
   chýba v CSV, chýba aj tam** — nie je to nezávislý zdroj na obnovu tohto
   konkrétneho poľa (issue 181: overené na 80 objednávkach, všade prázdne
   v oboch exportoch aj v samotnej administrácii). Užitočný ako RÝCHLA
-  prvá kontrola pred Playwright vzorkou (stiahni raz cez `curl` na dev2 do
-  `/tmp`, over cez `python3`, potom zmaž), ale nečakaj od neho zázrak pri
-  tomto poli.
+  prvá kontrola pred Playwright vzorkou (stiahni raz cez `curl` na
+  `forestshop-dev` do `/tmp`, over cez `python3`, potom zmaž), ale nečakaj
+  od neho zázrak pri tomto poli.
 - **CSV-injection ochrana (issue 153) sedí v `csv.ts`'s `dataRowToLine`, NIE
   vo validácii vyššie prúdu.** `formula-guard.ts`'s `csvSafe` sa aplikuje na
   KAŽDÚ bunku KAŽDÉHO dátového riadku PRIAMO pri zápise CSV — chráni aj

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ test-results/
 # Lokálny pnpm store (`.pnpm-store/`, ak je nakonfigurovaný store-dir mimo
 # globálneho) — build artefakt, nikdy v git histórii.
 .pnpm-store/
+
+# Izolované worktrees dispatchnutých agentov (dočasné, nikdy sa necommitujú)
+.claude/worktrees/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.217",
+  "version": "0.3.0-dev.218",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Dokumentačný balík po presune nasadzovania z dev2 na `forestshop-dev` (issue 366).
Tri tikety, jedna vetva, jeden beh CI — dva z nich menia ten istý súbor
(`.claude/rules/backups.md`), tretí je rovnaký vzor v ďalších playbook súboroch.

## Čo sa mení

- **`.claude/rules/backups.md`** — pribudol popis PRIMÁRNEHO zálohovania na
  `forestshop-dev` (smer PULL, `backup-db-local.sh` cron `15 2 * * *` v UTC,
  read-only `rrsync` kľúč, samostatný cieľový adresár na dev1, retencia 14 dní)
  a úvod teraz jasne rozlišuje primárne zálohovanie od dev2, ktoré ostáva len
  ako statická rollback kópia.
- **`.claude/rules/shop-feed.md`, `orders.md`, `shoptet-writeback.md`,
  `catalog.md`, `deploy.md`** — operačné ssh/psql/docker príkazy prepnuté z
  dev2 na `forestshop-dev`. Historické záznamy ostali nedotknuté zámerne
  (opisujú, čo sa vtedy stalo, a stále platia) — rovnaký vzor ako v issue 366.
- **`.gitignore`** — `.claude/worktrees/` (dočasné worktrees dispatchnutých
  agentov sa nikdy necommitujú).

## Overenie

Live overené priamo na `forestshop-dev` (relácia beží na tom stroji): crontab,
obsah `backup-db-local.sh`, `authorized_keys` s `rrsync -ro` obmedzením, reálne
súbory v `/srv/forestshop/backups/`, mená bežiacich kontajnerov, premenné v
živom kontajneri. dev1-strana zálohovacieho reťazca sa z tohto stroja overiť
NEDÁ (žiadna sieťová cesta) — v dokumente je to výslovne označené.

Lokálne brány zelené (typecheck + lint + testy: 716/716 API, 598/598 web).
Nezávislý review: 1 🟡 opravená (vymyslený údaj o časovom odstupe cronov), 1 🔵
ponechaná po dohode.

Jedna skutočná nezrovnalosť nájdená pri review (dva nezhodné zdroje o čase
dev1 pull cronu) je vyfiltrovaná do samostatného tiketu #376, lebo si vyžaduje
reláciu s prístupom na dev1.

Closes #367
Closes #372
Closes #371
