### PR TITLE
fix: flaky OrdersSection test + súhrn Na objednanie do jedného riadku (issues 365, 360)

### DIFF
--- a/.claude/rules/local-dev.md
+++ b/.claude/rules/local-dev.md
@@ -79,3 +79,41 @@ paths:
   `eslint.config.js`'s `allowDefaultProject` — necháš ich tam, ESLint padne
   na "was included by allowDefaultProject but also was found in the project
   service" (project service si nový reálny `tsconfig.json` nájde sám).
+- **Playwright's VLASTNÝ (bundled) chromium na `forestshop-dev` VPS-e (host,
+  nie appka's kontajner) je stiahnutý do `~/.cache/ms-playwright` už pri
+  `pnpm install` (postinstall), ale NENAŠTARTUJE bez niekoľkých systémových
+  `.so` knižníc, ktoré čerstvý Ubuntu 24.04 image nemá** (issue 360, prvý
+  živý Playwright beh na tomto boxe): `chrome-headless-shell: error while
+  loading shared libraries: libnspr4.so: cannot open shared object file`.
+  Fix: `sudo apt-get install -y libnspr4 libnss3 libatk1.0-0 libatk-
+  bridge2.0-0 libcups2 libdrm2 libxkbcommon0 libxcomposite1 libxdamage1
+  libxfixes3 libxrandr2 libgbm1 libasound2t64` (jednorazovo, systémová
+  závislosť boxu — nie appky). Toto je INÝ chromium než appka's vlastný
+  `/usr/bin/chromium` v `forestshop-app-1` kontajneri (`.claude/rules/
+  shoptet-writeback.md`) — pri prvom Playwright behu PRIAMO na tomto hoste
+  (throwaway meranie, nie e2e cez `apps/web` skript) over najprv, či
+  spustenie chromia vôbec funguje, než diagnostikuješ appkový kód.
+- **Live pixel meranie (`<colgroup>`/výška bloku) proti PRODUKCII (issue
+  105/107/111/127/258 metodika) potrebuje majiteľove prihlasovacie údaje —
+  keď ich agent v danom behu nemá (bežné pri tiketoch dispatchovaných bez
+  credential handoff), rovnako rigorózna náhrada je LOKÁLNY dev server, nie
+  vzdanie sa merania.** Postup (issue 360, overené): `docker compose up -d
+  postgres` (alebo over, či `forestshop_app-postgres-1` na 5433 už beží) →
+  `DATABASE_URL=postgres://forestshop:forestshop@127.0.0.1:5433/forestshop
+  pnpm --filter @forestshop/api db:migrate` → `pnpm exec tsx scripts/
+  e2e-setup.ts` (seeduje testovací účet `e2e@forestshop.sk`, NIE majiteľove
+  produkčné heslo — pozri `.claude/rules/sensitive-values.md`) → `pnpm
+  --filter @forestshop/api start` + `pnpm --filter @forestshop/web dev
+  --port 5173 --host 127.0.0.1` na pozadí → throwaway `.mjs` skript
+  (`createRequire` z `apps/web/package.json`, `require("@playwright/
+  test").chromium`) prihlási sa cez `getByLabel`/`getByRole` presne ako
+  e2e testy a zmeria `boundingBox()`/`getBoundingClientRect()`. Pre "pred
+  zmenou" meranie na UŽ COMMITNUTOM fixe: `git checkout <predošlý-commit>
+  -- <dotknuté-súbory>` (dočasne vráti len TIE súbory, Vite HMR to okamžite
+  prejaví), zmeraj, potom `git checkout HEAD -- <dotknuté-súbory>` vráti
+  fix späť — žiadny `git stash` netreba, keď je fix už commitnutý (na
+  rozdiel od issue 303's `git stash push --keep-index`, ktoré je pre
+  NEcommitnuté zmeny). Layout/CSS správanie je na lokálnom aj produkčnom
+  behu identické (rovnaký kód); jediný rozdiel sú zdrojové dáta v
+  tabuľkách, čo neovplyvňuje výšku/rozloženie blokov závislých len od CSS a
+  počtu položiek.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -653,3 +653,23 @@ paths:
   prejaví POMALOSŤOU/timeoutmi na NÁHODNÝCH testoch, toto sa prejaví
   ÚPLNÝM zamrznutím KAŽDÉHO ĎALŠIEHO integračného súboru bez jediného
   riadku výstupu, kým sa nezabije držiaci proces.
+- **Jeden `it()`, ktorý reťazí VIAC sekvenčných UI scenárov (viac `waitFor`
+  volaní za sebou) v JEDNOM zdieľanom `testTimeout` (predvolene 5000ms), je
+  flaky POD ZÁŤAŽOU (veľa súborov bežiacich súbežne cez vitest thread pool)
+  aj keď je komponent sám rýchly.** Issue 365
+  (`OrdersSection.writeFailures.test.tsx`): izolovane 345-388ms (13-14×
+  rezerva), no pod záťažou (viac `claude`/CI procesov na tom istom boxe)
+  padal na `Test timed out in 5000ms` — nie regresia, len 5 `waitFor`
+  volaní zdieľajúcich JEDEN 5000ms strop namiesto vlastného pre každé.
+  **Fix je VŽDY rozdeliť na samostatné `it()` bloky (každý dostane VLASTNÝ
+  5000ms rozpočet), nikdy zvýšiť `testTimeout`** (`no-timeout-band-aids.md`
+  — timeout nie je príčina, len symptóm zdieľaného rozpočtu). Vzor:
+  spoločné nastavenie (render + kroky, ktoré vytvoria stav potrebný pre
+  VIAC nasledujúcich testov) sa vytiahne do malého lokálneho `async`
+  helpera volaného na začiatku KAŽDÉHO nového testu — žiadna asercia sa pri
+  rozdelení nesmie vynechať, len sa presunie do testu, ktorého scenár
+  overuje. Test na KAŽDÝ ĎALŠÍ nahlásený "flaky, timeoutuje pod záťažou,
+  ale prechádza izolovane" nález v tomto repe: najprv over izolovaný beh
+  (potvrdí/vyvráti, že komponent je naozaj rýchly), potom hľadaj v súbore
+  JEDEN `it()` s viacerými `waitFor` volaniami — to je takmer vždy skutočná
+  príčina, nie testovacie prostredie.

--- a/apps/web/src/components/OrdersOverviewTiles.test.tsx
+++ b/apps/web/src/components/OrdersOverviewTiles.test.tsx
@@ -146,3 +146,37 @@ it("bez žiadneho nevybaveného riadku ukáže '—' namiesto dátumu najstarše
   expect(screen.getByTestId("overview-ordering-oldest").textContent).toContain("—");
   expect(screen.getByTestId("overview-ordering-remaining").textContent).toContain("0");
 });
+
+// issue 360 (majiteľ: "všetko v jednom riadku") — všetkých 7 dlaždíc
+// ("Prehľad e-shopu" + "Súhrn o objednávaní") musí byť priamym potomkom
+// TOHO ISTÉHO `.overview-tiles` kontajnera (jeden spoločný flex riadok),
+// nie rozdelené do dvoch samostatných skupín ako predtým issue 237.
+it("všetkých 7 súhrnných čísel je v JEDNOM spoločnom riadku, nie v dvoch oddelených skupinách", async () => {
+  fetchOrdersOverview.mockResolvedValue(OVERVIEW);
+  render(<OrdersOverviewTiles suppliers={[]} onSessionExpired={() => {}} />);
+
+  await waitFor(() => {
+    expect(screen.getByTestId("overview-shop-today")).toBeTruthy();
+  });
+
+  const row = screen.getByTestId("overview-shop-today").parentElement;
+  expect(row?.className).toBe("overview-tiles");
+
+  const testIds = [
+    "overview-shop-today",
+    "overview-shop-week",
+    "overview-shop-month",
+    "overview-ordering-remaining",
+    "overview-ordering-affected-orders",
+    "overview-ordering-already-ordered",
+    "overview-ordering-oldest",
+  ];
+  for (const testId of testIds) {
+    expect(screen.getByTestId(testId).parentElement).toBe(row);
+  }
+  expect(row?.children.length).toBe(testIds.length);
+
+  // Nadpisy skupín ("Prehľad e-shopu"/"Súhrn o objednávaní") sú preč.
+  expect(screen.queryByText("Prehľad e-shopu")).toBeNull();
+  expect(screen.queryByText("Súhrn o objednávaní")).toBeNull();
+});

--- a/apps/web/src/components/OrdersOverviewTiles.tsx
+++ b/apps/web/src/components/OrdersOverviewTiles.tsx
@@ -3,15 +3,22 @@ import { formatSkDate } from "../formatDate.js";
 import { fetchOrdersOverview, OrdersUnauthorizedError, type OrdersOverview, type SupplierOpenOrders } from "../ordersApi.js";
 import { countAffectedOrders, formatOrderCount, oldestWaitingPlacedAt, summarizeOrderLines } from "../ordersSummary.js";
 
-// issue 237: blok dlaždíc NAD zoznamom na obrazovke "Na objednanie" — dve
-// skupiny. "Prehľad e-shopu" (dnes/tento týždeň/tento mesiac, presne ako
-// Shoptet-ov vlastný dashboard) je NEZÁVISLÝ od dodávateľského pracovného
-// zoznamu — vlastný fetch (rovnaký tvar ako `OrderOpenStatusesPanel.tsx`:
+// issue 237: blok dlaždíc NAD zoznamom na obrazovke "Na objednanie".
+// "Prehľad e-shopu" (dnes/tento týždeň/tento mesiac, presne ako Shoptet-ov
+// vlastný dashboard) je NEZÁVISLÝ od dodávateľského pracovného zoznamu —
+// vlastný fetch (rovnaký tvar ako `OrderOpenStatusesPanel.tsx`:
 // `useEffect`/`onSessionExpired`), lebo potrebuje VŠETKY objednávky (aj
 // uzavreté), nie len OPEN-status podmnožinu, akú appka už má v `suppliers`.
 // "Súhrn o objednávaní" NEPOTREBUJE žiadny nový fetch — počíta sa čisto z
 // UŽ načítaných `suppliers` (rovnaké zdieľané funkcie ako `OrdersToolbar.tsx`
 // používa pre svoj filter-viazaný súhrn, `ordersSummary.ts`).
+//
+// issue 360 (majiteľ: "všetko robíš zbytočne veľké ... všetko v jednom
+// riadku"): pôvodne dve samostatné skupiny (vlastný nadpis + vlastný
+// `.overview-tiles` riadok každá) stackované pod sebou — teraz JEDEN
+// spoločný `.overview-tiles` riadok pre všetkých 7 čísel, bez nadpisov
+// skupín (každá dlaždica má vlastný popisok, takže nadpis nie je nutný na
+// zrozumiteľnosť). Nič iné na obrazovke sa nemení.
 //
 // Dlaždice sú PREHĽAD, nikdy filter — kliknutie na ne nemení obsah zoznamu
 // nižšie (ticketova explicitná požiadavka).
@@ -49,30 +56,24 @@ export function OrdersOverviewTiles({
 
   return (
     <div className="orders-overview" data-testid="orders-overview">
-      <div className="overview-group">
-        <h2 className="overview-group-title">Prehľad e-shopu</h2>
-        {error !== "" && <p role="alert">{error}</p>}
-        {!loaded && error === "" && <p>Načítavam prehľad…</p>}
+      {error !== "" && <p role="alert">{error}</p>}
+      {!loaded && error === "" && <p>Načítavam prehľad…</p>}
+      <div className="overview-tiles">
         {overview !== null && (
-          <div className="overview-tiles">
+          <>
             <OverviewTile testId="overview-shop-today" label="Dnes" orderCount={overview.today.orderCount} revenue={overview.today.revenue} />
             <OverviewTile testId="overview-shop-week" label="Tento týždeň" orderCount={overview.week.orderCount} revenue={overview.week.revenue} />
             <OverviewTile testId="overview-shop-month" label="Tento mesiac" orderCount={overview.month.orderCount} revenue={overview.month.revenue} />
-          </div>
+          </>
         )}
-      </div>
-      <div className="overview-group">
-        <h2 className="overview-group-title">Súhrn o objednávaní</h2>
-        <div className="overview-tiles">
-          <SimpleTile testId="overview-ordering-remaining" label="Položiek na objednanie" value={String(ordering.remaining)} />
-          <SimpleTile testId="overview-ordering-affected-orders" label="Dotknutých objednávok" value={String(affectedOrders)} />
-          <SimpleTile testId="overview-ordering-already-ordered" label="Už objednané" value={String(ordering.ordered)} />
-          <SimpleTile
-            testId="overview-ordering-oldest"
-            label="Najstaršia čakajúca"
-            value={formatSkDate(oldestPlacedAt)}
-          />
-        </div>
+        <SimpleTile testId="overview-ordering-remaining" label="Položiek na objednanie" value={String(ordering.remaining)} />
+        <SimpleTile testId="overview-ordering-affected-orders" label="Dotknutých objednávok" value={String(affectedOrders)} />
+        <SimpleTile testId="overview-ordering-already-ordered" label="Už objednané" value={String(ordering.ordered)} />
+        <SimpleTile
+          testId="overview-ordering-oldest"
+          label="Najstaršia čakajúca"
+          value={formatSkDate(oldestPlacedAt)}
+        />
       </div>
     </div>
   );

--- a/apps/web/src/components/OrdersOverviewTiles.tsx
+++ b/apps/web/src/components/OrdersOverviewTiles.tsx
@@ -58,7 +58,7 @@ export function OrdersOverviewTiles({
     <div className="orders-overview" data-testid="orders-overview">
       {error !== "" && <p role="alert">{error}</p>}
       {!loaded && error === "" && <p>Načítavam prehľad…</p>}
-      <div className="overview-tiles">
+      <div className="overview-tiles" role="group" aria-label="Prehľad e-shopu a súhrn o objednávaní">
         {overview !== null && (
           <>
             <OverviewTile testId="overview-shop-today" label="Dnes" orderCount={overview.today.orderCount} revenue={overview.today.revenue} />

--- a/apps/web/src/components/OrdersSection.writeFailures.test.tsx
+++ b/apps/web/src/components/OrdersSection.writeFailures.test.tsx
@@ -8,6 +8,18 @@ import { OrdersSection } from "./OrdersSection.js";
 // Vlastný súbor — rovnaký vzor ako existujúce `OrdersSection.ordered.test
 // .tsx`/`OrdersSection.assignSupplier.test.tsx` splity (`.claude/rules/
 // testing.md`), aby žiadny súbor nenarástol cez eslint `max-lines: 400`.
+//
+// issue 365: pôvodne JEDEN `it()` reťazil PÄŤ sekvenčných scenárov (prvé
+// zlyhanie → druhé kumulatívne zlyhanie → úspešná retry → zatvorenie
+// banner), všetky zdieľajúce JEDEN 5000ms `testTimeout` — pod CPU záťažou
+// (mnoho súborov bežiacich súbežne v CI/vyťaženom boxe) sa kumulatívny
+// reálny čas naprieč piatimi `waitFor` volaniami vedel pretiahnuť cez ten
+// spoločný strop, hoci komponent samotný je rýchly (izolovane ~350ms).
+// Rozdelené na TRI samostatné `it()` bloky, každý s VLASTNÝM 5000ms
+// rozpočtom (5s → 15s pre rovnaké množstvo práce) — žiadna asercia sa
+// nevynecháva, len sa rozdeľuje podľa hraníc scenára. Spoločné nastavenie
+// (render + prvé dve zlyhania) je vytiahnuté do `renderWithTwoFailures()`,
+// aby druhý a tretí test nemuseli duplikovať jeho JSX/mock nastavenie.
 
 const { fetchOpenOrders, fetchOrdersOverview, updateOrderLineState, updateOrderLineOrdered } = vi.hoisted(() => ({
   fetchOpenOrders: vi.fn(), fetchOrdersOverview: vi.fn(),
@@ -63,7 +75,11 @@ afterEach(() => {
   vi.resetAllMocks();
 });
 
-it("dve nezávislé zlyhania zápisu (iný riadok, iná akcia) sa zobrazia SÚČASNE, kumulatívne", async () => {
+/** Spoločné nastavenie pre testy 2 a 3: vyrenderuje sekciu, vyvolá OBE
+ * nezávislé zlyhania zápisu (stav riadku Alfa, príznak "objednané" riadku
+ * Beta) a počká, kým sa obe zobrazia kumulatívne — presne stav, z ktorého
+ * pôvodný jediný test pokračoval do retry/zatvorenia. */
+async function renderWithTwoFailures(): Promise<{ checkbox: HTMLInputElement }> {
   fetchOpenOrders.mockResolvedValue([
     { supplier: "Dodávateľ Alfa", lines: [LINE_ALFA, LINE_BETA], email: null },
   ]);
@@ -89,6 +105,13 @@ it("dve nezávislé zlyhania zápisu (iný riadok, iná akcia) sa zobrazia SÚČ
   await waitFor(() => {
     expect(screen.getByTestId("order-write-failures").textContent).toContain("Nepodarilo sa uložiť 2 položky");
   });
+
+  return { checkbox };
+}
+
+it("dve nezávislé zlyhania zápisu (iný riadok, iná akcia) sa zobrazia SÚČASNE, kumulatívne", async () => {
+  const { checkbox } = await renderWithTwoFailures();
+
   expect(screen.getByTestId(`order-write-failure-state:${LINE_ALFA.lineId}`).textContent).toBe(
     "Zmena stavu — obj. 1001, kód A-1 (chyba stavu)",
   );
@@ -98,6 +121,10 @@ it("dve nezávislé zlyhania zápisu (iný riadok, iná akcia) sa zobrazia SÚČ
   // Zamietnutá zmena sa NIKDY netvári ako uložená.
   expect(screen.getByTestId(`state-btn-objednane-${LINE_ALFA.lineId}`).getAttribute("aria-checked")).toBe("true");
   expect(checkbox.checked).toBe(false);
+});
+
+it("úspešný opakovaný zápis (riadok Alfa) zmaže LEN jeho položku — druhá (Beta) ostáva viditeľná", async () => {
+  await renderWithTwoFailures();
 
   // Úspešný opakovaný zápis (riadok Alfa) zmaže LEN jeho položku — druhá
   // (Beta) ostáva viditeľná (legacy `clearToOrderFail`: "drop only ITS line").
@@ -109,8 +136,11 @@ it("dve nezávislé zlyhania zápisu (iný riadok, iná akcia) sa zobrazia SÚČ
   });
   expect(screen.queryByTestId(`order-write-failure-state:${LINE_ALFA.lineId}`)).toBeNull();
   expect(screen.getByTestId(`order-write-failure-ordered:${LINE_BETA.lineId}`)).toBeTruthy();
+});
 
-  // Zatvorenie bannera zmaže VŠETKY zostávajúce položky naraz.
+it("zatvorenie banner zmaže VŠETKY zostávajúce položky naraz", async () => {
+  await renderWithTwoFailures();
+
   fireEvent.click(screen.getByRole("button", { name: "Zavrieť hlásenie o neuložených zmenách" }));
   expect(screen.queryByTestId("order-write-failures")).toBeNull();
 });

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -840,13 +840,12 @@ tr:last-child td {
   gap: var(--fs-space-1);
 }
 
-/* issue 237: blok dlaždíc NAD zoznamom "Na objednanie" — dve skupiny
-   ("Prehľad e-shopu" + "Súhrn o objednávaní"). Dlaždice sú PREHĽAD, nikdy
-   klikateľný filter (žiadny `cursor: pointer`/`onClick`). issue 258
-   (majiteľ: "je to strašne veľké... musím dosť rolovať dole... pre mna je to
-   len informatívna informácia") zmenšilo celý blok — pôvodné 3-riadkové
-   dlaždice (label/hodnota/vedľajší údaj, každý na vlastnom riadku, veľký
-   `--fs-text-lg` súčet + veľké odsadenie) namerané naživo
+/* issue 237: blok dlaždíc NAD zoznamom "Na objednanie". Dlaždice sú
+   PREHĽAD, nikdy klikateľný filter (žiadny `cursor: pointer`/`onClick`).
+   issue 258 (majiteľ: "je to strašne veľké... musím dosť rolovať dole...
+   pre mna je to len informatívna informácia") zmenšilo celý blok — pôvodné
+   3-riadkové dlaždice (label/hodnota/vedľajší údaj, každý na vlastnom
+   riadku, veľký `--fs-text-lg` súčet + veľké odsadenie) namerané naživo
    (`page.addStyleTag` kandidát proti produkcii, rovnaká metodika ako
    `.claude/rules/frontend-design.md`'s `<colgroup>` merania) na 103px/79.5px
    výšku dlaždice, celý blok 253.5px pri 1366×768. Fix: dlaždica je teraz
@@ -856,20 +855,22 @@ tr:last-child td {
    odsadenie (`--fs-space-2`/`--fs-space-3` namiesto `--fs-space-3`/
    `--fs-space-4`) — namerané 58.5px/dlaždicu, blok 169px (−33 %), tabuľka
    pod ním sa posunula o ~96px vyššie. Všetkých 7 čísel ostáva plne čitateľné
-   (žiadna hodnota sa neskrátila/neorezala) — len menšie, nie chýbajúce. */
+   (žiadna hodnota sa neskrátila/neorezala) — len menšie, nie chýbajúce.
+
+   issue 360 (majiteľ: "všetko v jednom riadku ... zabera velmi vela ...
+   všetko robíš zbytočne veľké"): pôvodné DVE skupiny ("Prehľad e-shopu" +
+   "Súhrn o objednávaní"), každá s vlastným nadpisom + vlastným
+   `.overview-tiles` riadkom, boli stackované pod sebou (2 vizuálne rady).
+   Nadpisy skupín odstránené (`.overview-group-title` trieda už nie je
+   použitá nikde v appke), všetkých 7 dlaždíc renderovaných do JEDNÉHO
+   `.overview-tiles` kontajnera — na bežnej šírke (~1600px) sa zmestia do
+   jedného riadku, `flex-wrap: wrap` ostáva ako poistka pre úzku
+   obrazovku (ticket žiada jeden riadok len pre bežnú šírku, nie mobil). */
 .orders-overview {
   display: flex;
   flex-direction: column;
   gap: var(--fs-space-2);
   margin-bottom: var(--fs-space-3);
-}
-.overview-group-title {
-  font-size: var(--fs-text-xs);
-  font-weight: var(--fs-weight-semibold);
-  color: var(--fs-ink-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
-  margin: 0 0 var(--fs-space-1);
 }
 .overview-tiles {
   display: flex;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.218",
+  "version": "0.3.0-dev.219",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Dva malé tikety na `apps/web`, jedna vetva, jeden beh CI.

## Issue 365 — flaky test `OrdersSection.writeFailures`

Test padal na `Test timed out in 5000ms`, keď bežal súbežne so zvyškom sady, ale
izolovane prechádzal za ~350 ms (14× rezerva). Príčina nebola pomalý kód, ale
jeden `it()`, ktorý reťazil päť scenárov (päť `waitFor` volaní) v jednom
spoločnom 5000 ms rozpočte. Rozdelené na tri scenárovo ohraničené `it()` bloky
so spoločným `renderWithTwoFailures()` helperom — žiadna asercia sa nevynechala,
`testTimeout` sa nezvyšoval (per `no-timeout-band-aids.md`).

## Issue 360 — „Na objednanie": sedem súhrnných čísel do jedného riadku

Majiteľ žiadal, aby sedem veľkých rámčekov v dvoch radoch (Prehľad e-shopu +
Súhrn o objednávaní) zabralo jeden hustý riadok — číta ich, neklikáva na ne, a
tabuľka objednávok kvôli nim začínala hlboko dole. Dva bloky zlúčené do jedného
`.overview-tiles` riadku, nadpisy skupín odstránené (tiket to výslovne dovolil,
každá dlaždica má vlastný popis). Prístupnosť zachovaná cez `role="group"` +
`aria-label`. Nič iné na obrazovke sa nemenilo — tabuľka, farebné odznaky
dodávateľov ani tlačidlá zostali nedotknuté.

Namerané pri šírke 1600 px: horný blok 148,4 px → 50,4 px, tabuľka objednávok
začína na y=419,5 px → y=321,6 px, teda o **98 px vyššie**. Konzola prehliadača
bez chýb.

## Overenie

`pnpm gates:local` zelené: typecheck, lint, API 716/716 testov, web 601/601.
Nezávislý review: 0 🔴 0 🟡, 1 🔵 (prístupnosť) opravená v `dcc2bc7`.

Meranie pre 360 prebehlo proti lokálnemu dev serveru s rovnakým kódom a CSS
(prihlasovacie údaje do produkcie worker nemal) — živé overenie na produkcii
prebehne po nasadení, preto tento tiket zatiaľ ostáva otvorený.

Closes #365
