### PR TITLE
E-maily zákazníkom: odosielateľ eshop@ + kontaktné údaje presne raz (issue 358, issue 379)

### DIFF
--- a/.claude/rules/deploy.md
+++ b/.claude/rules/deploy.md
@@ -398,3 +398,43 @@ paths:
   tento tunel: neber klientsku chybu/timeout ako dôkaz zlyhania behu — over
   server-side stav (advisory zámok, `job_run`, alebo priamo cieľová
   tabuľka) predtým, než sa čokoľvek reštartuje/opakuje.
+
+## Vývoj a produkcia bežia na TOM ISTOM 2-jadrovom stroji — 502 z preťaženia
+
+**Výpadok 12. 8. 2026 večer (`Bad gateway Error code 502` na
+`forestshop.newlevel.media`).** Príčina NEBOLA appka ani databáza: appka
+odpovedala lokálne `HTTP 200` za 8 ms, kontajner sa nereštartoval
+(`RestartCount=0`, `OOMKilled=false`). Padol `cloudflared` — všetky štyri
+spojenia na Cloudflare edge naraz odpadli s
+`TLS handshake with edge error: … i/o timeout` (`connIndex=0..3`) a znovu
+sa zaregistrovali až o minútu neskôr. To NIE JE sieťová chyba — je to
+hladovanie po CPU: v tom čase bežal na stroji `pnpm -r test` (plná sada
+vrátane integračných testov) a `load average` vyšplhal na **13,3 pri 2
+jadrách**. Tunel nestihol ani TLS handshake, takže Cloudflare nemal kam
+smerovať požiadavky.
+
+**Poučenie:** `forestshop-dev` je jediný 2-jadrový / 4 GB stroj, na ktorom
+beží PRODUKCIA aj VÝVOJ. Ťažký lokálny beh (plná sada testov, build,
+`pnpm -r test`) vie zhodiť produkčný tunel.
+
+**Trvalé opatrenia (nasadené na stroji 12. 8. 2026, prežijú reštart):**
+
+- **Prioritizácia CPU cez cgroup** — kontajnery (`system.slice`) majú
+  prednosť pred vývojom (`user.slice`):
+
+      sudo systemctl set-property user.slice CPUWeight=20
+      sudo systemctl set-property system.slice CPUWeight=500
+
+  Je to POMER, nie strop: keď produkcia nič nerobí, testy dostanú plný
+  výkon; pri súbehu dostane produkcia ~96 % času. Overenie:
+  `cat /sys/fs/cgroup/user.slice/cpu.weight` (má byť `20`).
+- **4 GB swap** (`/swapfile`, v `/etc/fstab`, `vm.swappiness=10`
+  v `/etc/sysctl.d/99-swappiness.conf`) — stroj predtým nemal žiadny a
+  `kswapd0` už bol aktívny.
+
+**Disciplína pri práci na tomto stroji:** lokálne spúšťaj len
+`pnpm gates:local` (typecheck + lint + unit). `pnpm test` / `pnpm -r test`
+ťahá aj integračné testy proti databáze — tie patria do CI, nie na ruku
+(pozri `.claude/rules/testing.md`). Keď appka odpovedá `502`, najprv over
+`cat /proc/loadavg` a `docker logs forestshop-cloudflared-1 | grep -i
+"handshake"`, až potom hľadaj chybu v kóde.

--- a/.claude/rules/mail-templates.md
+++ b/.claude/rules/mail-templates.md
@@ -124,3 +124,33 @@ paths:
   (`docker exec forestshop-app-1 node -e "..."`, plný príkaz v
   `.claude/rules/shop-feed.md`) — legitímne, nedeštruktívne (rovnaký
   UPSERT ako plánovaný beh), nie obchádzka.
+- **issue 379: kontaktný `TemplateValue` (`kind: "link"`) s `label`, ktorý
+  je UŽ SÁM osebe plne čitateľná/dosiahnuteľná hodnota (kontaktný e-mail,
+  telefón, doména — appka ich pozná v `context.ts`'s `globalContext`),
+  potrebuje `showUrlInText: false` — inak textová verzia vypíše "${label}
+  (${url})" aj keď `url` nesie TÚ ISTÚ informáciu (len s `mailto:`/`tel:`/
+  `https://` predponou), čo zákazník vidí ako zdvojenú adresu v JEDNOM
+  mieste ("eshop@forestshop.sk (mailto:eshop@forestshop.sk)"). Predvolené
+  `true` (nezmenené) je správne pre produktové/sledovacie odkazy, kde
+  `label` a `url` naozaj nesú RÔZNU informáciu (názov vs. adresa, ktorú
+  text-only klient nevie kliknúť) — nikdy neprepínaj default, len pridaj
+  `showUrlInText: false` na konkrétnu kontaktnú hodnotu.
+- **issue 379: textová verzia e-mailu (`assembleText`) NEMALA vlastnú
+  kontaktnú pätičku — `wrapEmailHtml` (issue 347) bola len pre HTML.**
+  Keď sa z tela šablóny (`registry.ts`) odstránili opakované vety s
+  `{{kontakt_email}}`/`{{kontakt_telefon}}`/`{{web_forestshop}}` (kontakt
+  je od issue 347 VŽDY vidieť v pätičke, takže veta bola čisté zdvojenie),
+  text by kontakt stratil ÚPLNE — preto pribudla `layout.ts`'s `wrapEmailText`
+  (rovnaké 3 riadky ako HTML pätička, bez značiek), volaná z RENDER.TS na
+  TOM ISTOM mieste ako `wrapEmailHtml` (`renderTemplate`'s nový voliteľný
+  3. parameter `{ footer?: boolean }`, default `true`; `renderEditedBody`
+  bezpodmienečne). **`supplier_order` (jediný čisto textový e-mail
+  DODÁVATEĽOVI, nikdy nemal kontaktnú vetu) je JEDINÝ opt-out
+  (`renderTemplate(..., { footer: false })`, `orders/mail.ts`) — pridanie
+  ĎALŠIEHO druhu e-mailu s vlastným `footer: false` výnimkou musí
+  potvrdiť, že naozaj nikdy nemal kontakt, inak `orders/mail.test.ts`-štýl
+  bajt-na-bajt test to odhalí.** Náhľad (`http/mail-template-routes.ts`'s
+  `POST /api/mail-templates/preview`) musí rovnako posielať `{ footer: key
+  !== "supplier_order" }` — bez toho by náhľad ukazoval pätičku, ktorú
+  skutočne odoslaný e-mail pre tento druh nikdy nemá (nájdené code review,
+  nie testom — preview endpoint dovtedy testoval len `nedostupne`).

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -48,6 +48,11 @@ const envSchema = z.object({
   MAIL_USER: z.string().optional(),
   MAIL_PASS: z.string().optional(),
   MAIL_FROM: z.string().optional(),
+  // issue 358: Reply-To, ZÁMERNE samostatná od `MAIL_FROM` (nie odvodená) —
+  // aby odpoveď dorazila na správnu adresu, aj keby sa `MAIL_FROM` niekedy
+  // zmenil. Bez nastavenia `createSmtpMailTransport` spadne späť na `from`
+  // (`modules/mail/transport.ts`'s `resolveMailSender`).
+  MAIL_REPLY_TO: z.string().optional(),
   // issue 122: spätný zápis odkazu na dodávateľa do Shoptetu cez hromadný CSV
   // import (Playwright). Skutočné prihlasovacie údaje — rovnaké pravidlo ako
   // `MAIL_PASS` vyššie, nikdy do repa/commit správy/logu. Obe nepovinné:

--- a/apps/api/src/http/mail-template-routes.ts
+++ b/apps/api/src/http/mail-template-routes.ts
@@ -69,7 +69,11 @@ export function registerMailTemplateRoutes(app: Hono<AppBindings>, db: Database)
     if (!isMailTemplateKey(key)) return c.json({ ok: false as const, error: "Neznámy druh e-mailu." });
     const errors = validateTemplateText({ subject, body }, allowedPlaceholderNames(key));
     if (errors.length > 0) return c.json({ ok: false as const, error: errors.join(" ") });
-    const rendered = renderTemplate({ subject, body }, await previewContext(db, key));
+    // issue 379 review finding: náhľad musí zrkadliť PRESNE to, čo appka
+    // skutočne pošle — `supplier_order` je jediný druh, ktorý si kontaktnú
+    // pätičku vypína (`orders/mail.ts`), inak by náhľad ukazoval pätičku,
+    // ktorú reálny odoslaný e-mail nikdy nemá.
+    const rendered = renderTemplate({ subject, body }, await previewContext(db, key), { footer: key !== "supplier_order" });
     return c.json({ ok: true as const, subject: rendered.subject, html: rendered.html, text: rendered.text });
   });
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -128,6 +128,8 @@ const sendSupplierMail =
         user: env.MAIL_USER,
         pass: env.MAIL_PASS,
         from: env.MAIL_FROM,
+        // issue 358: nezávislá od `from` — pozri `env.ts`/`transport.ts`.
+        replyTo: env.MAIL_REPLY_TO,
       });
 
 // issue 122: spätný zápis odkazu na dodávateľa do Shoptetu — rovnaká úvaha

--- a/apps/api/src/modules/mail-templates/context.ts
+++ b/apps/api/src/modules/mail-templates/context.ts
@@ -7,12 +7,25 @@ import type { TemplateValue } from "./render.js";
 export const KONTAKT_EMAIL = "eshop@forestshop.sk";
 export const KONTAKT_TELEFON = "+421 903 670 766";
 export const WEB_FORESTSHOP = "https://www.forestshop.sk";
+// issue 379: čitateľná forma webovej adresy — TÁ ISTÁ, akú ukazuje
+// `{{web_forestshop}}` aj pätička (`layout.ts`). Vytiahnutá sem, aby oba
+// miesta nemohli rozísť (predtým bol reťazec "www.forestshop.sk" napísaný
+// natvrdo na dvoch miestach).
+export const WEB_FORESTSHOP_LABEL = "www.forestshop.sk";
 
+// issue 379: majiteľ nahlásil, že telefón/e-mail/web sa v e-maile
+// opakujú — jeden zo zdrojov bola TÁTO textová verzia odkazu sama osebe:
+// `{{kontakt_email}}` v textovom móde vypisovala "eshop@forestshop.sk
+// (mailto:eshop@forestshop.sk)", lebo `label` a `url` sa formálne líšia
+// (predpona mailto:/tel:), hoci nesú TÚ ISTÚ informáciu. `showUrlInText:
+// false` vypína práve TÚTO zátvorku pre kontaktné polia — na rozdiel od
+// napr. produktového odkazu (`zoznam_nahrad`), kde adresa v texte naozaj
+// treba (nedá sa kliknúť), tu je čitateľná hodnota už sama plne dostačujúca.
 export function globalContext(): Record<string, TemplateValue> {
   return {
-    kontakt_email: { kind: "link", url: `mailto:${KONTAKT_EMAIL}`, label: KONTAKT_EMAIL },
-    kontakt_telefon: { kind: "link", url: `tel:${KONTAKT_TELEFON.replaceAll(" ", "")}`, label: KONTAKT_TELEFON },
-    web_forestshop: { kind: "link", url: WEB_FORESTSHOP, label: "www.forestshop.sk" },
+    kontakt_email: { kind: "link", url: `mailto:${KONTAKT_EMAIL}`, label: KONTAKT_EMAIL, showUrlInText: false },
+    kontakt_telefon: { kind: "link", url: `tel:${KONTAKT_TELEFON.replaceAll(" ", "")}`, label: KONTAKT_TELEFON, showUrlInText: false },
+    web_forestshop: { kind: "link", url: WEB_FORESTSHOP, label: WEB_FORESTSHOP_LABEL, showUrlInText: false },
   };
 }
 

--- a/apps/api/src/modules/mail-templates/layout.ts
+++ b/apps/api/src/modules/mail-templates/layout.ts
@@ -1,4 +1,4 @@
-import { KONTAKT_EMAIL, KONTAKT_TELEFON, WEB_FORESTSHOP } from "./context.js";
+import { KONTAKT_EMAIL, KONTAKT_TELEFON, WEB_FORESTSHOP, WEB_FORESTSHOP_LABEL } from "./context.js";
 
 // issue 347 — majiteľ: e-maily zákazníkom vyzerali "hrozne" (holá adresa ako
 // text odkazu, žiadny obrázok, telefón/e-mail stratené vo vete). Táto jedna
@@ -35,11 +35,26 @@ export function wrapEmailHtml(bodyHtml: string): string {
     '      <tr><td style="padding:20px 32px;border-top:1px solid #e5e0d8;font-size:13px;color:#666;">',
     `        <div style="margin-bottom:4px;">Tel.: <a href="${TEL_HREF}" style="color:${BRAND};text-decoration:none;">${KONTAKT_TELEFON}</a></div>`,
     `        <div style="margin-bottom:4px;">E-mail: <a href="mailto:${KONTAKT_EMAIL}" style="color:${BRAND};text-decoration:none;">${KONTAKT_EMAIL}</a></div>`,
-    `        <div><a href="${WEB_FORESTSHOP}" style="color:${BRAND};text-decoration:none;">www.forestshop.sk</a></div>`,
+    `        <div><a href="${WEB_FORESTSHOP}" style="color:${BRAND};text-decoration:none;">${WEB_FORESTSHOP_LABEL}</a></div>`,
     "      </td></tr>",
     "    </table>",
     "    </td></tr></table>",
     "  </body>",
     "</html>",
   ].join("\n");
+}
+
+// issue 379: textový analóg tej istej pätičky — predtým JESTVOVALA len pre
+// HTML (`wrapEmailHtml`), takže čistotextová verzia e-mailu nemala kontakt
+// NIKDE potom, čo sa z tela šablóny odstránili opakované vety s
+// `{{kontakt_email}}`/`{{kontakt_telefon}}` (issue 379 — kontakt sa NESMIE
+// opakovať v tele AJ v pätičke). Volá sa z TOHO ISTÉHO miesta ako
+// `wrapEmailHtml` (`render.ts`'s `renderTemplate`/`renderEditedBody`), takže
+// platí pre každý zákaznícky e-mail rovnako — OKREM `supplier_order`
+// (jediný čisto textový e-mail dodávateľovi, ktorý si toto explicitne
+// vypína cez `renderTemplate`'s `{ footer: false }`, `orders/mail.ts`, aby
+// ostal bajt na bajt nezmenený, `.claude/rules/mail-templates.md`).
+export function wrapEmailText(bodyText: string): string {
+  const footer = [`Tel.: ${KONTAKT_TELEFON}`, `E-mail: ${KONTAKT_EMAIL}`, WEB_FORESTSHOP_LABEL].join("\n");
+  return bodyText === "" ? footer : `${bodyText}\n\n${footer}`;
 }

--- a/apps/api/src/modules/mail-templates/registry.test.ts
+++ b/apps/api/src/modules/mail-templates/registry.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { KONTAKT_EMAIL, KONTAKT_TELEFON, WEB_FORESTSHOP_LABEL } from "./context.js";
 import { allowedPlaceholderNames, exampleContext, MAIL_TEMPLATE_KEYS, MAIL_TEMPLATE_KINDS, placeholdersFor } from "./registry.js";
 import { renderTemplate, validateTemplateText } from "./render.js";
 
@@ -42,5 +43,45 @@ describe("pôvodné znenia e-mailov", () => {
   it("zásielkové znenia sa navzájom líšia — eskalácia sa zlúčením nestratila", () => {
     const subjects = new Set((["posta_1", "posta_2", "posta_3", "posta_4"] as const).map((k) => MAIL_TEMPLATE_KINDS[k].defaultText.subject));
     expect(subjects.size).toBe(4);
+  });
+});
+
+// issue 379: majiteľ nahlásil, že telefón (3×), e-mail (2×) a webová adresa
+// (2×) sa v ODOSLANOM e-maile opakujú. Over PRE KAŽDÚ zákaznícku šablónu
+// (okrem `supplier_order` — jediný čisto textový e-mail DODÁVATEĽOVI, ktorý
+// kontaktnú pätičku výslovne vypína, `orders/mail.ts`), že hotový e-mail
+// nesie KAŽDÝ kontaktný údaj PRESNE RAZ, v texte aj v HTML.
+describe("kontaktné údaje v odoslanom e-maile sa objavia presne raz (issue 379)", () => {
+  const CUSTOMER_FACING_KEYS = MAIL_TEMPLATE_KEYS.filter((k) => k !== "supplier_order");
+
+  /** Počet výskytov `needle`, ktorý nie je súčasťou DLHŠIEHO reťazca (napr.
+   * "www.forestshop.sk/vyhladavanie/..." v produktovom odkaze) — inak by
+   * `nedostupne_alternativa`'s náhradový odkaz falošne pripočítal ďalší
+   * výskyt webovej adresy. */
+  function countStandalone(haystack: string, needle: string): number {
+    const escaped = needle.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const re = new RegExp(`${escaped}(?![\\w/])`, "g");
+    return (haystack.match(re) ?? []).length;
+  }
+
+  it.each(CUSTOMER_FACING_KEYS)("%s: textová verzia má telefón/e-mail/web presne raz", (key) => {
+    const out = renderTemplate(MAIL_TEMPLATE_KINDS[key].defaultText, exampleContext(key));
+    expect(countStandalone(out.text, KONTAKT_TELEFON)).toBe(1);
+    expect(countStandalone(out.text, KONTAKT_EMAIL)).toBe(1);
+    expect(countStandalone(out.text, WEB_FORESTSHOP_LABEL)).toBe(1);
+  });
+
+  it.each(CUSTOMER_FACING_KEYS)("%s: HTML verzia má VIDITEĽNÝ telefón/e-mail/web presne raz (hlavičkové logo sa nepočíta)", (key) => {
+    const out = renderTemplate(MAIL_TEMPLATE_KINDS[key].defaultText, exampleContext(key));
+    expect((out.html.match(new RegExp(`>${KONTAKT_TELEFON.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}<`, "g")) ?? []).length).toBe(1);
+    expect((out.html.match(new RegExp(`>${KONTAKT_EMAIL.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}<`, "g")) ?? []).length).toBe(1);
+    expect((out.html.match(new RegExp(`>${WEB_FORESTSHOP_LABEL.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}<`, "g")) ?? []).length).toBe(1);
+  });
+
+  it("supplier_order (dodávateľovi, nie zákazníkovi) NEMÁ kontaktnú pätičku — ostáva bajt na bajt ako predtým", () => {
+    const out = renderTemplate(MAIL_TEMPLATE_KINDS.supplier_order.defaultText, exampleContext("supplier_order"), { footer: false });
+    expect(out.text).not.toContain(KONTAKT_TELEFON);
+    expect(out.text).not.toContain(KONTAKT_EMAIL);
+    expect(out.text).not.toContain(WEB_FORESTSHOP_LABEL);
   });
 });

--- a/apps/api/src/modules/mail-templates/registry.ts
+++ b/apps/api/src/modules/mail-templates/registry.ts
@@ -67,7 +67,20 @@ const CISLO_OBJEDNAVKY: PlaceholderDef = {
   example: { kind: "text", text: "20260123" },
 };
 
-const PODPIS_TIM = ["S pozdravom,", "**Tím Forestshop.sk**", "{{web_forestshop}}"].join("\n");
+// issue 379: `{{web_forestshop}}` sa TU už nespomína — pätička (`layout.ts`'s
+// `wrapEmailHtml`/`wrapEmailText`, teraz predvolene pripájaná ku KAŽDÉMU
+// e-mailu) je od issue 347 JEDINÉ kanonické miesto pre web adresu; podpis
+// tesne pred pätičkou ju predtým opakoval ("dva krát adresa" z tiketu).
+const PODPIS_TIM = ["S pozdravom,", "**Tím Forestshop.sk**"].join("\n");
+
+// issue 379: JEDNA veta namiesto opakovania {{kontakt_email}}/
+// {{kontakt_telefon}} v tele KAŽDEJ šablóny — kontakt je od issue 347 VŽDY
+// vidieť v pätičke (klikací telefón aj e-mail), takže vypisovať ho ešte raz
+// vo vete bolo presne to zdvojenie, čo majiteľ nahlásil ("dva krát cislo a
+// dva krat email", neskôr upresnené na "tri krát" v HTML — vo vete AJ v
+// pätičke). Zdieľaná konštanta = jedno miesto na opravu pre všetky šablóny,
+// ktoré vetu používajú (tiketov bod 4).
+const KONTAKTUJTE_NAS = "Ak máte akékoľvek otázky, pokojne nás kontaktujte.";
 
 const POSTA_PLACEHOLDERS: readonly PlaceholderDef[] = [
   MENO,
@@ -102,7 +115,7 @@ function postaBody(intro: string, urgency: string): string {
     "",
     "👉 Stav zásielky môžete sledovať tu: {{odkaz_sledovanie}}",
     "",
-    "Ak máte akékoľvek otázky, pokojne nás kontaktujte na {{kontakt_email}}.",
+    KONTAKTUJTE_NAS,
     "",
     PODPIS_TIM,
   ].join("\n");
@@ -125,7 +138,6 @@ const KINDS: readonly MailTemplateKind[] = [
         "",
         "S pozdravom,",
         "**Drlík, Forestshop.sk**",
-        "{{web_forestshop}}",
       ].join("\n"),
     },
   },
@@ -156,7 +168,7 @@ const KINDS: readonly MailTemplateKind[] = [
         "{{#ak zoznam_nahrad}}Radi by sme vám preto ponúkli tieto **alternatívne produkty**:{{inak}}Radi vám pomôžeme nájsť vhodnú alternatívu — stačí nás kontaktovať.{{/ak}}",
         "{{zoznam_nahrad}}",
         "",
-        "Ak máte akékoľvek otázky, pokojne nás kontaktujte na {{kontakt_email}} alebo na telefónnom čísle {{kontakt_telefon}}.",
+        KONTAKTUJTE_NAS,
         "",
         "Ďakujeme vám za dôveru.",
         "",
@@ -212,7 +224,7 @@ const KINDS: readonly MailTemplateKind[] = [
       subject: "Posledná výzva: zásielka bude vrátená | {{cislo_zasielky}}",
       body: postaBody(
         `napriek opakovaným upozorneniam vaša zásielka č. **{{cislo_zasielky}}** je stále nevyzdvihnutá ${POSTA_MIESTO}.`,
-        "Zásielka bude v najbližších dňoch vrátená späť. Ak ju stále chcete, prosím kontaktujte nás čo najskôr na {{kontakt_email}} alebo telefonicky.",
+        "Zásielka bude v najbližších dňoch vrátená späť. Ak ju stále chcete, prosím kontaktujte nás čo najskôr.",
       ),
     },
   },
@@ -232,7 +244,7 @@ const KINDS: readonly MailTemplateKind[] = [
         "",
         "👉 V prípade potreby zmeny, alternatívy alebo potvrdenia z vašej strany vás budeme osobne kontaktovať v najbližšom čase.",
         "",
-        "Ďakujeme vám za trpezlivosť a dôveru. Ak máte akékoľvek otázky, pokojne nás kontaktujte na {{kontakt_email}} alebo na telefónnom čísle {{kontakt_telefon}}.",
+        "Ďakujeme vám za trpezlivosť a dôveru. " + KONTAKTUJTE_NAS,
         "",
         PODPIS_TIM,
       ].join("\n"),
@@ -283,7 +295,7 @@ const KINDS: readonly MailTemplateKind[] = [
         "",
         "radi by sme vás informovali, že vaše objednávky {{zoznam_objednavok}} spolu odosielame ako JEDNU zásielku — ušetríte tak na poštovnom aj na čakaní.",
         "",
-        "Ak máte akékoľvek otázky, pokojne nás kontaktujte na {{kontakt_email}} alebo na telefónnom čísle {{kontakt_telefon}}.",
+        KONTAKTUJTE_NAS,
         "",
         PODPIS_TIM,
       ].join("\n"),

--- a/apps/api/src/modules/mail-templates/render.test.ts
+++ b/apps/api/src/modules/mail-templates/render.test.ts
@@ -25,9 +25,13 @@ const CTX: TemplateContext = {
 
 const ALLOWED = new Set(Object.keys(CTX));
 
+// issue 379: presný textový tvar kontaktnej pätičky, ktorú `wrapEmailText`
+// pripája ku KAŽDÉMU textovému výstupu (default `{ footer: true }`).
+const KONTAKT_FOOTER_TEXT = "Tel.: +421 903 670 766\nE-mail: eshop@forestshop.sk\nwww.forestshop.sk";
+
 describe("renderTemplate — dosadzovanie polí", () => {
   it("dosadí text a odkaz do HTML aj do čistého textu", () => {
-    const out = renderTemplate({ subject: "Objednávka {{cislo_objednavky}}", body: "Dobrý deň, {{meno_zakaznika}}.\n\nSledovanie: {{odkaz_sledovanie}}" }, CTX);
+    const out = renderTemplate({ subject: "Objednávka {{cislo_objednavky}}", body: "Dobrý deň, {{meno_zakaznika}}.\n\nSledovanie: {{odkaz_sledovanie}}" }, CTX, { footer: false });
     expect(out.subject).toBe("Objednávka 20260123");
     expect(out.html).toContain("<p>Dobrý deň, Ján Novák.</p>");
     expect(out.html).toContain('<a href="https://tandt.posta.sk/x" target="_blank">https://tandt.posta.sk/x</a>');
@@ -35,14 +39,14 @@ describe("renderTemplate — dosadzovanie polí", () => {
   });
 
   it("neznáme pole sa ticho zahodí (uložiť sa taká šablóna vôbec nedá — viď kontrolu nižšie)", () => {
-    const out = renderTemplate({ subject: "x", body: "A{{neexistuje}}B" }, CTX);
+    const out = renderTemplate({ subject: "x", body: "A{{neexistuje}}B" }, CTX, { footer: false });
     expect(out.text).toBe("AB");
   });
 });
 
 describe("renderTemplate — tučné písmo", () => {
   it("spáruje hviezdičky OKOLO zástupného poľa (padli by do dvoch rôznych útržkov)", () => {
-    const out = renderTemplate({ subject: "x", body: "Dobrý deň, **{{meno_zakaznika}}**," }, CTX);
+    const out = renderTemplate({ subject: "x", body: "Dobrý deň, **{{meno_zakaznika}}**," }, CTX, { footer: false });
     expect(out.html).toContain("<p>Dobrý deň, <strong>Ján Novák</strong>,</p>");
     expect(out.text).toBe("Dobrý deň, Ján Novák,");
   });
@@ -77,16 +81,16 @@ describe("renderTemplate — podmienky", () => {
   const body = "{{#ak termin_vyzdvihnutia}}do {{termin_vyzdvihnutia}}{{inak}}čo najskôr{{/ak}}";
 
   it("prázdna hodnota vezme vetvu {{inak}}", () => {
-    expect(renderTemplate({ subject: "x", body }, CTX).text).toBe("čo najskôr");
+    expect(renderTemplate({ subject: "x", body }, CTX, { footer: false }).text).toBe("čo najskôr");
   });
 
   it("vyplnená hodnota vezme prvú vetvu", () => {
     const ctx = { ...CTX, termin_vyzdvihnutia: { kind: "text" as const, text: "12. 8. 2026" } };
-    expect(renderTemplate({ subject: "x", body }, ctx).text).toBe("do 12. 8. 2026");
+    expect(renderTemplate({ subject: "x", body }, ctx, { footer: false }).text).toBe("do 12. 8. 2026");
   });
 
   it("prázdny zoznam je pre podmienku nevyplnená hodnota", () => {
-    const out = renderTemplate({ subject: "x", body: "{{#ak prazdny_zoznam}}je{{inak}}nie je{{/ak}}" }, CTX);
+    const out = renderTemplate({ subject: "x", body: "{{#ak prazdny_zoznam}}je{{inak}}nie je{{/ak}}" }, CTX, { footer: false });
     expect(out.text).toBe("nie je");
   });
 });
@@ -100,7 +104,7 @@ describe("renderTemplate — zoznam", () => {
   // issue 347: názov a adresa idú na SAMOSTATNÉ riadky — nikdy "názov (url)",
   // aby text v poštovom klientovi nikdy neukázal adresu zdvojenú v zátvorke.
   it("v texte idú názov a adresa na samostatné riadky, nikdy adresa v zátvorke", () => {
-    const out = renderTemplate({ subject: "x", body: "Náhrady:\n{{zoznam_nahrad}}" }, CTX);
+    const out = renderTemplate({ subject: "x", body: "Náhrady:\n{{zoznam_nahrad}}" }, CTX, { footer: false });
     expect(out.text).toBe("Náhrady:\n- Podkolienky BOBR\nhttps://e.sk/bobr");
     expect(out.text).not.toContain("(https://e.sk/bobr)");
   });
@@ -215,17 +219,20 @@ describe("renderEditedBody — jednorazová ručná úprava (issue 277)", () => 
     const out = renderEditedBody("Dobrý deň,\nešte dopĺňam vetu.\n\nS pozdravom,\nobchod");
     expect(out.html).toContain("<p>Dobrý deň,<br>\n      ešte dopĺňam vetu.</p>");
     expect(out.html).toContain("<p>S pozdravom,<br>\n      obchod</p>");
-    expect(out.text).toBe("Dobrý deň,\nešte dopĺňam vetu.\n\nS pozdravom,\nobchod");
+    expect(out.text).toBe(`Dobrý deň,\nešte dopĺňam vetu.\n\nS pozdravom,\nobchod\n\n${KONTAKT_FOOTER_TEXT}`);
   });
 
   // issue 347: ručne upravený text (okno náhľadu pred odoslaním) dostane
   // TÚ ISTÚ spoločnú kostru (hlavička/pätička) ako šablónou vygenerovaný
-  // e-mail — kostra sa aplikuje na oboch vykresľovacích cestách.
-  it("dostane rovnakú hlavičku/pätičku ako šablónou vygenerovaný e-mail (issue 347)", () => {
+  // e-mail — kostra sa aplikuje na oboch vykresľovacích cestách. issue 379:
+  // od teraz platí aj pre TEXTOVÚ pätičku (predtým ju `renderEditedBody`
+  // vôbec nemala).
+  it("dostane rovnakú hlavičku/pätičku ako šablónou vygenerovaný e-mail (issue 347), aj v textovej verzii (issue 379)", () => {
     const out = renderEditedBody("Ahoj.");
     expect(out.html).toContain(">Forestshop.sk<");
     expect(out.html).toContain('href="tel:+421903670766"');
     expect(out.html).toContain('href="mailto:eshop@forestshop.sk"');
+    expect(out.text).toBe(`Ahoj.\n\n${KONTAKT_FOOTER_TEXT}`);
   });
 
   it("HTML napísané obsluhou sa ESCAPUJE, nikdy sa nestane surovou značkou", () => {
@@ -238,11 +245,53 @@ describe("renderEditedBody — jednorazová ručná úprava (issue 277)", () => 
   it("prázdne odstavce (viac za sebou idúcich prázdnych riadkov) sa zahodia, nezostanú prázdne <p>", () => {
     const out = renderEditedBody("Prvý.\n\n\n\nDruhý.");
     expect(out.html.match(/<p>/g)).toHaveLength(2);
-    expect(out.text).toBe("Prvý.\n\nDruhý.");
+    expect(out.text).toBe(`Prvý.\n\nDruhý.\n\n${KONTAKT_FOOTER_TEXT}`);
   });
 
   it("okolité biele znaky celého textu aj každého odseku sa orežú", () => {
     const out = renderEditedBody("  \n  Ahoj.  \n\n  ");
+    expect(out.text).toBe(`Ahoj.\n\n${KONTAKT_FOOTER_TEXT}`);
+  });
+});
+
+// issue 379: majiteľ nahlásil, že telefón/e-mail/webová adresa sa v
+// odoslanom e-maile opakujú. Dva nezávislé zdroje toho istého symptómu:
+// (1) `{{kontakt_email}}`/`{{kontakt_telefon}}`/`{{web_forestshop}}`
+// zdvojovali SAMÉ SEBA v textovej verzii ("eshop@forestshop.sk
+// (mailto:eshop@forestshop.sk)") — `showUrlInText: false` to vypína,
+// (2) textová verzia predtým NEMALA kontaktnú pätičku vôbec (len HTML),
+// takže po odstránení opakovaných viet z tela šablóny (`registry.ts`) by
+// kontakt v texte úplne chýbal — `wrapEmailText` dopĺňa presne TAKÚTO
+// pätičku, akú má HTML, na TOM ISTOM mieste (`renderTemplate`).
+describe("renderTemplate — kontaktné údaje presne raz (issue 379)", () => {
+  const KONTAKT: TemplateContext = {
+    kontakt_email: { kind: "link", url: "mailto:eshop@forestshop.sk", label: "eshop@forestshop.sk", showUrlInText: false },
+    kontakt_telefon: { kind: "link", url: "tel:+421903670766", label: "+421 903 670 766", showUrlInText: false },
+  };
+
+  it("kontaktný odkaz so showUrlInText:false sa v texte ukáže LEN ako čitateľná hodnota, bez (mailto:...)/(tel:...) zátvorky", () => {
+    const out = renderTemplate({ subject: "x", body: "Píšte na {{kontakt_email}} alebo volajte {{kontakt_telefon}}." }, KONTAKT, { footer: false });
+    expect(out.text).toBe("Píšte na eshop@forestshop.sk alebo volajte +421 903 670 766.");
+    expect(out.text).not.toContain("(mailto:");
+    expect(out.text).not.toContain("(tel:");
+  });
+
+  it("odkaz BEZ showUrlInText (predvolené true) si zátvorku s adresou ponecháva — nezmenené správanie pre iné odkazy (napr. produktový)", () => {
+    const out = renderTemplate(
+      { subject: "x", body: "Sledovanie: {{odkaz}}" },
+      { odkaz: { kind: "link", url: "https://tandt.posta.sk/x", label: "Sledovanie zásielky" } },
+      { footer: false },
+    );
+    expect(out.text).toBe("Sledovanie: Sledovanie zásielky (https://tandt.posta.sk/x)");
+  });
+
+  it("pätička sa predvolene pripája k textovej verzii — predtým ju text vôbec nemal", () => {
+    const out = renderTemplate({ subject: "x", body: "Ahoj." }, {});
+    expect(out.text).toBe(`Ahoj.\n\n${KONTAKT_FOOTER_TEXT}`);
+  });
+
+  it("{ footer: false } textovú pätičku vypne — presne to, čo si opt-outuje supplier_order (orders/mail.ts)", () => {
+    const out = renderTemplate({ subject: "x", body: "Ahoj." }, {}, { footer: false });
     expect(out.text).toBe("Ahoj.");
   });
 });

--- a/apps/api/src/modules/mail-templates/render.ts
+++ b/apps/api/src/modules/mail-templates/render.ts
@@ -10,7 +10,7 @@
 //   **tučné**
 //   prázdny riadok = nový odstavec, jednoduchý riadok = zalomenie
 
-import { wrapEmailHtml } from "./layout.js";
+import { wrapEmailHtml, wrapEmailText } from "./layout.js";
 
 export interface TemplateListItem {
   readonly label: string;
@@ -29,7 +29,20 @@ export interface TemplateListItem {
 
 export type TemplateValue =
   | { readonly kind: "text"; readonly text: string }
-  | { readonly kind: "link"; readonly url: string; readonly label: string }
+  | {
+      readonly kind: "link";
+      readonly url: string;
+      readonly label: string;
+      // issue 379: keď je `label` už samo osebe plne čitateľná/dosiahnuteľná
+      // hodnota (kontaktný e-mail, telefón, doména — appka ich pozná v
+      // `context.ts`'s `globalContext`), zátvorka s adresou v TEXTOVEJ verzii
+      // (`"${label} (${url})"`) je čistá duplicita, lebo `url` nesie TÚ ISTÚ
+      // informáciu (len s `mailto:`/`tel:`/`https://` predponou). Default
+      // `true` (nezmenené správanie) — pre produktové/sledovacie odkazy, kde
+      // `label` a `url` naozaj nesú RÔZNU informáciu (názov vs. adresa,
+      // ktorú text-only klient nevie kliknúť), sa zátvorka ponecháva.
+      readonly showUrlInText?: boolean;
+    }
   | { readonly kind: "list"; readonly items: readonly TemplateListItem[]; readonly textPrefix?: string };
 
 export type TemplateContext = Readonly<Record<string, TemplateValue>>;
@@ -169,7 +182,11 @@ function valuePieces(value: TemplateValue | undefined, mode: Mode): Piece[] {
   if (value.kind === "link") {
     if (value.url === "") return [];
     const label = value.label === "" ? value.url : value.label;
-    if (mode === "text") return [{ p: "frag", s: label === value.url ? value.url : `${label} (${value.url})` }];
+    if (mode === "text") {
+      const showUrl = value.showUrlInText ?? true;
+      const text = label === value.url || !showUrl ? label : `${label} (${value.url})`;
+      return [{ p: "frag", s: text }];
+    }
     return [{ p: "frag", s: `<a href="${htmlEscape(value.url)}" target="_blank">${htmlEscape(label)}</a>` }];
   }
   return [{ p: "list", items: value.items, textPrefix: value.textPrefix ?? "" }];
@@ -315,12 +332,23 @@ function assembleSubject(pieces: readonly Piece[]): string {
     .trim();
 }
 
-export function renderTemplate(template: MailTemplateText, ctx: TemplateContext): RenderedEmail {
+export interface RenderTemplateOptions {
+  // issue 379: pätička (telefón/e-mail/web, `layout.ts`'s `wrapEmailText`)
+  // sa pripája k TEXTOVEJ verzii KAŽDÉHO e-mailu, default `true` — presne
+  // TAK ISTO, ako HTML verzia vždy dostáva `wrapEmailHtml`. Jediná výnimka
+  // je `supplier_order` (`orders/mail.ts`), jediný čisto textový e-mail bez
+  // akejkoľvek zmienky o kontaktoch v pôvodnom znení — ten si pätičku
+  // explicitne vypína, aby ostal bajt na bajt nezmenený.
+  readonly footer?: boolean;
+}
+
+export function renderTemplate(template: MailTemplateText, ctx: TemplateContext, options: RenderTemplateOptions = {}): RenderedEmail {
   const bodyNodes = parse(template.body);
+  const text = assembleText(toPieces(bodyNodes, ctx, "text"));
   return {
     subject: assembleSubject(toPieces(parse(template.subject), ctx, "text")),
     html: assembleHtml(toPieces(bodyNodes, ctx, "html")),
-    text: assembleText(toPieces(bodyNodes, ctx, "text")),
+    text: (options.footer ?? true) ? wrapEmailText(text) : text,
   };
 }
 
@@ -347,7 +375,11 @@ export function renderEditedBody(text: string): RenderedEditedBody {
     .filter((p) => p !== "");
   const htmlParagraphs = paragraphs.map((p) => `    <p>${htmlEscape(p).replaceAll("\n", "<br>\n      ")}</p>`);
   const html = wrapEmailHtml(htmlParagraphs.join("\n"));
-  return { html, text: paragraphs.join("\n\n") };
+  // issue 379: táto cesta je VŽDY zákaznícky e-mail (`nedostupne/send.ts`'s
+  // `editedBody`, jednorazová ručná úprava tesne pred odoslaním) — dostáva
+  // preto TÚ ISTÚ textovú pätičku ako `renderTemplate`, bez opt-outu (žiadny
+  // volajúci `renderEditedBody` nie je `supplier_order`).
+  return { html, text: wrapEmailText(paragraphs.join("\n\n")) };
 }
 
 /** Mená zástupných polí použitých v texte — vrátane tých v podmienkach. */

--- a/apps/api/src/modules/mail/transport.test.ts
+++ b/apps/api/src/modules/mail/transport.test.ts
@@ -11,7 +11,6 @@ describe("resolveMailSender", () => {
   it("from: použije explicitný config.from, keď je nastavený", () => {
     const { from } = resolveMailSender({
       host: "mbox.myshoptet.com",
-      port: 587,
       user: "info@forestshop.sk",
       from: "eshop@forestshop.sk",
     });
@@ -21,7 +20,6 @@ describe("resolveMailSender", () => {
   it("from: bez config.from spadne späť na SMTP účet (user)", () => {
     const { from } = resolveMailSender({
       host: "mbox.myshoptet.com",
-      port: 587,
       user: "info@forestshop.sk",
     });
     expect(from).toBe("info@forestshop.sk");
@@ -30,7 +28,6 @@ describe("resolveMailSender", () => {
   it("from: bez config.from AJ bez user spadne späť na host", () => {
     const { from } = resolveMailSender({
       host: "mbox.myshoptet.com",
-      port: 587,
     });
     expect(from).toBe("mbox.myshoptet.com");
   });
@@ -41,7 +38,6 @@ describe("resolveMailSender", () => {
     // replyTo VLASTNÁ hodnota, nikdy odvodená z from, keď je nastavená.
     const { from, replyTo } = resolveMailSender({
       host: "mbox.myshoptet.com",
-      port: 587,
       from: "novy-odosielatel@forestshop.sk",
       replyTo: "eshop@forestshop.sk",
     });
@@ -52,7 +48,6 @@ describe("resolveMailSender", () => {
   it("replyTo: bez config.replyTo spadne späť na rovnakú hodnotu ako from (appka nikdy nepošle mail bez Reply-To)", () => {
     const { from, replyTo } = resolveMailSender({
       host: "mbox.myshoptet.com",
-      port: 587,
       from: "eshop@forestshop.sk",
     });
     expect(replyTo).toBe(from);

--- a/apps/api/src/modules/mail/transport.test.ts
+++ b/apps/api/src/modules/mail/transport.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { resolveMailSender } from "./transport.js";
+
+// issue 358: majiteľ zistil, že e-maily zákazníkom odchádzajú z
+// info@forestshop.sk namiesto eshop@forestshop.sk, a appka doteraz vôbec
+// nenastavovala Reply-To. `resolveMailSender` je čistá funkcia (žiadny SMTP)
+// vytiahnutá z `createSmtpMailTransport`, aby sa dala otestovať bez
+// bežiaceho servera — presne rovnaké odvodenie, aké appka použije pri
+// KAŽDOM odoslaní zákazníkovi.
+describe("resolveMailSender", () => {
+  it("from: použije explicitný config.from, keď je nastavený", () => {
+    const { from } = resolveMailSender({
+      host: "mbox.myshoptet.com",
+      port: 587,
+      user: "info@forestshop.sk",
+      from: "eshop@forestshop.sk",
+    });
+    expect(from).toBe("eshop@forestshop.sk");
+  });
+
+  it("from: bez config.from spadne späť na SMTP účet (user)", () => {
+    const { from } = resolveMailSender({
+      host: "mbox.myshoptet.com",
+      port: 587,
+      user: "info@forestshop.sk",
+    });
+    expect(from).toBe("info@forestshop.sk");
+  });
+
+  it("from: bez config.from AJ bez user spadne späť na host", () => {
+    const { from } = resolveMailSender({
+      host: "mbox.myshoptet.com",
+      port: 587,
+    });
+    expect(from).toBe("mbox.myshoptet.com");
+  });
+
+  it("replyTo: použije explicitný config.replyTo, NEZÁVISLE od from", () => {
+    // issue 358, bod 2: Reply-To musí ostať eshop@forestshop.sk aj keby sa
+    // odosielateľ (From) v budúcnosti zmenil na niečo iné — preto je
+    // replyTo VLASTNÁ hodnota, nikdy odvodená z from, keď je nastavená.
+    const { from, replyTo } = resolveMailSender({
+      host: "mbox.myshoptet.com",
+      port: 587,
+      from: "novy-odosielatel@forestshop.sk",
+      replyTo: "eshop@forestshop.sk",
+    });
+    expect(from).toBe("novy-odosielatel@forestshop.sk");
+    expect(replyTo).toBe("eshop@forestshop.sk");
+  });
+
+  it("replyTo: bez config.replyTo spadne späť na rovnakú hodnotu ako from (appka nikdy nepošle mail bez Reply-To)", () => {
+    const { from, replyTo } = resolveMailSender({
+      host: "mbox.myshoptet.com",
+      port: 587,
+      from: "eshop@forestshop.sk",
+    });
+    expect(replyTo).toBe(from);
+    expect(replyTo).toBe("eshop@forestshop.sk");
+  });
+});

--- a/apps/api/src/modules/mail/transport.ts
+++ b/apps/api/src/modules/mail/transport.ts
@@ -28,10 +28,27 @@ export interface SmtpMailConfig {
   readonly user?: string | undefined;
   readonly pass?: string | undefined;
   readonly from?: string | undefined;
+  // issue 358: majiteľ zistil, že odpoveď zákazníka na e-mail appky pristála
+  // v inej schránke, než appka v texte sľubuje. ZÁMERNE nezávislé od `from`
+  // (nikdy sa z neho neodvodzuje samo) — "aj keby sa odosielateľ (From) v
+  // budúcnosti zmenil, Reply-To má ostať rovnaké" (tiket, bod 2). Bez
+  // nastavenia spadne späť na `from` (nižšie), appka nikdy nepošle mail bez
+  // Reply-To.
+  readonly replyTo?: string | undefined;
 }
 
+// Čistá funkcia (žiadny SMTP) — vytiahnutá z `createSmtpMailTransport`, aby
+// sa dala unit-testovať bez bežiaceho servera (issue 358).
 // Odosielateľ: explicitný `MAIL_FROM`, inak SMTP účet (`user`), inak
 // samotný host — appka nikdy nepošle mail bez hlavičky `From`.
+export function resolveMailSender(
+  config: Pick<SmtpMailConfig, "host" | "user" | "from" | "replyTo">,
+): { readonly from: string; readonly replyTo: string } {
+  const from = config.from ?? config.user ?? config.host;
+  const replyTo = config.replyTo ?? from;
+  return { from, replyTo };
+}
+
 export function createSmtpMailTransport(config: SmtpMailConfig): MailTransport {
   const transporter = nodemailer.createTransport({
     host: config.host,
@@ -45,11 +62,12 @@ export function createSmtpMailTransport(config: SmtpMailConfig): MailTransport {
         ? { user: config.user, pass: config.pass ?? "" }
         : undefined,
   });
-  const from = config.from ?? config.user ?? config.host;
+  const { from, replyTo } = resolveMailSender(config);
 
   return async (message: MailMessage): Promise<void> => {
     await transporter.sendMail({
       from,
+      replyTo,
       to: message.to,
       subject: message.subject,
       text: message.text,

--- a/apps/api/src/modules/orders/mail.ts
+++ b/apps/api/src/modules/orders/mail.ts
@@ -67,18 +67,27 @@ function formatSupplierOrderMailLine(line: SupplierOrderMailLine): string {
 // (0, 1, 2, 4, 5) bez behu integračných testov. Znenie prichádza z
 // upraviteľnej šablóny (issue 192); tento e-mail je jediný ČISTO TEXTOVÝ,
 // takže sa z výsledku berie len textová verzia.
+// issue 379: `{ footer: false }` — jediný explicitný opt-out z kontaktnej
+// pätičky (`layout.ts`'s `wrapEmailText`, teraz predvolene pripájaná ku
+// KAŽDÉMU `renderTemplate` výstupu). Pôvodné znenie tohto e-mailu nikdy
+// nespomínalo telefón/e-mail/web, takže pätička by pridala obsah, ktorý
+// predtým nebol — `orders/mail.test.ts` drží výsledok bajt na bajt.
 export function formatSupplierOrderMailText(
   template: MailTemplateText,
   supplier: string,
   lines: readonly SupplierOrderMailLine[],
 ): { readonly subject: string; readonly body: string } {
-  const rendered = renderTemplate(template, {
-    ...globalContext(),
-    dodavatel: textValue(supplier),
-    pocet_poloziek: textValue(String(lines.length)),
-    slovo_poloziek: textValue(itemsWord(lines.length)),
-    zoznam_poloziek: { kind: "list", items: lines.map((line) => ({ label: formatSupplierOrderMailLine(line) })) },
-  });
+  const rendered = renderTemplate(
+    template,
+    {
+      ...globalContext(),
+      dodavatel: textValue(supplier),
+      pocet_poloziek: textValue(String(lines.length)),
+      slovo_poloziek: textValue(itemsWord(lines.length)),
+      zoznam_poloziek: { kind: "list", items: lines.map((line) => ({ label: formatSupplierOrderMailLine(line) })) },
+    },
+    { footer: false },
+  );
   return { subject: rendered.subject, body: rendered.text };
 }
 

--- a/apps/api/tests/mail-edited-body.integration.test.ts
+++ b/apps/api/tests/mail-edited-body.integration.test.ts
@@ -17,6 +17,14 @@ import { withCleanDb } from "./helpers/db.js";
 // vygenerovanú šablónu), zapísať TO ISTÉ do Knihy odoslaných e-mailov, a
 // šablóna v `mail_template` musí po odoslaní ostať bajt na bajt nezmenená.
 // Falošný mail transport — nikdy skutočný SMTP (majiteľova podmienka).
+//
+// issue 379: `renderEditedBody` (`render.ts`) teraz bezpodmienečne pripája
+// kontaktnú pätičku (`wrapEmailText`) — táto cesta je VŽDY zákaznícky
+// e-mail, takže "presne to, čo obsluha upravila" v skutočnosti odíde ako
+// upravený text + pätička; `sendLoggedMail` zapisuje do Knihy presne to,
+// čo sa odoslalo (`mail-log/service.ts`, `.claude/rules/mail-log.md`), teda
+// aj tam ide upravený text + pätička.
+const KONTAKT_FOOTER_TEXT = "Tel.: +421 903 670 766\nE-mail: eshop@forestshop.sk\nwww.forestshop.sk";
 
 let close: (() => Promise<void>) | undefined;
 afterEach(async () => {
@@ -81,7 +89,7 @@ it("nedostupne: editedBody nahradí vygenerované znenie, šablóna ostáva nezm
   });
   expect(result).toEqual({ ok: true });
   expect(sent).toHaveLength(1);
-  expect(sent[0]?.text).toBe(editedText);
+  expect(sent[0]?.text).toBe(`${editedText}\n\n${KONTAKT_FOOTER_TEXT}`);
   expect(sent[0]?.html).toContain("váš tovar bohužiaľ nemáme skladom");
   expect(sent[0]?.html).not.toContain("Vlastné znenie pre");
   // Predmet ostáva z NEUPRAVENÉHO vyrenderovania (ticket edituje len text).
@@ -92,7 +100,7 @@ it("nedostupne: editedBody nahradí vygenerované znenie, šablóna ostáva nezm
 
   const logRow = (await db.select({ recipient: mailLog.recipient, body: mailLog.body }).from(mailLog))[0];
   expect(logRow?.recipient).toBe("jan@example.sk");
-  expect(logRow?.body).toBe(editedText);
+  expect(logRow?.body).toBe(`${editedText}\n\n${KONTAKT_FOOTER_TEXT}`);
 });
 
 async function seedActor(db: Awaited<ReturnType<typeof boot>>): Promise<string> {
@@ -131,11 +139,11 @@ it("order-merge: editedBody nahradí vygenerované znenie, Kniha uloží upraven
   });
   expect(result.status).toBe("sent");
   expect(sent).toHaveLength(1);
-  expect(sent[0]?.text).toBe(editedText);
+  expect(sent[0]?.text).toBe(`${editedText}\n\n${KONTAKT_FOOTER_TEXT}`);
   expect(sent[0]?.html).toContain("obe tvoje objednávky posielame spolu");
 
   const logRow = (await db.select({ body: mailLog.body }).from(mailLog))[0];
-  expect(logRow?.body).toBe(editedText);
+  expect(logRow?.body).toBe(`${editedText}\n\n${KONTAKT_FOOTER_TEXT}`);
 });
 
 // HTTP-úrovňový dôkaz — náhľad vracia `text` (frontend ho predvyplní do
@@ -203,9 +211,9 @@ it("HTTP: nedostupne náhľad vráti 'text', /send prijme editedBody, mail-log u
     body: JSON.stringify({ orderCode: "27700201", variantCode: "P277B", emailType: "nedostupne", previewToken: preview.previewToken, editedBody: editedText }),
   });
   expect((await sendRes.json() as { ok: boolean }).ok).toBe(true);
-  expect(nedostupneSent[0]?.text).toBe(editedText);
+  expect(nedostupneSent[0]?.text).toBe(`${editedText}\n\n${KONTAKT_FOOTER_TEXT}`);
 
   const logRes = await app.request("/api/mail-log", { headers: { cookie } });
   const logBody = (await logRes.json()) as { rows: { body: string | null }[] };
-  expect(logBody.rows[0]?.body).toBe(editedText);
+  expect(logBody.rows[0]?.body).toBe(`${editedText}\n\n${KONTAKT_FOOTER_TEXT}`);
 });

--- a/apps/api/tests/mail-templates.integration.test.ts
+++ b/apps/api/tests/mail-templates.integration.test.ts
@@ -114,6 +114,31 @@ it("náhľad vyrenderuje rozpísané (neuložené) znenie a nič neuloží", asy
   expect(await db.select().from(mailTemplates)).toHaveLength(0);
 });
 
+// issue 379 review finding: náhľad musí zrkadliť PRESNE to, čo appka
+// skutočne pošle — `supplier_order` je jediný druh, ktorý si kontaktnú
+// pätičku vypína (`orders/mail.ts`'s `{ footer: false }`), inak by náhľad
+// ukazoval pätičku, ktorú reálne odoslaný e-mail nikdy nemá.
+it("náhľad supplier_order NEMÁ kontaktnú pätičku — rovnako ako skutočne odoslaný e-mail", async () => {
+  const { app, cookie } = await boot("manazer");
+  const res = await app.request(
+    "/api/mail-templates/preview",
+    jsonRequest(cookie, "POST", { key: "supplier_order", subject: "Objednávka — {{dodavatel}}", body: "Objednávka — {{dodavatel}}\n{{zoznam_poloziek}}" }),
+  );
+  const payload = (await res.json()) as { ok: boolean; text: string };
+  expect(payload.ok).toBe(true);
+  expect(payload.text).not.toContain("Tel.:");
+  expect(payload.text).not.toContain("eshop@forestshop.sk");
+});
+
+it("náhľad ostatných druhov (napr. nedostupne) kontaktnú pätičku MÁ", async () => {
+  const { app, cookie } = await boot("manazer");
+  const res = await app.request("/api/mail-templates/preview", jsonRequest(cookie, "POST", { key: "nedostupne", subject: "Vec", body: "Ahoj." }));
+  const payload = (await res.json()) as { ok: boolean; text: string };
+  expect(payload.ok).toBe(true);
+  expect(payload.text).toContain("Tel.:");
+  expect(payload.text).toContain("eshop@forestshop.sk");
+});
+
 it("náhľad neplatnej šablóny vráti chybu namiesto rozbitého e-mailu", async () => {
   const { app, cookie } = await boot("manazer");
   const res = await app.request("/api/mail-templates/preview", jsonRequest(cookie, "POST", { key: "nedostupne", subject: "Vec", body: "{{vymyslene_pole}}" }));

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -134,6 +134,11 @@ services:
       MAIL_USER:
       MAIL_PASS:
       MAIL_FROM:
+      # issue 358: ZÁMERNE samostatná od MAIL_FROM (nie odvodená) — aby
+      # odpoveď zákazníka dorazila na správnu adresu, aj keby sa MAIL_FROM
+      # niekedy zmenil. Rovnaká úvaha ako MAIL_HOST vyššie (bare kľúč,
+      # `.optional()` v env.ts).
+      MAIL_REPLY_TO:
       # Skrytá kópia (BCC) na KAŽDOM maile dodávateľovi z obrazovky "Na
       # objednanie". Majiteľ 3. 8. 2026: "vsade zatial ma byt ked nieco
       # posiela mail dokial sa to neosvedci ze to funguje dobre" — chýbal

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.220",
+  "version": "0.3.0-dev.221",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.219",
+  "version": "0.3.0-dev.220",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.218",
+  "version": "0.3.0-dev.219",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Dva tickety okolo zákazníckych e-mailov (issue 358, issue 379). Oba majú akceptačnú
podmienku, ktorú vieme overiť až po nasadení naživo (skutočne odoslaný e-mail), preto
ich tento PR zámerne nezatvára — tickety sa zavrú ručne po overení na produkcii.

## issue 358 — odosielateľ eshop@forestshop.sk

- `resolveMailSender()` v `apps/api/src/modules/mail/transport.ts` počíta `From`/`Reply-To`
  z konfigurácie (`MAIL_FROM` → `MAIL_USER` → `MAIL_HOST`, `Reply-To` padá späť na `From`).
- Nová nezávislá premenná `MAIL_REPLY_TO` (`apps/api/src/env.ts`), zapojená na jedinom
  mieste vzniku transportu (`apps/api/src/index.ts`), plus kľúč v `docker-compose.prod.yml`.
- Overené, že všetkých šesť odosielateľov zákazníckych e-mailov ide cez jeden zdieľaný
  transport (`sendLoggedMail`), takže zmena platí plošne.
- Zvyšok je konfigurácia na produkcii: `MAIL_USER`/`MAIL_FROM` prepnúť na eshop@,
  doplniť `MAIL_REPLY_TO`; heslo sa nemení (overené, že rovnaké heslo prihlási aj eshop@).

## issue 379 — kontaktné údaje presne raz

- Pätička e-mailov zjednotená: telefón, e-mail a webová adresa majú jedno miesto.
- `showUrlInText` vypnuté tam, kde sa do textovej verzie duplikovali `(mailto:)`/`(tel:)`
  zátvorky za odkazom.
- Oprava je v zdieľanej šablónovej vrstve (`modules/mail-templates/{layout,render,registry,context}.ts`),
  takže platí pre všetky zákaznícke e-maily vrátane náhľadu a odoslania upraveného tela.
- Regresné testy počítajú výskyty každého kontaktného údaja (text aj HTML verzia).

## Testy

- `pnpm --filter @forestshop/api test` 742/742, `test:integration` 664/664
- `pnpm --filter @forestshop/web test` 601/601, `pnpm typecheck` čistý, lint čistý
