### PR TITLE
Emoji editor na Úlohy na dnes + overenie času záloh (issue 381, issue 376)

### DIFF
--- a/.claude/rules/backups.md
+++ b/.claude/rules/backups.md
@@ -25,9 +25,20 @@ Smer je preto obrátený:
 - **`/srv/forestshop/scripts/backup-db-local.sh`** (pridané do repa pri
   issue 366 — inak by ho `deploy.yml`'s `rsync -a --delete` z repového
   `scripts/` pri najbližšom nasadení potichu zmazal, keďže by existoval len
-  na serveri) beží cez cron `15 2 * * *`, **box-lokálny čas = UTC**
-  (`forestshop-dev`'s systémový čas je `Etc/UTC`, overené priamo
-  `timedatectl`). Robí LEN lokálnu časť: `pg_dump -Fc` databázy → over
+  na serveri) beží cez cron `15 2 * * *`, **box-lokálny čas — POZOR, mení
+  sa v čase, over vždy znova `timedatectl` pred prepočtom na UTC.** K
+  12. 8. 2026 21:xx (issue 376, overené priamo) `/etc/localtime` ukazuje na
+  `Europe/Bratislava` (aktuálne CEST, +02:00) — symlink bol podľa jeho
+  vlastného mtime zmenený TEN ISTÝ DEŇ o 18:29 CEST, teda box krátko po
+  svojom vzniku (issue 366, ráno 12. 8.) skutočne bežal na UTC (odtiaľ
+  pôvodná, teraz už neplatná poznámka "systémový čas je `Etc/UTC`"), no
+  odvtedy sa preklopil na Bratislava-local. `/etc/timezone` (súbor, ktorý
+  cron NEČÍTA — použitý je `/etc/localtime`) ostáva zastarane na
+  `Etc/UTC` a nie je spoľahlivý zdroj. Praktický dôsledok: dnes v noci
+  (12.→13. 8.) tento cron prvýkrát reálne pobeží o **02:15
+  Europe/Bratislava-local = 00:15 UTC v CEST** (v CET by to bolo 01:15
+  UTC) — NIE o 02:15 UTC, ako tvrdila pôvodná verzia tohto bulletu. Robí
+  LEN lokálnu časť: `pg_dump -Fc` databázy → over
   `pg_restore --list` PRED čímkoľvek ďalším (poškodený/prázdny dump zastaví
   skript hneď, `exit 1`, nikdy sa neoznačí za platný) → zašifruje `.env`
   (`gpg --symmetric`, heslo v `/srv/forestshop/.backup-passphrase`, mode
@@ -36,18 +47,36 @@ Smer je preto obrátený:
   `/srv/forestshop/backups/forestshop-<STAMP>.dump` + `.env.gpg`.
 - **dev1 si súbory STIAHNE vlastným pull cronom** —
   `~/backups/pull-forestshop-dev-backup.sh` (žije len na dev1, mimo tohto
-  repa). **Presný čas má DVA nezhodné zdroje, ani jeden overiteľný z tohto
-  stroja:** `backup-db-local.sh`'s vlastný hlavičkový komentár (už v repe,
-  napísaný pri issue 366 — pravdepodobne s priamym prístupom na dev1 v tom
-  čase) hovorí "beží 02:25 — 10 min po tomto skripte" (teda ~02:25 UTC, len
-  10 min odstup od zdrojového behu); issue 367's zadanie namiesto toho
-  tvrdí cron `30 4 * * *` **Bratislava-local**, čo v CEST vychádza na
-  ~02:30 UTC (15 min odstup) a v CET na ~03:30 UTC (1h15 odstup) — v OBOCH
-  prípadoch výrazne menej než "kladný odstup naprieč oboma pásmami" by
-  malo znamenať, a navyše nesedí s "10 min po tomto skripte". Túto
-  nezhodu NERIEŠIM sám (vyžaduje priamy pohľad na dev1's skutočný
-  crontab, `forestshop-dev` k dev1 nemá sieťovú cestu) — over `crontab -l`
-  priamo na dev1 pri najbližšej príležitosti a zapíš sem skutočný riadok.
+  repa). **Presný riadok dev1's crontabu (issue 376) ZOSTÁVA UNVERIFIED —
+  ale nie preto, že by sa to nedalo overiť z `forestshop-dev`.** `ssh
+  dev1`/`ssh 100.104.8.125` z tohto boxu naozaj zlyhávajú (žiadna sieťová
+  cesta, potvrdené), no dá sa to overiť NEPRIAMO — `forestshop-dev`'s
+  vlastný `auth.log` zaznamenáva KAŽDÉ prihlásenie reštrikovaným pull
+  kľúčom aj s presným časom. Postup, opakovateľný kýmkoľvek na tomto boxi:
+  1. zisti fingerprint kľúča z `~/.ssh/authorized_keys` (riadok
+     `command="/usr/bin/rrsync -ro ..." ssh-ed25519 ...
+     forestshop-dev-backup-pull@dev1`) cez `ssh-keygen -lf`;
+  2. `sudo grep '<fingerprint>' /var/log/auth.log` — každý riadok
+     `Accepted publickey for admin ... ssh2: ED25519 SHA256:<fingerprint>`
+     je jeden reálny pull, s UTC časovou pečiatkou v samotnom logu
+     (nezávisle od box-lokálneho `timedatectl` nastavenia vyššie).
+
+  K 12. 8. 2026 19:xx (deň, keď box vôbec prvýkrát začal bežať ako
+  `forestshop-dev` — `journalctl --list-boots` ukazuje prvý boot tejto
+  identity 12. 8. 2026 13:14 CEST) toto našlo presne 7 úspešných
+  prihlásení tým kľúčom, VŠETKY zhlukovo medzi 12:46:44–13:06:03 UTC toho
+  istého dňa — zjavne ručné testovanie pri zapájaní (issue 366/367 setup:
+  7× pripojenie za 20 minút, nie raz-denne opakovaný cron vzor). Nočné
+  okno `backup-db-local.sh`'s cronu (bullet vyššie) v tejto podobe boxu
+  ešte VÔBEC nenastalo (dnešné 02:15 už prešlo predtým, než box v tejto
+  identite existoval) — teda ani dev1's nadväzujúci pull cron nemal
+  doteraz ŽIADNU reálnu produkčnú príležitosť spustiť sa. Prvá reálna
+  noc je až 12.→13. 8. **Skutočný cyklický čas preto zatiaľ nemá dôkaz —
+  ani jeden z dvoch pôvodne citovaných zdrojov (02:25 UTC / cron
+  `30 4 * * *` Bratislava-local) sa nedal ani potvrdiť, ani vyvrátiť.**
+  Až po prvej reálnej noci zopakuj krok 2 vyššie — nový výsledok bude mať
+  presne jeden riadok s pravidelným denným časom namiesto zhluku, a ten
+  čas nahraď sem.
   Cieľ na dev1: **`~/backups/forestshop-dev/`** — samostatný adresár,
   ODDELENE od dev2's `~/backups/forestshop/` (nižšie), aby sa dve
   nezávislé zálohovacie histórie nikdy nepomiešali.
@@ -75,11 +104,15 @@ Smer je preto obrátený:
 `forestshop-dev`, takže box's vlastná strana (crontab, obsah skriptu,
 `authorized_keys`, reálne súbory v `/srv/forestshop/backups/` — napr.
 `forestshop-20260812T130301.dump` + `.env.gpg` z behu 12. 8. 2026) je overená
-priamym čítaním, nie len z textu tiketu. **dev1-strana** (pull skript, jeho
-vlastný crontab, obsah `~/backups/forestshop-dev/`) **nebola overená naživo
-z tohto stroja** — `forestshop-dev` nemá k dev1 žiadnu sieťovú cestu (`ssh
-dev1`/`ssh 100.104.8.125` obe zlyhali, presne z dôvodu popísaného vyššie) —
-tá časť je zdokumentovaná z pôvodného zadania issue 367.
+priamym čítaním, nie len z textu tiketu. **dev1-strana priamo (jeho vlastný
+crontab súbor, obsah `~/backups/forestshop-dev/`) sa naďalej NEDÁ overiť z
+tohto stroja** — `forestshop-dev` nemá k dev1 žiadnu sieťovú cestu (`ssh
+dev1`/`ssh 100.104.8.125` obe zlyhali). **Dev1's SKUTOČNÉ SPRÁVANIE (kedy sa
+naozaj pripája) sa ale DÁ overiť nepriamo** cez `forestshop-dev`'s vlastný
+`auth.log` (issue 376 — postup + zatiaľ nerozhodnutý výsledok pozri bullet
+"dev1 si súbory STIAHNE" vyššie): box beží v aktuálnej podobe len od
+12. 8. 2026, žiadna reálna noc ešte neprebehla, takže presný cyklický čas
+zatiaľ nemá dôkaz ani z jedného smeru.
 
 ## dev2 (statická rollback kópia)
 

--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -1205,3 +1205,45 @@ paths:
   container:** the true minimum width is `Σ(children widths) + gap ×
   (children − 1)`, not just `Σ(children widths)` — measure or compute
   that explicitly before trusting `space-between` to "make it fit".
+- **A toggle-open inline editor keyed by a single global scalar
+  (`editingXId`) whose "open" `onClick` UNCONDITIONALLY reseeds its draft
+  from the server value is a silent-data-loss trap** — issue 381 (majiteľ:
+  "to emoji ... sa správa hrozne"): `DailyTasksSection.tsx`'s emoji editor
+  let only ONE row be open at a time, and the ONLY way to "close" the
+  currently-open row was to open a DIFFERENT row's editor — but that same
+  `onClick` also unconditionally overwrote `emojiDraft[row.id]` with the
+  server value, so a draft typed but not yet saved was silently gone the
+  moment you switched away and back (naživo reprodukované, komentár na
+  tickete). Fix pattern: seed the draft ONLY if no in-memory entry already
+  exists for that id (`row.id in d ? d : {...d, [row.id]: seed}`), and
+  explicitly DELETE the draft entry on both successful save AND explicit
+  cancel — so a LATER reopen still gets a fresh server value (no
+  staleness), but a temporary switch-away-and-back does not lose anything.
+  **Two independent per-row toggle-open editors on the SAME row (text vs.
+  emoji, each its own `editingXId` scalar) can end up open SIMULTANEOUSLY**
+  if opening one never closes the other — found live via Playwright
+  against PRODUCTION (not by any existing test) as two duplicate 💾 save
+  buttons rendered side by side on one row. Fix: each "open X editor"
+  action must ALSO close any OTHER per-row editor open for the SAME row id
+  (`setEditingOtherId((current) => (current === row.id ? null : current))`
+  inside the "open" handler). **A Cancel/close button added NEXT TO an
+  existing Save button on a per-row editor needs the SAME `disabled={busy}`
+  guard Save already has** — found by an independent review dispatch, not a
+  test written first: without it, cancelling while THIS row's OWN save is
+  in flight, then reopening and retyping, lets the ORIGINAL (already
+  "cancelled" from the UI's perspective) save's success handler race
+  against and silently discard the NEW draft once it resolves — the same
+  class of bug the file's existing "latest ref" pattern
+  (`editingTextIdRef`/`editingEmojiIdRef`) already guards against for a
+  DIFFERENT row switching away, but it also applies WITHIN the same row
+  across a cancel+retype cycle. Any FUTURE per-row toggle-open editor
+  (draft + Save + Cancel) added to this app needs all three checks: does
+  "open" only seed-if-absent (never unconditionally overwrite)? does it
+  close any OTHER per-row editor on the SAME row? does Cancel share Save's
+  `disabled={busy}` guard?
+- **Deleting one dynamic key from a `Record<string,string>` React state
+  update triggers `@typescript-eslint/no-dynamic-delete`** (`delete
+  obj[dynamicKey]`, this repo's `strictTypeChecked` eslint config) — issue
+  381's `emojiDraft` cleanup. The lint-safe equivalent is `Object
+  .fromEntries(Object.entries(obj).filter(([key]) => key !== id))`, never
+  an `eslint-disable` comment.

--- a/.claude/rules/local-dev.md
+++ b/.claude/rules/local-dev.md
@@ -23,6 +23,16 @@ paths:
   `packageManager` (`pnpm@10.0.0`), nie nainštalovaná globálne. `.npmrc` má
   `engine-strict=true` — inštalácia zlyhá nahlas, ak Node/pnpm nesedí, namiesto
   tichého pokračovania so zlou verziou.
+- **Čerstvý `git worktree` checkout (napr. autopilot-worker's izolovaná
+  vetva) NEMÁ `node_modules`** — nie je súčasťou `.git`, každý strom si ho
+  musí založiť sám. Bez neho `pnpm run lint` NEHLÁSI "chýba inštalácia" —
+  vyzerá to ako reálna, obrovská porucha kódu: typescript-eslint's project
+  service nevie vyriešiť typy zo žiadneho importovaného balíka, takže
+  KAŽDÝ `.insert()`/`.values()`/atď. na cudzom module ohlási
+  `no-unsafe-call`/`no-unsafe-member-access` — desiatky tisíc falošných
+  chýb naraz (issue 376, nameraných presne 50546). Fix: `pnpm install`
+  PRED prvým lintom v novom worktree (rýchle, `pnpm-lock.yaml` je
+  nezmenený, len sa znovupoužijú balíky z pnpm store — žiadne sťahovanie).
 - **Lokálna databáza beží na porte 5433** (`docker-compose.yml`,
   `127.0.0.1:5433:5432`), **CI integration/e2e joby používajú 5432** (Postgres
   ako GitHub Actions `services:` kontajner, žiadny port-mapping konflikt s

--- a/apps/web/src/components/DailyTasksSection.test.tsx
+++ b/apps/web/src/components/DailyTasksSection.test.tsx
@@ -259,3 +259,34 @@ it("otvorenie textového editora zavrie emoji editor TOHO ISTÉHO riadku (nikdy 
   expect(screen.queryByTestId("uloha-emoji-input-task-a")).toBeNull();
   expect(screen.getByTestId("uloha-edit-input-task-a")).toBeTruthy();
 });
+
+// Nezávislý review dispatch (issue 381 PR) našiel doplnkový race: Zrušiť
+// nebolo chránené proti bežiacemu uloženiu TOHO ISTÉHO riadku — kliknutie
+// Zrušiť počas čakajúcej odpovede, znovu-otvorenie a nový rozpis by stále
+// mohli byť zahodené, keď PÔVODNÁ (už zrušená) odpoveď dorazí neskôr.
+it("Zrušiť je disabled, kým čaká uloženie TOHO ISTÉHO riadku (nedá sa obísť rozbehnuté uloženie)", async () => {
+  fetchDailyTasks.mockResolvedValue([ROW_A]);
+  let resolveSave: (v: boolean) => void = () => {};
+  updateDailyTaskEmoji.mockImplementationOnce(
+    () =>
+      new Promise<boolean>((resolve) => {
+        resolveSave = resolve;
+      }),
+  );
+  render(<DailyTasksSection onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("uloha-row-task-a");
+
+  fireEvent.click(screen.getByTestId("uloha-emoji-task-a"));
+  fireEvent.change(screen.getByTestId<HTMLInputElement>("uloha-emoji-input-task-a"), { target: { value: "🚚" } });
+  fireEvent.click(screen.getByTestId("uloha-emoji-save-task-a"));
+
+  // Odpoveď ešte NEDORAZILA — Zrušiť musí byť disabled, presne ako Uložiť.
+  expect(screen.getByTestId<HTMLButtonElement>("uloha-emoji-cancel-task-a").disabled).toBe(true);
+  fireEvent.click(screen.getByTestId("uloha-emoji-cancel-task-a"));
+  expect(screen.getByTestId("uloha-emoji-input-task-a")).toBeTruthy();
+
+  resolveSave(true);
+  await waitFor(() => {
+    expect(updateDailyTaskEmoji).toHaveBeenCalledWith("task-a", "🚚");
+  });
+});

--- a/apps/web/src/components/DailyTasksSection.test.tsx
+++ b/apps/web/src/components/DailyTasksSection.test.tsx
@@ -202,3 +202,60 @@ it("pri 401 POČAS mutácie (nielen počiatočného načítania) tiež zavolá o
     expect(onSessionExpired).toHaveBeenCalled();
   });
 });
+
+// Issue 381 (majiteľ: "to emoji čo si môžeš priradiť na úlohy na dnes tam
+// chcem mať ale sa správa hrozne") — naživo reprodukované na produkcii
+// (komentár na ticket-e): rozpísaný emoji draft sa ticho stratí pri
+// prepnutí na iný riadok, chýba Zrušiť, textový aj emoji editor sa dajú
+// mať otvorené súčasne na tom istom riadku.
+
+it("draft rozpísaného emoji PREŽIJE prepnutie na iný riadok a späť (bez uloženia)", async () => {
+  fetchDailyTasks.mockResolvedValue([ROW_B, ROW_A]);
+  render(<DailyTasksSection onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("uloha-row-task-a");
+
+  // Otvor emoji editor riadku A, rozpíš draft, NEULOŽ.
+  fireEvent.click(screen.getByTestId("uloha-emoji-task-a"));
+  fireEvent.change(screen.getByTestId<HTMLInputElement>("uloha-emoji-input-task-a"), { target: { value: "🎯" } });
+
+  // Appka dovolí len JEDEN otvorený naraz — otvorenie iného riadku ticho
+  // "zavrie" prvý.
+  fireEvent.click(screen.getByTestId("uloha-emoji-task-b"));
+  expect(screen.queryByTestId("uloha-emoji-input-task-a")).toBeNull();
+
+  // Zavri riadok B (Zrušiť, bez uloženia) a znova otvor riadok A — draft
+  // 🎯 musí byť STÁLE tam, appka ho nesmie zahodiť len preto, že si sa
+  // pozrel na iný riadok.
+  fireEvent.click(screen.getByTestId("uloha-emoji-cancel-task-b"));
+  fireEvent.click(screen.getByTestId("uloha-emoji-task-a"));
+  expect(screen.getByTestId<HTMLInputElement>("uloha-emoji-input-task-a").value).toBe("🎯");
+});
+
+it("Zrušiť v emoji editore ho zavrie BEZ uloženia a zahodí draft (ďalšie otvorenie ukáže znova serverovú hodnotu)", async () => {
+  fetchDailyTasks.mockResolvedValueOnce([ROW_A]);
+  render(<DailyTasksSection onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("uloha-row-task-a");
+
+  fireEvent.click(screen.getByTestId("uloha-emoji-task-a"));
+  fireEvent.change(screen.getByTestId<HTMLInputElement>("uloha-emoji-input-task-a"), { target: { value: "🚚" } });
+  fireEvent.click(screen.getByTestId("uloha-emoji-cancel-task-a"));
+
+  expect(updateDailyTaskEmoji).not.toHaveBeenCalled();
+  expect(screen.queryByTestId("uloha-emoji-input-task-a")).toBeNull();
+
+  fireEvent.click(screen.getByTestId("uloha-emoji-task-a"));
+  expect(screen.getByTestId<HTMLInputElement>("uloha-emoji-input-task-a").value).toBe("");
+});
+
+it("otvorenie textového editora zavrie emoji editor TOHO ISTÉHO riadku (nikdy oba naraz)", async () => {
+  fetchDailyTasks.mockResolvedValueOnce([ROW_A]);
+  render(<DailyTasksSection onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("uloha-row-task-a");
+
+  fireEvent.click(screen.getByTestId("uloha-emoji-task-a"));
+  expect(screen.getByTestId("uloha-emoji-input-task-a")).toBeTruthy();
+
+  fireEvent.click(screen.getByTestId("uloha-edit-task-a"));
+  expect(screen.queryByTestId("uloha-emoji-input-task-a")).toBeNull();
+  expect(screen.getByTestId("uloha-edit-input-task-a")).toBeTruthy();
+});

--- a/apps/web/src/components/DailyTasksSection.tsx
+++ b/apps/web/src/components/DailyTasksSection.tsx
@@ -21,6 +21,15 @@ import {
 // `ComponentType<SectionProps>` (`nav.ts`), lebo objekt s VIAC poľami (role
 // navyše) sa dá vždy odovzdať tam, kde sa čaká len podmnožina.
 
+// Issue 381: odstráni draft PRE JEDEN riadok z `emojiDraft` bez `delete`
+// operátora (`@typescript-eslint/no-dynamic-delete` zakazuje `delete
+// next[dynamickýKľúč]`) — filtrovanie cez `Object.entries` je funkčne
+// rovnaké, len lint-safe.
+function forgetEmojiDraft(draft: Record<string, string>, id: string): Record<string, string> {
+  if (!(id in draft)) return draft;
+  return Object.fromEntries(Object.entries(draft).filter(([key]) => key !== id));
+}
+
 export function DailyTasksSection({ onSessionExpired }: { readonly onSessionExpired: () => void }): JSX.Element {
   const [rows, setRows] = useState<readonly DailyTaskRow[] | null>(null);
   const [error, setError] = useState("");
@@ -149,6 +158,10 @@ export function DailyTasksSection({ onSessionExpired }: { readonly onSessionExpi
           // Rovnaký dôvod ako `saveText` vyššie — nezavrieť CUDZÍ, medzitým
           // otvorený emoji editor.
           if (editingEmojiIdRef.current === id) setEditingEmojiId(null);
+          // Issue 381: draft je teraz uložený, zahoď ho — ĎALŠIE otvorenie
+          // musí znova nasadiť čerstvú serverovú hodnotu, nie tento (už
+          // uložený, prípadne časom zastaraný) záznam.
+          setEmojiDraft((d) => forgetEmojiDraft(d, id));
           load();
         })
         .catch((err: unknown) => {
@@ -160,6 +173,40 @@ export function DailyTasksSection({ onSessionExpired }: { readonly onSessionExpi
     },
     [emojiDraft, load, handleActionError],
   );
+
+  // Issue 381: majiteľ nahlásil, že priraďovanie emoji "sa správa hrozne" —
+  // naživo overené (komentár na ticket-e): (1) rozpísaný draft sa ticho
+  // stratí pri prepnutí na iný riadok, (2) chýba Zrušiť, (3) textový aj
+  // emoji editor sa dajú mať otvorené súčasne na tom istom riadku. Tri
+  // opravy nižšie, minimálne, správanie funkcie samotnej nemenia.
+
+  // Draft sa nasadí len keď PRE TENTO riadok ešte neexistuje (prvé
+  // otvorenie od posledného uloženia/zrušenia) — nie bezpodmienečne pri
+  // KAŽDOM kliknutí. Vďaka tomu draft prežije prepnutie na iný riadok a
+  // späť namiesto toho, aby ho každé ďalšie otvorenie ticho prepísalo
+  // serverovou hodnotou.
+  const openEmojiEditor = useCallback((row: DailyTaskRow) => {
+    setEmojiDraft((d) => (row.id in d ? d : { ...d, [row.id]: row.emoji ?? "" }));
+    // Textový a emoji editor sa nesmú dať mať otvorené súčasne na tom
+    // istom riadku (viedlo to k dvom identickým 💾 tlačidlám vedľa seba).
+    setEditingTextId((current) => (current === row.id ? null : current));
+    setEditingEmojiId(row.id);
+  }, []);
+
+  const openTextEditor = useCallback((row: DailyTaskRow) => {
+    setTextDraft((d) => ({ ...d, [row.id]: row.text }));
+    setEditingEmojiId((current) => (current === row.id ? null : current));
+    setEditingTextId(row.id);
+  }, []);
+
+  // Explicitné Zrušiť pre emoji editor (textový editor už jedno má) —
+  // predtým bol jediný spôsob odchodu Uložiť, aj s prázdnou/nechcenou
+  // hodnotou. Draft sa zahodí, aby ďalšie otvorenie ukázalo znova
+  // serverovú hodnotu, nie tento zrušený pokus.
+  const cancelEmojiEdit = useCallback((id: string) => {
+    setEditingEmojiId((current) => (current === id ? null : current));
+    setEmojiDraft((d) => forgetEmojiDraft(d, id));
+  }, []);
 
   const removeTask = useCallback(
     (id: string) => {
@@ -331,6 +378,18 @@ export function DailyTasksSection({ onSessionExpired }: { readonly onSessionExpi
                     >
                       💾
                     </button>
+                    <button
+                      type="button"
+                      className="uloha-icon-btn"
+                      onClick={() => {
+                        cancelEmojiEdit(row.id);
+                      }}
+                      title="Zrušiť"
+                      aria-label="Zrušiť úpravu emoji"
+                      data-testid={`uloha-emoji-cancel-${row.id}`}
+                    >
+                      ✕
+                    </button>
                   </>
                 )}
 
@@ -340,8 +399,7 @@ export function DailyTasksSection({ onSessionExpired }: { readonly onSessionExpi
                       type="button"
                       className="uloha-icon-btn"
                       onClick={() => {
-                        setTextDraft((d) => ({ ...d, [row.id]: row.text }));
-                        setEditingTextId(row.id);
+                        openTextEditor(row);
                       }}
                       title="Upraviť text"
                       aria-label={`Upraviť text úlohy ${row.text}`}
@@ -354,8 +412,7 @@ export function DailyTasksSection({ onSessionExpired }: { readonly onSessionExpi
                         type="button"
                         className="uloha-icon-btn"
                         onClick={() => {
-                          setEmojiDraft((d) => ({ ...d, [row.id]: row.emoji ?? "" }));
-                          setEditingEmojiId(row.id);
+                          openEmojiEditor(row);
                         }}
                         title="Pridať/zmeniť emoji"
                         aria-label={`Pridať/zmeniť emoji úlohy ${row.text}`}

--- a/apps/web/src/components/DailyTasksSection.tsx
+++ b/apps/web/src/components/DailyTasksSection.tsx
@@ -378,9 +378,16 @@ export function DailyTasksSection({ onSessionExpired }: { readonly onSessionExpi
                     >
                       💾
                     </button>
+                    {/* Review dispatch (issue 381): bez `disabled={busy}` by Zrušiť
+                        počas ROZBEHNUTÉHO uloženia TOHO ISTÉHO riadku otvorilo
+                        okno na race — zrušenie + nový rozpis medzitým a
+                        následné doručenie PÔVODNEJ (už "zrušenej") odpovede
+                        by ten nový rozpis ticho zahodilo cez `saveEmoji`'s
+                        `forgetEmojiDraft`. Rovnaký `busy` guard ako má Save. */}
                     <button
                       type="button"
                       className="uloha-icon-btn"
+                      disabled={busy}
                       onClick={() => {
                         cancelEmojiEdit(row.id);
                       }}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,7 +2,19 @@ import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 
 export default tseslint.config(
-  { ignores: ["**/dist/**", "**/dist-types/**", "**/node_modules/**", "**/*.config.js"] },
+  {
+    ignores: [
+      "**/dist/**",
+      "**/dist-types/**",
+      "**/node_modules/**",
+      "**/*.config.js",
+      // Izolované worktrees dispatchnutých agentov: sú to celé kópie repa, ktoré
+      // typovaný parser nevie priradiť k tomuto tsconfigu (allowDefaultProject
+      // sedí len na koreňové apps/*/…config.ts), takže lint na nich padá na
+      // parsing errors, hoci ich obsah sa nikdy necommituje.
+      ".claude/worktrees/**",
+    ],
+  },
   js.configs.recommended,
   ...tseslint.configs.strictTypeChecked,
   {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.221",
+  "version": "0.3.0-dev.223",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.221",
+  "version": "0.3.0-dev.222",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Dva tickety + jedna údržbová oprava lintu.

## issue 381 — emoji na obrazovke Úlohy na dnes

Funkcia zostáva, opravené je jej ovládanie (`apps/web/src/components/DailyTasksSection.tsx`).
Naživo reprodukované prejavy:

- rozpísané emoji sa ticho stratilo, keď sa medzitým otvoril editor na inom riadku,
- emoji editor nemal tlačidlo Zrušiť (na rozdiel od textového),
- na tom istom riadku sa dali otvoriť oba editory naraz (dve rovnaké tlačidlá vedľa seba),
- tlačidlo Zrušiť počas prebiehajúceho ukladania mohlo zahodiť novo rozpísanú zmenu (nález z review).

Ku každému prejavu regresný test (RED pred opravou, GREEN po nej), spolu 4 nové testy.

## issue 376 — čas nočného sťahovania záloh na dev1

Dokumentačná oprava. Skutočný čas sa zatiaľ overiť NEDAL — server vznikol dnes cez deň,
prvé reálne nočné okno je až dnes v noci — a `.claude/rules/backups.md` to teraz priznáva
a dáva reprodukovateľný postup na overenie (odtlačok kľúča z `authorized_keys` → `grep`
v `auth.log`). Ticket zámerne zostáva otvorený, zavrie sa po prvej noci s reálnymi časmi.
Opravená aj zastaraná poznámka „box-lokálny čas = UTC" (box beží na Europe/Bratislava).

## Údržba

`eslint.config.js` ignoruje `.claude/worktrees/**` — sú to celé kópie repa, ktoré typovaný
parser nevie priradiť k tomuto tsconfigu, takže lint na nich padal a blokoval každý push,
keď paralelne bežal dispatchnutý agent.

## Testy

- `pnpm gates:local`: typecheck čistý, lint čistý, 742 API + 605 web testov zelených
