### PR TITLE
Upozornenia: kalendár 3 najbližšie udalosti + kompaktnejšie karty (issue 382)

### DIFF
--- a/.claude/rules/calendar.md
+++ b/.claude/rules/calendar.md
@@ -70,3 +70,16 @@ paths:
   začalo čakať. Prvý pokus (`toHaveCount(0)` hneď po prihlásení, bez
   `waitForResponse`) by prešiel aj VŽDY (komponent renderuje `null` aj
   počas načítavania, aj pri `configured:false`) — nedokazoval by nič.
+- **Issue 382 (majiteľ chce vidieť TRI najbližšie udalosti, nie jednu):
+  `resolveNextEvent(icsText, now)` sa premenovalo na `resolveNextEvents
+  (icsText, now, limit)` — vracia ZORADENÉ pole (max `limit`, konštanta
+  `NEXT_EVENTS_LIMIT = 3` v `constants.ts`), nikdy singulárny `T | null`.
+  Rovnaká zmena prešla CELÝM reťazcom: `NextEventResult`'s `event` →
+  `events` (`service.ts`), HTTP odpoveď `event` → `events`
+  (`calendar-routes.ts`), zod schéma aj `NextCalendarEventCard.tsx`
+  (mapuje pole na max 3 riadky). Žiadna INÁ logika (poradie, filtrovanie
+  CANCELLED, celodenné/RRULE spracovanie) sa nemenila — len návratový
+  tvar a orezanie na `limit`. Pri KAŽDOM ĎALŠOM "zobraz N namiesto 1"
+  tickete v tomto module: rovnaký vzor (funkcia dostane `limit` parameter,
+  vráti pole, `.slice(0, limit)` na konci), nie duplicitná druhá funkcia
+  vedľa pôvodnej.

--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -1205,3 +1205,55 @@ paths:
   container:** the true minimum width is `Σ(children widths) + gap ×
   (children − 1)`, not just `Σ(children widths)` — measure or compute
   that explicitly before trusting `space-between` to "make it fit".
+- **`grid-template-columns: repeat(auto-fill, minmax(X, 1fr))` squeezes a
+  LONE item to a fraction of the container instead of giving it the full
+  width — `auto-fit` is almost always what you actually want.** Issue 382
+  (`.upozornenia-list`, majiteľ: "nech sa vojde viac vedľa seba, keď je
+  miesto"): the first attempt used `auto-fill`, which RESERVES as many
+  column tracks as fit the container's width at the given minimum, even
+  when those tracks hold no item — a container wide enough for 3 tracks
+  with only ONE real card in it still gets 3 equal `1fr` tracks, so the
+  one card gets ~1/3 the width instead of the full width. This broke an
+  EXISTING e2e test (issue 327's "action row stays on one line") the
+  moment a test created just one card — the card's real width dropped
+  from ~1300px to ~420px and its button row wrapped to two lines,
+  LOOKING exactly like a regression in the button-row CSS itself, when
+  the real cause was the grid keyword. `auto-fit` collapses genuinely
+  EMPTY tracks to 0 width and lets `1fr` redistribute their share to the
+  tracks that DO hold an item — a lone card gets 100% of the width
+  (identical to the previous `flex-direction: column` behavior), while N
+  cards still sit side by side exactly like `auto-fill` would arrange
+  them. Use `auto-fit` by default for a "cards that wrap when there's
+  room" grid; reach for `auto-fill` only when you deliberately want
+  visible empty slots reserved (rare — a fixed-size palette/swatch grid,
+  not a variable-count card list).
+- **The `minmax(X, 1fr)` MINIMUM in that same pattern needs a
+  `min(Xpx, 100%)` wrapper whenever the container can ever be narrower
+  than X — a bare `minmax(500px, 1fr)` overflows on any screen under
+  500px, and on a `wide: true` tab (`nav.ts`) that overflow is SILENTLY
+  CLIPPED, not scrollable, because `.main-wide` has `overflow-x: hidden`
+  (this file, §1).** Found by an independent review dispatch on issue
+  382, not by any existing test — confirmed live at 375px
+  (`document.documentElement.scrollWidth` stayed pinned to the forced
+  minimum while `window.innerWidth` was smaller, meaning content past
+  the edge was genuinely unreachable, no scrollbar). Fix:
+  `minmax(min(500px, 100%), 1fr)` — identical behavior above 500px
+  (`min` picks the 500px branch), but on a narrower container `min`
+  picks `100%` instead, so the track shrinks to fit rather than forcing
+  overflow. Any FUTURE `auto-fit`/`auto-fill` grid on a `wide: true`
+  screen in this app needs this same `min(...)` wrapper — verify with a
+  live narrow-viewport check (this file's own established methodology,
+  issues 161/190/291), not just a wide-screen screenshot.
+- **The exact minimum column width for a "keep this card's inline
+  action row on one line" grid floor is NOT a round guess — measure it
+  live with `page.addStyleTag` overriding `grid-template-columns` to a
+  sequence of candidate PIXEL widths (not percentages), same technique
+  as the `<colgroup>` methodology (issues 105/107/111/127) applied to a
+  grid instead of a table.** Issue 382's `.upozornenia-actions` (issue
+  327's date input + 4 buttons) wraps to two lines below ~490px card
+  width — binary-searched live (340→500px candidates) rather than
+  assumed, landing on a 500px floor (small margin above the measured
+  ~487px threshold). A round guess here would either break the existing
+  one-line invariant (too narrow) or needlessly suppress multi-column
+  layout on common viewports (too wide, e.g. picking 600px+ "to be
+  safe").

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -125,6 +125,22 @@ paths:
   dodávateľa by teda prežívali z predošlého e2e behu do ďalšieho, presne tá
   istá tichá pasca, akú `.claude/rules/supplier-stock.md` popisuje pre
   integračné testy. Pri KAŽDEJ novej koreňovej tabuľke uprav OBA zoznamy naraz.
+- **`upozornenie` tabuľka CHÝBA v OBOCH TRUNCATE zoznamoch (`scripts/
+  e2e-setup.ts` AJ `apps/api/tests/helpers/db.ts`) — nájdené issue 382,
+  zapísané ako #384, zatiaľ NEOPRAVENÉ.** Neškodilo to, kým karty boli
+  vždy `flex-direction: column` (vždy celá šírka, bez ohľadu na počet) —
+  po issue 382's CSS Grid rozložení (`.upozornenia-list`) môžu
+  NEVYMAZANÉ riadky z PREDCHÁDZAJÚCEHO lokálneho behu (`upozornenia
+  .spec.ts`'s hlavný flow test navyše ÚMYSELNE necháva 2 karty
+  needeletnuté — testuje odloženie/vrátenie, nie mazanie) zmeniť SKUTOČNÝ
+  počet stĺpcov mriežky, a teda aj šírku/výšku existujúcich testovaných
+  kariet — presne toto najprv vyzeralo ako regresia v issue 327's teste
+  ("pás akcií karty ≥25% nižší"), kým sa nenašlo, že príčinou boli
+  LEFTOVER riadky z predchádzajúceho behu, nie samotná CSS zmena. Pred
+  DÔVEROVANÍM akémukoľvek "regresia v `upozornenia.spec.ts`" nálezu na
+  TOMTO lokálnom boxe: `docker exec <postgres-kontajner> psql -U
+  forestshop -d forestshop -c "TRUNCATE TABLE upozornenie RESTART
+  IDENTITY;"` a over znova, kým #384 nie je opravené.
 - **Pridanie čo i len JEDNÉHO variantu do e2e seedu posunie pevné počty v
   `catalog.spec.ts`** (`"Nájdených: N"` aj `"Variantov v katalógu (vrátane
   chýbajúcich): N"`) — nie je to nič, čo by sa dalo obísť, len sa na to musí

--- a/apps/api/src/http/calendar-routes.ts
+++ b/apps/api/src/http/calendar-routes.ts
@@ -14,8 +14,8 @@ import { requireUser, type AppBindings } from "./middleware.js";
 // (rovnaký "configured" vzor ako `dpd-routes.ts`'s `DpdRunDeps`).
 export function registerCalendarRoutes(app: Hono<AppBindings>, db: Database, deps?: NextEventService): void {
   app.get("/api/upozornenia/next-event", requireUser(db), async (c) => {
-    if (deps === undefined) return c.json({ configured: false as const, event: null, error: false });
+    if (deps === undefined) return c.json({ configured: false as const, events: [], error: false });
     const result = await deps.getNextEvent(new Date());
-    return c.json({ configured: true as const, event: result.ok ? result.event : null, error: !result.ok });
+    return c.json({ configured: true as const, events: result.ok ? result.events : [], error: !result.ok });
   });
 }

--- a/apps/api/src/modules/calendar/constants.ts
+++ b/apps/api/src/modules/calendar/constants.ts
@@ -17,6 +17,9 @@ export const NEXT_EVENT_ERROR_CACHE_TTL_MS = 2 * 60 * 1000;
  * zachytenie ročne sa opakujúcej udalosti (napr. narodeniny), no konečné. */
 export const RECURRENCE_EXPANSION_WINDOW_DAYS = 400;
 
+/** issue 382: majiteľ chce vidieť TRI najbližšie udalosti, nie jednu. */
+export const NEXT_EVENTS_LIMIT = 3;
+
 /** Strop veľkosti stiahnutého ICS tela — osobný kalendár je rádovo KB až
  * jednotky MB; 10 MB je veľkorysá, no konečná hranica proti
  * nepriateľskému/pokazenému serveru (rovnaký princíp ako `catalog/

--- a/apps/api/src/modules/calendar/next-event.test.ts
+++ b/apps/api/src/modules/calendar/next-event.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, it } from "vitest";
-import { resolveNextEvent } from "./next-event.js";
+import { resolveNextEvents } from "./next-event.js";
 
 // issue 309: čisté testy nad ICS textom — ŽIADNY test v tomto module (ani v
 // tomto súbore) sa NIKDY nepripája na skutočný Google, presne rovnaká
 // disciplína ako Shoptet/Pošta SK/dodávateľské stránky/DPD portál
 // (`.claude/rules/testing.md`).
+//
+// issue 382: `resolveNextEvent` (jedna udalosť) sa premenovalo na
+// `resolveNextEvents` (pole, max `limit`) — majiteľ chce vidieť TRI
+// najbližšie, nie jednu. Existujúce testy pod jednou udalosťou volajú
+// `next()` (limit 1, vezme prvý prvok poľa) — nová logika (poradie,
+// filtrovanie) je nezmenená, len vracia pole namiesto singulárnej hodnoty.
 
 function ics(lines: readonly string[]): string {
   return ["BEGIN:VCALENDAR", "VERSION:2.0", ...lines, "END:VCALENDAR"].join("\r\n");
@@ -12,13 +18,17 @@ function ics(lines: readonly string[]): string {
 
 const NOW = new Date("2026-08-08T10:00:00Z");
 
-describe("resolveNextEvent — základné prípady", () => {
-  it("prázdny kalendár (0 udalostí) vráti null", () => {
-    expect(resolveNextEvent(ics([]), NOW)).toBeNull();
+function next(icsText: string) {
+  return resolveNextEvents(icsText, NOW, 1)[0] ?? null;
+}
+
+describe("resolveNextEvents — základné prípady", () => {
+  it("prázdny kalendár (0 udalostí) vráti prázdne pole", () => {
+    expect(resolveNextEvents(ics([]), NOW, 3)).toEqual([]);
   });
 
   it("obsah bez BEGIN:VCALENDAR je nahlas považovaný za pokazený feed", () => {
-    expect(() => resolveNextEvent("toto nie je ICS vôbec", NOW)).toThrow(/BEGIN:VCALENDAR/);
+    expect(() => resolveNextEvents("toto nie je ICS vôbec", NOW, 3)).toThrow(/BEGIN:VCALENDAR/);
   });
 
   it("jedna časovaná (TZID) udalosť v budúcnosti sa vráti s dateLabel a allDay:false", () => {
@@ -31,7 +41,7 @@ describe("resolveNextEvent — základné prípady", () => {
       "DTEND;TZID=Europe/Bratislava:20260812T100000",
       "END:VEVENT",
     ]);
-    const result = resolveNextEvent(text, NOW);
+    const result = next(text);
     expect(result).toEqual({ title: "Stretnutie s dodávateľom", dateLabel: "streda 12. 8.", allDay: false });
   });
 
@@ -45,7 +55,7 @@ describe("resolveNextEvent — základné prípady", () => {
       "DTEND;TZID=Europe/Bratislava:20260801T100000",
       "END:VEVENT",
     ]);
-    expect(resolveNextEvent(text, NOW)).toBeNull();
+    expect(next(text)).toBeNull();
   });
 
   it("PREBIEHAJÚCA udalosť (začala pred `now`, ešte neskončila) sa počíta ako najbližšia — dispatch: 'najbližšia = neskončila'", () => {
@@ -58,7 +68,7 @@ describe("resolveNextEvent — základné prípady", () => {
       "DTEND;TZID=Europe/Bratislava:20260808T140000",
       "END:VEVENT",
     ]);
-    const result = resolveNextEvent(text, NOW);
+    const result = next(text);
     expect(result?.title).toBe("Prebiehajúca schôdza");
   });
 
@@ -79,7 +89,7 @@ describe("resolveNextEvent — základné prípady", () => {
       "DTEND;TZID=Europe/Bratislava:20260810T100000",
       "END:VEVENT",
     ]);
-    const result = resolveNextEvent(text, NOW);
+    const result = next(text);
     expect(result?.title).toBe("Skoršia");
   });
 
@@ -94,11 +104,11 @@ describe("resolveNextEvent — základné prípady", () => {
       "STATUS:CANCELLED",
       "END:VEVENT",
     ]);
-    expect(resolveNextEvent(text, NOW)).toBeNull();
+    expect(next(text)).toBeNull();
   });
 });
 
-describe("resolveNextEvent — celodenné (VALUE=DATE) udalosti", () => {
+describe("resolveNextEvents — celodenné (VALUE=DATE) udalosti", () => {
   it("celodenná udalosť DNES sa počíta ako neskončená (end je exkluzívna hranica nasledujúceho dňa)", () => {
     const text = ics([
       "BEGIN:VEVENT",
@@ -109,7 +119,7 @@ describe("resolveNextEvent — celodenné (VALUE=DATE) udalosti", () => {
       "DTEND;VALUE=DATE:20260809",
       "END:VEVENT",
     ]);
-    const result = resolveNextEvent(text, NOW);
+    const result = next(text);
     expect(result?.title).toBe("Sviatok");
     expect(result?.allDay).toBe(true);
   });
@@ -124,7 +134,7 @@ describe("resolveNextEvent — celodenné (VALUE=DATE) udalosti", () => {
       "DTEND;VALUE=DATE:20260808",
       "END:VEVENT",
     ]);
-    expect(resolveNextEvent(text, NOW)).toBeNull();
+    expect(next(text)).toBeNull();
   });
 
   it("dateLabel má presne tvar 'deň dátum. mesiac.' v slovenčine", () => {
@@ -137,12 +147,12 @@ describe("resolveNextEvent — celodenné (VALUE=DATE) udalosti", () => {
       "DTEND;VALUE=DATE:20260813",
       "END:VEVENT",
     ]);
-    const result = resolveNextEvent(text, NOW);
+    const result = next(text);
     expect(result?.dateLabel).toBe("streda 12. 8.");
   });
 });
 
-describe("resolveNextEvent — opakujúce sa udalosti (RRULE)", () => {
+describe("resolveNextEvents — opakujúce sa udalosti (RRULE)", () => {
   it("týždenne opakujúca sa udalosť vráti NAJBLIŽŠIU budúcu inštanciu, nie prvý výskyt v minulosti", () => {
     const text = ics([
       "BEGIN:VEVENT",
@@ -154,7 +164,7 @@ describe("resolveNextEvent — opakujúce sa udalosti (RRULE)", () => {
       "RRULE:FREQ=WEEKLY;BYDAY=MO",
       "END:VEVENT",
     ]);
-    const result = resolveNextEvent(text, NOW);
+    const result = next(text);
     // NOW = streda 2026-08-08 10:00 UTC → najbližší pondelok je 2026-08-10.
     expect(result?.title).toBe("Týždenná porada");
     expect(result?.dateLabel).toBe("pondelok 10. 8.");
@@ -172,12 +182,12 @@ describe("resolveNextEvent — opakujúce sa udalosti (RRULE)", () => {
       "EXDATE;TZID=Europe/Bratislava:20260810T090000",
       "END:VEVENT",
     ]);
-    const result = resolveNextEvent(text, NOW);
+    const result = next(text);
     expect(result?.dateLabel).toBe("pondelok 17. 8.");
   });
 });
 
-describe("resolveNextEvent — viacero VEVENT typov naraz", () => {
+describe("resolveNextEvents — viacero VEVENT typov naraz", () => {
   it("kombinácia jednorazovej + opakujúcej sa udalosti vyberie skutočne najbližšiu z OBOCH", () => {
     const text = ics([
       "BEGIN:VEVENT",
@@ -196,7 +206,56 @@ describe("resolveNextEvent — viacero VEVENT typov naraz", () => {
       "RRULE:FREQ=WEEKLY;BYDAY=MO",
       "END:VEVENT",
     ]);
-    const result = resolveNextEvent(text, NOW);
+    const result = next(text);
     expect(result?.title).toBe("Jednorazová skoro");
+  });
+});
+
+// issue 382: majiteľ chce vidieť TRI najbližšie udalosti, nie jednu.
+describe("resolveNextEvents — limit (issue 382)", () => {
+  function threeFutureEvents(): string {
+    return ics([
+      "BEGIN:VEVENT",
+      "UID:prva@test",
+      "DTSTAMP:20260101T000000Z",
+      "SUMMARY:Prvá",
+      "DTSTART;TZID=Europe/Bratislava:20260809T090000",
+      "DTEND;TZID=Europe/Bratislava:20260809T100000",
+      "END:VEVENT",
+      "BEGIN:VEVENT",
+      "UID:druha@test",
+      "DTSTAMP:20260101T000000Z",
+      "SUMMARY:Druhá",
+      "DTSTART;TZID=Europe/Bratislava:20260810T090000",
+      "DTEND;TZID=Europe/Bratislava:20260810T100000",
+      "END:VEVENT",
+      "BEGIN:VEVENT",
+      "UID:tretia@test",
+      "DTSTAMP:20260101T000000Z",
+      "SUMMARY:Tretia",
+      "DTSTART;TZID=Europe/Bratislava:20260811T090000",
+      "DTEND;TZID=Europe/Bratislava:20260811T100000",
+      "END:VEVENT",
+    ]);
+  }
+
+  it("vráti až `limit` najbližších udalostí, ZORADENÉ podľa najskoršieho začiatku", () => {
+    const result = resolveNextEvents(threeFutureEvents(), NOW, 3);
+    expect(result.map((e) => e.title)).toEqual(["Prvá", "Druhá", "Tretia"]);
+  });
+
+  it("keď je dostupných udalostí MENEJ než `limit`, vráti len toľko, koľko naozaj je (nikdy sa nedopĺňa)", () => {
+    const result = resolveNextEvents(threeFutureEvents(), NOW, 10);
+    expect(result).toHaveLength(3);
+  });
+
+  it("keď je dostupných udalostí VIAC než `limit`, orezáva sa presne na `limit`, nikdy viac", () => {
+    const result = resolveNextEvents(threeFutureEvents(), NOW, 2);
+    expect(result.map((e) => e.title)).toEqual(["Prvá", "Druhá"]);
+  });
+
+  it("`limit: 1` sa správa rovnako ako pôvodná singulárna funkcia (prvý prvok poľa)", () => {
+    const result = resolveNextEvents(threeFutureEvents(), NOW, 1);
+    expect(result).toEqual([{ title: "Prvá", dateLabel: "nedeľa 9. 8.", allDay: false }]);
   });
 });

--- a/apps/api/src/modules/calendar/next-event.ts
+++ b/apps/api/src/modules/calendar/next-event.ts
@@ -59,8 +59,12 @@ function hasNotEnded(candidate: Candidate, now: Date): boolean {
  * stránka vrátená s HTTP 200) ticho vyzeral ako "žiadna nadchádzajúca
  * udalosť" namiesto toho, aby nahlas zlyhal (dispatch: "Fetch failure /
  * malformed feed → fail loud, never crash, never show raw error").
+ *
+ * issue 382: majiteľ chce TRI najbližšie udalosti, nie jednu — `limit`
+ * rozhoduje koľko sa vráti (zoradené podľa najskoršieho začiatku), NIKDY
+ * viac než reálne dostupných kandidátov.
  */
-export function resolveNextEvent(icsText: string, now: Date): NextCalendarEvent | null {
+export function resolveNextEvents(icsText: string, now: Date, limit: number): NextCalendarEvent[] {
   if (!icsText.includes("BEGIN:VCALENDAR")) {
     throw new Error("Stiahnutý obsah nevyzerá ako platný ICS kalendár (chýba BEGIN:VCALENDAR)");
   }
@@ -86,7 +90,5 @@ export function resolveNextEvent(icsText: string, now: Date): NextCalendarEvent 
   }
 
   const upcoming = candidates.filter((c) => hasNotEnded(c, now)).sort((a, b) => a.start.getTime() - b.start.getTime());
-  const next = upcoming[0];
-  if (next === undefined) return null;
-  return { title: next.title, dateLabel: formatDateLabel(next.start), allDay: next.allDay };
+  return upcoming.slice(0, limit).map((c) => ({ title: c.title, dateLabel: formatDateLabel(c.start), allDay: c.allDay }));
 }

--- a/apps/api/src/modules/calendar/service.test.ts
+++ b/apps/api/src/modules/calendar/service.test.ts
@@ -28,6 +28,42 @@ describe("createNextEventService — cache", () => {
     await expect(service.getNextEvent(NOW)).resolves.toEqual({ ok: false });
   });
 
+  // issue 382: majiteľ chce TRI najbližšie udalosti — `getNextEvent` vracia
+  // pole (`events`), nie singulárnu `event` hodnotu.
+  it("nakonfigurované s TROMI budúcimi udalosťami vráti pole VŠETKÝCH troch (limit 3)", async () => {
+    const ics = [
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      "BEGIN:VEVENT",
+      "UID:e1@test",
+      "DTSTAMP:20260101T000000Z",
+      "SUMMARY:Prvá",
+      "DTSTART;TZID=Europe/Bratislava:20260809T090000",
+      "DTEND;TZID=Europe/Bratislava:20260809T100000",
+      "END:VEVENT",
+      "BEGIN:VEVENT",
+      "UID:e2@test",
+      "DTSTAMP:20260101T000000Z",
+      "SUMMARY:Druhá",
+      "DTSTART;TZID=Europe/Bratislava:20260810T090000",
+      "DTEND;TZID=Europe/Bratislava:20260810T100000",
+      "END:VEVENT",
+      "BEGIN:VEVENT",
+      "UID:e3@test",
+      "DTSTAMP:20260101T000000Z",
+      "SUMMARY:Tretia",
+      "DTSTART;TZID=Europe/Bratislava:20260811T090000",
+      "DTEND;TZID=Europe/Bratislava:20260811T100000",
+      "END:VEVENT",
+      "END:VCALENDAR",
+    ].join("\r\n");
+    const fetchIcs = vi.fn().mockResolvedValue(ics);
+    const service = createNextEventService(fetchIcs);
+    const result = await service.getNextEvent(NOW);
+    expect(result.ok).toBe(true);
+    expect(result.ok && result.events.map((e) => e.title)).toEqual(["Prvá", "Druhá", "Tretia"]);
+  });
+
   it("zlyhanie sa cachuje LEN na kratšiu error TTL — po jej uplynutí appka skúsi znova", async () => {
     const fetchIcs = vi.fn().mockRejectedValueOnce(new Error("výpadok")).mockResolvedValueOnce(ICS);
     const service = createNextEventService(fetchIcs);
@@ -38,14 +74,14 @@ describe("createNextEventService — cache", () => {
     // Po uplynutí error TTL — skúsi znova a tentokrát uspeje.
     const result = await service.getNextEvent(new Date(NOW.getTime() + NEXT_EVENT_ERROR_CACHE_TTL_MS + 1));
     expect(fetchIcs).toHaveBeenCalledTimes(2);
-    expect(result).toEqual({ ok: true, event: null });
+    expect(result).toEqual({ ok: true, events: [] });
   });
 
   it("úspešné-ale-prázdne (žiadna udalosť) sa cachuje ako úspešný výsledok, nie ako chyba", async () => {
     const fetchIcs = vi.fn().mockResolvedValue(ICS);
     const service = createNextEventService(fetchIcs);
     const result = await service.getNextEvent(NOW);
-    expect(result).toEqual({ ok: true, event: null });
+    expect(result).toEqual({ ok: true, events: [] });
   });
 
   it("SÚBEŽNÉ volania počas prebiehajúceho fetchu zdieľajú JEDEN prísľub — fetchIcs sa zavolá len raz", async () => {

--- a/apps/api/src/modules/calendar/service.ts
+++ b/apps/api/src/modules/calendar/service.ts
@@ -8,10 +8,12 @@
 
 import { log } from "../../logger.js";
 import type { IcsFetcher } from "./fetcher.js";
-import { resolveNextEvent, type NextCalendarEvent } from "./next-event.js";
-import { NEXT_EVENT_ERROR_CACHE_TTL_MS, NEXT_EVENT_OK_CACHE_TTL_MS } from "./constants.js";
+import { resolveNextEvents, type NextCalendarEvent } from "./next-event.js";
+import { NEXT_EVENT_ERROR_CACHE_TTL_MS, NEXT_EVENT_OK_CACHE_TTL_MS, NEXT_EVENTS_LIMIT } from "./constants.js";
 
-export type NextEventResult = { readonly ok: true; readonly event: NextCalendarEvent | null } | { readonly ok: false };
+// issue 382: pole namiesto singulárnej udalosti — majiteľ chce TRI
+// najbližšie, nie jednu (`NEXT_EVENTS_LIMIT`).
+export type NextEventResult = { readonly ok: true; readonly events: readonly NextCalendarEvent[] } | { readonly ok: false };
 
 export interface NextEventService {
   getNextEvent(now: Date): Promise<NextEventResult>;
@@ -34,8 +36,8 @@ export function createNextEventService(fetchIcs: IcsFetcher): NextEventService {
   async function refresh(now: Date): Promise<CacheEntry> {
     try {
       const icsText = await fetchIcs();
-      const event = resolveNextEvent(icsText, now);
-      return { result: { ok: true, event }, cachedAtMs: now.getTime(), ttlMs: NEXT_EVENT_OK_CACHE_TTL_MS };
+      const events = resolveNextEvents(icsText, now, NEXT_EVENTS_LIMIT);
+      return { result: { ok: true, events }, cachedAtMs: now.getTime(), ttlMs: NEXT_EVENT_OK_CACHE_TTL_MS };
     } catch (error) {
       const rawErrorMessage = error instanceof Error ? error.message : String(error);
       // Chybová hláška NIKDY neobsahuje URL (`fetcher.ts`'s vlastný

--- a/apps/api/tests/calendar-http.integration.test.ts
+++ b/apps/api/tests/calendar-http.integration.test.ts
@@ -64,19 +64,22 @@ it("bez dodanej nextEvent service vráti configured:false, žiadny fetch sa nevo
   const { app, cookie } = await boot();
   const res = await app.request("/api/upozornenia/next-event", { headers: { cookie } });
   expect(res.status).toBe(200);
-  await expect(res.json()).resolves.toEqual({ configured: false, event: null, error: false });
+  await expect(res.json()).resolves.toEqual({ configured: false, events: [], error: false });
 });
 
-it("s nakonfigurovanou service vráti najbližšiu udalosť z (falošne) stiahnutého ICS", async () => {
+// issue 382: majiteľ chce TRI najbližšie udalosti — trasa vracia pole
+// `events`, nie singulárnu `event` hodnotu.
+it("s nakonfigurovanou service vráti najbližšie udalosti z (falošne) stiahnutého ICS", async () => {
   const service = createNextEventService(() => Promise.resolve(icsWithEventTomorrow()));
   const { app, cookie } = await boot(service);
   const res = await app.request("/api/upozornenia/next-event", { headers: { cookie } });
   expect(res.status).toBe(200);
-  const body = (await res.json()) as { configured: boolean; error: boolean; event: { title: string; allDay: boolean } | null };
+  const body = (await res.json()) as { configured: boolean; error: boolean; events: { title: string; allDay: boolean }[] };
   expect(body.configured).toBe(true);
   expect(body.error).toBe(false);
-  expect(body.event?.title).toBe("Stretnutie s dodávateľom");
-  expect(body.event?.allDay).toBe(false);
+  expect(body.events).toHaveLength(1);
+  expect(body.events[0]?.title).toBe("Stretnutie s dodávateľom");
+  expect(body.events[0]?.allDay).toBe(false);
 });
 
 it("keď fetch zlyhá, appka vráti error:true, nikdy surovú chybu ani pád", async () => {
@@ -84,7 +87,7 @@ it("keď fetch zlyhá, appka vráti error:true, nikdy surovú chybu ani pád", a
   const { app, cookie } = await boot(service);
   const res = await app.request("/api/upozornenia/next-event", { headers: { cookie } });
   expect(res.status).toBe(200);
-  await expect(res.json()).resolves.toEqual({ configured: true, event: null, error: true });
+  await expect(res.json()).resolves.toEqual({ configured: true, events: [], error: true });
 });
 
 it("neprihlásený dostane 401", async () => {

--- a/apps/web/src/calendarApi.test.ts
+++ b/apps/web/src/calendarApi.test.ts
@@ -13,29 +13,39 @@ describe("fetchNextCalendarEvent", () => {
     vi.unstubAllGlobals();
   });
 
-  it("nenakonfigurované → configured:false, event:null", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ configured: false, event: null, error: false })));
-    await expect(fetchNextCalendarEvent()).resolves.toEqual({ configured: false, event: null, error: false });
+  it("nenakonfigurované → configured:false, events:[]", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ configured: false, events: [], error: false })));
+    await expect(fetchNextCalendarEvent()).resolves.toEqual({ configured: false, events: [], error: false });
   });
 
-  it("nakonfigurované s udalosťou → vráti event presne tak, ako ho poslal server", async () => {
-    const body = { configured: true, event: { title: "Stretnutie", dateLabel: "utorok 12. 8.", allDay: false }, error: false };
+  // issue 382: majiteľ chce TRI najbližšie udalosti — server posiela pole,
+  // klient ho vráti presne tak, ako prišlo (žiadne orezanie na klientovi).
+  it("nakonfigurované s TROMI udalosťami → vráti pole presne tak, ako ho poslal server", async () => {
+    const body = {
+      configured: true,
+      events: [
+        { title: "Prvá", dateLabel: "utorok 12. 8.", allDay: false },
+        { title: "Druhá", dateLabel: "streda 13. 8.", allDay: false },
+        { title: "Tretia", dateLabel: "štvrtok 14. 8.", allDay: true },
+      ],
+      error: false,
+    };
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse(body)));
     await expect(fetchNextCalendarEvent()).resolves.toEqual(body);
   });
 
   it("401 (vypršaná relácia) sa NIKDY nezobrazí ako chyba — bezpečný default", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ error: "Neprihlásený" }, 401)));
-    await expect(fetchNextCalendarEvent()).resolves.toEqual({ configured: false, event: null, error: false });
+    await expect(fetchNextCalendarEvent()).resolves.toEqual({ configured: false, events: [], error: false });
   });
 
   it("sieťová chyba (fetch vyhodí) sa NIKDY nepropaguje ďalej — bezpečný default", async () => {
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
-    await expect(fetchNextCalendarEvent()).resolves.toEqual({ configured: false, event: null, error: false });
+    await expect(fetchNextCalendarEvent()).resolves.toEqual({ configured: false, events: [], error: false });
   });
 
   it("nevalidná odpoveď (zlý tvar JSON) sa NIKDY nepropaguje ďalej — bezpečný default", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ nezmysel: true })));
-    await expect(fetchNextCalendarEvent()).resolves.toEqual({ configured: false, event: null, error: false });
+    await expect(fetchNextCalendarEvent()).resolves.toEqual({ configured: false, events: [], error: false });
   });
 });

--- a/apps/web/src/calendarApi.ts
+++ b/apps/web/src/calendarApi.ts
@@ -4,9 +4,10 @@ import { z } from "zod";
 // Samostatný modul od `upozorneniaApi.ts` (rovnaký dôvod ako na strane API
 // — nie DB-backed "upozornenie", nezávislý read-through pohľad).
 
+// issue 382: pole (až tri udalosti), nie jedna — majiteľova žiadosť.
 const nextEventSchema = z.object({
   configured: z.boolean(),
-  event: z.object({ title: z.string(), dateLabel: z.string(), allDay: z.boolean() }).nullable(),
+  events: z.array(z.object({ title: z.string(), dateLabel: z.string(), allDay: z.boolean() })),
   error: z.boolean(),
 });
 export type NextCalendarEventResult = z.infer<typeof nextEventSchema>;
@@ -16,7 +17,7 @@ export type NextCalendarEventResult = z.infer<typeof nextEventSchema>;
 // nástenke, nikdy nesmie zablokovať/zobraziť chybu namiesto zvyšku
 // "Upozornenia" (rovnaký princíp ako `fetchUpozorneniaCount`'s tolerantný
 // bezpečný default).
-const UNAVAILABLE: NextCalendarEventResult = { configured: false, event: null, error: false };
+const UNAVAILABLE: NextCalendarEventResult = { configured: false, events: [], error: false };
 
 export async function fetchNextCalendarEvent(): Promise<NextCalendarEventResult> {
   try {

--- a/apps/web/src/components/NextCalendarEventCard.test.tsx
+++ b/apps/web/src/components/NextCalendarEventCard.test.tsx
@@ -11,7 +11,7 @@ afterEach(() => {
 });
 
 it("nenakonfigurované → nič sa nezobrazí (žiadna karta)", async () => {
-  fetchNextCalendarEvent.mockResolvedValue({ configured: false, event: null, error: false });
+  fetchNextCalendarEvent.mockResolvedValue({ configured: false, events: [], error: false });
   render(<NextCalendarEventCard />);
   await waitFor(() => {
     expect(fetchNextCalendarEvent).toHaveBeenCalledTimes(1);
@@ -19,23 +19,42 @@ it("nenakonfigurované → nič sa nezobrazí (žiadna karta)", async () => {
   expect(screen.queryByTestId("next-calendar-event")).toBeNull();
 });
 
-it("nakonfigurované s udalosťou → ukáže dátum aj názov", async () => {
-  fetchNextCalendarEvent.mockResolvedValue({ configured: true, event: { title: "Stretnutie s dodávateľom", dateLabel: "utorok 12. 8.", allDay: false }, error: false });
+it("nakonfigurované s JEDNOU udalosťou → ukáže dátum aj názov", async () => {
+  fetchNextCalendarEvent.mockResolvedValue({ configured: true, events: [{ title: "Stretnutie s dodávateľom", dateLabel: "utorok 12. 8.", allDay: false }], error: false });
   render(<NextCalendarEventCard />);
   const card = await screen.findByTestId("next-calendar-event");
   expect(card.textContent).toContain("utorok 12. 8.");
   expect(card.textContent).toContain("Stretnutie s dodávateľom");
 });
 
-it("nakonfigurované, žiadna udalosť → čestná hláška, nie prázdna karta", async () => {
-  fetchNextCalendarEvent.mockResolvedValue({ configured: true, event: null, error: false });
+// issue 382: majiteľ chce vidieť TRI najbližšie udalosti, nie jednu.
+it("nakonfigurované s TROMI udalosťami → ukáže všetky tri, každú vo VLASTNOM riadku", async () => {
+  fetchNextCalendarEvent.mockResolvedValue({
+    configured: true,
+    events: [
+      { title: "Prvá schôdza", dateLabel: "utorok 12. 8.", allDay: false },
+      { title: "Druhá schôdza", dateLabel: "streda 13. 8.", allDay: false },
+      { title: "Tretia schôdza", dateLabel: "štvrtok 14. 8.", allDay: true },
+    ],
+    error: false,
+  });
+  render(<NextCalendarEventCard />);
+  const card = await screen.findByTestId("next-calendar-event");
+  expect(card.textContent).toContain("Prvá schôdza");
+  expect(card.textContent).toContain("Druhá schôdza");
+  expect(card.textContent).toContain("Tretia schôdza");
+  expect(card.querySelectorAll(".next-calendar-event-row")).toHaveLength(3);
+});
+
+it("nakonfigurované, žiadna udalosť (prázdne pole) → čestná hláška, nie prázdna karta", async () => {
+  fetchNextCalendarEvent.mockResolvedValue({ configured: true, events: [], error: false });
   render(<NextCalendarEventCard />);
   const card = await screen.findByTestId("next-calendar-event");
   expect(card.textContent).toMatch(/žiadna nadchádzajúca udalosť/i);
 });
 
 it("nakonfigurované, chyba pri načítaní → čestná hláška o zlyhaní, nikdy surová chyba", async () => {
-  fetchNextCalendarEvent.mockResolvedValue({ configured: true, event: null, error: true });
+  fetchNextCalendarEvent.mockResolvedValue({ configured: true, events: [], error: true });
   render(<NextCalendarEventCard />);
   const card = await screen.findByTestId("next-calendar-event");
   expect(card.textContent).toMatch(/sa nepodarilo načítať/i);
@@ -43,7 +62,7 @@ it("nakonfigurované, chyba pri načítaní → čestná hláška o zlyhaní, ni
 
 describe("mountedRef guard", () => {
   it("výsledok doručený PO odmountovaní sa NEZAPÍŠE (žiadna React varovanie/pád)", async () => {
-    let resolveFetch: (value: { configured: boolean; event: null; error: boolean }) => void = () => {
+    let resolveFetch: (value: { configured: boolean; events: never[]; error: boolean }) => void = () => {
       throw new Error("nemalo sa zavolať pred nastavením");
     };
     fetchNextCalendarEvent.mockReturnValue(
@@ -53,7 +72,7 @@ describe("mountedRef guard", () => {
     );
     const { unmount } = render(<NextCalendarEventCard />);
     unmount();
-    resolveFetch({ configured: true, event: null, error: false });
+    resolveFetch({ configured: true, events: [], error: false });
     await new Promise((r) => setTimeout(r, 0));
     // Nič nepadlo — to je celý dôkaz (`mountedRef` guard v komponente).
   });

--- a/apps/web/src/components/NextCalendarEventCard.tsx
+++ b/apps/web/src/components/NextCalendarEventCard.tsx
@@ -37,13 +37,18 @@ export function NextCalendarEventCard(): JSX.Element | null {
   return (
     <div className="card next-calendar-event-card" data-testid="next-calendar-event">
       {result.error ? (
-        <p>Najbližšiu udalosť z kalendára sa nepodarilo načítať.</p>
-      ) : result.event === null ? (
-        <p>V kalendári nie je žiadna nadchádzajúca udalosť.</p>
+        <p className="next-calendar-event-row">Najbližšiu udalosť z kalendára sa nepodarilo načítať.</p>
+      ) : result.events.length === 0 ? (
+        <p className="next-calendar-event-row">V kalendári nie je žiadna nadchádzajúca udalosť.</p>
       ) : (
-        <p>
-          📅 <strong>{result.event.dateLabel}</strong> — {result.event.title}
-        </p>
+        // issue 382: až TRI najbližšie udalosti namiesto jednej — každá
+        // vlastný kompaktný riadok (`.next-calendar-event-row`, žiadny
+        // predvolený prehliadačový `<p>` margin), nie samostatné karty.
+        result.events.map((event, i) => (
+          <p className="next-calendar-event-row" key={`${event.dateLabel}-${event.title}-${String(i)}`}>
+            📅 <strong>{event.dateLabel}</strong> — {event.title}
+          </p>
+        ))
       )}
     </div>
   );

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2154,10 +2154,22 @@ tr:last-child td {
    stĺpec (rovnaké ako predtým) — presne to, čo ticket žiada ("KDE to
    obsah dovolí", nie vynútene všade). Test pre KAŽDÚ ĎALŠIU zmenu tejto
    dolnej hranice: zmeraj `.upozornenie-actions` výšku pri kandidátnej
-   šírke naživo, nikdy nehádaj okrúhle číslo. */
+   šírke naživo, nikdy nehádaj okrúhle číslo.
+   **Code review nález: holé `minmax(500px, 1fr)` bez `min(...)` obalu
+   pretečie na úzkej obrazovke.** Táto záložka je `wide: true` (`nav.ts`)
+   → `.main-wide` má `overflow-x: hidden` (vyššie v tomto súbore) — na
+   šírke, kde je dostupný priestor menší než 500px (mobil, úzke okno so
+   zbaleným/rozbaleným bočným panelom), by JEDEN stĺpec zostal vynútene
+   500px široký a zvyšok by sa ticho ODREZAL (žiadny scroll na obnovenie,
+   `overflow-x: hidden` ho jednoducho skryje) — presne opak toho, čo
+   `overflow-x: hidden` má chrániť. `minmax(min(500px, 100%), 1fr)` rieši
+   toto BEZ media query: dolná hranica je "500px, alebo 100 % dostupnej
+   šírky, podľa toho, čo je menšie" — na širokej obrazovke sa správa
+   identicky (500px), na úzkej sa stĺpec zmenší na celú (jedinú) dostupnú
+   šírku namiesto pretečenia. */
 .upozornenia-list {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(500px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(500px, 100%), 1fr));
   align-items: start;
   gap: var(--fs-space-4);
 }

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -733,9 +733,28 @@ tr:last-child td {
 }
 
 /* issue 309: "Eshop → Upozornenia" — najbližšia udalosť z Google kalendára,
-   nad prepínačom záložiek. */
+   nad prepínačom záložiek.
+   issue 382 (majiteľ: "ten obdlžnik nech je polovičny na výšku"): rámček
+   bol oproti textu zbytočne vysoký — namerané 73.59px pre JEDNU udalosť pri
+   predvolenom `.card` paddingu (12px/12px) a NEZTLMENOM prehliadačovom
+   `<p>` marginu (~1em/1em navyše). Prvý pokus (`--fs-space-2` padding +
+   `--fs-text-sm`/1.3 riadkovanie + `--fs-space-1` medzera medzi riadkami)
+   naživo nameral len 72.67px PRE TRI udalosti — sotva pod baseline, ďaleko
+   od "polovica". `--fs-text-xs` (12px, appka's vlastná čitateľnosti
+   podlaha, issue 303) + `line-height:1.2` + `padding: var(--fs-space-1)`
+   (4px) + BEZ medzery medzi riadkami (žiadny token pod 4px, tri krátke
+   jednoriadkové položky bez medzery ostávajú čitateľné vďaka vlastnému
+   riadkovaniu) naživo nameralo 53.2px pre TRI udalosti — pod polovicou
+   pôvodnej JEDNEJ (36.8px) sa nedá ísť bez porušenia 12px podlahy, ale
+   toto je najtesnejšie, čo appka dnes dovolí. */
 .next-calendar-event-card {
   margin-bottom: var(--fs-space-4);
+  padding: var(--fs-space-1) var(--fs-space-4);
+}
+.next-calendar-event-row {
+  margin: 0;
+  font-size: var(--fs-text-xs);
+  line-height: 1.2;
 }
 
 /* ---------------- 5. PRIHLASOVACIA OBRAZOVKA ---------------- */
@@ -2106,9 +2125,40 @@ tr:last-child td {
   gap: var(--fs-space-4);
   margin: var(--fs-space-2) 0 var(--fs-space-4);
 }
+/* issue 382 (majiteľ: "vsetko je pod sebou aj ked to vobec nemusi byt"):
+   `auto-fit`/`minmax` necháva prehliadač sám rozhodnúť, koľko kariet sa
+   zmestí vedľa seba pri danej šírke — na úzkej obrazovke spadne späť na
+   jeden stĺpec (rovnaké správanie ako predtým), na širšej ich poukladá
+   vedľa seba bez potreby ručne stanoveného breakpointu. **`auto-fit`, NIE
+   `auto-fill`** — prvý pokus s `auto-fill` rozbil existujúci e2e test
+   (issue 327's "pás akcií karty ≥25 % nižší"): `auto-fill` REZERVUJE
+   toľko stĺpcových stôp, koľko sa ich zmestí, AJ KEĎ sú prázdne (nemajú
+   kartu) — s JEDNOU kartou v zozname to znamenalo, že karta dostala len
+   1/N dostupnej šírky namiesto celej. `auto-fit` NAOPAK skolabuje prázdne
+   stopy na 0px a `1fr` rozdelí zvyšnú šírku medzi SKUTOČNE obsadené
+   stĺpce — jedna karta dostane celú šírku (rovnaké správanie ako predošlý
+   `flex-direction: column`), viac kariet sa poukladá vedľa seba presne
+   rovnako ako `auto-fill` by urobil.
+   **`minmax` dolná hranica je 500px, NIE ľubovoľné okrúhle číslo — naživo
+   zmerané (`page.addStyleTag` na `grid-template-columns`, rovnaká metodika
+   ako issue 105/107/111/127) proti existujúcej karte s dátumovým poľom +
+   4 tlačidlami (issue 327's `.upozornenie-actions`): pás akcií zostáva na
+   JEDNOM riadku (25.59px) až OD ~490px šírky karty, POD touto hranicou sa
+   zalomí na dva riadky (52.39px, presne dvojnásobná výška) — teda presne
+   ten istý bug, čo issue 303/327 opravili, by sa vrátil pre KAŽDÚ kartu,
+   ktorá by sa v mriežke ocitla užšia než táto hranica. 500px (malá
+   rezerva nad zmeraných ~487px) drží kartu VŽDY dosť širokú, aby jej
+   akčný pás nikdy nezalomil, bez ohľadu na to, koľko stĺpcov sa vedľa
+   seba zmestí — dôsledok je, že viacstĺpcové rozloženie sa reálne
+   prejaví až od širších obrazoviek (≥ ~1600px), na 1280px ostáva jeden
+   stĺpec (rovnaké ako predtým) — presne to, čo ticket žiada ("KDE to
+   obsah dovolí", nie vynútene všade). Test pre KAŽDÚ ĎALŠIU zmenu tejto
+   dolnej hranice: zmeraj `.upozornenie-actions` výšku pri kandidátnej
+   šírke naživo, nikdy nehádaj okrúhle číslo. */
 .upozornenia-list {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(500px, 1fr));
+  align-items: start;
   gap: var(--fs-space-4);
 }
 .upozornenie-card {

--- a/apps/web/tests/e2e/upozornenia.spec.ts
+++ b/apps/web/tests/e2e/upozornenia.spec.ts
@@ -208,6 +208,19 @@ test("desktop (1600px): pás akcií karty je ≥25 % nižší než issue 303's b
 // (`getBoundingClientRect`), nie len prítomnosťou CSS triedy `grid`
 // v štýlopise (rovnaký princíp ako issue 263's `getComputedStyle`
 // farebný dôkaz namiesto kontroly `className`).
+//
+// Code review otázka: nezávisí tento test na PARITE/počte prípadných
+// leftover kariet z predchádzajúceho testu v tomto súbore (ten svoje
+// dve karty úmyselne NEMAŽE — testuje odloženie/vrátenie, nie mazanie)?
+// NIE — `listUpozornenia` triedi `asc(dueAt), desc(createdAt)`
+// (`queries.ts`); ani táto dvojica, ani predošlé leftover karty nikdy
+// nenastavujú `dueAt` (zostáva `null`, radí sa AŽ ZA všetky s termínom),
+// takže v rámci "bez termínu" skupiny vyhráva `desc(createdAt)` — dve
+// PRÁVE vytvorené karty sú vždy najnovšie, teda vždy prvé dve v poradí,
+// teda vždy v PRVOM riadku mriežky, bez ohľadu na to, koľko starších
+// kariet leží pod nimi. Overené naživo aj so 4 reálnymi kartami v
+// tabuľke (2 z predchádzajúceho testu + tieto 2) — test prešiel
+// rovnako spoľahlivo ako s čistou tabuľkou.
 test("desktop (1600px): dve karty upozornení sa uložia VEDĽA SEBA, nie pod sebou (issue 382)", async ({ page }) => {
   const chyby: string[] = [];
   page.on("console", (m) => {

--- a/apps/web/tests/e2e/upozornenia.spec.ts
+++ b/apps/web/tests/e2e/upozornenia.spec.ts
@@ -201,3 +201,51 @@ test("desktop (1600px): pás akcií karty je ≥25 % nižší než issue 303's b
 
   expect(chyby).toEqual([]);
 });
+
+// issue 382 (majiteľ: "vsetko je pod sebou aj ked to vobec nemusi byt"):
+// dve karty sa na dostatočne širokej obrazovke poukladajú VEDĽA SEBA
+// (rovnaký `top`, rôzny `left`), nie pod sebou — dôkaz reálnym rozložením
+// (`getBoundingClientRect`), nie len prítomnosťou CSS triedy `grid`
+// v štýlopise (rovnaký princíp ako issue 263's `getComputedStyle`
+// farebný dôkaz namiesto kontroly `className`).
+test("desktop (1600px): dve karty upozornení sa uložia VEDĽA SEBA, nie pod sebou (issue 382)", async ({ page }) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.setViewportSize({ width: 1600, height: 1000 });
+  await page.goto("/?tab=upozornenia");
+  await page.getByLabel("E-mail").fill(E2E_UPOZORNENIA_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await expect(page.getByRole("heading", { name: "Upozornenia" })).toBeVisible();
+
+  for (const nadpis of ["Vedľa seba — prvá", "Vedľa seba — druhá"]) {
+    await page.getByTestId("upozornenie-new").click();
+    await page.getByTestId("upozornenie-form-title").fill(nadpis);
+    await page.getByTestId("upozornenie-form-save").click();
+    await expect(page.getByTestId("upozornenie-form")).toBeHidden();
+  }
+
+  const prva = kartaSNadpisom(page, "Vedľa seba — prvá");
+  const druha = kartaSNadpisom(page, "Vedľa seba — druhá");
+  await expect(prva).toBeVisible();
+  await expect(druha).toBeVisible();
+
+  const [boxPrva, boxDruha] = await Promise.all([prva.boundingBox(), druha.boundingBox()]);
+  if (boxPrva === null || boxDruha === null) throw new Error("karta nemá bounding box");
+  // Rovnaký `top` (v tom istom riadku mriežky) A odlišný `left` (nie
+  // navzájom prekrytá) — to je jediný spoľahlivý dôkaz "vedľa seba", nie
+  // len "obe niekde viditeľné".
+  expect(Math.abs(boxPrva.y - boxDruha.y), "obe karty musia byť v tom istom riadku (rovnaký top)").toBeLessThan(2);
+  expect(Math.abs(boxPrva.x - boxDruha.x), "karty sa nesmú prekrývať na tej istej x-pozícii").toBeGreaterThan(100);
+
+  await druha.getByRole("button", { name: "Odstrániť", exact: true }).click();
+  await prva.getByRole("button", { name: "Odstrániť", exact: true }).click(); // upratanie po teste
+
+  expect(chyby).toEqual([]);
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.222",
+  "version": "0.3.0-dev.224",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
issue 382 — Eshop → Upozornenia. Zadanie majiteľa: kalendár ukáž tri najbližšie
udalosti namiesto jednej, karta má byť výrazne nižšia (rámček je voči textu
zbytočne vysoký) a zvyšné upozornenia lepšie využiť na výšku, keď nemusia byť
všetky pod sebou.

## Namerané pred / po (1280×900, naživo)

| | pred | po |
|---|---|---|
| Kalendárová karta | 73,59 px pri **jednej** udalosti | 53,17 px pri **troch** |
| Zoznam upozornení (5 kariet) | 628 px pod sebou | 370,7 px v dvoch stĺpcoch |

Tri udalosti sa teda vojdú do menšej výšky, než dnes zaberá jedna — presne to,
čo si majiteľ pýtal. Ďalšie zmenšovanie karty už blokuje vlastný minimálny
čitateľný text tejto appky (12 px, issue 303).

## Zmeny

- API: `resolveNextEvent` → `resolveNextEvents(icsText, now, limit)` vracia
  zoradené pole obmedzené na `NEXT_EVENTS_LIMIT = 3`; `service.ts` a
  `calendar-routes.ts` idú za tým (`event` → `events`).
- Web: `calendarApi.ts` + `NextCalendarEventCard.tsx` vykresľujú až tri
  kompaktné riadky; `app.css` sťahuje výšku karty a mení `.upozornenia-list`
  z `flex-direction: column` na `grid-template-columns: repeat(auto-fit,
  minmax(min(500px, 100%), 1fr))`.
- Nový e2e test v `apps/web/tests/e2e/upozornenia.spec.ts` dokazuje cez
  `getBoundingClientRect`, že karty naozaj stoja vedľa seba.

Nález z review: holé `minmax(500px, 1fr)` by na úzkych obrazovkách obsah ticho
orezalo (`overflow-x: hidden`) — opravené cez `min(500px, 100%)`, overené
naživo pri 375 px.

## Testy

API 747/747, web 602/602, cielené e2e `upozornenia.spec.ts` 3/3 (opakovane),
typecheck čistý, lint čistý.
