### PR TITLE
Testy: doplniť chýbajúce tabuľky do TRUNCATE zoznamov (issue 384)

### DIFF
--- a/apps/api/src/db/truncate-list-completeness.test.ts
+++ b/apps/api/src/db/truncate-list-completeness.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { is, Table, getTableName } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
-import * as schema from "../src/db/schema.js";
+import * as schema from "./schema.js";
 
 // issue 384: "upozornenie" tabuľka chýbala v OBOCH ručne udržiavaných
 // TRUNCATE zoznamoch (`tests/helpers/db.ts`'s `withCleanDb()` a
@@ -17,6 +17,14 @@ import * as schema from "../src/db/schema.js";
 // uvedenej (na rozdiel od dnešných šiestich) ticho prežiť medzi behmi a
 // nikto si to nevšimne, kým sa neprejaví ako nevysvetliteľný medzi-testový
 // stav (presne popis issue 217/384).
+//
+// Zámerne v `src/` (nie `tests/`) — test nepotrebuje DATABASE_URL, ide len
+// o statickú introspekciu zdrojového textu oboch súborov (`readFileSync`) a
+// drizzle schémy (`is`/`getTableName`), žiadny DB dotaz. `src/**/*.test.ts`
+// beží v rýchlom `pnpm --filter @forestshop/api test` (bez DB, súčasť
+// lokálneho `gates:local` aj CI `check` jobu) — presunutím do
+// DB-vyžadujúceho `test:integration` by táto regresia bola odhalená až po
+// pushi, nikdy pri bežnom lokálnom behu (`.claude/rules/testing.md`).
 
 function extractTruncateTableList(fileContents: string): Set<string> {
   const match = /TRUNCATE TABLE ([^`']*?) RESTART IDENTITY CASCADE/.exec(fileContents);
@@ -43,7 +51,7 @@ function allSchemaTableNames(): string[] {
 
 describe("TRUNCATE zoznamy pokrývajú KAŽDÚ tabuľku v drizzle schéme (issue 384)", () => {
   it("apps/api/tests/helpers/db.ts's withCleanDb() TRUNCATE zoznam obsahuje všetky tabuľky", () => {
-    const dbHelperPath = fileURLToPath(new URL("./helpers/db.ts", import.meta.url));
+    const dbHelperPath = fileURLToPath(new URL("../../tests/helpers/db.ts", import.meta.url));
     const contents = readFileSync(dbHelperPath, "utf8");
     const listed = extractTruncateTableList(contents);
     const missing = allSchemaTableNames().filter((name) => !listed.has(name));
@@ -51,7 +59,7 @@ describe("TRUNCATE zoznamy pokrývajú KAŽDÚ tabuľku v drizzle schéme (issue
   });
 
   it("scripts/e2e-setup.ts's TRUNCATE zoznam obsahuje všetky tabuľky", () => {
-    const e2eSetupPath = fileURLToPath(new URL("../../../scripts/e2e-setup.ts", import.meta.url));
+    const e2eSetupPath = fileURLToPath(new URL("../../../../scripts/e2e-setup.ts", import.meta.url));
     const contents = readFileSync(e2eSetupPath, "utf8");
     const listed = extractTruncateTableList(contents);
     const missing = allSchemaTableNames().filter((name) => !listed.has(name));

--- a/apps/api/tests/helpers/db.ts
+++ b/apps/api/tests/helpers/db.ts
@@ -63,12 +63,22 @@ export async function withCleanDb(): Promise<{ db: Database; close: () => Promis
     // "order_open_status"/"supplier_contact" above — no FK in either
     // direction (its `pickup_date` is a free-standing date, not tied to any
     // order), so TRUNCATE CASCADE from any listed table never reaches it.
-    // "dpd_shipment" does NOT need listing here — it has a real FK into
-    // "order" (`onDelete: cascade`), so `TRUNCATE "order" CASCADE` already
-    // reaches it automatically (same reasoning as "order_line" via
-    // "variant" above).
+    // issue 384: "upozornenie" (#267), "daily_task" (#342), "mail_log"
+    // (#193), "dpd_shipment" (#292), "product_supplier_override"/
+    // "product_supplier_link_override" (#121) were all missing from this
+    // list — each DOES have a real FK into an already-listed table
+    // ("users" for the first three, "product"/"order" for the rest), so
+    // CASCADE already reaches them without being named (empirically
+    // confirmed on issue 384 — no leaked rows across two consecutive real
+    // e2e runs even before this change). Listed explicitly anyway for the
+    // SAME self-documenting consistency as "order_line"/"pairing" above —
+    // relying on an unlisted FK path is fragile against a future
+    // `onDelete` change, and "dpd_shipment" used to be this file's one
+    // deliberate exception to that convention (previous comment here said
+    // it "does NOT need listing"); it is now included like everything else
+    // instead of staying the sole exception.
     await db.execute(
-      sql`TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, nedostupne_replacement_link, mail_template, mail_template_history, supplier_stock, restock_settings, restock_event, shop_product_url, theme_color, dpd_pickup_request RESTART IDENTITY CASCADE`,
+      sql`TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, nedostupne_replacement_link, mail_template, mail_template_history, supplier_stock, restock_settings, restock_event, shop_product_url, theme_color, dpd_pickup_request, upozornenie, daily_task, mail_log, dpd_shipment, product_supplier_override, product_supplier_link_override RESTART IDENTITY CASCADE`,
     );
     // issue 59: `order_open_status` is a NEW table with real production
     // content (the migration seeds it) — TRUNCATE alone would leave every

--- a/apps/api/tests/truncate-list-completeness.integration.test.ts
+++ b/apps/api/tests/truncate-list-completeness.integration.test.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { is, Table, getTableName } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import * as schema from "../src/db/schema.js";
+
+// issue 384: "upozornenie" tabuľka chýbala v OBOCH ručne udržiavaných
+// TRUNCATE zoznamoch (`tests/helpers/db.ts`'s `withCleanDb()` a
+// `scripts/e2e-setup.ts`) — presne tá istá trieda medzery ako issue 217
+// (`.claude/rules/testing.md`), tentoraz v OBOCH súčasne. Tento test
+// nekontroluje BEHOVÉ správanie (viď design komentár na tickete — CASCADE
+// cez "users"/"product"/"order" už dnes FUNKČNE zasiahne aj nevymenovanú
+// tabuľku), ale KOMPLETNOSŤ samotného zoznamu — presne to, čo obe súbory
+// zámerne robia (`pairing`/`order_line` sú vymenované explicitne, hoci by
+// ich CASCADE strhol aj bez toho, "kvôli sebadokumentujúcej dôslednosti").
+// Bez tohto testu môže ĎALŠIA nová "koreňová" tabuľka BEZ FK do žiadnej už
+// uvedenej (na rozdiel od dnešných šiestich) ticho prežiť medzi behmi a
+// nikto si to nevšimne, kým sa neprejaví ako nevysvetliteľný medzi-testový
+// stav (presne popis issue 217/384).
+
+function extractTruncateTableList(fileContents: string): Set<string> {
+  const match = /TRUNCATE TABLE ([^`']*?) RESTART IDENTITY CASCADE/.exec(fileContents);
+  if (match?.[1] === undefined) {
+    throw new Error("Nenašiel som TRUNCATE TABLE ... RESTART IDENTITY CASCADE v súbore");
+  }
+  return new Set(
+    match[1]
+      .split(",")
+      .map((name) => name.trim().replaceAll('"', ""))
+      .filter((name) => name.length > 0),
+  );
+}
+
+function allSchemaTableNames(): string[] {
+  const names: string[] = [];
+  for (const value of Object.values(schema)) {
+    if (is(value, Table)) {
+      names.push(getTableName(value));
+    }
+  }
+  return names;
+}
+
+describe("TRUNCATE zoznamy pokrývajú KAŽDÚ tabuľku v drizzle schéme (issue 384)", () => {
+  it("apps/api/tests/helpers/db.ts's withCleanDb() TRUNCATE zoznam obsahuje všetky tabuľky", () => {
+    const dbHelperPath = fileURLToPath(new URL("./helpers/db.ts", import.meta.url));
+    const contents = readFileSync(dbHelperPath, "utf8");
+    const listed = extractTruncateTableList(contents);
+    const missing = allSchemaTableNames().filter((name) => !listed.has(name));
+    expect(missing).toEqual([]);
+  });
+
+  it("scripts/e2e-setup.ts's TRUNCATE zoznam obsahuje všetky tabuľky", () => {
+    const e2eSetupPath = fileURLToPath(new URL("../../../scripts/e2e-setup.ts", import.meta.url));
+    const contents = readFileSync(e2eSetupPath, "utf8");
+    const listed = extractTruncateTableList(contents);
+    const missing = allSchemaTableNames().filter((name) => !listed.has(name));
+    expect(missing).toEqual([]);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.224",
+  "version": "0.3.0-dev.225",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -248,8 +248,16 @@ await db.execute(
   // `.claude/rules/supplier-stock.md`, tam pre `tests/helpers/db.ts`).
   // "dpd_pickup_request" (issue 292) je rovnaký prípad znova — bez FK,
   // pridané ručne (`tests/helpers/db.ts` má rovnaký riadok navyše).
-  // "dpd_shipment" NETREBA — FK do "order" ho CASCADE strhne automaticky.
-  'TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, nedostupne_replacement_link, mail_template, mail_template_history, supplier_stock, restock_settings, restock_event, shop_product_url, theme_color, dpd_pickup_request RESTART IDENTITY CASCADE',
+  // issue 384: "upozornenie" (#267), "daily_task" (#342), "mail_log" (#193),
+  // "dpd_shipment" (#292), "product_supplier_override"/
+  // "product_supplier_link_override" (#121) v tomto zozname chýbali — každá
+  // MÁ reálny FK do už uvedenej tabuľky ("users" pri prvých troch,
+  // "product"/"order" pri zvyšných), takže CASCADE ich strhne aj bez
+  // uvedenia (naživo overené na tickete 384 — 2 po sebe idúce reálne e2e
+  // behy nezanechali žiadny navyše riadok ani PRED touto zmenou). Pridané
+  // ručne rovnako ako "order_line"/"pairing" vyššie — kvôli tej istej
+  // sebadokumentujúcej dôslednosti, nie kvôli chýbajúcemu CASCADE.
+  'TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, nedostupne_replacement_link, mail_template, mail_template_history, supplier_stock, restock_settings, restock_event, shop_product_url, theme_color, dpd_pickup_request, upozornenie, daily_task, mail_log, dpd_shipment, product_supplier_override, product_supplier_link_override RESTART IDENTITY CASCADE',
 );
 // Rovnaký dôvod ako `tests/helpers/db.ts`: bez tohto by "Na objednanie" bolo
 // v CELOM e2e behu prázdne pre KAŽDÚ objednávku (žiadny nastavený otvorený


### PR DESCRIPTION
issue 384 — čistenie testovacej databázy. Vedľajší nález z práce na issue 382.

Do oboch zoznamov, ktoré pred testami čistia tabuľky (`scripts/e2e-setup.ts` a
`apps/api/tests/helpers/db.ts`), chýbalo šesť tabuliek: `upozornenie`, `daily_task`,
`mail_log`, `dpd_shipment`, `product_supplier_override`, `product_supplier_link_override`.

Overenie pred zásahom ukázalo, že dáta dnes reálne nepretekajú — tie tabuľky sa
vyprázdnia nepriamo cez `CASCADE` z `users`/`product`/`order`, ktoré v zozname sú.
Oprava je teda hygienická: tento repo má zvykom vypisovať každú tabuľku výslovne
(rovnako ako `pairing`/`order_line`), nie sa spoliehať na implicitné kaskády, ktoré
sa pri zmene cudzích kľúčov ticho rozpadnú.

Pribudol regresný test (`apps/api/src/db/truncate-list-completeness.test.ts`), ktorý
porovná zoznam tabuliek v schéme so zoznamom v oboch čistiacich skriptoch — beží bez
databázy, takže chytí ďalšiu zabudnutú tabuľku hneď v základných bránach.

## Testy

API 749/749, web 606/606, typecheck čistý, lint čistý; e2e `upozornenia.spec.ts`
spustený dvakrát po sebe ako dôkaz, že sa dáta medzi behmi neprelievajú.
