### PR TITLE
Párovanie produktov E1: čisté funkcie jadra (issue 387)

### DIFF
--- a/.claude/rules/pairing-search.md
+++ b/.claude/rules/pairing-search.md
@@ -1,0 +1,74 @@
+---
+paths:
+  - "apps/api/src/modules/pairing-search/**"
+---
+
+# Profesionálne párovanie produktov — jadro vyhľadávania (issue 387)
+
+Port starej appky (`https://github.com/zbynekdrlik/parovanie-produktov`,
+commit `60b6164`) do tejto appky, po etapách (E1..E9 — návrh
+https://github.com/zbynekdrlik/forestshop-app/issues/387#issuecomment-5273377438).
+**Tento súbor NAHRADÍ `.claude/rules/restock-links.md`, keď E8 vyradí #311**
+(návrh, sekcia 4) — dovtedy existujú vedľa seba.
+
+- **`rapidfuzz.fuzz.token_set_ratio` je CASE-SENSITIVE bez akéhokoľvek
+  predspracovania (žiadne `.lower()`) a stará appka ho volá presne takto
+  (`ranking.py`'s `_name_score`) — npm balík `fuzzball` (fuzzywuzzy port)
+  dáva na REÁLNYCH príkladoch výrazne INÉ hodnoty** (issue 387 E1, naživo
+  overené: "Strike Nohavice DEERHUNTER 3989-388" vs "Strike Nohavice
+  Deerhunter 3989" → rapidfuzz 66,67, fuzzball 100 — `fuzzball` si vstup
+  interne inak predspracúva). Preto `token-set-ratio.ts` je VLASTNÁ
+  implementácia, nie `fuzzball`. Algoritmus (klasický fuzzywuzzy/rapidfuzz
+  `token_set_ratio`: tokenizácia na whitespace → zoradený prienik/rozdiely
+  množín tokenov → `max()` z troch `ratio()` volaní, kde `ratio(a,b) = (1 -
+  indelDistance(a,b)/(len(a)+len(b)))*100` a `indelDistance = len(a)+len(b)
+  - 2*LCS(a,b)`) bol pred portom overený proti NAINŠTALOVANEJ `rapidfuzz`
+  (pip) na 700 náhodných/štruktúrovaných dvojiciach vrátane slovenskej
+  diakritiky — 0/700 nezhôd. Test pri KAŽDEJ ĎALŠEJ zmene tohto súboru:
+  neuprav vzorec bez opätovného overenia proti skutočnej `rapidfuzz`
+  (`pip install --break-system-packages rapidfuzz` na tomto boxe, alebo
+  ekvivalent), nikdy len proti `fuzzball`/vlastnej intuícii.
+- **`rapidfuzz.fuzz.token_set_ratio('', 'x')` (a ľubovoľný prázdny/len-
+  whitespace vstup na jednej strane) vracia `0`, HOCI čistý fuzzywuzzy
+  vzorec bez explicitného guardu by dal `100`** (prázdny `sorted_sect`
+  porovnaný s prázdnym `sorted_1to2`/`sorted_2to1` — `ratio("","")=100`).
+  `tokenSetRatio` preto má explicitný guard na začiatku (`s1.trim()===""
+  || s2.trim()===""` → `0`), overený empiricky proti rapidfuzz, nie
+  odvodený z dokumentácie vzorca.
+- **Externý dodávateľský kód (`external_code`) je v tejto appke stĺpec
+  VARIANTU, nie zoskupeného produktu ako v starej appke (CSV grouping mal
+  presne jeden kód na zoskupený produkt — prvý neprázdny videný pri
+  groupingu).** `types.ts`'s `PairingProduct.externalCodes` preto nesie
+  POLE všetkých odlišných, neprázdnych kódov naprieč variantmi produktu.
+  `queries.ts`'s `buildQueryLadder`/`buildQueryVariants` skúšajú KAŽDÝ kód
+  ako samostatný stupienok/variant (pred menovými), `ranking.ts`'s
+  `isCodeHit` je pravdivé, keď sa HOCIKTORÝ z kódov nájde v kandidátovi
+  (`.some(...)`, nikdy len `externalCodes[0]`). Táto adaptácia je MOJA
+  interpretácia návrhovej vety „query set skúša VŠETKY odlišné external
+  kódy variantov" — overená review subagentom, konzistentne aplikovaná v
+  oboch súboroch.
+- **`normalize.ts`'s `clean_name`'s vedúci-index regex (`^\d{1,3}\s+(?=\D)`)
+  NEODREZE 4+-ciferné čísla na začiatku mena** — "1003 Bunda FOREST" ostáva
+  nedotknuté (regex sa zastaví po 3 číslicach a potrebuje whitespace hneď
+  za nimi, čo pri "1003" nesedí), zatiaľ čo "100 Bunda FOREST" → "Bunda
+  FOREST". Zámerné (chráni pred odrezaním skutočného číselného kódu na
+  začiatku mena), presne ako stará appka — over pri KAŽDEJ zmene tohto
+  regexu proti `normalize.py`'s pôvodnému, nikdy nezjednodušuj hranicu.
+- **Tento monorepo má `noUncheckedIndexedAccess: true`** (`tsconfig.base.
+  json`) — akýkoľvek `pole[i]`/`retazec[i]` prístup vracia `T | undefined`,
+  aj keď je index dokázateľne v rozsahu (DP tabuľky v `token-set-ratio.ts`,
+  `ranked[0]` po kontrole `candidates.length`). Vzor použitý tu: `?? 0`/`??
+  ""` fallback pri numerických/reťazcových DP bunkách (runtime hodnota je
+  vždy definovaná, fallback len uspokojuje statickú kontrolu),
+  `const [best] = ranked; if (!best) return ...;` namiesto `ranked[0]`
+  priamo tam, kde by chýbajúca hodnota bola SKUTOČNÁ chyba (nedosiahnuteľná
+  vetva s komentárom prečo).
+- **Fixtúrové testy proti REÁLNYM referenčným hodnotám (nie len proti
+  vlastnej intuícii o algoritme) sú JEDINÝ spoľahlivý spôsob, ako overiť
+  doslovný port číselného algoritmu.** `token-set-ratio.test.ts` nesie
+  presné hodnoty odchytené z nainštalovanej `rapidfuzz` — pri ĎALŠOM porte
+  numerického algoritmu zo starej appky (napr. E2's parsery, E4's verify
+  kaskáda) rovnaký vzor: nainštaluj referenčnú knižnicu/skript, vygeneruj
+  batériu vstup→výstup dvojíc, over TS port proti nim priamo (nie len proti
+  ručne napísaným testom, ktoré by mohli zopakovať rovnakú chybu ako
+  implementácia).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,3 +110,4 @@ Per-area rules live in `.claude/rules/<area>.md` with `paths:` frontmatter.
 - Vypredané → Skladom: návrhy odkazov (#311 — deterministický návrh podľa zhody mena+dodávateľa, zdieľaná zapisovacia cesta s #239, žiadne AI dohady) → `.claude/rules/restock-links.md`
 - Preprava DPD (#292 — per-zásielkový Playwright robot na dpdshipper.sk, appka-vlastný `dpd_shipment`/`dpd_pickup_request` záznam, náhľad pred odoslaním, fail-loud nedomapovaný formulár) → `.claude/rules/dpd.md`
 - Google kalendár — najbližšia udalosť (#309 — samostatný modul od `upozornenia` (žiadny dedupKey/resolve), krátkodobá in-memory cache namiesto scheduler jobu, node-ical proces-TZ past pri celodenných udalostiach) → `.claude/rules/calendar.md`
+- Profesionálne párovanie produktov (#387 E1+ — port starej appky @60b6164, rapidfuzz case-sensitive token_set_ratio, viac-kódová adaptácia, nahradí `restock-links.md` po E8) → `.claude/rules/pairing-search.md`

--- a/apps/api/src/modules/pairing-search/normalize.test.ts
+++ b/apps/api/src/modules/pairing-search/normalize.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { cleanName, codePresent } from "./normalize.js";
+
+// Fixtúry prevzaté priamo z `tests/test_normalize.py` starej appky (commit
+// 60b6164, issue 387 E1) — over doslovnú zhodu správania.
+describe("cleanName", () => {
+  it("strips a leading order index", () => {
+    expect(cleanName("01 Ponožky BOBR - jar/jeseň")).toBe("Ponožky BOBR - jar/jeseň");
+  });
+
+  it("collapses internal whitespace runs", () => {
+    expect(cleanName("Bunda   FOREST\t1003")).toBe("Bunda FOREST 1003");
+  });
+
+  it("leaves a name without a leading index untouched", () => {
+    expect(cleanName("Strike Nohavice DEERHUNTER 3989-388")).toBe("Strike Nohavice DEERHUNTER 3989-388");
+  });
+
+  it("strips a 1-3 digit leading index but never a 4+ digit product code", () => {
+    expect(cleanName("100 Bunda FOREST")).toBe("Bunda FOREST");
+    // "1003" is FOUR digits — the index pattern caps at \d{1,3}, so a
+    // real product-code-like number at the start must survive untouched.
+    expect(cleanName("1003 Bunda FOREST")).toBe("1003 Bunda FOREST");
+  });
+
+  it("never strips a leading index when it is followed by another number", () => {
+    // The lookahead requires a non-digit right after the whitespace — two
+    // consecutive numeric tokens are never an "index + name" shape.
+    expect(cleanName("10 20 Bunda")).toBe("10 20 Bunda");
+  });
+
+  it("handles null/undefined/empty input", () => {
+    expect(cleanName(null)).toBe("");
+    expect(cleanName(undefined)).toBe("");
+    expect(cleanName("")).toBe("");
+    expect(cleanName("   ")).toBe("");
+  });
+
+  it("trims outer whitespace even without a leading index", () => {
+    expect(cleanName("  Nôž lovecký Helle 110  ")).toBe("Nôž lovecký Helle 110");
+  });
+});
+
+describe("codePresent", () => {
+  // Regresný prípad zo `test_ranking.py`: krátky číselný kód "110" sa
+  // NESMIE zhodnúť s podreťazcom dlhšieho čísla "1100".
+  it("does not match a short numeric code as a substring of a longer run", () => {
+    expect(codePresent("110", "Nôž Helle model 1100")).toBe(false);
+  });
+
+  it("matches a short numeric code as a whole delimited token", () => {
+    expect(codePresent("110", "Nôž lovecký model 110 oceľ")).toBe(true);
+  });
+
+  it("matches at the start of the haystack", () => {
+    expect(codePresent("OB570", "OB570 nohavice HART RANDO")).toBe(true);
+  });
+
+  it("matches at the end of the haystack", () => {
+    expect(codePresent("OB570", "nohavice HART RANDO OB570")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(codePresent("ob570", "Nohavice HART RANDO OB570")).toBe(true);
+    expect(codePresent("OB570", "nohavice hart rando ob570")).toBe(true);
+  });
+
+  it("does not match when the code is only a prefix of a longer token", () => {
+    expect(codePresent("OB57", "nohavice HART RANDO OB570")).toBe(false);
+  });
+
+  it("does not match when the code is only a suffix of a longer token", () => {
+    expect(codePresent("B570", "nohavice HART RANDO OB570")).toBe(false);
+  });
+
+  it("returns false for a missing code", () => {
+    expect(codePresent(null, "anything")).toBe(false);
+    expect(codePresent(undefined, "anything")).toBe(false);
+    expect(codePresent("", "anything")).toBe(false);
+  });
+
+  it("returns false when the haystack does not contain the code at all", () => {
+    expect(codePresent("ZZ9", "Bunda DEERHUNTER Strike 3989")).toBe(false);
+  });
+
+  it("escapes regex-special characters in the code", () => {
+    expect(codePresent("3989-388", "produkt 3989-388 skladom")).toBe(true);
+    expect(codePresent("3989-388", "produkt 39894388 skladom")).toBe(false);
+  });
+});

--- a/apps/api/src/modules/pairing-search/normalize.ts
+++ b/apps/api/src/modules/pairing-search/normalize.ts
@@ -1,0 +1,44 @@
+// Doslovný port `src/parovanie/normalize.py` zo starej appky (commit
+// 60b6164, issue 387 E1 — návrh https://github.com/zbynekdrlik/
+// forestshop-app/issues/387#issuecomment-5273377438, sekcia „Čo sa
+// portuje 1:1"). Žiadna sieť, žiadna DB — čisté funkcie.
+
+// Kolaps akéhokoľvek behu whitespace na jednu medzeru (rovnaké ako Python's
+// `re.sub(r"\s+", " ", ...)`).
+const WHITESPACE_RUN = /\s+/g;
+
+// Vedúci číselný index poradia zo Shoptet exportu ("01 Ponožky BOBR" →
+// "Ponožky BOBR") — presne `normalize.py`'s `_LEADING_INDEX =
+// re.compile(r"^\d{1,3}\s+(?=\D)")`. 1-3 číslice + medzery + lookahead na
+// NE-číslicu (aby sa nikdy neodrezal skutočný číselný kód na začiatku mena).
+const LEADING_INDEX = /^\d{1,3}\s+(?=\D)/;
+
+/**
+ * `clean_name(s)` zo starej appky: orež okrajové whitespace, zlúč vnútorné
+ * behy whitespace na jednu medzeru, odstráň vedúci číselný index poradia.
+ * Poradie krokov (strip → collapse → strip index → strip) je zámerne
+ * zachované rovnaké ako v Pythone.
+ */
+export function cleanName(raw: string | null | undefined): string {
+  const trimmed = (raw ?? "").trim();
+  const collapsed = trimmed.replace(WHITESPACE_RUN, " ");
+  const withoutIndex = collapsed.replace(LEADING_INDEX, "");
+  return withoutIndex.trim();
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * `code_present(code, hay)` zo starej appky: True, keď sa `code` vyskytuje v
+ * `hay` ako CELÝ alfanumerický token — nie ako podreťazec dlhšieho behu.
+ * Takže "110" sedí v "model 110 x", ale NIE v "...1100". Case-insensitive.
+ * Chráni pred krátkymi/číselnými dodávateľskými kódmi falošne zhodujúcimi
+ * nesúvisiace produkty (čo by zapísalo zlú URL na doobjednanie).
+ */
+export function codePresent(code: string | null | undefined, hay: string | null | undefined): boolean {
+  if (!code) return false;
+  const pattern = new RegExp(`(?<![0-9a-z])${escapeRegExp(code.toLowerCase())}(?![0-9a-z])`);
+  return pattern.test((hay ?? "").toLowerCase());
+}

--- a/apps/api/src/modules/pairing-search/queries.test.ts
+++ b/apps/api/src/modules/pairing-search/queries.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import { buildQueryLadder, buildQueryVariants, GENERIC_WORDS } from "./queries.js";
+import type { PairingProduct } from "./types.js";
+
+function product(name: string, externalCodes: readonly string[] = []): PairingProduct {
+  return { productKey: "k", name, supplier: "BETALOV", externalCodes };
+}
+
+// query ladder — port `tests/test_matcher.py` + `tests/test_normalize.py`'s
+// `build_query` scenarios (starej appky, commit 60b6164), tu overené na
+// hlave `buildQueryLadder` (nahrádza starý samostatný `build_query`).
+describe("buildQueryLadder", () => {
+  it("prefers the external code over the name", () => {
+    expect(buildQueryLadder(product("Nohavice HART RANDO XHP", ["OB570"]))[0]).toBe("OB570");
+  });
+
+  it("uses the clean full name (as the first rung) when there is no external code", () => {
+    expect(buildQueryLadder(product("Strike Nohavice DEERHUNTER 3989-388"))[0]).toBe(
+      "Strike Nohavice DEERHUNTER 3989-388",
+    );
+  });
+
+  it("falls back through 3-token then 2-token prefixes for a long name", () => {
+    // Port `test_matcher.py`'s `test_falls_back_to_shorter_query_when_code_and_full_name_miss`:
+    // ladder = [code, full name, first-3, first-2], deduped.
+    const p = product("Bunda DEERHUNTER Strike 3989", ["ZZ9"]);
+    expect(buildQueryLadder(p)).toEqual([
+      "ZZ9",
+      "Bunda DEERHUNTER Strike 3989",
+      "Bunda DEERHUNTER Strike",
+      "Bunda DEERHUNTER",
+    ]);
+  });
+
+  it("does not add a first-3/first-2 rung for a name with 2 or fewer tokens", () => {
+    expect(buildQueryLadder(product("Opasok kožený"))).toEqual(["Opasok kožený"]);
+  });
+
+  it("tries ALL distinct variant external codes before falling back to the name (E1 adaptation)", () => {
+    // The old appka carried exactly one `external_code` per grouped product;
+    // here it is a per-variant column, so every distinct code gets its own
+    // rung before the name-based ones. (Name kept to <=2 tokens so no
+    // first-3/first-2 rung is added, isolating the multi-code behavior.)
+    const p = product("HART RANDO", ["60177/46", "60177/48"]);
+    expect(buildQueryLadder(p)).toEqual(["60177/46", "60177/48", "HART RANDO"]);
+  });
+
+  it("deduplicates identical variant codes while preserving first-seen order", () => {
+    const p = product("HART RANDO", ["OB570", "OB570"]);
+    expect(buildQueryLadder(p)).toEqual(["OB570", "HART RANDO"]);
+  });
+
+  it("returns an empty ladder for a product with no name and no codes", () => {
+    expect(buildQueryLadder(product(""))).toEqual([]);
+  });
+});
+
+// query variants — port `tests/test_gather.py` (starej appky, commit
+// 60b6164).
+describe("buildQueryVariants", () => {
+  it("puts the external code first", () => {
+    const variants = buildQueryVariants(product("Nohavice HART RANDO XHP", ["OB570"]));
+    expect(variants[0]).toBe("OB570");
+  });
+
+  it("produces the full name, the generic-stripped form, and prefix groups, with no duplicates", () => {
+    const variants = buildQueryVariants(product("Nohavice HART RANDO XHP"));
+    expect(variants).toContain("Nohavice HART RANDO XHP");
+    expect(variants).toContain("HART RANDO XHP");
+    expect(variants).toContain("Nohavice HART RANDO");
+    expect(new Set(variants).size).toBe(variants.length);
+  });
+
+  it("does not strip a generic word that is not the leading token", () => {
+    // GENERIC-word stripping only ever removes a LEADING run of tokens
+    // (`matcher.py`'s query_variants loop starts at i=0 and only advances
+    // forward, stopping the instant the current token is non-generic) —
+    // a 2-token name has no prefix/suffix groups either (needs >2 tokens),
+    // so the ONLY variant produced is the untouched full name.
+    expect(buildQueryVariants(product("HART nohavice"))).toEqual(["HART nohavice"]);
+  });
+
+  it("never strips ALL tokens even if the whole name is generic", () => {
+    // `while i < len(toks) - 1` keeps at least one token.
+    const variants = buildQueryVariants(product("Nohavice Bunda"));
+    expect(variants).toContain("Bunda");
+    expect(variants).not.toContain("");
+  });
+
+  it("includes prefix and suffix token groups for both the full and stripped names", () => {
+    const variants = buildQueryVariants(product("Nohavice HART RANDO XHP MODEL"));
+    // full name (5 tokens): prefix-3, suffix-3, prefix-2, suffix-2
+    expect(variants).toContain("Nohavice HART RANDO"); // prefix-3
+    expect(variants).toContain("RANDO XHP MODEL"); // suffix-3
+    expect(variants).toContain("Nohavice HART"); // prefix-2
+    expect(variants).toContain("XHP MODEL"); // suffix-2
+    // stripped name (4 tokens, leading "Nohavice" removed)
+    expect(variants).toContain("HART RANDO XHP"); // prefix-3 of stripped
+    expect(variants).toContain("RANDO XHP MODEL"); // suffix-3 of stripped
+  });
+
+  it("carries ALL distinct variant external codes, each deduplicated (E1 adaptation)", () => {
+    const p = product("HART RANDO XHP", ["OB570", "OB571", "OB570"]);
+    const variants = buildQueryVariants(p);
+    expect(variants.slice(0, 2)).toEqual(["OB570", "OB571"]);
+  });
+
+  it("returns an empty list for a product with no name and no codes", () => {
+    expect(buildQueryVariants(product(""))).toEqual([]);
+  });
+});
+
+describe("GENERIC_WORDS", () => {
+  it("carries both diacritic and stripped-diacritic forms, ported verbatim from the old appka", () => {
+    // Spot-check a representative sample from `matcher.py`'s GENERIC set —
+    // full 46-word parity is exercised indirectly by the stripping tests
+    // above.
+    for (const word of ["nohavice", "bunda", "košeľa", "kosela", "ponožky", "membrána", "membrana"]) {
+      expect(GENERIC_WORDS.has(word)).toBe(true);
+    }
+    expect(GENERIC_WORDS.size).toBe(46);
+  });
+});

--- a/apps/api/src/modules/pairing-search/queries.ts
+++ b/apps/api/src/modules/pairing-search/queries.ts
@@ -1,0 +1,136 @@
+// Doslovný port `src/parovanie/matcher.py`'s `query_ladder`/`query_variants`
+// zo starej appky (commit 60b6164, issue 387 E1), ADAPTOVANÝ na viacero
+// `external_code` hodnôt na produkt namiesto jednej — pozri `types.ts`'s
+// hlavičkový komentár a návrh (issue 387 komentár, sekcia „Čo sa adaptuje").
+
+import { cleanName } from "./normalize.js";
+import type { PairingProduct } from "./types.js";
+
+// Generické slovenské kategóriové/prídavné slová, ktoré produkt
+// nerozlišujú — DOSLOVNÝ port `matcher.py`'s `GENERIC` množiny (46 slov,
+// obe diakritické aj bezdiakritické tvary zachované presne).
+export const GENERIC_WORDS: ReadonlySet<string> = new Set([
+  "nohavice",
+  "bunda",
+  "mikina",
+  "vesta",
+  "košeľa",
+  "kosela",
+  "tričko",
+  "tricko",
+  "komplet",
+  "set",
+  "súprava",
+  "suprava",
+  "ponožky",
+  "ponozky",
+  "čiapka",
+  "ciapka",
+  "rukavice",
+  "kraťasy",
+  "kratasy",
+  "šortky",
+  "sortky",
+  "obuv",
+  "topánky",
+  "topanky",
+  "čižmy",
+  "cizmy",
+  "opasok",
+  "taška",
+  "taska",
+  "batoh",
+  "dámske",
+  "damske",
+  "pánske",
+  "panske",
+  "detské",
+  "detske",
+  "letné",
+  "letne",
+  "zimné",
+  "zimne",
+  "poľovnícke",
+  "polovnicke",
+  "strelecké",
+  "strelecke",
+  "membrána",
+  "membrana",
+]);
+
+function dedupPreserveOrder(items: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const item of items) {
+    if (item && !seen.has(item)) {
+      seen.add(item);
+      out.push(item);
+    }
+  }
+  return out;
+}
+
+// Python's `token.lower().strip("-,.")` — orež tieto znaky z OBOCH koncov,
+// nikdy z vnútra tokenu.
+function stripPunctLower(token: string): string {
+  return token
+    .toLowerCase()
+    .replace(/^[-,.]+/, "")
+    .replace(/[-,.]+$/, "");
+}
+
+/**
+ * Zoradené dopyty na postupné skúšanie, kým jeden nevráti kandidátov —
+ * port `matcher.py`'s `query_ladder`. Dlhé presné dopyty na dodávateľských
+ * vyhľadávačoch často miss-nú, preto rebrík postupne skracuje meno.
+ *
+ * Adaptácia (E1): stará appka niesla presne JEDEN `external_code` na
+ * zoskupený produkt (prvý neprázdny variantný kód videný pri CSV
+ * groupingu). Tu je `external_code` per-VARIANT stĺpec, takže rebrík
+ * skúša VŠETKY odlišné kódy produktu (každý na vlastnom stupienku) pred
+ * tým, než padne na meno-založené stupienky.
+ */
+export function buildQueryLadder(product: PairingProduct): string[] {
+  const queries: string[] = [...product.externalCodes];
+  const name = cleanName(product.name);
+  if (name) {
+    queries.push(name);
+    const tokens = name.split(" ");
+    if (tokens.length > 3) queries.push(tokens.slice(0, 3).join(" "));
+    if (tokens.length > 2) queries.push(tokens.slice(0, 2).join(" "));
+  }
+  return dedupPreserveOrder(queries);
+}
+
+/**
+ * Niekoľko foriem dopytu na maximalizáciu recall-u — port `matcher.py`'s
+ * `query_variants`: externý kód, celé meno, meno s odstránenými vedúcimi
+ * generickými slovami, a prefix aj suffix skupiny tokenov (3 a 2) z
+ * celého aj orezaného mena. Neskorší AI verifikátor (mimo rozsahu E1)
+ * dedupuje a vyberá z tejto únie.
+ *
+ * Rovnaká viac-kódová adaptácia ako `buildQueryLadder`.
+ */
+export function buildQueryVariants(product: PairingProduct): string[] {
+  const queries: string[] = [...product.externalCodes];
+  const name = cleanName(product.name);
+  if (name) {
+    queries.push(name);
+    const tokens = name.split(" ");
+    let i = 0;
+    while (i < tokens.length - 1 && GENERIC_WORDS.has(stripPunctLower(tokens[i] ?? ""))) {
+      i += 1;
+    }
+    const stripped = i > 0 ? tokens.slice(i) : tokens;
+    if (i > 0) queries.push(stripped.join(" "));
+    for (const base of [tokens, stripped]) {
+      for (const n of [3, 2]) {
+        if (base.length > n) {
+          queries.push(base.slice(0, n).join(" ")); // prefix
+          queries.push(base.slice(-n).join(" ")); // suffix
+        }
+      }
+    }
+  }
+  return dedupPreserveOrder(queries);
+}

--- a/apps/api/src/modules/pairing-search/ranking.test.ts
+++ b/apps/api/src/modules/pairing-search/ranking.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { pickBest, rank } from "./ranking.js";
+import type { PairingCandidate, PairingProduct } from "./types.js";
+
+function product(name: string, externalCodes: readonly string[] = []): PairingProduct {
+  return { productKey: "k", name, supplier: "BETALOV", externalCodes };
+}
+
+function candidate(name: string, url: string, code: string | null = null): PairingCandidate {
+  return { name, url, code, price: null, rawScore: 0, codeHit: false };
+}
+
+// Fixtúry prevzaté z `tests/test_ranking.py` starej appky (commit 60b6164,
+// issue 387 E1).
+describe("pickBest", () => {
+  it("scores a supplier-code match as high confidence, always above a pure name match", () => {
+    const p = product("Nohavice HART RANDO XHP", ["OB570"]);
+    const candidates = [candidate("Iné", "https://h/ine"), candidate("HART RANDO XHP nohavice", "https://h/hart-rando-ob570")];
+    const { candidate: best, confidence } = pickBest(p, candidates);
+    expect(confidence).toBe("high");
+    expect(best?.url.toLowerCase()).toContain("ob570");
+  });
+
+  it("ranks the closest name match first among purely name-based candidates", () => {
+    const p = product("Strike Nohavice DEERHUNTER 3989-388");
+    const candidates = [
+      candidate("Ciapka iná", "https://w/ciapka"),
+      candidate("Strike Nohavice Deerhunter 3989", "https://w/strike-deerhunter-3989"),
+    ];
+    const ranked = rank(p, candidates);
+    expect(ranked[0]?.url).toContain("deerhunter");
+    const { candidate: best, confidence } = pickBest(p, candidates);
+    expect(["high", "medium", "low"]).toContain(confidence);
+    expect(best?.url).toBe("https://w/strike-deerhunter-3989");
+  });
+
+  it("returns none for an empty candidate list", () => {
+    const { candidate: best, confidence } = pickBest(product("X"), []);
+    expect(best).toBeNull();
+    expect(confidence).toBe("none");
+  });
+
+  it("does NOT let a short numeric code false-match as a substring of a longer one", () => {
+    // Regression: external_code '110' must NOT match candidate '...model 1100'.
+    const p = product("Nôž lovecký Helle 110", ["110"]);
+    const candidates = [candidate("Nôž Helle model 1100", "https://h/noz-helle-1100")];
+    const { confidence } = pickBest(p, candidates);
+    expect(confidence).not.toBe("high");
+  });
+
+  it("still boosts to high when a short code appears as a whole delimited token", () => {
+    const p = product("Nôž 110", ["110"]);
+    const candidates = [candidate("Nôž lovecký model 110 oceľ", "https://h/noz-110")];
+    const { confidence } = pickBest(p, candidates);
+    expect(confidence).toBe("high");
+  });
+
+  it("still returns the best (weak) candidate instead of null when the score is very low", () => {
+    // Old appka's `pick_best` auto-fill: even a weak match is returned as
+    // "low", never discarded — only an EMPTY candidate list yields "none".
+    const p = product("Mikina softshell Pinewood zelená XL");
+    const candidates = [candidate("Ciapka iná úplne odlišná", "https://w/ciapka")];
+    const { candidate: best, confidence } = pickBest(p, candidates);
+    expect(best).not.toBeNull();
+    expect(confidence).toBe("low");
+  });
+
+  it("returns medium confidence for a solid name match without a code hit", () => {
+    const p = product("Rukavice kožené čierne 42");
+    const candidates = [candidate("Rukavice kožené čierne", "https://s/rukavice-kozene-cierne")];
+    const { confidence } = pickBest(p, candidates);
+    expect(confidence).toBe("medium");
+  });
+});
+
+describe("rank — E1 multi-code adaptation (product carries several variant external codes)", () => {
+  it("counts a code hit when ANY of the product's variant codes appears in the candidate (not just the first)", () => {
+    const p = product("HART RANDO", ["60177/46", "60177/48"]);
+    // Only the SECOND variant code ("60177/48") literally appears — proves
+    // the check is not hardwired to `externalCodes[0]`.
+    const candidates = [candidate("HART RANDO model 60177/48", "https://s/hart-rando")];
+    const ranked = rank(p, candidates);
+    expect(ranked[0]?.codeHit).toBe(true);
+    expect(ranked[0]?.rawScore).toBeGreaterThanOrEqual(1000);
+  });
+
+  it("never mutates the input candidate array — returns new scored objects", () => {
+    const p = product("HART RANDO", ["OB570"]);
+    const original = candidate("Iné", "https://x/y");
+    const candidates = [original];
+    rank(p, candidates);
+    expect(original.rawScore).toBe(0);
+    expect(original.codeHit).toBe(false);
+  });
+
+  it("never counts a code hit when the product has no external codes at all", () => {
+    const p = product("HART RANDO");
+    const candidates = [candidate("HART RANDO model", "https://s/hart-rando")];
+    const ranked = rank(p, candidates);
+    expect(ranked[0]?.codeHit).toBe(false);
+  });
+});

--- a/apps/api/src/modules/pairing-search/ranking.ts
+++ b/apps/api/src/modules/pairing-search/ranking.ts
@@ -1,0 +1,63 @@
+// Doslovný port `src/parovanie/ranking.py` zo starej appky (commit
+// 60b6164, issue 387 E1): kód-zhoda VŽDY prebije menovú zhodu (+1000),
+// inak rozhoduje `token_set_ratio` na vyčistenom mene. Prahy istoty
+// ≥1000 high / ≥80 medium / inak low — vždy sa vráti najlepší kandidát,
+// aj slabý (`pick_best`'s posledný riadok v starej appke, „auto-fill").
+
+import { cleanName, codePresent } from "./normalize.js";
+import { tokenSetRatio } from "./token-set-ratio.js";
+import type { PairingCandidate, PairingConfidence, PairingProduct } from "./types.js";
+
+// Adaptácia (E1, rovnaká ako `queries.ts`): produkt môže niesť VIACERO
+// externých kódov (jeden per variant) namiesto starej appka's jedného —
+// zhoda platí, keď sa hociktorý z nich vyskytne v kandidátovej "hay"
+// (meno + URL + kód).
+function isCodeHit(product: PairingProduct, candidate: PairingCandidate): boolean {
+  if (product.externalCodes.length === 0) return false;
+  const hay = [candidate.name, candidate.url, candidate.code ?? ""].filter(Boolean).join(" ");
+  return product.externalCodes.some((code) => codePresent(code, hay));
+}
+
+function nameScore(product: PairingProduct, candidate: PairingCandidate): number {
+  return tokenSetRatio(cleanName(product.name), candidate.name);
+}
+
+/**
+ * Zoradí kandidátov podľa `rawScore` zostupne — port `ranking.py`'s
+ * `rank()`. Na rozdiel od starej appky (mutuje `Candidate.raw_score` na
+ * mieste) vracia NOVÉ objekty — vstupné pole ostáva nedotknuté.
+ */
+export function rank(product: PairingProduct, candidates: readonly PairingCandidate[]): PairingCandidate[] {
+  const scored = candidates.map((candidate): PairingCandidate => {
+    const codeHit = isCodeHit(product, candidate);
+    const rawScore = codeHit ? 1000 + nameScore(product, candidate) : nameScore(product, candidate);
+    return { ...candidate, rawScore, codeHit };
+  });
+  return scored.sort((a, b) => b.rawScore - a.rawScore);
+}
+
+export interface PairingPick {
+  readonly candidate: PairingCandidate | null;
+  readonly confidence: PairingConfidence;
+}
+
+/**
+ * Vyberie najlepšieho kandidáta a jeho istotu — port `ranking.py`'s
+ * `pick_best()`. Prázdny zoznam kandidátov → `none`. Inak sa VŽDY vráti
+ * najlepší nájdený kandidát (auto-fill), aj keď je jeho skóre nízke —
+ * stará appka mala pre tento prípad samostatnú `>= 50.0` vetvu, ktorá
+ * vracala rovnaké `"low"` ako vetva pod ňou; tu je preto zjednodušená na
+ * jeden `else` bez straty správania (over: staré `>= 50.0` aj fallback
+ * vetva vracajú identický reťazec).
+ */
+export function pickBest(product: PairingProduct, candidates: readonly PairingCandidate[]): PairingPick {
+  if (candidates.length === 0) return { candidate: null, confidence: "none" };
+  const [best] = rank(product, candidates);
+  // `candidates.length > 0` guarantees `rank()` (a same-length `.map()`)
+  // returns a non-empty array too — this check only satisfies
+  // `noUncheckedIndexedAccess`'s static narrowing, never a real runtime path.
+  if (!best) return { candidate: null, confidence: "none" };
+  if (best.rawScore >= 1000) return { candidate: best, confidence: "high" };
+  if (best.rawScore >= 80) return { candidate: best, confidence: "medium" };
+  return { candidate: best, confidence: "low" };
+}

--- a/apps/api/src/modules/pairing-search/token-set-ratio.test.ts
+++ b/apps/api/src/modules/pairing-search/token-set-ratio.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { tokenSetRatio } from "./token-set-ratio.js";
+
+// Presné referenčné hodnoty odchytené z NAINŠTALOVANEJ `rapidfuzz` (pip,
+// 3.14.5) — `rapidfuzz.fuzz.token_set_ratio(a, b)`, tá istá funkcia, akú
+// volá stará appka (`ranking.py`'s `_name_score`), issue 387 E1. Celý
+// algoritmus (LCS-based Indel `ratio` + token-set zoradenie/prienik) bol
+// pred portom overený proti tejto knižnici na 700 náhodných/štruktúrovaných
+// dvojiciach vrátane slovenskej diakritiky (0/700 nezhôd, scratchpad skript
+// pri vývoji, nekomitovaný) — tu je fixovaná podmnožina ako regresný dôkaz.
+describe("tokenSetRatio — exact parity fixtures vs. rapidfuzz.fuzz.token_set_ratio", () => {
+  const cases: readonly [string, string, number][] = [
+    // Case-sensitivity: rapidfuzz.fuzz.token_set_ratio is CASE-SENSITIVE by
+    // default and the old appka never lowercases before calling it — a
+    // token differing only in case does NOT count as an exact token match.
+    ["Strike Nohavice DEERHUNTER 3989-388", "Strike Nohavice Deerhunter 3989", 66.66666666666666],
+    ["HART RANDO XHP", "HART RANDO XHP nohavice", 100],
+    ["Nôž lovecký Helle 110", "Nôž Helle model 1100", 78.04878048780488],
+    ["Ponožky BOBR - jar/jeseň", "Ponožky BOBR jar jeseň merino", 79.24528301886792],
+    ["Bunda FOREST 1003", "FOREST bunda zimná model 1003", 78.57142857142857],
+    ["Nohavice HART RANDO XHP", "Iné", 0],
+    ["Bunda DEERHUNTER Strike", "Bunda Deerhunter Strike", 68.57142857142857],
+    ["rovnaky text", "rovnaky text", 100],
+    ["Nôž 110", "Nôž lovecký model 110 oceľ", 100],
+    ["Mikina softshell Pinewood zelená XL", "Softshell mikina PINEWOOD", 40],
+    ["Ciapka iná", "Strike Nohavice Deerhunter 3989-388", 13.333333333333329],
+  ];
+
+  it.each(cases)("tokenSetRatio(%j, %j) ≈ %s", (a, b, expected) => {
+    expect(tokenSetRatio(a, b)).toBeCloseTo(expected, 6);
+  });
+
+  it("returns 0 for empty or whitespace-only input on either side (rapidfuzz guard)", () => {
+    expect(tokenSetRatio("", "abc")).toBe(0);
+    expect(tokenSetRatio("abc", "")).toBe(0);
+    expect(tokenSetRatio("   ", "abc")).toBe(0);
+    expect(tokenSetRatio("", "")).toBe(0);
+  });
+
+  it("returns 100 for identical single-token strings", () => {
+    expect(tokenSetRatio("a", "a")).toBe(100);
+  });
+});

--- a/apps/api/src/modules/pairing-search/token-set-ratio.ts
+++ b/apps/api/src/modules/pairing-search/token-set-ratio.ts
@@ -1,0 +1,77 @@
+// Vlastná implementácia `rapidfuzz.fuzz.token_set_ratio` (issue 387 E1).
+// Návrh (issue 387 komentár, sekcia „Čo sa portuje 1:1") povolil buď
+// knižnicu `fuzzball`, alebo vlastnú implementáciu s fixtúrovými testami
+// proti výstupom starej appky — nainštalovaná `fuzzball` (npm) na batérii
+// príkladov z návrhu dáva VÝRAZNE odlišné hodnoty od skutočnej rapidfuzz
+// (napr. "Strike Nohavice DEERHUNTER 3989-388" vs "Strike Nohavice
+// Deerhunter 3989": rapidfuzz 66,67, fuzzball 100 — fuzzball si vstup
+// interne inak predspracúva/lowercase-uje, rapidfuzz je case-SENSITIVE a
+// stará appka volá `fuzz.token_set_ratio` priamo bez `.lower()`), preto
+// vlastná implementácia nižšie.
+//
+// Algoritmus overený proti nainštalovanej `rapidfuzz` (pip, verzia
+// 3.14.5) na 700 náhodných + štruktúrovaných dvojiciach vrátane
+// slovenskej diakritiky — 700/700 zhoda na desatinné miesto (scratchpad
+// skript použitý pri overovaní, nekomitovaný). Vzorec:
+//   ratio(a,b)          = (1 - indelDistance(a,b) / (len(a)+len(b))) * 100
+//   indelDistance(a,b)  = len(a) + len(b) - 2 * LCS(a,b)
+//   tokenSetRatio(s1,s2) = max(ratio(sect, 1to2), ratio(sect, 2to1), ratio(1to2, 2to1))
+// kde `sect`/`1to2`/`2to1` sú zoradené (Unicode code-point poradie, presne
+// ako Python's `sorted()`) reťazce zostavené z prieniku a rozdielov
+// množín tokenov — klasický fuzzywuzzy/rapidfuzz `token_set_ratio`
+// algoritmus, ktorý stará appka používa cez `rapidfuzz.fuzz`.
+
+/** Dĺžka najdlhšej spoločnej podpostupnosti (LCS) — DP O(n·m), n/m sú dĺžky
+ * jednotlivých dopytov/mien (rádovo desiatky znakov), nikdy veľké vstupy. */
+function lcsLength(a: string, b: string): number {
+  const n = a.length;
+  const m = b.length;
+  if (n === 0 || m === 0) return 0;
+  let prev = new Array<number>(m + 1).fill(0);
+  for (let i = 1; i <= n; i += 1) {
+    const curr = new Array<number>(m + 1).fill(0);
+    for (let j = 1; j <= m; j += 1) {
+      const match = a[i - 1] === b[j - 1];
+      curr[j] = match ? (prev[j - 1] ?? 0) + 1 : Math.max(prev[j] ?? 0, curr[j - 1] ?? 0);
+    }
+    prev = curr;
+  }
+  return prev[m] ?? 0;
+}
+
+/** Port `rapidfuzz.fuzz.ratio` (Indel-distance-based normalizovaná zhoda). */
+function ratio(a: string, b: string): number {
+  const total = a.length + b.length;
+  if (total === 0) return 100;
+  const distance = total - 2 * lcsLength(a, b);
+  return (1 - distance / total) * 100;
+}
+
+function tokenize(s: string): string[] {
+  const trimmed = s.trim();
+  return trimmed === "" ? [] : trimmed.split(/\s+/);
+}
+
+/**
+ * Port `rapidfuzz.fuzz.token_set_ratio(s1, s2)` — case-SENSITIVE, žiadne
+ * predspracovanie okrem tokenizácie na whitespace (presne ako stará appka
+ * volá rapidfuzz priamo bez `.lower()`/`full_process`). Prázdny/len-
+ * whitespace vstup na oboch stranách → 0 (rapidfuzz's `validate_string`
+ * guard — overené empiricky, nevyplýva to len z tokenizácie).
+ */
+export function tokenSetRatio(s1: string, s2: string): number {
+  if (s1.trim() === "" || s2.trim() === "") return 0;
+
+  const tokens1 = new Set(tokenize(s1));
+  const tokens2 = new Set(tokenize(s2));
+
+  const intersection = [...tokens1].filter((t) => tokens2.has(t)).sort();
+  const diff1to2 = [...tokens1].filter((t) => !tokens2.has(t)).sort();
+  const diff2to1 = [...tokens2].filter((t) => !tokens1.has(t)).sort();
+
+  const sortedSect = intersection.join(" ");
+  const sorted1to2 = `${sortedSect} ${diff1to2.join(" ")}`.trim();
+  const sorted2to1 = `${sortedSect} ${diff2to1.join(" ")}`.trim();
+
+  return Math.max(ratio(sortedSect, sorted1to2), ratio(sortedSect, sorted2to1), ratio(sorted1to2, sorted2to1));
+}

--- a/apps/api/src/modules/pairing-search/types.test.ts
+++ b/apps/api/src/modules/pairing-search/types.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { toPairingProduct } from "./types.js";
+
+describe("toPairingProduct", () => {
+  it("collects distinct, non-empty external codes across all variants, in first-seen order", () => {
+    const p = toPairingProduct(
+      { key: "guid-1", name: "Nohavice HART RANDO XHP", supplier: "BETALOV" },
+      [{ externalCode: "60177/46" }, { externalCode: "60177/48" }, { externalCode: "60177/46" }],
+    );
+    expect(p.productKey).toBe("guid-1");
+    expect(p.name).toBe("Nohavice HART RANDO XHP");
+    expect(p.supplier).toBe("BETALOV");
+    expect(p.externalCodes).toEqual(["60177/46", "60177/48"]);
+  });
+
+  it("drops null/empty/whitespace-only external codes", () => {
+    const p = toPairingProduct({ key: "guid-2", name: "Bunda FOREST", supplier: null }, [
+      { externalCode: null },
+      { externalCode: "" },
+      { externalCode: "   " },
+      { externalCode: "OB570" },
+    ]);
+    expect(p.externalCodes).toEqual(["OB570"]);
+    expect(p.supplier).toBeNull();
+  });
+
+  it("returns an empty externalCodes list for a product with no variants", () => {
+    const p = toPairingProduct({ key: "guid-3", name: "X", supplier: null }, []);
+    expect(p.externalCodes).toEqual([]);
+  });
+
+  it("trims whitespace around an otherwise valid external code", () => {
+    const p = toPairingProduct({ key: "guid-4", name: "X", supplier: "ODIMON" }, [{ externalCode: "  ZZ9  " }]);
+    expect(p.externalCodes).toEqual(["ZZ9"]);
+  });
+});

--- a/apps/api/src/modules/pairing-search/types.ts
+++ b/apps/api/src/modules/pairing-search/types.ts
@@ -1,0 +1,74 @@
+// Typy jadra párovacieho vyhľadávania (issue 387 E1) — adaptácia starej
+// appka's `parovanie/models.py` `Product`/`Candidate` na katalógový model
+// tejto appky. Návrh (https://github.com/zbynekdrlik/forestshop-app/
+// issues/387#issuecomment-5273377438, sekcia „Čo sa adaptuje"): jednotka
+// párovania je PRODUKT (`product.key` = guid) s variantmi pod ním —
+// nahrádza starý (supplier, pairCode|meno) grouping z CSV. `external_code`
+// je u nás per-VARIANT (na rozdiel od starej appky, kde bol jeden na
+// zoskupený produkt), takže `PairingProduct.externalCodes` nesie VŠETKY
+// odlišné, neprázdne kódy naprieč variantmi produktu — silnejšie než starý
+// „prvý neprázdny".
+
+/** Vstupný riadok z `products` tabuľky, potrebný pre adaptér nižšie. */
+export interface CatalogProductRow {
+  readonly key: string;
+  readonly name: string;
+  readonly supplier: string | null;
+}
+
+/** Vstupný riadok z `variants` tabuľky, potrebný pre adaptér nižšie. */
+export interface CatalogVariantRow {
+  readonly externalCode: string | null;
+}
+
+/** Produkt pripravený pre `queries.ts`/`ranking.ts` — čistá dátová štruktúra. */
+export interface PairingProduct {
+  readonly productKey: string;
+  readonly name: string;
+  readonly supplier: string | null;
+  readonly externalCodes: readonly string[];
+}
+
+/**
+ * Kandidát z vyhľadávania u dodávateľa — port `models.py`'s `Candidate`.
+ * `rawScore`/`codeHit` sú diagnostické polia, ktoré dopĺňa `ranking.ts`'s
+ * `rank()` (a zodpovedajú `pairing_candidate`'s `raw_score`/`code_hit`
+ * stĺpcom z návrhu, sekcia „DB schéma" — pripravené na E3).
+ */
+export interface PairingCandidate {
+  readonly name: string;
+  readonly url: string;
+  readonly code: string | null;
+  readonly price: string | null;
+  readonly rawScore: number;
+  readonly codeHit: boolean;
+}
+
+/** Istota návrhu — port `models.py`'s `Match.confidence` reťazcových hodnôt. */
+export type PairingConfidence = "high" | "medium" | "low" | "none";
+
+/**
+ * Adaptér: (produkt, jeho varianty) → `PairingProduct`. Deduplikuje
+ * `externalCode`, zahadzuje prázdne/`null` hodnoty, zachováva poradie
+ * prvého výskytu (rovnaká disciplína ako `queries.ts`'s dedup).
+ */
+export function toPairingProduct(
+  product: CatalogProductRow,
+  variants: readonly CatalogVariantRow[],
+): PairingProduct {
+  const seen = new Set<string>();
+  const externalCodes: string[] = [];
+  for (const variant of variants) {
+    const code = variant.externalCode?.trim();
+    if (code && !seen.has(code)) {
+      seen.add(code);
+      externalCodes.push(code);
+    }
+  }
+  return {
+    productKey: product.key,
+    name: product.name,
+    supplier: product.supplier,
+    externalCodes,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.225",
+  "version": "0.3.0-dev.226",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Etapa E1 z issue 387 (profesionálne párovanie produktov podľa starej appky
`parovanie-produktov` @ 60b6164). Schválený návrh architektúry + design komentár:
issue 387. Tento PR je prvá z ôsmich etáp — čisté funkcie jadra, zatiaľ nikde
nezapojené (žiadna sieť, žiadna DB, žiadna zmena správania appky).

## Obsah

Nový modul `apps/api/src/modules/pairing-search/`:

- `normalize.ts` — čistenie mena (kolaps medzier + orezanie vedúceho číselného
  indexu) a `code_present` s celotokenovou hranicou („110" nikdy nematchne „1100"),
  portované z `normalize.py` starej appky.
- `queries.ts` — rebríček dopytov (kód → celé meno → prvé 3 → prvé 2 tokeny) +
  varianty dopytov so 46-slovným zoznamom generických slov, dedup so zachovaním
  poradia; adaptácia: produkt skúša VŠETKY odlišné externé kódy svojich variantov.
- `ranking.ts` — hodnotenie kandidátov: zhoda kódu ⇒ +1000 (vždy prebije meno),
  inak podobnosť mien; prahy ≥1000 / ≥80 / zvyšok; vždy vráti najlepšieho kandidáta.
- `token-set-ratio.ts` — vlastná implementácia podobnosti mien: npm `fuzzball` sa
  od `rapidfuzz` (ktorý používala stará appka) líši, tak je implementácia overená
  bajt-po-bajte proti skutočnému rapidfuzz na 700 pároch + fixtúrach — 0 nezhôd.
- `types.ts` — typy + adaptér z `product`/`variant` riadkov.

## Testy

59 nových unit testov (fixtúry reprodukujúce správanie starej appky vrátane
slovenskej diakritiky a hraníc kódov); celé `gates:local` zelené — API 808 testov,
web 606, typecheck aj lint čisté. Nezávislé review: 0 🔴 0 🟡 0 🔵 (komentár na tikete).

Issue 387 zostáva otvorené — zavrie sa až po poslednej etape a živom overení.
