### PR TITLE
Párovanie produktov E2: SearchClient + adaptéry dodávateľov (issue 387)

### DIFF
--- a/.claude/rules/pairing-search.md
+++ b/.claude/rules/pairing-search.md
@@ -72,3 +72,74 @@ https://github.com/zbynekdrlik/forestshop-app/issues/387#issuecomment-5273377438
   batériu vstup→výstup dvojíc, over TS port proti nim priamo (nie len proti
   ručne napísaným testom, ktoré by mohli zopakovať rovnakú chybu ako
   implementácia).
+
+## E2 — SearchClient + 3 adaptéry (`client.ts`, `adapters/`)
+
+- **`code`/`price` sa pri PARSOVANÍ VÝSLEDKOV VYHĽADÁVANIA nikdy
+  nenapĺňajú — zostávajú `null`, doslovne ako stará appka.** Ani jeden z
+  troch `suppliers/*.py` parserov `Candidate.code`/`.price` nenastavuje
+  (`models.Candidate(name, url)`, defaulty `None`) — kód sa dopĺňa až pri
+  overení na DETAILE produktu (`verify.py`, mimo E2, plánované E4). Zadanie
+  E2 síce menuje "kód/cena" medzi extrahovanými poľami, ale doslovný port
+  necháva `code`/`price` `null` — pri ĎALŠEJ zmene parsera never sa nepokúšaj
+  "vylepšiť" extrakciu o cenu/kód zo search-výsledkov, kým sa nezmení sám
+  zdrojový kontrakt (`PairingCandidate`).
+- **`SupplierAdapter` (`adapters/types.ts`) zlučuje starú appka's oddelený
+  `config.SUPPLIERS` (URL šablóny) + `client.PARSERS` (parsery) do JEDNÉHO
+  objektu na dodávateľa, registrovaného v `adapters/registry.ts` pod
+  `adapterKey`.** `baseUrl`/`buildSearchUrl` sú súčasťou KÓDU adaptéra, nie
+  DB — `supplier.wholesale_base_url` (E1's `schema-pairing.ts`) je pre
+  zobrazenie/budúce overenie (E3+), nikdy pre stavbu vyhľadávacej URL.
+  Nový dodávateľ = nový `adapters/<meno>.ts` súbor + 1 riadok v
+  `registry.ts` (presne ako stará appka's "Pridanie nového dodávateľa"
+  postup, `.claude/skills/suppliers/SKILL.md`).
+- **Živo overené 13. 8. 2026 — všetky tri selektory zo starej appky STÁLE
+  PLATIA bezo zmeny** od 27. 6. 2026: `div.product-miniature__title a.link`
+  (wetland/PrestaShop), `#snippet--productList` + `.product-col` +
+  `a.mh-100`/`.product-title a` (betalov/Nette), `.product-list__results`
+  + `a.product-card` + `img[alt]` (odimon/BUXUS). Pri drifte markupu
+  (E2's riziko #2 v návrhu) over PRVÝ krok vždy živým `curl` (session
+  warm-up + throttle, presne ako `client.ts`), nikdy len proti fixtúre —
+  fixtúra je z definície malá/stará.
+- **BETALOV's `#snippet--productList` má DVA tab-pane so SAMOSTATNÝMI CSS
+  triedami na kartu** — `#home` (mriežka) používa `.product-col`, `#profile`
+  (zoznam) používa `.product-card` BEZ `product-col`. Parser scopuje na
+  `.product-col`, takže zoznamový pohľad sa NIKDY neparsuje — na živej
+  stránke preto NEEXISTUJE prirodzený duplikát v rámci `.product-col`
+  (overené 13. 8. 2026, dopyt "nohavice": 16 kariet, 16 distinct URL).
+  Dedup/exclusion-prefix testy preto používajú SKONŠTRUOVANÉ karty
+  (zdokumentované priamo v komentári fixtúry) — rovnaký precedens ako
+  `supplier-stock/fixtures/rosler-vypredane-noz-entita.html`.
+- **cheerio's `$.root()` má typ `Cheerio<Document>`, NIE `Cheerio<Element>`
+  — premenná `snippet.length > 0 ? snippet : $.root()` (zmiešaný typ) sa
+  nedá bezpečne zavolať `.find(...)` na nej pod `strictTypeChecked`**
+  (`TS2684: The 'this' context ... is not assignable`). Fix (vzor v
+  `betalov.ts`/`odimon.ts`): DVE samostatne typované vetvy —
+  `scope.length > 0 ? scope.find(selector) : $(selector)` (fallback
+  hľadá selektor na CELOM dokumente, nie cez `.find()` na
+  `Cheerio<Document>`) — nikdy si neuklad `$.root()` do premennej, ktorú
+  neskôr voláš `.find()`.
+- **`Record<string, string>` objekt (napr. HTTP hlavičky) pod
+  `noPropertyAccessFromIndexSignature`/`strictTypeChecked` VYŽADUJE
+  bracket notáciu pri PRIRADENÍ NOVÉHO kľúča po inicializácii** —
+  `headers.cookie = x` hlási `TS4111`, `headers["cookie"] = x` prejde.
+  Platí to len pre prístup MIMO object-literal inicializátora (kľúče
+  zadané priamo v `{ "user-agent": ..., accept: ... }` sú v poriadku).
+- **`SearchClient`'s throttle (0,7 s) je identity-check proti
+  `nativeFetcher` singletonu (`this.fetcher === nativeFetcher`), presne
+  ako stará appka's `fetch is _DEFAULT_FETCH`** — test naň (nikdy live
+  sieť) potrebuje `vi.stubGlobal("fetch", ...)` PLUS `sleep` injektovaný
+  cez `SearchClientOptions.sleep` (fetcher sa necháva na predvolený
+  `nativeFetcher`, aby identity-check prešiel) — pozri `client.test.ts`'s
+  "throttles 700ms" test. Injektovaný fake `Fetcher` (bežný prípad vo
+  väčšine testov) throttle VYNECHÁVA úplne, aj keď `throttleMs`/`sleep` sú
+  nastavené — to je zámer, nie diera.
+- **Diagnostická technika: keď `grep`/`Edit`'s string-match ticho nenájde
+  reťazec, ktorý v súbore PREUKÁZATEĽNE JE (`Read` ho ukáže)** — over
+  najprv, či súbor neobsahuje skutočný NUL bajt (`python3 -c "print(b'\x00'
+  in open(cesta,'rb').read())"`); `grep` bez `-a` traktuje takýto súbor
+  ako binárny a ticho nič nevráti (žiadna chyba, len prázdny výstup), aj
+  keď `head`/`cat`/`wc -l` fungujú normálne. Vzniklo tu autorskou chybou
+  pri skladaní obsahu nástroja `Write` (zamýšľaná medzera sa zapísala ako
+  NUL) — oprava je priamy binárny `read().replace(b"\x00", b" ")`, nikdy
+  prepis celého súboru odhadom správneho obsahu.

--- a/.claude/rules/pairing-search.md
+++ b/.claude/rules/pairing-search.md
@@ -143,3 +143,35 @@ https://github.com/zbynekdrlik/forestshop-app/issues/387#issuecomment-5273377438
   pri skladaní obsahu nástroja `Write` (zamýšľaná medzera sa zapísala ako
   NUL) — oprava je priamy binárny `read().replace(b"\x00", b" ")`, nikdy
   prepis celého súboru odhadom správneho obsahu.
+- **Cookie header pre retry v `fetchWithRetry` sa MUSÍ stavať NANOVO pred
+  KAŽDÝM pokusom, nikdy raz vopred pred celou slučkou** — pôvodná
+  implementácia dostávala `headers: Record<string,string>` ako HOTOVÝ
+  objekt (postavený RAZ, pred prvým pokusom), takže cookie uložená do
+  cookie jaru PO neúspešnom 1. pokuse (napr. session cookie vydaná spolu
+  s 503) sa na 2. pokus vôbec nedostala — `headers` bol zmrazený snímok
+  spred jej príchodu. Fix: `buildHeaders: () => Record<string,string>`
+  (factory, volaná vnútri `for` slučky pred KAŽDÝM `rawFetch`), nie
+  statický objekt. **Nájdené VLASTNÝM regresným testom pri prvom behu**
+  (`client.test.ts`'s "captures a Set-Cookie carried on a FAILED attempt")
+  — presne dôkaz, že aj pri doslovnom porte s vysokou dôverou treba
+  regresný test na KAŽDÉ tvrdenie o správaní, nielen na tie, čo pôsobia
+  rizikovo. Rovnaký test pri ĎALŠOM stavovom fetcheri/retry mechanizme v
+  appke: ak sa hlavičky/stav menia MEDZI pokusmi tej istej operácie,
+  over explicitne, že KAŽDÝ pokus číta AKTUÁLNY stav, nie stav zachytený
+  pred prvým pokusom.
+- **WHATWG `URL` konštruktor je PRÍSNY parser, na rozdiel od Pythonovho
+  zhovievavého `urllib.parse.urljoin`/`urldefrag`** — vyhadzuje na tvaroch
+  vstupu, ktoré by Python ticho spracoval (živo overené: `new URL("http://
+  [", base)` aj `new URL("http://exam ple.com/x", base)` obe vyhodia
+  `TypeError: Invalid URL`). Pri DOSLOVNOM porte kódu, ktorý v Pythone
+  nikdy nepotreboval per-item try/except (lebo `urljoin` jednoducho
+  nevyhadzuje), preto TREBA pridať izoláciu, ktorú Python nemal — inak
+  JEDNA pokazená karta na živej stránke zhodí `.each()` slučku a zahodí aj
+  všetky OSTATNÉ platné kandidáty (review nález, issue 387 E2). Riešenie
+  tu: `resolveAndStripFragment` (`adapters/url.ts`) vracia `string | null`
+  namiesto vyhodenia — volajúci (KAŽDÝ z troch adaptérov) kontroluje
+  `null` presne tak, ako už kontroluje prázdny `href`. Test pri KAŽDOM
+  ĎALŠOM 1:1 porte Python kódu, ktorý sa spolieha na `urljoin`/`urldefrag`/
+  iné zhovievavé parsovanie: over, či JS/TS ekvivalent (`URL`,
+  `URLSearchParams`, ...) vyhadzuje na rovnakých vstupoch — ak áno, obal
+  ho tak, aby zlyhanie JEDNÉHO záznamu nezhodilo celý dávkový cyklus.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,6 +15,7 @@
     "@hono/node-server": "^1.13.0",
     "@hono/zod-validator": "^0.4.0",
     "@node-rs/argon2": "^2.0.0",
+    "cheerio": "^1.0.0",
     "drizzle-orm": "^0.38.0",
     "hono": "^4.6.0",
     "node-ical": "^0.27.1",

--- a/apps/api/src/modules/pairing-search/adapters/betalov.test.ts
+++ b/apps/api/src/modules/pairing-search/adapters/betalov.test.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { betalovAdapter, parseBetalovSearch } from "./betalov.js";
+
+function fixture(name: string): string {
+  return readFileSync(fileURLToPath(new URL(`../fixtures/${name}`, import.meta.url)), "utf8");
+}
+
+const VYSLEDKY = fixture("betalov-vysledky-nohavice.html");
+const PRAZDNE = fixture("betalov-prazdne-vysledky.html");
+
+describe("parseBetalovSearch", () => {
+  it("extracts name/url from real .product-col cards inside #snippet--productList", () => {
+    const candidates = parseBetalovSearch(VYSLEDKY);
+    // 5 kariet vo fixtúre: karta 4 je duplikát karty 1 (dedup), karta 5 je
+    // vylúčená cesta /kosik (exclusion) — zostávajú 3 skutočné produkty.
+    expect(candidates).toHaveLength(3);
+    expect(candidates[0]).toEqual({
+      name: "Detské outdoorové nohavice - Combi",
+      url: "https://www.huntingshop.eu/detske-outdoorove-nohavice-combi-14695",
+      code: null,
+      price: null,
+      rawScore: 0,
+      codeHit: false,
+    });
+    expect(candidates[1]?.name).toBe("Armotion Class-T dámske nohavice");
+    expect(candidates[2]?.name).toBe("WADERA - Detské krátke nohavice - Hnedé");
+  });
+
+  it("dedups the repeated card by canonical URL", () => {
+    const candidates = parseBetalovSearch(VYSLEDKY);
+    const urls = candidates.map((candidate) => candidate.url);
+    expect(new Set(urls).size).toBe(urls.length);
+    expect(urls.filter((url) => url.endsWith("detske-outdoorove-nohavice-combi-14695"))).toHaveLength(1);
+  });
+
+  it("excludes navigation-prefix paths (/kosik) even when they appear as a .product-col card", () => {
+    const candidates = parseBetalovSearch(VYSLEDKY);
+    expect(candidates.some((candidate) => candidate.url.includes("/kosik"))).toBe(false);
+  });
+
+  it("returns an empty list when both tab-panes are empty", () => {
+    expect(parseBetalovSearch(PRAZDNE)).toEqual([]);
+  });
+});
+
+describe("betalovAdapter", () => {
+  it("builds the URL-encoded search URL against huntingshop.eu", () => {
+    expect(betalovAdapter.buildSearchUrl("nohavice s medzerou")).toBe(
+      "https://www.huntingshop.eu/hladanie?search=nohavice%20s%20medzerou",
+    );
+  });
+
+  it("carries the adapterKey matching supplier.adapter_key", () => {
+    expect(betalovAdapter.adapterKey).toBe("betalov");
+    expect(betalovAdapter.baseUrl).toBe("https://www.huntingshop.eu");
+  });
+});

--- a/apps/api/src/modules/pairing-search/adapters/betalov.test.ts
+++ b/apps/api/src/modules/pairing-search/adapters/betalov.test.ts
@@ -43,6 +43,58 @@ describe("parseBetalovSearch", () => {
   it("returns an empty list when both tab-panes are empty", () => {
     expect(parseBetalovSearch(PRAZDNE)).toEqual([]);
   });
+
+  // Syntetické HTML zlomky (nie živo stiahnuté fixtúry) — testujú
+  // ŠTRUKTURÁLNE vetvy (chýbajúci mh-100/chýbajúci #snippet--productList),
+  // nie nuansu reálneho markupu.
+  it("falls back to .product-title a href when a.mh-100 is missing on the card", () => {
+    const html =
+      '<div class="product-col"><h3 class="product-title"><a href="len-title-odkaz">Len title odkaz</a></h3></div>';
+    expect(parseBetalovSearch(html)).toEqual([
+      {
+        name: "Len title odkaz",
+        url: "https://www.huntingshop.eu/len-title-odkaz",
+        code: null,
+        price: null,
+        rawScore: 0,
+        codeHit: false,
+      },
+    ]);
+  });
+
+  it("searches the whole document for .product-col when #snippet--productList is absent", () => {
+    const html =
+      '<div class="product-col"><a href="/x" class="mh-100">img</a>' +
+      '<h3 class="product-title"><a href="x">Bez snippetu</a></h3></div>';
+    expect(parseBetalovSearch(html)).toEqual([
+      {
+        name: "Bez snippetu",
+        url: "https://www.huntingshop.eu/x",
+        code: null,
+        price: null,
+        rawScore: 0,
+        codeHit: false,
+      },
+    ]);
+  });
+
+  it("skips a single malformed href without losing the other, valid cards (review finding, issue 387 E2)", () => {
+    const html =
+      '<div class="product-col"><a href="http://[" class="mh-100">img</a>' +
+      '<h3 class="product-title"><a href="http://[">Pokazená</a></h3></div>' +
+      '<div class="product-col"><a href="/dobra" class="mh-100">img</a>' +
+      '<h3 class="product-title"><a href="dobra">Dobrá karta</a></h3></div>';
+    expect(parseBetalovSearch(html)).toEqual([
+      {
+        name: "Dobrá karta",
+        url: "https://www.huntingshop.eu/dobra",
+        code: null,
+        price: null,
+        rawScore: 0,
+        codeHit: false,
+      },
+    ]);
+  });
 });
 
 describe("betalovAdapter", () => {

--- a/apps/api/src/modules/pairing-search/adapters/betalov.ts
+++ b/apps/api/src/modules/pairing-search/adapters/betalov.ts
@@ -1,0 +1,100 @@
+// BETALOV (huntingshop.eu, Nette) — doslovný port `src/parovanie/
+// suppliers/betalov.py` zo starej appky (commit 60b6164, issue 387 E2).
+//
+// huntingshop.eu vykresľuje výsledky vyhľadávania cez Nette AJAX snippet
+// (`#snippet--productList`) — BEZ platnej relácie (`client.ts`'s per-host
+// warm-up) je tento kontajner prázdny (`.claude/rules/pairing-search.md`).
+// Kontajner nesie DVA tab-pane (`#home` = mriežka, `#profile` = zoznam) so
+// SAMOSTATNÝMI CSS triedami na kartu (`.product-col` vs. `.product-card`
+// bez `product-col`) — parser scopuje na `#snippet--productList` a vyberá
+// LEN `.product-col` karty (mriežkový pohľad), presne ako stará appka
+// (`scope.select(".product-col")`); zoznamový pohľad sa tak nikdy
+// neparsuje dvakrát.
+//
+// Na KAŽDEJ karte sa najprv skúsi náhľadový odkaz `a.mh-100` (má vedúcu
+// lomku, teda dobre tvarovaný), a až keď chýba, padá sa na `.product-title
+// a` (BEZ vedúcej lomky na tomto webe). `_EXCLUDE_PREFIXES` je doslovný
+// port navigačných/účtových ciest, ktoré by sa inak (teoreticky) dostali
+// do výsledkového kontajnera. Dedup podľa kanonickej URL.
+//
+// Živo overené 13. 8. 2026 (`fixtures/betalov-vysledky-nohavice.html`,
+// `fixtures/betalov-prazdne-vysledky.html`) — selektory aj `#snippet--
+// productList`/`.product-col` tvar sa zhodujú so starou appka's
+// dokumentáciou z 27. 6. 2026.
+
+import * as cheerio from "cheerio";
+import type { PairingCandidate } from "../types.js";
+import type { SupplierAdapter } from "./types.js";
+import { belongsToBase, resolveAndStripFragment } from "./url.js";
+
+const BASE_URL = "https://www.huntingshop.eu";
+
+// Doslovný port `suppliers/betalov.py`'s `_EXCLUDE_PREFIXES` — navigačné/
+// účtové/utilitné cesty tejto Nette appky, nikdy produktové karty.
+const EXCLUDE_PREFIXES = [
+  "/kosik",
+  "/prihlasenie",
+  "/registracia",
+  "/kontakt",
+  "/hladanie",
+  "/obchodne",
+  "/ochrana",
+  "/blog",
+  "/clanok",
+  "/kategoria",
+  "/znacka",
+  "/akcia",
+  "/akcie",
+  "/novinky",
+  "/assets",
+  "/assets2",
+  "/upload",
+  "/vyrobca",
+] as const;
+
+export function parseBetalovSearch(html: string): PairingCandidate[] {
+  const $ = cheerio.load(html);
+  const snippet = $("#snippet--productList");
+  // `$.root()` je typu `Cheerio<Document>` (nie `Cheerio<Element>`) — radšej
+  // dve samostatne typované vetvy (`.find()` v scope / `$(selector)` na
+  // celom dokumente) než premenná zmiešaného typu, ktorej `.find()` by TS
+  // odmietol (`noUncheckedIndexedAccess`/`strictTypeChecked` nesúhlasí s
+  // `this` typu `Cheerio<Element> | Cheerio<Document>`).
+  const cards = snippet.length > 0 ? snippet.find(".product-col") : $(".product-col");
+
+  const out: PairingCandidate[] = [];
+  const seen = new Set<string>();
+
+  cards.each((_index, element) => {
+    const card = $(element);
+
+    let href = card.find("a.mh-100").first().attr("href") ?? "";
+    if (!href) {
+      href = card.find(".product-title a").first().attr("href") ?? "";
+    }
+    if (!href) return;
+
+    // Port `urljoin(base_url + "/", href.lstrip("/"))` — obe formy (vedúca
+    // lomka aj bez nej) sa normalizujú na rovnaký absolútny tvar.
+    const url = resolveAndStripFragment(href.replace(/^\/+/, ""), `${BASE_URL}/`);
+    if (!belongsToBase(url, BASE_URL)) return;
+
+    const path = url.slice(BASE_URL.length);
+    if (EXCLUDE_PREFIXES.some((prefix) => path.startsWith(prefix))) return;
+
+    if (seen.has(url)) return;
+    seen.add(url);
+
+    const name = card.find(".product-title a").first().text().trim();
+    out.push({ name, url, code: null, price: null, rawScore: 0, codeHit: false });
+  });
+
+  return out;
+}
+
+export const betalovAdapter: SupplierAdapter = {
+  adapterKey: "betalov",
+  baseUrl: BASE_URL,
+  buildSearchUrl: (query) => `${BASE_URL}/hladanie?search=${encodeURIComponent(query)}`,
+  parseSearchResults: parseBetalovSearch,
+};

--- a/apps/api/src/modules/pairing-search/adapters/betalov.ts
+++ b/apps/api/src/modules/pairing-search/adapters/betalov.ts
@@ -77,7 +77,7 @@ export function parseBetalovSearch(html: string): PairingCandidate[] {
     // Port `urljoin(base_url + "/", href.lstrip("/"))` — obe formy (vedúca
     // lomka aj bez nej) sa normalizujú na rovnaký absolútny tvar.
     const url = resolveAndStripFragment(href.replace(/^\/+/, ""), `${BASE_URL}/`);
-    if (!belongsToBase(url, BASE_URL)) return;
+    if (url === null || !belongsToBase(url, BASE_URL)) return;
 
     const path = url.slice(BASE_URL.length);
     if (EXCLUDE_PREFIXES.some((prefix) => path.startsWith(prefix))) return;

--- a/apps/api/src/modules/pairing-search/adapters/odimon.test.ts
+++ b/apps/api/src/modules/pairing-search/adapters/odimon.test.ts
@@ -36,6 +36,40 @@ describe("parseOdimonSearch", () => {
   it("returns an empty list when .product-list__results has no cards", () => {
     expect(parseOdimonSearch(PRAZDNE)).toEqual([]);
   });
+
+  // Syntetické HTML zlomky (nie živo stiahnuté fixtúry) — testujú
+  // ŠTRUKTURÁLNE vetvy, nie nuansu reálneho markupu.
+  it("searches the whole document for a.product-card when .product-list__results is absent", () => {
+    const html = '<a class="product-card" href="https://www.odimon.sk/x"><img alt="Bez kontajnera"></a>';
+    expect(parseOdimonSearch(html)).toEqual([
+      {
+        name: "Bez kontajnera",
+        url: "https://www.odimon.sk/x",
+        code: null,
+        price: null,
+        rawScore: 0,
+        codeHit: false,
+      },
+    ]);
+  });
+
+  it("skips a single malformed href without losing the other, valid cards (review finding, issue 387 E2)", () => {
+    const html =
+      '<div class="product-list__results">' +
+      '<a class="product-card" href="http://["><img alt="Pokazená"></a>' +
+      '<a class="product-card" href="https://www.odimon.sk/dobra"><img alt="Dobrá karta"></a>' +
+      "</div>";
+    expect(parseOdimonSearch(html)).toEqual([
+      {
+        name: "Dobrá karta",
+        url: "https://www.odimon.sk/dobra",
+        code: null,
+        price: null,
+        rawScore: 0,
+        codeHit: false,
+      },
+    ]);
+  });
 });
 
 describe("odimonAdapter", () => {

--- a/apps/api/src/modules/pairing-search/adapters/odimon.test.ts
+++ b/apps/api/src/modules/pairing-search/adapters/odimon.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { odimonAdapter, parseOdimonSearch } from "./odimon.js";
+
+function fixture(name: string): string {
+  return readFileSync(fileURLToPath(new URL(`../fixtures/${name}`, import.meta.url)), "utf8");
+}
+
+const VYSLEDKY = fixture("odimon-vysledky-nohavice.html");
+const PRAZDNE = fixture("odimon-prazdne-vysledky.html");
+
+describe("parseOdimonSearch", () => {
+  it("extracts name from img[alt] and url from a.product-card, code/price stay null", () => {
+    const candidates = parseOdimonSearch(VYSLEDKY);
+    // 4 karty vo fixtúre, karta 4 je duplikát karty 1 — po dedupe 3.
+    expect(candidates).toHaveLength(3);
+    expect(candidates[0]).toEqual({
+      name: "Termoprádlo nohavice modal Termovel",
+      url: "https://www.odimon.sk/obuv-a-oblecenie/polovnicke-oblecenie/polovnicke-termopradlo/termopradlo-nohavice-modal-termovel",
+      code: null,
+      price: null,
+      rawScore: 0,
+      codeHit: false,
+    });
+    expect(candidates[1]?.name).toBe("Pánske poľovnícke nohavice Michal");
+    expect(candidates[2]?.name).toBe("Poľovnícke nohavice Deerhunter Ram");
+  });
+
+  it("dedups the repeated card by canonical URL", () => {
+    const candidates = parseOdimonSearch(VYSLEDKY);
+    const urls = candidates.map((candidate) => candidate.url);
+    expect(new Set(urls).size).toBe(urls.length);
+  });
+
+  it("returns an empty list when .product-list__results has no cards", () => {
+    expect(parseOdimonSearch(PRAZDNE)).toEqual([]);
+  });
+});
+
+describe("odimonAdapter", () => {
+  it("builds the URL-encoded search URL against odimon.sk", () => {
+    expect(odimonAdapter.buildSearchUrl("nohavice s medzerou")).toBe(
+      "https://www.odimon.sk/vysledky-vyhladavania?term=nohavice%20s%20medzerou",
+    );
+  });
+
+  it("carries the adapterKey matching supplier.adapter_key", () => {
+    expect(odimonAdapter.adapterKey).toBe("odimon");
+    expect(odimonAdapter.baseUrl).toBe("https://www.odimon.sk");
+  });
+});

--- a/apps/api/src/modules/pairing-search/adapters/odimon.ts
+++ b/apps/api/src/modules/pairing-search/adapters/odimon.ts
@@ -1,0 +1,61 @@
+// ODIMON (odimon.sk, BUXUS) — doslovný port `src/parovanie/suppliers/
+// odimon.py` zo starej appky (commit 60b6164, issue 387 E2).
+//
+// odimon.sk vykresľuje výsledky staticky (server-side), ale je cookie-
+// gated rovnako ako BETALOV — `client.ts`'s per-host warm-up (BUXUS
+// session cookie) musí prebehnúť pred vyhľadávacím requestom (`.claude/
+// rules/pairing-search.md`). Každá karta JE priamo `a.product-card`
+// (celý odkaz, nie obal okolo neho) — meno produktu nesie `img[alt]`
+// (záložne `img[title]`), NIE text kotvy. Scope `.product-list__results`
+// vylučuje filtrovacie fasety, mini-košík a karusel „odporúčaných"
+// produktov (`.claude/rules/supplier-stock.md` potvrdzuje, že JSON-LD na
+// tejto doméne vie klamať — preto sa meno berie z viditeľného `alt`, nie z
+// JSON-LD). Žiadny exclusion-prefix zoznam netreba — účtové/košíkové
+// odkazy na tomto webe nikdy nenesú triedu `product-card`.
+//
+// Živo overené 13. 8. 2026 (`fixtures/odimon-vysledky-nohavice.html`,
+// `fixtures/odimon-prazdne-vysledky.html`) — selektory aj `.product-
+// list__results`/`a.product-card` tvar sa zhodujú so starou appka's
+// dokumentáciou z 27. 6. 2026.
+
+import * as cheerio from "cheerio";
+import type { PairingCandidate } from "../types.js";
+import type { SupplierAdapter } from "./types.js";
+import { belongsToBase, resolveAndStripFragment } from "./url.js";
+
+const BASE_URL = "https://www.odimon.sk";
+
+export function parseOdimonSearch(html: string): PairingCandidate[] {
+  const $ = cheerio.load(html);
+  const results = $(".product-list__results");
+  // Rovnaký dôvod ako `betalov.ts`: dve typované vetvy namiesto premennej
+  // zmiešaného typu `Cheerio<Element> | Cheerio<Document>`.
+  const cards = results.length > 0 ? results.find("a.product-card") : $("a.product-card");
+
+  const out: PairingCandidate[] = [];
+  const seen = new Set<string>();
+
+  cards.each((_index, element) => {
+    const anchor = $(element);
+    const href = (anchor.attr("href") ?? "").trim();
+    if (!href) return;
+
+    const url = resolveAndStripFragment(href, `${BASE_URL}/`);
+    if (!belongsToBase(url, BASE_URL)) return;
+    if (seen.has(url)) return;
+    seen.add(url);
+
+    const img = anchor.find("img").first();
+    const name = (img.attr("alt") ?? img.attr("title") ?? "").trim();
+    out.push({ name, url, code: null, price: null, rawScore: 0, codeHit: false });
+  });
+
+  return out;
+}
+
+export const odimonAdapter: SupplierAdapter = {
+  adapterKey: "odimon",
+  baseUrl: BASE_URL,
+  buildSearchUrl: (query) => `${BASE_URL}/vysledky-vyhladavania?term=${encodeURIComponent(query)}`,
+  parseSearchResults: parseOdimonSearch,
+};

--- a/apps/api/src/modules/pairing-search/adapters/odimon.ts
+++ b/apps/api/src/modules/pairing-search/adapters/odimon.ts
@@ -41,7 +41,7 @@ export function parseOdimonSearch(html: string): PairingCandidate[] {
     if (!href) return;
 
     const url = resolveAndStripFragment(href, `${BASE_URL}/`);
-    if (!belongsToBase(url, BASE_URL)) return;
+    if (url === null || !belongsToBase(url, BASE_URL)) return;
     if (seen.has(url)) return;
     seen.add(url);
 

--- a/apps/api/src/modules/pairing-search/adapters/registry.test.ts
+++ b/apps/api/src/modules/pairing-search/adapters/registry.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { adapterFor, SUPPLIER_ADAPTERS } from "./registry.js";
+
+describe("SUPPLIER_ADAPTERS registry", () => {
+  it("carries exactly the three E2 adapters keyed by their adapterKey", () => {
+    expect(new Set(SUPPLIER_ADAPTERS.keys())).toEqual(new Set(["wetland", "betalov", "odimon"]));
+  });
+
+  it("adapterFor resolves a known key to the matching adapter", () => {
+    expect(adapterFor("wetland")?.baseUrl).toBe("https://www.wetland.sk");
+    expect(adapterFor("betalov")?.baseUrl).toBe("https://www.huntingshop.eu");
+    expect(adapterFor("odimon")?.baseUrl).toBe("https://www.odimon.sk");
+  });
+
+  it("adapterFor returns undefined for an unknown key", () => {
+    expect(adapterFor("neexistujuci-dodavatel")).toBeUndefined();
+  });
+});

--- a/apps/api/src/modules/pairing-search/adapters/registry.ts
+++ b/apps/api/src/modules/pairing-search/adapters/registry.ts
@@ -1,0 +1,18 @@
+// Registry dodávateľských adaptérov (issue 387 E2) — nahrádza starú
+// appka's `client.PARSERS` dict, kľúčovaný podľa `adapterKey` namiesto
+// pevného `SUPPLIERS` reťazca (`config.py`). Zámerne oddelené od
+// `client.ts`, aby si testy vedeli vybrať konkrétny adaptér bez potreby
+// inštanciovať `SearchClient`.
+
+import type { SupplierAdapter } from "./types.js";
+import { betalovAdapter } from "./betalov.js";
+import { odimonAdapter } from "./odimon.js";
+import { wetlandAdapter } from "./wetland.js";
+
+export const SUPPLIER_ADAPTERS: ReadonlyMap<string, SupplierAdapter> = new Map(
+  [wetlandAdapter, betalovAdapter, odimonAdapter].map((adapter) => [adapter.adapterKey, adapter]),
+);
+
+export function adapterFor(adapterKey: string): SupplierAdapter | undefined {
+  return SUPPLIER_ADAPTERS.get(adapterKey);
+}

--- a/apps/api/src/modules/pairing-search/adapters/types.ts
+++ b/apps/api/src/modules/pairing-search/adapters/types.ts
@@ -1,0 +1,28 @@
+// Rozhranie pre dodávateľského adaptéra (issue 387 E2) — jeden modul na
+// dodávateľa (`wetland.ts`/`betalov.ts`/`odimon.ts`), zaregistrovaný v
+// `registry.ts` pod `adapterKey` (rovnaký reťazec ako `supplier.adapter_key`
+// stĺpec, `schema-pairing.ts`). `buildSearchUrl`/`parseSearchResults`
+// nahrádzajú starú appka's `config.SUPPLIERS`/`client.PARSERS` dvojicu
+// (`src/parovanie/config.py`+`suppliers/*.py`) jedným objektom na dodávateľa.
+
+import type { PairingCandidate } from "../types.js";
+
+export interface SupplierAdapter {
+  /** Zhoduje sa s `supplier.adapter_key` v DB (pripravené na E3). */
+  readonly adapterKey: string;
+  /** Koreň dodávateľského webu, napr. `"https://www.wetland.sk"` — bez
+   *  koncovej lomky, presne ako stará appka's `SupplierConfig.base_url`. */
+  readonly baseUrl: string;
+  /** Zostaví absolútnu URL vyhľadávacej stránky pre danú (nekódovanú) query. */
+  buildSearchUrl(query: string): string;
+  /**
+   * Vyparsuje HTML vyhľadávacej stránky na kandidátov. `code`/`price` sú
+   * VŽDY `null` — stará appka ich pri parsovaní výsledkov tiež nikdy
+   * nenapĺňala (`models.Candidate(name, url)`, defaulty `code=None,
+   * price=None`); dopĺňajú sa až pri overení kódu na detaile produktu
+   * (`verify.py`, mimo rozsahu E2 — plánované na E4). `rawScore`/`codeHit`
+   * sú neutrálne (`0`/`false`) — `ranking.ts`'s `rank()` ich vždy prepíše
+   * vlastným výpočtom, nikdy nečíta vstupnú hodnotu.
+   */
+  parseSearchResults(html: string): readonly PairingCandidate[];
+}

--- a/apps/api/src/modules/pairing-search/adapters/url.test.ts
+++ b/apps/api/src/modules/pairing-search/adapters/url.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { belongsToBase, resolveAndStripFragment } from "./url.js";
+
+describe("resolveAndStripFragment", () => {
+  it("resolves a relative href against the base and strips the fragment", () => {
+    expect(resolveAndStripFragment("/nohavice/x#/9-velkost-48", "https://www.wetland.sk")).toBe(
+      "https://www.wetland.sk/nohavice/x",
+    );
+  });
+
+  it("leaves an already-absolute href untouched apart from the fragment", () => {
+    expect(resolveAndStripFragment("https://www.wetland.sk/x#frag", "https://www.wetland.sk")).toBe(
+      "https://www.wetland.sk/x",
+    );
+  });
+
+  it("returns null (never throws) for a malformed href — WHATWG URL is stricter than Python's urljoin", () => {
+    // Review finding, issue 387 E2: WHATWG `URL` rejects this (unlike
+    // Python's lenient urljoin/urldefrag) — a caller that let this throw
+    // would abort its whole .each() loop and lose every other candidate.
+    expect(resolveAndStripFragment("http://[", "https://www.wetland.sk")).toBeNull();
+  });
+});
+
+describe("belongsToBase", () => {
+  it("accepts a URL under the base path", () => {
+    expect(belongsToBase("https://www.wetland.sk/x", "https://www.wetland.sk")).toBe(true);
+  });
+
+  it("accepts the bare base URL itself", () => {
+    expect(belongsToBase("https://www.wetland.sk", "https://www.wetland.sk")).toBe(true);
+  });
+
+  it("rejects a different domain that merely shares the base as a string prefix", () => {
+    // Review finding, issue 387 E2: a bare startsWith (the literal port of
+    // Python's `url.startswith(base_url)`) would wrongly accept this.
+    expect(belongsToBase("https://www.wetland.sk.evil.example/x", "https://www.wetland.sk")).toBe(false);
+  });
+
+  it("rejects an unrelated host", () => {
+    expect(belongsToBase("https://evil.example/x", "https://www.wetland.sk")).toBe(false);
+  });
+});

--- a/apps/api/src/modules/pairing-search/adapters/url.ts
+++ b/apps/api/src/modules/pairing-search/adapters/url.ts
@@ -10,17 +10,35 @@
 /**
  * Spojí `href` s `baseUrl` (WHATWG `URL` rezolúcia — rovnaké správanie ako
  * Python's `urljoin` pre tieto tvary vstupu) a odrezáva `#fragment`
- * (`urldefrag`). Vyhadzuje pri nespracovateľnej URL — volajúci parser to
- * necháva prejsť ako chybu tohto konkrétneho výsledku, nie tichú stratu.
+ * (`urldefrag`). Vráti `null` pri nespracovateľnej URL namiesto vyhodenia
+ * — WHATWG `URL` je (na rozdiel od Pythonovho zhovievavého `urljoin`/
+ * `urldefrag`) PRÍSNY parser (živo overené: `new URL("http://exam
+ * ple.com/x", …)` aj `new URL("http://[", …)` obe vyhadzujú), takže
+ * vyhodenie z tejto funkcie by pri jednej pokazenej karte zhodilo CELÝ
+ * `.each()` cyklus volajúceho parsera a zahodilo aj VŠETKY ostatné, platné
+ * kandidáty na tej istej stránke (review nález, issue 387 E2) — presne
+ * tomu má "chyba len tohto výsledku" hlavičkový komentár tejto funkcie
+ * zabrániť, `null` návrat to zaručuje priamo v type systéme namiesto
+ * spoliehania sa na to, že si to KAŽDÝ volajúci nezabudne obaliť.
  */
-export function resolveAndStripFragment(href: string, baseUrl: string): string {
-  const url = new URL(href, baseUrl);
-  url.hash = "";
-  return url.toString();
+export function resolveAndStripFragment(href: string, baseUrl: string): string | null {
+  try {
+    const url = new URL(href, baseUrl);
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return null;
+  }
 }
 
-/** `true`, keď `url` patrí do `baseUrl`'s domény (port starej appka's
- *  `url.startswith(base_url)` reťazcovej kontroly). */
+/**
+ * `true`, keď `url` patrí do `baseUrl`'s domény — port starej appka's
+ * `url.startswith(base_url)` kontroly, ALE s hranicou znaku (review nález,
+ * issue 387 E2): holé `startsWith` by pustilo aj `https://www.wetland.sk.
+ * evil.example/x` proti `baseUrl="https://www.wetland.sk"`. `baseUrl` je
+ * tu vždy natvrdo zapísaná konštanta adaptéra (nikdy vstup od útočníka),
+ * takže ide o obranu do hĺbky, nie o opravu skutočne zneužiteľnej diery.
+ */
 export function belongsToBase(url: string, baseUrl: string): boolean {
-  return url.startsWith(baseUrl);
+  return url === baseUrl || url.startsWith(`${baseUrl}/`);
 }

--- a/apps/api/src/modules/pairing-search/adapters/url.ts
+++ b/apps/api/src/modules/pairing-search/adapters/url.ts
@@ -1,0 +1,26 @@
+// Zdieľané URL pomôcky pre dodávateľské parsery (issue 387 E2) — port
+// starej appka's `urllib.parse.urljoin`+`urldefrag` dvojice (`suppliers/
+// {wetland,betalov,odimon}.py`) na natívne WHATWG `URL`. Všetky tri
+// parsery potrebujú TO ISTÉ: spojiť relatívny/absolútny `href` s koreňom
+// dodávateľa, odrezať `#fragment` (produktová URL na wetland.sk nesie
+// `#/variant-velkost`, ktorý sa do kandidáta nemá dostať), a overiť, že
+// výsledná URL naozaj patrí danému dodávateľovi (chráni pred externým
+// odkazom vo výsledkovej karte).
+
+/**
+ * Spojí `href` s `baseUrl` (WHATWG `URL` rezolúcia — rovnaké správanie ako
+ * Python's `urljoin` pre tieto tvary vstupu) a odrezáva `#fragment`
+ * (`urldefrag`). Vyhadzuje pri nespracovateľnej URL — volajúci parser to
+ * necháva prejsť ako chybu tohto konkrétneho výsledku, nie tichú stratu.
+ */
+export function resolveAndStripFragment(href: string, baseUrl: string): string {
+  const url = new URL(href, baseUrl);
+  url.hash = "";
+  return url.toString();
+}
+
+/** `true`, keď `url` patrí do `baseUrl`'s domény (port starej appka's
+ *  `url.startswith(base_url)` reťazcovej kontroly). */
+export function belongsToBase(url: string, baseUrl: string): boolean {
+  return url.startsWith(baseUrl);
+}

--- a/apps/api/src/modules/pairing-search/adapters/wetland.test.ts
+++ b/apps/api/src/modules/pairing-search/adapters/wetland.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { parseWetlandSearch, wetlandAdapter } from "./wetland.js";
+
+function fixture(name: string): string {
+  return readFileSync(fileURLToPath(new URL(`../fixtures/${name}`, import.meta.url)), "utf8");
+}
+
+const VYSLEDKY = fixture("wetland-vysledky-nohavice.html");
+const PRAZDNE = fixture("wetland-prazdne-vysledky.html");
+
+describe("parseWetlandSearch", () => {
+  it("extracts name/url from real search-result markup, code/price stay null", () => {
+    const candidates = parseWetlandSearch(VYSLEDKY);
+    // 4 karty vo fixtúre, ale karta 4 je duplikát karty 1 (iný fragment) —
+    // po dedupe zostávajú 3 (`.claude/rules/pairing-search.md` doslovný port).
+    expect(candidates).toHaveLength(3);
+    expect(candidates[0]).toEqual({
+      name: "DEERHUNTER Pro Gamekeeper Boot Trousers - poľovnícke nohavice",
+      url: "https://www.wetland.sk/nohavice/deerhunter-pro-gamekeeper-boot-trousers-polovnicke-nohavice-111-592",
+      code: null,
+      price: null,
+      rawScore: 0,
+      codeHit: false,
+    });
+    expect(candidates[1]?.name).toBe("DEERHUNTER Strike Extreme Pull-Over Trousers - ochranné nohavice");
+    expect(candidates[2]?.name).toBe("DEERHUNTER Lady Excape Winter Trousers - dámske nohavice");
+  });
+
+  it("strips the #/variant fragment and dedups the two occurrences by canonical URL", () => {
+    const candidates = parseWetlandSearch(VYSLEDKY);
+    const urls = candidates.map((candidate) => candidate.url);
+    // Žiadna URL neobsahuje fragment.
+    for (const url of urls) {
+      expect(url).not.toContain("#");
+    }
+    // Žiadny duplikát.
+    expect(new Set(urls).size).toBe(urls.length);
+  });
+
+  it("returns an empty list when the search page has no results", () => {
+    expect(parseWetlandSearch(PRAZDNE)).toEqual([]);
+  });
+});
+
+describe("wetlandAdapter", () => {
+  it("builds the URL-encoded search URL against wetland.sk", () => {
+    expect(wetlandAdapter.buildSearchUrl("nohavice s medzerou")).toBe(
+      "https://www.wetland.sk/vyhladavanie?controller=search&s=nohavice%20s%20medzerou",
+    );
+  });
+
+  it("carries the adapterKey matching supplier.adapter_key", () => {
+    expect(wetlandAdapter.adapterKey).toBe("wetland");
+    expect(wetlandAdapter.baseUrl).toBe("https://www.wetland.sk");
+  });
+});

--- a/apps/api/src/modules/pairing-search/adapters/wetland.test.ts
+++ b/apps/api/src/modules/pairing-search/adapters/wetland.test.ts
@@ -42,6 +42,34 @@ describe("parseWetlandSearch", () => {
   it("returns an empty list when the search page has no results", () => {
     expect(parseWetlandSearch(PRAZDNE)).toEqual([]);
   });
+
+  // Synteticky zostavený HTML zlomok (nie živo stiahnutá fixtúra) — testuje
+  // ŠTRUKTURÁLNU vetvu (chýbajúci primárny selektor), nie nuansu reálneho
+  // markupu, ktorá by inak zaslúžila commitnutú fixtúru.
+  it("falls back to a.product-miniature__link when the primary title selector matches nothing", () => {
+    const html =
+      '<a class="product-miniature__link" href="/x" title="Miniatúra produktu">' +
+      '<img alt="obrázok"></a>';
+    expect(parseWetlandSearch(html)).toEqual([
+      { name: "Miniatúra produktu", url: "https://www.wetland.sk/x", code: null, price: null, rawScore: 0, codeHit: false },
+    ]);
+  });
+
+  it("skips a single malformed href without losing the other, valid cards (review finding, issue 387 E2)", () => {
+    const html =
+      '<div class="product-miniature__title"><a class="link" href="http://[">Pokazená karta</a></div>' +
+      '<div class="product-miniature__title"><a class="link" href="/nohavice/dobra">Dobrá karta</a></div>';
+    expect(parseWetlandSearch(html)).toEqual([
+      {
+        name: "Dobrá karta",
+        url: "https://www.wetland.sk/nohavice/dobra",
+        code: null,
+        price: null,
+        rawScore: 0,
+        codeHit: false,
+      },
+    ]);
+  });
 });
 
 describe("wetlandAdapter", () => {

--- a/apps/api/src/modules/pairing-search/adapters/wetland.ts
+++ b/apps/api/src/modules/pairing-search/adapters/wetland.ts
@@ -1,0 +1,57 @@
+// WETLAND (wetland.sk, PrestaShop) — doslovný port `src/parovanie/
+// suppliers/wetland.py` zo starej appky (commit 60b6164, issue 387 E2).
+//
+// Primárny selektor: `div.product-miniature__title a.link` — každá karta
+// výsledku má tento vnorený odkaz, ktorý nesie AJ meno produktu (text
+// uzla), AJ kanonickú URL (href). Záložný selektor
+// `a.product-miniature__link` (odkaz na miniatúru obrázku) sa použije,
+// LEN keď primárny vráti 0 zhôd — presne ako stará appka (`if not
+// anchors: anchors = soup.select(...)`, nie zlúčenie oboch naraz).
+// Produktová URL nesie `#/<id>-velkost-<veľkosť>` fragment (predvolená
+// veľkosť varianta) — odrezáva sa (`resolveAndStripFragment`) a duplicitné
+// URL naprieč viacerými fragmentmi toho istého produktu sa deduplikujú.
+//
+// Živo overené 13. 8. 2026 (`fixtures/wetland-vysledky-nohavice.html`,
+// `fixtures/wetland-prazdne-vysledky.html`) — selektory aj tvar URL sa
+// zhodujú so starou appka's dokumentáciou z 27. 6. 2026.
+
+import * as cheerio from "cheerio";
+import type { PairingCandidate } from "../types.js";
+import type { SupplierAdapter } from "./types.js";
+import { belongsToBase, resolveAndStripFragment } from "./url.js";
+
+const BASE_URL = "https://www.wetland.sk";
+
+export function parseWetlandSearch(html: string): PairingCandidate[] {
+  const $ = cheerio.load(html);
+  const out: PairingCandidate[] = [];
+  const seen = new Set<string>();
+
+  let anchors = $("div.product-miniature__title a.link");
+  if (anchors.length === 0) {
+    anchors = $("a.product-miniature__link");
+  }
+
+  anchors.each((_index, element) => {
+    const anchor = $(element);
+    const href = anchor.attr("href");
+    if (!href) return;
+
+    const url = resolveAndStripFragment(href, BASE_URL);
+    if (!belongsToBase(url, BASE_URL)) return;
+    if (seen.has(url)) return;
+    seen.add(url);
+
+    const name = (anchor.text().trim() || anchor.attr("title") || "").trim();
+    out.push({ name, url, code: null, price: null, rawScore: 0, codeHit: false });
+  });
+
+  return out;
+}
+
+export const wetlandAdapter: SupplierAdapter = {
+  adapterKey: "wetland",
+  baseUrl: BASE_URL,
+  buildSearchUrl: (query) => `${BASE_URL}/vyhladavanie?controller=search&s=${encodeURIComponent(query)}`,
+  parseSearchResults: parseWetlandSearch,
+};

--- a/apps/api/src/modules/pairing-search/adapters/wetland.ts
+++ b/apps/api/src/modules/pairing-search/adapters/wetland.ts
@@ -38,7 +38,7 @@ export function parseWetlandSearch(html: string): PairingCandidate[] {
     if (!href) return;
 
     const url = resolveAndStripFragment(href, BASE_URL);
-    if (!belongsToBase(url, BASE_URL)) return;
+    if (url === null || !belongsToBase(url, BASE_URL)) return;
     if (seen.has(url)) return;
     seen.add(url);
 

--- a/apps/api/src/modules/pairing-search/client.test.ts
+++ b/apps/api/src/modules/pairing-search/client.test.ts
@@ -1,0 +1,222 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PairingCandidate } from "./types.js";
+import {
+  createSessionFetcher,
+  nativeFetcher,
+  SearchClient,
+  type Fetcher,
+  type RawFetcher,
+  type RawResponse,
+} from "./client.js";
+
+function fakeResponse(text: string, options: { status?: number; setCookie?: readonly string[] } = {}): RawResponse {
+  return {
+    status: options.status ?? 200,
+    getSetCookie: () => options.setCookie ?? [],
+    text: () => Promise.resolve(text),
+  };
+}
+
+describe("SearchClient", () => {
+  it("delegates to the injected Fetcher and parses via the resolved adapter", async () => {
+    const calls: string[] = [];
+    const fetcher: Fetcher = (url) => {
+      calls.push(url);
+      return Promise.resolve('<div class="product-list__results"></div>');
+    };
+    const client = new SearchClient({ fetcher });
+
+    const candidates = await client.search("odimon", "nohavice");
+
+    expect(candidates).toEqual([]);
+    expect(calls).toEqual(["https://www.odimon.sk/vysledky-vyhladavania?term=nohavice"]);
+  });
+
+  it("caches by (adapterKey, query) — a second identical search never calls the fetcher again", async () => {
+    let callCount = 0;
+    const fetcher: Fetcher = () => {
+      callCount += 1;
+      return Promise.resolve('<div class="product-list__results"></div>');
+    };
+    const client = new SearchClient({ fetcher });
+
+    await client.search("odimon", "rovnaky dopyt");
+    await client.search("odimon", "rovnaky dopyt");
+
+    expect(callCount).toBe(1);
+  });
+
+  it("a different query for the same supplier is NOT a cache hit", async () => {
+    let callCount = 0;
+    const fetcher: Fetcher = () => {
+      callCount += 1;
+      return Promise.resolve('<div class="product-list__results"></div>');
+    };
+    const client = new SearchClient({ fetcher });
+
+    await client.search("odimon", "prva");
+    await client.search("odimon", "druha");
+
+    expect(callCount).toBe(2);
+  });
+
+  it("throws for an unknown adapterKey", async () => {
+    const client = new SearchClient({ fetcher: () => Promise.resolve("") });
+    await expect(client.search("neexistujuci", "x")).rejects.toThrow(/neznámy pairing-search adaptér/);
+  });
+
+  it("never throttles for an injected (non-native) fetcher", async () => {
+    const sleepCalls: number[] = [];
+    const fetcher: Fetcher = () => Promise.resolve('<div class="product-list__results"></div>');
+    const client = new SearchClient({
+      fetcher,
+      sleep: (ms) => {
+        sleepCalls.push(ms);
+        return Promise.resolve();
+      },
+    });
+
+    await client.search("odimon", "test");
+
+    expect(sleepCalls).toEqual([]);
+  });
+
+  it("returns candidates with rawScore/codeHit=0/false and code/price=null (ranking.ts fills these in later)", async () => {
+    const fetcher: Fetcher = () =>
+      Promise.resolve(
+        '<div class="product-list__results"><a class="product-card" href="https://www.odimon.sk/p"><img alt="Test produkt"></a></div>',
+      );
+    const client = new SearchClient({ fetcher });
+
+    const candidates = await client.search("odimon", "test");
+
+    expect(candidates).toEqual<readonly PairingCandidate[]>([
+      { name: "Test produkt", url: "https://www.odimon.sk/p", code: null, price: null, rawScore: 0, codeHit: false },
+    ]);
+  });
+});
+
+describe("SearchClient real-fetcher throttle path (nativeFetcher identity)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("throttles 700ms before the request when the fetcher IS nativeFetcher — never for a custom one", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(new Response('<div class="product-list__results"></div>', { status: 200 }))),
+    );
+    const sleepCalls: number[] = [];
+    // fetcher omitted => defaults to nativeFetcher => isReal === true.
+    const client = new SearchClient({
+      sleep: (ms) => {
+        sleepCalls.push(ms);
+        return Promise.resolve();
+      },
+    });
+
+    await client.search("odimon", "nazivo-stubovana-siet-throttle-test");
+
+    expect(sleepCalls).toEqual([700]);
+  });
+});
+
+describe("createSessionFetcher", () => {
+  it("warms the host once (homepage GET) before the first request to that host", async () => {
+    const requestedUrls: string[] = [];
+    const rawFetch: RawFetcher = (url) => {
+      requestedUrls.push(url);
+      return Promise.resolve(fakeResponse("<html></html>"));
+    };
+    const fetcher = createSessionFetcher({ rawFetch, sleep: () => Promise.resolve() });
+
+    await fetcher("https://example.sk/search?q=a");
+    await fetcher("https://example.sk/search?q=b");
+
+    // Warm-up (homepage) happens exactly once, before the first real request;
+    // second call to the SAME host must not warm up again.
+    expect(requestedUrls).toEqual([
+      "https://example.sk/",
+      "https://example.sk/search?q=a",
+      "https://example.sk/search?q=b",
+    ]);
+  });
+
+  it("still marks the host as warmed even when the warm-up request itself fails", async () => {
+    let warmupAttempts = 0;
+    const rawFetch: RawFetcher = (url) => {
+      if (url === "https://example.sk/") {
+        warmupAttempts += 1;
+        return Promise.reject(new Error("warm-up network error"));
+      }
+      return Promise.resolve(fakeResponse("<html></html>"));
+    };
+    const fetcher = createSessionFetcher({ rawFetch, sleep: () => Promise.resolve() });
+
+    await fetcher("https://example.sk/search?q=a");
+    await fetcher("https://example.sk/search?q=b");
+
+    // Port `_warm`'s Python behaviour: failed warm-up is attempted exactly
+    // once per host, never retried on a later request to the same host.
+    expect(warmupAttempts).toBe(1);
+  });
+
+  it("propagates a Set-Cookie from warm-up into the Cookie header of the following request", async () => {
+    const seenCookieHeaders: (string | undefined)[] = [];
+    const rawFetch: RawFetcher = (url, init) => {
+      seenCookieHeaders.push(init.headers["cookie"]);
+      if (url === "https://example.sk/") {
+        return Promise.resolve(fakeResponse("<html></html>", { setCookie: ["PHPSESSID=abc123; Path=/; HttpOnly"] }));
+      }
+      return Promise.resolve(fakeResponse("<html>results</html>"));
+    };
+    const fetcher = createSessionFetcher({ rawFetch, sleep: () => Promise.resolve() });
+
+    await fetcher("https://example.sk/search?q=a");
+
+    expect(seenCookieHeaders).toEqual([undefined, "PHPSESSID=abc123"]);
+  });
+
+  it("retries up to 3 attempts with 1.5*(attempt+1)s backoff, then throws", async () => {
+    let attempts = 0;
+    const sleepCalls: number[] = [];
+    const rawFetch: RawFetcher = (url) => {
+      if (url === "https://example.sk/") return Promise.resolve(fakeResponse("<html></html>"));
+      attempts += 1;
+      return Promise.reject(new Error("boom"));
+    };
+    const fetcher = createSessionFetcher({
+      rawFetch,
+      sleep: (ms) => {
+        sleepCalls.push(ms);
+        return Promise.resolve();
+      },
+    });
+
+    await expect(fetcher("https://example.sk/search?q=a")).rejects.toThrow(/fetch zlyhal aj po opakovaných/);
+    expect(attempts).toBe(3);
+    expect(sleepCalls).toEqual([1500, 3000, 4500]);
+  });
+
+  it("retries on a non-2xx HTTP status, then succeeds on a later attempt", async () => {
+    let searchAttempts = 0;
+    const rawFetch: RawFetcher = (url) => {
+      if (url === "https://example.sk/") return Promise.resolve(fakeResponse("<html></html>"));
+      searchAttempts += 1;
+      if (searchAttempts < 2) return Promise.resolve(fakeResponse("", { status: 503 }));
+      return Promise.resolve(fakeResponse("<html>ok</html>"));
+    };
+    const fetcher = createSessionFetcher({ rawFetch, sleep: () => Promise.resolve() });
+
+    const text = await fetcher("https://example.sk/search?q=a");
+
+    expect(text).toBe("<html>ok</html>");
+    expect(searchAttempts).toBe(2);
+  });
+});
+
+describe("nativeFetcher", () => {
+  it("is a stable module-level singleton (identity used for the throttle isReal check)", () => {
+    expect(nativeFetcher).toBe(nativeFetcher);
+  });
+});

--- a/apps/api/src/modules/pairing-search/client.test.ts
+++ b/apps/api/src/modules/pairing-search/client.test.ts
@@ -213,6 +213,30 @@ describe("createSessionFetcher", () => {
     expect(text).toBe("<html>ok</html>");
     expect(searchAttempts).toBe(2);
   });
+
+  it("captures a Set-Cookie carried on a FAILED (non-2xx) attempt, not just the final success (review finding)", async () => {
+    let searchAttempts = 0;
+    const seenCookieHeaders: (string | undefined)[] = [];
+    const rawFetch: RawFetcher = (url, init) => {
+      seenCookieHeaders.push(init.headers["cookie"]);
+      if (url === "https://example.sk/") return Promise.resolve(fakeResponse("<html></html>"));
+      searchAttempts += 1;
+      if (searchAttempts < 2) {
+        // A 503 that ALSO issues a fresh session cookie — real servers do
+        // this (e.g. a load balancer re-routing + stamping a new sticky
+        // session cookie on the error response itself).
+        return Promise.resolve(fakeResponse("", { status: 503, setCookie: ["retry_session=xyz; Path=/"] }));
+      }
+      return Promise.resolve(fakeResponse("<html>ok</html>"));
+    };
+    const fetcher = createSessionFetcher({ rawFetch, sleep: () => Promise.resolve() });
+
+    await fetcher("https://example.sk/search?q=a");
+
+    // [warm-up, 1st (503) attempt, 2nd (success) attempt] — the cookie
+    // issued on the FAILED 1st attempt must already be present on the 2nd.
+    expect(seenCookieHeaders).toEqual([undefined, undefined, "retry_session=xyz"]);
+  });
 });
 
 describe("nativeFetcher", () => {

--- a/apps/api/src/modules/pairing-search/client.ts
+++ b/apps/api/src/modules/pairing-search/client.ts
@@ -12,7 +12,8 @@
 //   `_warm` v starej appke skúsi warm-up presne raz a host označí za
 //   "warmed" AJ pri zlyhaní (žiadny opakovaný pokus pri ďalšom dopyte na
 //   ten istý host) — port zachováva toto správanie doslovne.
-// - **Throttle 0,7 s** pred KAŽDÝM reálnym requestom (nikdy pri
+// - **Throttle 0,7 s** raz pred KAŽDÝM `SearchClient.search()` volaním,
+//   ktoré skutočne ide na sieť (nie pri cache hite, nikdy pri
 //   injektovanom fake fetcheri v testoch — identity-check proti
 //   `nativeFetcher`, port Pythonovho `fetch is _DEFAULT_FETCH`).
 // - **3 pokusy s backoffom 1,5·(pokus+1) s** — doslovný port vrátane toho,
@@ -25,6 +26,7 @@
 //   zdieľateľná naprieč viacerými `SearchClient` inštanciami (rovnaký
 //   zámer ako Pythonov `cache: dict | None` konštruktorový parameter).
 
+import { log } from "../../logger.js";
 import type { PairingCandidate } from "./types.js";
 import { adapterFor } from "./adapters/registry.js";
 
@@ -96,34 +98,43 @@ function baseHeaders(cookie: string): Record<string, string> {
   return headers;
 }
 
-interface FetchOutcome {
-  readonly text: string;
-  readonly setCookie: readonly string[];
-}
-
 /** Port `_SessionFetcher.__call__`'s retry slučky: 3 pokusy, 2xx inak
- *  chyba, backoff 1,5·(pokus+1) s medzi pokusmi (aj po poslednom). */
+ *  chyba, backoff 1,5·(pokus+1) s medzi pokusmi (aj po poslednom).
+ *
+ *  `buildHeaders` sa volá NANOVO PRED KAŽDÝM pokusom (nie raz vopred) —
+ *  `onResponseCookies` (nižšie) sa volá pre KAŽDÚ prijatú odpoveď (aj
+ *  ne-2xx), takže cookie vydaná spolu s napr. 503 na 1. pokuse MUSÍ byť
+ *  súčasťou hlavičiek 2. pokusu (review nález, issue 387 E2 — jeden
+ *  vopred zmrazený `headers` objekt by ju stratil, presnú regresiu na to
+ *  drží `client.test.ts`'s "captures a Set-Cookie carried on a FAILED
+ *  (non-2xx) attempt" test). Port `requests.Session`'s správania, ktoré
+ *  cookies extrahuje zo VŠETKÝCH odpovedí, nielen z tej poslednej
+ *  úspešnej. */
 async function fetchWithRetry(
   rawFetch: RawFetcher,
   url: string,
-  headers: Record<string, string>,
+  buildHeaders: () => Record<string, string>,
   sleep: (ms: number) => Promise<void>,
-): Promise<FetchOutcome> {
+  onResponseCookies: (setCookie: readonly string[]) => void,
+): Promise<string> {
   let lastError: unknown;
   for (let attempt = 0; attempt < MAX_RETRIES; attempt += 1) {
     try {
-      const response = await rawFetch(url, { headers });
+      const response = await rawFetch(url, { headers: buildHeaders() });
+      onResponseCookies(response.getSetCookie());
       if (response.status < 200 || response.status >= 300) {
         throw new Error(`HTTP ${String(response.status)}`);
       }
-      const text = await response.text();
-      return { text, setCookie: response.getSetCookie() };
+      return await response.text();
     } catch (error) {
       lastError = error;
+      const reason = error instanceof Error ? error.message : String(error);
+      log.warn({ url, attempt: attempt + 1, reason }, "pairing-search: fetch zlyhal, skúšam znova");
       await sleep(1.5 * (attempt + 1) * 1000);
     }
   }
   const reason = lastError instanceof Error ? lastError.message : String(lastError);
+  log.error({ url, attempts: MAX_RETRIES, reason }, "pairing-search: fetch zlyhal aj po opakovaných pokusoch");
   throw new Error(`fetch zlyhal aj po opakovaných pokusoch: ${url} (${reason})`);
 }
 
@@ -174,10 +185,13 @@ export function createSessionFetcher(options: SessionFetcherOptions = {}): Fetch
     try {
       const response = await rawFetch(`https://${host}/`, { headers: baseHeaders(cookieHeaderFor(host)) });
       storeSetCookies(host, response.getSetCookie());
-    } catch {
+      log.info({ host }, "pairing-search: zohriata session (homepage warm-up)");
+    } catch (error) {
       // Port `_warm`'s `except Exception: log.warning(...)` — zlyhaný
       // warm-up sa neopakuje, host sa napriek tomu označí za "warmed"
       // (nižšie, mimo try/catch, presne ako v Pythone).
+      const reason = error instanceof Error ? error.message : String(error);
+      log.warn({ host, reason }, "pairing-search: warm-up zlyhal, host sa aj tak označí za zohriaty");
     }
     warmedHosts.add(host);
   }
@@ -185,9 +199,15 @@ export function createSessionFetcher(options: SessionFetcherOptions = {}): Fetch
   return async (url: string): Promise<string> => {
     const host = hostOf(url);
     await warmHost(host);
-    const outcome = await fetchWithRetry(rawFetch, url, baseHeaders(cookieHeaderFor(host)), sleep);
-    storeSetCookies(host, outcome.setCookie);
-    return outcome.text;
+    return fetchWithRetry(
+      rawFetch,
+      url,
+      () => baseHeaders(cookieHeaderFor(host)),
+      sleep,
+      (setCookie) => {
+        storeSetCookies(host, setCookie);
+      },
+    );
   };
 }
 
@@ -241,6 +261,7 @@ export class SearchClient {
     const url = adapter.buildSearchUrl(query);
     const html = await this.fetcher(url);
     const candidates = adapter.parseSearchResults(html);
+    log.info({ adapterKey, query, count: candidates.length }, "pairing-search: vyhľadávanie dokončené");
     this.cache.set(cacheKey, candidates);
     return candidates;
   }

--- a/apps/api/src/modules/pairing-search/client.ts
+++ b/apps/api/src/modules/pairing-search/client.ts
@@ -1,0 +1,247 @@
+// HTTP vyhľadávací klient (issue 387 E2) — doslovný port `src/parovanie/
+// client.py`'s `SearchClient`+`_SessionFetcher` dvojice zo starej appky
+// (commit 60b6164). Hranica siete je celá izolovaná v `nodeFetch` (jediné
+// miesto, ktoré sa dotýka skutočného `fetch`, rovnaký vzor ako `supplier-
+// stock/page-fetcher.ts`'s `PageFetcher`) — testy dodajú vlastný `Fetcher`
+// a NIKDY nechodia na skutočný dodávateľský web.
+//
+// Chovanie (návrh, sekcia „SearchClient's chovanie", overené naživo
+// 13. 8. 2026 proti wetland.sk/huntingshop.eu/odimon.sk):
+// - **Homepage warm-up RAZ per host** — huntingshop.eu (Nette) aj
+//   odimon.sk (BUXUS) vrátia PRÁZDNE výsledky bez platnej session cookie;
+//   `_warm` v starej appke skúsi warm-up presne raz a host označí za
+//   "warmed" AJ pri zlyhaní (žiadny opakovaný pokus pri ďalšom dopyte na
+//   ten istý host) — port zachováva toto správanie doslovne.
+// - **Throttle 0,7 s** pred KAŽDÝM reálnym requestom (nikdy pri
+//   injektovanom fake fetcheri v testoch — identity-check proti
+//   `nativeFetcher`, port Pythonovho `fetch is _DEFAULT_FETCH`).
+// - **3 pokusy s backoffom 1,5·(pokus+1) s** — doslovný port vrátane toho,
+//   že sa čaká AJ po poslednom neúspešnom pokuse pred vyhodením chyby
+//   (Pythonov `for attempt in range(MAX_RETRIES): ... time.sleep(...)`
+//   beží ešte raz po poslednom zlyhaní, potom až `raise`).
+// - **Timeout 25 s** na KAŽDÝ jednotlivý pokus (`AbortController`,
+//   rovnaký vzor ako `page-fetcher.ts`'s `readBounded`/timer).
+// - **In-memory cache** kľúčovaná (adapterKey, query) — voliteľne
+//   zdieľateľná naprieč viacerými `SearchClient` inštanciami (rovnaký
+//   zámer ako Pythonov `cache: dict | None` konštruktorový parameter).
+
+import type { PairingCandidate } from "./types.js";
+import { adapterFor } from "./adapters/registry.js";
+
+const USER_AGENT =
+  "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36";
+const THROTTLE_MS = 700;
+const REQUEST_TIMEOUT_MS = 25_000;
+const MAX_RETRIES = 3;
+
+/** Minimálne rozhranie skutočnej HTTP odpovede, ktoré `client.ts` potrebuje
+ *  — vlastné, nie priamo DOM `Response`, aby testy vedeli podhodiť triviálny
+ *  fake objekt (rovnaký zámer ako `page-fetcher.ts`'s `PageFetchResult`). */
+export interface RawResponse {
+  readonly status: number;
+  /** `Headers.getSetCookie()` — VŠETKY `Set-Cookie` hlavičky oddelene
+   *  (undici/Node 24 ju podporuje); nikdy `headers.get("set-cookie")`,
+   *  ktorý by viacero hlavičiek zlúčil čiarkou a rozbil hodnoty s vlastnou
+   *  čiarkou (napr. `Expires=Wed, 09 Jun ...`). */
+  getSetCookie(): readonly string[];
+  text(): Promise<string>;
+}
+
+export type RawFetcher = (url: string, init: { headers: Record<string, string> }) => Promise<RawResponse>;
+
+/** Skutočné sťahovanie cez natívny `fetch`. Nikdy nevolaná priamo testami. */
+export const nodeFetch: RawFetcher = async (url, init) => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => {
+    controller.abort();
+  }, REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, { headers: init.headers, redirect: "follow", signal: controller.signal });
+    return {
+      status: response.status,
+      getSetCookie: () => response.headers.getSetCookie(),
+      text: () => response.text(),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+function realSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+/** Port Pythonovho `urlsplit(url).netloc` — host (+port, ak je) danej URL. */
+function hostOf(url: string): string {
+  return new URL(url).host;
+}
+
+/** Prvý `meno=hodnota` pár zo `Set-Cookie` hlavičky (zvyšok — `Path=`,
+ *  `Expires=`, `HttpOnly`, ... — appka nepotrebuje, len ho posiela ďalej
+ *  naspäť dodávateľovi cez `Cookie:` hlavičku). */
+function parseSetCookiePair(header: string): readonly [string, string] | null {
+  const body = header.split(";", 1)[0] ?? "";
+  const eq = body.indexOf("=");
+  if (eq === -1) return null;
+  const name = body.slice(0, eq).trim();
+  const value = body.slice(eq + 1).trim();
+  return name ? [name, value] : null;
+}
+
+function baseHeaders(cookie: string): Record<string, string> {
+  const headers: Record<string, string> = { "user-agent": USER_AGENT, accept: "text/html,application/xhtml+xml" };
+  if (cookie) headers["cookie"] = cookie;
+  return headers;
+}
+
+interface FetchOutcome {
+  readonly text: string;
+  readonly setCookie: readonly string[];
+}
+
+/** Port `_SessionFetcher.__call__`'s retry slučky: 3 pokusy, 2xx inak
+ *  chyba, backoff 1,5·(pokus+1) s medzi pokusmi (aj po poslednom). */
+async function fetchWithRetry(
+  rawFetch: RawFetcher,
+  url: string,
+  headers: Record<string, string>,
+  sleep: (ms: number) => Promise<void>,
+): Promise<FetchOutcome> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt += 1) {
+    try {
+      const response = await rawFetch(url, { headers });
+      if (response.status < 200 || response.status >= 300) {
+        throw new Error(`HTTP ${String(response.status)}`);
+      }
+      const text = await response.text();
+      return { text, setCookie: response.getSetCookie() };
+    } catch (error) {
+      lastError = error;
+      await sleep(1.5 * (attempt + 1) * 1000);
+    }
+  }
+  const reason = lastError instanceof Error ? lastError.message : String(lastError);
+  throw new Error(`fetch zlyhal aj po opakovaných pokusoch: ${url} (${reason})`);
+}
+
+/** Funkcia, ktorá pre danú URL vráti telo HTML odpovede — `SearchClient`
+ *  vidí LEN toto, nikdy priamo `RawFetcher`/cookies/retry (tie žijú vo
+ *  vnútri `createSessionFetcher`, presne ako Pythonov `_SessionFetcher`
+ *  bol jediná implementácia `Callable[[str], str]` typu, ktorý `SearchClient`
+ *  poznal). Testy injektujú vlastný `Fetcher`, ktorý celú túto vrstvu
+ *  obchádza. */
+export type Fetcher = (url: string) => Promise<string>;
+
+export interface SessionFetcherOptions {
+  readonly rawFetch?: RawFetcher;
+  readonly sleep?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Stavový fetcher s per-host cookie jar + homepage warm-up + retry — port
+ * `client.py`'s `_SessionFetcher`. Každé volanie vrátenej funkcie warm-uje
+ * svoj host (raz), pošle uložené cookies, a pri zlyhaní opakuje.
+ */
+export function createSessionFetcher(options: SessionFetcherOptions = {}): Fetcher {
+  const rawFetch = options.rawFetch ?? nodeFetch;
+  const sleep = options.sleep ?? realSleep;
+  const cookieJar = new Map<string, Map<string, string>>();
+  const warmedHosts = new Set<string>();
+
+  function cookieHeaderFor(host: string): string {
+    const jar = cookieJar.get(host);
+    if (!jar || jar.size === 0) return "";
+    return Array.from(jar.entries())
+      .map(([name, value]) => `${name}=${value}`)
+      .join("; ");
+  }
+
+  function storeSetCookies(host: string, setCookie: readonly string[]): void {
+    if (setCookie.length === 0) return;
+    const jar = cookieJar.get(host) ?? new Map<string, string>();
+    for (const header of setCookie) {
+      const pair = parseSetCookiePair(header);
+      if (pair) jar.set(pair[0], pair[1]);
+    }
+    cookieJar.set(host, jar);
+  }
+
+  async function warmHost(host: string): Promise<void> {
+    if (warmedHosts.has(host)) return;
+    try {
+      const response = await rawFetch(`https://${host}/`, { headers: baseHeaders(cookieHeaderFor(host)) });
+      storeSetCookies(host, response.getSetCookie());
+    } catch {
+      // Port `_warm`'s `except Exception: log.warning(...)` — zlyhaný
+      // warm-up sa neopakuje, host sa napriek tomu označí za "warmed"
+      // (nižšie, mimo try/catch, presne ako v Pythone).
+    }
+    warmedHosts.add(host);
+  }
+
+  return async (url: string): Promise<string> => {
+    const host = hostOf(url);
+    await warmHost(host);
+    const outcome = await fetchWithRetry(rawFetch, url, baseHeaders(cookieHeaderFor(host)), sleep);
+    storeSetCookies(host, outcome.setCookie);
+    return outcome.text;
+  };
+}
+
+/** Jediná zdieľaná "reálna" inštancia — identity-check proti nej rozhoduje,
+ *  či `SearchClient` throttluje (port Pythonovho `fetch is _DEFAULT_FETCH`). */
+export const nativeFetcher: Fetcher = createSessionFetcher();
+
+export interface SearchClientOptions {
+  readonly fetcher?: Fetcher;
+  readonly cache?: Map<string, readonly PairingCandidate[]>;
+  readonly throttleMs?: number;
+  readonly sleep?: (ms: number) => Promise<void>;
+}
+
+/** HTTP vyhľadávací klient — port `client.py`'s `SearchClient`. */
+export class SearchClient {
+  private readonly fetcher: Fetcher;
+  private readonly cache: Map<string, readonly PairingCandidate[]>;
+  private readonly throttleMs: number;
+  private readonly isReal: boolean;
+  private readonly sleep: (ms: number) => Promise<void>;
+
+  constructor(options: SearchClientOptions = {}) {
+    this.fetcher = options.fetcher ?? nativeFetcher;
+    this.cache = options.cache ?? new Map<string, readonly PairingCandidate[]>();
+    this.throttleMs = options.throttleMs ?? THROTTLE_MS;
+    this.isReal = this.fetcher === nativeFetcher;
+    this.sleep = options.sleep ?? realSleep;
+  }
+
+  /**
+   * Vyhľadá `query` u dodávateľa `adapterKey` (`registry.ts`) a vráti
+   * spárovaných kandidátov — cachovaných podľa (adapterKey, query).
+   */
+  async search(adapterKey: string, query: string): Promise<readonly PairingCandidate[]> {
+    const adapter = adapterFor(adapterKey);
+    if (!adapter) {
+      throw new Error(`neznámy pairing-search adaptér: ${adapterKey}`);
+    }
+
+    const cacheKey = `${adapterKey} ${query}`;
+    const cached = this.cache.get(cacheKey);
+    // `.has()` (nie truthy-check na `cached`) — 0 nájdených kandidátov je
+    // platný, cachovateľný výsledok (port Pythonovho `if key in self._cache`).
+    if (this.cache.has(cacheKey)) return cached ?? [];
+
+    if (this.isReal && this.throttleMs > 0) {
+      await this.sleep(this.throttleMs);
+    }
+
+    const url = adapter.buildSearchUrl(query);
+    const html = await this.fetcher(url);
+    const candidates = adapter.parseSearchResults(html);
+    this.cache.set(cacheKey, candidates);
+    return candidates;
+  }
+}

--- a/apps/api/src/modules/pairing-search/fixtures/betalov-prazdne-vysledky.html
+++ b/apps/api/src/modules/pairing-search/fixtures/betalov-prazdne-vysledky.html
@@ -1,0 +1,25 @@
+<!--
+  Orezaná vzorka https://www.huntingshop.eu/hladanie?search=<náhodný
+  neexistujúci reťazec> (issue 387 E2, živý fetch 13. 8. 2026, po session
+  warm-up). Reálny tvar prázdneho `#snippet--productList` — oba tab-pane
+  (`home` aj `profile`) sú prítomné, ale bez jedinej `.product-col`/
+  `.product-card` karty.
+-->
+<html lang="sk">
+<head><title>Vyhľadávanie: zzzznonexistentqueryxyzabc9999 | huntingshop.eu</title></head>
+<body>
+<div class="tab-content mb-5" data-ajax-append id="snippet--productList">
+  <div class="tab-pane fade show active" id="home" role="tabpanel">
+    <div class="row grid-view">
+    </div>
+  </div>
+  <div class="tab-pane fade " id="profile" role="tabpanel">
+    <div class="row grid-view-list overflow-hidden">
+      <div class="row grid-view-list">
+      </div>
+    </div>
+  </div>
+</div>
+<div id="snippet--paginator"></div>
+</body>
+</html>

--- a/apps/api/src/modules/pairing-search/fixtures/betalov-vysledky-nohavice.html
+++ b/apps/api/src/modules/pairing-search/fixtures/betalov-vysledky-nohavice.html
@@ -1,0 +1,116 @@
+<!--
+  Orezaná vzorka https://www.huntingshop.eu/hladanie?search=nohavice (issue
+  387 E2, živý fetch 13. 8. 2026, po session warm-up GET na homepage — bez
+  neho by `#snippet--productList` bol prázdny, `.claude/rules/pairing-
+  search.md`). Karty 1–3 sú DOSLOVNE prevzaté (href aj názov nezmenené,
+  odstránený len okolitý balast — swiper komentáre, cena, obľúbené tlačidlo,
+  ktoré parser nečíta). Táto konkrétna živá odpoveď nemala v rámci
+  `.product-col` žiadny prirodzený duplikát ani vylúčenú cestu, preto:
+    - Karta 4 je karta 1 znova (identická reálna URL) — mechanizmus testu
+      dedup podľa URL (rovnaký princíp ako `wetland-vysledky-nohavice.html`).
+    - Karta 5 je SKONŠTRUOVANÁ (nie naživo nájdená) — má rovnakú skutočnú
+      štruktúru karty, ale `mh-100` odkaz mieri na `/kosik` (skutočná
+      položka `_EXCLUDE_PREFIXES` zoznamu) — overuje, že navigačná cesta sa
+      vylúči, aj keby sa objavila vo výsledkovom kontajneri.
+-->
+<html lang="sk">
+<head><title>Vyhľadávanie: nohavice | huntingshop.eu</title></head>
+<body>
+<div class="tab-content mb-5" data-ajax-append id="snippet--productList">
+  <div class="tab-pane fade show active" id="home" role="tabpanel">
+    <div class="row grid-view">
+
+      <div class="product-col col-sm-6 col-md-4 col-lg-4 col-xl-3">
+        <div class="product-card ">
+          <div class="product-thumb-nail text-center d-flex flex-column justify-content-center ">
+            <a href="/detske-outdoorove-nohavice-combi-14695" class="mh-100">
+              <img class="product-image w-100" src="/upload/images/product/md__14695-detske-outdoorove-nohavice-combi-1.webp" alt="Detské outdoorové nohavice - Combi">
+            </a>
+          </div>
+          <div class="product-content ">
+            <h3 class="product-title mb-0 text-center w-100 mh-100 " style="min-height: 70px;">
+              <a href="detske-outdoorove-nohavice-combi-14695">
+                Detské outdoorové nohavice - Combi
+              </a>
+            </h3>
+          </div>
+        </div>
+      </div>
+
+      <div class="product-col col-sm-6 col-md-4 col-lg-4 col-xl-3">
+        <div class="product-card ">
+          <div class="product-thumb-nail text-center d-flex flex-column justify-content-center ">
+            <a href="/armotion-class-t-damske-nohavice-14306" class="mh-100">
+              <img class="product-image w-100" src="/upload/images/product/md__14306-armotion-class-t-damske-nohavice-1.webp" alt="Armotion Class-T dámske nohavice">
+            </a>
+          </div>
+          <div class="product-content ">
+            <h3 class="product-title mb-0 text-center w-100 mh-100 " style="min-height: 70px;">
+              <a href="armotion-class-t-damske-nohavice-14306">
+                Armotion Class-T dámske nohavice
+              </a>
+            </h3>
+          </div>
+        </div>
+      </div>
+
+      <div class="product-col col-sm-6 col-md-4 col-lg-4 col-xl-3">
+        <div class="product-card ">
+          <div class="product-thumb-nail text-center d-flex flex-column justify-content-center ">
+            <a href="/wadera-detske-kratke-nohavice-hnede-14266" class="mh-100">
+              <img class="product-image w-100" src="/upload/images/product/md__14266-wadera-detske-kratke-nohavice-hnede-1.webp" alt="WADERA - Detské krátke nohavice - Hnedé">
+            </a>
+          </div>
+          <div class="product-content ">
+            <h3 class="product-title mb-0 text-center w-100 mh-100 " style="min-height: 70px;">
+              <a href="wadera-detske-kratke-nohavice-hnede-14266">
+                WADERA - Detské krátke nohavice - Hnedé
+              </a>
+            </h3>
+          </div>
+        </div>
+      </div>
+
+      <div class="product-col col-sm-6 col-md-4 col-lg-4 col-xl-3">
+        <div class="product-card ">
+          <div class="product-thumb-nail text-center d-flex flex-column justify-content-center ">
+            <a href="/detske-outdoorove-nohavice-combi-14695" class="mh-100">
+              <img class="product-image w-100" src="/upload/images/product/md__14695-detske-outdoorove-nohavice-combi-1.webp" alt="Detské outdoorové nohavice - Combi">
+            </a>
+          </div>
+          <div class="product-content ">
+            <h3 class="product-title mb-0 text-center w-100 mh-100 " style="min-height: 70px;">
+              <a href="detske-outdoorove-nohavice-combi-14695">
+                Detské outdoorové nohavice - Combi
+              </a>
+            </h3>
+          </div>
+        </div>
+      </div>
+
+      <div class="product-col col-sm-6 col-md-4 col-lg-4 col-xl-3">
+        <div class="product-card ">
+          <div class="product-thumb-nail text-center d-flex flex-column justify-content-center ">
+            <a href="/kosik" class="mh-100">
+              <img class="product-image w-100" src="/upload/images/icons/cart.svg" alt="Košík">
+            </a>
+          </div>
+          <div class="product-content ">
+            <h3 class="product-title mb-0 text-center w-100 mh-100 " style="min-height: 70px;">
+              <a href="kosik">Košík</a>
+            </h3>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <div class="tab-pane fade " id="profile" role="tabpanel">
+    <div class="row grid-view-list overflow-hidden">
+      <div class="row grid-view-list"></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/apps/api/src/modules/pairing-search/fixtures/odimon-prazdne-vysledky.html
+++ b/apps/api/src/modules/pairing-search/fixtures/odimon-prazdne-vysledky.html
@@ -1,0 +1,18 @@
+<!--
+  Orezaná vzorka https://www.odimon.sk/vysledky-vyhladavania?term=<náhodný
+  neexistujúci reťazec> (issue 387 E2, živý fetch 13. 8. 2026, po session
+  warm-up). Reálny tvar prázdneho `.product-list__results` — kontajner je
+  prítomný ("0 produktov"), ale bez jedinej `a.product-card` karty.
+-->
+<html lang="sk">
+<head><title>Výsledky vyhľadávania: zzzznonexistentqueryxyzabc9999 | odimon.sk</title></head>
+<body>
+<div class="col-lg-9 col-md-9 col-sm-12 fs-products__col product-list_col product-list_col--products">
+  <div class="product-list__results">
+    <div class="product-list__info-box-wrapper fs_results_info">
+      <div class="product-list-info-box"><b>0</b> produktov</div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/apps/api/src/modules/pairing-search/fixtures/odimon-vysledky-nohavice.html
+++ b/apps/api/src/modules/pairing-search/fixtures/odimon-vysledky-nohavice.html
@@ -1,0 +1,66 @@
+<!--
+  Orezaná vzorka https://www.odimon.sk/vysledky-vyhladavania?term=nohavice
+  (issue 387 E2, živý fetch 13. 8. 2026, po session warm-up GET na homepage —
+  BUXUS cookie-gated presne ako huntingshop.eu). Karty 1–3 sú DOSLOVNE
+  prevzaté (href aj `alt` text nezmenené, odstránený len obalový balast —
+  data-track-product JSON atribúty, cena, promo štítky). Táto konkrétna
+  živá odpoveď nemala žiadny prirodzený duplikát, preto karta 4 je karta 1
+  znova (identická reálna URL) — mechanizmus testu dedup podľa URL (rovnaký
+  princíp ako `wetland-vysledky-nohavice.html`/`betalov-vysledky-
+  nohavice.html`). `.claude/rules/supplier-stock.md` potvrdzuje, že
+  `odimon.sk` je BUXUS a JSON-LD na tejto doméne nie je pre stránku
+  vyhľadávania relevantné (parser meno berie z `img[alt]`).
+-->
+<html lang="sk">
+<head><title>Výsledky vyhľadávania: nohavice | odimon.sk</title></head>
+<body>
+<div class="col-lg-9 col-md-9 col-sm-12 fs-products__col product-list_col product-list_col--products">
+  <div class="product-list__results">
+    <div class="product-list__info-box-wrapper fs_results_info">
+      <div class="product-list-info-box"><b>146</b> produktov</div>
+    </div>
+
+    <div class="item col-xs-6 col-lg-3">
+      <div class="product tag-product-card">
+        <div class="image">
+          <a href="https://www.odimon.sk/obuv-a-oblecenie/polovnicke-oblecenie/polovnicke-termopradlo/termopradlo-nohavice-modal-termovel" class="product-card">
+            <img class="img-responsive lazy" alt="Termoprádlo nohavice modal Termovel">
+          </a>
+        </div>
+      </div>
+    </div>
+
+    <div class="item col-xs-6 col-lg-3">
+      <div class="product tag-product-card">
+        <div class="image">
+          <a href="https://www.odimon.sk/obuv-a-oblecenie/margita-oblecenie/panske-polovnicke-nohavice-michal" class="product-card">
+            <img class="img-responsive lazy" alt="Pánske poľovnícke nohavice Michal ">
+          </a>
+        </div>
+      </div>
+    </div>
+
+    <div class="item col-xs-6 col-lg-3">
+      <div class="product tag-product-card">
+        <div class="image">
+          <a href="https://www.odimon.sk/obuv-a-oblecenie/deerhunter-oblecenie/nohavice-deerhunter/polovnicke-nohavice-deerhunter-ram" class="product-card">
+            <img class="img-responsive lazy" alt="Poľovnícke nohavice Deerhunter Ram">
+          </a>
+        </div>
+      </div>
+    </div>
+
+    <div class="item col-xs-6 col-lg-3">
+      <div class="product tag-product-card">
+        <div class="image">
+          <a href="https://www.odimon.sk/obuv-a-oblecenie/polovnicke-oblecenie/polovnicke-termopradlo/termopradlo-nohavice-modal-termovel" class="product-card">
+            <img class="img-responsive lazy" alt="Termoprádlo nohavice modal Termovel">
+          </a>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</div>
+</body>
+</html>

--- a/apps/api/src/modules/pairing-search/fixtures/wetland-prazdne-vysledky.html
+++ b/apps/api/src/modules/pairing-search/fixtures/wetland-prazdne-vysledky.html
@@ -1,0 +1,18 @@
+<!--
+  Orezaná vzorka https://www.wetland.sk/vyhladavanie?controller=search&s=<náhodný
+  neexistujúci reťazec> (issue 387 E2, živý fetch 13. 8. 2026). Reálna stránka
+  bez výsledkov — nadpis aj text sú doslovné, žiadna `product-miniature__title`
+  karta nikde v dokumente (0 zhôd, over: `grep -c product-miniature`).
+-->
+<html lang="sk">
+<head><title>Vyhľadávanie: zzzznonexistentqueryxyzabc9999 | wetland.sk</title></head>
+<body>
+  <h1 id="js-product-list-header">
+    Vášmu vyhľadávaniu nezodpovedajú žiadne výsledky :
+    "zzzznonexistentqueryxyzabc9999"
+  </h1>
+  <section id="content" class="page-content page-not-found">
+    <p>Skúste prosím použiť iné výrazy popisujúce to, čo hľadáte.</p>
+  </section>
+</body>
+</html>

--- a/apps/api/src/modules/pairing-search/fixtures/wetland-vysledky-nohavice.html
+++ b/apps/api/src/modules/pairing-search/fixtures/wetland-vysledky-nohavice.html
@@ -1,0 +1,29 @@
+<!--
+  Orezaná vzorka https://www.wetland.sk/vyhladavanie?controller=search&s=nohavice
+  (issue 387 E2, živý fetch 13. 8. 2026, po session warm-up GET na homepage).
+  Prvé tri karty sú DOSLOVNE skopírované z reálnej odpovede (href aj text
+  názvu nezmenené). Štvrtá karta je REÁLNA prvá karta znova, len s iným
+  fragmentom (`#/10-velkost-50` namiesto `#/9-velkost-48`) — na tejto
+  konkrétnej živej stránke sa žiadny prirodzený duplikát (rovnaká URL pred
+  `#`, iný fragment veľkosti) nenašiel, tento pár preto simuluje presne ten
+  jav, ktorý `urldefrag` + dedup podľa URL musí zvládnuť (mechanizmus, nie
+  naživo nájdená vzorka — rovnaký princíp ako `supplier-stock/fixtures/
+  rosler-vypredane-noz-entita.html`).
+-->
+<html lang="sk">
+<head><title>Vyhľadávanie: nohavice | wetland.sk</title></head>
+<body>
+  <div class="product-miniature__title">
+    <a class="link" href="https://www.wetland.sk/nohavice/deerhunter-pro-gamekeeper-boot-trousers-polovnicke-nohavice-111-592#/9-velkost-48">DEERHUNTER Pro Gamekeeper Boot Trousers - poľovnícke nohavice</a>
+  </div>
+  <div class="product-miniature__title">
+    <a class="link" href="https://www.wetland.sk/nohavice/deerhunter-strike-extreme-pull-over-trousers-ochranne-nohavice-60-19897#/46-velkost-l_xl">DEERHUNTER Strike Extreme Pull-Over Trousers - ochranné nohavice</a>
+  </div>
+  <div class="product-miniature__title">
+    <a class="link" href="https://www.wetland.sk/nohavice/deerhunter-lady-excape-winter-trousers-damske-nohavice-101-20063#/7-velkost-44">DEERHUNTER Lady Excape Winter Trousers - dámske nohavice</a>
+  </div>
+  <div class="product-miniature__title">
+    <a class="link" href="https://www.wetland.sk/nohavice/deerhunter-pro-gamekeeper-boot-trousers-polovnicke-nohavice-111-592#/10-velkost-50">DEERHUNTER Pro Gamekeeper Boot Trousers - poľovnícke nohavice</a>
+  </div>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.226",
+  "version": "0.3.0-dev.227",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@node-rs/argon2':
         specifier: ^2.0.0
         version: 2.0.2
+      cheerio:
+        specifier: ^1.0.0
+        version: 1.2.0
       drizzle-orm:
         specifier: ^0.38.0
         version: 0.38.4(@types/pg@8.20.0)(@types/react@19.2.17)(pg@8.22.0)(react@19.2.8)
@@ -1258,6 +1261,9 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
   brace-expansion@1.1.16:
     resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
@@ -1296,6 +1302,13 @@ packages:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
 
+  cheerio-select@2.1.0:
+    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
+
+  cheerio@1.2.0:
+    resolution: {integrity: sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==}
+    engines: {node: '>=20.18.1'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -1313,9 +1326,16 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-select@5.2.2:
+    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -1349,6 +1369,19 @@ packages:
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
   drizzle-kit@0.31.10:
     resolution: {integrity: sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==}
@@ -1448,6 +1481,21 @@ packages:
 
   electron-to-chromium@1.5.398:
     resolution: {integrity: sha512-AsvhAxopJGh6museTDMIjn6JpDYOfgu4RLlygomt87MUwBUqTfd/1EiPtx10/LZE8xpTvkP2E9Gafq7lkLtodQ==}
+
+  encoding-sniffer@0.2.1:
+    resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
 
   entities@8.0.0:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
@@ -1602,6 +1650,13 @@ packages:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -1734,6 +1789,9 @@ packages:
     resolution: {integrity: sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==}
     engines: {node: '>=6.0.0'}
 
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
@@ -1753,6 +1811,15 @@ packages:
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
+
+  parse5-parser-stream@7.1.2:
+    resolution: {integrity: sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
@@ -1914,6 +1981,9 @@ packages:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
 
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
@@ -2061,6 +2131,10 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
+    engines: {node: '>=20.18.1'}
+
   undici@8.9.0:
     resolution: {integrity: sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==}
     engines: {node: '>=22.19.0'}
@@ -2194,6 +2268,15 @@ packages:
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
 
   whatwg-mimetype@5.0.0:
     resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
@@ -3162,6 +3245,8 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
+  boolbase@1.0.0: {}
+
   brace-expansion@1.1.16:
     dependencies:
       balanced-match: 1.0.2
@@ -3202,6 +3287,29 @@ snapshots:
 
   check-error@2.1.3: {}
 
+  cheerio-select@2.1.0:
+    dependencies:
+      boolbase: 1.0.0
+      css-select: 5.2.2
+      css-what: 6.2.2
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+
+  cheerio@1.2.0:
+    dependencies:
+      cheerio-select: 2.1.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      encoding-sniffer: 0.2.1
+      htmlparser2: 10.1.0
+      parse5: 7.3.0
+      parse5-htmlparser2-tree-adapter: 7.1.0
+      parse5-parser-stream: 7.1.2
+      undici: 7.29.0
+      whatwg-mimetype: 4.0.0
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -3218,10 +3326,20 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-select@5.2.2:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
   css-tree@3.2.1:
     dependencies:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
+
+  css-what@6.2.2: {}
 
   csstype@3.2.3: {}
 
@@ -3246,6 +3364,24 @@ snapshots:
 
   dom-accessibility-api@0.5.16: {}
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
   drizzle-kit@0.31.10:
     dependencies:
       '@drizzle-team/brocli': 0.10.2
@@ -3261,6 +3397,17 @@ snapshots:
       react: 19.2.8
 
   electron-to-chromium@1.5.398: {}
+
+  encoding-sniffer@0.2.1:
+    dependencies:
+      iconv-lite: 0.6.3
+      whatwg-encoding: 3.1.1
+
+  entities@4.5.0: {}
+
+  entities@6.0.1: {}
+
+  entities@7.0.1: {}
 
   entities@8.0.0: {}
 
@@ -3481,6 +3628,17 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   ignore@5.3.2: {}
 
   ignore@7.0.6: {}
@@ -3600,6 +3758,10 @@ snapshots:
 
   nodemailer@9.0.3: {}
 
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
+
   on-exit-leak-free@2.1.2: {}
 
   optionator@0.9.4:
@@ -3622,6 +3784,19 @@ snapshots:
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    dependencies:
+      domhandler: 5.0.3
+      parse5: 7.3.0
+
+  parse5-parser-stream@7.1.2:
+    dependencies:
+      parse5: 7.3.0
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
 
   parse5@8.0.1:
     dependencies:
@@ -3788,6 +3963,8 @@ snapshots:
 
   safe-stable-stringify@2.5.0: {}
 
+  safer-buffer@2.1.2: {}
+
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
@@ -3911,6 +4088,8 @@ snapshots:
 
   undici-types@7.18.2: {}
 
+  undici@7.29.0: {}
+
   undici@8.9.0: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.7):
@@ -4017,6 +4196,12 @@ snapshots:
       xml-name-validator: 5.0.0
 
   webidl-conversions@8.0.1: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
 
   whatwg-mimetype@5.0.0: {}
 


### PR DESCRIPTION
Etapa E2 z issue 387 (profesionálne párovanie produktov, port starej appky @ 60b6164).
Druhá z ôsmich etáp — vyhľadávací HTTP klient + adaptéry troch dodávateľov. Stále bez
zapojenia do behu appky (žiadna zmena správania), zapojenie príde v E3.

## Obsah

- `pairing-search/client.ts` — SearchClient portovaný z `client.py` starej appky:
  homepage warm-up per host (Nette/BUXUS session cookie — bez neho prázdne výsledky),
  odstup 0,7 s, 3 opakovania s odstupom 1,5·(n+1) s, timeout 25 s, in-memory cache
  (dodávateľ, dopyt); hranica siete izolovaná pre testy (fake fetcher).
- `pairing-search/adapters/{wetland,betalov,odimon}.ts` + `types.ts` + `registry.ts`
  (kľúčované cez `supplier.adapterKey`) — parsery portované doslovne, vrátane scope
  selektorov, BETALOV exclusion zoznamu a dedupu podľa URL.
- 6 živých HTML fixtúr (výsledky + prázdne výsledky, všetky tri eshopy) + parser testy.
- Nová závislosť `cheerio` (HTML parsovanie).

Review (nezávislý čerstvý kontext): 3 🟡 nájdené a opravené v tej istej vetve —
strata cookie pri neúspešnom pokuse (Cookie hlavička sa stavia per pokus), jeden
chybný odkaz už nezhodí parsovanie celej stránky (WHATWG URL je prísnejšia než
Python urljoin), doplnené pino logovanie.

## Overenie

Živý smoke test cez skutočný klient po opravách: wetland „bunda deerhunter" → 12
kandidátov, betalov „bunda" → 16, odimon „bunda" → 20 (dôkaz v komentári na tikete).
V CI žiadne živé volania — len fixtúry.

## Testy

API 855 testov zelených (66 súborov), web 606, typecheck aj lint čisté.

Issue 387 zostáva otvorené — zavrie sa po poslednej etape a živom overení.
