### PR TITLE
Párovanie produktov E3: DB kandidátov + nočný zberný beh (issue 387)

### DIFF
--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -235,3 +235,31 @@ paths:
   ako duplicitu. Prvý reálny prípad + plné odôvodnenie: issue 267's
   `upozornenie_dedup_key_uq` (`.claude/rules/upozornenia.md`), nájdené
   integračným testom PRED mergom, nie odhadom.
+- **Drizzle-ov AUTO-generovaný FK názov (`<tabuľka>_<stĺpec>_<cudzia
+  tabuľka>_<cudzí stĺpec>_fk`, keď je FK deklarovaná inline cez
+  `.references(...)` na stĺpci) môže PREKROČIŤ Postgres-ov 63-bajtový
+  `NAMEDATALEN` limit identifikátora, keď obe tabuľky majú dlhšie mená.**
+  Postgres taký názov TICHO orezáva pri `CREATE TABLE`/`ALTER TABLE ADD
+  CONSTRAINT` (žiadna chyba, žiadne varovanie), ale `drizzle-kit`'s
+  snapshot JSON si pamätá PLNÝ, nikdy-neintrospektovaný názov — zistené
+  issue 387 E3 review (`pairing_candidate.product_key` →
+  `pairing_candidate_set.product_key`: auto-názov
+  `pairing_candidate_product_key_pairing_candidate_set_product_key_fk` má
+  69 znakov). Dôsledok: budúci `db:generate`, ktorý by túto konkrétnu FK
+  menil (zmena `onDelete`, premenovanie stĺpca), by vygeneroval `ALTER
+  TABLE ... DROP CONSTRAINT "<69-znakový názov>"` proti reálnej DB, kde
+  constraint v skutočnosti existuje pod ORAZANÝM (63-znakovým) menom —
+  migrácia by zlyhala na "constraint does not exist". Fix: pri KAŽDEJ
+  novej FK medzi dvomi tabuľkami, ktorých mená + stĺpce dokopy prekročia
+  ~55 znakov, nepoužívaj inline `.references(...)` — namiesto toho
+  deklaruj stĺpec bez neho a pridaj explicitne pomenovanú `foreignKey({
+  name: "<krátky-názov>", columns: [t.stlpec], foreignColumns:
+  [cudziaTabulka.stlpec] }).onDelete("cascade")` do tabuľkinho
+  constraint-array (`(t) => [...]`). Over PO KAŽDEJ takejto zmene: zresetuj
+  lokálnu DB od nuly (`DROP SCHEMA public, drizzle CASCADE` — `drizzle`
+  schéma nesie `__drizzle_migrations`, `TRUNCATE`/`DROP SCHEMA public` samo
+  osebe ju NEVYMAŽE, takže opakovaný `db:migrate` po holom
+  `public`-reset-e ticho preskočí VŠETKY migrácie ako "už aplikované" a
+  nevytvorí žiadnu tabuľku) → `db:migrate` odznova → `select conname from
+  pg_constraint where conrelid = '<tabuľka>'::regclass;` — potvrď, že meno
+  je PRESNE také, aké si zadal, nie orezané.

--- a/.claude/rules/pairing-search.md
+++ b/.claude/rules/pairing-search.md
@@ -175,3 +175,69 @@ https://github.com/zbynekdrlik/forestshop-app/issues/387#issuecomment-5273377438
   iné zhovievavé parsovanie: over, či JS/TS ekvivalent (`URL`,
   `URLSearchParams`, ...) vyhadzuje na rovnakých vstupoch — ak áno, obal
   ho tak, aby zlyhanie JEDNÉHO záznamu nezhodilo celý dávkový cyklus.
+
+## E3 — DB + gather job (`run.ts`, `select.ts`, `schema-pairing-review.ts`)
+
+- **`gather_candidates` (top-K review, `query_variants` union), NIE
+  `match_one` (priamy CSV-import match, `query_ladder` sekvenčný fallback)
+  — stará appka MALA obe funkcie a robia rozdielne veci.** `matcher.py`'s
+  `match_one` sa zastaví na PRVOM dopyte, čo vrátil kandidátov. `gather_
+  candidates` (k=8) skúša VŠETKY dopyty, poolu je kandidátov podľa URL
+  naprieč nimi a vráti top-K — TOTO je funkcia, ktorú nová appka's top-8
+  review obrazovka reálne portuje (návrh: „top-K = 8, únia všetkých
+  query_variants"). Zadanie tejto etapy malo skratkovité „query ladder →
+  SearchClient", čo je nepresné — `run.ts` používa `buildQueryVariants`,
+  nikdy `buildQueryLadder`. Test pri KAŽDOM ďalšom porte funkcie zo starej
+  appky, ktorá má VIAC príbuzných variantov (napr. E4's `verify.py` môže
+  mať podobný pár): priamo v zdrojáku over, KTORÁ funkcia zodpovedá
+  cieľovému správaniu, nikdy neodvodzuj z podobného mena.
+- **`suppliers` (schema-pairing.ts, F4/#44) UŽ EXISTOVALA, prázdna — E3 ju
+  len naplnila.** Migračný seed je `ON CONFLICT (name) DO UPDATE SET
+  adapter_key=…, wholesale_base_url=…` (nie `DO NOTHING`) — keby riadok pre
+  daného dodávateľa už niekedy vznikol ručne, tento seed ho DOPLNÍ, nikdy
+  nezduplikuje. `currency` sa pri konflikte nemení. Rovnaký vzor pri
+  KAŽDOM ďalšom "existujúca tabuľka konečne dostane obsah" seede.
+- **`product.supplier` (Shoptet-ov voľný text) je case/whitespace-
+  insensitívny kľúč do `suppliers.name` — existujúci `orders/supplier-
+  key.ts`'s `normalizeSupplierKeyJs` (predtým len pre dodávateľské
+  zoskupenie objednávok) je PRESNE tá istá normalizácia, čo potrebuje
+  párovací výber.** Produkt, ktorého `product.supplier` nesedí so ŽIADNYM
+  `suppliers` riadkom s vyplneným `adapter_key`, sa gatherom NIKDY
+  nevyberie — presne ako stará appka spracovávala VÝHRADNE (supplier,
+  pairCode) skupiny patriace jej trom `config.SUPPLIERS` (`csv_loader.py`'s
+  `load_rows(path, suppliers)` filter), nikdy celý katalóg.
+- **Checkpoint = per-produkt TRANSAKČNÝ upsert (delete+insert kandidátov +
+  candidate_set upsert v JEDNEJ transakcii), ŽIADNA cursor tabuľka.**
+  Obnoviteľnosť po páde príde ZADARMO z `input_hash`: produkt už
+  committnutý v predošlom (spadnutom) behu má `input_hash` zhodný so svojím
+  aktuálnym stavom → `select.ts` ho ďalší beh sám preskočí. Zamietnutá
+  alternatíva (design komentár na tickete): samostatná cursor tabuľka —
+  menej stavu bez nej, žiadne riziko neplatného kurzora pri zmene eligible
+  množiny medzi behmi.
+- **Časový (nie počtový) strop behu** — na rozdiel od `restock`'s
+  `MAX_PER_RUN` (počet zápisov do CUDZIEHO systému) je gatherov nákladový
+  faktor SIEŤOVÝ ČAS na produkt (viac `query_variants` × throttle 0,7s ×
+  až 3 retry), ktorý sa medzi produktmi výrazne líši — počtový strop by
+  negarantoval predvídateľnú dĺžku behu. `RUN_TIME_BUDGET_MS` sa
+  kontroluje PRED každým ďalším produktom (nikdy uprostred jeho
+  transakcie); `clock`/`timeBudgetMs` sú injektovateľné pre testy —
+  deterministický test vynúti "spracuj presne 1 produkt, potom stop"
+  sekvenciou vopred pripravených návratových hodnôt `clock()` (`[0, 0,
+  1000]` s `timeBudgetMs: 1` — prvé volanie = deadline výpočet, druhé =
+  pred-item0 kontrola < deadline, tretie = pred-item1 kontrola ≥ deadline).
+- **REVIEW NÁLEZ (🔴, opravené pred mergom): nový advisory zámok kľúč
+  KOLIDOVAL s existujúcim, lebo `.claude/rules/scheduler.md`'s vlastný
+  registr bol zastaraný.** Návrh aj zadanie E3 menovali `787_878_007` ako
+  "voľný" — v skutočnosti už mesiace patril `SUPPLIER_STOCK_RUN_LOCK_KEY`
+  (`supplier-stock/constants.ts`, issue 212), ale registr v `scheduler.md`
+  ho (spolu s `restock`'s `008`) NIKDY nezaznamenal. Oba sú session-scoped
+  `pg_advisory_lock` — kolízia by znamenala BEZČASOVÉ vzájomné zablokovanie
+  dvoch nesúvisiacich behov. Oprava: `787_878_009`, registr doplnený.
+  **Test pri KAŽDOM ďalšom advisory zámku: never dôveruj číslu z návrhu/
+  zadania naslepo — `grep -rn "787_878_0" apps/api/src` PRIAMO v kóde je
+  jediný spoľahlivý zdroj pravdy, playbook je len pomôcka a môže zaostávať.**
+- **`pairing_candidate.raw_score` je `numeric` (string na JS strane), nie
+  `real`/`doublePrecision`** — v CELEJ appke sa floaty ukladajú VÝHRADNE
+  cez `numeric` (peňažné polia), žiadny natívny float typ sa nikde
+  nepoužíva. `rawScore` (number z `ranking.ts`) sa pri zápise konvertuje
+  `.toFixed(4)`.

--- a/.claude/rules/scheduler.md
+++ b/.claude/rules/scheduler.md
@@ -84,7 +84,17 @@ paths:
   issue 172 — pozri nižšie), `787_878_005` (`ORDER_REMINDER_RUN_LOCK_KEY`,
   `order-reminder/constants.ts`, issue 173), `787_878_006`
   (`NEDOSTUPNE_SEND_LOCK_KEY`, `nedostupne/constants.ts`, issue 176 —
-  serializuje jedno odoslanie, tento modul nemá naplánovaný beh).
+  serializuje jedno odoslanie, tento modul nemá naplánovaný beh),
+  `787_878_007` (`SUPPLIER_STOCK_RUN_LOCK_KEY`, `supplier-stock/constants.ts`,
+  issue 212), `787_878_008` (`RESTOCK_RUN_LOCK_KEY`, `restock/constants.ts`,
+  issue 213), `787_878_009` (`PAIRING_SEARCH_RUN_LOCK_KEY`,
+  `pairing-search/constants.ts`, issue 387 E3 — **tento zoznam bol PRED
+  touto opravou zastaraný a nezahŕňal `007`/`008` vôbec** — E3's návrh aj
+  zadanie preto omylom menovali `007` ako "voľný", hoci už mesiace patril
+  `supplier-stock`u; review na E3 to našlo predtým, než sa dostalo do
+  produkcie. Over TOTO CELÉ znenie (nielen posledné číslo) pred pridaním
+  ĎALŠIEHO kľúča — zastaraný zoznam je presne to, čo spôsobilo túto
+  kolíziu).
   `ordersImportJob`/`pruneRawOrdersJob` (#22/#28) nepridali žiadny nový kľúč
   (pozri bod vyššie). `shoptetWritebackJob` (issue 122) tiež žiadny nepridal
   — v tomto tickete niet manuálneho HTTP triggeru na tú istú prácu (na

--- a/apps/api/drizzle/0047_brief_yellowjacket.sql
+++ b/apps/api/drizzle/0047_brief_yellowjacket.sql
@@ -31,7 +31,7 @@ CREATE TABLE "pairing_search_settings" (
 );
 --> statement-breakpoint
 ALTER TABLE "pairing_candidate_set" ADD CONSTRAINT "pairing_candidate_set_product_key_product_key_fk" FOREIGN KEY ("product_key") REFERENCES "public"."product"("key") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "pairing_candidate" ADD CONSTRAINT "pairing_candidate_product_key_pairing_candidate_set_product_key_fk" FOREIGN KEY ("product_key") REFERENCES "public"."pairing_candidate_set"("product_key") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pairing_candidate" ADD CONSTRAINT "pairing_candidate_product_key_fk" FOREIGN KEY ("product_key") REFERENCES "public"."pairing_candidate_set"("product_key") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 CREATE UNIQUE INDEX "pairing_candidate_product_url_uq" ON "pairing_candidate" USING btree ("product_key","url");--> statement-breakpoint
 CREATE INDEX "pairing_candidate_product_idx" ON "pairing_candidate" USING btree ("product_key");--> statement-breakpoint
 -- issue 387 E3: "suppliers" (schema-pairing.ts, #44) UŽ EXISTUJE, len bola

--- a/apps/api/drizzle/0047_odd_northstar.sql
+++ b/apps/api/drizzle/0047_odd_northstar.sql
@@ -1,0 +1,55 @@
+CREATE TYPE "public"."pairing_confidence" AS ENUM('high', 'medium', 'low', 'none');--> statement-breakpoint
+CREATE TYPE "public"."pairing_verdict" AS ENUM('ok', 'unsure');--> statement-breakpoint
+CREATE TABLE "pairing_candidate_set" (
+	"product_key" text PRIMARY KEY NOT NULL,
+	"gathered_at" timestamp with time zone NOT NULL,
+	"queries" jsonb NOT NULL,
+	"input_hash" text NOT NULL,
+	"chosen_url" text,
+	"chosen_reason" text,
+	"confidence" "pairing_confidence" NOT NULL,
+	"verdict" "pairing_verdict",
+	"verdict_checked_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE "pairing_candidate" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"product_key" text NOT NULL,
+	"position" integer NOT NULL,
+	"name" text NOT NULL,
+	"url" text NOT NULL,
+	"code" text,
+	"price" numeric(12, 2),
+	"raw_score" numeric(8, 4) NOT NULL,
+	"code_hit" boolean NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "pairing_search_settings" (
+	"id" text PRIMARY KEY NOT NULL,
+	"enabled" boolean DEFAULT false NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "pairing_candidate_set" ADD CONSTRAINT "pairing_candidate_set_product_key_product_key_fk" FOREIGN KEY ("product_key") REFERENCES "public"."product"("key") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pairing_candidate" ADD CONSTRAINT "pairing_candidate_product_key_pairing_candidate_set_product_key_fk" FOREIGN KEY ("product_key") REFERENCES "public"."pairing_candidate_set"("product_key") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "pairing_candidate_product_url_uq" ON "pairing_candidate" USING btree ("product_key","url");--> statement-breakpoint
+CREATE INDEX "pairing_candidate_product_idx" ON "pairing_candidate" USING btree ("product_key");--> statement-breakpoint
+-- issue 387 E3: "suppliers" (schema-pairing.ts, #44) UŽ EXISTUJE, len bola
+-- doteraz prázdna ("adapter_key konečne dostane využitie" — návrh, sekcia
+-- "Existujúce tabuľky"). Seeduje/upsertne presne 3 riadky, kľúčované
+-- rovnakým veľkými-písmenami tvarom mena, aký stará appka používala ako kľúč
+-- do svojho config.py's SUPPLIERS dictu (overené v config.py priamo,
+-- issue 387 komentár "overenie platnosti"). ON CONFLICT DO UPDATE (nie DO
+-- NOTHING) — keby riadok pre daného dodávateľa už existoval (napr. založený
+-- ručne pri katalógovej práci pred E3), tento seed len DOPLNÍ/OPRAVÍ
+-- adapter_key + wholesale_base_url, nikdy nezduplikuje riadok (presne podľa
+-- zadania "možno už existujú z katalógu — potom len doplň adapter_key,
+-- neduplikuj"). "currency" sa pri konflikte NEPREPISUJE (mohla byť ručne
+-- nastavená inak), len pri INSERTe dostáva predvolené 'EUR'.
+INSERT INTO "supplier" ("name", "currency", "wholesale_base_url", "adapter_key") VALUES
+	('WETLAND', 'EUR', 'https://www.wetland.sk', 'wetland'),
+	('BETALOV', 'EUR', 'https://www.huntingshop.eu', 'betalov'),
+	('ODIMON', 'EUR', 'https://www.odimon.sk', 'odimon')
+ON CONFLICT ("name") DO UPDATE SET
+	"adapter_key" = excluded."adapter_key",
+	"wholesale_base_url" = excluded."wholesale_base_url";

--- a/apps/api/drizzle/meta/0047_snapshot.json
+++ b/apps/api/drizzle/meta/0047_snapshot.json
@@ -1,0 +1,3383 @@
+{
+  "id": "1cdc7427-2efe-4dfe-9c05-68125894b285",
+  "prevId": "ef8c57c1-5648-4c6b-890b-8a9124745b67",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_code": {
+          "name": "external_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_open_status": {
+      "name": "order_open_status",
+      "schema": "",
+      "columns": {
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Vybavuje sa'"
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop_remark": {
+          "name": "shop_remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shoptet_order_id": {
+          "name": "shoptet_order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_updated_at": {
+          "name": "comment_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_synced_at": {
+          "name": "comment_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_carrier_name": {
+          "name": "shipping_carrier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_price_with_vat": {
+          "name": "total_price_with_vat",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_marked_at": {
+          "name": "claim_marked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_note": {
+          "name": "claim_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_full_name": {
+          "name": "delivery_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_company": {
+          "name": "delivery_company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_street": {
+          "name": "delivery_street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_house_number": {
+          "name": "delivery_house_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_city": {
+          "name": "delivery_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_zip": {
+          "name": "delivery_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_country_name": {
+          "name": "delivery_country_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_name": {
+          "name": "payment_method_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_to_pay": {
+          "name": "price_to_pay",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_link_override": {
+      "name": "product_supplier_link_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_link_override_product_key_product_key_fk": {
+          "name": "product_supplier_link_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_link_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_override": {
+      "name": "product_supplier_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_override_product_key_product_key_fk": {
+          "name": "product_supplier_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing": {
+      "name": "pairing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_url": {
+          "name": "supplier_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "pairing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'navrhnute'"
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pairing_state_idx": {
+          "name": "pairing_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_confirmed_by_idx": {
+          "name": "pairing_confirmed_by_idx",
+          "columns": [
+            {
+              "expression": "confirmed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_variant_code_variant_code_fk": {
+          "name": "pairing_variant_code_variant_code_fk",
+          "tableFrom": "pairing",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pairing_confirmed_by_users_id_fk": {
+          "name": "pairing_confirmed_by_users_id_fk",
+          "tableFrom": "pairing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pairing_variant_code_unique": {
+          "name": "pairing_variant_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pairing_confirmation_ck": {
+          "name": "pairing_confirmation_ck",
+          "value": "(\"pairing\".\"state\" = 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)\n        OR (\"pairing\".\"state\" != 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NULL AND \"pairing\".\"confirmed_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier": {
+      "name": "supplier",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wholesale_base_url": {
+          "name": "wholesale_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_key": {
+          "name": "adapter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_settings": {
+      "name": "posta_uncollected_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_state": {
+      "name": "posta_uncollected_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notify_count": {
+          "name": "notify_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_state": {
+          "name": "terminal_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_settings": {
+      "name": "order_reminder_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_state": {
+      "name": "order_reminder_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_replacement_link": {
+      "name": "nedostupne_replacement_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nedostupne_replacement_link_variant_idx": {
+          "name": "nedostupne_replacement_link_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_state": {
+      "name": "nedostupne_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "nedostupne_email_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nedostupne_state_order_variant_type_uq": {
+          "name": "nedostupne_state_order_variant_type_uq",
+          "columns": [
+            {
+              "expression": "order_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template_history": {
+      "name": "mail_template_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "mail_template_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_template_history_key_idx": {
+          "name": "mail_template_history_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_template_history_changed_by_user_id_users_id_fk": {
+          "name": "mail_template_history_changed_by_user_id_users_id_fk",
+          "tableFrom": "mail_template_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template": {
+      "name": "mail_template",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail_template_updated_by_user_id_users_id_fk": {
+          "name": "mail_template_updated_by_user_id_users_id_fk",
+          "tableFrom": "mail_template",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_log": {
+      "name": "mail_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "mail_log_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_log_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "mail_log_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_log_created_idx": {
+          "name": "mail_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_log_source_created_idx": {
+          "name": "mail_log_source_created_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_log_actor_user_id_users_id_fk": {
+          "name": "mail_log_actor_user_id_users_id_fk",
+          "tableFrom": "mail_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_stock": {
+      "name": "supplier_stock",
+      "schema": "",
+      "columns": {
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "supplier_availability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "supplier_stock_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "supplier_stock_host_idx": {
+          "name": "supplier_stock_host_idx",
+          "columns": [
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "supplier_stock_avail_idx": {
+          "name": "supplier_stock_avail_idx",
+          "columns": [
+            {
+              "expression": "availability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "supplier_stock_link_size_label_pk": {
+          "name": "supplier_stock_link_size_label_pk",
+          "columns": [
+            "link",
+            "size_label"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_event": {
+      "name": "restock_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_link": {
+          "name": "supplier_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_availability_text": {
+          "name": "supplier_availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "supplier_price": {
+          "name": "supplier_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "restock_event_at_idx": {
+          "name": "restock_event_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "restock_event_variant_idx": {
+          "name": "restock_event_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_settings": {
+      "name": "restock_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shop_product_url": {
+      "name": "shop_product_url",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.theme_color": {
+      "name": "theme_color",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "theme_color_updated_by_user_id_users_id_fk": {
+          "name": "theme_color_updated_by_user_id_users_id_fk",
+          "tableFrom": "theme_color",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upozornenie": {
+      "name": "upozornenie",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "upozornenie_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "upozornenie_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedup_key": {
+          "name": "dedup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postponed_until": {
+          "name": "postponed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seen_at": {
+          "name": "seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "upozornenie_dedup_key_uq": {
+          "name": "upozornenie_dedup_key_uq",
+          "columns": [
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "resolved_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upozornenie_resolved_at_idx": {
+          "name": "upozornenie_resolved_at_idx",
+          "columns": [
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upozornenie_dedup_key_idx": {
+          "name": "upozornenie_dedup_key_idx",
+          "columns": [
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upozornenie_resolved_by_user_id_users_id_fk": {
+          "name": "upozornenie_resolved_by_user_id_users_id_fk",
+          "tableFrom": "upozornenie",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "upozornenie_created_by_user_id_users_id_fk": {
+          "name": "upozornenie_created_by_user_id_users_id_fk",
+          "tableFrom": "upozornenie",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dpd_pickup_request": {
+      "name": "dpd_pickup_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "pickup_date": {
+          "name": "pickup_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "dpd_operation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dpd_shipment": {
+      "name": "dpd_shipment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "dpd_operation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parcel_number": {
+          "name": "parcel_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cod_amount": {
+          "name": "cod_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dpd_shipment_order_uq": {
+          "name": "dpd_shipment_order_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dpd_shipment_order_id_order_id_fk": {
+          "name": "dpd_shipment_order_id_order_id_fk",
+          "tableFrom": "dpd_shipment",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_task": {
+      "name": "daily_task",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "done_at": {
+          "name": "done_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "daily_task_user_id_created_at_idx": {
+          "name": "daily_task_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_task_user_id_users_id_fk": {
+          "name": "daily_task_user_id_users_id_fk",
+          "tableFrom": "daily_task",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing_candidate_set": {
+      "name": "pairing_candidate_set",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gathered_at": {
+          "name": "gathered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "queries": {
+          "name": "queries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chosen_url": {
+          "name": "chosen_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chosen_reason": {
+          "name": "chosen_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "pairing_confidence",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "pairing_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verdict_checked_at": {
+          "name": "verdict_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pairing_candidate_set_product_key_product_key_fk": {
+          "name": "pairing_candidate_set_product_key_product_key_fk",
+          "tableFrom": "pairing_candidate_set",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing_candidate": {
+      "name": "pairing_candidate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_score": {
+          "name": "raw_score",
+          "type": "numeric(8, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_hit": {
+          "name": "code_hit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pairing_candidate_product_url_uq": {
+          "name": "pairing_candidate_product_url_uq",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_candidate_product_idx": {
+          "name": "pairing_candidate_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_candidate_product_key_pairing_candidate_set_product_key_fk": {
+          "name": "pairing_candidate_product_key_pairing_candidate_set_product_key_fk",
+          "tableFrom": "pairing_candidate",
+          "tableTo": "pairing_candidate_set",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "product_key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing_search_settings": {
+      "name": "pairing_search_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne"
+      ]
+    },
+    "public.pairing_state": {
+      "name": "pairing_state",
+      "schema": "public",
+      "values": [
+        "navrhnute",
+        "potvrdene"
+      ]
+    },
+    "public.nedostupne_email_type": {
+      "name": "nedostupne_email_type",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "alternativa"
+      ]
+    },
+    "public.mail_template_action": {
+      "name": "mail_template_action",
+      "schema": "public",
+      "values": [
+        "save",
+        "reset"
+      ]
+    },
+    "public.mail_log_source": {
+      "name": "mail_log_source",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "posta_uncollected",
+        "order_reminder",
+        "supplier_order",
+        "order_merge"
+      ]
+    },
+    "public.mail_log_status": {
+      "name": "mail_log_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.mail_log_trigger": {
+      "name": "mail_log_trigger",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "manual"
+      ]
+    },
+    "public.supplier_availability": {
+      "name": "supplier_availability",
+      "schema": "public",
+      "values": [
+        "available",
+        "unavailable",
+        "unknown"
+      ]
+    },
+    "public.supplier_stock_source": {
+      "name": "supplier_stock_source",
+      "schema": "public",
+      "values": [
+        "json_ld",
+        "meta",
+        "text",
+        "size_list",
+        "none"
+      ]
+    },
+    "public.upozornenie_source": {
+      "name": "upozornenie_source",
+      "schema": "public",
+      "values": [
+        "vlastne",
+        "appka"
+      ]
+    },
+    "public.upozornenie_type": {
+      "name": "upozornenie_type",
+      "schema": "public",
+      "values": [
+        "vlastna_poznamka",
+        "nevyzdvihnuta_zasielka",
+        "vratenie",
+        "vratena_zasielka",
+        "objednavka_visi"
+      ]
+    },
+    "public.dpd_operation_status": {
+      "name": "dpd_operation_status",
+      "schema": "public",
+      "values": [
+        "submitted",
+        "failed"
+      ]
+    },
+    "public.pairing_confidence": {
+      "name": "pairing_confidence",
+      "schema": "public",
+      "values": [
+        "high",
+        "medium",
+        "low",
+        "none"
+      ]
+    },
+    "public.pairing_verdict": {
+      "name": "pairing_verdict",
+      "schema": "public",
+      "values": [
+        "ok",
+        "unsure"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/0047_snapshot.json
+++ b/apps/api/drizzle/meta/0047_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "1cdc7427-2efe-4dfe-9c05-68125894b285",
+  "id": "432c39b3-8681-49d6-b5d0-ce4f777f837c",
   "prevId": "ef8c57c1-5648-4c6b-890b-8a9124745b67",
   "version": "7",
   "dialect": "postgresql",
@@ -3139,8 +3139,8 @@
         }
       },
       "foreignKeys": {
-        "pairing_candidate_product_key_pairing_candidate_set_product_key_fk": {
-          "name": "pairing_candidate_product_key_pairing_candidate_set_product_key_fk",
+        "pairing_candidate_product_key_fk": {
+          "name": "pairing_candidate_product_key_fk",
           "tableFrom": "pairing_candidate",
           "tableTo": "pairing_candidate_set",
           "columnsFrom": [

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -334,8 +334,8 @@
     {
       "idx": 47,
       "version": "7",
-      "when": 1786578862351,
-      "tag": "0047_odd_northstar",
+      "when": 1786580717528,
+      "tag": "0047_brief_yellowjacket",
       "breakpoints": true
     }
   ]

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -330,6 +330,13 @@
       "when": 1786464616133,
       "tag": "0046_third_master_mold",
       "breakpoints": true
+    },
+    {
+      "idx": 47,
+      "version": "7",
+      "when": 1786578862351,
+      "tag": "0047_odd_northstar",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema-pairing-review.ts
+++ b/apps/api/src/db/schema-pairing-review.ts
@@ -3,7 +3,7 @@
 // 5273377438, sekcia "DB schéma"). `pairing_decision` (E6) sa v tomto
 // súbore ZÁMERNE NEROBÍ — mimo rozsahu E3.
 
-import { boolean, index, integer, jsonb, numeric, pgEnum, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { boolean, foreignKey, index, integer, jsonb, numeric, pgEnum, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
 import { products } from "./schema-catalog.js";
 
 export const pairingConfidence = pgEnum("pairing_confidence", ["high", "medium", "low", "none"]);
@@ -41,9 +41,15 @@ export const pairingCandidates = pgTable(
   "pairing_candidate",
   {
     id: uuid("id").primaryKey().defaultRandom(),
-    productKey: text("product_key")
-      .notNull()
-      .references(() => pairingCandidateSets.productKey, { onDelete: "cascade" }),
+    // Bez `.references()` priamo tu — FK je nižšie explicitne pomenovaná
+    // `foreignKey({...})` (review nález: drizzle-ov AUTO-generovaný názov
+    // `pairing_candidate_product_key_pairing_candidate_set_product_key_fk`
+    // má 69 znakov, nad Postgres-ovým 63-bajtovým `NAMEDATALEN` limitom —
+    // Postgres ho TICHO orezáva pri vytvorení, ale `drizzle-kit`'s snapshot
+    // JSON si pamätá plný, nikdy-neintrospektovaný 69-znakový názov, takže
+    // budúci `db:generate`, ktorý by túto FK menil, by vygeneroval `ALTER
+    // TABLE ... DROP CONSTRAINT` na názov, ktorý v živej DB neexistuje).
+    productKey: text("product_key").notNull(),
     // Poradie v rámci top-8 (0 = najlepší podľa `rank()`), 0..7.
     position: integer("position").notNull(),
     name: text("name").notNull(),
@@ -63,6 +69,11 @@ export const pairingCandidates = pgTable(
   (t) => [
     uniqueIndex("pairing_candidate_product_url_uq").on(t.productKey, t.url),
     index("pairing_candidate_product_idx").on(t.productKey),
+    foreignKey({
+      name: "pairing_candidate_product_key_fk",
+      columns: [t.productKey],
+      foreignColumns: [pairingCandidateSets.productKey],
+    }).onDelete("cascade"),
   ],
 );
 

--- a/apps/api/src/db/schema-pairing-review.ts
+++ b/apps/api/src/db/schema-pairing-review.ts
@@ -1,0 +1,77 @@
+// Trvalé úložisko profesionálneho párovania (issue 387 E3) — návrh
+// (https://github.com/zbynekdrlik/forestshop-app/issues/387#issuecomment-
+// 5273377438, sekcia "DB schéma"). `pairing_decision` (E6) sa v tomto
+// súbore ZÁMERNE NEROBÍ — mimo rozsahu E3.
+
+import { boolean, index, integer, jsonb, numeric, pgEnum, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { products } from "./schema-catalog.js";
+
+export const pairingConfidence = pgEnum("pairing_confidence", ["high", "medium", "low", "none"]);
+export const pairingVerdict = pgEnum("pairing_verdict", ["ok", "unsure"]);
+
+// Jeden riadok na PRODUKT — výsledok POSLEDNÉHO gather behu (issue 387 E3's
+// `run.ts`). `input_hash` (meno + zoradené external kódy variantov, `input-
+// hash.ts`) je to, čo appku robí INKREMENTÁLNOU: gather beh vyberá len
+// produkty, ktoré NEMAJÚ tento riadok vôbec, ALEBO ho majú s ROZDIELNYM
+// `input_hash` (katalógový import zmenil meno/kódy odvtedy). `verdict`/
+// `verdict_checked_at` ostávajú `null` v E3 — vyplní ich AŽ E4 (overenie
+// kódu na detaile kandidáta).
+export const pairingCandidateSets = pgTable("pairing_candidate_set", {
+  productKey: text("product_key")
+    .primaryKey()
+    .references(() => products.key, { onDelete: "cascade" }),
+  gatheredAt: timestamp("gathered_at", { withTimezone: true }).notNull(),
+  // Dopyty SKUTOČNE použité pri tomto behu (`buildQueryVariants`'s únia,
+  // `gather_candidates`'s `used` — nie `buildQueryLadder`, viď design
+  // komentár na tickete) — diagnostika, prečo/ako sa kandidáti našli.
+  queries: jsonb("queries").$type<string[]>().notNull(),
+  inputHash: text("input_hash").notNull(),
+  chosenUrl: text("chosen_url"),
+  chosenReason: text("chosen_reason"),
+  confidence: pairingConfidence("confidence").notNull(),
+  verdict: pairingVerdict("verdict"),
+  verdictCheckedAt: timestamp("verdict_checked_at", { withTimezone: true }),
+});
+
+// Top-8 kandidátov posledného gather behu — KAŽDÝ gather beh nahradí CELÚ
+// množinu kandidátov daného produktu (delete+insert v tej istej transakcii
+// ako `pairing_candidate_set` upsert, `run.ts`), nikdy inkrementálny diff —
+// kandidáti sú vždy "posledný pohľad na top-8", nie história.
+export const pairingCandidates = pgTable(
+  "pairing_candidate",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    productKey: text("product_key")
+      .notNull()
+      .references(() => pairingCandidateSets.productKey, { onDelete: "cascade" }),
+    // Poradie v rámci top-8 (0 = najlepší podľa `rank()`), 0..7.
+    position: integer("position").notNull(),
+    name: text("name").notNull(),
+    url: text("url").notNull(),
+    // `code`/`price` sú `null` pri parsovaní VÝSLEDKOV VYHĽADÁVANIA (E2's
+    // adaptéry ich nikdy nenapĺňajú, presne ako stará appka) — dopĺňa ich
+    // AŽ E4's overenie na detaile kandidáta.
+    code: text("code"),
+    price: numeric("price", { precision: 12, scale: 2 }),
+    // Repo konvencia: numeric floaty sa ukladajú cez `numeric` (string na
+    // JS strane), nikdy `real`/`doublePrecision` (`.claude/rules/
+    // database.md`) — `raw_score` nie je peniaze, ale konzistencia s
+    // JEDINÝM float-storage vzorom v celej appke sa dodržiava aj tu.
+    rawScore: numeric("raw_score", { precision: 8, scale: 4 }).notNull(),
+    codeHit: boolean("code_hit").notNull(),
+  },
+  (t) => [
+    uniqueIndex("pairing_candidate_product_url_uq").on(t.productKey, t.url),
+    index("pairing_candidate_product_idx").on(t.productKey),
+  ],
+);
+
+// Singleton Štart/Stop prepínač — presný vzor `restock_settings`
+// (`schema-restock.ts`): ŽIADEN migračný seed riadok, chýbajúci riadok sa v
+// `isPairingSearchEnabled` interpretuje ako `false` (fail-closed, appka
+// nezačne v noci obiehať dodávateľov, kým ju niekto výslovne nezapne).
+export const pairingSearchSettings = pgTable("pairing_search_settings", {
+  id: text("id").primaryKey(),
+  enabled: boolean("enabled").notNull().default(false),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull(),
+});

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -15,3 +15,4 @@ export * from "./schema-theme-colors.js";
 export * from "./schema-upozornenia.js";
 export * from "./schema-dpd.js";
 export * from "./schema-daily-tasks.js";
+export * from "./schema-pairing-review.js";

--- a/apps/api/src/http/app.ts
+++ b/apps/api/src/http/app.ts
@@ -26,6 +26,7 @@ import { registerOrderFlagsRoutes } from "./order-flags-routes.js";
 import { registerOrderMergeRoutes, type OrderMergeRunDeps } from "./order-merge-routes.js";
 import { requireSameOrigin } from "./origin-check.js";
 import { registerPairingRoutes } from "./pairing-routes.js";
+import { registerPairingSearchRoutes } from "./pairing-search-routes.js";
 import { registerPostaUncollectedRoutes, type PostaUncollectedRunDeps } from "./posta-uncollected-routes.js";
 import { registerProductLinksRoutes } from "./product-links-routes.js";
 import { registerProductDetailRoutes } from "./product-detail-routes.js";
@@ -209,6 +210,11 @@ export function createApp(
   registerSchedulerRoutes(app, db);
   registerSupplierRoutes(app, db, options.sendSupplierMail);
   registerPairingRoutes(app, db);
+  // issue 387 E3: "Profesionálne párovanie produktov" — gather beh, žiadne
+  // prihlasovacie údaje netreba (SearchClient je vždy reálny, čítanie
+  // verejných vyhľadávacích stránok dodávateľov), na rozdiel od
+  // `restock`/`shoptet-writeback` vyššie.
+  registerPairingSearchRoutes(app, db);
   // issue 239: "Eshop → Párovanie produktov" — zoznam produktov bez
   // dodávateľskej linky + doplnenie/oprava (zapisuje do rovnakej
   // `product_supplier_link_override` tabuľky ako #121, žiadna nová cesta do

--- a/apps/api/src/http/pairing-search-routes.ts
+++ b/apps/api/src/http/pairing-search-routes.ts
@@ -1,0 +1,144 @@
+// issue 387 E3: HTTP vrstva pre gather beh. Návrh (sekcia 2) menuje "POST
+// run-now, GET status" — `PUT /enabled` je pridané nad rámec tohto zoznamu,
+// aby `enabled` (Štart/Stop, default vypnuté) malo VÔBEC nejakú cestu na
+// "ručné zapnutie" (design komentár na tickete, "Menšie odchýlky"): presne
+// ten istý vzor majú VŠETKY tri existujúce automatizácie v appke
+// (`restock-routes.ts`, `posta-uncollected-routes.ts`,
+// `order-reminder-routes.ts`).
+
+import { zValidator } from "@hono/zod-validator";
+import { eq } from "drizzle-orm";
+import type { Hono } from "hono";
+import { z } from "zod";
+import type { Database } from "../db/client.js";
+import { jobRuns } from "../db/schema.js";
+import { log } from "../logger.js";
+import { record } from "../modules/audit/service.js";
+import { PAIRING_SEARCH_JOB_NAME } from "../modules/pairing-search/constants.js";
+import type { PairingSearchRunResult } from "../modules/pairing-search/run.js";
+import { runPairingSearch } from "../modules/pairing-search/run.js";
+import { isPairingSearchEnabled, setPairingSearchEnabled } from "../modules/pairing-search/settings.js";
+import { getLatestJobRun } from "../modules/scheduler/queries.js";
+import { requireRole, requireUser, type AppBindings } from "./middleware.js";
+import { requireSameOrigin } from "./origin-check.js";
+
+const setEnabledBody = z.object({ enabled: z.boolean() });
+
+function isRunResult(detail: unknown): detail is PairingSearchRunResult {
+  return typeof detail === "object" && detail !== null && "eligible" in detail;
+}
+
+/**
+ * Manuálne "Spustiť teraz" zapisuje `job_run` TÝM ISTÝM vzorom, aký
+ * `scheduler.ts`'s interná `executeJob` používa (rovnaká kópia ako
+ * `posta-uncollected-routes.ts`/`restock-routes.ts`'s vlastné
+ * `runAndRecord`) — aby `GET /api/pairing-search/status` videl ručný beh
+ * HNEĎ, nielen po ďalšom nočnom ticku.
+ */
+async function runAndRecord(db: Database, now: Date): Promise<PairingSearchRunResult> {
+  const [inserted] = await db
+    .insert(jobRuns)
+    .values({ jobName: PAIRING_SEARCH_JOB_NAME, startedAt: now, status: "running" })
+    .returning({ id: jobRuns.id });
+  const runId = inserted?.id;
+  try {
+    const result = await runPairingSearch({ db, now });
+    if (runId !== undefined) {
+      await db.update(jobRuns).set({ status: "success", finishedAt: new Date(), detail: result }).where(eq(jobRuns.id, runId));
+    }
+    return result;
+  } catch (error) {
+    const rawErrorMessage = error instanceof Error ? error.message : String(error);
+    log.error({ rawErrorMessage }, "Profesionálne párovanie: ručný beh zlyhal");
+    if (runId !== undefined) {
+      await db.update(jobRuns).set({ status: "failure", finishedAt: new Date(), errorMessage: rawErrorMessage }).where(eq(jobRuns.id, runId));
+    }
+    throw error;
+  }
+}
+
+export function registerPairingSearchRoutes(app: Hono<AppBindings>, db: Database): void {
+  app.get("/api/pairing-search/status", requireUser(db), async (c) => {
+    const [enabled, lastRun] = await Promise.all([isPairingSearchEnabled(db), getLatestJobRun(db, PAIRING_SEARCH_JOB_NAME)]);
+    return c.json({
+      enabled,
+      lastRun:
+        lastRun === null
+          ? null
+          : {
+              startedAt: lastRun.startedAt,
+              finishedAt: lastRun.finishedAt,
+              status: lastRun.status,
+              errorMessage: lastRun.errorMessage,
+              result: isRunResult(lastRun.detail) ? lastRun.detail : null,
+              skippedReason:
+                typeof lastRun.detail === "object" &&
+                lastRun.detail !== null &&
+                "skipped" in lastRun.detail &&
+                (lastRun.detail as { readonly skipped?: unknown }).skipped === true
+                  ? ((lastRun.detail as { readonly reason?: unknown }).reason ?? "")
+                  : null,
+            },
+    });
+  });
+
+  // Štart/Stop gate-uje LEN naplánovaný nočný beh (`scheduler/jobs.ts`'s
+  // `pairingSearchJob`), nikdy "Spustiť teraz" nižšie — rovnaká úvaha ako
+  // `restock`/`posta-uncollected`/`order-reminder`.
+  app.put(
+    "/api/pairing-search/enabled",
+    requireSameOrigin(),
+    requireUser(db),
+    requireRole("admin", "manazer"),
+    zValidator("json", setEnabledBody),
+    async (c) => {
+      const { enabled } = c.req.valid("json");
+      const user = c.get("user");
+      const now = new Date();
+      await setPairingSearchEnabled(db, enabled, now);
+      await record(db, {
+        at: now,
+        actorUserId: user.userId,
+        action: "pairing_search.enabled.set",
+        entity: "pairing_search_settings",
+        data: { enabled },
+      });
+      log.info({ actorUserId: user.userId, enabled }, "Profesionálne párovanie: Štart/Stop");
+      return c.json({ ok: true as const, enabled });
+    },
+  );
+
+  app.post(
+    "/api/pairing-search/run-now",
+    requireSameOrigin(),
+    requireUser(db),
+    requireRole("admin", "manazer"),
+    async (c) => {
+      const user = c.get("user");
+      const now = new Date();
+      let result: PairingSearchRunResult;
+      try {
+        result = await runAndRecord(db, now);
+      } catch {
+        return c.json({ ok: false as const, error: "Beh zlyhal." }, 500);
+      }
+      await record(db, {
+        at: now,
+        actorUserId: user.userId,
+        action: "pairing_search.run_now",
+        entity: "job_run",
+        data: {
+          eligible: result.eligible,
+          processed: result.processed,
+          succeeded: result.succeeded,
+          failed: result.failed,
+        },
+      });
+      log.info(
+        { actorUserId: user.userId, eligible: result.eligible, processed: result.processed, succeeded: result.succeeded, failed: result.failed },
+        "Profesionálne párovanie: ručné spustenie",
+      );
+      return c.json({ ok: true as const, result });
+    },
+  );
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -24,6 +24,7 @@ import {
   ordersImportJob,
   orderNoteWritebackJob,
   orderReminderJob,
+  pairingSearchJob,
   shopFeedJob,
   supplierStockJob,
   restockJob,
@@ -33,6 +34,7 @@ import {
   sessionCleanupJob,
   shoptetWritebackJob,
 } from "./modules/scheduler/jobs.js";
+import { runPairingSearch } from "./modules/pairing-search/run.js";
 import { DEFAULT_SHOP_FEED_URL } from "./modules/shop-feed/constants.js";
 import { createHttpShopFeedFetcher } from "./modules/shop-feed/fetcher.js";
 import { runShopFeed } from "./modules/shop-feed/run.js";
@@ -288,6 +290,12 @@ const scheduler = startScheduler(db, [
   shopFeedJob((db2, now) => runShopFeed({ db: db2, now, fetchFeed: fetchShopFeed })),
   supplierStockJob((db2, now) => runSupplierStock({ db: db2, now, fetchPage: fetchSupplierPage })),
   restockJob(runRestockFn),
+  // issue 387 E3: žiadne prihlasovacie údaje potrebné (verejné vyhľadávacie
+  // stránky dodávateľov) — na rozdiel od `restockJob`/`shoptetWritebackJob`
+  // vyššie sa `run` tu nikdy nezostavuje ako `undefined`. Automatika je
+  // napriek tomu default VYPNUTÁ (`pairing_search_settings.enabled`) —
+  // `pairingSearchJob`'s vlastná kontrola pred behom, nie chýbajúca konfigurácia.
+  pairingSearchJob((db2, now) => runPairingSearch({ db: db2, now })),
 ]);
 
 // `@hono/node-server`'s `serveStatic` prints its OWN `console.error` on every

--- a/apps/api/src/modules/pairing-search/constants.ts
+++ b/apps/api/src/modules/pairing-search/constants.ts
@@ -1,0 +1,27 @@
+// issue 387 E3: konštanty gather behu.
+
+export const PAIRING_SEARCH_JOB_NAME = "pairing-search";
+export const PAIRING_SEARCH_SETTINGS_ID = "default";
+
+// Ďalší voľný kľúč v registri (`.claude/rules/scheduler.md`) — schválený
+// priamo v návrhu (sekcia 5, bod 3): "session-scoped advisory lock
+// 787_878_007". Session-scoped (nie transakčný), rovnaký vzor ako
+// `posta-uncollected/run.ts`'s `POSTA_UNCOLLECTED_RUN_LOCK_KEY` — beh robí
+// desiatky sekvenčných sieťových volaní na dodávateľov, držať jednu DB
+// transakciu otvorenú počas nich by zbytočne zaťažovalo connection pool.
+export const PAIRING_SEARCH_RUN_LOCK_KEY = 787_878_007;
+
+// Top-K kandidátov ponechaných po ranku (návrh: "top-K = 8, únia všetkých
+// query_variants") — port starej appky's `gather_candidates(..., k=8)`.
+export const CANDIDATE_LIMIT = 8;
+
+// Časový (nie počtový) strop JEDNÉHO behu — nákladový faktor gatheru je
+// SIEŤOVÝ ČAS na produkt (viac query variantov × throttle 0,7s × až 3
+// retry), ktorý sa medzi produktmi výrazne líši, takže počtový strop
+// (`restock`'s `MAX_PER_RUN` vzor) by negarantoval predvídateľnú dĺžku
+// behu (design komentár na tickete, "Zamietnutá alternatíva"). Beh, ktorý
+// prekročí tento rozpočet, sa PO dokončení AKTUÁLNEHO produktu (nikdy
+// uprostred jeho transakcie) zastaví — `stoppedEarly: true` v
+// `job_run.detail` — a pokračuje nasledujúcu noc odtiaľ, kde skončil
+// (`input_hash` inkrementálnosť, `select.ts`).
+export const RUN_TIME_BUDGET_MS = 20 * 60_000;

--- a/apps/api/src/modules/pairing-search/constants.ts
+++ b/apps/api/src/modules/pairing-search/constants.ts
@@ -3,13 +3,22 @@
 export const PAIRING_SEARCH_JOB_NAME = "pairing-search";
 export const PAIRING_SEARCH_SETTINGS_ID = "default";
 
-// Ďalší voľný kľúč v registri (`.claude/rules/scheduler.md`) — schválený
-// priamo v návrhu (sekcia 5, bod 3): "session-scoped advisory lock
-// 787_878_007". Session-scoped (nie transakčný), rovnaký vzor ako
-// `posta-uncollected/run.ts`'s `POSTA_UNCOLLECTED_RUN_LOCK_KEY` — beh robí
-// desiatky sekvenčných sieťových volaní na dodávateľov, držať jednu DB
-// transakciu otvorenú počas nich by zbytočne zaťažovalo connection pool.
-export const PAIRING_SEARCH_RUN_LOCK_KEY = 787_878_007;
+// Návrh (sekcia 5, bod 3) aj zadanie tejto etapy pôvodne menovali
+// "787_878_007" — REVIEW NÁLEZ (issue 387 E3): ten kľúč UŽ patrí
+// `SUPPLIER_STOCK_RUN_LOCK_KEY` (`supplier-stock/constants.ts`, issue 212,
+// zmergované dávno pred touto etapou) — `.claude/rules/scheduler.md`'s
+// vlastný registr bol v čase návrhu zastaraný (nezahŕňal `007` ani `008`
+// [`RESTOCK_RUN_LOCK_KEY`]), takže kolízia prešla nepovšimnutá. Postgres
+// advisory zámky zdieľajú JEDEN priestor kľúčov bez ohľadu na to, ktorý
+// modul ich vzal — bez opravy by súbežný beh gatheru a `supplier-stock`
+// scrapera (oba session-scoped, oba môžu bežať dlho) NAVZÁJOM ZABLOKOVAL
+// bez timeoutu. `009` je prvý skutočne voľný kľúč (over `.claude/rules/
+// scheduler.md`'s aktualizovaný registr pred ĎALŠÍM pridaním). Session-
+// scoped (nie transakčný), rovnaký vzor ako `posta-uncollected/run.ts`'s
+// `POSTA_UNCOLLECTED_RUN_LOCK_KEY` — beh robí desiatky sekvenčných
+// sieťových volaní na dodávateľov, držať jednu DB transakciu otvorenú
+// počas nich by zbytočne zaťažovalo connection pool.
+export const PAIRING_SEARCH_RUN_LOCK_KEY = 787_878_009;
 
 // Top-K kandidátov ponechaných po ranku (návrh: "top-K = 8, únia všetkých
 // query_variants") — port starej appky's `gather_candidates(..., k=8)`.

--- a/apps/api/src/modules/pairing-search/input-hash.test.ts
+++ b/apps/api/src/modules/pairing-search/input-hash.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { computeInputHash } from "./input-hash.js";
+import type { PairingProduct } from "./types.js";
+
+function product(overrides: Partial<PairingProduct> = {}): PairingProduct {
+  return {
+    productKey: "p1",
+    name: "Bunda Wetland",
+    supplier: "WETLAND",
+    externalCodes: [],
+    ...overrides,
+  };
+}
+
+describe("computeInputHash", () => {
+  it("je deterministický pre rovnaký vstup", () => {
+    expect(computeInputHash(product())).toBe(computeInputHash(product()));
+  });
+
+  it("mení sa pri zmene mena", () => {
+    expect(computeInputHash(product({ name: "Bunda Wetland" }))).not.toBe(
+      computeInputHash(product({ name: "Iné meno" })),
+    );
+  });
+
+  it("mení sa pri zmene external kódov", () => {
+    expect(computeInputHash(product({ externalCodes: ["A1"] }))).not.toBe(
+      computeInputHash(product({ externalCodes: ["A1", "B2"] })),
+    );
+  });
+
+  it("NEZÁVISÍ od poradia external kódov (zoraďuje sa pred hashovaním)", () => {
+    expect(computeInputHash(product({ externalCodes: ["A1", "B2"] }))).toBe(
+      computeInputHash(product({ externalCodes: ["B2", "A1"] })),
+    );
+  });
+
+  it("NEZÁVISÍ od productKey/supplier — len meno + kódy určujú zastaranie", () => {
+    expect(computeInputHash(product({ productKey: "p1", supplier: "WETLAND" }))).toBe(
+      computeInputHash(product({ productKey: "p2", supplier: "ODIMON" })),
+    );
+  });
+});

--- a/apps/api/src/modules/pairing-search/input-hash.ts
+++ b/apps/api/src/modules/pairing-search/input-hash.ts
@@ -1,0 +1,24 @@
+// issue 387 E3: detekcia zastarania kandidátov — "input_hash (hash mena +
+// external kódov — detekcia zastarania)" (návrh, sekcia "DB schéma"). Čistá
+// funkcia (žiadna DB/sieť) — `select.ts` ju volá pre KAŽDÝ produkt a
+// porovnáva s `pairing_candidate_set.input_hash` uloženým z posledného
+// gather behu; rozdielna hodnota = katalógový import zmenil meno/kódy
+// odvtedy, produkt je znova eligible aj keď kandidátov už má.
+
+import { createHash } from "node:crypto";
+import type { PairingProduct } from "./types.js";
+
+/**
+ * Stabilný hash produktu pre detekciu zastarania. `externalCodes` sa
+ * zoraďuje pred hashovaním (`toPairingProduct` už zachováva poradie prvého
+ * výskytu — dva behy s TÝMI ISTÝMI kódmi, ale iným poradím variantov v DB
+ * dopyte, by inak dali RÔZNY hash pre ROVNAKÝ obsah, čo by spôsobilo
+ * zbytočný re-gather).
+ */
+export function computeInputHash(product: PairingProduct): string {
+  const payload = JSON.stringify({
+    name: product.name,
+    externalCodes: [...product.externalCodes].sort(),
+  });
+  return createHash("sha256").update(payload).digest("hex");
+}

--- a/apps/api/src/modules/pairing-search/run.ts
+++ b/apps/api/src/modules/pairing-search/run.ts
@@ -1,0 +1,208 @@
+// Beh gather automatizácie (issue 387 E3) — pre KAŽDÝ eligible produkt
+// (`select.ts`) skúsi VŠETKY `buildQueryVariants` (union, port starej
+// appky's `matcher.py`'s `gather_candidates(product, client, k=8)` — NIE
+// `match_one`/`query_ladder`, viď design komentár na tickete), poolu je
+// kandidátov podľa URL naprieč všetkými dopytmi, rankuje CELÝ pool a
+// zapíše top-8 + `pickBest()`'s voľbu.
+//
+// Checkpoint = per-produkt TRANSAKČNÝ upsert (`upsertCandidateSet`) —
+// žiadna samostatná cursor tabuľka. Pád uprostred behu necháva už
+// committnuté produkty s AKTUÁLNYM `input_hash` (ďalší beh ich sám
+// preskočí, `select.ts`), zatiaľ čo produkt, pri ktorom beh spadol, nemá
+// zapísaný nový `input_hash` → zostáva eligible pre ďalší beh. Per-produkt
+// VÝNIMKA (sieť/parsing) sa zaloguje a zapíše do `errors`, cyklus
+// pokračuje ĎALŠÍM produktom — ten istý princíp ako `posta-uncollected/
+// run.ts`.
+
+import { eq } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { pairingCandidateSets, pairingCandidates } from "../../db/schema.js";
+import { log } from "../../logger.js";
+import { CANDIDATE_LIMIT, PAIRING_SEARCH_RUN_LOCK_KEY, RUN_TIME_BUDGET_MS } from "./constants.js";
+import { SearchClient } from "./client.js";
+import { buildQueryVariants } from "./queries.js";
+import { pickBest, rank, type PairingPick } from "./ranking.js";
+import { selectEligibleProducts, type EligibleProduct } from "./select.js";
+import type { PairingCandidate, PairingConfidence } from "./types.js";
+
+export interface PairingSearchRunError {
+  readonly productKey: string;
+  readonly message: string;
+}
+
+export interface PairingSearchRunResult {
+  readonly checkedAt: string;
+  /** Koľko produktov beh na ZAČIATKU vôbec našiel ako eligible (pred
+   * uplatnením časového stropu). */
+  readonly eligible: number;
+  readonly processed: number;
+  readonly succeeded: number;
+  readonly failed: number;
+  readonly errors: readonly PairingSearchRunError[];
+  /** `true` = beh narazil na `RUN_TIME_BUDGET_MS` skôr, než stihol
+   * spracovať všetkých eligible produktov — pokračuje nasledujúcu noc. */
+  readonly stoppedEarly: boolean;
+}
+
+export interface RunPairingSearchOptions {
+  readonly db: Database;
+  readonly now: Date;
+  /** Iba pre testy — nahradí skutočný sieťový `SearchClient`. */
+  readonly searchClient?: SearchClient;
+  /** Iba pre testy — skráti/predĺži časový rozpočet behu. */
+  readonly timeBudgetMs?: number;
+  /** Iba pre testy — deterministický zdroj "uplynutého času" namiesto
+   * skutočného `Date.now()`. */
+  readonly clock?: () => number;
+}
+
+// Ďalší voľný advisory zámok kľúč, session-scoped (rovnaký vzor ako
+// `posta-uncollected/run.ts`'s `POSTA_UNCOLLECTED_RUN_LOCK_KEY`) — vlastné,
+// vyhradené pripojenie z poolu, NIE transakcia okolo celého behu (desiatky
+// sekvenčných sieťových volaní na dodávateľov by zbytočne zaťažovali
+// connection pool, keby ich obopínala jedna otvorená DB transakcia).
+export async function runPairingSearch(options: RunPairingSearchOptions): Promise<PairingSearchRunResult> {
+  const { db } = options;
+  const lockClient = await db.$client.connect();
+  try {
+    await lockClient.query("select pg_advisory_lock($1)", [PAIRING_SEARCH_RUN_LOCK_KEY]);
+    return await runPairingSearchLocked(options);
+  } finally {
+    await lockClient.query("select pg_advisory_unlock($1)", [PAIRING_SEARCH_RUN_LOCK_KEY]);
+    lockClient.release();
+  }
+}
+
+async function runPairingSearchLocked(options: RunPairingSearchOptions): Promise<PairingSearchRunResult> {
+  const { db, now } = options;
+  const searchClient = options.searchClient ?? new SearchClient();
+  const timeBudgetMs = options.timeBudgetMs ?? RUN_TIME_BUDGET_MS;
+  const clock = options.clock ?? Date.now;
+
+  const eligible = await selectEligibleProducts(db);
+  const deadlineMs = clock() + timeBudgetMs;
+
+  let processed = 0;
+  let succeeded = 0;
+  const errors: PairingSearchRunError[] = [];
+  let stoppedEarly = false;
+
+  for (const item of eligible) {
+    if (clock() >= deadlineMs) {
+      stoppedEarly = true;
+      break;
+    }
+    processed += 1;
+    try {
+      const { queries, candidates } = await gatherCandidates(searchClient, item);
+      const pick = pickBest(item.product, candidates);
+      await upsertCandidateSet(db, {
+        productKey: item.product.productKey,
+        gatheredAt: now,
+        queries,
+        inputHash: item.inputHash,
+        chosenUrl: pick.candidate?.url ?? null,
+        chosenReason: buildChosenReason(pick),
+        confidence: pick.confidence,
+        candidates,
+      });
+      succeeded += 1;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      log.error(
+        { productKey: item.product.productKey, rawErrorMessage: message },
+        "pairing-search: gather zlyhal pre produkt, pokračujem ďalším",
+      );
+      errors.push({ productKey: item.product.productKey, message });
+    }
+  }
+
+  return {
+    checkedAt: now.toISOString(),
+    eligible: eligible.length,
+    processed,
+    succeeded,
+    failed: errors.length,
+    errors,
+    stoppedEarly,
+  };
+}
+
+/** Port `matcher.py`'s `gather_candidates` — skúsi VŠETKY query varianty
+ * (nikdy sa nezastaví na prvom, ktorý niečo vrátil), poolu je kandidátov
+ * podľa URL (prvý výskyt vyhráva, rovnaký vzor ako Pythonov
+ * `pool.setdefault`), rankuje CELÝ pool proti produktu, vráti top-K. */
+async function gatherCandidates(
+  client: SearchClient,
+  item: EligibleProduct,
+): Promise<{ readonly queries: readonly string[]; readonly candidates: readonly PairingCandidate[] }> {
+  const queryVariants = buildQueryVariants(item.product);
+  const pool = new Map<string, PairingCandidate>();
+  for (const query of queryVariants) {
+    const found = await client.search(item.adapterKey, query);
+    for (const candidate of found) {
+      if (!pool.has(candidate.url)) pool.set(candidate.url, candidate);
+    }
+  }
+  const ranked = rank(item.product, [...pool.values()]);
+  return { queries: queryVariants, candidates: ranked.slice(0, CANDIDATE_LIMIT) };
+}
+
+/** Krátky ľudsky čitateľný dôvod voľby — nová appka's pole, stará appka ho
+ * nemala (mala len číselnú `confidence`). Diagnostický text pre budúcu
+ * obrazovku (E5/E6), žiadny funkčný dopad v E3. */
+function buildChosenReason(pick: PairingPick): string | null {
+  if (pick.candidate === null) return null;
+  if (pick.candidate.codeHit) return "kód dodávateľa sa zhoduje";
+  return `zhoda mena (${String(Math.round(pick.candidate.rawScore))} %)`;
+}
+
+interface UpsertCandidateSetInput {
+  readonly productKey: string;
+  readonly gatheredAt: Date;
+  readonly queries: readonly string[];
+  readonly inputHash: string;
+  readonly chosenUrl: string | null;
+  readonly chosenReason: string | null;
+  readonly confidence: PairingConfidence;
+  readonly candidates: readonly PairingCandidate[];
+}
+
+/** Checkpoint — JEDNA transakcia na produkt: upsert `candidate_set` +
+ * úplná náhrada jeho `pairing_candidate` riadkov (delete+insert, nikdy
+ * inkrementálny diff — top-8 je vždy "posledný pohľad", nie história).
+ * `verdict`/`verdict_checked_at` ostávajú `null` (E4). */
+async function upsertCandidateSet(db: Database, input: UpsertCandidateSetInput): Promise<void> {
+  await db.transaction(async (tx) => {
+    const setValues = {
+      gatheredAt: input.gatheredAt,
+      queries: [...input.queries],
+      inputHash: input.inputHash,
+      chosenUrl: input.chosenUrl,
+      chosenReason: input.chosenReason,
+      confidence: input.confidence,
+      verdict: null,
+      verdictCheckedAt: null,
+    };
+    await tx
+      .insert(pairingCandidateSets)
+      .values({ productKey: input.productKey, ...setValues })
+      .onConflictDoUpdate({ target: pairingCandidateSets.productKey, set: setValues });
+
+    await tx.delete(pairingCandidates).where(eq(pairingCandidates.productKey, input.productKey));
+    if (input.candidates.length > 0) {
+      await tx.insert(pairingCandidates).values(
+        input.candidates.map((candidate, position) => ({
+          productKey: input.productKey,
+          position,
+          name: candidate.name,
+          url: candidate.url,
+          code: candidate.code,
+          price: candidate.price,
+          rawScore: candidate.rawScore.toFixed(4),
+          codeHit: candidate.codeHit,
+        })),
+      );
+    }
+  });
+}

--- a/apps/api/src/modules/pairing-search/select.ts
+++ b/apps/api/src/modules/pairing-search/select.ts
@@ -1,0 +1,94 @@
+// issue 387 E3: výber produktov pre gather beh — "iba produkty bez
+// efektívneho odkazu, ktoré nemajú kandidátov alebo majú zmenený
+// input_hash; prioritne vypredané-viditeľné" (návrh, sekcia 5 bod 3).
+//
+// Rovnaký MVP vzor ako `product-links/queries.ts`'s `listProductLinks`/
+// `restock-links/queries.ts`'s `listRestockLinkSuggestions` — celý katalóg
+// (rádovo tisícky produktov) sa načíta a filtruje v pamäti, nie SQL JOIN so
+// vstavaným hashovaním (input_hash porovnanie je nutne JS-side, keďže
+// `computeInputHash` je čistá JS funkcia).
+
+import { eq } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { pairingCandidateSets, productSupplierLinkOverrides, products, suppliers, variants } from "../../db/schema.js";
+import { resolveEffectiveSupplierLink } from "../orders/effective-supplier-link.js";
+import { normalizeSupplierKeyJs } from "../orders/supplier-key.js";
+import { SELLABLE_VISIBILITY } from "../restock/constants.js";
+import { computeInputHash } from "./input-hash.js";
+import { toPairingProduct, type PairingProduct } from "./types.js";
+
+export interface EligibleProduct {
+  readonly product: PairingProduct;
+  readonly adapterKey: string;
+  readonly inputHash: string;
+  /** "vypredané-viditeľné" — rovnaká populácia ako #311 (`variant.state ===
+   * "out_of_stock" && productVisibility === "visible" && missingSince ===
+   * null`), zoradené PRED ostatnými (design: "prioritne"). */
+  readonly soldOutVisible: boolean;
+}
+
+export async function selectEligibleProducts(db: Database): Promise<readonly EligibleProduct[]> {
+  const supplierRows = await db.select({ name: suppliers.name, adapterKey: suppliers.adapterKey }).from(suppliers);
+  const adapterByNormalizedSupplier = new Map<string, string>();
+  for (const row of supplierRows) {
+    if (row.adapterKey !== null) adapterByNormalizedSupplier.set(normalizeSupplierKeyJs(row.name), row.adapterKey);
+  }
+  // Bez ANI JEDNÉHO dodávateľa so známym adaptérom (napr. čerstvá DB pred
+  // migračným seedom) niet zmysel čítať zvyšok katalógu vôbec.
+  if (adapterByNormalizedSupplier.size === 0) return [];
+
+  const productRows = await db
+    .select({
+      key: products.key,
+      name: products.name,
+      supplier: products.supplier,
+      internalNote: products.internalNote,
+      overrideUrl: productSupplierLinkOverrides.url,
+    })
+    .from(products)
+    .leftJoin(productSupplierLinkOverrides, eq(productSupplierLinkOverrides.productKey, products.key));
+
+  const variantRows = await db
+    .select({
+      productKey: variants.productKey,
+      externalCode: variants.externalCode,
+      state: variants.state,
+      productVisibility: variants.productVisibility,
+      missingSince: variants.missingSince,
+    })
+    .from(variants);
+  const variantsByProduct = new Map<string, typeof variantRows>();
+  for (const row of variantRows) {
+    const bucket = variantsByProduct.get(row.productKey);
+    if (bucket === undefined) variantsByProduct.set(row.productKey, [row]);
+    else bucket.push(row);
+  }
+
+  const hashRows = await db.select({ productKey: pairingCandidateSets.productKey, inputHash: pairingCandidateSets.inputHash }).from(pairingCandidateSets);
+  const hashByProduct = new Map(hashRows.map((row) => [row.productKey, row.inputHash]));
+
+  const eligible: EligibleProduct[] = [];
+  for (const row of productRows) {
+    const effective = resolveEffectiveSupplierLink(row.internalNote, row.overrideUrl);
+    if (effective.url !== null) continue;
+
+    const adapterKey = adapterByNormalizedSupplier.get(normalizeSupplierKeyJs(row.supplier ?? ""));
+    if (adapterKey === undefined) continue;
+
+    const productVariants = variantsByProduct.get(row.key) ?? [];
+    const pairingProduct = toPairingProduct(
+      { key: row.key, name: row.name, supplier: row.supplier },
+      productVariants.map((v) => ({ externalCode: v.externalCode })),
+    );
+    const inputHash = computeInputHash(pairingProduct);
+    if (hashByProduct.get(row.key) === inputHash) continue;
+
+    const soldOutVisible = productVariants.some(
+      (v) => v.state === "out_of_stock" && v.productVisibility === SELLABLE_VISIBILITY && v.missingSince === null,
+    );
+    eligible.push({ product: pairingProduct, adapterKey, inputHash, soldOutVisible });
+  }
+
+  eligible.sort((a, b) => Number(b.soldOutVisible) - Number(a.soldOutVisible) || a.product.productKey.localeCompare(b.product.productKey));
+  return eligible;
+}

--- a/apps/api/src/modules/pairing-search/settings.ts
+++ b/apps/api/src/modules/pairing-search/settings.ts
@@ -1,0 +1,24 @@
+import { eq } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { pairingSearchSettings } from "../../db/schema.js";
+import { PAIRING_SEARCH_SETTINGS_ID } from "./constants.js";
+
+/** `true` len keď riadok existuje A `enabled = true` — chýbajúci riadok
+ * (žiadny migračný seed, presne ako `restock_settings`) sa berie ako
+ * VYPNUTÉ, nikdy ako zapnuté (rovnaká fail-closed disciplína ako
+ * `restock`/`posta-uncollected`: appka nezačne v noci obiehať dodávateľov,
+ * kým ju niekto výslovne nezapne). */
+export async function isPairingSearchEnabled(db: Database): Promise<boolean> {
+  const [row] = await db
+    .select({ enabled: pairingSearchSettings.enabled })
+    .from(pairingSearchSettings)
+    .where(eq(pairingSearchSettings.id, PAIRING_SEARCH_SETTINGS_ID));
+  return row?.enabled ?? false;
+}
+
+export async function setPairingSearchEnabled(db: Database, enabled: boolean, now: Date): Promise<void> {
+  await db
+    .insert(pairingSearchSettings)
+    .values({ id: PAIRING_SEARCH_SETTINGS_ID, enabled, updatedAt: now })
+    .onConflictDoUpdate({ target: pairingSearchSettings.id, set: { enabled, updatedAt: now } });
+}

--- a/apps/api/src/modules/scheduler/jobs.ts
+++ b/apps/api/src/modules/scheduler/jobs.ts
@@ -17,6 +17,9 @@ import { SHOP_FEED_JOB_NAME } from "../shop-feed/constants.js";
 import type { ShopFeedRunResult } from "../shop-feed/run.js";
 import { SUPPLIER_STOCK_JOB_NAME } from "../supplier-stock/constants.js";
 import type { SupplierStockRunResult } from "../supplier-stock/run.js";
+import { PAIRING_SEARCH_JOB_NAME } from "../pairing-search/constants.js";
+import { isPairingSearchEnabled } from "../pairing-search/settings.js";
+import type { PairingSearchRunResult } from "../pairing-search/run.js";
 import type { ScheduledJob } from "./types.js";
 
 export const CATALOG_IMPORT_JOB_NAME = "catalog-import";
@@ -373,6 +376,35 @@ export function shopFeedJob(run: RunShopFeed): ScheduledJob {
     schedule: { kind: "daily", hourLocal: 3, minuteLocal: 50 },
     async run(db, now) {
       return { detail: await run(db, now) };
+    },
+  };
+}
+
+export type RunPairingSearch = (db: Database, now: Date) => Promise<PairingSearchRunResult>;
+
+/**
+ * "Profesionálne párovanie produktov" — gather beh (issue 387 E3), denne o
+ * 03:35 Europe/Bratislava (zadanie), teda pred `shopFeedJob` (03:50) aj
+ * ostatnými nočnými jobmi nižšie (04:20/04:50).
+ *
+ * MÁ `enabled` prepínač, default VYPNUTÝ — na rozdiel od `shopFeedJob`
+ * (číta len verejný feed) tento beh reálne obieha weby dodávateľov
+ * (WETLAND/BETALOV/ODIMON), čo appka nemá začať robiť v noci skôr, než
+ * bude čo ukazovať (E4/E5 dodá overenie + obrazovku). "Spustiť teraz"
+ * (`http/pairing-search-routes.ts`) beží VŽDY bez ohľadu naň — rovnaká
+ * úvaha ako `postaUncollectedJob`/`orderReminderJob`/`restockJob` vyššie.
+ */
+export function pairingSearchJob(run: RunPairingSearch): ScheduledJob {
+  return {
+    name: PAIRING_SEARCH_JOB_NAME,
+    schedule: { kind: "daily", hourLocal: 3, minuteLocal: 35 },
+    async run(db, now) {
+      const enabled = await isPairingSearchEnabled(db);
+      if (!enabled) {
+        return { detail: { skipped: true, reason: "automatizácia je vypnutá (Štart/Stop)" } };
+      }
+      const result = await run(db, now);
+      return { detail: result };
     },
   };
 }

--- a/apps/api/tests/helpers/db.ts
+++ b/apps/api/tests/helpers/db.ts
@@ -77,8 +77,16 @@ export async function withCleanDb(): Promise<{ db: Database; close: () => Promis
     // deliberate exception to that convention (previous comment here said
     // it "does NOT need listing"); it is now included like everything else
     // instead of staying the sole exception.
+    // issue 387 E3: "pairing_candidate_set"/"pairing_candidate" DO have a
+    // real FK chain into "product" (cascade), so `TRUNCATE product CASCADE`
+    // already reaches them transitively — listed explicitly anyway for the
+    // SAME self-documenting consistency as "dpd_shipment"/"pairing" above.
+    // "pairing_search_settings" is the SAME situation as "restock_settings"
+    // above — no FK in either direction (singleton id), and (like
+    // "restock_settings") the migration seeds NO default row, so no reseed
+    // is needed below either.
     await db.execute(
-      sql`TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, nedostupne_replacement_link, mail_template, mail_template_history, supplier_stock, restock_settings, restock_event, shop_product_url, theme_color, dpd_pickup_request, upozornenie, daily_task, mail_log, dpd_shipment, product_supplier_override, product_supplier_link_override RESTART IDENTITY CASCADE`,
+      sql`TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, nedostupne_replacement_link, mail_template, mail_template_history, supplier_stock, restock_settings, restock_event, shop_product_url, theme_color, dpd_pickup_request, upozornenie, daily_task, mail_log, dpd_shipment, product_supplier_override, product_supplier_link_override, pairing_candidate, pairing_candidate_set, pairing_search_settings RESTART IDENTITY CASCADE`,
     );
     // issue 59: `order_open_status` is a NEW table with real production
     // content (the migration seeds it) — TRUNCATE alone would leave every

--- a/apps/api/tests/pairing-search-run.integration.test.ts
+++ b/apps/api/tests/pairing-search-run.integration.test.ts
@@ -295,7 +295,7 @@ describe("pairing-search: gather beh (issue 387 E3)", () => {
   // .test.ts`'s "dva súbežné behy sa serializujú" — `pg_try_advisory_lock`
   // (neblokujúci) z DRUHÉHO pripojenia MUSÍ zlyhať, kým je beh zaseknutý na
   // falošnom, ešte nevyriešenom sieťovom volaní.
-  it("dva súbežné behy sa serializujú (advisory zámok 787_878_007), nikdy neprebehnú naraz", async () => {
+  it("dva súbežné behy sa serializujú (advisory zámok PAIRING_SEARCH_RUN_LOCK_KEY), nikdy neprebehnú naraz", async () => {
     const db = await boot();
     await seedSupplier(db, "WETLAND", "wetland");
     await seedProduct(db, "P1", { name: "Bunda Wetland" });

--- a/apps/api/tests/pairing-search-run.integration.test.ts
+++ b/apps/api/tests/pairing-search-run.integration.test.ts
@@ -1,0 +1,335 @@
+import { eq } from "drizzle-orm";
+import pg from "pg";
+import { afterEach, describe, expect, it } from "vitest";
+import type { Database } from "../src/db/client.js";
+import { pairingCandidateSets, pairingCandidates, products, suppliers, variants } from "../src/db/schema.js";
+import { SearchClient, type Fetcher } from "../src/modules/pairing-search/client.js";
+import { PAIRING_SEARCH_RUN_LOCK_KEY } from "../src/modules/pairing-search/constants.js";
+import { runPairingSearch } from "../src/modules/pairing-search/run.js";
+import { insertTestSnapshot } from "./helpers/catalog.js";
+import { withCleanDb } from "./helpers/db.js";
+
+const NOW = new Date("2026-08-13T03:35:00.000Z");
+const LATER = new Date("2026-08-14T03:35:00.000Z");
+
+let close: (() => Promise<void>) | undefined;
+let checker: pg.Client | undefined;
+
+afterEach(async () => {
+  await checker?.end();
+  checker = undefined;
+  await close?.();
+  close = undefined;
+});
+
+async function boot(): Promise<Database> {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  return ctx.db;
+}
+
+async function seedSupplier(db: Database, name: string, adapterKey: string | null): Promise<void> {
+  await db.insert(suppliers).values({ name, currency: "EUR", wholesaleBaseUrl: "https://www.wetland.sk", adapterKey });
+}
+
+interface SeedProductOptions {
+  readonly supplier?: string | null;
+  readonly internalNote?: string | null;
+  readonly externalCode?: string | null;
+  readonly state?: "sellable" | "out_of_stock" | "discontinued";
+  readonly productVisibility?: string;
+  readonly missingSince?: Date | null;
+  readonly name?: string;
+}
+
+async function seedProduct(db: Database, key: string, opts: SeedProductOptions = {}): Promise<void> {
+  const snapshotId = await insertTestSnapshot(db);
+  await db.insert(products).values({
+    key,
+    name: opts.name ?? `Bunda ${key}`,
+    supplier: opts.supplier === undefined ? "WETLAND" : opts.supplier,
+    internalNote: opts.internalNote ?? null,
+    firstSeenAt: NOW,
+    lastSeenAt: NOW,
+    lastSeenSnapshotId: snapshotId,
+  });
+  await db.insert(variants).values({
+    code: `${key}-V1`,
+    productKey: key,
+    guid: key,
+    sizeLabel: null,
+    pairCode: null,
+    externalCode: opts.externalCode ?? null,
+    name: opts.name ?? `Bunda ${key}`,
+    currency: "EUR",
+    price: "10.00",
+    stock: 5,
+    availabilityInStockText: "Skladom",
+    availabilityOutOfStockText: "Vypredané",
+    availabilityText: "Skladom",
+    productVisibility: opts.productVisibility ?? "visible",
+    state: opts.state ?? "sellable",
+    firstSeenAt: NOW,
+    lastSeenAt: NOW,
+    lastSeenSnapshotId: snapshotId,
+    missingSince: opts.missingSince ?? null,
+  });
+}
+
+/** Minimálna WETLAND vyhľadávacia karta — presne selektor `wetland.ts`
+ * očakáva (`div.product-miniature__title a.link`). */
+function wetlandCard(name: string, href: string): string {
+  return `<div class="product-miniature__title"><a class="link" href="${href}">${name}</a></div>`;
+}
+
+function fakeWetlandFetcher(html: string, onCall?: (url: string) => void): Fetcher {
+  return (url) => {
+    onCall?.(url);
+    return Promise.resolve(html);
+  };
+}
+
+describe("pairing-search: gather beh (issue 387 E3)", () => {
+  it("zapíše chosen_url a top kandidátov pre eligible produkt (menová zhoda, medium)", async () => {
+    const db = await boot();
+    await seedSupplier(db, "WETLAND", "wetland");
+    await seedProduct(db, "P1", { name: "Bunda Wetland" });
+
+    const html = `<div>${wetlandCard("Bunda Wetland", "https://www.wetland.sk/p/1")}${wetlandCard("Úplne iný produkt", "https://www.wetland.sk/p/2")}</div>`;
+    const searchClient = new SearchClient({ fetcher: fakeWetlandFetcher(html) });
+
+    const result = await runPairingSearch({ db, now: NOW, searchClient });
+
+    expect(result).toMatchObject({ eligible: 1, processed: 1, succeeded: 1, failed: 0, stoppedEarly: false });
+
+    const [set] = await db.select().from(pairingCandidateSets).where(eq(pairingCandidateSets.productKey, "P1"));
+    expect(set?.confidence).toBe("medium");
+    expect(set?.chosenUrl).toBe("https://www.wetland.sk/p/1");
+    expect(set?.chosenReason).toContain("zhoda mena");
+    expect(set?.gatheredAt.toISOString()).toBe(NOW.toISOString());
+    expect(set?.queries.length).toBeGreaterThan(0);
+
+    const candidates = await db.select().from(pairingCandidates).where(eq(pairingCandidates.productKey, "P1"));
+    expect(candidates).toHaveLength(2);
+    expect(candidates.find((c) => c.position === 0)?.url).toBe("https://www.wetland.sk/p/1");
+  });
+
+  it("kódová zhoda vždy vyhrá nad menovou (confidence high, aj keď meno nesedí)", async () => {
+    const db = await boot();
+    await seedSupplier(db, "WETLAND", "wetland");
+    await seedProduct(db, "P1", { name: "Nohavice X", externalCode: "KOD777" });
+
+    const html = `<div>${wetlandCard("Úplne iný text KOD777 model", "https://www.wetland.sk/p/kod")}${wetlandCard("Nohavice X", "https://www.wetland.sk/p/name")}</div>`;
+    const searchClient = new SearchClient({ fetcher: fakeWetlandFetcher(html) });
+
+    const result = await runPairingSearch({ db, now: NOW, searchClient });
+
+    expect(result.succeeded).toBe(1);
+    const [set] = await db.select().from(pairingCandidateSets).where(eq(pairingCandidateSets.productKey, "P1"));
+    expect(set?.confidence).toBe("high");
+    expect(set?.chosenUrl).toBe("https://www.wetland.sk/p/kod");
+    expect(set?.chosenReason).toBe("kód dodávateľa sa zhoduje");
+
+    const chosen = await db
+      .select()
+      .from(pairingCandidates)
+      .where(eq(pairingCandidates.productKey, "P1"));
+    expect(chosen.find((c) => c.url === "https://www.wetland.sk/p/kod")?.codeHit).toBe(true);
+  });
+
+  it("produkt s dodávateľom BEZ známeho adaptéra sa nikdy nevyberie", async () => {
+    const db = await boot();
+    await seedSupplier(db, "WETLAND", "wetland");
+    await seedProduct(db, "P1", { supplier: "CUDZÍ DODÁVATEĽ NEZNÁMY" });
+
+    const searchClient = new SearchClient({ fetcher: fakeWetlandFetcher("<div></div>") });
+    const result = await runPairingSearch({ db, now: NOW, searchClient });
+
+    expect(result).toMatchObject({ eligible: 0, processed: 0 });
+    const rows = await db.select().from(pairingCandidateSets);
+    expect(rows).toHaveLength(0);
+  });
+
+  it("produkt s už existujúcim efektívnym odkazom (internalNote) sa nikdy nevyberie", async () => {
+    const db = await boot();
+    await seedSupplier(db, "WETLAND", "wetland");
+    await seedProduct(db, "P1", { internalNote: "https://existing.example.com/produkt" });
+
+    const searchClient = new SearchClient({ fetcher: fakeWetlandFetcher("<div></div>") });
+    const result = await runPairingSearch({ db, now: NOW, searchClient });
+
+    expect(result).toMatchObject({ eligible: 0, processed: 0 });
+  });
+
+  it("inkrementálnosť: nezmenený produkt sa na DRUHOM behu nevyberie znova (input_hash sedí)", async () => {
+    const db = await boot();
+    await seedSupplier(db, "WETLAND", "wetland");
+    await seedProduct(db, "P1", { name: "Bunda Wetland" });
+
+    let calls = 0;
+    const html = `<div>${wetlandCard("Bunda Wetland", "https://www.wetland.sk/p/1")}</div>`;
+    const searchClient = new SearchClient({
+      fetcher: fakeWetlandFetcher(html, () => {
+        calls += 1;
+      }),
+    });
+
+    await runPairingSearch({ db, now: NOW, searchClient });
+    expect(calls).toBeGreaterThan(0);
+    const callsAfterFirstRun = calls;
+
+    const second = await runPairingSearch({ db, now: LATER, searchClient });
+
+    expect(second).toMatchObject({ eligible: 0, processed: 0 });
+    expect(calls).toBe(callsAfterFirstRun);
+
+    const [set] = await db.select().from(pairingCandidateSets).where(eq(pairingCandidateSets.productKey, "P1"));
+    expect(set?.gatheredAt.toISOString()).toBe(NOW.toISOString());
+  });
+
+  it("zmena mena produktu (iný input_hash) ho spraví znova eligible", async () => {
+    const db = await boot();
+    await seedSupplier(db, "WETLAND", "wetland");
+    await seedProduct(db, "P1", { name: "Bunda Wetland" });
+
+    const html = `<div>${wetlandCard("Bunda Wetland", "https://www.wetland.sk/p/1")}</div>`;
+    const searchClient = new SearchClient({ fetcher: fakeWetlandFetcher(html) });
+    await runPairingSearch({ db, now: NOW, searchClient });
+
+    await db.update(products).set({ name: "Bunda Wetland Nová" }).where(eq(products.key, "P1"));
+
+    const second = await runPairingSearch({ db, now: LATER, searchClient });
+
+    expect(second).toMatchObject({ eligible: 1, succeeded: 1 });
+    const [set] = await db.select().from(pairingCandidateSets).where(eq(pairingCandidateSets.productKey, "P1"));
+    expect(set?.gatheredAt.toISOString()).toBe(LATER.toISOString());
+  });
+
+  // Design komentár na tickete ("Zvolený prístup"): checkpoint = per-produkt
+  // transakcia, ŽIADNA cursor tabuľka — obnoviteľnosť príde ZADARMO z
+  // input_hash. Tento test to dokazuje: produkt, pri ktorom sieťové
+  // volanie vyhodí, sa NEZAPÍŠE (zostáva eligible pre ďalší beh), zatiaľ čo
+  // SÚRODENSKÝ produkt v TOM ISTOM behu sa committne a na ĎALŠOM behu sa
+  // už NEOPAKUJE.
+  it("obnoviteľnosť po páde uprostred: zlyhaný produkt sa zaloguje, pokračuje sa, ostatné sa committnú a na ďalšom behu sa neopakujú", async () => {
+    const db = await boot();
+    await seedSupplier(db, "WETLAND", "wetland");
+    await seedProduct(db, "OK", { name: "Bunda OK" });
+    await seedProduct(db, "FAIL", { name: "Bunda FAIL" });
+
+    let okCalls = 0;
+    const failingFetcher: Fetcher = (url) => {
+      if (url.includes("FAIL") || url.toLowerCase().includes("fail")) {
+        return Promise.reject(new Error("simulovaný sieťový pád"));
+      }
+      okCalls += 1;
+      return Promise.resolve(`<div>${wetlandCard("Bunda OK", "https://www.wetland.sk/p/ok")}</div>`);
+    };
+    const failingClient = new SearchClient({ fetcher: failingFetcher });
+
+    const first = await runPairingSearch({ db, now: NOW, searchClient: failingClient });
+
+    expect(first).toMatchObject({ eligible: 2, processed: 2, succeeded: 1, failed: 1 });
+    expect(first.errors).toHaveLength(1);
+    expect(first.errors[0]?.productKey).toBe("FAIL");
+    expect(first.errors[0]?.message).toContain("simulovaný sieťový pád");
+    expect(okCalls).toBeGreaterThan(0);
+
+    const okSet = await db.select().from(pairingCandidateSets).where(eq(pairingCandidateSets.productKey, "OK"));
+    expect(okSet).toHaveLength(1);
+    const failSet = await db.select().from(pairingCandidateSets).where(eq(pairingCandidateSets.productKey, "FAIL"));
+    expect(failSet).toHaveLength(0);
+
+    // Druhý beh (opravená appka/sieť) — fixnutý fetcher, ktorý loguje volania.
+    const secondCalls: string[] = [];
+    const fixedClient = new SearchClient({
+      fetcher: fakeWetlandFetcher(`<div>${wetlandCard("Bunda FAIL", "https://www.wetland.sk/p/fail")}</div>`, (url) => {
+        secondCalls.push(url);
+      }),
+    });
+
+    const second = await runPairingSearch({ db, now: LATER, searchClient: fixedClient });
+
+    // LEN "FAIL" je eligible — "OK" má nezmenený input_hash, ďalší beh ho
+    // vôbec nevyberie (žiadne ĎALŠIE sieťové volanie preň).
+    expect(second).toMatchObject({ eligible: 1, processed: 1, succeeded: 1, failed: 0 });
+    expect(secondCalls.length).toBeGreaterThan(0);
+    const failSetAfter = await db.select().from(pairingCandidateSets).where(eq(pairingCandidateSets.productKey, "FAIL"));
+    expect(failSetAfter[0]?.chosenUrl).toBe("https://www.wetland.sk/p/fail");
+  });
+
+  // Design komentár: časový (nie počtový) strop + "prioritne vypredané-
+  // viditeľné" (návrh sekcia 5 bod 3) — kombinovaný dôkaz oboch naraz.
+  it("časový strop zastaví beh PO prvom produkte a spracuje PRIORITNE vypredaný-viditeľný", async () => {
+    const db = await boot();
+    await seedSupplier(db, "WETLAND", "wetland");
+    // Bežný (nie vypredaný) produkt — abecedne PRVÝ, aby bez priority
+    // vyhrával on.
+    await seedProduct(db, "A-BEZNY", { name: "Bunda A", state: "sellable" });
+    // Vypredaný-viditeľný — má prednosť napriek abecedne neskoršiemu kľúču.
+    await seedProduct(db, "B-VYPREDANY", {
+      name: "Bunda B",
+      state: "out_of_stock",
+      productVisibility: "visible",
+      missingSince: null,
+    });
+
+    const html = `<div>${wetlandCard("Bunda", "https://www.wetland.sk/p/x")}</div>`;
+    const searchClient = new SearchClient({ fetcher: fakeWetlandFetcher(html) });
+
+    const clockValues = [0, 0, 1000];
+    let clockIndex = 0;
+    const clock = (): number => clockValues[clockIndex++] ?? 1000;
+
+    const result = await runPairingSearch({ db, now: NOW, searchClient, timeBudgetMs: 1, clock });
+
+    expect(result).toMatchObject({ eligible: 2, processed: 1, succeeded: 1, stoppedEarly: true });
+
+    const vypredanySet = await db.select().from(pairingCandidateSets).where(eq(pairingCandidateSets.productKey, "B-VYPREDANY"));
+    expect(vypredanySet).toHaveLength(1);
+    const beznySet = await db.select().from(pairingCandidateSets).where(eq(pairingCandidateSets.productKey, "A-BEZNY"));
+    expect(beznySet).toHaveLength(0);
+  });
+
+  // Rovnaká DETERMINISTICKÁ technika ako `posta-uncollected-run.integration
+  // .test.ts`'s "dva súbežné behy sa serializujú" — `pg_try_advisory_lock`
+  // (neblokujúci) z DRUHÉHO pripojenia MUSÍ zlyhať, kým je beh zaseknutý na
+  // falošnom, ešte nevyriešenom sieťovom volaní.
+  it("dva súbežné behy sa serializujú (advisory zámok 787_878_007), nikdy neprebehnú naraz", async () => {
+    const db = await boot();
+    await seedSupplier(db, "WETLAND", "wetland");
+    await seedProduct(db, "P1", { name: "Bunda Wetland" });
+
+    let releaseFetch: (() => void) | undefined;
+    const blockedUntilReleased = new Promise<void>((resolve) => {
+      releaseFetch = resolve;
+    });
+    const blockingFetcher: Fetcher = async () => {
+      await blockedUntilReleased;
+      return `<div>${wetlandCard("Bunda Wetland", "https://www.wetland.sk/p/1")}</div>`;
+    };
+    const blockingClient = new SearchClient({ fetcher: blockingFetcher });
+
+    const runPromise = runPairingSearch({ db, now: NOW, searchClient: blockingClient });
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const databaseUrl = process.env["DATABASE_URL"];
+    if (databaseUrl === undefined || databaseUrl === "") throw new Error("DATABASE_URL chýba");
+    checker = new pg.Client({ connectionString: databaseUrl });
+    await checker.connect();
+    const midRun = await checker.query<{ pg_try_advisory_lock: boolean }>("select pg_try_advisory_lock($1)", [
+      PAIRING_SEARCH_RUN_LOCK_KEY,
+    ]);
+    expect(midRun.rows[0]?.pg_try_advisory_lock).toBe(false);
+
+    releaseFetch?.();
+    await runPromise;
+
+    const afterRun = await checker.query<{ pg_try_advisory_lock: boolean }>("select pg_try_advisory_lock($1)", [
+      PAIRING_SEARCH_RUN_LOCK_KEY,
+    ]);
+    expect(afterRun.rows[0]?.pg_try_advisory_lock).toBe(true);
+    await checker.query("select pg_advisory_unlock($1)", [PAIRING_SEARCH_RUN_LOCK_KEY]);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.227",
+  "version": "0.3.0-dev.228",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -257,7 +257,12 @@ await db.execute(
   // behy nezanechali žiadny navyše riadok ani PRED touto zmenou). Pridané
   // ručne rovnako ako "order_line"/"pairing" vyššie — kvôli tej istej
   // sebadokumentujúcej dôslednosti, nie kvôli chýbajúcemu CASCADE.
-  'TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, nedostupne_replacement_link, mail_template, mail_template_history, supplier_stock, restock_settings, restock_event, shop_product_url, theme_color, dpd_pickup_request, upozornenie, daily_task, mail_log, dpd_shipment, product_supplier_override, product_supplier_link_override RESTART IDENTITY CASCADE',
+  // issue 387 E3: "pairing_candidate_set"/"pairing_candidate" majú reálny FK
+  // reťazec do "product" (cascade), takže by ich CASCADE strhol aj bez
+  // uvedenia — pridané ručne rovnako ako riadok vyššie. "pairing_search_
+  // settings" je rovnaká situácia ako "restock_settings" (žiadny FK,
+  // singleton id, žiadny migračný seed riadok — netreba reseed nižšie).
+  'TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, nedostupne_replacement_link, mail_template, mail_template_history, supplier_stock, restock_settings, restock_event, shop_product_url, theme_color, dpd_pickup_request, upozornenie, daily_task, mail_log, dpd_shipment, product_supplier_override, product_supplier_link_override, pairing_candidate, pairing_candidate_set, pairing_search_settings RESTART IDENTITY CASCADE',
 );
 // Rovnaký dôvod ako `tests/helpers/db.ts`: bez tohto by "Na objednanie" bolo
 // v CELOM e2e behu prázdne pre KAŽDÚ objednávku (žiadny nastavený otvorený


### PR DESCRIPTION
Etapa E3 z issue 387 (profesionálne párovanie produktov, port starej appky @ 60b6164).
Tretia z ôsmich etáp — databáza kandidátov + nočný zberný beh. Job je zámerne
VYPNUTÝ (predvolene), zapne sa až keď bude čo ukazovať (E5 obrazovka).

## Obsah

- Migrácia + `schema-pairing-review.ts`: `pairing_candidate_set` (na produkt: kedy sa
  hľadalo, dopyty, odtlačok vstupu, vybraný kandidát + istota high/medium/low/none),
  `pairing_candidate` (top-8 kandidátov, UNIQUE(product_key, url)),
  `pairing_search_settings` (Start/Stop, default vypnuté); seed dodávateľov
  WETLAND/BETALOV/ODIMON do dosiaľ prázdnej tabuľky `supplier`.
- `run.ts` — zberný beh: výber produktov bez efektívneho odkazu (prioritne vypredané
  viditeľné), únia variantov dopytov → SearchClient → ranking → top-8; zápis per
  produkt v JEDNEJ transakcii = checkpoint (beh je obnoviteľný po páde, bez kurzorovej
  tabuľky); inkrementálnosť podľa odtlačku vstupu; časový strop s pokračovaním ďalšiu noc.
- Denný scheduler job (03:35) + „Spustiť teraz" HTTP route, session advisory zámok.

Review (čerstvý kontext) chytilo pred mergom 2 reálne chyby: navrhnutý kľúč advisory
zámku kolidoval s existujúcim zámkom dodávateľského skladu (presunuté na vlastný kľúč
+ opravený register v playbooku) a automaticky generovaný názov cudzieho kľúča
presahoval 63-bajtový limit Postgresu (explicitný názov). Obe overené resetom lokálnej
DB od nuly a plným behom migrácií + testov.

## Testy

API unit 860/860, integračné 673 testov v 88 súboroch (2× — pred aj po review
opravách), typecheck aj lint čisté.

Issue 387 zostáva otvorené — zavrie sa po poslednej etape a živom overení.
