### PR TITLE
Párovanie produktov E4: overenie kandidáta kódom (issue 387)

### DIFF
--- a/.claude/rules/pairing-search.md
+++ b/.claude/rules/pairing-search.md
@@ -241,3 +241,74 @@ https://github.com/zbynekdrlik/forestshop-app/issues/387#issuecomment-5273377438
   cez `numeric` (peňažné polia), žiadny natívny float typ sa nikde
   nepoužíva. `rawScore` (number z `ranking.ts`) sa pri zápise konvertuje
   `.toFixed(4)`.
+
+## E4 — Verify + auto-výber (`verify.ts`)
+
+- **`verify.py`'s `code_verdict`/`extract_page` NEBOLI volané zo starej
+  appky's hlavného pipeline (`matcher.py`) vôbec** — grep celého `src/`
+  ukázal jediné volania z `webreview/app.py` (len title, live náhľad) a z
+  testov. Skutočným účelom bola pravdepodobne príprava pre externý AI-
+  verifikačný krok, ktorý sa NEportuje (design komentár, sekcia 5,
+  posledný odsek — "voliteľné neskôr"). Táto appka repurpose-uje presne
+  TÚ ISTÚ kaskádu ako AUTOMATICKÝ (ne-AI) OK/UNSURE gate priamo nad
+  `pick_best()`'s `chosen_url`. Test pri porte ĎALŠEJ funkcie zo starej
+  appky: over `grep`om, KTO ju reálne volá v `src/`, nikdy nepredpokladaj
+  účel len z jej mena/umiestnenia — dva rôzne, podobne znejúce
+  "verifikačné" mechanizmy (AI-krok vs. deterministický kód-gate) môžu
+  zdieľať tú istú portovanú funkciu s úplne iným volajúcim kontextom.
+- **ODIMON (BUXUS) NEMÁ vlastný kódový selektor v starej appke — žiadna
+  fixtúra, generický fallback (`[itemprop=sku]`/`.product-code`/`.sku`/
+  `.kod`/`[data-code]`) na živej stránke NIČ netrafí.** Živo overené
+  13. 8. 2026: skutočný markup je `<li class="product-property-item">
+  <span class="product-property__title">Kód produktu:</span><span
+  class="product-property__value">PO22811</span></li>` — úplne iná
+  trieda selektorov než WETLAND (`.detail__title`/`.detail__right`) aj
+  BETALOV (`.fs-5` regex). `verify.ts` preto pridáva ŠTVRTÝ kaskádový
+  krok (`.product-property-item` → `.product-property__title` obsahujúce
+  "kód" → `.product-property__value`), zaradený PRED generický fallback —
+  toto je NOVÝ krok mimo doslovného portu, nie chyba pri kopírovaní.
+  Zdôvodnené v design komentári na tickete ako technické rozhodnutie
+  (žiadny používateľský dôsledok sa nemení — stále len OK/UNSURE, nikdy
+  false-ok), nie majiteľova otázka. Test pri PORTE ĎALŠIEHO Python
+  kódu, ktorého docstring/komentár tvrdí "generický fallback pokrýva
+  zvyšok" bez fixtúry pre KAŽDÉHO dodávateľa: over živo proti REÁLNEJ
+  stránke KAŽDÉHO dodávateľa, ktorého sa to týka — "generický" nemusí
+  znamenať univerzálny, len že autor nenašiel čas/dôvod na vlastný krok.
+- **Cheerio's `??` reťazec na `.attr()`/`.text()` fallbacku sa RÔZNI od
+  Pythonovho `or` — `or` padá na ĎALŠÍ zdroj aj pri PRÁZDNOM (nie len
+  chýbajúcom/None) reťazci, `??` len pri `null`/`undefined`.** Review
+  nález (issue 387 E4): `el.get("content") or el.get("data-code") or
+  el.get_text(...)` (Python) vs. pôvodné `el.attr("content") ??
+  el.attr("data-code") ?? el.text()` (TS) — `content=""` by v TS verzii
+  celú cestu zastavilo namiesto skúsenia `data-code`/textu na TOM ISTOM
+  elemente. Fix: `||` namiesto `??` pre TENTO KONKRÉTNY vzor ("skús
+  viacero zdrojov, prvý NEPRÁZDNY vyhráva") — `pnpm lint` ostal čistý
+  (`@typescript-eslint/prefer-nullish-coalescing` je type-aware a na
+  potenciálne prázdnom `string` type `||` nehlási). Test pri KAŽDOM
+  ĎALŠOM porte Pythonovho `a or b or c` vzoru na string hodnoty (nie
+  booleans/objekty): `||` je SPRÁVNY preklad, `??` je TICHÁ zmena
+  správania pri prázdnom (nie chýbajúcom) reťazci.
+- **Funkcia, ktorej DOKSTRING sľubuje "sieťová AJ parse chyba sa nikdy
+  nevyhodí ďalej", musí mať OBE kroky v JEDNOM `try`/`catch` — try len
+  okolo fetchu, dokstring sľubujúci aj parse-bezpečnosť, je TICHO
+  nepravdivý.** Review nález: pôvodná `verifyCandidateCode` mala
+  `try { html = await fetch(...) } catch {...}` a `codeVerdict(extractPage(
+  html))` AŽ ZA týmto blokom (mimo try) — parse-krokový throw (cheerio/
+  regex) by prešiel cez `verifyPickIfWarranted` až do `run.ts`'s
+  per-produkt `try`, čo by zahodilo CELÝ gathered candidate set daného
+  produktu (nielen krok overenia) až do ďalšieho nočného behu. Fix: jeden
+  spoločný `try` okolo fetch AJ `extractPage`/`codeVerdict`. Test pri
+  KAŽDEJ ĎALŠEJ funkcii s podobným "nikdy nezhodí volajúceho" sľubom vo
+  vlastnom dokstringu: over, že KAŽDÝ krok, ktorý dokstring menuje, je
+  SKUTOČNE vnútri chráneného bloku — nie len ten najzrejmejší (sieť).
+- **`SearchClient.fetchPage(url)` (NOVÁ verejná metóda) zdieľa `this.
+  fetcher` (per-host cookie jar + retry + warm-up) aj throttle-if-real
+  logiku so `.search()`, ZÁMERNE nie samostatný fetcher z `supplier-
+  stock/page-fetcher.ts`.** Dôvod: kandidátova detailná URL je na TOM
+  ISTOM hoste ako search výsledky, a Nette (BETALOV)/BUXUS (ODIMON)
+  vyžadujú platnú session cookie pre OBOJE — zdieľaný fetcher profituje
+  zo session už zohriatej `.search()` volaniami v tom istom gather
+  cykle, samostatný `supplier-stock`-štýl fetcher (bez cookie jaru) by
+  musel host znova warm-upovať a strácal by session medzi search a
+  detail fetchmi. Bez cache (na rozdiel od `.search()`) — detailná URL
+  je vždy jedinečná, cache by nikdy nehitla.

--- a/apps/api/src/modules/pairing-search/client.ts
+++ b/apps/api/src/modules/pairing-search/client.ts
@@ -265,4 +265,19 @@ export class SearchClient {
     this.cache.set(cacheKey, candidates);
     return candidates;
   }
+
+  /**
+   * Stiahne DETAILNÚ stránku kandidáta (issue 387 E4's `verify.ts`) — ROVNAKÝ
+   * throttle-if-real ako `.search()`, ale BEZ cache (detailná URL je vždy
+   * jedinečná, na rozdiel od (adapterKey, query) párov). Zdieľa TEN ISTÝ
+   * `this.fetcher` (session cookie jar + retry + warm-up z `.search()`
+   * volaní v tom istom gather cykle), takže detail-page fetch profituje z
+   * už zohriatej relácie na daný host namiesto opätovného warm-upu.
+   */
+  async fetchPage(url: string): Promise<string> {
+    if (this.isReal && this.throttleMs > 0) {
+      await this.sleep(this.throttleMs);
+    }
+    return this.fetcher(url);
+  }
 }

--- a/apps/api/src/modules/pairing-search/fixtures/betalov-detail-nohavice.html
+++ b/apps/api/src/modules/pairing-search/fixtures/betalov-detail-nohavice.html
@@ -1,0 +1,17 @@
+<!--
+  Orezaná vzorka https://www.huntingshop.eu/detske-outdoorove-nohavice-
+  combi-14695 (issue 387 E4, živý fetch 13. 8. 2026, po session warm-up).
+  `.fs-5` obsahuje "Katalógové číslo: <kód>" — DOSLOVNE z reálnej stránky.
+-->
+<html lang="sk">
+<head><title>Detské outdoorové nohavice - Combi | huntingshop.eu</title></head>
+<body>
+  <h1 class="modal-product-title mb-4 me-lg-3 me-0">Detské outdoorové nohavice - Combi</h1>
+  <div class="my-4 d-flex flex-lg-row flex-column justify-content-between align-items-lg-center align-items-start">
+    <h2 id="titleDescription" class="title "></h2>
+    <span class="fs-5">
+      Katalógové číslo: OB3022
+    </span>
+  </div>
+</body>
+</html>

--- a/apps/api/src/modules/pairing-search/fixtures/odimon-detail-nohavice.html
+++ b/apps/api/src/modules/pairing-search/fixtures/odimon-detail-nohavice.html
@@ -1,0 +1,29 @@
+<!--
+  Orezaná vzorka https://www.odimon.sk/obuv-a-oblecenie/polovnicke-
+  oblecenie/polovnicke-termopradlo/termopradlo-nohavice-modal-termovel
+  (issue 387 E4, živý fetch 13. 8. 2026, po session warm-up). Stará appka
+  NEMALA vlastný selektor pre ODIMON (žiadna fixtúra ani docstring
+  v `60b6164`'s `verify.py`) — generický fallback ([itemprop=sku]/
+  .product-code/.sku/.kod/[data-code]) na tejto stránke NIČ netrafí.
+  `.product-property-item` (Kategória PRED Kód produktu, presne ako na
+  reálnej stránke — over, že kaskáda preskočí "Kategória" a nájde AŽ
+  položku s "kód" v popisku) so `.product-property__value` je NOVÁ,
+  živo overená trieda selektorov pridaná v E4 (design komentár na
+  tickete, "Rozhodnutie k ODIMON").
+-->
+<html lang="sk">
+<head><title>Termoprádlo nohavice modal Termovel | odimon.sk</title></head>
+<body>
+  <h1 class="product-title" itemprop="name">Termoprádlo nohavice modal Termovel</h1>
+  <ul class="product-properties">
+    <li class="product-property-item">
+      <span class="product-property__title">Kategória:</span>
+      <span class="product-property__value">Poľovnícke termoprádlo</span>
+    </li>
+    <li class="product-property-item">
+      <span class="product-property__title">Kód produktu:</span>
+      <span class="product-property__value">PO22811</span>
+    </li>
+  </ul>
+</body>
+</html>

--- a/apps/api/src/modules/pairing-search/fixtures/wetland-detail-nohavice.html
+++ b/apps/api/src/modules/pairing-search/fixtures/wetland-detail-nohavice.html
@@ -1,0 +1,24 @@
+<!--
+  Orezaná vzorka https://www.wetland.sk/nohavice/deerhunter-pro-gamekeeper-
+  boot-trousers-polovnicke-nohavice-111-592 (issue 387 E4, živý fetch
+  13. 8. 2026, po session warm-up). `.detail__title` "Značka" PRED "Kód" je
+  DOSLOVNE z reálnej stránky — over, že kaskáda preskočí ju (nemá "kód" v
+  texte) a nezastaví sa na prvom `.detail__title` vôbec, len na tom, čo
+  text obsahuje "kód".
+-->
+<html lang="sk">
+<head><title>DEERHUNTER Pro Gamekeeper Boot Trousers | wetland.sk</title></head>
+<body>
+  <h1 class="h2 product__name">DEERHUNTER Pro Gamekeeper Boot Trousers - poľovnícke nohavice</h1>
+  <ul class="product__details">
+    <li class="detail">
+      <div class="detail__left"><span class="detail__title">Značka</span></div>
+      <div class="detail__right"><a href="https://www.wetland.sk/brand/deerhunter-4436">DEERHUNTER</a></div>
+    </li>
+    <li class="detail">
+      <div class="detail__left"><span class="detail__title">Kód</span></div>
+      <div class="detail__right"><span>3726-391-48@</span></div>
+    </li>
+  </ul>
+</body>
+</html>

--- a/apps/api/src/modules/pairing-search/run.ts
+++ b/apps/api/src/modules/pairing-search/run.ts
@@ -1,9 +1,16 @@
-// Beh gather automatizácie (issue 387 E3) — pre KAŽDÝ eligible produkt
+// Beh gather automatizácie (issue 387 E3+E4) — pre KAŽDÝ eligible produkt
 // (`select.ts`) skúsi VŠETKY `buildQueryVariants` (union, port starej
 // appky's `matcher.py`'s `gather_candidates(product, client, k=8)` — NIE
 // `match_one`/`query_ladder`, viď design komentár na tickete), poolu je
 // kandidátov podľa URL naprieč všetkými dopytmi, rankuje CELÝ pool a
 // zapíše top-8 + `pickBest()`'s voľbu.
+//
+// **E4:** po `pickBest()`, keď je vybraný kandidát s `confidence`
+// `high`/`medium`, overí sa jeho kód na detailnej stránke
+// (`verify.ts`'s `verifyCandidateCode`) a výsledok (`verdict`/
+// `verdictCheckedAt`) sa zapíše do TOHO ISTÉHO checkpointu. `low`/`none`
+// (alebo žiadny kandidát) sa NIKDY neoveruje — šetrí requesty (dispatch
+// E4, bod 2) a nízkoistotný kandidát má beztak malú šancu na zhodu.
 //
 // Checkpoint = per-produkt TRANSAKČNÝ upsert (`upsertCandidateSet`) —
 // žiadna samostatná cursor tabuľka. Pád uprostred behu necháva už
@@ -12,7 +19,9 @@
 // zapísaný nový `input_hash` → zostáva eligible pre ďalší beh. Per-produkt
 // VÝNIMKA (sieť/parsing) sa zaloguje a zapíše do `errors`, cyklus
 // pokračuje ĎALŠÍM produktom — ten istý princíp ako `posta-uncollected/
-// run.ts`.
+// run.ts`. Overenie SAMO nikdy nevyhodí (`verifyCandidateCode` zachytáva
+// vlastné sieťové chyby a vracia `unsure`), takže nemôže spôsobiť túto
+// per-produkt výnimku.
 
 import { eq } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
@@ -23,7 +32,8 @@ import { SearchClient } from "./client.js";
 import { buildQueryVariants } from "./queries.js";
 import { pickBest, rank, type PairingPick } from "./ranking.js";
 import { selectEligibleProducts, type EligibleProduct } from "./select.js";
-import type { PairingCandidate, PairingConfidence } from "./types.js";
+import type { PairingCandidate, PairingConfidence, PairingProduct, PairingVerdict } from "./types.js";
+import { verifyCandidateCode } from "./verify.js";
 
 export interface PairingSearchRunError {
   readonly productKey: string;
@@ -96,6 +106,7 @@ async function runPairingSearchLocked(options: RunPairingSearchOptions): Promise
     try {
       const { queries, candidates } = await gatherCandidates(searchClient, item);
       const pick = pickBest(item.product, candidates);
+      const { verdict, verdictCheckedAt } = await verifyPickIfWarranted(searchClient, item.product, pick, now);
       await upsertCandidateSet(db, {
         productKey: item.product.productKey,
         gatheredAt: now,
@@ -104,6 +115,8 @@ async function runPairingSearchLocked(options: RunPairingSearchOptions): Promise
         chosenUrl: pick.candidate?.url ?? null,
         chosenReason: buildChosenReason(pick),
         confidence: pick.confidence,
+        verdict,
+        verdictCheckedAt,
         candidates,
       });
       succeeded += 1;
@@ -148,6 +161,30 @@ async function gatherCandidates(
   return { queries: queryVariants, candidates: ranked.slice(0, CANDIDATE_LIMIT) };
 }
 
+interface VerifyOutcomeFields {
+  readonly verdict: PairingVerdict | null;
+  readonly verdictCheckedAt: Date | null;
+}
+
+/**
+ * E4: overí kódovú zhodu vybraného kandidáta, ale LEN keď `confidence` je
+ * `high`/`medium` (dispatch: "Verify len pre chosen_url s confidence
+ * high/medium — šetri requesty"). `low`/`none`/žiadny kandidát → `verdict`/
+ * `verdictCheckedAt` ostávajú `null`, presne ako E3 pred touto zmenou.
+ */
+async function verifyPickIfWarranted(
+  client: SearchClient,
+  product: PairingProduct,
+  pick: PairingPick,
+  now: Date,
+): Promise<VerifyOutcomeFields> {
+  if (pick.candidate === null || (pick.confidence !== "high" && pick.confidence !== "medium")) {
+    return { verdict: null, verdictCheckedAt: null };
+  }
+  const outcome = await verifyCandidateCode(client, pick.candidate.url, product);
+  return { verdict: outcome.verdict, verdictCheckedAt: now };
+}
+
 /** Krátky ľudsky čitateľný dôvod voľby — nová appka's pole, stará appka ho
  * nemala (mala len číselnú `confidence`). Diagnostický text pre budúcu
  * obrazovku (E5/E6), žiadny funkčný dopad v E3. */
@@ -165,13 +202,16 @@ interface UpsertCandidateSetInput {
   readonly chosenUrl: string | null;
   readonly chosenReason: string | null;
   readonly confidence: PairingConfidence;
+  readonly verdict: PairingVerdict | null;
+  readonly verdictCheckedAt: Date | null;
   readonly candidates: readonly PairingCandidate[];
 }
 
 /** Checkpoint — JEDNA transakcia na produkt: upsert `candidate_set` +
  * úplná náhrada jeho `pairing_candidate` riadkov (delete+insert, nikdy
  * inkrementálny diff — top-8 je vždy "posledný pohľad", nie história).
- * `verdict`/`verdict_checked_at` ostávajú `null` (E4). */
+ * `verdict`/`verdict_checked_at` ostávajú `null`, keď `verifyPickIfWarranted`
+ * overenie preskočilo (`confidence` nízka alebo bez kandidáta, issue 387 E4). */
 async function upsertCandidateSet(db: Database, input: UpsertCandidateSetInput): Promise<void> {
   await db.transaction(async (tx) => {
     const setValues = {
@@ -181,8 +221,8 @@ async function upsertCandidateSet(db: Database, input: UpsertCandidateSetInput):
       chosenUrl: input.chosenUrl,
       chosenReason: input.chosenReason,
       confidence: input.confidence,
-      verdict: null,
-      verdictCheckedAt: null,
+      verdict: input.verdict,
+      verdictCheckedAt: input.verdictCheckedAt,
     };
     await tx
       .insert(pairingCandidateSets)

--- a/apps/api/src/modules/pairing-search/types.ts
+++ b/apps/api/src/modules/pairing-search/types.ts
@@ -48,6 +48,15 @@ export interface PairingCandidate {
 export type PairingConfidence = "high" | "medium" | "low" | "none";
 
 /**
+ * Výsledok kódového overenia (issue 387 E4, port `verify.py`'s
+ * `code_verdict`) — `ok` = kód produktu bol nájdený na stránke kandidáta,
+ * `unsure` = nenašiel sa (alebo produkt nemá žiadny kód na overenie, alebo
+ * sa stránku nepodarilo stiahnuť). Overenie NIKDY nevráti "false-ok" —
+ * chýbajúci dôkaz vždy znamená `unsure`, nikdy `ok`.
+ */
+export type PairingVerdict = "ok" | "unsure";
+
+/**
  * Adaptér: (produkt, jeho varianty) → `PairingProduct`. Deduplikuje
  * `externalCode`, zahadzuje prázdne/`null` hodnoty, zachováva poradie
  * prvého výskytu (rovnaká disciplína ako `queries.ts`'s dedup).

--- a/apps/api/src/modules/pairing-search/verify.test.ts
+++ b/apps/api/src/modules/pairing-search/verify.test.ts
@@ -1,0 +1,139 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { SearchClient, type Fetcher } from "./client.js";
+import type { PairingProduct } from "./types.js";
+import { codeVerdict, extractPage, verifyCandidateCode } from "./verify.js";
+
+function fixture(name: string): string {
+  return readFileSync(fileURLToPath(new URL(`fixtures/${name}`, import.meta.url)), "utf8");
+}
+
+const WETLAND_DETAIL = fixture("wetland-detail-nohavice.html");
+const BETALOV_DETAIL = fixture("betalov-detail-nohavice.html");
+const ODIMON_DETAIL = fixture("odimon-detail-nohavice.html");
+
+function product(externalCodes: readonly string[], name = "Testovací produkt"): PairingProduct {
+  return { productKey: "P1", name, supplier: "WETLAND", externalCodes };
+}
+
+describe("extractPage — kódová kaskáda (issue 387 E4, port verify.py's extract_page)", () => {
+  it("WETLAND (PrestaShop): preskočí .detail__title 'Značka' a nájde .detail__title 'Kód' -> .detail__right", () => {
+    const page = extractPage(WETLAND_DETAIL);
+    expect(page.code).toBe("3726-391-48@");
+    expect(page.title).toBe("DEERHUNTER Pro Gamekeeper Boot Trousers - poľovnícke nohavice");
+  });
+
+  it("BETALOV (Nette): .fs-5 regex 'Katalógové číslo: X'", () => {
+    const page = extractPage(BETALOV_DETAIL);
+    expect(page.code).toBe("OB3022");
+    expect(page.title).toBe("Detské outdoorové nohavice - Combi");
+  });
+
+  it("ODIMON (BUXUS, odchýlka od doslovného portu): preskočí 'Kategória' a nájde .product-property-item s 'kód' v popisku", () => {
+    const page = extractPage(ODIMON_DETAIL);
+    expect(page.code).toBe("PO22811");
+    expect(page.title).toBe("Termoprádlo nohavice modal Termovel");
+  });
+
+  it("generický fallback (bez <h1>): itemprop=sku + title-tag so stripnutým '| Site' chvostom", () => {
+    const html =
+      '<html><head><title>Produkt XY | Forestshop</title></head><body>' +
+      '<span itemprop="sku">ABC123</span></body></html>';
+    const page = extractPage(html);
+    expect(page.title).toBe("Produkt XY");
+    expect(page.code).toBe("ABC123");
+  });
+
+  it("title-tag so ' - ' oddeľovačom (bez '|') sa tiež strihá na prvú časť", () => {
+    const html = "<html><head><title>Produkt XY - Forestshop</title></head><body></body></html>";
+    expect(extractPage(html).title).toBe("Produkt XY");
+  });
+
+  it("žiadny <h1> ani <title> -> prázdny title", () => {
+    expect(extractPage("<html><head></head><body><p>nič</p></body></html>").title).toBe("");
+  });
+
+  it("kód sa nikde na stránke nenašiel -> code je null", () => {
+    const html = "<html><body><h1>Nejaký produkt</h1><p>bez akéhokoľvek kódu</p></body></html>";
+    expect(extractPage(html).code).toBeNull();
+  });
+
+  it(".detail__title bez slova 'kód' v texte (napr. len 'Značka') sa nikdy nepoužije ako zdroj kódu", () => {
+    const html =
+      '<html><body><h1>X</h1><ul><li class="detail">' +
+      '<div class="detail__left"><span class="detail__title">Značka</span></div>' +
+      '<div class="detail__right">DEERHUNTER</div></li></ul></body></html>';
+    expect(extractPage(html).code).toBeNull();
+  });
+});
+
+describe("codeVerdict — port verify.py's code_verdict (viac-kódová adaptácia)", () => {
+  it("produkt bez external kódu je VŽDY unsure — nikdy false-ok", () => {
+    const result = codeVerdict(product([]), { title: "čokoľvek", code: null });
+    expect(result.verdict).toBe("unsure");
+  });
+
+  it("kód sa nachádza priamo v extrahovanom .code poli -> ok", () => {
+    const result = codeVerdict(product(["OB570"]), { title: "HART RANDO XHP OB570", code: "OB570" });
+    expect(result.verdict).toBe("ok");
+    expect(result.reason).toContain("OB570");
+  });
+
+  it("kód sa nenašiel na stránke -> unsure", () => {
+    const result = codeVerdict(product(["OB570"]), { title: "Iný produkt", code: "ZZ9" });
+    expect(result.verdict).toBe("unsure");
+  });
+
+  it("regresia: kód '376' sa nezhoduje ako podreťazec '3760' (code_present hranica)", () => {
+    const result = codeVerdict(product(["376"]), { title: "Lampáš model 3760", code: null });
+    expect(result.verdict).toBe("unsure");
+  });
+
+  it("kód '376' sedí, keď je ohraničený (nie súčasť dlhšieho behu)", () => {
+    const result = codeVerdict(product(["376"]), { title: "Lampáš model 376 LED", code: "376" });
+    expect(result.verdict).toBe("ok");
+  });
+
+  it("viac external kódov (adaptácia na per-variant kódy): zhoda platí, keď sedí HOCIKTORÝ z nich", () => {
+    const result = codeVerdict(product(["NESEDI1", "SEDI2", "NESEDI3"]), { title: "Produkt SEDI2 model", code: null });
+    expect(result.verdict).toBe("ok");
+    expect(result.reason).toContain("SEDI2");
+  });
+
+  it("žiadny z viacerých kódov nesedí -> unsure, dôvod cituje všetky", () => {
+    const result = codeVerdict(product(["A1", "B2"]), { title: "Nič také tu nie je", code: null });
+    expect(result.verdict).toBe("unsure");
+    expect(result.reason).toContain("A1");
+    expect(result.reason).toContain("B2");
+  });
+});
+
+describe("verifyCandidateCode — sieťový wrapper (SearchClient.fetchPage)", () => {
+  it("produkt bez external kódu sa NIKDY nefetchuje (šetrí requesty) a vráti unsure", async () => {
+    let called = false;
+    const fetcher: Fetcher = () => {
+      called = true;
+      return Promise.resolve(WETLAND_DETAIL);
+    };
+    const client = new SearchClient({ fetcher });
+    const result = await verifyCandidateCode(client, "https://www.wetland.sk/x", product([]));
+    expect(result.verdict).toBe("unsure");
+    expect(called).toBe(false);
+  });
+
+  it("úspešný fetch + zhodný kód -> ok", async () => {
+    const fetcher: Fetcher = () => Promise.resolve(WETLAND_DETAIL);
+    const client = new SearchClient({ fetcher });
+    const result = await verifyCandidateCode(client, "https://www.wetland.sk/x", product(["3726-391-48@"]));
+    expect(result.verdict).toBe("ok");
+  });
+
+  it("zlyhaný fetch (sieťová chyba) sa NIKDY nevyhodí ďalej -> unsure s dôvodom", async () => {
+    const fetcher: Fetcher = () => Promise.reject(new Error("simulovaný sieťový pád"));
+    const client = new SearchClient({ fetcher });
+    const result = await verifyCandidateCode(client, "https://www.wetland.sk/x", product(["KOD1"]));
+    expect(result.verdict).toBe("unsure");
+    expect(result.reason).toContain("simulovaný sieťový pád");
+  });
+});

--- a/apps/api/src/modules/pairing-search/verify.ts
+++ b/apps/api/src/modules/pairing-search/verify.ts
@@ -116,12 +116,16 @@ function extractOdimonCode($: cheerio.CheerioAPI): string | null {
 
 const GENERIC_CODE_SELECTORS = ['[itemprop="sku"]', ".product-code", ".sku", ".kod", "[data-code]"] as const;
 
-/** 3. Generický fallback: `content`/`data-code` atribút, inak text. */
+/** 3. Generický fallback: `content`/`data-code` atribút, inak text. Port
+ *  Python's `el.get("content") or el.get("data-code") or el.get_text(...)`
+ *  — `or` padá na ĎALŠÍ zdroj aj pri PRÁZDNOM (nie len chýbajúcom) reťazci,
+ *  preto `||` (nie `??`, review nález issue 387 E4: `??` by pri prázdnom
+ *  `content=""` zastavilo na ňom namiesto skúsenia `data-code`/textu). */
 function extractGenericCode($: cheerio.CheerioAPI): string | null {
   for (const selector of GENERIC_CODE_SELECTORS) {
     const el = $(selector).first();
     if (el.length === 0) continue;
-    const value = (el.attr("content") ?? el.attr("data-code") ?? el.text()).trim();
+    const value = (el.attr("content") || el.attr("data-code") || el.text()).trim();
     if (value.length > 0) return value;
   }
   return null;
@@ -176,13 +180,17 @@ export async function verifyCandidateCode(
   if (product.externalCodes.length === 0) {
     return { verdict: "unsure", reason: "produkt nemá žiadny external kód na overenie" };
   }
-  let html: string;
+  // Sieťová ANI parse chyba sa nikdy nevyhodí ďalej — obe (fetch aj
+  // extractPage/codeVerdict) sú v JEDNOM try, aby zlyhanie overenia nikdy
+  // nezhodilo celý per-produkt gather cyklus (`run.ts`), presne ako
+  // dokstring sľubuje (review nález issue 387 E4: pôvodná verzia chránila
+  // len fetch, nie parsovanie).
   try {
-    html = await client.fetchPage(url);
+    const html = await client.fetchPage(url);
+    return codeVerdict(product, extractPage(html));
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    log.warn({ url, message }, "pairing-search: verify fetch zlyhal, verdikt unsure");
-    return { verdict: "unsure", reason: `stránku kandidáta sa nepodarilo stiahnuť (${message})` };
+    log.warn({ url, message }, "pairing-search: verify zlyhal, verdikt unsure");
+    return { verdict: "unsure", reason: `overenie kandidáta zlyhalo (${message})` };
   }
-  return codeVerdict(product, extractPage(html));
 }

--- a/apps/api/src/modules/pairing-search/verify.ts
+++ b/apps/api/src/modules/pairing-search/verify.ts
@@ -1,0 +1,188 @@
+// Kódové overenie vybraného kandidáta (issue 387 E4) — doslovný port
+// `src/parovanie/verify.py`'s title+code časti `extract_page` +
+// `code_verdict` zo starej appky (commit 60b6164). Design komentár na
+// tickete (sekcia "Čo sa adaptuje"): price sa NEPORTUJE (meta kandidáta sa
+// znovupoužije zo `supplier-stock` v E5) — "verify.ts pridáva len kódovú
+// kaskádu". Stará appka volala tieto funkcie z externého AI-verifikačného
+// kroku, ktorý sa tu neportuje (design, sekcia 5, posledný odsek) — táto
+// appka repurpose-uje presnú kaskádu ako AUTOMATICKÝ OK/UNSURE gate nad
+// `pick_best()`'s `chosen_url` (`run.ts`).
+//
+// **Kaskáda na kód** (pôvodná, `verify.py`):
+// 1. PrestaShop (wetland): `.detail__title` element, ktorého text obsahuje
+//    "kód" → najbližší predok `<li>` (alebo `div[class*=detail]` fallback)
+//    → jeho `.detail__right` text.
+// 2. Nette (betalov/huntingshop.eu): `.fs-5` element, regex
+//    `(?:katalógové číslo|kód|sku)\s*[:\-]?\s*(.+)`.
+// 3. Generický fallback: `[itemprop="sku"]`/`.product-code`/`.sku`/`.kod`/
+//    `[data-code]` — `content`/`data-code` atribút alebo text.
+//
+// **Odchýlka od doslovného portu (živo overené 13. 8. 2026, design komentár
+// "Rozhodnutie k ODIMON"):** stará appka nemala vlastný ODIMON selektor
+// (žiadna fixtúra, generický fallback na živej stránke nič netrafí).
+// Krok 2b nižšie (`.product-property-item`) je NOVÝ, pridaný medzi Nette a
+// generický fallback — bez neho by ODIMON kandidáti VŽDY skončili na
+// `unsure` (bezpečné, ale zbytočne slabé pokrytie tretiny dodávateľov).
+
+import * as cheerio from "cheerio";
+import { codePresent } from "./normalize.js";
+import type { SearchClient } from "./client.js";
+import type { PairingProduct, PairingVerdict } from "./types.js";
+import { log } from "../../logger.js";
+
+/** Výstup kódovej kaskády — port `extract_page`'s title+code polí (price sa
+ *  neportuje, viď komentár vyššie). */
+export interface PageExtract {
+  readonly title: string;
+  readonly code: string | null;
+}
+
+export interface VerifyOutcome {
+  readonly verdict: PairingVerdict;
+  readonly reason: string;
+}
+
+const WHITESPACE_RUN = /\s+/g;
+
+function collapseWhitespace(value: string): string {
+  return value.replace(WHITESPACE_RUN, " ").trim();
+}
+
+/** Port `extract_page`'s title vetva: `<h1>` text, inak `<title>` so
+ *  stripnutým "| Site"/" - Site" chvostom, inak prázdny reťazec. */
+function extractTitle($: cheerio.CheerioAPI): string {
+  const h1 = $("h1").first();
+  if (h1.length > 0) return h1.text();
+
+  const titleTag = $("title").first();
+  if (titleTag.length === 0) return "";
+  const raw = titleTag.text().trim();
+  if (!raw.includes("|") && !raw.includes(" - ")) return raw;
+  // Python: `raw.split("|")[0].split(" - ")[0].strip()` — OBE rozdelenia sa
+  // aplikujú sekvenčne, keď je prítomný ASPOŇ jeden z oddeľovačov.
+  const afterPipe = raw.split("|")[0] ?? raw;
+  return afterPipe.split(" - ")[0] ?? afterPipe;
+}
+
+/** 1. PrestaShop (wetland): `.detail__title` obsahujúce "kód" → najbližší
+ *  `<li>` predok (alebo `div[class*=detail]` fallback) → `.detail__right`. */
+function extractPrestaShopCode($: cheerio.CheerioAPI): string | null {
+  let code: string | null = null;
+  $(".detail__title").each((_index, element) => {
+    const label = $(element);
+    if (!label.text().trim().toLowerCase().includes("kód")) return undefined;
+    const li = label.closest("li");
+    const row = li.length > 0 ? li : label.closest('div[class*="detail"]');
+    if (row.length > 0) {
+      const right = row.find(".detail__right").first();
+      if (right.length > 0) {
+        const text = right.text().trim();
+        code = text.length > 0 ? text : null;
+      }
+    }
+    return false; // port Python's `break` — zastaví sa na PRVOM zhodnom labeli
+  });
+  return code;
+}
+
+const NETTE_CODE_RE = /(?:katalógové číslo|kód|sku)\s*[:-]?\s*(.+)/i;
+
+/** 2. Nette (betalov/huntingshop.eu): `.fs-5` regex "Katalógové číslo: X". */
+function extractNetteCode($: cheerio.CheerioAPI): string | null {
+  for (const element of $(".fs-5").toArray()) {
+    const text = $(element).text().trim();
+    const match = NETTE_CODE_RE.exec(text);
+    if (match) {
+      const captured = (match[1] ?? "").trim();
+      return captured.length > 0 ? captured : null;
+    }
+  }
+  return null;
+}
+
+/** 2b. ODIMON (BUXUS) — NOVÝ krok, mimo doslovného portu (viď komentár na
+ *  vrchu súboru): `.product-property-item` so `.product-property__title`
+ *  obsahujúcim "kód" → `.product-property__value`. */
+function extractOdimonCode($: cheerio.CheerioAPI): string | null {
+  for (const element of $(".product-property-item").toArray()) {
+    const item = $(element);
+    const label = item.find(".product-property__title").first().text().trim().toLowerCase();
+    if (!label.includes("kód")) continue;
+    const value = item.find(".product-property__value").first().text().trim();
+    return value.length > 0 ? value : null;
+  }
+  return null;
+}
+
+const GENERIC_CODE_SELECTORS = ['[itemprop="sku"]', ".product-code", ".sku", ".kod", "[data-code]"] as const;
+
+/** 3. Generický fallback: `content`/`data-code` atribút, inak text. */
+function extractGenericCode($: cheerio.CheerioAPI): string | null {
+  for (const selector of GENERIC_CODE_SELECTORS) {
+    const el = $(selector).first();
+    if (el.length === 0) continue;
+    const value = (el.attr("content") ?? el.attr("data-code") ?? el.text()).trim();
+    if (value.length > 0) return value;
+  }
+  return null;
+}
+
+function extractCode($: cheerio.CheerioAPI): string | null {
+  return (
+    extractPrestaShopCode($) ?? extractNetteCode($) ?? extractOdimonCode($) ?? extractGenericCode($) ?? null
+  );
+}
+
+/** Port `extract_page` (title+code časť — price sa neportuje). */
+export function extractPage(html: string): PageExtract {
+  const $ = cheerio.load(html);
+  return { title: collapseWhitespace(extractTitle($)), code: extractCode($) };
+}
+
+/**
+ * Port `code_verdict` — adaptované na VIAC external kódov (jeden per
+ * variant, rovnaký vzor ako `ranking.ts`'s `isCodeHit`): zhoda platí, keď
+ * SA HOCIKTORÝ z `product.externalCodes` nájde v title+code haystacku.
+ * Produkt bez žiadneho external kódu je VŽDY `unsure` — nikdy `ok` bez
+ * dôkazu (dispatch akceptačné kritérium E4).
+ */
+export function codeVerdict(product: PairingProduct, page: PageExtract): VerifyOutcome {
+  if (product.externalCodes.length === 0) {
+    return { verdict: "unsure", reason: "produkt nemá žiadny external kód na overenie" };
+  }
+  const hay = [page.title, page.code ?? ""].filter((part) => part.length > 0).join(" ");
+  const matchedCode = product.externalCodes.find((code) => codePresent(code, hay));
+  if (matchedCode !== undefined) {
+    return { verdict: "ok", reason: `kód ${matchedCode} sa nachádza na stránke kandidáta` };
+  }
+  return {
+    verdict: "unsure",
+    reason: `žiadny z kódov produktu (${product.externalCodes.join(", ")}) sa na stránke kandidáta nenašiel`,
+  };
+}
+
+/**
+ * Stiahne detailnú stránku kandidáta cez `SearchClient.fetchPage` (zdieľaný
+ * fetcher — session cookie jar + throttle-if-real, rovnaký ako `.search()`)
+ * a vráti kódový verdikt. Sieťová/parse chyba sa NIKDY nevyhodí ďalej —
+ * zachytáva sa a vracia `unsure` s dôvodom, aby zlyhanie overenia nezhodilo
+ * celý per-produkt gather cyklus (`run.ts`).
+ */
+export async function verifyCandidateCode(
+  client: SearchClient,
+  url: string,
+  product: PairingProduct,
+): Promise<VerifyOutcome> {
+  if (product.externalCodes.length === 0) {
+    return { verdict: "unsure", reason: "produkt nemá žiadny external kód na overenie" };
+  }
+  let html: string;
+  try {
+    html = await client.fetchPage(url);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.warn({ url, message }, "pairing-search: verify fetch zlyhal, verdikt unsure");
+    return { verdict: "unsure", reason: `stránku kandidáta sa nepodarilo stiahnuť (${message})` };
+  }
+  return codeVerdict(product, extractPage(html));
+}

--- a/apps/api/tests/pairing-search-verify.integration.test.ts
+++ b/apps/api/tests/pairing-search-verify.integration.test.ts
@@ -1,0 +1,176 @@
+// Vydelené z `pairing-search-run.integration.test.ts` (issue 387 E4), aby
+// ani jeden súbor nenarástol cez eslint `max-lines: 400` (`.claude/rules/
+// testing.md`) — E3's gather beh testy zostávajú tam, E4's kódové overenie
+// je tu.
+
+import { eq } from "drizzle-orm";
+import { afterEach, describe, expect, it } from "vitest";
+import type { Database } from "../src/db/client.js";
+import { pairingCandidateSets, products, suppliers, variants } from "../src/db/schema.js";
+import { SearchClient, type Fetcher } from "../src/modules/pairing-search/client.js";
+import { runPairingSearch } from "../src/modules/pairing-search/run.js";
+import { insertTestSnapshot } from "./helpers/catalog.js";
+import { withCleanDb } from "./helpers/db.js";
+
+const NOW = new Date("2026-08-13T03:35:00.000Z");
+
+let close: (() => Promise<void>) | undefined;
+
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+});
+
+async function boot(): Promise<Database> {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  return ctx.db;
+}
+
+async function seedSupplier(db: Database): Promise<void> {
+  await db.insert(suppliers).values({ name: "WETLAND", currency: "EUR", wholesaleBaseUrl: "https://www.wetland.sk", adapterKey: "wetland" });
+}
+
+interface SeedProductOptions {
+  readonly externalCode?: string | null;
+  readonly name?: string;
+}
+
+async function seedProduct(db: Database, key: string, opts: SeedProductOptions = {}): Promise<void> {
+  const snapshotId = await insertTestSnapshot(db);
+  const name = opts.name ?? `Bunda ${key}`;
+  await db.insert(products).values({
+    key,
+    name,
+    supplier: "WETLAND",
+    internalNote: null,
+    firstSeenAt: NOW,
+    lastSeenAt: NOW,
+    lastSeenSnapshotId: snapshotId,
+  });
+  await db.insert(variants).values({
+    code: `${key}-V1`,
+    productKey: key,
+    guid: key,
+    sizeLabel: null,
+    pairCode: null,
+    externalCode: opts.externalCode ?? null,
+    name,
+    currency: "EUR",
+    price: "10.00",
+    stock: 5,
+    availabilityInStockText: "Skladom",
+    availabilityOutOfStockText: "Vypredané",
+    availabilityText: "Skladom",
+    productVisibility: "visible",
+    state: "sellable",
+    firstSeenAt: NOW,
+    lastSeenAt: NOW,
+    lastSeenSnapshotId: snapshotId,
+    missingSince: null,
+  });
+}
+
+function wetlandCard(name: string, href: string): string {
+  return `<div class="product-miniature__title"><a class="link" href="${href}">${name}</a></div>`;
+}
+
+/** Detailná stránka kandidáta — presne `.detail__title`="Kód" ->
+ *  `.detail__right` kaskáda z `verify.ts` (mirror `wetland-detail-
+ *  nohavice.html` fixtúry). */
+function wetlandDetailPage(code: string | null): string {
+  const codeBlock =
+    code === null
+      ? ""
+      : `<li class="detail"><div class="detail__left"><span class="detail__title">Kód</span></div><div class="detail__right"><span>${code}</span></div></li>`;
+  return `<html><body><h1>Detail kandidáta</h1><ul class="product__details">${codeBlock}</ul></body></html>`;
+}
+
+/** Smeruje podľa URL: `vyhladavanie` -> search výsledky, inak (kandidátova
+ *  detailná URL) -> zadaná detail stránka. Zaznamenáva KAŽDÉ volanie do
+ *  `calls`, aby testy vedeli overiť, či k detail-page fetchu vôbec došlo
+ *  (dispatch E4: "šetri requesty" pre low/none confidence aj pre produkt
+ *  bez external kódu). */
+function routingFetcher(searchHtml: string, detailHtml: string, calls: string[]): Fetcher {
+  return (url) => {
+    calls.push(url);
+    return Promise.resolve(url.includes("vyhladavanie") ? searchHtml : detailHtml);
+  };
+}
+
+describe("pairing-search: kódové overenie (issue 387 E4)", () => {
+  it("vysoká istota (kódová zhoda) + kód sedí na detaile -> verdict ok, verdictCheckedAt = now", async () => {
+    const db = await boot();
+    await seedSupplier(db);
+    await seedProduct(db, "P1", { name: "Nohavice X", externalCode: "KOD777" });
+
+    const searchHtml = wetlandCard("Úplne iný text KOD777 model", "https://www.wetland.sk/p/kod");
+    const calls: string[] = [];
+    const client = new SearchClient({ fetcher: routingFetcher(searchHtml, wetlandDetailPage("KOD777"), calls) });
+
+    await runPairingSearch({ db, now: NOW, searchClient: client });
+
+    const [set] = await db.select().from(pairingCandidateSets).where(eq(pairingCandidateSets.productKey, "P1"));
+    expect(set?.confidence).toBe("high");
+    expect(set?.verdict).toBe("ok");
+    expect(set?.verdictCheckedAt?.toISOString()).toBe(NOW.toISOString());
+    expect(calls.some((url) => url === "https://www.wetland.sk/p/kod")).toBe(true);
+  });
+
+  it("vysoká istota, ale kód sa na DETAILNEJ stránke kandidáta nenašiel -> verdict unsure", async () => {
+    const db = await boot();
+    await seedSupplier(db);
+    await seedProduct(db, "P1", { name: "Nohavice X", externalCode: "KOD777" });
+
+    const searchHtml = wetlandCard("Úplne iný text KOD777 model", "https://www.wetland.sk/p/kod");
+    const calls: string[] = [];
+    // Detailná stránka nesie INÝ kód (napr. dodávateľ zmenil produkt medzi
+    // gatherom a verify fetchom) — kandidát bol vybraný na search-výsledku,
+    // ale skutočný detail ho nepotvrdí.
+    const client = new SearchClient({ fetcher: routingFetcher(searchHtml, wetlandDetailPage("INY-KOD"), calls) });
+
+    await runPairingSearch({ db, now: NOW, searchClient: client });
+
+    const [set] = await db.select().from(pairingCandidateSets).where(eq(pairingCandidateSets.productKey, "P1"));
+    expect(set?.confidence).toBe("high");
+    expect(set?.verdict).toBe("unsure");
+  });
+
+  it("nízka istota (low, menová zhoda pod 80) -> verify sa VÔBEC nezavolá, žiadny detail-page fetch, verdict null", async () => {
+    const db = await boot();
+    await seedSupplier(db);
+    await seedProduct(db, "P1", { name: "Bunda Wetland" });
+
+    const searchHtml = wetlandCard("Úplne nesúvisiaci produkt XYZ", "https://www.wetland.sk/p/low");
+    const calls: string[] = [];
+    const client = new SearchClient({ fetcher: routingFetcher(searchHtml, wetlandDetailPage("HOCICO"), calls) });
+
+    await runPairingSearch({ db, now: NOW, searchClient: client });
+
+    const [set] = await db.select().from(pairingCandidateSets).where(eq(pairingCandidateSets.productKey, "P1"));
+    expect(set?.confidence).toBe("low");
+    expect(set?.verdict).toBeNull();
+    expect(set?.verdictCheckedAt).toBeNull();
+    expect(calls.some((url) => url === "https://www.wetland.sk/p/low")).toBe(false);
+  });
+
+  it("medium istota (menová zhoda), ale produkt BEZ external kódu -> verdict unsure BEZ akéhokoľvek detail-page fetchu", async () => {
+    const db = await boot();
+    await seedSupplier(db);
+    await seedProduct(db, "P1", { name: "Bunda Wetland Super", externalCode: null });
+
+    const searchHtml = wetlandCard("Bunda Wetland Super", "https://www.wetland.sk/p/medium");
+    const calls: string[] = [];
+    const client = new SearchClient({ fetcher: routingFetcher(searchHtml, wetlandDetailPage("HOCICO"), calls) });
+
+    await runPairingSearch({ db, now: NOW, searchClient: client });
+
+    const [set] = await db.select().from(pairingCandidateSets).where(eq(pairingCandidateSets.productKey, "P1"));
+    expect(set?.confidence).toBe("medium");
+    expect(set?.verdict).toBe("unsure");
+    // `verifyCandidateCode` sa krátko spojí PRED sieťou (`product.
+    // externalCodes.length === 0`) — žiadne ĎALŠIE volanie na
+    // "/p/medium" nad rámec search dopytov.
+    expect(calls.some((url) => url === "https://www.wetland.sk/p/medium")).toBe(false);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.228",
+  "version": "0.3.0-dev.229",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Etapa E4 z issue 387 (profesionálne párovanie produktov, port starej appky @ 60b6164).
Štvrtá z ôsmich etáp — automatické overenie vybraného kandidáta kódom na jeho
detailnej stránke.

## Obsah

- `pairing-search/verify.ts` — kaskáda selektorov na kód portovaná z `verify.py`
  (PrestaShop → Nette → generické selektory), doplnená o štvrtý krok pre ODIMON
  (stará appka preň selektor nemala — nový je overený naživo). Verdikt `ok`/`unsure`;
  produkt bez externého kódu = vždy `unsure`, nikdy falošné `ok`.
- Zapojenie do zberného behu: verdikt sa overuje len pre kandidátov s istotou
  high/medium (šetrenie requestov) a ukladá do `pairing_candidate_set`.
- Nález pri porte: funkcie z `verify.py` stará appka vo svojej reálnej pipeline nikdy
  nevolala (používal ich len jej živý náhľad a testy) — tu sú zapojené ako plnohodnotná
  automatická brána.

## Živé overenie (skutočný klient, žiadne fake-y)

Známy kód vs. vymyslený kód, všetci traja dodávatelia:
WETLAND `ok`/`unsure`, BETALOV `ok`/`unsure`, ODIMON `ok`/`unsure` — presné kódy
a dôkaz v komentári na tikete.

Review (čerstvý kontext): 0 🔴, 2 🟡 opravené v tej istej vetve, 2 🔵 zdokumentované.

## Testy

18 nových unit + 4 integračné; celkovo API unit 878/878, web 606/606, integračné
677 testov v 89 súboroch, typecheck aj lint čisté.

Issue 387 zostáva otvorené — zavrie sa po poslednej etape a živom overení.
