### PR TITLE
Párovanie produktov E5: obrazovka Párovanie — čítanie (issue 387)

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -1299,3 +1299,29 @@ paths:
   one-line invariant (too narrow) or needlessly suppress multi-column
   layout on common viewports (too wide, e.g. picking 600px+ "to be
   safe").
+- **A NEW nav tab whose label is a strict PREFIX of an ALREADY-EXISTING
+  tab's label (`nav.ts`) AND which ALSO carries a left-menu badge count
+  cannot be found unambiguously by `getByRole` at all — neither
+  `{ exact: true }` nor a plain substring query.** Issue 387 E5's new
+  "Párovanie" tab sits alongside the existing "Párovanie produktov" (#239) —
+  a classic prefix collision (`.claude/rules/testing.md`'s established
+  class, issues 240/311), but this one has an EXTRA twist: `Sidebar.tsx`'s
+  badge-carrying `<span>` sets its OWN `aria-label` (`${tab.label}:
+  ${count}`) as a CHILD of the tab `<button>`, and a descendant's
+  `aria-label` concatenates into the ANCESTOR button's computed accessible
+  name — so once the badge attaches (count resolves from `null`), the
+  button's real name becomes `"Párovanie Párovanie: 2"`, not bare
+  `"Párovanie"`. `{ name: "Párovanie", exact: true }` then finds ZERO
+  matches (the real name has the badge suffix); a bare substring query for
+  `"Párovanie"` finds TWO matches (both this tab AND "Párovanie produktov",
+  since "Párovanie" is a substring of both). Neither Playwright locator
+  option resolves it. **Fix: `data-testid="nav-tab-${tab.id}"` added
+  directly to `Sidebar.tsx`'s tab `<button>` (additive — every tab gets
+  one, unique by construction, zero collision risk with anything
+  accessible-name-based)** — `page.getByTestId("nav-tab-<id>")` sidesteps
+  the whole accessible-name computation. Test for ANY future nav tab whose
+  label is a prefix/substring of an existing one: does it ALSO carry a
+  `badgeCounts`/`badgeStatus` entry (`App.tsx`)? If yes, `exact: true` will
+  NOT work once the badge is populated (only works for a badge-less tab,
+  the `restock-links.md`'s "Vypredané → Skladom" precedent) — reach for the
+  `data-testid` instead of trying to out-clever the accessible-name string.

--- a/.claude/rules/pairing-search.md
+++ b/.claude/rules/pairing-search.md
@@ -385,3 +385,23 @@ https://github.com/zbynekdrlik/forestshop-app/issues/387#issuecomment-5273377438
   záložka, ktorej meno je prefixom existujúcej, A ZÁROVEŇ nesie odznak počtu)
   — plný mechanizmus a fix zdokumentovaný v `.claude/rules/frontend-
   design.md` (hľadaj "nav-tab-"), nie duplikovaný tu.
+- **Nová e2e fixtúra (`scripts/e2e-fixtures-pairing-review.ts`, PR pre issue
+  387 E5) zhodila 4 EXISTUJÚCE testy v `catalog.spec.ts` — spadla len preto,
+  že vlastný `pairing-review.spec.ts` prešiel izolovane pri prvom overení,
+  nikdy sa nespustil CELÝ balík pred pushom.** Tri nové produkty
+  (`E2E-PR-CHYBA`/`E2E-PR-NENAJDENY`/`E2E-PR-SLINKOU`) sú `state: "sellable"`,
+  `productVisibility: "visible"` — presne tá istá trieda ako issue 217/337
+  (`.claude/rules/testing.md`'s "Pridanie čo i len JEDNÉHO variantu do e2e
+  seedu posunie pevné počty v `catalog.spec.ts`"): total `103→106`, filter
+  "sellable" `72→75`, "missing"(1) nezmenené (žiadny z troch je `missing`).
+  Zvolené riešenie je AKTUALIZÁCIA pevných počtov (precedens issue 337), nie
+  izolácia — celkový počet by sa musel zvýšiť aj tak (nové produkty MUSIA byť
+  reálne katalógové varianty, inak by pairing-review populácia — INNER JOIN
+  na `pairing_candidate_set` — nemala čo zobraziť), takže "izolovať od
+  catalog počtov" nie je pre TOTAL nikdy možné, len pre "sellable" filter.
+  **Test na KAŽDÚ ĎALŠIU novú e2e fixtúru vyčlenenú do vlastného súboru
+  (vzor `seedXFixtures`, `scripts/e2e-setup.ts`): spusti CELÝ e2e balík
+  (`pnpm --filter @forestshop/web e2e`), nikdy len vlastný nový spec súbor —
+  presne rovnaká past ako `aria-label`/`getByRole`/nav-záložka kolízie
+  zdokumentované v `.claude/rules/testing.md`, len tentoraz cez ZDIEĽANÝ
+  POČET namiesto zdieľaného selektora.**

--- a/.claude/rules/pairing-search.md
+++ b/.claude/rules/pairing-search.md
@@ -1,6 +1,12 @@
 ---
 paths:
   - "apps/api/src/modules/pairing-search/**"
+  - "apps/api/src/modules/pairing-review/**"
+  - "apps/api/src/http/pairing-review-routes.ts"
+  - "apps/web/src/pairingReviewApi.ts"
+  - "apps/web/src/components/PairingReview*.tsx"
+  - "apps/web/tests/e2e/pairing-review.spec.ts"
+  - "scripts/e2e-fixtures-pairing-review.ts"
 ---
 
 # Profesionálne párovanie produktov — jadro vyhľadávania (issue 387)
@@ -312,3 +318,70 @@ https://github.com/zbynekdrlik/forestshop-app/issues/387#issuecomment-5273377438
   musel host znova warm-upovať a strácal by session medzi search a
   detail fetchmi. Bez cache (na rozdiel od `.search()`) — detailná URL
   je vždy jedinečná, cache by nikdy nehitla.
+
+## E5 — Obrazovka Párovanie, čítanie (`pairing-review/`, `PairingReviewSection.tsx`)
+
+- **Populácia je "produkty S `pairing_candidate_set` riadkom" (INNER JOIN),
+  nie "produkty vhodné na gather".** `pairing-search/select.ts`'s
+  `selectEligibleProducts` (E3) rieši ÚPLNE inú otázku ("koho má gather
+  ešte spracovať/prespracovať") — E5's `listPairingReview` (`pairing-review/
+  queries.ts`) nad tým NESTAVIA, číta VLASTNÝ, jednoduchší dopyt priamo z
+  `pairing_candidate_set`. Produkt, ktorý nočný beh ešte nikdy nezbieral, sa
+  na tejto obrazovke nezobrazí vôbec — to je ZÁMER (zadanie: "zoznam
+  produktov S kandidátmi"), nie chyba/medzera.
+- **`pairing_decision` (E6) v čase E5 EŠTE NEEXISTUJE — "Nezrevidované"
+  filter/odznak/progress preto NIE JE "chýba rozhodnutie", je to "chýba
+  EFEKTÍVNA dodávateľská linka"** (`resolveEffectiveSupplierLink`, tá istá
+  funkcia ako `product-links`/`restock-links`, zohľadňujúca AJ
+  `product_supplier_link_override` AJ `internalNote`). Design komentár na
+  tickete (issue 387 E5) toto rozhodnutie explicitne zdôvodňuje a
+  poznamenáva, že E6 môže tento predikát ĎALEJ zúžiť (napr. vylúčiť produkty
+  rozhodnuté `unavailable`/`discontinued`) BEZ zmeny API kontraktu ani tejto
+  obrazovky — pri práci na E6 over najprv, či `unreviewed`'s SQL/JS predikát
+  v `queries.ts` ešte zodpovedá aktuálnemu zámeru, než sa píše nová logika
+  vedľa neho.
+- **`matched`/`unmatched` = `pairing_candidate_set.chosen_url !== null`,
+  NIKDY `confidence !== "none"` priamo** — funkčne rovnaké (`ranking.ts`'s
+  `pickBest()` vracia `confidence: "none"` PRÁVE VTEDY, keď `candidates.length
+  === 0`, teda `chosen_url` je vtedy vždy `null`), ale `chosen_url` je
+  priamy, jednoznačný stĺpec bez potreby poznať `pickBest()`'s vnútorné
+  správanie — over TOTO tvrdenie priamo v `ranking.ts` pri KAŽDEJ ďalšej
+  zmene `pickBest()`u, nie len tu v playbooku.
+- **Naša strana karty (`ourUrl`/`ourImageUrl`) ide cez `shop_product_url`
+  spárovaný podľa KTORÉHOKOĽVEK kódu variantu produktu** (deterministicky —
+  najmenší kód vyhráva pri viacerých zhodách, rovnaký vzor ako
+  `nedostupne/resolve-products.ts`'s `findMatchingCode`), fallback na
+  `…/vyhladavanie/?string=<meno>` presne ako stará appka. Meta (cena/sklad)
+  je rozsah (`priceMin`/`priceMax`) naprieč VŠETKÝMI variantmi produktu — na
+  rozdiel od starej appky (jeden variant = jeden riadok) môže mať produkt
+  tejto appky viac cien naraz.
+- **Kandidátova strana ukazuje LEN `chosenUrl`, nikdy celých top-8.**
+  Rozbaľovací panel so všetkými kandidátmi (výber jedného, manuálne URL) je
+  E6-ova ROZHODOVACIA UI (design komentár, sekcia 3) — E5 je explicitne "BEZ
+  akčných tlačidiel". Lazy live-fetch meta endpoint (analóg starej appky's
+  `/api/images`) bol pre E5 ZÁMERNE preskočený (technické rozhodnutie, nie
+  medzera) — všetko, čo karta potrebuje (meno/URL/skóre/istota/verdikt), je
+  už persistované z E3/E4; ak E6's rozhodovací panel skutočne potrebuje
+  živú cenu/obrázok kandidáta, TAM sa má live-fetch pridať, nie predtým.
+- **Worktree založený PRED tým, než predchádzajúca etapa domergovala do
+  `dev`, obsahuje STARÝ kód bez nej — `git status`/`git log origin/dev..HEAD`
+  prázdne NEZNAMENÁ "som na aktuálnom stave dev", znamená len "moje commity
+  sú podmnožinou origin/dev-u v čase FETCHU".** E5's worktree bol založený
+  na E3's merge bode (`a6c0c10`/`d031c27`) TESNE PRED tým, než E4's
+  round-integrácia dobehla (`4a0707b`, `origin/dev` verzia `0.3.0-dev.229`) —
+  dispatch prompt správne hlásil "dev = .229", ale worktree samo malo ešte
+  `.228` a ANI JEDEN E4 súbor (`verify.ts`, zapojenie do `run.ts`). Bez `git
+  merge origin/dev` PRED prvým commitom by E5 stavalo na E1-E3 kóde a E4's
+  zmeny (najmä `pairing_candidate_set.verdict`, ktorý E5 priamo zobrazuje)
+  by chýbali z worktree úplne, hoci sú dávno zmergované. **Pri KAŽDEJ ĎALŠEJ
+  etape tejto sériovej reťaze (E6-E9): PRED prvým riadkom kódu vždy `git
+  fetch origin && git log HEAD..origin/dev --oneline` — ak nie je prázdne,
+  `git merge origin/dev` PRED verziovým bumpom**, presne ako predpisuje
+  autopilot-workerov vlastný CYCLE krok 1 ("RESUME, don't restart") — v
+  paralelnom worktree-dispatchi (issue #317) je to bežný, nie výnimočný
+  prípad, keďže susedná etapa sa mohla domergovať PO založení tohto
+  worktree, ale PRED začiatkom skutočnej práce naň.
+- **Substring/accessible-name kolízia s BADGE odznakom** (nová viditeľná
+  záložka, ktorej meno je prefixom existujúcej, A ZÁROVEŇ nesie odznak počtu)
+  — plný mechanizmus a fix zdokumentovaný v `.claude/rules/frontend-
+  design.md` (hľadaj "nav-tab-"), nie duplikovaný tu.

--- a/apps/api/src/http/app.ts
+++ b/apps/api/src/http/app.ts
@@ -26,6 +26,7 @@ import { registerOrderFlagsRoutes } from "./order-flags-routes.js";
 import { registerOrderMergeRoutes, type OrderMergeRunDeps } from "./order-merge-routes.js";
 import { requireSameOrigin } from "./origin-check.js";
 import { registerPairingRoutes } from "./pairing-routes.js";
+import { registerPairingReviewRoutes } from "./pairing-review-routes.js";
 import { registerPairingSearchRoutes } from "./pairing-search-routes.js";
 import { registerPostaUncollectedRoutes, type PostaUncollectedRunDeps } from "./posta-uncollected-routes.js";
 import { registerProductLinksRoutes } from "./product-links-routes.js";
@@ -215,6 +216,13 @@ export function createApp(
   // verejných vyhľadávacích stránok dodávateľov), na rozdiel od
   // `restock`/`shoptet-writeback` vyššie.
   registerPairingSearchRoutes(app, db);
+  // issue 387 E5: "Eshop → Párovanie" — LEN čítanie nad tým, čo E3/E4
+  // zozbierali/overili (karty + filtre). Rozhodnutia (E6) ešte neexistujú —
+  // žiadna zapisovacia trasa tu, samostatné od `registerPairingRoutes`
+  // (skrytá F4 "Kontrola párovania") aj `registerProductLinksRoutes` nižšie
+  // (#239 "Párovanie produktov") — obe ostávajú nedotknuté (design komentár
+  // na tickete: E9 ich prípadné vyradenie potrebuje výslovný súhlas majiteľa).
+  registerPairingReviewRoutes(app, db);
   // issue 239: "Eshop → Párovanie produktov" — zoznam produktov bez
   // dodávateľskej linky + doplnenie/oprava (zapisuje do rovnakej
   // `product_supplier_link_override` tabuľky ako #121, žiadna nová cesta do

--- a/apps/api/src/http/pairing-review-routes.ts
+++ b/apps/api/src/http/pairing-review-routes.ts
@@ -1,0 +1,32 @@
+import { zValidator } from "@hono/zod-validator";
+import type { Hono } from "hono";
+import { z } from "zod";
+import type { Database } from "../db/client.js";
+import { listPairingReview } from "../modules/pairing-review/queries.js";
+import { requireUser, type AppBindings } from "./middleware.js";
+
+// issue 387 E5: "Eshop → Párovanie" — LEN čítanie (karty + filtre nad tým, čo
+// E3/E4 zozbierali a overili). Rozhodnutia/zápis prídu až v E6 — žiadna
+// POST trasa tu.
+
+// Prázdna hodnota (`page=`) sa má správať ako neprítomný parameter, rovnaký
+// vzor ako `restock-links-routes.ts`/`product-links-routes.ts`'s `pageParam`.
+const pageParam = z.preprocess(
+  (value) => (value === "" ? undefined : value),
+  z.coerce.number().int().min(1).max(100_000).default(1),
+);
+
+const pairingReviewQuery = z.object({
+  filter: z.enum(["unreviewed", "matched", "unmatched", "st1", "st2", "st3", "all"]).default("unreviewed"),
+  page: pageParam,
+  pageSize: z.coerce.number().int().min(1).max(200).default(50),
+});
+
+export function registerPairingReviewRoutes(app: Hono<AppBindings>, db: Database): void {
+  // Rovnaké oprávnenie ako `restock-links`/`product-links` čítanie
+  // (`requireUser`, žiadne rolové obmedzenie) — každý prihlásený smie vidieť
+  // stav párovania.
+  app.get("/api/pairing-review", requireUser(db), zValidator("query", pairingReviewQuery), async (c) =>
+    c.json(await listPairingReview(db, c.req.valid("query"))),
+  );
+}

--- a/apps/api/src/modules/pairing-review/queries.ts
+++ b/apps/api/src/modules/pairing-review/queries.ts
@@ -1,0 +1,295 @@
+// issue 387 E5: "Eshop → Párovanie" — čítacia obrazovka nad tým, čo E3
+// (gather) + E4 (verify) už zozbierali a overili. Populácia je "produkty S
+// KANDIDÁTMI" (INNER JOIN na `pairing_candidate_set` — produkt, ktorý gather
+// ešte nespracoval, sa tu nezobrazuje vôbec, presne ako zadanie žiada).
+//
+// Filtre/badge/progress bez `pairing_decision` (E6, tu ešte neexistuje) —
+// pozri design komentár na tickete (issue 387 E5): "unreviewed" ZNAMENÁ
+// "produkt z gather populácie BEZ efektívnej dodávateľskej linky" (doslovná
+// zhoda so zadaním "nezrevidovaných BEZ ODKAZU"), nie "bez rozhodnutia" (to
+// pole tu neexistuje). Rovnaký MVP vzor ako `product-links/queries.ts`/
+// `restock-links/queries.ts`/`pairing-search/select.ts` — celá relevantná
+// populácia (rádovo stovky, nie celý katalóg) sa načíta a filtruje/triedi/
+// stránkuje v JS, keďže `resolveEffectiveSupplierLink` je čistá JS funkcia
+// nad `internalNote`, nedá sa vyjadriť ako SQL predikát bez duplicity.
+
+import { inArray } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import {
+  pairingCandidates,
+  pairingCandidateSets,
+  productSupplierLinkOverrides,
+  products,
+  shopProductUrl,
+  variants,
+} from "../../db/schema.js";
+import { resolveEffectiveSupplierLink } from "../orders/effective-supplier-link.js";
+import type { PairingConfidence, PairingVerdict } from "../pairing-search/types.js";
+import { SELLABLE_VISIBILITY } from "../restock/constants.js";
+
+export type PairingReviewFilter = "unreviewed" | "matched" | "unmatched" | "st1" | "st2" | "st3" | "all";
+export type PairingReviewProductState = "sellable" | "out_of_stock" | "discontinued";
+
+// Fallback presne ako stará appka (`webreview/app.js`'s `renderCard`) — keď
+// appka nepozná priamy odkaz z feedu (issue 220's `shop_product_url`),
+// ponúkne aspoň vyhľadávanie podľa mena na vlastnom e-shope.
+const OWN_SHOP_SEARCH_BASE = "https://www.forestshop.sk/vyhladavanie/?string=";
+
+export interface PairingReviewChosenCandidate {
+  readonly name: string;
+  readonly url: string;
+  readonly rawScore: number;
+  readonly codeHit: boolean;
+}
+
+export interface PairingReviewItem {
+  readonly productKey: string;
+  readonly productName: string;
+  readonly supplier: string | null;
+  readonly externalCodes: readonly string[];
+  readonly variantCount: number;
+  /** Rollup `variant.state` na produkt — pozri `rollupProductState` nižšie. */
+  readonly productState: PairingReviewProductState;
+  readonly priceMin: string | null;
+  readonly priceMax: string | null;
+  readonly currency: string | null;
+  /** Nikdy `null` — padá na `OWN_SHOP_SEARCH_BASE` fallback, presne ako stará appka. */
+  readonly ourUrl: string;
+  readonly ourImageUrl: string | null;
+  /** `true` = appka už pozná EFEKTÍVNU dodávateľskú linku (override alebo
+   * extrahovaná z `internalNote`) — toto JE "unreviewed" predikát (viď hlavička súboru). */
+  readonly hasEffectiveLink: boolean;
+  readonly gatheredAt: string;
+  readonly confidence: PairingConfidence;
+  readonly chosenReason: string | null;
+  readonly verdict: PairingVerdict | null;
+  /** `null` presne keď `confidence === "none"` (gather nenašiel u dodávateľa nič). */
+  readonly chosenCandidate: PairingReviewChosenCandidate | null;
+}
+
+export interface PairingReviewSearchInput {
+  readonly filter: PairingReviewFilter;
+  readonly page: number;
+  readonly pageSize: number;
+}
+
+export interface PairingReviewSearchResult {
+  readonly total: number;
+  /** Celá gather populácia (počet `pairing_candidate_set` riadkov), nezávisle
+   * od `filter` — menovateľ pre progress. */
+  readonly gatheredTotal: number;
+  /** Koľko z `gatheredTotal` už MÁ efektívnu linku — čitateľ pre progress
+   * (doplnok `unreviewed` počtu, ktorý číta rovnaký endpoint s `filter=unreviewed`). */
+  readonly linkedTotal: number;
+  readonly items: readonly PairingReviewItem[];
+}
+
+interface VariantRow {
+  readonly productKey: string;
+  readonly code: string;
+  readonly externalCode: string | null;
+  readonly state: PairingReviewProductState;
+  readonly productVisibility: string;
+  readonly missingSince: Date | null;
+  readonly price: string | null;
+  readonly currency: string | null;
+}
+
+/** Nejaký variant `sellable` → Skladom; inak nejaký `out_of_stock` a VIDITEĽNÝ
+ * (rovnaká podmienka ako `pairing-search/select.ts`'s `soldOutVisible`) →
+ * Nie je skladom; inak → Už sa nebude predávať. `detailOnly` samo osebe nie
+ * je "vypnuté" (`.claude/rules/catalog.md`'s `availability.ts` pravidlo) —
+ * zachytené tým, že len `out_of_stock` + `SELLABLE_VISIBILITY` počíta ako
+ * "Nie je skladom", nikdy len `out_of_stock`. Produkt bez VARIANTOV vôbec
+ * (teoreticky nemožné — katalógový import ich vždy páruje) padá na "Už sa
+ * nebude predávať", nikdy nevyhodí. */
+function rollupProductState(rows: readonly VariantRow[]): PairingReviewProductState {
+  if (rows.some((r) => r.state === "sellable")) return "sellable";
+  if (rows.some((r) => r.state === "out_of_stock" && r.productVisibility === SELLABLE_VISIBILITY && r.missingSince === null)) {
+    return "out_of_stock";
+  }
+  return "discontinued";
+}
+
+export async function listPairingReview(db: Database, input: PairingReviewSearchInput): Promise<PairingReviewSearchResult> {
+  const setRows = await db
+    .select({
+      productKey: pairingCandidateSets.productKey,
+      gatheredAt: pairingCandidateSets.gatheredAt,
+      chosenUrl: pairingCandidateSets.chosenUrl,
+      chosenReason: pairingCandidateSets.chosenReason,
+      confidence: pairingCandidateSets.confidence,
+      verdict: pairingCandidateSets.verdict,
+    })
+    .from(pairingCandidateSets);
+  if (setRows.length === 0) return { total: 0, gatheredTotal: 0, linkedTotal: 0, items: [] };
+
+  const productKeys = setRows.map((r) => r.productKey);
+
+  const productRows = await db
+    .select({ key: products.key, name: products.name, supplier: products.supplier, internalNote: products.internalNote })
+    .from(products)
+    .where(inArray(products.key, productKeys));
+  const productByKey = new Map(productRows.map((r) => [r.key, r]));
+
+  const overrideRows = await db
+    .select({ productKey: productSupplierLinkOverrides.productKey, url: productSupplierLinkOverrides.url })
+    .from(productSupplierLinkOverrides)
+    .where(inArray(productSupplierLinkOverrides.productKey, productKeys));
+  const overrideByProduct = new Map(overrideRows.map((r) => [r.productKey, r.url]));
+
+  const variantRows: VariantRow[] = await db
+    .select({
+      productKey: variants.productKey,
+      code: variants.code,
+      externalCode: variants.externalCode,
+      state: variants.state,
+      productVisibility: variants.productVisibility,
+      missingSince: variants.missingSince,
+      price: variants.price,
+      currency: variants.currency,
+    })
+    .from(variants)
+    .where(inArray(variants.productKey, productKeys));
+  const variantsByProduct = new Map<string, VariantRow[]>();
+  for (const row of variantRows) {
+    const bucket = variantsByProduct.get(row.productKey);
+    if (bucket === undefined) variantsByProduct.set(row.productKey, [row]);
+    else bucket.push(row);
+  }
+
+  const variantCodes = variantRows.map((r) => r.code);
+  const feedRows =
+    variantCodes.length === 0
+      ? []
+      : await db
+          .select({ code: shopProductUrl.code, url: shopProductUrl.url, imageUrl: shopProductUrl.imageUrl })
+          .from(shopProductUrl)
+          .where(inArray(shopProductUrl.code, variantCodes));
+  const feedByCode = new Map(feedRows.map((r) => [r.code, r]));
+
+  const candidateRows = await db
+    .select({
+      productKey: pairingCandidates.productKey,
+      name: pairingCandidates.name,
+      url: pairingCandidates.url,
+      rawScore: pairingCandidates.rawScore,
+      codeHit: pairingCandidates.codeHit,
+    })
+    .from(pairingCandidates)
+    .where(inArray(pairingCandidates.productKey, productKeys));
+  // Kľúčované (productKey, url) — presne dvojica, čo `pairing_candidate`'s
+  // vlastný `UNIQUE(product_key, url)` index vynucuje, takže zhoda je vždy
+  // jednoznačná. Len kandidát rovný `chosenUrl` sa naozaj vyhľadá nižšie
+  // (E5 ukazuje LEN navrhnutého kandidáta, nie všetkých top-8 — design komentár).
+  const candidateByKey = new Map(candidateRows.map((r) => [`${r.productKey} ${r.url}`, r]));
+
+  const allItems: PairingReviewItem[] = [];
+  for (const set of setRows) {
+    const product = productByKey.get(set.productKey);
+    // Osirotený `pairing_candidate_set` riadok (produkt medzičasom zmizol z
+    // katalógu) — nikdy sa nezobrazí, rovnaká disciplína ako `select.ts`'s
+    // review-nález o `missingSince` (informačná poznámka, nie porušenie).
+    if (product === undefined) continue;
+
+    const productVariants = variantsByProduct.get(set.productKey) ?? [];
+
+    const seenCodes = new Set<string>();
+    const externalCodes: string[] = [];
+    for (const v of productVariants) {
+      const code = v.externalCode?.trim();
+      if (code !== undefined && code !== "" && !seenCodes.has(code)) {
+        seenCodes.add(code);
+        externalCodes.push(code);
+      }
+    }
+
+    let ourUrl: string | null = null;
+    let ourImageUrl: string | null = null;
+    // Deterministické poradie (najmenší kód vyhráva), rovnaký princíp ako
+    // `resolve-products.ts`'s `orderBy(shopProductUrl.code)` pri viacerých zhodách.
+    for (const v of [...productVariants].sort((a, b) => a.code.localeCompare(b.code))) {
+      const hit = feedByCode.get(v.code);
+      if (hit !== undefined) {
+        ourUrl = hit.url;
+        ourImageUrl = hit.imageUrl;
+        break;
+      }
+    }
+    if (ourUrl === null) ourUrl = OWN_SHOP_SEARCH_BASE + encodeURIComponent(product.name);
+
+    const prices = productVariants
+      .map((v) => v.price)
+      .filter((p): p is string => p !== null)
+      .map(Number)
+      .filter((n) => Number.isFinite(n));
+    const priceMin = prices.length > 0 ? Math.min(...prices).toFixed(2) : null;
+    const priceMax = prices.length > 0 ? Math.max(...prices).toFixed(2) : null;
+    const currency = productVariants.find((v) => v.currency !== null)?.currency ?? null;
+
+    const effective = resolveEffectiveSupplierLink(product.internalNote, overrideByProduct.get(set.productKey) ?? null);
+
+    const chosenCandidateRow = set.chosenUrl === null ? undefined : candidateByKey.get(`${set.productKey} ${set.chosenUrl}`);
+    const chosenCandidate: PairingReviewChosenCandidate | null =
+      chosenCandidateRow === undefined
+        ? null
+        : { name: chosenCandidateRow.name, url: chosenCandidateRow.url, rawScore: Number(chosenCandidateRow.rawScore), codeHit: chosenCandidateRow.codeHit };
+
+    allItems.push({
+      productKey: set.productKey,
+      productName: product.name,
+      supplier: product.supplier,
+      externalCodes,
+      variantCount: productVariants.length,
+      productState: rollupProductState(productVariants),
+      priceMin,
+      priceMax,
+      currency,
+      ourUrl,
+      ourImageUrl,
+      hasEffectiveLink: effective.url !== null,
+      gatheredAt: set.gatheredAt.toISOString(),
+      confidence: set.confidence,
+      chosenReason: set.chosenReason,
+      verdict: set.verdict,
+      chosenCandidate,
+    });
+  }
+
+  const gatheredTotal = allItems.length;
+  const linkedTotal = allItems.filter((item) => item.hasEffectiveLink).length;
+
+  const filtered = allItems.filter((item) => {
+    switch (input.filter) {
+      case "unreviewed":
+        return !item.hasEffectiveLink;
+      case "matched":
+        return item.chosenCandidate !== null;
+      case "unmatched":
+        return item.chosenCandidate === null;
+      case "st1":
+        return item.productState === "sellable";
+      case "st2":
+        return item.productState === "out_of_stock";
+      case "st3":
+        return item.productState === "discontinued";
+      case "all":
+        return true;
+    }
+  });
+
+  // Unmatched-last (design komentár, zadanie bod 3): napárované PRED
+  // nenapárovanými, sekundárne meno (sk locale) — rovnaký vzor ako
+  // `product-links`/`restock-links`.
+  filtered.sort((a, b) => {
+    const matchedOrder = Number(a.chosenCandidate === null) - Number(b.chosenCandidate === null);
+    if (matchedOrder !== 0) return matchedOrder;
+    return a.productName.localeCompare(b.productName, "sk");
+  });
+
+  const total = filtered.length;
+  const start = (input.page - 1) * input.pageSize;
+  const items = filtered.slice(start, start + input.pageSize);
+
+  return { total, gatheredTotal, linkedTotal, items };
+}

--- a/apps/api/tests/pairing-review-http.integration.test.ts
+++ b/apps/api/tests/pairing-review-http.integration.test.ts
@@ -1,0 +1,339 @@
+import { afterEach, expect, it } from "vitest";
+import type { Database } from "../src/db/client.js";
+import {
+  pairingCandidates,
+  pairingCandidateSets,
+  productSupplierLinkOverrides,
+  products,
+  shopProductUrl,
+  users,
+  variants,
+} from "../src/db/schema.js";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import type { UserRole } from "../src/modules/auth/service.js";
+import { insertTestSnapshot } from "./helpers/catalog.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 387 E5: "Eshop → Párovanie" — LEN čítanie (`GET /api/pairing-review`).
+// Rozhodnutia (E6) tu ešte neexistujú.
+
+const HESLO = "test-heslo-abc"; // testovacie údaje, nie tajomstvo
+
+let close: (() => Promise<void>) | undefined;
+
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  resetLoginRateLimit();
+});
+
+async function boot(role: UserRole) {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const [pouzivatel] = await ctx.db
+    .insert(users)
+    .values({ email: "manazer@forestshop.sk", passwordHash: await hashPassword(HESLO), displayName: "Manažér", role })
+    .returning({ id: users.id });
+  if (pouzivatel === undefined) throw new Error("testovací používateľ sa nepodarilo vložiť");
+
+  const app = createApp(ctx.db, { cookieSecure: false });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "manazer@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie, db: ctx.db };
+}
+
+interface Telo {
+  readonly total: number;
+  readonly gatheredTotal: number;
+  readonly linkedTotal: number;
+  readonly items: {
+    readonly productKey: string;
+    readonly productName: string;
+    readonly supplier: string | null;
+    readonly externalCodes: string[];
+    readonly variantCount: number;
+    readonly productState: "sellable" | "out_of_stock" | "discontinued";
+    readonly priceMin: string | null;
+    readonly priceMax: string | null;
+    readonly ourUrl: string;
+    readonly ourImageUrl: string | null;
+    readonly hasEffectiveLink: boolean;
+    readonly confidence: "high" | "medium" | "low" | "none";
+    readonly verdict: "ok" | "unsure" | null;
+    readonly chosenCandidate: { readonly name: string; readonly url: string; readonly rawScore: number; readonly codeHit: boolean } | null;
+  }[];
+}
+
+async function seedProduct(
+  db: Database,
+  snapshotId: string,
+  productKey: string,
+  over: {
+    readonly name: string;
+    readonly supplier?: string | null;
+    readonly internalNote?: string | null;
+    readonly variants?: readonly {
+      readonly code: string;
+      readonly externalCode?: string | null;
+      readonly state?: "sellable" | "out_of_stock" | "discontinued";
+      readonly productVisibility?: string;
+      readonly missingSince?: Date | null;
+      readonly price?: string | null;
+    }[];
+  },
+): Promise<void> {
+  const now = new Date("2026-08-13T00:00:00Z");
+  await db.insert(products).values({
+    key: productKey,
+    name: over.name,
+    supplier: over.supplier ?? null,
+    internalNote: over.internalNote ?? null,
+    firstSeenAt: now,
+    lastSeenAt: now,
+    lastSeenSnapshotId: snapshotId,
+  });
+  const variantSpecs = over.variants ?? [{ code: `${productKey}/1` }];
+  for (const v of variantSpecs) {
+    await db.insert(variants).values({
+      code: v.code,
+      productKey,
+      guid: productKey,
+      externalCode: v.externalCode ?? null,
+      name: over.name,
+      price: v.price ?? null,
+      stock: 0,
+      availabilityInStockText: "Skladom",
+      availabilityOutOfStockText: "Vypredané",
+      availabilityText: v.state === "out_of_stock" ? "Vypredané" : "Skladom",
+      productVisibility: v.productVisibility ?? "visible",
+      state: v.state ?? "sellable",
+      missingSince: v.missingSince ?? null,
+      firstSeenAt: now,
+      lastSeenAt: now,
+      lastSeenSnapshotId: snapshotId,
+    });
+  }
+}
+
+async function seedCandidateSet(
+  db: Database,
+  productKey: string,
+  over: {
+    readonly chosenUrl?: string | null;
+    readonly confidence?: "high" | "medium" | "low" | "none";
+    readonly verdict?: "ok" | "unsure" | null;
+    readonly candidates?: readonly { readonly url: string; readonly name: string; readonly rawScore: string; readonly codeHit: boolean }[];
+  } = {},
+): Promise<void> {
+  await db.insert(pairingCandidateSets).values({
+    productKey,
+    gatheredAt: new Date("2026-08-13T03:35:00Z"),
+    queries: ["dopyt"],
+    inputHash: "hash-" + productKey,
+    chosenUrl: over.chosenUrl ?? null,
+    chosenReason: over.chosenUrl !== undefined && over.chosenUrl !== null ? "najlepší nájdený" : null,
+    confidence: over.confidence ?? (over.chosenUrl !== undefined && over.chosenUrl !== null ? "medium" : "none"),
+    verdict: over.verdict ?? null,
+    verdictCheckedAt: over.verdict !== undefined && over.verdict !== null ? new Date("2026-08-13T03:36:00Z") : null,
+  });
+  for (const [i, c] of (over.candidates ?? []).entries()) {
+    await db.insert(pairingCandidates).values({
+      productKey,
+      position: i,
+      name: c.name,
+      url: c.url,
+      rawScore: c.rawScore,
+      codeHit: c.codeHit,
+    });
+  }
+}
+
+it("bez prihlásenia vráti 401", async () => {
+  const { app } = await boot("manazer");
+  expect((await app.request("/api/pairing-review")).status).toBe(401);
+});
+
+it("produkt BEZ pairing_candidate_set riadku (gather ho ešte nespracoval) sa v zozname vôbec nezobrazí", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedProduct(db, snapshotId, "PR-NEGATHER", { name: "Negatherovaný produkt" });
+
+  const telo = (await (await app.request("/api/pairing-review?filter=all", { headers: { cookie } })).json()) as Telo;
+  expect(telo.items.some((i) => i.productKey === "PR-NEGATHER")).toBe(false);
+  expect(telo.gatheredTotal).toBe(0);
+});
+
+it("napárovaný produkt (chosenUrl) nesie navrhnutého kandidáta so skóre/istotou/kódovým overením", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedProduct(db, snapshotId, "PR-MATCHED", {
+    name: "Bunda Alfa Zimná",
+    supplier: "DODAVATEL-PR",
+    variants: [{ code: "PR-MATCHED/1", externalCode: "KOD-123" }],
+  });
+  await seedCandidateSet(db, "PR-MATCHED", {
+    chosenUrl: "https://dodavatel.example.com/bunda-alfa",
+    confidence: "high",
+    verdict: "ok",
+    candidates: [{ url: "https://dodavatel.example.com/bunda-alfa", name: "Bunda Alfa", rawScore: "1080.5000", codeHit: true }],
+  });
+
+  const telo = (await (await app.request("/api/pairing-review?filter=matched", { headers: { cookie } })).json()) as Telo;
+  const item = telo.items.find((i) => i.productKey === "PR-MATCHED");
+  expect(item).toBeDefined();
+  expect(item?.confidence).toBe("high");
+  expect(item?.verdict).toBe("ok");
+  expect(item?.chosenCandidate).toMatchObject({ name: "Bunda Alfa", url: "https://dodavatel.example.com/bunda-alfa", rawScore: 1080.5, codeHit: true });
+});
+
+it("nenapárovaný produkt (confidence none, žiadny kandidát) má chosenCandidate null a padne do filtra 'unmatched'", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedProduct(db, snapshotId, "PR-UNMATCHED", { name: "Produkt bez kandidáta u dodávateľa" });
+  await seedCandidateSet(db, "PR-UNMATCHED", { confidence: "none" });
+
+  const telo = (await (await app.request("/api/pairing-review?filter=unmatched", { headers: { cookie } })).json()) as Telo;
+  const item = telo.items.find((i) => i.productKey === "PR-UNMATCHED");
+  expect(item?.chosenCandidate).toBeNull();
+  expect(item?.confidence).toBe("none");
+
+  const matchedTelo = (await (await app.request("/api/pairing-review?filter=matched", { headers: { cookie } })).json()) as Telo;
+  expect(matchedTelo.items.some((i) => i.productKey === "PR-UNMATCHED")).toBe(false);
+});
+
+// "unreviewed" (default) = gather populácia BEZ efektívnej dodávateľskej
+// linky — design komentár na tickete (issue 387 E5), nie "bez rozhodnutia"
+// (pairing_decision tu ešte neexistuje, E6).
+it("'unreviewed' = produkt z gather populácie BEZ efektívnej linky — produkt S linkou (internalNote) v ňom NIE JE", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedProduct(db, snapshotId, "PR-BEZLINKY", { name: "Produkt bez linky" });
+  await seedCandidateSet(db, "PR-BEZLINKY", { confidence: "none" });
+  await seedProduct(db, snapshotId, "PR-SLINKOU", {
+    name: "Produkt s linkou",
+    internalNote: "https://dodavatel.example.com/uz-ma-linku",
+  });
+  await seedCandidateSet(db, "PR-SLINKOU", { confidence: "none" });
+
+  const telo = (await (await app.request("/api/pairing-review?filter=unreviewed", { headers: { cookie } })).json()) as Telo;
+  expect(telo.items.some((i) => i.productKey === "PR-BEZLINKY")).toBe(true);
+  expect(telo.items.some((i) => i.productKey === "PR-SLINKOU")).toBe(false);
+  // gatheredTotal/linkedTotal sa počítajú nad CELOU gather populáciou,
+  // nezávisle od `filter` — progress bar/badge na tomto stoja.
+  expect(telo.gatheredTotal).toBe(2);
+  expect(telo.linkedTotal).toBe(1);
+});
+
+it("efektívna linka LEN z override (bez internalNote) tiež vyradí produkt z 'unreviewed'", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedProduct(db, snapshotId, "PR-OVERRIDE", { name: "Produkt s override linkou" });
+  await seedCandidateSet(db, "PR-OVERRIDE", { confidence: "none" });
+  await db.insert(productSupplierLinkOverrides).values({ productKey: "PR-OVERRIDE", url: "https://dodavatel.example.com/z-override", updatedAt: new Date() });
+
+  const telo = (await (await app.request("/api/pairing-review?filter=unreviewed", { headers: { cookie } })).json()) as Telo;
+  expect(telo.items.some((i) => i.productKey === "PR-OVERRIDE")).toBe(false);
+});
+
+it("rollup stavu produktu: nejaký sellable variant → st1 (Skladom)", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedProduct(db, snapshotId, "PR-ST1", {
+    name: "Produkt Skladom",
+    variants: [
+      { code: "PR-ST1/1", state: "out_of_stock" },
+      { code: "PR-ST1/2", state: "sellable" },
+    ],
+  });
+  await seedCandidateSet(db, "PR-ST1");
+
+  const telo = (await (await app.request("/api/pairing-review?filter=st1", { headers: { cookie } })).json()) as Telo;
+  expect(telo.items.map((i) => i.productKey)).toContain("PR-ST1");
+  expect(telo.items.find((i) => i.productKey === "PR-ST1")?.productState).toBe("sellable");
+});
+
+it("rollup stavu produktu: žiadny sellable, ale out_of_stock+viditeľný → st2 (Nie je skladom)", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedProduct(db, snapshotId, "PR-ST2", { name: "Produkt vypredaný", variants: [{ code: "PR-ST2/1", state: "out_of_stock" }] });
+  await seedCandidateSet(db, "PR-ST2");
+
+  const telo = (await (await app.request("/api/pairing-review?filter=st2", { headers: { cookie } })).json()) as Telo;
+  expect(telo.items.find((i) => i.productKey === "PR-ST2")?.productState).toBe("out_of_stock");
+});
+
+// `detailOnly`/skryté out_of_stock samo osebe NIE JE "Nie je skladom" —
+// `.claude/rules/catalog.md`'s availability.ts pravidlo, rollup padá na st3.
+it("rollup stavu produktu: out_of_stock ale SKRYTÝ (nie 'visible') → st3 (Už sa nebude predávať), nikdy st2", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedProduct(db, snapshotId, "PR-ST3", {
+    name: "Produkt ukončený predaj",
+    variants: [{ code: "PR-ST3/1", state: "out_of_stock", productVisibility: "detailOnly" }],
+  });
+  await seedCandidateSet(db, "PR-ST3");
+
+  const telo = (await (await app.request("/api/pairing-review?filter=st3", { headers: { cookie } })).json()) as Telo;
+  expect(telo.items.find((i) => i.productKey === "PR-ST3")?.productState).toBe("discontinued");
+  const st2 = (await (await app.request("/api/pairing-review?filter=st2", { headers: { cookie } })).json()) as Telo;
+  expect(st2.items.some((i) => i.productKey === "PR-ST3")).toBe(false);
+});
+
+it("naša URL/obrázok prichádza zo shop_product_url zhody podľa kódu variantu, inak padá na vyhľadávací fallback", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedProduct(db, snapshotId, "PR-FEED", { name: "Produkt s feedom", variants: [{ code: "PR-FEED/1" }] });
+  await db.insert(shopProductUrl).values({ code: "PR-FEED/1", url: "https://www.forestshop.sk/produkt-s-feedom", imageUrl: "https://www.forestshop.sk/img/x.jpg", fetchedAt: new Date() });
+  await seedCandidateSet(db, "PR-FEED");
+
+  await seedProduct(db, snapshotId, "PR-NOFEED", { name: "Produkt Bez Feedu", variants: [{ code: "PR-NOFEED/1" }] });
+  await seedCandidateSet(db, "PR-NOFEED");
+
+  const telo = (await (await app.request("/api/pairing-review?filter=all", { headers: { cookie } })).json()) as Telo;
+  const withFeed = telo.items.find((i) => i.productKey === "PR-FEED");
+  expect(withFeed?.ourUrl).toBe("https://www.forestshop.sk/produkt-s-feedom");
+  expect(withFeed?.ourImageUrl).toBe("https://www.forestshop.sk/img/x.jpg");
+
+  const withoutFeed = telo.items.find((i) => i.productKey === "PR-NOFEED");
+  expect(withoutFeed?.ourUrl).toBe("https://www.forestshop.sk/vyhladavanie/?string=" + encodeURIComponent("Produkt Bez Feedu"));
+  expect(withoutFeed?.ourImageUrl).toBeNull();
+});
+
+// Unmatched-last (design komentár, zadanie E5 bod 3) — napárované PRED
+// nenapárovanými, sekundárne meno (sk locale).
+it("triedenie: napárované PRED nenapárovanými (unmatched-last), sekundárne podľa mena", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedProduct(db, snapshotId, "PR-RAD-Z", { name: "Z produkt nenapárovaný" });
+  await seedCandidateSet(db, "PR-RAD-Z", { confidence: "none" });
+  await seedProduct(db, snapshotId, "PR-RAD-B", { name: "B produkt napárovaný" });
+  await seedCandidateSet(db, "PR-RAD-B", { chosenUrl: "https://dodavatel.example.com/b", candidates: [{ url: "https://dodavatel.example.com/b", name: "B", rawScore: "80.0000", codeHit: false }] });
+  await seedProduct(db, snapshotId, "PR-RAD-A", { name: "A produkt napárovaný" });
+  await seedCandidateSet(db, "PR-RAD-A", { chosenUrl: "https://dodavatel.example.com/a", candidates: [{ url: "https://dodavatel.example.com/a", name: "A", rawScore: "80.0000", codeHit: false }] });
+
+  const telo = (await (await app.request("/api/pairing-review?filter=all&pageSize=10", { headers: { cookie } })).json()) as Telo;
+  const order = telo.items.map((i) => i.productKey).filter((k) => k.startsWith("PR-RAD-"));
+  expect(order).toEqual(["PR-RAD-A", "PR-RAD-B", "PR-RAD-Z"]);
+});
+
+// issue 331's precedens: `total`/`gatheredTotal`/`linkedTotal` sa počítajú
+// nad CELOU (odfiltrovanou/celkovou) množinou nezávisle od `pageSize` —
+// badge v menu na tomto stojí.
+it("total/gatheredTotal/linkedTotal sa počítajú nezávisle od pageSize", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedProduct(db, snapshotId, "PR-BADGE-1", { name: "Bez linky Prvý" });
+  await seedCandidateSet(db, "PR-BADGE-1", { confidence: "none" });
+  await seedProduct(db, snapshotId, "PR-BADGE-2", { name: "Bez linky Druhý" });
+  await seedCandidateSet(db, "PR-BADGE-2", { confidence: "none" });
+
+  const telo = (await (await app.request("/api/pairing-review?filter=unreviewed&page=1&pageSize=1", { headers: { cookie } })).json()) as Telo;
+  expect(telo.total).toBe(2);
+  expect(telo.items).toHaveLength(1);
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -11,6 +11,7 @@ import { fetchOrderFlagCounts } from "./orderFlagsApi.js";
 import { OrderFlagsBadgeRefreshContext } from "./orderFlagsBadgeContext.js";
 import { fetchOrderReminderStatus } from "./orderReminderApi.js";
 import { OrdersRemainingCountContext } from "./ordersRemainingCountContext.js";
+import { fetchPairingReviewUnreviewedCount } from "./pairingReviewApi.js";
 import { fetchPostaUncollectedStatus } from "./postaUncollectedApi.js";
 import { fetchRestockLinksMissingCount } from "./restockLinksApi.js";
 import { RestockLinksBadgeRefreshContext } from "./restockLinksBadgeContext.js";
@@ -108,6 +109,29 @@ export function App(): JSX.Element {
     };
   }, [me, activeTabId, restockLinksRefreshNonce]);
 
+  // issue 387 E5: odznak "Párovanie" — rovnaký PRIAMY vzor ako
+  // `restockLinksMissingCount` vyššie (musí byť známy hneď po prihlásení,
+  // viditeľný AJ pri nule — issue 331's poučenie o VIDITEĽNOSTI). "unreviewed"
+  // (design komentár na tickete) = koľko produktov z gather populácie ešte
+  // NEMÁ efektívnu dodávateľskú linku — E5 nemá ŽIADNU mutáciu, ktorá by toto
+  // číslo menila (rozhodnutia prídu v E6), preto ŽIADEN refresh-nonce/context
+  // navyše — len fetch pri prihlásení/zmene záložky, presne ako `automationStatus`.
+  const [pairingReviewUnreviewedCount, setPairingReviewUnreviewedCount] = useState<number | null>(null);
+  useEffect(() => {
+    if (me === null) return;
+    let cancelled = false;
+    fetchPairingReviewUnreviewedCount()
+      .then((count) => {
+        if (!cancelled) setPairingReviewUnreviewedCount(count);
+      })
+      .catch(() => {
+        // Sieťový výpadok — odznak zostane na poslednej známej hodnote.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [me, activeTabId]);
+
   // issue 290: odznaky "Výmena tovaru"/"Vrátený tovar"/"Reklamácie" — rovnaký
   // priamy vzor ako `upozorneniaCount` vyššie (JEDEN endpoint, `App.tsx` si
   // ho volá sám, počty musia byť známe hneď po prihlásení). Na rozdiel od
@@ -150,6 +174,8 @@ export function App(): JSX.Element {
     // presne to majiteľovi chýbalo, keď číslo poznal len z ručného SQL
     // dopytu).
     if (restockLinksMissingCount !== null) counts["restock-links"] = restockLinksMissingCount;
+    // issue 387 E5: rovnaký princíp ako "restock-links" vyššie — vidno AJ pri nule.
+    if (pairingReviewUnreviewedCount !== null) counts["pairing-review"] = pairingReviewUnreviewedCount;
     // issue 290: na rozdiel od "orders"/"upozornenia" vyššie (odznak sa
     // ukazuje AJ pri nule — appka tým hovorí "toto číslo poznám, je 0")
     // tieto tri odznaky sa VÔBEC nezobrazujú pri nule (ticket: "shown only
@@ -166,7 +192,7 @@ export function App(): JSX.Element {
     // istý tvar bugu ako `UpozorneniaSection.tsx`'s `withBusy`), takže lint
     // to nezachytí a stará hodnota (chýbajúce odznaky hneď po prihlásení,
     // kým sa nespustí NEJAKÝ INÝ trigger) prežije bez varovania.
-  }, [ordersRemainingCount, upozorneniaCount, restockLinksMissingCount, orderFlagCounts]);
+  }, [ordersRemainingCount, upozorneniaCount, restockLinksMissingCount, pairingReviewUnreviewedCount, orderFlagCounts]);
 
   // issue 185: stav zapnuté/vypnuté pre "Automatizácie" priečinok v menu.
   // Na rozdiel od `ordersRemainingCount` vyššie (publikované OBRAZOVKOU

--- a/apps/web/src/components/PairingReviewCard.tsx
+++ b/apps/web/src/components/PairingReviewCard.tsx
@@ -1,0 +1,105 @@
+import type { JSX } from "react";
+import type { PairingReviewItem } from "../pairingReviewApi.js";
+
+// issue 387 E5: karta jedného produktu, vyčlenená VOPRED z `PairingReviewSection.tsx`
+// (rovnaký princíp ako `OrderLineRow.tsx`/`UpozornenieCard.tsx` — dvojstĺpcová
+// karta má dosť JSX na prekročenie eslint `max-lines: 400` v jednom súbore,
+// `.claude/rules/frontend-design.md`). ČISTO zobrazovacia — E5 je LEN
+// čítanie, žiadne callbacky/akcie (tie prídu v E6).
+
+const STATE_LABELS: Readonly<Record<PairingReviewItem["productState"], string>> = {
+  sellable: "🟢 Skladom",
+  out_of_stock: "📦 Nie je skladom",
+  discontinued: "🚫 Už sa nebude predávať",
+};
+
+const CONFIDENCE_LABELS: Readonly<Record<PairingReviewItem["confidence"], string>> = {
+  high: "vysoká istota",
+  medium: "stredná istota",
+  low: "nízka istota",
+  none: "žiadna",
+};
+
+const VERDICT_LABELS: Readonly<Record<NonNullable<PairingReviewItem["verdict"]>, string>> = {
+  ok: "✓ kód overený na stránke",
+  unsure: "kód sa na stránke nenašiel",
+};
+
+function formatPriceRange(item: PairingReviewItem): string | null {
+  if (item.priceMin === null || item.priceMax === null) return null;
+  const currencySuffix = item.currency !== null && item.currency !== "" && item.currency !== "EUR" ? ` ${item.currency}` : " €";
+  if (item.priceMin === item.priceMax) return `${item.priceMin}${currencySuffix}`;
+  return `${item.priceMin}–${item.priceMax}${currencySuffix}`;
+}
+
+export function PairingReviewCard({ item }: { readonly item: PairingReviewItem }): JSX.Element {
+  const priceRange = formatPriceRange(item);
+  const codes = item.externalCodes.length > 0 ? item.externalCodes.join(", ") : "—";
+
+  return (
+    <div className="card pairing-review-card" data-testid={`pairing-review-card-${item.productKey}`}>
+      <div className="pairing-review-grid">
+        <div className="pairing-review-side">
+          <div className="pairing-review-label">Náš produkt</div>
+          <a
+            className="pairing-review-name"
+            href={item.ourUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            data-testid={`pairing-review-our-link-${item.productKey}`}
+          >
+            {item.productName}
+          </a>
+          <div className="pairing-review-meta">
+            {item.supplier ?? "(bez dodávateľa)"} · kódy: {codes} · {String(item.variantCount)} variant(ov)
+          </div>
+          <span
+            className={"pairing-review-state-badge pairing-review-state-" + item.productState}
+            data-testid={`pairing-review-state-${item.productKey}`}
+          >
+            {STATE_LABELS[item.productState]}
+          </span>
+          {priceRange !== null && <div className="pairing-review-price">💶 {priceRange}</div>}
+          <div className="pairing-review-imgbox">
+            {item.ourImageUrl !== null ? (
+              <img src={item.ourImageUrl} alt={item.productName} loading="lazy" />
+            ) : (
+              <span className="pairing-review-noimg">bez obrázka</span>
+            )}
+          </div>
+        </div>
+
+        <div className="pairing-review-side">
+          <div className="pairing-review-label">Navrhnutý kandidát</div>
+          {item.chosenCandidate === null ? (
+            <p className="pairing-review-nocandidate" data-testid={`pairing-review-no-candidate-${item.productKey}`}>
+              Nenašiel sa žiadny kandidát u dodávateľa.
+            </p>
+          ) : (
+            <div data-testid={`pairing-review-candidate-${item.productKey}`}>
+              <a
+                className="pairing-review-name"
+                href={item.chosenCandidate.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                data-testid={`pairing-review-candidate-link-${item.productKey}`}
+              >
+                {item.chosenCandidate.name}
+              </a>
+              <div className="pairing-review-meta">
+                skóre {item.chosenCandidate.rawScore.toFixed(1)} · {CONFIDENCE_LABELS[item.confidence]}
+                {item.chosenCandidate.codeHit && " · kód sedí"}
+              </div>
+              {item.verdict !== null && (
+                <div className={"pairing-review-verdict pairing-review-verdict-" + item.verdict} data-testid={`pairing-review-verdict-${item.productKey}`}>
+                  {VERDICT_LABELS[item.verdict]}
+                </div>
+              )}
+            </div>
+          )}
+          <p className="pairing-review-placeholder">Rozhodovanie príde v ďalšej etape.</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/PairingReviewSection.test.tsx
+++ b/apps/web/src/components/PairingReviewSection.test.tsx
@@ -1,0 +1,140 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { PairingReviewSection } from "./PairingReviewSection.js";
+
+const { searchPairingReview } = vi.hoisted(() => ({ searchPairingReview: vi.fn() }));
+
+// `PairingReviewUnauthorizedError` ostáva SKUTOČNÁ trieda (rovnaký dôvod ako
+// `RestockLinkSuggestionsSection.test.tsx`/`NedostupneSection.test.tsx` —
+// `instanceof` v komponente musí fungovať aj v teste).
+vi.mock("../pairingReviewApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../pairingReviewApi.js")>();
+  return { ...actual, searchPairingReview };
+});
+
+const { PairingReviewUnauthorizedError } = await import("../pairingReviewApi.js");
+
+const MATCHED_ITEM = {
+  productKey: "PR-1",
+  productName: "Bunda Alfa Zimná",
+  supplier: "DODAVATEL-PR",
+  externalCodes: ["KOD-123"],
+  variantCount: 2,
+  productState: "sellable" as const,
+  priceMin: "59.90",
+  priceMax: "64.90",
+  currency: "EUR",
+  ourUrl: "https://www.forestshop.sk/bunda-alfa",
+  ourImageUrl: "https://www.forestshop.sk/img/bunda.jpg",
+  hasEffectiveLink: false,
+  gatheredAt: "2026-08-13T03:35:00.000Z",
+  confidence: "high" as const,
+  chosenReason: "najlepší nájdený",
+  verdict: "ok" as const,
+  chosenCandidate: { name: "Bunda Alfa", url: "https://dodavatel.example.com/bunda-alfa", rawScore: 1080.5, codeHit: true },
+};
+
+const UNMATCHED_ITEM = {
+  productKey: "PR-2",
+  productName: "Produkt bez kandidáta",
+  supplier: null,
+  externalCodes: [],
+  variantCount: 1,
+  productState: "out_of_stock" as const,
+  priceMin: null,
+  priceMax: null,
+  currency: null,
+  ourUrl: "https://www.forestshop.sk/vyhladavanie/?string=Produkt%20bez%20kandid%C3%A1ta",
+  ourImageUrl: null,
+  hasEffectiveLink: false,
+  gatheredAt: "2026-08-13T03:35:00.000Z",
+  confidence: "none" as const,
+  chosenReason: null,
+  verdict: null,
+  chosenCandidate: null,
+};
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+  window.localStorage.clear();
+});
+
+it("zobrazí karty pre napárovaný aj nenapárovaný produkt s progress počítadlom", async () => {
+  searchPairingReview.mockResolvedValue({ total: 2, gatheredTotal: 5, linkedTotal: 3, items: [MATCHED_ITEM, UNMATCHED_ITEM] });
+
+  render(<PairingReviewSection onSessionExpired={() => {}} />);
+
+  const matchedCard = await screen.findByTestId("pairing-review-card-PR-1");
+  expect(matchedCard.textContent).toContain("Bunda Alfa Zimná");
+  expect(matchedCard.textContent).toContain("Bunda Alfa");
+  expect(screen.getByTestId("pairing-review-verdict-PR-1").textContent).toContain("overený");
+
+  const unmatchedCard = screen.getByTestId("pairing-review-card-PR-2");
+  expect(unmatchedCard.textContent).toContain("Produkt bez kandidáta");
+  expect(screen.getByTestId("pairing-review-no-candidate-PR-2")).toBeDefined();
+
+  expect(screen.getByTestId("pairing-review-progress").textContent).toContain("3 / 5 s odkazom");
+});
+
+it("keď zoznam nezodpovedá žiadnemu produktu, zobrazí informačnú vetu", async () => {
+  searchPairingReview.mockResolvedValue({ total: 0, gatheredTotal: 0, linkedTotal: 0, items: [] });
+
+  render(<PairingReviewSection onSessionExpired={() => {}} />);
+
+  await screen.findByTestId("pairing-review-empty");
+});
+
+it("pri 401 zavolá onSessionExpired namiesto zobrazenia všeobecnej chyby", async () => {
+  searchPairingReview.mockRejectedValue(new PairingReviewUnauthorizedError());
+  const onSessionExpired = vi.fn();
+
+  render(<PairingReviewSection onSessionExpired={onSessionExpired} />);
+
+  await waitFor(() => {
+    expect(onSessionExpired).toHaveBeenCalledTimes(1);
+  });
+});
+
+// Default filter je "unreviewed" (design komentár na tickete, issue 387 E5) —
+// prvé volanie po mounte MUSÍ toto poslať, aj bez akéhokoľvek predošlého
+// localStorage záznamu.
+it("predvolený filter pri prvom otvorení je 'unreviewed'", async () => {
+  searchPairingReview.mockResolvedValue({ total: 0, gatheredTotal: 0, linkedTotal: 0, items: [] });
+
+  render(<PairingReviewSection onSessionExpired={() => {}} />);
+
+  await waitFor(() => {
+    expect(searchPairingReview).toHaveBeenCalledWith({ filter: "unreviewed", page: 1 });
+  });
+});
+
+it("klik na iný filter znova načíta zoznam s novým filtrom a zapamätá si ho do localStorage", async () => {
+  searchPairingReview.mockResolvedValue({ total: 0, gatheredTotal: 0, linkedTotal: 0, items: [] });
+
+  render(<PairingReviewSection onSessionExpired={() => {}} />);
+  await screen.findByTestId("pairing-review-empty");
+
+  searchPairingReview.mockClear();
+  searchPairingReview.mockResolvedValue({ total: 1, gatheredTotal: 4, linkedTotal: 4, items: [MATCHED_ITEM] });
+
+  screen.getByTestId("pairing-review-filter-matched").click();
+
+  await waitFor(() => {
+    expect(searchPairingReview).toHaveBeenCalledWith({ filter: "matched", page: 1 });
+  });
+  expect(window.localStorage.getItem("pairingReviewFilter")).toBe("matched");
+});
+
+// Substring kolízia s "Párovanie produktov" (#239) — pozri design komentár
+// na tickete: `getByRole` musí byť `exact: true`, inak by zasiahol OBE
+// záložky. Tento test dokazuje, že karta samotná (nie navigácia) NEPOUŽÍVA
+// zdieľaný nejednoznačný accessible name.
+it("hlavička karty 'Náš produkt' je odlíšená od 'Navrhnutý kandidát' — bez vlastného <h1>/<h2> obrazovky", async () => {
+  searchPairingReview.mockResolvedValue({ total: 1, gatheredTotal: 1, linkedTotal: 0, items: [MATCHED_ITEM] });
+
+  render(<PairingReviewSection onSessionExpired={() => {}} />);
+  await screen.findByTestId("pairing-review-card-PR-1");
+
+  expect(screen.queryByRole("heading")).toBeNull();
+});

--- a/apps/web/src/components/PairingReviewSection.tsx
+++ b/apps/web/src/components/PairingReviewSection.tsx
@@ -193,7 +193,7 @@ export function PairingReviewSection({ onSessionExpired }: { readonly onSessionE
           <button
             key={f}
             type="button"
-            className={"chip" + (f === filter ? " active" : " chip-all")}
+            className={"chip" + (f === filter ? " active" : " chip-neutral")}
             data-testid={`pairing-review-filter-${f}`}
             onClick={() => {
               changeFilter(f);

--- a/apps/web/src/components/PairingReviewSection.tsx
+++ b/apps/web/src/components/PairingReviewSection.tsx
@@ -1,0 +1,236 @@
+import { useCallback, useEffect, useRef, useState, type JSX } from "react";
+import {
+  PAGE_SIZE,
+  PAIRING_REVIEW_FILTERS,
+  PairingReviewUnauthorizedError,
+  searchPairingReview,
+  type PairingReviewFilter,
+  type PairingReviewItem,
+} from "../pairingReviewApi.js";
+import { useLoadMore } from "../useLoadMore.js";
+import { PairingReviewCard } from "./PairingReviewCard.js";
+
+// issue 387 E5: "Eshop → Párovanie" — čítacia obrazovka (karty + filtre) nad
+// tým, čo E3 (gather)/E4 (verify) zozbierali. LEN čítanie, žiadne akcie
+// (rozhodnutia prídu v E6). Design komentár na tickete (issue 387 E5):
+// "unreviewed" (default filter, aj badge v `App.tsx`) = "produkt z gather
+// populácie BEZ efektívnej dodávateľskej linky" — pairing_decision (E6) tu
+// ešte neexistuje.
+//
+// Konvencie appky (`.claude/rules/frontend-design.md`): `useLoadMore` pre
+// stránkovanie, "latest ref" vzor pre `.then()`, `mountedRef` StrictMode-
+// bezpečný vzor (issue 251 — `mountedRef.current = true` nastavené AJ v tele
+// efektu, nielen v `useRef` počiatočnej hodnote). Viditeľná záložka v `NAV`
+// (`nav.ts`) — ŽIADEN vlastný `<h1>`/`<h2>`, `App.tsx`/`Topbar` ho vykreslí sám.
+
+const FILTER_LABELS: Readonly<Record<PairingReviewFilter, string>> = {
+  unreviewed: "Nezrevidované",
+  matched: "Napárované (AI)",
+  unmatched: "Nenapárované",
+  st1: "🟢 Skladom",
+  st2: "📦 Nie skladom",
+  st3: "🚫 Nepredáva sa",
+  all: "Všetky",
+};
+
+const FILTER_STORAGE_KEY = "pairingReviewFilter";
+const SCROLL_STORAGE_KEY = "pairingReviewScrollY";
+
+function readStoredFilter(): PairingReviewFilter {
+  try {
+    const stored = window.localStorage.getItem(FILTER_STORAGE_KEY);
+    if (stored !== null && (PAIRING_REVIEW_FILTERS as readonly string[]).includes(stored)) return stored as PairingReviewFilter;
+  } catch {
+    // Prehliadač s vypnutým úložiskom — padni na predvolený filter.
+  }
+  return "unreviewed";
+}
+
+// issue 342 vzor (`DailyTasksSection.tsx`): obrazovka nemá žiadne rolové
+// rozlíšenie (E5 je čisto čítanie, bez akcií) — užší typ props než zdieľané
+// `SectionProps` je platný podtyp `ComponentType<SectionProps>` (nav.ts),
+// keďže `App.tsx` odovzdáva SKUTOČNÝ objekt, nie literál (žiadna "excess
+// property" kontrola).
+export function PairingReviewSection({ onSessionExpired }: { readonly onSessionExpired: () => void }): JSX.Element {
+  const [filter, setFilter] = useState<PairingReviewFilter>(readStoredFilter);
+  const [items, setItems] = useState<readonly PairingReviewItem[]>([]);
+  const [total, setTotal] = useState(0);
+  const [gatheredTotal, setGatheredTotal] = useState(0);
+  const [linkedTotal, setLinkedTotal] = useState(0);
+  const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState("");
+
+  const searchSeq = useRef(0);
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const loadMoreState = useLoadMore<PairingReviewItem>({
+    mountedRef,
+    onAppend: (newItems, newTotal) => {
+      setItems((prev) => [...prev, ...newItems]);
+      setTotal(newTotal);
+    },
+    onError: () => {
+      setError("Načítanie ďalších položiek zlyhalo.");
+    },
+  });
+
+  // issue 337 vzor (`RestockLinkSuggestionsSection.tsx`/`CatalogPage.tsx`):
+  // "Načítať ďalšie" musí siahnuť po ĎALŠEJ strane TOHO filtra, čo vyprodukoval
+  // AKTUÁLNE zobrazené `items`, nie live hodnotu `filter` (tá sa môže medzitým
+  // rozísť, keby užívateľ prepol filter tesne pred kliknutím).
+  const loadedFilterRef = useRef(filter);
+
+  const load = useCallback((f: PairingReviewFilter) => {
+    const seq = (searchSeq.current += 1);
+    setError("");
+    loadedFilterRef.current = f;
+    loadMoreState.reset();
+    searchPairingReview({ filter: f, page: 1 })
+      .then((result) => {
+        if (!mountedRef.current || seq !== searchSeq.current) return;
+        setItems(result.items);
+        setTotal(result.total);
+        setGatheredTotal(result.gatheredTotal);
+        setLinkedTotal(result.linkedTotal);
+        setLoaded(true);
+      })
+      .catch((err: unknown) => {
+        if (!mountedRef.current || seq !== searchSeq.current) return;
+        setLoaded(true);
+        if (err instanceof PairingReviewUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setItems([]);
+        setTotal(0);
+        setError("Zoznam sa nepodarilo načítať.");
+      });
+    // `onSessionExpired` je stabilná funkcia z `App.tsx` — zámerne mimo
+    // závislostí, presne ako sesterské obrazovky (tento repo nemá
+    // `eslint-plugin-react-hooks`, `.claude/rules/frontend-design.md`, takže
+    // tu nejde o obídenie lintu — len rovnaký, dnes bežný vzor v appke).
+  }, []);
+
+  useEffect(() => {
+    load(filter);
+    // Filter sa mení LEN explicitným klikom nižšie (ktorý sám volá `load`) —
+    // tento efekt beží iba raz pri mounte, presne ako sesterské obrazovky.
+  }, []);
+
+  const changeFilter = useCallback(
+    (next: PairingReviewFilter) => {
+      setFilter(next);
+      try {
+        window.localStorage.setItem(FILTER_STORAGE_KEY, next);
+      } catch {
+        // Úložisko vypnuté — appka funguje ďalej, len bez zapamätania.
+      }
+      window.scrollTo(0, 0);
+      load(next);
+    },
+    [load],
+  );
+
+  // Zapamätanie scrollu (rovnaký princíp ako stará appka — `webreview/app.js`).
+  const scrollTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  useEffect(() => {
+    function onScroll(): void {
+      if (scrollTimer.current !== undefined) clearTimeout(scrollTimer.current);
+      scrollTimer.current = setTimeout(() => {
+        try {
+          window.localStorage.setItem(SCROLL_STORAGE_KEY, String(window.scrollY));
+        } catch {
+          // Úložisko vypnuté — bez zapamätania scrollu appka stále funguje.
+        }
+      }, 150);
+    }
+    window.addEventListener("scroll", onScroll);
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      if (scrollTimer.current !== undefined) clearTimeout(scrollTimer.current);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!loaded) return;
+    try {
+      const y = Number.parseInt(window.localStorage.getItem(SCROLL_STORAGE_KEY) ?? "0", 10);
+      if (y > 0) window.scrollTo(0, y);
+    } catch {
+      // Úložisko vypnuté — bez obnovenia scrollu appka stále funguje.
+    }
+    // Obnoviť scroll len RAZ, hneď po prvom úspešnom načítaní.
+  }, [loaded]);
+
+  const progressPct = gatheredTotal > 0 ? Math.round((100 * linkedTotal) / gatheredTotal) : 0;
+  const showingAll = total === 0 || items.length >= total;
+
+  return (
+    <section data-testid="pairing-review-section">
+      <p>
+        Produkty, ktoré appka už porovnala s ponukou dodávateľov (WETLAND/BETALOV/ODIMON) — vľavo náš produkt, vpravo
+        najlepší nájdený kandidát. Rozhodovanie (potvrdenie odkazu, „Nie je skladom“, „Už sa nebude predávať“) príde v
+        ďalšej etape; táto obrazovka zatiaľ len ukazuje stav.
+      </p>
+
+      <div className="pairing-review-progress" data-testid="pairing-review-progress">
+        <span className="pairing-review-progress-text">
+          {String(linkedTotal)} / {String(gatheredTotal)} s odkazom
+        </span>
+        <div className="pairing-review-progress-bar">
+          <div className="pairing-review-progress-bar-fill" style={{ width: `${String(progressPct)}%` }} />
+        </div>
+      </div>
+
+      <div className="chip-row" data-testid="pairing-review-filters">
+        {PAIRING_REVIEW_FILTERS.map((f) => (
+          <button
+            key={f}
+            type="button"
+            className={"chip" + (f === filter ? " active" : " chip-all")}
+            data-testid={`pairing-review-filter-${f}`}
+            onClick={() => {
+              changeFilter(f);
+            }}
+          >
+            {FILTER_LABELS[f]}
+          </button>
+        ))}
+      </div>
+
+      {error !== "" && <p role="alert">{error}</p>}
+      <p data-testid="pairing-review-total">
+        {showingAll ? `Nájdených: ${String(total)}` : `Nájdených: ${String(total)} (zobrazených prvých ${String(items.length)})`}
+      </p>
+
+      {loaded && total === 0 ? (
+        <p data-testid="pairing-review-empty">Žiadny produkt v tomto filtri.</p>
+      ) : (
+        <div className="pairing-review-list">
+          {items.map((item) => (
+            <PairingReviewCard key={item.productKey} item={item} />
+          ))}
+        </div>
+      )}
+
+      {items.length < total && (
+        <button
+          type="button"
+          data-testid="load-more"
+          disabled={loadMoreState.loadingMore}
+          onClick={() => {
+            loadMoreState.loadMore((page) => searchPairingReview({ filter: loadedFilterRef.current, page }));
+          }}
+        >
+          {loadMoreState.loadingMore ? "Načítavam…" : `Načítať ďalšie (${String(Math.min(PAGE_SIZE, total - items.length))})`}
+        </button>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -200,6 +200,17 @@ export function Sidebar({
                         key={tab.id}
                         type="button"
                         className={"tab" + (tab.id === activeTabId ? " active" : "")}
+                        // issue 387 E5 (review nález): odznak-nesúci tlačidlo
+                        // spája SVOJU accessible-name značku s odznakovým
+                        // `aria-label`om (napr. "Párovanie" + "Párovanie: 2" →
+                        // "Párovanie Párovanie: 2") — keď má tab ZÁROVEŇ
+                        // meno, čo je PREFIXOM iného existujúceho tabu (napr.
+                        // "Párovanie" / "Párovanie produktov"), ani `exact:
+                        // true` (rozbije sa o odznakový suffix), ani obyčajný
+                        // substring (nájde OBOCH) nevie tlačidlo jednoznačne
+                        // vybrať. `data-testid` obchádza celý accessible-name
+                        // problém.
+                        data-testid={`nav-tab-${tab.id}`}
                         aria-current={tab.id === activeTabId ? "page" : undefined}
                         aria-label={rail ? railLabel : undefined}
                         title={rail ? railLabel : undefined}

--- a/apps/web/src/nav.test.ts
+++ b/apps/web/src/nav.test.ts
@@ -27,12 +27,14 @@ import { DEFAULT_TAB_ID, HIDDEN_TABS, NAV, findTab, isVisibleTabId } from "./nav
 // "Upozornenia" doňho a pridalo novú záložku "Úlohy na dnes".
 // Issue 345 pridalo "Objednávky predajňa" hneď za "Na objednanie" (obe sú
 // "zoznam objednávok" obrazovky).
+// Issue 387 E5 pridalo "Párovanie" hneď za "Párovanie produktov" (#239) —
+// najbližší príbuzný obsah, obe zatiaľ bežia vedľa seba.
 // Tento test je najbližšie k tomu, čo strojovo overiť dá (registrácia, nie DOM).
-it("NAV má štyri priečinky (Dôležité/Eshop/Systém/Automatizácie), s 2/10/3/5 záložkami v poradí podľa dôležitosti", () => {
+it("NAV má štyri priečinky (Dôležité/Eshop/Systém/Automatizácie), s 2/11/3/5 záložkami v poradí podľa dôležitosti", () => {
   expect(NAV).toHaveLength(4);
   expect(NAV.map((f) => f.label)).toEqual(["Dôležité", "Eshop", "Systém", "Automatizácie"]);
   expect(NAV[0]?.tabs).toHaveLength(2);
-  expect(NAV[1]?.tabs).toHaveLength(10);
+  expect(NAV[1]?.tabs).toHaveLength(11);
   expect(NAV[2]?.tabs).toHaveLength(3);
   expect(NAV[3]?.tabs).toHaveLength(5);
   expect(NAV[0]?.tabs.map((t) => t.label)).toEqual(["Upozornenia", "Úlohy na dnes"]);
@@ -44,6 +46,7 @@ it("NAV má štyri priečinky (Dôležité/Eshop/Systém/Automatizácie), s 2/10
     "Vrátený tovar",
     "Reklamácie",
     "Párovanie produktov",
+    "Párovanie",
     "Vyhľadať",
     "Zlúčenie objednávok",
     "Preprava DPD",
@@ -104,6 +107,7 @@ it("findTab nájde viditeľnú aj skrytú záložku podľa id, neznáme id vrát
   expect(findTab("returned")?.label).toBe("Vrátený tovar");
   expect(findTab("claims")?.label).toBe("Reklamácie");
   expect(findTab("restock-links")?.label).toBe("Vypredané → Skladom: návrhy odkazov");
+  expect(findTab("pairing-review")?.label).toBe("Párovanie");
   expect(findTab("upozornenia")?.label).toBe("Upozornenia");
   expect(findTab("ulohy")?.label).toBe("Úlohy na dnes");
   expect(findTab("neexistuje")).toBeUndefined();
@@ -124,6 +128,8 @@ it("isVisibleTabId rozlíši viditeľné (NAV) od skrytých (HIDDEN_TABS)", () =
   expect(isVisibleTabId("claims")).toBe(true);
   // issue 311: nová viditeľná záložka "Vypredané → Skladom: návrhy odkazov".
   expect(isVisibleTabId("restock-links")).toBe(true);
+  // issue 387 E5: nová viditeľná záložka "Párovanie".
+  expect(isVisibleTabId("pairing-review")).toBe(true);
   // issue 342: nová viditeľná záložka "Úlohy na dnes" (v priečinku "Dôležité").
   expect(isVisibleTabId("ulohy")).toBe(true);
   for (const hiddenId of Object.keys(HIDDEN_TABS)) {

--- a/apps/web/src/nav.ts
+++ b/apps/web/src/nav.ts
@@ -12,6 +12,7 @@ import { NedostupneSection } from "./components/NedostupneSection.js";
 import { OrderMergeSection } from "./components/OrderMergeSection.js";
 import { OrderReminderSection } from "./components/OrderReminderSection.js";
 import { OrdersSection } from "./components/OrdersSection.js";
+import { PairingReviewSection } from "./components/PairingReviewSection.js";
 import { PairingSection } from "./components/PairingSection.js";
 import { PostaUncollectedSection } from "./components/PostaUncollectedSection.js";
 import { RestockLinkSuggestionsSection } from "./components/RestockLinkSuggestionsSection.js";
@@ -130,6 +131,14 @@ export const NAV: readonly NavFolder[] = [
       // sem (nie do Automatizácie), je to obrazovka, na ktorej obsluha
       // pracuje, presne ako "Na objednanie"/"Nedostupné tovary".
       { id: "supplier-links", label: "Párovanie produktov", icon: "🔗", Component: SupplierLinksSection, wide: true },
+      // issue 387 E5: "profesionálne párovanie" — port starej appky
+      // (`webreview`), karty (náš produkt vs. dodávateľov navrhnutý kandidát)
+      // nad tým, čo E3 (gather)/E4 (verify) zozbierali. Patrí HNEĎ ZA
+      // "Párovanie produktov" (#239) — najbližší príbuzný obsah, obe zatiaľ
+      // BEŽIA VEDĽA SEBA (design komentár na tickete: prípadné vyradenie
+      // #239/F4 je E9, len po výslovnom súhlase majiteľa). Rozhodnutia (E6)
+      // tu ešte nie sú — obrazovka je LEN čítanie.
+      { id: "pairing-review", label: "Párovanie", icon: "🧩", Component: PairingReviewSection, wide: true },
       // issue 240: "rýchla ruka" na JEDEN konkrétny kus tovaru/objednávku —
       // nájsť + rovno opraviť dodávateľskú linku. Patrí sem z rovnakého
       // dôvodu ako "Párovanie produktov" vyššie (obsluha na nej pracuje,

--- a/apps/web/src/pairingReviewApi.ts
+++ b/apps/web/src/pairingReviewApi.ts
@@ -1,0 +1,94 @@
+import { z } from "zod";
+
+// issue 387 E5: "Eshop → Párovanie" — zrkadlí `GET /api/pairing-review`
+// (`apps/api/src/http/pairing-review-routes.ts`). LEN čítanie — rozhodnutia
+// (E6) tu ešte neexistujú, žiadna zapisovacia funkcia v tomto súbore.
+
+export const PAIRING_REVIEW_FILTERS = ["unreviewed", "matched", "unmatched", "st1", "st2", "st3", "all"] as const;
+export type PairingReviewFilter = (typeof PAIRING_REVIEW_FILTERS)[number];
+
+const chosenCandidateSchema = z.object({
+  name: z.string(),
+  url: z.string(),
+  rawScore: z.number(),
+  codeHit: z.boolean(),
+});
+
+const itemSchema = z.object({
+  productKey: z.string(),
+  productName: z.string(),
+  supplier: z.string().nullable(),
+  externalCodes: z.array(z.string()),
+  variantCount: z.number(),
+  productState: z.enum(["sellable", "out_of_stock", "discontinued"]),
+  priceMin: z.string().nullable(),
+  priceMax: z.string().nullable(),
+  currency: z.string().nullable(),
+  ourUrl: z.string(),
+  ourImageUrl: z.string().nullable(),
+  hasEffectiveLink: z.boolean(),
+  gatheredAt: z.string(),
+  confidence: z.enum(["high", "medium", "low", "none"]),
+  chosenReason: z.string().nullable(),
+  verdict: z.enum(["ok", "unsure"]).nullable(),
+  chosenCandidate: chosenCandidateSchema.nullable(),
+});
+export type PairingReviewItem = z.infer<typeof itemSchema>;
+
+const searchSchema = z.object({
+  total: z.number(),
+  gatheredTotal: z.number(),
+  linkedTotal: z.number(),
+  items: z.array(itemSchema),
+});
+export type PairingReviewSearchResult = z.infer<typeof searchSchema>;
+
+export const PAGE_SIZE = 50;
+
+/** Relácia medzitým vypršala (401) — rovnaký vzor ako ostatné čítacie API klienty. */
+export class PairingReviewUnauthorizedError extends Error {
+  constructor() {
+    super("Neprihlásený");
+  }
+}
+
+const errorBodySchema = z.object({ error: z.string() });
+
+async function serverErrorMessage(response: Response, fallback: string): Promise<string> {
+  try {
+    const parsed = errorBodySchema.safeParse(await response.json());
+    if (parsed.success) return parsed.data.error;
+  } catch {
+    // Telo nie je platný JSON (alebo chýba) — použi všeobecnú hlášku.
+  }
+  return fallback;
+}
+
+async function readJson(response: Response, fallback: string): Promise<unknown> {
+  if (response.status === 401) throw new PairingReviewUnauthorizedError();
+  if (!response.ok) throw new Error(await serverErrorMessage(response, fallback));
+  return await response.json();
+}
+
+export async function searchPairingReview(input: { readonly filter: PairingReviewFilter; readonly page: number }): Promise<PairingReviewSearchResult> {
+  const query = new URLSearchParams({ filter: input.filter, page: String(input.page), pageSize: String(PAGE_SIZE) });
+  const response = await fetch(`/api/pairing-review?${query.toString()}`);
+  return searchSchema.parse(await readJson(response, "Zoznam párovania sa nepodarilo načítať"));
+}
+
+const countSchema = z.object({ total: z.number() });
+
+// Badge v ľavom menu (`App.tsx`, rovnaký priamy vzor ako `restockLinksMissingCount`,
+// issue 331) — musí byť známy hneď po prihlásení. Znovupoužíva TEN ISTÝ
+// `GET /api/pairing-review` s `filter=unreviewed&pageSize=1` (lacný dopyt,
+// `total` sa v `listPairingReview` počíta nad CELOU odfiltrovanou množinou
+// nezávisle od `pageSize`). Chyba (401/sieť) sa nikdy nehádže — odznak
+// zostane na poslednej známej hodnote.
+export async function fetchPairingReviewUnreviewedCount(): Promise<number> {
+  const query = new URLSearchParams({ filter: "unreviewed", page: "1", pageSize: "1" });
+  const response = await fetch(`/api/pairing-review?${query.toString()}`);
+  if (response.status === 401) return 0;
+  if (!response.ok) return 0;
+  const parsed = countSchema.safeParse(await response.json());
+  return parsed.success ? parsed.data.total : 0;
+}

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2883,3 +2883,150 @@ a.upozornenie-title:hover {
   border-color: var(--fs-danger);
   background: var(--fs-danger-bg);
 }
+
+/* ---------------- 19. ESHOP → PÁROVANIE (issue 387 E5) ---------------- */
+/* Karty (nie tabuľka — dvojstĺpcové porovnanie náš produkt vs. dodávateľ,
+   presne ako stará appka's `webreview` UX, ale VLASTNÝ dizajn nad appkinými
+   tokenmi — `.claude/rules/frontend-design.md`'s "legacy app je referencia
+   len na správanie, nikdy na vzhľad"). */
+.pairing-review-progress {
+  display: flex;
+  align-items: center;
+  gap: var(--fs-space-3);
+  margin: var(--fs-space-3) 0;
+  font-size: var(--fs-text-sm);
+}
+.pairing-review-progress-text {
+  color: var(--fs-ink-muted);
+  white-space: nowrap;
+}
+.pairing-review-progress-bar {
+  flex: 1 1 auto;
+  min-width: 0;
+  height: 8px;
+  background: var(--fs-surface-alt);
+  border-radius: 999px;
+  overflow: hidden;
+}
+.pairing-review-progress-bar-fill {
+  height: 100%;
+  background: var(--fs-brand);
+  border-radius: 999px;
+  transition: width 0.2s;
+}
+
+.pairing-review-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--fs-space-4);
+  margin-top: var(--fs-space-4);
+}
+.pairing-review-card {
+  padding: var(--fs-space-4);
+}
+/* Dva stĺpce (náš produkt / dodávateľov kandidát) — `minmax(0, 1fr)` na
+   OBOCH stranách (nie holé `1fr 1fr`), aby dlhý názov/URL nikdy nevynútil
+   vodorovné pretečenie `.main-wide`u (ten má `overflow-x: hidden` — issue
+   382's poučenie o `min()`/`minmax(0,...)` na `wide: true` obrazovke). Pod
+   36rem (kratšia čítacia šírka než klasické tabuľkové 48rem obrazovky, lebo
+   karta má menej stĺpcov na zúženie) sa stĺpce zalomia pod seba. */
+.pairing-review-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: var(--fs-space-5);
+}
+@media (max-width: 36rem) {
+  .pairing-review-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+.pairing-review-side {
+  min-width: 0;
+}
+.pairing-review-label {
+  font-size: var(--fs-text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--fs-ink-muted);
+  margin-bottom: var(--fs-space-1);
+}
+.pairing-review-name {
+  display: block;
+  font-weight: var(--fs-weight-semibold);
+  font-size: var(--fs-text-md);
+  color: var(--fs-brand-strong);
+  text-decoration: none;
+  overflow-wrap: break-word;
+}
+.pairing-review-name:hover {
+  text-decoration: underline;
+}
+.pairing-review-meta {
+  font-size: var(--fs-text-sm);
+  color: var(--fs-ink-muted);
+  margin: var(--fs-space-1) 0;
+  overflow-wrap: break-word;
+}
+.pairing-review-state-badge {
+  display: inline-block;
+  font-size: var(--fs-text-xs);
+  font-weight: var(--fs-weight-semibold);
+  padding: var(--fs-space-1) var(--fs-space-3);
+  border-radius: 999px;
+  margin: var(--fs-space-1) 0;
+}
+.pairing-review-state-sellable {
+  background: var(--fs-success-bg);
+  color: var(--fs-success);
+}
+.pairing-review-state-out_of_stock {
+  background: var(--fs-warning-bg);
+  color: var(--fs-warning);
+}
+.pairing-review-state-discontinued {
+  background: var(--fs-surface-alt);
+  color: var(--fs-ink-muted);
+}
+.pairing-review-price {
+  font-size: var(--fs-text-sm);
+  font-weight: var(--fs-weight-semibold);
+  color: var(--fs-ink);
+  margin: var(--fs-space-1) 0;
+}
+.pairing-review-imgbox {
+  margin-top: var(--fs-space-2);
+}
+.pairing-review-imgbox img {
+  max-width: 100%;
+  width: 96px;
+  height: 96px;
+  object-fit: contain;
+  background: var(--fs-surface-alt);
+  border: 1px solid var(--fs-border);
+  border-radius: var(--fs-radius-sm);
+}
+.pairing-review-noimg {
+  font-size: var(--fs-text-xs);
+  color: var(--fs-ink-faint);
+}
+.pairing-review-nocandidate {
+  font-size: var(--fs-text-sm);
+  color: var(--fs-ink-muted);
+  margin: var(--fs-space-1) 0;
+}
+.pairing-review-verdict {
+  font-size: var(--fs-text-xs);
+  margin-top: var(--fs-space-1);
+}
+.pairing-review-verdict-ok {
+  color: var(--fs-success);
+}
+.pairing-review-verdict-unsure {
+  color: var(--fs-warning);
+}
+.pairing-review-placeholder {
+  font-size: var(--fs-text-xs);
+  color: var(--fs-ink-faint);
+  font-style: italic;
+  margin-top: var(--fs-space-3);
+}

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -970,6 +970,17 @@ tr:last-child td {
   color: var(--fs-ink);
   border-color: var(--fs-border);
 }
+/* issue 387 E5 (review nález): rovnaký neutrálny vzhľad ako `.chip-all`
+   vyššie, ale VLASTNÝM menom — `.chip-all` je od issue 263 vyhradené pre
+   súhrnný "Všetci" čip BEZ dátového stavu (OrdersToolbar.tsx); filtrovacie
+   čipy na tejto obrazovke (Nezrevidované/Napárované/…/Skladom/…) nie sú
+   "všetci", len bežné neaktívne filtre — zdieľanie `.chip-all`'ovho mena by
+   bolo zavádzajúce pre budúceho čitateľa. */
+.chip.chip-neutral {
+  background: var(--fs-surface-alt);
+  color: var(--fs-ink);
+  border-color: var(--fs-border);
+}
 .chip.done {
   background: var(--chip-done-bg);
   color: var(--chip-done-text);

--- a/apps/web/tests/e2e/catalog.spec.ts
+++ b/apps/web/tests/e2e/catalog.spec.ts
@@ -38,14 +38,17 @@ test("manažér vidí stav katalógu, vyhľadá variant a konzola je čistá", a
   // Skladom: návrhy odkazov" ("E2E-RL-CHYBA"/"E2E-RL-NAVRH"/"E2E-RL-CUDZI",
   // issue 311, `scripts/e2e-fixtures-restock-links.ts`)
   // + 60 seedovaných produktov pre "Načítať ďalšie" (issue 337, "E2E-PAGE-
-  // 001".."E2E-PAGE-060", `scripts/e2e-fixtures-pagination.ts`) = 103.
+  // 001".."E2E-PAGE-060", `scripts/e2e-fixtures-pagination.ts`) + 3 seedované
+  // produkty pre "Eshop → Párovanie" ("E2E-PR-CHYBA"/"E2E-PR-NENAJDENY"/
+  // "E2E-PR-SLINKOU", issue 387 E5, `scripts/e2e-fixtures-pairing-review.ts`)
+  // = 106.
   // Prví dvaja (PREP-1/PREP-2) aj "E2E-RL-CHYBA" sú `out_of_stock` (nemenia
-  // "sellable"/"missing" nižšie), zvyšných 5 aj všetkých 60 "E2E-PAGE-*" sú
-  // `sellable` (posúvajú filter "sellable" 7→72 nižšie), "missing"(1) sa
-  // nemení ani jedným z nich.
+  // "sellable"/"missing" nižšie), zvyšných 5 aj všetkých 60 "E2E-PAGE-*" aj
+  // všetky 3 "E2E-PR-*" sú `sellable` (posúvajú filter "sellable" 7→75
+  // nižšie), "missing"(1) sa nemení ani jedným z nich.
   await expect(page.getByTestId("snapshot")).toContainText("Posledný import: prijatý");
-  await expect(page.getByTestId("counts")).toContainText("Variantov v katalógu (vrátane chýbajúcich): 103");
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 103 (zobrazených prvých 50)");
+  await expect(page.getByTestId("counts")).toContainText("Variantov v katalógu (vrátane chýbajúcich): 106");
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 106 (zobrazených prvých 50)");
 
   await page.getByLabel("Kód alebo názov").fill("40237/3XL");
   await page.getByRole("button", { name: "Hľadať", exact: true }).click();
@@ -65,17 +68,19 @@ test("filter podľa stavu zúži zoznam na predajné varianty", async ({ page })
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 103 (zobrazených prvých 50)");
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 106 (zobrazených prvých 50)");
   await page.getByLabel("Stav", { exact: true }).selectOption("sellable");
   await page.getByRole("button", { name: "Hľadať", exact: true }).click();
 
-  // 72 = 7 od issue 219 (variant "40237/L" má oba texty dostupnosti prázdne,
+  // 75 = 7 od issue 219 (variant "40237/L" má oba texty dostupnosti prázdne,
   // čo znamená predvolenú dostupnosť Shoptetu — "Skladom", nie vypredané) +
   // 2 sellable produkty issue 239's fixtúry ("E2E-PL-CHYBA"/"E2E-PL-OPRAVA")
   // + 1 sellable produkt issue 240's fixtúry ("E2E-SEARCH-1") + 2 sellable
   // produkty issue 311's fixtúry ("E2E-RL-NAVRH"/"E2E-RL-CUDZI") + 60 sellable
-  // produktov issue 337's fixtúry ("E2E-PAGE-001".."E2E-PAGE-060").
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 72 (zobrazených prvých 50)");
+  // produktov issue 337's fixtúry ("E2E-PAGE-001".."E2E-PAGE-060") + 3
+  // sellable produkty issue 387 E5's fixtúry ("E2E-PR-CHYBA"/"E2E-PR-
+  // NENAJDENY"/"E2E-PR-SLINKOU").
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 75 (zobrazených prvých 50)");
   await expect(page.getByTestId("variant-40237/M")).toBeVisible();
 });
 
@@ -87,7 +92,7 @@ test("filter 'Chýbajúce' nájde presne označený variant a riadok ukazuje, od
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 103 (zobrazených prvých 50)");
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 106 (zobrazených prvých 50)");
   await page.getByLabel("Stav", { exact: true }).selectOption("missing");
   await page.getByRole("button", { name: "Hľadať", exact: true }).click();
 
@@ -144,7 +149,7 @@ test("import (ešte prebiehajúci) nesmie prepísať MEDZITÝM zmenený filter z
   await page.getByLabel("E-mail").fill(E2E_RACE_EMAIL);
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 103 (zobrazených prvých 50)");
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 106 (zobrazených prvých 50)");
 
   await page.getByRole("button", { name: "Stiahnuť a naimportovať export" }).click();
 

--- a/apps/web/tests/e2e/nav.spec.ts
+++ b/apps/web/tests/e2e/nav.spec.ts
@@ -36,7 +36,7 @@ const E2E_NAV_EMAIL = "e2e-nav@forestshop.sk";
 // samostatnom `daily-tasks.spec.ts`, rovnaký vzor). Issue 345 (2026-08-11)
 // pridáva "Objednávky predajňa" HNEĎ ZA "Na objednanie" — dvadsiata záložka
 // celkovo (funkčný test v samostatnom `floor-orders.spec.ts`, rovnaký vzor).
-test("ľavé menu má štyri priečinky (Dôležité/Eshop/Systém/Automatizácie) s dvadsiatimi záložkami, klik prepne obrazovku, panel sa zbalí do lišty a stav si pamätá, konzola je čistá", async ({
+test("ľavé menu má štyri priečinky (Dôležité/Eshop/Systém/Automatizácie) s dvadsiatimi jeden záložkami, klik prepne obrazovku, panel sa zbalí do lišty a stav si pamätá, konzola je čistá", async ({
   page,
 }) => {
   const chyby: string[] = [];
@@ -73,8 +73,8 @@ test("ľavé menu má štyri priečinky (Dôležité/Eshop/Systém/Automatizáci
   await expect(page.getByRole("button", { name: "Systém" })).toHaveAttribute("aria-expanded", "true");
   await expect(page.getByRole("button", { name: "Automatizácie" })).toHaveAttribute("aria-expanded", "true");
 
-  // Presne dvadsať záložiek v CELOM menu.
-  await expect(page.locator(".side-nav .tab")).toHaveCount(20);
+  // Presne dvadsaťjeden záložiek v CELOM menu (issue 387 E5 pridalo "Párovanie").
+  await expect(page.locator(".side-nav .tab")).toHaveCount(21);
   await expect(page.getByRole("button", { name: "Sync zo Shoptetu" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Texty e-mailov" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Na objednanie" })).toBeVisible();
@@ -86,6 +86,12 @@ test("ľavé menu má štyri priečinky (Dôležité/Eshop/Systém/Automatizáci
   await expect(page.getByRole("button", { name: "Vrátený tovar" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Reklamácie" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Párovanie produktov" })).toBeVisible();
+  // issue 387 E5: nová záložka "Párovanie" — substring-om obsiahnuté v
+  // "Párovanie produktov" vyššie AJ vo VLASTNOM odznakovom aria-label
+  // ("Párovanie Párovanie: N" — ani `exact: true`, ani obyčajný substring
+  // ju jednoznačne nenájdu naraz), preto `data-testid` (`Sidebar.tsx`'s
+  // `nav-tab-${tab.id}`), nie `getByRole`.
+  await expect(page.getByTestId("nav-tab-pairing-review")).toBeVisible();
   await expect(page.getByRole("button", { name: "Vyhľadať" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Zlúčenie objednávok" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Upozornenia" })).toBeVisible();
@@ -216,7 +222,7 @@ test("ľavé menu má štyri priečinky (Dôležité/Eshop/Systém/Automatizáci
 
   // Hlavičky priečinkov zmiznú, ikony všetkých modulov ostanú.
   await expect(page.getByRole("button", { name: "Systém" })).toHaveCount(0);
-  await expect(page.locator(".side-nav .tab")).toHaveCount(20);
+  await expect(page.locator(".side-nav .tab")).toHaveCount(21);
   // Názov sa v lište ukáže bublinou pri prejdení myšou.
   await expect(page.getByRole("button", { name: "Na objednanie" })).toHaveAttribute(
     "title",

--- a/apps/web/tests/e2e/pairing-review.spec.ts
+++ b/apps/web/tests/e2e/pairing-review.spec.ts
@@ -1,0 +1,93 @@
+import { expect, test } from "@playwright/test";
+
+const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
+// VLASTNÝ izolovaný účet (rovnaký mechanizmus ako `E2E_NAVRHY_ODKAZOV_EMAIL`,
+// `.claude/rules/frontend-design.md`) — zdieľaný `e2e@forestshop.sk` je už
+// na hranici `MAX_ATTEMPTS`. Musí sa zhodovať s `scripts/e2e-fixtures-
+// pairing-review.ts`'s `E2E_PAROVANIE_REVIEW_EMAIL`.
+const E2E_PAROVANIE_REVIEW_EMAIL = "e2e-parovanie-review@forestshop.sk";
+
+// issue 387 E5: "Eshop → Párovanie" — VIDITEĽNÁ záložka (`nav.ts`, priečinok
+// Eshop). Fixtúry (`scripts/e2e-fixtures-pairing-review.ts`): "E2E-PR-CHYBA"
+// (bez efektívnej linky, MÁ navrhnutého kandidáta — "unreviewed"+"matched"),
+// "E2E-PR-NENAJDENY" (bez efektívnej linky, ŽIADNY kandidát — dokazuje
+// "Nenašiel sa žiadny kandidát" stav) a "E2E-PR-SLINKOU" (UŽ MÁ efektívnu
+// linku — dokazuje, že predvolený "Nezrevidované" filter ho VYLÚČI, viditeľný
+// len pri "Všetky"). Substring kolízia s "Párovanie produktov" (#239) —
+// `{ name: "Párovanie", exact: true }` je POVINNÉ na tejto záložke, presne
+// ako `nav.spec.ts`.
+
+test("predvolený filter 'Nezrevidované' ukáže produkty bez linky (s aj bez kandidáta), vylúči produkt, čo linku už má; konzola je čistá", async ({
+  page,
+}) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/");
+  await page.getByLabel("E-mail").fill(E2E_PAROVANIE_REVIEW_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+
+  // `data-testid`, nie `getByRole` — "Párovanie" je substring-om AJ
+  // "Párovanie produktov" AJ VLASTNÉHO odznakového aria-label ("Párovanie
+  // Párovanie: N"), viď `nav.spec.ts`'s rovnaký komentár.
+  await page.getByTestId("nav-tab-pairing-review").click();
+  await expect(page.getByRole("heading", { name: "Párovanie", exact: true })).toBeVisible();
+
+  // Napárovaný produkt — karta ukazuje náš produkt aj navrhnutého kandidáta,
+  // BEZ akýchkoľvek akčných tlačidiel (E5 je len čítanie, E6 pridá rozhodovanie).
+  const chybaKarta = page.getByTestId("pairing-review-card-E2E-PR-CHYBA");
+  await expect(chybaKarta).toBeVisible();
+  await expect(chybaKarta).toContainText("E2E Bunda Alfa Nezrevidovaná");
+  await expect(page.getByTestId("pairing-review-candidate-E2E-PR-CHYBA")).toContainText("E2E Bunda Alfa u dodávateľa");
+  await expect(chybaKarta.getByRole("button")).toHaveCount(0);
+
+  // Nenapárovaný produkt (gather nenašiel u dodávateľa nič) — vlastná hláška.
+  const nenajdenyKarta = page.getByTestId("pairing-review-card-E2E-PR-NENAJDENY");
+  await expect(nenajdenyKarta).toBeVisible();
+  await expect(page.getByTestId("pairing-review-no-candidate-E2E-PR-NENAJDENY")).toContainText("Nenašiel sa žiadny kandidát");
+
+  // Produkt, čo UŽ MÁ efektívnu linku — "Nezrevidované" ho vylúči.
+  await expect(page.getByTestId("pairing-review-card-E2E-PR-SLINKOU")).toHaveCount(0);
+
+  // Prepnutie na "Všetky" ho odkryje — dôkaz, že filter naozaj filtruje,
+  // nie že appka o produkte jednoducho nevie.
+  await page.getByTestId("pairing-review-filter-all").click();
+  await expect(page.getByTestId("pairing-review-card-E2E-PR-SLINKOU")).toBeVisible();
+
+  expect(chyby).toEqual([]);
+});
+
+// issue 387 E5 (design komentár na tickete): odznak v ľavom menu = počet
+// "nezrevidovaných" (bez efektívnej linky), viditeľný AJ pri nasledujúcom
+// prihlásení bez otvorenia záložky (rovnaký priamy vzor ako issue 331's
+// `nav-badge-restock-links`).
+test("odznak v menu ukazuje počet nezrevidovaných HNEĎ po prihlásení, bez otvorenia záložky; konzola je čistá", async ({ page }) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/");
+  await page.getByLabel("E-mail").fill(E2E_PAROVANIE_REVIEW_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+
+  // Predvolená landing obrazovka je "Na objednanie" (issue 302) — odznak
+  // musí byť vidno TU. Zdieľaná globálna DB (iné spec súbory môžu bežať
+  // súbežne) — over PLATNÝ tvar, nie presnú hodnotu, rovnaký princíp ako
+  // `nav.spec.ts`'s `nav-badge-orders`.
+  const odznak = page.getByTestId("nav-badge-pairing-review");
+  await expect(odznak).toBeVisible();
+  await expect(odznak).toHaveText(/^\d+$/);
+
+  expect(chyby).toEqual([]);
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.229",
+  "version": "0.3.0-dev.230",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-fixtures-pairing-review.ts
+++ b/scripts/e2e-fixtures-pairing-review.ts
@@ -1,0 +1,101 @@
+// issue 387 E5: "Eshop → Párovanie" — vyčlenené z `e2e-setup.ts` (eslint
+// `max-lines: 400`, `.claude/rules/testing.md`), rovnaký vzor ako existujúci
+// `e2e-fixtures-restock-links.ts` (#311). TRI VLASTNÉ, dovtedy nepoužité
+// jednovariantné produkty, každý s vlastným `pairing_candidate_set` riadkom
+// (E5's populácia = "produkty S kandidátmi", INNER JOIN): jeden BEZ
+// efektívnej linky s napárovaným kandidátom ("unreviewed" + "matched"),
+// jeden BEZ efektívnej linky bez kandidáta ("unreviewed" + "unmatched" —
+// dokazuje "Nenašiel sa žiadny kandidát" stav), a jeden UŽ S linkou
+// (dokazuje, že "unreviewed" filter/odznak ho vylúči — design komentár na
+// tickete, issue 387 E5).
+import type { Database } from "../apps/api/src/db/client.js";
+import { pairingCandidates, pairingCandidateSets, products, users, variants } from "../apps/api/src/db/schema.js";
+import { hashPassword } from "../apps/api/src/modules/auth/passwords.js";
+
+// Musí sa zhodovať s hodnotou v `apps/web/tests/e2e/pairing-review.spec.ts` —
+// VLASTNÝ izolovaný účet (rovnaký mechanizmus ako `E2E_NAVRHY_ODKAZOV_EMAIL` —
+// zdieľaný `e2e@forestshop.sk` je už na hranici `MAX_ATTEMPTS`).
+export const E2E_PAROVANIE_REVIEW_EMAIL = "e2e-parovanie-review@forestshop.sk";
+
+export async function seedPairingReviewFixtures(db: Database, teraz: Date, snapshotId: string, heslo: string): Promise<void> {
+  await db.insert(users).values({
+    email: E2E_PAROVANIE_REVIEW_EMAIL,
+    passwordHash: await hashPassword(heslo),
+    displayName: "E2E Manažér",
+    role: "manazer",
+  });
+
+  async function seedProdukt(key: string, name: string, over: { readonly internalNote?: string | null } = {}): Promise<void> {
+    await db.insert(products).values({
+      key,
+      name,
+      supplier: "E2E Dodávateľ Párovanie",
+      internalNote: over.internalNote ?? null,
+      firstSeenAt: teraz,
+      lastSeenAt: teraz,
+      lastSeenSnapshotId: snapshotId,
+    });
+    await db.insert(variants).values({
+      code: key,
+      productKey: key,
+      guid: key,
+      externalCode: `${key}-KOD`,
+      name,
+      stock: 5,
+      availabilityInStockText: "Skladom",
+      availabilityOutOfStockText: "Vypredané",
+      availabilityText: "Skladom",
+      productVisibility: "visible",
+      state: "sellable",
+      firstSeenAt: teraz,
+      lastSeenAt: teraz,
+      lastSeenSnapshotId: snapshotId,
+    });
+  }
+
+  await seedProdukt("E2E-PR-CHYBA", "E2E Bunda Alfa Nezrevidovaná");
+  await db.insert(pairingCandidateSets).values({
+    productKey: "E2E-PR-CHYBA",
+    gatheredAt: teraz,
+    queries: ["e2e bunda alfa"],
+    inputHash: "e2e-hash-chyba",
+    chosenUrl: "https://e2e-dodavatel.example.com/bunda-alfa-navrh",
+    chosenReason: "najlepší nájdený",
+    confidence: "medium",
+    verdict: null,
+  });
+  await db.insert(pairingCandidates).values({
+    productKey: "E2E-PR-CHYBA",
+    position: 0,
+    name: "E2E Bunda Alfa u dodávateľa",
+    url: "https://e2e-dodavatel.example.com/bunda-alfa-navrh",
+    rawScore: "85.0000",
+    codeHit: false,
+  });
+
+  await seedProdukt("E2E-PR-NENAJDENY", "E2E Produkt Bez Kandidáta");
+  await db.insert(pairingCandidateSets).values({
+    productKey: "E2E-PR-NENAJDENY",
+    gatheredAt: teraz,
+    queries: ["e2e produkt bez kandidáta"],
+    inputHash: "e2e-hash-nenajdeny",
+    chosenUrl: null,
+    chosenReason: null,
+    confidence: "none",
+    verdict: null,
+  });
+
+  await seedProdukt("E2E-PR-SLINKOU", "E2E Produkt Už S Linkou", {
+    internalNote: "https://e2e-dodavatel.example.com/uz-ma-linku",
+  });
+  await db.insert(pairingCandidateSets).values({
+    productKey: "E2E-PR-SLINKOU",
+    gatheredAt: teraz,
+    queries: ["e2e produkt už s linkou"],
+    inputHash: "e2e-hash-slinkou",
+    chosenUrl: null,
+    chosenReason: null,
+    confidence: "none",
+    verdict: null,
+  });
+}

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -23,6 +23,7 @@ import { seedOrderFlagsFixtures } from "./e2e-fixtures-order-flags.js";
 import { seedPaginationFixtures } from "./e2e-fixtures-pagination.js";
 import { seedProductLinksFixtures } from "./e2e-fixtures-product-links.js";
 import { seedRestockEventsFixtures } from "./e2e-fixtures-restock-events.js";
+import { seedPairingReviewFixtures } from "./e2e-fixtures-pairing-review.js";
 import { seedRestockLinksFixtures } from "./e2e-fixtures-restock-links.js";
 import { seedSearchFixtures } from "./e2e-fixtures-search.js";
 
@@ -281,12 +282,7 @@ await db.insert(users).values({ email: "e2e@forestshop.sk", passwordHash: await 
 await db.insert(users).values({ email: E2E_HESLO_ZMENA_EMAIL, passwordHash: await hashPassword(E2E_HESLO), displayName: "E2E Manažér", role: "manazer" });
 await db.insert(users).values({ email: E2E_SKUPINY_EMAIL, passwordHash: await hashPassword(E2E_HESLO), displayName: "E2E Manažér", role: "manazer" });
 await db.insert(users).values({ email: E2E_NAV_EMAIL, passwordHash: await hashPassword(E2E_HESLO), displayName: "E2E Manažér", role: "manazer" });
-await db.insert(users).values({
-  email: E2E_OTVORENE_STAVY_EMAIL,
-  passwordHash: await hashPassword(E2E_HESLO),
-  displayName: "E2E Manažér",
-  role: "manazer",
-});
+await db.insert(users).values({ email: E2E_OTVORENE_STAVY_EMAIL, passwordHash: await hashPassword(E2E_HESLO), displayName: "E2E Manažér", role: "manazer" });
 await db.insert(users).values({
   email: E2E_OBJEDNANE_EMAIL,
   passwordHash: await hashPassword(E2E_HESLO),
@@ -828,5 +824,8 @@ await seedPaginationFixtures(db, teraz, snapshotPrepinanie);
 
 // issue 345: fixtúra vyčlenená do vlastného súboru, rovnaký dôvod ako vyššie.
 await seedFloorOrdersFixtures(db, E2E_HESLO);
+
+// issue 387 E5: fixtúra vyčlenená do vlastného súboru, rovnaký dôvod ako vyššie.
+await seedPairingReviewFixtures(db, teraz, snapshotPrepinanie, E2E_HESLO);
 
 await pool.end();


### PR DESCRIPTION
Etapa E5 z issue 387 (profesionálne párovanie produktov, port starej appky @ 60b6164).
Piata z ôsmich etáp — nová obrazovka **Eshop → Párovanie** (zatiaľ len na prezeranie;
rozhodovanie ✓/✗ príde v E6).

## Obsah

- API: `pairing-review/queries.ts` + `GET /api/pairing-review` — produkty, ktoré nočný
  zber porovnal s ponukou dodávateľov, ich kandidáti, náš odkaz/obrázok zo shop feedu.
- Web: `PairingReviewSection.tsx` + `PairingReviewCard.tsx` — karty v dvoch stĺpcoch
  ako v starej appke (vľavo náš produkt s badge stavu, vpravo navrhnutý kandidát so
  skóre/istotou/verdiktom kódu), filtre s pamäťou (localStorage), pamäť skrolovania,
  progress bar, badge počtu nezrevidovaných v ľavom menu.
- Existujúce obrazovky Párovanie produktov (#239) a Kontrola párovania (F4) nedotknuté.
- „Nezrevidované" je do E6 (tabuľka rozhodnutí) definované ako „bez efektívneho odkazu
  na dodávateľa" — zámerná, dopredu kompatibilná voľba zapísaná na tikete.

Review (čerstvý kontext): 1 🔴 (zastaraný počet tabov v nav.spec.ts — zhodilo by CI),
1 🟡 (chýbajúci e2e spec), 1 🔵 — všetko opravené v tej istej vetve. Pri e2e sa navyše
našiel reálny Playwright chyták s prefixovými labelmi tabov — vyriešené data-testid,
zapísané do playbooku.

## Testy

12 integračných (API) + 6 komponentových (web) + nový e2e spec s vlastným účtom
a fixtúrami; celkovo web 612 testov, API 878, typecheck aj lint čisté.

Issue 387 zostáva otvorené — zavrie sa po poslednej etape a živom overení.
