### PR TITLE
Párovanie produktov E6: rozhodnutia na obrazovke (issue 387) + overený čas záloh (issue 376)

### DIFF
--- a/.claude/rules/backups.md
+++ b/.claude/rules/backups.md
@@ -47,12 +47,14 @@ Smer je preto obrátený:
   `/srv/forestshop/backups/forestshop-<STAMP>.dump` + `.env.gpg`.
 - **dev1 si súbory STIAHNE vlastným pull cronom** —
   `~/backups/pull-forestshop-dev-backup.sh` (žije len na dev1, mimo tohto
-  repa). **Presný riadok dev1's crontabu (issue 376) ZOSTÁVA UNVERIFIED —
-  ale nie preto, že by sa to nedalo overiť z `forestshop-dev`.** `ssh
-  dev1`/`ssh 100.104.8.125` z tohto boxu naozaj zlyhávajú (žiadna sieťová
-  cesta, potvrdené), no dá sa to overiť NEPRIAMO — `forestshop-dev`'s
-  vlastný `auth.log` zaznamenáva KAŽDÉ prihlásenie reštrikovaným pull
-  kľúčom aj s presným časom. Postup, opakovateľný kýmkoľvek na tomto boxi:
+  repa). **Presný čas dev1's crontabu je OVERENÝ** (issue 376, overené
+  13. 8. 2026 z prvej reálnej noci 12.→13. 8. 2026): cron beží
+  **`30 4 * * *` Bratislava-local = 04:30 Europe/Bratislava = 02:30 UTC
+  (v CEST).** `ssh dev1`/`ssh 100.104.8.125` z tohto boxu naozaj zlyhávajú
+  (žiadna sieťová cesta, potvrdené), no overilo sa to NEPRIAMO —
+  `forestshop-dev`'s vlastný `auth.log` zaznamenáva KAŽDÉ prihlásenie
+  reštrikovaným pull kľúčom aj s presným časom. Postup, opakovateľný
+  kýmkoľvek na tomto boxi:
   1. zisti fingerprint kľúča z `~/.ssh/authorized_keys` (riadok
      `command="/usr/bin/rrsync -ro ..." ssh-ed25519 ...
      forestshop-dev-backup-pull@dev1`) cez `ssh-keygen -lf`;
@@ -60,23 +62,24 @@ Smer je preto obrátený:
      `Accepted publickey for admin ... ssh2: ED25519 SHA256:<fingerprint>`
      je jeden reálny pull, s UTC časovou pečiatkou v samotnom logu
      (nezávisle od box-lokálneho `timedatectl` nastavenia vyššie).
+     **POZOR na formát:** tento box's `auth.log` má ISO časové pečiatky
+     (`2026-08-13T02:30:02...`), NIE tradičný syslog tvar (`Aug 13 ...`) —
+     `grep 'Aug 13'` nenájde nič, hľadaj rok-mesiac-deň prefix (`2026-08-`).
 
   K 12. 8. 2026 19:xx (deň, keď box vôbec prvýkrát začal bežať ako
   `forestshop-dev` — `journalctl --list-boots` ukazuje prvý boot tejto
-  identity 12. 8. 2026 13:14 CEST) toto našlo presne 7 úspešných
+  identity 12. 8. 2026 13:14 CEST) tento postup našiel presne 7 úspešných
   prihlásení tým kľúčom, VŠETKY zhlukovo medzi 12:46:44–13:06:03 UTC toho
   istého dňa — zjavne ručné testovanie pri zapájaní (issue 366/367 setup:
-  7× pripojenie za 20 minút, nie raz-denne opakovaný cron vzor). Nočné
-  okno `backup-db-local.sh`'s cronu (bullet vyššie) v tejto podobe boxu
-  ešte VÔBEC nenastalo (dnešné 02:15 už prešlo predtým, než box v tejto
-  identite existoval) — teda ani dev1's nadväzujúci pull cron nemal
-  doteraz ŽIADNU reálnu produkčnú príležitosť spustiť sa. Prvá reálna
-  noc je až 12.→13. 8. **Skutočný cyklický čas preto zatiaľ nemá dôkaz —
-  ani jeden z dvoch pôvodne citovaných zdrojov (02:25 UTC / cron
-  `30 4 * * *` Bratislava-local) sa nedal ani potvrdiť, ani vyvrátiť.**
-  Až po prvej reálnej noci zopakuj krok 2 vyššie — nový výsledok bude mať
-  presne jeden riadok s pravidelným denným časom namiesto zhluku, a ten
-  čas nahraď sem.
+  7× pripojenie za 20 minút, nie raz-denne opakovaný cron vzor), takže
+  vtedy skutočný cyklus ešte nemal dôkaz — nočné okno v tejto podobe boxu
+  ešte vôbec nenastalo. **Prvá reálna noc (12.→13. 8. 2026) to potvrdila:**
+  ten istý kľúč sa prihlásil PRESNE RAZ, z `85.248.11.235`, s časovou
+  pečiatkou `Accepted publickey ...` **2026-08-13T02:30:02** v `auth.log`
+  (= 02:30 UTC = 04:30 Europe/Bratislava v CEST). To potvrdzuje hypotézu
+  cronu `30 4 * * *` Bratislava-local (a vyvracia dovtedy súbežne
+  zvažovanú hypotézu ~02:25 UTC z `backup-db-local.sh`'s hlavičkového
+  komentára).
   Cieľ na dev1: **`~/backups/forestshop-dev/`** — samostatný adresár,
   ODDELENE od dev2's `~/backups/forestshop/` (nižšie), aby sa dve
   nezávislé zálohovacie histórie nikdy nepomiešali.
@@ -109,10 +112,9 @@ crontab súbor, obsah `~/backups/forestshop-dev/`) sa naďalej NEDÁ overiť z
 tohto stroja** — `forestshop-dev` nemá k dev1 žiadnu sieťovú cestu (`ssh
 dev1`/`ssh 100.104.8.125` obe zlyhali). **Dev1's SKUTOČNÉ SPRÁVANIE (kedy sa
 naozaj pripája) sa ale DÁ overiť nepriamo** cez `forestshop-dev`'s vlastný
-`auth.log` (issue 376 — postup + zatiaľ nerozhodnutý výsledok pozri bullet
-"dev1 si súbory STIAHNE" vyššie): box beží v aktuálnej podobe len od
-12. 8. 2026, žiadna reálna noc ešte neprebehla, takže presný cyklický čas
-zatiaľ nemá dôkaz ani z jedného smeru.
+`auth.log` (issue 376 — postup + overený výsledok pozri bullet "dev1 si
+súbory STIAHNE" vyššie): prvá reálna noc (12.→13. 8. 2026) potvrdila cron
+`30 4 * * *` Bratislava-local (04:30 = 02:30 UTC v CEST).
 
 ## dev2 (statická rollback kópia)
 

--- a/.claude/rules/pairing-search.md
+++ b/.claude/rules/pairing-search.md
@@ -385,3 +385,80 @@ https://github.com/zbynekdrlik/forestshop-app/issues/387#issuecomment-5273377438
   záložka, ktorej meno je prefixom existujúcej, A ZÁROVEŇ nesie odznak počtu)
   — plný mechanizmus a fix zdokumentovaný v `.claude/rules/frontend-
   design.md` (hľadaj "nav-tab-"), nie duplikovaný tu.
+
+## E6 — Rozhodnutia (`pairing-review/decisions.ts`, `pairing_decision`, `PairingReviewCard.tsx`)
+
+- **Guard proti súbežnému prepisu je "posledný zápis vyhráva"
+  (`onConflictDoUpdate`), NIE optimistický zámok** — design komentár na
+  tickete (issue 387 E6) zvažoval aj `updated_at` round-trip aj
+  `SELECT ... FOR UPDATE`, oboje zamietnuté ako zbytočná zložitosť pre
+  nízkofrekventovanú ručnú akciu bez precedensu v appke. `decided_at`/
+  `updated_at` stĺpce napriek tomu existujú OBIDVA (vždy tá istá hodnota v
+  tejto verzii) — čisto ako príprava, keby to niekedy bolo treba zmeniť bez
+  ďalšej migrácie. Konflikt sa NIKDY nepredchádza, len sa SPÄTNE zaznamená
+  do auditu (`previousStatus`/`previousUrl`) — rovnaký princíp ako
+  `upsertProductSupplierLink` už dnes robí pre samotnú linku.
+- **`upsertProductSupplierLink` (`orders/supplier-link-assignment.ts`, #239)
+  dostalo `export` — jediná zmena existujúceho súboru, čisto aditívna.**
+  Dôvod: `setPairingDecision`'s `good`/`manual` vetva potrebuje zapísať
+  `pairing_decision` AJ `product_supplier_link_override` v JEDNEJ
+  transakcii, ale `setProductSupplierLinkForProduct` (existujúci wrapper)
+  SAMA otvára `db.transaction(...)` — vnorená transakcia by nefungovala.
+  Zdieľané jadro (`upsertProductSupplierLink`, prijíma `UpsertExecutor` =
+  `Pick<Database, "select"|"insert">`) sa preto volá PRIAMO s VLASTNÝM `tx`.
+  Rovnaký vzor pri KAŽDEJ ďalšej potrebe "spoj DVA existujúce zápisy do
+  jednej transakcie": exportuj zdieľané JADRO (nie wrapper), nikdy nevnáraj
+  `db.transaction` do `db.transaction`.
+- **"unreviewed" (E5's `!hasEffectiveLink`) sa E6 NEZUŽUJE naivne na "žiadne
+  rozhodnutie vôbec"** (to bol starej appky's doslovný `status === null`) —
+  produkt s efektívnou linkou ZALOŽENOU MIMO tejto obrazovky (napr. cez
+  "Párovanie produktov" #239 predtým, než sa naň niekedy rozhodlo tu) sa
+  bez rozhodnutia stále počíta ako "má odkaz, netreba naň upozorňovať".
+  Skutočná zmena: `unreviewed` = `!hasEffectiveLink && !(decision existuje
+  && status IN (unavailable, discontinued))` — TERMINÁLNE rozhodnutia
+  (čo linku NIKDY nedostanú) sa vyradia AJ bez linky, `good`/`manual` sú už
+  vyradené cez prvú podmienku (vždy majú linku). Over toto pri KAŽDEJ ďalšej
+  úprave predikátu — doslovný port starej appky by tu bol TICHO nesprávny.
+- **"↩ Vrátiť" NIKDY nemaže `product_supplier_link_override`** (dizajnové
+  rozhodnutie, design komentár na tickete) — dôsledok je ASYMETRIA, ktorú
+  treba poznať pred ďalšou zmenou: revert `unavailable`/`discontinued`
+  (žiadna linka) VRÁTI produkt do "unreviewed" (presne "Vrátiť vracia do
+  nezrevidovaných", zadaniev akceptácia). Revert `good`/`manual` NEVRÁTI —
+  linka naďalej existuje, takže produkt zostáva MIMO "unreviewed" (nájditeľný
+  cez "Všetky"/"Napárované", už bez odznaku/rozhodnutia). Toto NIE JE bug —
+  je to priamy dôsledok E5's vlastnej `unreviewed` definície (bez linky), nie
+  "bez rozhodnutia". Integračný test `pairing-review-decisions-http
+  .integration.test.ts` dokazuje OBE vetvy explicitne oddelene.
+- **`GET /:productKey/candidates` je LAZY (fetchne sa AŽ pri otvorení panelu
+  "✗ Zlé"/"✗ Zmeniť"), nikdy vložené do hlavného `GET /api/pairing-review`
+  zoznamu** — E5 už zamietla živý meta-fetch (obrázok/cena) ako zbytočnú
+  záťaž; E6 pridáva len malý endpoint nad UŽ perzistovanými `pairing_
+  candidate` riadkami (meno/URL/skóre/kód-zhoda), volaný len keď ho
+  reviewer skutočne potrebuje. Vloženie všetkých top-8 do KAŽDEJ položky
+  zoznamu by zbytočne nafúklo payload kariet, čo sa nikdy nerozbalia.
+- **Karta (`PairingReviewCard.tsx`) je od E6 STAVOVÁ, ale panel/busy/
+  candidates stav je PER-KARTE lokálny `useState`, nikdy globálny scalar**
+  (na rozdiel od `DailyTasksSection.tsx`'s `editingXId` vzoru, ktorý issue
+  381 dokumentuje ako past — `.claude/rules/frontend-design.md`). Viac
+  kariet smie mať panel otvorený súčasne bez kolízie, jeden zdieľaný `busy`
+  guard na karte blokuje VŠETKY jej vlastné akčné tlačidlá naraz. Po
+  úspešnom zápise sa NEROBÍ optimistický lokálny update poľa `item` —
+  `PairingReviewSection`'s `onDecided` prop znova načíta AKTUÁLNY filter na
+  stranu 1 zo servera (jediný zdroj pravdy, žiadna duplicitná klientská
+  filter-logika).
+- **Farba odznaku rozhodnutia (`pairing-review-decision-<status>`) je PODĽA
+  STATUSU, nie jedna pevná farba pre všetky štyri** (review nález) —
+  `good`/`manual` zelená (`--fs-success`), `unavailable` žltá
+  (`--fs-warning`, dočasný/re-kontrola), `discontinued` sivá
+  (`--fs-surface-alt`/`--fs-ink-muted`, konečný) — rovnaký princíp ako
+  `.pairing-review-state-*` (produkt stav Skladom/Nie je skladom/Ukončené).
+- **Plný lokálny e2e beh (nie len kolízna dvojica pairing-review+nav) pri
+  E6 objavil PREDOŠLÚ (E5) medzeru** — `catalog.spec.ts`'s natvrdo napísané
+  počty (103/72) nikdy nezohľadnili E5's 3 nové sellable varianty
+  (`E2E-PR-CHYBA`/`NENAJDENY`/`SLINKOU`), presne ten "pridanie jedného
+  variantu do e2e seedu posunie pevné počty" gotcha z `.claude/rules/
+  testing.md`. Oprava (106/75) je v E6's PR, mimo E6's vlastného kódu.
+  **Poučenie pre KAŽDÚ ĎALŠIU etapu tejto sériovej reťaze:** spustiť PLNÝ
+  lokálny e2e beh aspoň RAZ za pár etáp (nielen kolíznu dvojicu) — kolízna
+  dvojica chytá len PRIAME substring/aria kolízie, nikdy vzdialené číselné
+  závislosti ako `catalog.spec.ts`'s celkový počet.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -689,3 +689,34 @@ paths:
   (potvrdí/vyvráti, že komponent je naozaj rýchly), potom hľadaj v súbore
   JEDEN `it()` s viacerými `waitFor` volaniami — to je takmer vždy skutočná
   príčina, nie testovacie prostredie.
+- **`pnpm --filter @forestshop/web e2e -- <súbor1> <súbor2>` NEFILTRUJE na
+  tie súbory — spustí CELÚ e2e sadu.** `package.json`'s `"e2e": "playwright
+  test"` skript už je len 2 slová; pnpm-ov vlastný `--` pred argumentmi PRE
+  skript sa cez `pnpm --filter X e2e --` odovzdá do PRÍKAZU AKO DOSLOVNÝ
+  ĎALŠÍ ARGUMENT (`playwright test "--" "<súbor1>" "<súbor2>"`), nie ako
+  oddeľovač, ktorý pnpm sám skonzumuje — Playwright potom dostane `--` ako
+  neplatný prvý filter, čo v praxi znamená "žiadny filter", takže beží
+  úplne všetko (issue 387 E6, naživo overené: namiesto 2 zadaných spec
+  súborov sa spustilo 61 testov naprieč celým `tests/e2e/`, vrátane
+  nesúvisiaceho `catalog.spec.ts`). **Funkčný spôsob, ako lokálne spustiť
+  LEN vybrané spec súbory:** obísť `package.json`'s `e2e` skript úplne,
+  volať `playwright` priamo cez `pnpm --filter @forestshop/web exec
+  playwright test tests/e2e/<súbor1>.spec.ts tests/e2e/<súbor2>.spec.ts`
+  (`exec`, nie samotný skript-alias) — `webServer`'s `reuseExistingServer:
+  false` (`playwright.config.ts`) navyše znamená, že KAŽDÉ takéto
+  spustenie reseeduje appku odznova (nikdy nezdieľa už bežiaci server z
+  predošlého volania), takže postupné volania sú vzájomne bezpečné.
+  **Ten istý príkaz navyše potrebuje `DATABASE_URL` NASTAVENÉ v
+  spúšťajúcom shelli** (`DATABASE_URL=postgres://forestshop:forestshop
+  @127.0.0.1:5433/forestshop pnpm --filter @forestshop/web exec playwright
+  test ...`) — `playwright.config.ts`'s `webServer` (`e2e-setup.ts` +
+  `api start`) žiadnu predvolenú hodnotu NEMÁ, na rozdiel od CI (kde ju
+  GitHub Actions-ov Postgres service kontajner nastavuje automaticky);
+  bez nej appka's `env.ts` zhodí `webServer` proces hneď pri štarte
+  ("Chybná konfigurácia prostredia... DATABASE_URL... Required"), a
+  Playwright to nahlási len ako všeobecné "Process from config.webServer
+  was not able to start" bez zjavnej príčiny v prvom riadku výstupu — nie
+  je to samostatná, dovtedy nezdokumentovaná medzera (líši sa od "Live
+  pixel meranie" vzoru v `.claude/rules/local-dev.md`, ktorý rieši
+  `db:migrate`/`api start` priamo, nie `pnpm ... e2e`'s vlastný webServer
+  subproces).

--- a/apps/api/drizzle/0048_brave_iron_patriot.sql
+++ b/apps/api/drizzle/0048_brave_iron_patriot.sql
@@ -1,0 +1,14 @@
+CREATE TYPE "public"."pairing_decision_status" AS ENUM('good', 'manual', 'unavailable', 'discontinued');--> statement-breakpoint
+CREATE TABLE "pairing_decision" (
+	"product_key" text PRIMARY KEY NOT NULL,
+	"status" "pairing_decision_status" NOT NULL,
+	"url" text,
+	"decided_by" uuid NOT NULL,
+	"decided_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL,
+	"state_synced_at" timestamp with time zone,
+	CONSTRAINT "pairing_decision_url_ck" CHECK (("pairing_decision"."status" IN ('good','manual') AND "pairing_decision"."url" IS NOT NULL) OR ("pairing_decision"."status" IN ('unavailable','discontinued') AND "pairing_decision"."url" IS NULL))
+);
+--> statement-breakpoint
+ALTER TABLE "pairing_decision" ADD CONSTRAINT "pairing_decision_product_key_product_key_fk" FOREIGN KEY ("product_key") REFERENCES "public"."product"("key") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pairing_decision" ADD CONSTRAINT "pairing_decision_decided_by_users_id_fk" FOREIGN KEY ("decided_by") REFERENCES "public"."users"("id") ON DELETE restrict ON UPDATE no action;

--- a/apps/api/drizzle/meta/0048_snapshot.json
+++ b/apps/api/drizzle/meta/0048_snapshot.json
@@ -1,0 +1,3481 @@
+{
+  "id": "d137f6c9-6118-459f-820c-ee48ee774005",
+  "prevId": "432c39b3-8681-49d6-b5d0-ce4f777f837c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_code": {
+          "name": "external_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_open_status": {
+      "name": "order_open_status",
+      "schema": "",
+      "columns": {
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Vybavuje sa'"
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop_remark": {
+          "name": "shop_remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shoptet_order_id": {
+          "name": "shoptet_order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_updated_at": {
+          "name": "comment_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_synced_at": {
+          "name": "comment_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_carrier_name": {
+          "name": "shipping_carrier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_price_with_vat": {
+          "name": "total_price_with_vat",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_marked_at": {
+          "name": "claim_marked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_note": {
+          "name": "claim_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_full_name": {
+          "name": "delivery_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_company": {
+          "name": "delivery_company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_street": {
+          "name": "delivery_street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_house_number": {
+          "name": "delivery_house_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_city": {
+          "name": "delivery_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_zip": {
+          "name": "delivery_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_country_name": {
+          "name": "delivery_country_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_name": {
+          "name": "payment_method_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_to_pay": {
+          "name": "price_to_pay",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_link_override": {
+      "name": "product_supplier_link_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_link_override_product_key_product_key_fk": {
+          "name": "product_supplier_link_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_link_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_override": {
+      "name": "product_supplier_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_override_product_key_product_key_fk": {
+          "name": "product_supplier_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing": {
+      "name": "pairing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_url": {
+          "name": "supplier_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "pairing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'navrhnute'"
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pairing_state_idx": {
+          "name": "pairing_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_confirmed_by_idx": {
+          "name": "pairing_confirmed_by_idx",
+          "columns": [
+            {
+              "expression": "confirmed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_variant_code_variant_code_fk": {
+          "name": "pairing_variant_code_variant_code_fk",
+          "tableFrom": "pairing",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pairing_confirmed_by_users_id_fk": {
+          "name": "pairing_confirmed_by_users_id_fk",
+          "tableFrom": "pairing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pairing_variant_code_unique": {
+          "name": "pairing_variant_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pairing_confirmation_ck": {
+          "name": "pairing_confirmation_ck",
+          "value": "(\"pairing\".\"state\" = 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)\n        OR (\"pairing\".\"state\" != 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NULL AND \"pairing\".\"confirmed_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier": {
+      "name": "supplier",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wholesale_base_url": {
+          "name": "wholesale_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_key": {
+          "name": "adapter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_settings": {
+      "name": "posta_uncollected_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_state": {
+      "name": "posta_uncollected_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notify_count": {
+          "name": "notify_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_state": {
+          "name": "terminal_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_settings": {
+      "name": "order_reminder_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_state": {
+      "name": "order_reminder_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_replacement_link": {
+      "name": "nedostupne_replacement_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nedostupne_replacement_link_variant_idx": {
+          "name": "nedostupne_replacement_link_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_state": {
+      "name": "nedostupne_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "nedostupne_email_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nedostupne_state_order_variant_type_uq": {
+          "name": "nedostupne_state_order_variant_type_uq",
+          "columns": [
+            {
+              "expression": "order_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template_history": {
+      "name": "mail_template_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "mail_template_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_template_history_key_idx": {
+          "name": "mail_template_history_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_template_history_changed_by_user_id_users_id_fk": {
+          "name": "mail_template_history_changed_by_user_id_users_id_fk",
+          "tableFrom": "mail_template_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template": {
+      "name": "mail_template",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail_template_updated_by_user_id_users_id_fk": {
+          "name": "mail_template_updated_by_user_id_users_id_fk",
+          "tableFrom": "mail_template",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_log": {
+      "name": "mail_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "mail_log_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_log_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "mail_log_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_log_created_idx": {
+          "name": "mail_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_log_source_created_idx": {
+          "name": "mail_log_source_created_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_log_actor_user_id_users_id_fk": {
+          "name": "mail_log_actor_user_id_users_id_fk",
+          "tableFrom": "mail_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_stock": {
+      "name": "supplier_stock",
+      "schema": "",
+      "columns": {
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "supplier_availability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "supplier_stock_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "supplier_stock_host_idx": {
+          "name": "supplier_stock_host_idx",
+          "columns": [
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "supplier_stock_avail_idx": {
+          "name": "supplier_stock_avail_idx",
+          "columns": [
+            {
+              "expression": "availability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "supplier_stock_link_size_label_pk": {
+          "name": "supplier_stock_link_size_label_pk",
+          "columns": [
+            "link",
+            "size_label"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_event": {
+      "name": "restock_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_link": {
+          "name": "supplier_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_availability_text": {
+          "name": "supplier_availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "supplier_price": {
+          "name": "supplier_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "restock_event_at_idx": {
+          "name": "restock_event_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "restock_event_variant_idx": {
+          "name": "restock_event_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_settings": {
+      "name": "restock_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shop_product_url": {
+      "name": "shop_product_url",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.theme_color": {
+      "name": "theme_color",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "theme_color_updated_by_user_id_users_id_fk": {
+          "name": "theme_color_updated_by_user_id_users_id_fk",
+          "tableFrom": "theme_color",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upozornenie": {
+      "name": "upozornenie",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "upozornenie_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "upozornenie_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedup_key": {
+          "name": "dedup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postponed_until": {
+          "name": "postponed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seen_at": {
+          "name": "seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "upozornenie_dedup_key_uq": {
+          "name": "upozornenie_dedup_key_uq",
+          "columns": [
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "resolved_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upozornenie_resolved_at_idx": {
+          "name": "upozornenie_resolved_at_idx",
+          "columns": [
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upozornenie_dedup_key_idx": {
+          "name": "upozornenie_dedup_key_idx",
+          "columns": [
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upozornenie_resolved_by_user_id_users_id_fk": {
+          "name": "upozornenie_resolved_by_user_id_users_id_fk",
+          "tableFrom": "upozornenie",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "upozornenie_created_by_user_id_users_id_fk": {
+          "name": "upozornenie_created_by_user_id_users_id_fk",
+          "tableFrom": "upozornenie",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dpd_pickup_request": {
+      "name": "dpd_pickup_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "pickup_date": {
+          "name": "pickup_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "dpd_operation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dpd_shipment": {
+      "name": "dpd_shipment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "dpd_operation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parcel_number": {
+          "name": "parcel_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cod_amount": {
+          "name": "cod_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dpd_shipment_order_uq": {
+          "name": "dpd_shipment_order_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dpd_shipment_order_id_order_id_fk": {
+          "name": "dpd_shipment_order_id_order_id_fk",
+          "tableFrom": "dpd_shipment",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_task": {
+      "name": "daily_task",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "done_at": {
+          "name": "done_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "daily_task_user_id_created_at_idx": {
+          "name": "daily_task_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_task_user_id_users_id_fk": {
+          "name": "daily_task_user_id_users_id_fk",
+          "tableFrom": "daily_task",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing_candidate_set": {
+      "name": "pairing_candidate_set",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gathered_at": {
+          "name": "gathered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "queries": {
+          "name": "queries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chosen_url": {
+          "name": "chosen_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chosen_reason": {
+          "name": "chosen_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "pairing_confidence",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "pairing_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verdict_checked_at": {
+          "name": "verdict_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pairing_candidate_set_product_key_product_key_fk": {
+          "name": "pairing_candidate_set_product_key_product_key_fk",
+          "tableFrom": "pairing_candidate_set",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing_candidate": {
+      "name": "pairing_candidate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_score": {
+          "name": "raw_score",
+          "type": "numeric(8, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_hit": {
+          "name": "code_hit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pairing_candidate_product_url_uq": {
+          "name": "pairing_candidate_product_url_uq",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_candidate_product_idx": {
+          "name": "pairing_candidate_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_candidate_product_key_fk": {
+          "name": "pairing_candidate_product_key_fk",
+          "tableFrom": "pairing_candidate",
+          "tableTo": "pairing_candidate_set",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "product_key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing_decision": {
+      "name": "pairing_decision",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "pairing_decision_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_synced_at": {
+          "name": "state_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pairing_decision_product_key_product_key_fk": {
+          "name": "pairing_decision_product_key_product_key_fk",
+          "tableFrom": "pairing_decision",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pairing_decision_decided_by_users_id_fk": {
+          "name": "pairing_decision_decided_by_users_id_fk",
+          "tableFrom": "pairing_decision",
+          "tableTo": "users",
+          "columnsFrom": [
+            "decided_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pairing_decision_url_ck": {
+          "name": "pairing_decision_url_ck",
+          "value": "(\"pairing_decision\".\"status\" IN ('good','manual') AND \"pairing_decision\".\"url\" IS NOT NULL) OR (\"pairing_decision\".\"status\" IN ('unavailable','discontinued') AND \"pairing_decision\".\"url\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pairing_search_settings": {
+      "name": "pairing_search_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne"
+      ]
+    },
+    "public.pairing_state": {
+      "name": "pairing_state",
+      "schema": "public",
+      "values": [
+        "navrhnute",
+        "potvrdene"
+      ]
+    },
+    "public.nedostupne_email_type": {
+      "name": "nedostupne_email_type",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "alternativa"
+      ]
+    },
+    "public.mail_template_action": {
+      "name": "mail_template_action",
+      "schema": "public",
+      "values": [
+        "save",
+        "reset"
+      ]
+    },
+    "public.mail_log_source": {
+      "name": "mail_log_source",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "posta_uncollected",
+        "order_reminder",
+        "supplier_order",
+        "order_merge"
+      ]
+    },
+    "public.mail_log_status": {
+      "name": "mail_log_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.mail_log_trigger": {
+      "name": "mail_log_trigger",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "manual"
+      ]
+    },
+    "public.supplier_availability": {
+      "name": "supplier_availability",
+      "schema": "public",
+      "values": [
+        "available",
+        "unavailable",
+        "unknown"
+      ]
+    },
+    "public.supplier_stock_source": {
+      "name": "supplier_stock_source",
+      "schema": "public",
+      "values": [
+        "json_ld",
+        "meta",
+        "text",
+        "size_list",
+        "none"
+      ]
+    },
+    "public.upozornenie_source": {
+      "name": "upozornenie_source",
+      "schema": "public",
+      "values": [
+        "vlastne",
+        "appka"
+      ]
+    },
+    "public.upozornenie_type": {
+      "name": "upozornenie_type",
+      "schema": "public",
+      "values": [
+        "vlastna_poznamka",
+        "nevyzdvihnuta_zasielka",
+        "vratenie",
+        "vratena_zasielka",
+        "objednavka_visi"
+      ]
+    },
+    "public.dpd_operation_status": {
+      "name": "dpd_operation_status",
+      "schema": "public",
+      "values": [
+        "submitted",
+        "failed"
+      ]
+    },
+    "public.pairing_confidence": {
+      "name": "pairing_confidence",
+      "schema": "public",
+      "values": [
+        "high",
+        "medium",
+        "low",
+        "none"
+      ]
+    },
+    "public.pairing_decision_status": {
+      "name": "pairing_decision_status",
+      "schema": "public",
+      "values": [
+        "good",
+        "manual",
+        "unavailable",
+        "discontinued"
+      ]
+    },
+    "public.pairing_verdict": {
+      "name": "pairing_verdict",
+      "schema": "public",
+      "values": [
+        "ok",
+        "unsure"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -337,6 +337,13 @@
       "when": 1786580717528,
       "tag": "0047_brief_yellowjacket",
       "breakpoints": true
+    },
+    {
+      "idx": 48,
+      "version": "7",
+      "when": 1786589109618,
+      "tag": "0048_brave_iron_patriot",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema-pairing-review.ts
+++ b/apps/api/src/db/schema-pairing-review.ts
@@ -3,8 +3,12 @@
 // 5273377438, sekcia "DB schéma"). `pairing_decision` (E6) sa v tomto
 // súbore ZÁMERNE NEROBÍ — mimo rozsahu E3.
 
-import { boolean, foreignKey, index, integer, jsonb, numeric, pgEnum, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { boolean, check, foreignKey, index, integer, jsonb, numeric, pgEnum, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
 import { products } from "./schema-catalog.js";
+// `users` sa importuje PRIAMO zo svojho sibling súboru, nikdy cez barrel
+// `schema.js` — ten by vytvoril kruhový import (`.claude/rules/database.md`).
+import { users } from "./schema-users.js";
 
 export const pairingConfidence = pgEnum("pairing_confidence", ["high", "medium", "low", "none"]);
 export const pairingVerdict = pgEnum("pairing_verdict", ["ok", "unsure"]);
@@ -86,3 +90,55 @@ export const pairingSearchSettings = pgTable("pairing_search_settings", {
   enabled: boolean("enabled").notNull().default(false),
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull(),
 });
+
+// issue 387 E6 — človekove rozhodnutie o produkte, presne štvorica starej
+// appky (`webreview/app.py`'s DECISIONS status hodnoty). Neprítomnosť
+// riadku = "nezrevidované" (`pairing-review/queries.ts`'s `unreviewed`
+// filter, forward-kompat rozšírené o TENTO stĺpec — design komentár na
+// tickete, issue 387 E5). "↩ Vrátiť" = DELETE riadku (nikdy status navyše).
+export const pairingDecisionStatus = pgEnum("pairing_decision_status", ["good", "manual", "unavailable", "discontinued"]);
+
+export const pairingDecisions = pgTable(
+  "pairing_decision",
+  {
+    productKey: text("product_key")
+      .primaryKey()
+      .references(() => products.key, { onDelete: "cascade" }),
+    status: pairingDecisionStatus("status").notNull(),
+    // `good`/`manual` ⇒ NOT NULL (potvrdená/vybraná dodávateľská URL);
+    // `unavailable`/`discontinued` ⇒ vždy NULL (žiadny odkaz, len stav) —
+    // vynútené `pairing_decision_url_ck` nižšie.
+    url: text("url"),
+    // RESTRICT (nie CASCADE/SET NULL) — zmazanie používateľa nesmie ticho
+    // stratiť, KTO rozhodol (`.claude/rules/database.md`'s poučenie: FK
+    // "set null" pri stĺpci, čo CHECK viaže na iný stav, sa v praxi nikdy
+    // neuplatní; tu navyše ide o priamu auditnú stopu, RESTRICT je
+    // pravdivejší popis zámeru).
+    decidedBy: uuid("decided_by")
+      .notNull()
+      .references(() => users.id, { onDelete: "restrict" }),
+    // Business čas TOHTO rozhodnutia (obnovuje sa pri KAŽDOM prepísaní, nie
+    // len pri prvom vytvorení riadku — appka nedrží históriu rozhodnutí,
+    // len posledné). `updatedAt` nesie v tejto verzii VŽDY tú istú hodnotu
+    // ako `decidedAt` (obe stĺpce sa nastavujú v tom istom upserte) —
+    // ponechané ako samostatný technický stĺpec (rovnaká konvencia ako
+    // `productSupplierLinkOverrides.updatedAt`) len preto, aby prípadný
+    // BUDÚCI optimistický zámok (design komentár, zamietnutý variant 1)
+    // nevyžadoval ďalšiu migráciu — guard proti súbežnému prepisu je dnes
+    // "posledný zápis vyhráva" (`onConflictDoUpdate`, atomický v Postgrese),
+    // konflikt sa zaznamenáva SPÄTNE cez audit, nie PREDCHÁDZA.
+    decidedAt: timestamp("decided_at", { withTimezone: true }).notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull(),
+    // Nullable — vyplní AŽ E7 (stavový writeback do Shoptetu), keď reálne
+    // odošle STAV (unavailable/discontinued) dodávateľovi. Táto etapa ho
+    // len VŽDY nuluje pri každom novom/zmenenom rozhodnutí (predošlý sync,
+    // ak nejaký bol, sa týkal STARÉHO stavu).
+    stateSyncedAt: timestamp("state_synced_at", { withTimezone: true }),
+  },
+  (t) => [
+    check(
+      "pairing_decision_url_ck",
+      sql`(${t.status} IN ('good','manual') AND ${t.url} IS NOT NULL) OR (${t.status} IN ('unavailable','discontinued') AND ${t.url} IS NULL)`,
+    ),
+  ],
+);

--- a/apps/api/src/http/pairing-review-routes.ts
+++ b/apps/api/src/http/pairing-review-routes.ts
@@ -2,12 +2,18 @@ import { zValidator } from "@hono/zod-validator";
 import type { Hono } from "hono";
 import { z } from "zod";
 import type { Database } from "../db/client.js";
-import { listPairingReview } from "../modules/pairing-review/queries.js";
-import { requireUser, type AppBindings } from "./middleware.js";
+import { log } from "../logger.js";
+import { supplierLinkUrlBody } from "../modules/orders/supplier-link-assignment.js";
+import { setPairingDecision } from "../modules/pairing-review/decisions.js";
+import { listPairingCandidatesForProduct, listPairingReview } from "../modules/pairing-review/queries.js";
+import { requireRole, requireUser, type AppBindings } from "./middleware.js";
+import { requireSameOrigin } from "./origin-check.js";
 
-// issue 387 E5: "Eshop → Párovanie" — LEN čítanie (karty + filtre nad tým, čo
-// E3/E4 zozbierali a overili). Rozhodnutia/zápis prídu až v E6 — žiadna
-// POST trasa tu.
+// issue 387 E5: "Eshop → Párovanie" — čítanie (karty + filtre nad tým, čo
+// E3/E4 zozbierali a overili). issue 387 E6: pridáva rozhodnutia (POST) +
+// lazy zoznam kandidátov pre panel (GET) — rovnaké oprávnenie ako
+// `product-links-routes.ts`'s zápisová trasa (`requireRole("admin",
+// "manazer")` + `requireSameOrigin()`).
 
 // Prázdna hodnota (`page=`) sa má správať ako neprítomný parameter, rovnaký
 // vzor ako `restock-links-routes.ts`/`product-links-routes.ts`'s `pageParam`.
@@ -22,11 +28,63 @@ const pairingReviewQuery = z.object({
   pageSize: z.coerce.number().int().min(1).max(200).default(50),
 });
 
+// `productKey` je export's `guid` (rovnaký komentár ako `product-links-
+// routes.ts`'s `productLinkParam`) — bezpečné ako cestový segment.
+const pairingReviewProductParam = z.object({ productKey: z.string().min(1).max(200) });
+
+// issue 387 E6 — diskriminovaná únia presne podľa design komentára:
+// `good` nenesie žiadne telo (server sám dohľadá `chosenUrl`), `manual`
+// nesie `url` (zdieľaná zod validácia `supplierLinkUrlBody`, rovnaká ako
+// `product-links`), zvyšné tri nenesú nič.
+const pairingDecisionBody = z.discriminatedUnion("status", [
+  z.object({ status: z.literal("good") }),
+  z.object({ status: z.literal("manual"), url: supplierLinkUrlBody.shape.url }),
+  z.object({ status: z.literal("unavailable") }),
+  z.object({ status: z.literal("discontinued") }),
+  z.object({ status: z.literal("revert") }),
+]);
+
 export function registerPairingReviewRoutes(app: Hono<AppBindings>, db: Database): void {
   // Rovnaké oprávnenie ako `restock-links`/`product-links` čítanie
   // (`requireUser`, žiadne rolové obmedzenie) — každý prihlásený smie vidieť
   // stav párovania.
   app.get("/api/pairing-review", requireUser(db), zValidator("query", pairingReviewQuery), async (c) =>
     c.json(await listPairingReview(db, c.req.valid("query"))),
+  );
+
+  // issue 387 E6 — lazy top-8 kandidátov pre rozhodovací panel (design
+  // komentár: volané AŽ pri otvorení panelu, nikdy vložené do hlavného
+  // zoznamu). Rovnaké oprávnenie ako čítanie vyššie — panel smie OTVORIŤ
+  // ktokoľvek prihlásený, akčné tlačidlá vnútri sa gatujú na frontende podľa
+  // roly a POST nižšie ich aj tak vyžaduje.
+  app.get(
+    "/api/pairing-review/:productKey/candidates",
+    requireUser(db),
+    zValidator("param", pairingReviewProductParam),
+    async (c) => c.json({ candidates: await listPairingCandidatesForProduct(db, c.req.valid("param").productKey) }),
+  );
+
+  // issue 387 E6 — rozhodnutie. Rovnaké oprávnenie ako existujúci `POST
+  // /api/product-links/:productKey` (#239): `requireRole("admin","manazer")`.
+  app.post(
+    "/api/pairing-review/:productKey/decision",
+    requireSameOrigin(),
+    requireUser(db),
+    requireRole("admin", "manazer"),
+    zValidator("param", pairingReviewProductParam),
+    zValidator("json", pairingDecisionBody),
+    async (c) => {
+      const { productKey } = c.req.valid("param");
+      const body = c.req.valid("json");
+      const user = c.get("user");
+      const now = new Date();
+
+      const result = await setPairingDecision(db, { ...body, productKey, actorUserId: user.userId, now });
+      if (result === "not_found") return c.json({ error: "Produkt sa nenašiel" }, 404);
+      if (result === "no_candidate") return c.json({ error: "Tento produkt nemá navrhnutého kandidáta na potvrdenie" }, 400);
+
+      log.info({ actorUserId: user.userId, productKey, status: body.status }, "rozhodnutie o párovaní produktu");
+      return c.json({ ok: true as const, status: body.status });
+    },
   );
 }

--- a/apps/api/src/modules/orders/supplier-link-assignment.ts
+++ b/apps/api/src/modules/orders/supplier-link-assignment.ts
@@ -37,9 +37,9 @@ export const supplierLinkUrlBody = z.object({
 // Zúžený parameter (rovnaký vzor ako `audit/service.ts`'s `AuditExecutor`,
 // `.claude/rules/database.md`) — musí bežať aj s `tx` (`PgTransaction`),
 // ktorý zdieľa `.select()`/`.insert()` s `Database`, ale nemá jej `$client`.
-type UpsertExecutor = Pick<Database, "select" | "insert">;
+export type UpsertExecutor = Pick<Database, "select" | "insert">;
 
-interface UpsertProductSupplierLinkInput {
+export interface UpsertProductSupplierLinkInput {
   readonly productKey: string;
   readonly url: string;
   readonly actorUserId: string;
@@ -49,11 +49,15 @@ interface UpsertProductSupplierLinkInput {
   readonly lineId: string | null;
 }
 
-// Zdieľané jadro OBOCH zápisových ciest nižšie (`setProductSupplierLink`
-// cez `lineId`, `setProductSupplierLinkForProduct` cez priamy `productKey`)
-// — rovnaký upsert + audit záznam, líšia sa len v tom, AKO sa `productKey`
-// zistí a či existuje `lineId` na zaznamenanie do auditu.
-async function upsertProductSupplierLink(
+// Zdieľané jadro VŠETKÝCH zápisových ciest nižšie/inde (`setProductSupplierLink`
+// cez `lineId`, `setProductSupplierLinkForProduct` cez priamy `productKey`,
+// issue 387 E6's `pairing-review/decisions.ts` cez VLASTNÚ transakciu, keď
+// treba `pairing_decision` upsert + túto linku zapísať ATOMICKY spolu) —
+// rovnaký upsert + audit záznam. Exportované (issue 387 E6) presne preto,
+// aby VLASTNÁ transakcia mohla toto jadro zavolať s SVOJÍM `tx`, namiesto
+// volania `setProductSupplierLinkForProduct` (tá by otvorila DRUHÚ,
+// vnorenú transakciu).
+export async function upsertProductSupplierLink(
   tx: UpsertExecutor,
   input: UpsertProductSupplierLinkInput,
 ): Promise<"ok"> {

--- a/apps/api/src/modules/pairing-review/decisions.ts
+++ b/apps/api/src/modules/pairing-review/decisions.ts
@@ -1,0 +1,188 @@
+import { eq } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { pairingCandidateSets, pairingDecisions, products } from "../../db/schema.js";
+import { record } from "../audit/service.js";
+import { upsertProductSupplierLink, type UpsertExecutor } from "../orders/supplier-link-assignment.js";
+
+// issue 387 E6 — "Eshop → Párovanie": aplikácia ČLOVEKOVHO rozhodnutia.
+// Design komentár na tickete (issue 387 E6) — guard proti súbežnému prepisu
+// je "posledný zápis vyhráva" (`onConflictDoUpdate`, atomický v Postgrese,
+// rovnaký vzor ako `upsertProductSupplierLink` samo), NIE optimistický
+// zámok — konflikt sa zaznamenáva SPÄTNE cez audit (`previousStatus`/
+// `previousUrl`), nikdy sa mu nepredchádza zamykaním.
+
+export type PairingDecisionStatus = "good" | "manual" | "unavailable" | "discontinued";
+
+interface BaseInput {
+  readonly productKey: string;
+  readonly actorUserId: string;
+  readonly now: Date;
+}
+
+// Diskriminovaná únia presne podľa design komentára: `good` (server SÁM
+// dohľadá `chosenUrl` z `pairing_candidate_set` — nikdy sa nedôveruje
+// klientom poslanej URL pre "AI kandidáta"), `manual` (klient POSIELA URL —
+// vybraný kandidát ALEBO ručne vpísaná adresa, zod validácia na HTTP hranici
+// rovnaká ako `product-links`), `unavailable`/`discontinued` (žiadna URL),
+// `revert` (DELETE riadku).
+export type SetPairingDecisionInput =
+  | (BaseInput & { readonly status: "good" })
+  | (BaseInput & { readonly status: "manual"; readonly url: string })
+  | (BaseInput & { readonly status: "unavailable" })
+  | (BaseInput & { readonly status: "discontinued" })
+  | (BaseInput & { readonly status: "revert" });
+
+export type SetPairingDecisionResult = "ok" | "not_found" | "no_candidate";
+
+interface UpsertDecisionRowInput {
+  readonly productKey: string;
+  readonly status: PairingDecisionStatus;
+  readonly url: string | null;
+  readonly actorUserId: string;
+  readonly now: Date;
+}
+
+// Zdieľané jadro pre KAŽDÝ neprázdny (non-revert) zápis nižšie — upsert
+// `pairing_decision` riadku + auditný záznam nesúci PREDOŠLÚ hodnotu (rovnaký
+// princíp ako `upsertProductSupplierLink`'s vlastný audit). `state_synced_at`
+// sa VŽDY nuluje — predošlý sync (ak nejaký existoval) sa týkal STARÉHO
+// stavu, E7 ho musí zistiť/odoslať odznova.
+async function upsertPairingDecisionRow(tx: UpsertExecutor, input: UpsertDecisionRowInput): Promise<void> {
+  const [previous] = await tx
+    .select({ status: pairingDecisions.status, url: pairingDecisions.url })
+    .from(pairingDecisions)
+    .where(eq(pairingDecisions.productKey, input.productKey))
+    .limit(1);
+
+  await tx
+    .insert(pairingDecisions)
+    .values({
+      productKey: input.productKey,
+      status: input.status,
+      url: input.url,
+      decidedBy: input.actorUserId,
+      decidedAt: input.now,
+      updatedAt: input.now,
+      stateSyncedAt: null,
+    })
+    .onConflictDoUpdate({
+      target: pairingDecisions.productKey,
+      set: {
+        status: input.status,
+        url: input.url,
+        decidedBy: input.actorUserId,
+        decidedAt: input.now,
+        updatedAt: input.now,
+        stateSyncedAt: null,
+      },
+    });
+
+  await record(tx, {
+    at: input.now,
+    actorUserId: input.actorUserId,
+    action: "pairing_decision.changed",
+    entity: "pairing_decision",
+    entityId: input.productKey,
+    data: {
+      productKey: input.productKey,
+      previousStatus: previous?.status ?? null,
+      previousUrl: previous?.url ?? null,
+      newStatus: input.status,
+      newUrl: input.url,
+    },
+  });
+}
+
+export async function setPairingDecision(db: Database, input: SetPairingDecisionInput): Promise<SetPairingDecisionResult> {
+  return db.transaction(async (tx) => {
+    if (input.status === "revert") {
+      // Zámerne NEMAŽE odkaz v `product_supplier_link_override` (design
+      // komentár na tickete) — človek ho môže chcieť ponechať aj po
+      // vrátení rozhodnutia späť na "nezrevidované".
+      const [previous] = await tx
+        .select({ status: pairingDecisions.status, url: pairingDecisions.url })
+        .from(pairingDecisions)
+        .where(eq(pairingDecisions.productKey, input.productKey))
+        .limit(1);
+      // Idempotentné: "↩ Vrátiť" na produkte, čo už žiadne rozhodnutie nemá
+      // (dvojklik / zastaraná karta), je no-op ok, nikdy chyba — nič sa
+      // nezmenilo, takže sa ani nepíše audit záznam (rovnaký princíp ako
+      // "audit `entity` = to, čo sa REÁLNE mutuje", `.claude/rules/orders.md`).
+      if (previous === undefined) return "ok";
+
+      await tx.delete(pairingDecisions).where(eq(pairingDecisions.productKey, input.productKey));
+      await record(tx, {
+        at: input.now,
+        actorUserId: input.actorUserId,
+        action: "pairing_decision.reverted",
+        entity: "pairing_decision",
+        entityId: input.productKey,
+        data: { productKey: input.productKey, previousStatus: previous.status, previousUrl: previous.url },
+      });
+      return "ok";
+    }
+
+    if (input.status === "good") {
+      const [set] = await tx
+        .select({ chosenUrl: pairingCandidateSets.chosenUrl })
+        .from(pairingCandidateSets)
+        .where(eq(pairingCandidateSets.productKey, input.productKey))
+        .limit(1);
+      if (set === undefined) return "not_found";
+      // Obranná kontrola — frontend zobrazuje "✓ Dobré" LEN keď karta má
+      // `chosenCandidate` (`chosenUrl !== null`), ale server nikdy nedôveruje
+      // klientovmu UI stavu.
+      if (set.chosenUrl === null) return "no_candidate";
+
+      await upsertProductSupplierLink(tx, {
+        productKey: input.productKey,
+        url: set.chosenUrl,
+        actorUserId: input.actorUserId,
+        now: input.now,
+        lineId: null,
+      });
+      await upsertPairingDecisionRow(tx, {
+        productKey: input.productKey,
+        status: "good",
+        url: set.chosenUrl,
+        actorUserId: input.actorUserId,
+        now: input.now,
+      });
+      return "ok";
+    }
+
+    if (input.status === "manual") {
+      const [product] = await tx.select({ key: products.key }).from(products).where(eq(products.key, input.productKey)).limit(1);
+      if (product === undefined) return "not_found";
+
+      await upsertProductSupplierLink(tx, {
+        productKey: input.productKey,
+        url: input.url,
+        actorUserId: input.actorUserId,
+        now: input.now,
+        lineId: null,
+      });
+      await upsertPairingDecisionRow(tx, {
+        productKey: input.productKey,
+        status: "manual",
+        url: input.url,
+        actorUserId: input.actorUserId,
+        now: input.now,
+      });
+      return "ok";
+    }
+
+    // "unavailable" | "discontinued" — žiadna URL, žiadny link-override zápis.
+    const [product] = await tx.select({ key: products.key }).from(products).where(eq(products.key, input.productKey)).limit(1);
+    if (product === undefined) return "not_found";
+
+    await upsertPairingDecisionRow(tx, {
+      productKey: input.productKey,
+      status: input.status,
+      url: null,
+      actorUserId: input.actorUserId,
+      now: input.now,
+    });
+    return "ok";
+  });
+}

--- a/apps/api/src/modules/pairing-review/queries.ts
+++ b/apps/api/src/modules/pairing-review/queries.ts
@@ -3,21 +3,24 @@
 // KANDIDÁTMI" (INNER JOIN na `pairing_candidate_set` — produkt, ktorý gather
 // ešte nespracoval, sa tu nezobrazuje vôbec, presne ako zadanie žiada).
 //
-// Filtre/badge/progress bez `pairing_decision` (E6, tu ešte neexistuje) —
-// pozri design komentár na tickete (issue 387 E5): "unreviewed" ZNAMENÁ
-// "produkt z gather populácie BEZ efektívnej dodávateľskej linky" (doslovná
-// zhoda so zadaním "nezrevidovaných BEZ ODKAZU"), nie "bez rozhodnutia" (to
-// pole tu neexistuje). Rovnaký MVP vzor ako `product-links/queries.ts`/
+// issue 387 E6: `pairing_decision` (E5's forward-kompat poznámka) teraz
+// EXISTUJE — "unreviewed" ostáva PRIMÁRNE "bez efektívnej linky" (E5's
+// doslovná zhoda so zadaním), ĎALEJ ZÚŽENÉ o produkty, čo už dostali
+// TERMINÁLNE rozhodnutie (`unavailable`/`discontinued` — tie linku NIKDY
+// nedostanú, ale SÚ zrevidované, netreba na ne ďalej upozorňovať). Design
+// komentár na tickete (issue 387 E6): API kontrakt sa nemení, len sa
+// definícia SPRESŇUJE. Rovnaký MVP vzor ako `product-links/queries.ts`/
 // `restock-links/queries.ts`/`pairing-search/select.ts` — celá relevantná
 // populácia (rádovo stovky, nie celý katalóg) sa načíta a filtruje/triedi/
 // stránkuje v JS, keďže `resolveEffectiveSupplierLink` je čistá JS funkcia
 // nad `internalNote`, nedá sa vyjadriť ako SQL predikát bez duplicity.
 
-import { inArray } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
 import {
   pairingCandidates,
   pairingCandidateSets,
+  pairingDecisions,
   productSupplierLinkOverrides,
   products,
   shopProductUrl,
@@ -26,6 +29,7 @@ import {
 import { resolveEffectiveSupplierLink } from "../orders/effective-supplier-link.js";
 import type { PairingConfidence, PairingVerdict } from "../pairing-search/types.js";
 import { SELLABLE_VISIBILITY } from "../restock/constants.js";
+import type { PairingDecisionStatus } from "./decisions.js";
 
 export type PairingReviewFilter = "unreviewed" | "matched" | "unmatched" | "st1" | "st2" | "st3" | "all";
 export type PairingReviewProductState = "sellable" | "out_of_stock" | "discontinued";
@@ -40,6 +44,15 @@ export interface PairingReviewChosenCandidate {
   readonly url: string;
   readonly rawScore: number;
   readonly codeHit: boolean;
+}
+
+// issue 387 E6 — posledné (jediné, appka nedrží históriu) rozhodnutie o
+// produkte, `null` = nezrevidované vôbec. Karta ho potrebuje na vykreslenie
+// odznaku/panelu "↩ Vrátiť"/"Zmeniť" bez ďalšieho volania.
+export interface PairingReviewDecision {
+  readonly status: PairingDecisionStatus;
+  readonly url: string | null;
+  readonly decidedAt: string;
 }
 
 export interface PairingReviewItem {
@@ -65,6 +78,8 @@ export interface PairingReviewItem {
   readonly verdict: PairingVerdict | null;
   /** `null` presne keď `confidence === "none"` (gather nenašiel u dodávateľa nič). */
   readonly chosenCandidate: PairingReviewChosenCandidate | null;
+  /** issue 387 E6 — posledné rozhodnutie, `null` = nezrevidované vôbec (viď `PairingReviewDecision`). */
+  readonly decision: PairingReviewDecision | null;
 }
 
 export interface PairingReviewSearchInput {
@@ -182,7 +197,22 @@ export async function listPairingReview(db: Database, input: PairingReviewSearch
   // vlastný `UNIQUE(product_key, url)` index vynucuje, takže zhoda je vždy
   // jednoznačná. Len kandidát rovný `chosenUrl` sa naozaj vyhľadá nižšie
   // (E5 ukazuje LEN navrhnutého kandidáta, nie všetkých top-8 — design komentár).
-  const candidateByKey = new Map(candidateRows.map((r) => [`${r.productKey} ${r.url}`, r]));
+  const candidateByKey = new Map(candidateRows.map((r) => [`${r.productKey} ${r.url}`, r]));
+
+  // issue 387 E6 — posledné rozhodnutie na produkt, `undefined` keď žiadne.
+  // Samostatný dopyt + Mapa (nie SQL JOIN), rovnaký MVP vzor ako každý iný
+  // spájaný zdroj v tejto funkcii — appka vždy spája v JS, nikdy v SQL, keď
+  // ide o odvodenú/filtrovanú obrazovkovú logiku (hlavička súboru).
+  const decisionRows = await db
+    .select({
+      productKey: pairingDecisions.productKey,
+      status: pairingDecisions.status,
+      url: pairingDecisions.url,
+      decidedAt: pairingDecisions.decidedAt,
+    })
+    .from(pairingDecisions)
+    .where(inArray(pairingDecisions.productKey, productKeys));
+  const decisionByProduct = new Map(decisionRows.map((r) => [r.productKey, r]));
 
   const allItems: PairingReviewItem[] = [];
   for (const set of setRows) {
@@ -229,11 +259,15 @@ export async function listPairingReview(db: Database, input: PairingReviewSearch
 
     const effective = resolveEffectiveSupplierLink(product.internalNote, overrideByProduct.get(set.productKey) ?? null);
 
-    const chosenCandidateRow = set.chosenUrl === null ? undefined : candidateByKey.get(`${set.productKey} ${set.chosenUrl}`);
+    const chosenCandidateRow = set.chosenUrl === null ? undefined : candidateByKey.get(`${set.productKey} ${set.chosenUrl}`);
     const chosenCandidate: PairingReviewChosenCandidate | null =
       chosenCandidateRow === undefined
         ? null
         : { name: chosenCandidateRow.name, url: chosenCandidateRow.url, rawScore: Number(chosenCandidateRow.rawScore), codeHit: chosenCandidateRow.codeHit };
+
+    const decisionRow = decisionByProduct.get(set.productKey);
+    const decision: PairingReviewDecision | null =
+      decisionRow === undefined ? null : { status: decisionRow.status, url: decisionRow.url, decidedAt: decisionRow.decidedAt.toISOString() };
 
     allItems.push({
       productKey: set.productKey,
@@ -253,16 +287,29 @@ export async function listPairingReview(db: Database, input: PairingReviewSearch
       chosenReason: set.chosenReason,
       verdict: set.verdict,
       chosenCandidate,
+      decision,
     });
   }
 
   const gatheredTotal = allItems.length;
   const linkedTotal = allItems.filter((item) => item.hasEffectiveLink).length;
 
+  // issue 387 E6 — "unreviewed" (design komentár na tickete): bez efektívnej
+  // linky A bez TERMINÁLNEHO rozhodnutia (unavailable/discontinued nikdy
+  // nedostanú linku, ale SÚ zrevidované — netreba na ne ďalej upozorňovať).
+  // `good`/`manual` rozhodnutia VŽDY produkujú `hasEffectiveLink === true`
+  // (zdieľaný zápis vždy nastaví override), takže pre ne je táto podmienka
+  // redundantná s prvou časťou — ponechaná explicitne pre čitateľnosť.
+  function isUnreviewed(item: PairingReviewItem): boolean {
+    if (item.hasEffectiveLink) return false;
+    if (item.decision !== null && (item.decision.status === "unavailable" || item.decision.status === "discontinued")) return false;
+    return true;
+  }
+
   const filtered = allItems.filter((item) => {
     switch (input.filter) {
       case "unreviewed":
-        return !item.hasEffectiveLink;
+        return isUnreviewed(item);
       case "matched":
         return item.chosenCandidate !== null;
       case "unmatched":
@@ -292,4 +339,34 @@ export async function listPairingReview(db: Database, input: PairingReviewSearch
   const items = filtered.slice(start, start + input.pageSize);
 
   return { total, gatheredTotal, linkedTotal, items };
+}
+
+export interface PairingReviewCandidate {
+  readonly name: string;
+  readonly url: string;
+  readonly rawScore: number;
+  readonly codeHit: boolean;
+}
+
+// issue 387 E6 — top-8 kandidátov produktu pre rozhodovací panel ("✗ Zlé" →
+// zoznam s "Vybrať"). LAZY (volá sa AŽ pri otvorení panelu, design komentár
+// na tickete) — hlavný zoznam vyššie ukazuje len `chosenCandidate`, nikdy
+// všetkých 8, aby sa nezaťažoval payload každej karty, čo sa nikdy
+// nerozbalí. Dáta sú UŽ perzistované z E2-E4 (`pairing_candidate`), žiadny
+// živý fetch (E5 to explicitne zamietla, kým to nebolo treba).
+export async function listPairingCandidatesForProduct(db: Database, productKey: string): Promise<readonly PairingReviewCandidate[]> {
+  const rows = await db
+    .select({
+      name: pairingCandidates.name,
+      url: pairingCandidates.url,
+      rawScore: pairingCandidates.rawScore,
+      codeHit: pairingCandidates.codeHit,
+      position: pairingCandidates.position,
+    })
+    .from(pairingCandidates)
+    .where(eq(pairingCandidates.productKey, productKey));
+
+  return rows
+    .sort((a, b) => a.position - b.position)
+    .map((r) => ({ name: r.name, url: r.url, rawScore: Number(r.rawScore), codeHit: r.codeHit }));
 }

--- a/apps/api/tests/helpers/db.ts
+++ b/apps/api/tests/helpers/db.ts
@@ -85,8 +85,13 @@ export async function withCleanDb(): Promise<{ db: Database; close: () => Promis
     // above — no FK in either direction (singleton id), and (like
     // "restock_settings") the migration seeds NO default row, so no reseed
     // is needed below either.
+    // issue 387 E6: "pairing_decision" has a real FK chain into "product"
+    // (cascade) AND "users" (restrict — TRUNCATE CASCADE ignores per-row
+    // ON DELETE actions, so this still cascades) — either alone already
+    // reaches it transitively, listed explicitly anyway for the SAME
+    // self-documenting consistency as "pairing_candidate_set" above.
     await db.execute(
-      sql`TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, nedostupne_replacement_link, mail_template, mail_template_history, supplier_stock, restock_settings, restock_event, shop_product_url, theme_color, dpd_pickup_request, upozornenie, daily_task, mail_log, dpd_shipment, product_supplier_override, product_supplier_link_override, pairing_candidate, pairing_candidate_set, pairing_search_settings RESTART IDENTITY CASCADE`,
+      sql`TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, nedostupne_replacement_link, mail_template, mail_template_history, supplier_stock, restock_settings, restock_event, shop_product_url, theme_color, dpd_pickup_request, upozornenie, daily_task, mail_log, dpd_shipment, product_supplier_override, product_supplier_link_override, pairing_candidate, pairing_candidate_set, pairing_search_settings, pairing_decision RESTART IDENTITY CASCADE`,
     );
     // issue 59: `order_open_status` is a NEW table with real production
     // content (the migration seeds it) — TRUNCATE alone would leave every

--- a/apps/api/tests/helpers/pairing-review.ts
+++ b/apps/api/tests/helpers/pairing-review.ts
@@ -1,0 +1,93 @@
+import type { Database } from "../../src/db/client.js";
+import { pairingCandidates, pairingCandidateSets, products, variants } from "../../src/db/schema.js";
+
+// issue 387 E5/E6 — zdieľané seed helpery pre `pairing-review-http
+// .integration.test.ts` (E5, čítanie) aj `pairing-review-decisions-http
+// .integration.test.ts` (E6, rozhodnutia) — vyčlenené SEM, aby ani jeden
+// súbor nenarástol cez eslint `max-lines: 400` (`.claude/rules/testing.md`'s
+// zavedený vzor: `orders-http.integration.test.ts`/`orders-http-state
+// .integration.test.ts` split).
+
+export async function seedPairingReviewProduct(
+  db: Database,
+  snapshotId: string,
+  productKey: string,
+  over: {
+    readonly name: string;
+    readonly supplier?: string | null;
+    readonly internalNote?: string | null;
+    readonly variants?: readonly {
+      readonly code: string;
+      readonly externalCode?: string | null;
+      readonly state?: "sellable" | "out_of_stock" | "discontinued";
+      readonly productVisibility?: string;
+      readonly missingSince?: Date | null;
+      readonly price?: string | null;
+    }[];
+  },
+): Promise<void> {
+  const now = new Date("2026-08-13T00:00:00Z");
+  await db.insert(products).values({
+    key: productKey,
+    name: over.name,
+    supplier: over.supplier ?? null,
+    internalNote: over.internalNote ?? null,
+    firstSeenAt: now,
+    lastSeenAt: now,
+    lastSeenSnapshotId: snapshotId,
+  });
+  const variantSpecs = over.variants ?? [{ code: `${productKey}/1` }];
+  for (const v of variantSpecs) {
+    await db.insert(variants).values({
+      code: v.code,
+      productKey,
+      guid: productKey,
+      externalCode: v.externalCode ?? null,
+      name: over.name,
+      price: v.price ?? null,
+      stock: 0,
+      availabilityInStockText: "Skladom",
+      availabilityOutOfStockText: "Vypredané",
+      availabilityText: v.state === "out_of_stock" ? "Vypredané" : "Skladom",
+      productVisibility: v.productVisibility ?? "visible",
+      state: v.state ?? "sellable",
+      missingSince: v.missingSince ?? null,
+      firstSeenAt: now,
+      lastSeenAt: now,
+      lastSeenSnapshotId: snapshotId,
+    });
+  }
+}
+
+export async function seedPairingCandidateSet(
+  db: Database,
+  productKey: string,
+  over: {
+    readonly chosenUrl?: string | null;
+    readonly confidence?: "high" | "medium" | "low" | "none";
+    readonly verdict?: "ok" | "unsure" | null;
+    readonly candidates?: readonly { readonly url: string; readonly name: string; readonly rawScore: string; readonly codeHit: boolean }[];
+  } = {},
+): Promise<void> {
+  await db.insert(pairingCandidateSets).values({
+    productKey,
+    gatheredAt: new Date("2026-08-13T03:35:00Z"),
+    queries: ["dopyt"],
+    inputHash: "hash-" + productKey,
+    chosenUrl: over.chosenUrl ?? null,
+    chosenReason: over.chosenUrl !== undefined && over.chosenUrl !== null ? "najlepší nájdený" : null,
+    confidence: over.confidence ?? (over.chosenUrl !== undefined && over.chosenUrl !== null ? "medium" : "none"),
+    verdict: over.verdict ?? null,
+    verdictCheckedAt: over.verdict !== undefined && over.verdict !== null ? new Date("2026-08-13T03:36:00Z") : null,
+  });
+  for (const [i, c] of (over.candidates ?? []).entries()) {
+    await db.insert(pairingCandidates).values({
+      productKey,
+      position: i,
+      name: c.name,
+      url: c.url,
+      rawScore: c.rawScore,
+      codeHit: c.codeHit,
+    });
+  }
+}

--- a/apps/api/tests/pairing-review-decisions-http.integration.test.ts
+++ b/apps/api/tests/pairing-review-decisions-http.integration.test.ts
@@ -1,0 +1,316 @@
+import { eq } from "drizzle-orm";
+import { afterEach, expect, it } from "vitest";
+import { auditEvents, pairingDecisions, productSupplierLinkOverrides, users } from "../src/db/schema.js";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import type { UserRole } from "../src/modules/auth/service.js";
+import { insertTestSnapshot } from "./helpers/catalog.js";
+import { withCleanDb } from "./helpers/db.js";
+import { seedPairingCandidateSet as seedCandidateSet, seedPairingReviewProduct as seedProduct } from "./helpers/pairing-review.js";
+
+// issue 387 E6: "Eshop → Párovanie" — rozhodnutia (`POST /api/pairing-review/
+// :productKey/decision`, `GET /api/pairing-review/:productKey/candidates`).
+// Vyčlenené OD `pairing-review-http.integration.test.ts` (E5, čisté čítanie),
+// aby ani jeden súbor nenarástol cez eslint `max-lines: 400` (`.claude/rules/
+// testing.md`'s zavedený vzor).
+
+const HESLO = "test-heslo-abc"; // testovacie údaje, nie tajomstvo
+
+let close: (() => Promise<void>) | undefined;
+
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  resetLoginRateLimit();
+});
+
+async function boot(role: UserRole) {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const [pouzivatel] = await ctx.db
+    .insert(users)
+    .values({ email: "manazer@forestshop.sk", passwordHash: await hashPassword(HESLO), displayName: "Manažér", role })
+    .returning({ id: users.id });
+  if (pouzivatel === undefined) throw new Error("testovací používateľ sa nepodarilo vložiť");
+
+  const app = createApp(ctx.db, { cookieSecure: false });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "manazer@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie, db: ctx.db, userId: pouzivatel.id };
+}
+
+function decide(app: ReturnType<typeof createApp>, cookie: string, productKey: string, body: unknown) {
+  return app.request(`/api/pairing-review/${productKey}/decision`, {
+    method: "POST",
+    headers: { "content-type": "application/json", cookie },
+    body: JSON.stringify(body),
+  });
+}
+
+async function unreviewedKeys(app: ReturnType<typeof createApp>, cookie: string): Promise<string[]> {
+  const telo = (await (await app.request("/api/pairing-review?filter=unreviewed&pageSize=100", { headers: { cookie } })).json()) as {
+    readonly items: { readonly productKey: string }[];
+  };
+  return telo.items.map((i) => i.productKey);
+}
+
+it("bez prihlásenia vráti 401", async () => {
+  const { app } = await boot("manazer");
+  expect((await decide(app, "", "X", { status: "good" })).status).toBe(401);
+});
+
+it("rola 'citanie' nemá právo rozhodovať (403)", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedProduct(db, snapshotId, "PR-403", { name: "Produkt" });
+  await seedCandidateSet(db, "PR-403", { chosenUrl: "https://d.example.com/x" });
+
+  expect((await decide(app, cookie, "PR-403", { status: "good" })).status).toBe(403);
+});
+
+it("'good': v JEDNEJ transakcii zapíše override AJ pairing_decision, okamžite viditeľné na hasEffectiveLink; oba audit záznamy existujú", async () => {
+  const { app, cookie, db, userId } = await boot("manazer");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedProduct(db, snapshotId, "PR-GOOD", { name: "Bunda Alfa" });
+  await seedCandidateSet(db, "PR-GOOD", {
+    chosenUrl: "https://dodavatel.example.com/bunda-alfa",
+    candidates: [{ url: "https://dodavatel.example.com/bunda-alfa", name: "Bunda Alfa u dodávateľa", rawScore: "1080.0000", codeHit: true }],
+  });
+
+  const res = await decide(app, cookie, "PR-GOOD", { status: "good" });
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ ok: true, status: "good" });
+
+  const [override] = await db.select().from(productSupplierLinkOverrides).where(eq(productSupplierLinkOverrides.productKey, "PR-GOOD"));
+  expect(override?.url).toBe("https://dodavatel.example.com/bunda-alfa");
+
+  const [decision] = await db.select().from(pairingDecisions).where(eq(pairingDecisions.productKey, "PR-GOOD"));
+  expect(decision?.status).toBe("good");
+  expect(decision?.url).toBe("https://dodavatel.example.com/bunda-alfa");
+  expect(decision?.decidedBy).toBe(userId);
+  expect(decision?.stateSyncedAt).toBeNull();
+
+  const events = await db.select().from(auditEvents).where(eq(auditEvents.entityId, "PR-GOOD"));
+  expect(events.map((e) => e.entity).sort()).toEqual(["pairing_decision", "product_supplier_link_override"]);
+
+  const telo = (await (await app.request("/api/pairing-review?filter=all", { headers: { cookie } })).json()) as {
+    readonly items: { readonly productKey: string; readonly hasEffectiveLink: boolean; readonly decision: { readonly status: string; readonly url: string | null } | null }[];
+  };
+  const item = telo.items.find((i) => i.productKey === "PR-GOOD");
+  expect(item?.hasEffectiveLink).toBe(true);
+  expect(item?.decision).toEqual({ status: "good", url: "https://dodavatel.example.com/bunda-alfa", decidedAt: expect.any(String) as string });
+  expect(await unreviewedKeys(app, cookie)).not.toContain("PR-GOOD");
+});
+
+it("'good' bez navrhnutého kandidáta (confidence none) vráti 400 a NIČ nezapíše", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedProduct(db, snapshotId, "PR-NOCAND", { name: "Produkt bez kandidáta" });
+  await seedCandidateSet(db, "PR-NOCAND", { confidence: "none" });
+
+  const res = await decide(app, cookie, "PR-NOCAND", { status: "good" });
+  expect(res.status).toBe(400);
+
+  const rows = await db.select().from(pairingDecisions).where(eq(pairingDecisions.productKey, "PR-NOCAND"));
+  expect(rows).toHaveLength(0);
+});
+
+it("'good' na produkte bez pairing_candidate_set riadku vráti 404", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedProduct(db, snapshotId, "PR-NEGATHER", { name: "Negatherovaný" });
+
+  expect((await decide(app, cookie, "PR-NEGATHER", { status: "good" })).status).toBe(404);
+});
+
+it("'manual': zapíše KLIENTOM poslanú URL (vybraný kandidát alebo ručná adresa), nie chosenUrl", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedProduct(db, snapshotId, "PR-MANUAL", { name: "Produkt s výberom" });
+  await seedCandidateSet(db, "PR-MANUAL", {
+    chosenUrl: "https://dodavatel.example.com/top",
+    candidates: [
+      { url: "https://dodavatel.example.com/top", name: "Top kandidát", rawScore: "90.0000", codeHit: false },
+      { url: "https://dodavatel.example.com/druhy", name: "Druhý kandidát", rawScore: "70.0000", codeHit: false },
+    ],
+  });
+
+  const res = await decide(app, cookie, "PR-MANUAL", { status: "manual", url: "https://dodavatel.example.com/druhy" });
+  expect(res.status).toBe(200);
+
+  const [override] = await db.select().from(productSupplierLinkOverrides).where(eq(productSupplierLinkOverrides.productKey, "PR-MANUAL"));
+  expect(override?.url).toBe("https://dodavatel.example.com/druhy");
+  const [decision] = await db.select().from(pairingDecisions).where(eq(pairingDecisions.productKey, "PR-MANUAL"));
+  expect(decision?.status).toBe("manual");
+  expect(decision?.url).toBe("https://dodavatel.example.com/druhy");
+});
+
+it("'manual' s neplatnou URL (nie http) zlyhá na zod validácii skôr, než sa čokoľvek zapíše", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedProduct(db, snapshotId, "PR-BADURL", { name: "Produkt" });
+  await seedCandidateSet(db, "PR-BADURL", { confidence: "none" });
+
+  const res = await decide(app, cookie, "PR-BADURL", { status: "manual", url: "nie-je-to-url" });
+  expect(res.status).toBe(400);
+  const rows = await db.select().from(pairingDecisions).where(eq(pairingDecisions.productKey, "PR-BADURL"));
+  expect(rows).toHaveLength(0);
+});
+
+it("'unavailable': žiadny override zápis, produkt je zrevidovaný (vypadne z 'unreviewed') aj bez linky", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedProduct(db, snapshotId, "PR-NEDOSTUPNY", { name: "Vypredaný produkt" });
+  await seedCandidateSet(db, "PR-NEDOSTUPNY", { confidence: "none" });
+  expect(await unreviewedKeys(app, cookie)).toContain("PR-NEDOSTUPNY");
+
+  const res = await decide(app, cookie, "PR-NEDOSTUPNY", { status: "unavailable" });
+  expect(res.status).toBe(200);
+
+  const overrides = await db.select().from(productSupplierLinkOverrides).where(eq(productSupplierLinkOverrides.productKey, "PR-NEDOSTUPNY"));
+  expect(overrides).toHaveLength(0);
+  const [decision] = await db.select().from(pairingDecisions).where(eq(pairingDecisions.productKey, "PR-NEDOSTUPNY"));
+  expect(decision?.status).toBe("unavailable");
+  expect(decision?.url).toBeNull();
+
+  expect(await unreviewedKeys(app, cookie)).not.toContain("PR-NEDOSTUPNY");
+});
+
+it("'discontinued': rovnaké správanie ako 'unavailable' — žiadny override, produkt je zrevidovaný", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedProduct(db, snapshotId, "PR-KONIEC", { name: "Ukončený produkt" });
+  await seedCandidateSet(db, "PR-KONIEC", { confidence: "none" });
+
+  const res = await decide(app, cookie, "PR-KONIEC", { status: "discontinued" });
+  expect(res.status).toBe(200);
+
+  const [decision] = await db.select().from(pairingDecisions).where(eq(pairingDecisions.productKey, "PR-KONIEC"));
+  expect(decision?.status).toBe("discontinued");
+  expect(await unreviewedKeys(app, cookie)).not.toContain("PR-KONIEC");
+});
+
+it("'revert' na produkte s TERMINÁLNYM rozhodnutím (unavailable) vráti produkt do 'unreviewed' — DELETE riadku", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedProduct(db, snapshotId, "PR-VRATIT", { name: "Produkt na vrátenie" });
+  await seedCandidateSet(db, "PR-VRATIT", { confidence: "none" });
+  expect((await decide(app, cookie, "PR-VRATIT", { status: "unavailable" })).status).toBe(200);
+  expect(await unreviewedKeys(app, cookie)).not.toContain("PR-VRATIT");
+
+  const res = await decide(app, cookie, "PR-VRATIT", { status: "revert" });
+  expect(res.status).toBe(200);
+
+  const rows = await db.select().from(pairingDecisions).where(eq(pairingDecisions.productKey, "PR-VRATIT"));
+  expect(rows).toHaveLength(0);
+  expect(await unreviewedKeys(app, cookie)).toContain("PR-VRATIT");
+
+  const events = await db.select().from(auditEvents).where(eq(auditEvents.entityId, "PR-VRATIT"));
+  expect(events.some((e) => e.action === "pairing_decision.reverted")).toBe(true);
+});
+
+// Zámerný dizajn (design komentár na tickete, issue 387 E6): "Vrátiť" NIKDY
+// nemaže `product_supplier_link_override` — človek ho môže chcieť ponechať.
+// Dôsledok: revert 'good'/'manual' rozhodnutia zmaže SAMOTNÉ rozhodnutie
+// (odznak/panel na karte zmizne), ale keďže efektívna linka naďalej
+// existuje, produkt NEVYPADNE do "unreviewed" (to by bolo v rozpore s E5's
+// vlastnou definíciou "unreviewed = bez efektívnej linky") — nájditeľný je
+// ďalej cez "Všetky"/"Napárované" filter.
+it("'revert' na 'good' rozhodnutí zmaže decision riadok, ale NIKDY nezmaže override — produkt zostáva MIMO 'unreviewed'", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedProduct(db, snapshotId, "PR-VRATIT-GOOD", { name: "Dobre rozhodnutý produkt" });
+  await seedCandidateSet(db, "PR-VRATIT-GOOD", { chosenUrl: "https://dodavatel.example.com/x" });
+  expect((await decide(app, cookie, "PR-VRATIT-GOOD", { status: "good" })).status).toBe(200);
+
+  expect((await decide(app, cookie, "PR-VRATIT-GOOD", { status: "revert" })).status).toBe(200);
+
+  const decisionRows = await db.select().from(pairingDecisions).where(eq(pairingDecisions.productKey, "PR-VRATIT-GOOD"));
+  expect(decisionRows).toHaveLength(0);
+  const overrideRows = await db.select().from(productSupplierLinkOverrides).where(eq(productSupplierLinkOverrides.productKey, "PR-VRATIT-GOOD"));
+  expect(overrideRows).toHaveLength(1);
+  expect(await unreviewedKeys(app, cookie)).not.toContain("PR-VRATIT-GOOD");
+});
+
+it("'revert' na produkte BEZ rozhodnutia je idempotentný no-op — ok, žiadny nový audit záznam", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedProduct(db, snapshotId, "PR-NOOP", { name: "Nezrevidovaný produkt" });
+  await seedCandidateSet(db, "PR-NOOP", { confidence: "none" });
+
+  const res = await decide(app, cookie, "PR-NOOP", { status: "revert" });
+  expect(res.status).toBe(200);
+
+  const events = await db.select().from(auditEvents).where(eq(auditEvents.entityId, "PR-NOOP"));
+  expect(events).toHaveLength(0);
+});
+
+it("prepísanie EXISTUJÚCEHO rozhodnutia (posledný zápis vyhráva) prepíše status/url a zaznamená PREDOŠLÚ hodnotu do auditu", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedProduct(db, snapshotId, "PR-PREPIS", { name: "Produkt na prepis" });
+  await seedCandidateSet(db, "PR-PREPIS", { confidence: "none" });
+
+  expect((await decide(app, cookie, "PR-PREPIS", { status: "unavailable" })).status).toBe(200);
+  expect((await decide(app, cookie, "PR-PREPIS", { status: "discontinued" })).status).toBe(200);
+
+  const [decision] = await db.select().from(pairingDecisions).where(eq(pairingDecisions.productKey, "PR-PREPIS"));
+  expect(decision?.status).toBe("discontinued");
+
+  const events = await db.select().from(auditEvents).where(eq(auditEvents.entityId, "PR-PREPIS"));
+  const changed = events.filter((e) => e.action === "pairing_decision.changed");
+  expect(changed).toHaveLength(2);
+  const second = changed.find((e) => (e.data as { readonly newStatus: string }).newStatus === "discontinued");
+  expect((second?.data as { readonly previousStatus: string | null }).previousStatus).toBe("unavailable");
+});
+
+it("GET /:productKey/candidates vráti top kandidátov zoradených podľa position", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedProduct(db, snapshotId, "PR-CANDS", { name: "Produkt s kandidátmi" });
+  await seedCandidateSet(db, "PR-CANDS", {
+    chosenUrl: "https://dodavatel.example.com/a",
+    candidates: [
+      { url: "https://dodavatel.example.com/a", name: "A", rawScore: "90.0000", codeHit: true },
+      { url: "https://dodavatel.example.com/b", name: "B", rawScore: "50.0000", codeHit: false },
+    ],
+  });
+
+  const res = await app.request("/api/pairing-review/PR-CANDS/candidates", { headers: { cookie } });
+  expect(res.status).toBe(200);
+  const telo = (await res.json()) as { readonly candidates: { readonly name: string; readonly url: string; readonly rawScore: number; readonly codeHit: boolean }[] };
+  expect(telo.candidates.map((c) => c.name)).toEqual(["A", "B"]);
+  expect(telo.candidates[0]).toMatchObject({ url: "https://dodavatel.example.com/a", rawScore: 90, codeHit: true });
+});
+
+it("GET /:productKey/candidates bez prihlásenia vráti 401", async () => {
+  const { app } = await boot("manazer");
+  expect((await app.request("/api/pairing-review/PR-X/candidates")).status).toBe(401);
+});
+
+it("CHECK obmedzenie: 'good'/'manual' s NULL url zlyhá na DB úrovni", async () => {
+  const { db, userId } = await boot("manazer");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedProduct(db, snapshotId, "PR-CHECK-1", { name: "Produkt" });
+  const now = new Date();
+  await expect(
+    db.insert(pairingDecisions).values({ productKey: "PR-CHECK-1", status: "good", url: null, decidedBy: userId, decidedAt: now, updatedAt: now }),
+  ).rejects.toThrow();
+});
+
+it("CHECK obmedzenie: 'unavailable'/'discontinued' s VYPLNENOU url zlyhá na DB úrovni", async () => {
+  const { db, userId } = await boot("manazer");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedProduct(db, snapshotId, "PR-CHECK-2", { name: "Produkt" });
+  const now = new Date();
+  await expect(
+    db
+      .insert(pairingDecisions)
+      .values({ productKey: "PR-CHECK-2", status: "unavailable", url: "https://x.example.com", decidedBy: userId, decidedAt: now, updatedAt: now }),
+  ).rejects.toThrow();
+});

--- a/apps/api/tests/pairing-review-http.integration.test.ts
+++ b/apps/api/tests/pairing-review-http.integration.test.ts
@@ -1,20 +1,15 @@
 import { afterEach, expect, it } from "vitest";
-import type { Database } from "../src/db/client.js";
-import {
-  pairingCandidates,
-  pairingCandidateSets,
-  productSupplierLinkOverrides,
-  products,
-  shopProductUrl,
-  users,
-  variants,
-} from "../src/db/schema.js";
+import { productSupplierLinkOverrides, shopProductUrl, users } from "../src/db/schema.js";
 import { createApp } from "../src/http/app.js";
 import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
 import { hashPassword } from "../src/modules/auth/passwords.js";
 import type { UserRole } from "../src/modules/auth/service.js";
 import { insertTestSnapshot } from "./helpers/catalog.js";
 import { withCleanDb } from "./helpers/db.js";
+// issue 387 E6: `seedProduct`/`seedCandidateSet` vyčlenené do zdieľaného
+// helpera (`helpers/pairing-review.ts`), aby ich vedel použiť aj nový
+// `pairing-review-decisions-http.integration.test.ts` bez duplikácie.
+import { seedPairingCandidateSet as seedCandidateSet, seedPairingReviewProduct as seedProduct } from "./helpers/pairing-review.js";
 
 // issue 387 E5: "Eshop → Párovanie" — LEN čítanie (`GET /api/pairing-review`).
 // Rozhodnutia (E6) tu ešte neexistujú.
@@ -68,90 +63,6 @@ interface Telo {
     readonly verdict: "ok" | "unsure" | null;
     readonly chosenCandidate: { readonly name: string; readonly url: string; readonly rawScore: number; readonly codeHit: boolean } | null;
   }[];
-}
-
-async function seedProduct(
-  db: Database,
-  snapshotId: string,
-  productKey: string,
-  over: {
-    readonly name: string;
-    readonly supplier?: string | null;
-    readonly internalNote?: string | null;
-    readonly variants?: readonly {
-      readonly code: string;
-      readonly externalCode?: string | null;
-      readonly state?: "sellable" | "out_of_stock" | "discontinued";
-      readonly productVisibility?: string;
-      readonly missingSince?: Date | null;
-      readonly price?: string | null;
-    }[];
-  },
-): Promise<void> {
-  const now = new Date("2026-08-13T00:00:00Z");
-  await db.insert(products).values({
-    key: productKey,
-    name: over.name,
-    supplier: over.supplier ?? null,
-    internalNote: over.internalNote ?? null,
-    firstSeenAt: now,
-    lastSeenAt: now,
-    lastSeenSnapshotId: snapshotId,
-  });
-  const variantSpecs = over.variants ?? [{ code: `${productKey}/1` }];
-  for (const v of variantSpecs) {
-    await db.insert(variants).values({
-      code: v.code,
-      productKey,
-      guid: productKey,
-      externalCode: v.externalCode ?? null,
-      name: over.name,
-      price: v.price ?? null,
-      stock: 0,
-      availabilityInStockText: "Skladom",
-      availabilityOutOfStockText: "Vypredané",
-      availabilityText: v.state === "out_of_stock" ? "Vypredané" : "Skladom",
-      productVisibility: v.productVisibility ?? "visible",
-      state: v.state ?? "sellable",
-      missingSince: v.missingSince ?? null,
-      firstSeenAt: now,
-      lastSeenAt: now,
-      lastSeenSnapshotId: snapshotId,
-    });
-  }
-}
-
-async function seedCandidateSet(
-  db: Database,
-  productKey: string,
-  over: {
-    readonly chosenUrl?: string | null;
-    readonly confidence?: "high" | "medium" | "low" | "none";
-    readonly verdict?: "ok" | "unsure" | null;
-    readonly candidates?: readonly { readonly url: string; readonly name: string; readonly rawScore: string; readonly codeHit: boolean }[];
-  } = {},
-): Promise<void> {
-  await db.insert(pairingCandidateSets).values({
-    productKey,
-    gatheredAt: new Date("2026-08-13T03:35:00Z"),
-    queries: ["dopyt"],
-    inputHash: "hash-" + productKey,
-    chosenUrl: over.chosenUrl ?? null,
-    chosenReason: over.chosenUrl !== undefined && over.chosenUrl !== null ? "najlepší nájdený" : null,
-    confidence: over.confidence ?? (over.chosenUrl !== undefined && over.chosenUrl !== null ? "medium" : "none"),
-    verdict: over.verdict ?? null,
-    verdictCheckedAt: over.verdict !== undefined && over.verdict !== null ? new Date("2026-08-13T03:36:00Z") : null,
-  });
-  for (const [i, c] of (over.candidates ?? []).entries()) {
-    await db.insert(pairingCandidates).values({
-      productKey,
-      position: i,
-      name: c.name,
-      url: c.url,
-      rawScore: c.rawScore,
-      codeHit: c.codeHit,
-    });
-  }
 }
 
 it("bez prihlásenia vráti 401", async () => {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -12,6 +12,7 @@ import { OrderFlagsBadgeRefreshContext } from "./orderFlagsBadgeContext.js";
 import { fetchOrderReminderStatus } from "./orderReminderApi.js";
 import { OrdersRemainingCountContext } from "./ordersRemainingCountContext.js";
 import { fetchPairingReviewUnreviewedCount } from "./pairingReviewApi.js";
+import { PairingReviewBadgeRefreshContext } from "./pairingReviewBadgeContext.js";
 import { fetchPostaUncollectedStatus } from "./postaUncollectedApi.js";
 import { fetchRestockLinksMissingCount } from "./restockLinksApi.js";
 import { RestockLinksBadgeRefreshContext } from "./restockLinksBadgeContext.js";
@@ -109,14 +110,20 @@ export function App(): JSX.Element {
     };
   }, [me, activeTabId, restockLinksRefreshNonce]);
 
-  // issue 387 E5: odznak "Párovanie" — rovnaký PRIAMY vzor ako
+  // issue 387 E5/E6: odznak "Párovanie" — rovnaký PRIAMY vzor ako
   // `restockLinksMissingCount` vyššie (musí byť známy hneď po prihlásení,
   // viditeľný AJ pri nule — issue 331's poučenie o VIDITEĽNOSTI). "unreviewed"
   // (design komentár na tickete) = koľko produktov z gather populácie ešte
-  // NEMÁ efektívnu dodávateľskú linku — E5 nemá ŽIADNU mutáciu, ktorá by toto
-  // číslo menila (rozhodnutia prídu v E6), preto ŽIADEN refresh-nonce/context
-  // navyše — len fetch pri prihlásení/zmene záložky, presne ako `automationStatus`.
+  // NEMÁ efektívnu dodávateľskú linku A nemá TERMINÁLNE rozhodnutie. issue 387
+  // E6 pridalo mutácie (rozhodnutia) — `PairingReviewCard`/`Section` zavolá
+  // `refresh()` (cez `PairingReviewBadgeRefreshContext`) po každom úspešnom
+  // zápise, rovnaký vzor ako `restockLinksBadgeRefresh` vyššie.
   const [pairingReviewUnreviewedCount, setPairingReviewUnreviewedCount] = useState<number | null>(null);
+  const [pairingReviewRefreshNonce, setPairingReviewRefreshNonce] = useState(0);
+  const pairingReviewBadgeRefresh = useCallback(() => {
+    setPairingReviewRefreshNonce((n) => n + 1);
+  }, []);
+  const pairingReviewBadgeContextValue = useMemo(() => ({ refresh: pairingReviewBadgeRefresh }), [pairingReviewBadgeRefresh]);
   useEffect(() => {
     if (me === null) return;
     let cancelled = false;
@@ -130,7 +137,7 @@ export function App(): JSX.Element {
     return () => {
       cancelled = true;
     };
-  }, [me, activeTabId]);
+  }, [me, activeTabId, pairingReviewRefreshNonce]);
 
   // issue 290: odznaky "Výmena tovaru"/"Vrátený tovar"/"Reklamácie" — rovnaký
   // priamy vzor ako `upozorneniaCount` vyššie (JEDEN endpoint, `App.tsx` si
@@ -314,36 +321,38 @@ export function App(): JSX.Element {
     <OrdersRemainingCountContext.Provider value={ordersRemainingCountContextValue}>
       <UpozorneniaBadgeRefreshContext.Provider value={upozorneniaBadgeContextValue}>
         <RestockLinksBadgeRefreshContext.Provider value={restockLinksBadgeContextValue}>
-          <OrderFlagsBadgeRefreshContext.Provider value={orderFlagsBadgeContextValue}>
-            <div className="app-shell">
-              <Sidebar
-                folders={NAV}
-                activeTabId={activeTabId}
-                onSelectTab={selectTab}
-                badgeCounts={badgeCounts}
-                badgeStatus={automationStatus}
-              />
-              <div className="main">
-                <Topbar
-                  title={isVisibleTabId(activeTabId) ? (tab?.label ?? null) : null}
-                  greeting={`Prihlásený: ${me.displayName} (${me.role})`}
-                  role={me.role}
-                  onSessionExpired={reload}
-                  onLogout={logout}
-                  passwordPanelOpen={passwordPanelOpen}
-                  onTogglePasswordPanel={() => {
-                    setPasswordPanelOpen((open) => !open);
-                  }}
-                >
-                  <ChangePasswordForm email={me.email} onSessionExpired={reload} />
-                </Topbar>
-                <main className={tab?.wide === true ? "main-wide" : undefined}>
-                  {logoutError !== "" && <p role="alert">{logoutError}</p>}
-                  {ActiveComponent !== null && <ActiveComponent role={me.role} onSessionExpired={reload} />}
-                </main>
+          <PairingReviewBadgeRefreshContext.Provider value={pairingReviewBadgeContextValue}>
+            <OrderFlagsBadgeRefreshContext.Provider value={orderFlagsBadgeContextValue}>
+              <div className="app-shell">
+                <Sidebar
+                  folders={NAV}
+                  activeTabId={activeTabId}
+                  onSelectTab={selectTab}
+                  badgeCounts={badgeCounts}
+                  badgeStatus={automationStatus}
+                />
+                <div className="main">
+                  <Topbar
+                    title={isVisibleTabId(activeTabId) ? (tab?.label ?? null) : null}
+                    greeting={`Prihlásený: ${me.displayName} (${me.role})`}
+                    role={me.role}
+                    onSessionExpired={reload}
+                    onLogout={logout}
+                    passwordPanelOpen={passwordPanelOpen}
+                    onTogglePasswordPanel={() => {
+                      setPasswordPanelOpen((open) => !open);
+                    }}
+                  >
+                    <ChangePasswordForm email={me.email} onSessionExpired={reload} />
+                  </Topbar>
+                  <main className={tab?.wide === true ? "main-wide" : undefined}>
+                    {logoutError !== "" && <p role="alert">{logoutError}</p>}
+                    {ActiveComponent !== null && <ActiveComponent role={me.role} onSessionExpired={reload} />}
+                  </main>
+                </div>
               </div>
-            </div>
-          </OrderFlagsBadgeRefreshContext.Provider>
+            </OrderFlagsBadgeRefreshContext.Provider>
+          </PairingReviewBadgeRefreshContext.Provider>
         </RestockLinksBadgeRefreshContext.Provider>
       </UpozorneniaBadgeRefreshContext.Provider>
     </OrdersRemainingCountContext.Provider>

--- a/apps/web/src/components/PairingReviewCard.test.tsx
+++ b/apps/web/src/components/PairingReviewCard.test.tsx
@@ -1,0 +1,214 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { PairingReviewCard } from "./PairingReviewCard.js";
+
+// issue 387 E6 — rozhodovacia UX karty (`.claude/rules/frontend-design.md`'s
+// toggle-open panel vzor). Vyčlenené OD `PairingReviewSection.test.tsx` (E5,
+// list-rendering), rovnaký princíp ako `OrderLineRow.*.test.tsx`/
+// `UpozornenieCard.*.test.ts` — karta má VLASTNÝ test súbor.
+
+const { fetchPairingCandidates, sendPairingDecision } = vi.hoisted(() => ({
+  fetchPairingCandidates: vi.fn(),
+  sendPairingDecision: vi.fn(),
+}));
+
+// `PairingReviewUnauthorizedError` ostáva SKUTOČNÁ trieda (rovnaký dôvod ako
+// `PairingReviewSection.test.tsx` — `instanceof` v komponente musí fungovať).
+vi.mock("../pairingReviewApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../pairingReviewApi.js")>();
+  return { ...actual, fetchPairingCandidates, sendPairingDecision };
+});
+
+const { PairingReviewUnauthorizedError } = await import("../pairingReviewApi.js");
+
+const MATCHED_ITEM = {
+  productKey: "PR-1",
+  productName: "Bunda Alfa Zimná",
+  supplier: "DODAVATEL-PR",
+  externalCodes: ["KOD-123"],
+  variantCount: 2,
+  productState: "sellable" as const,
+  priceMin: "59.90",
+  priceMax: "64.90",
+  currency: "EUR",
+  ourUrl: "https://www.forestshop.sk/bunda-alfa",
+  ourImageUrl: "https://www.forestshop.sk/img/bunda.jpg",
+  hasEffectiveLink: false,
+  gatheredAt: "2026-08-13T03:35:00.000Z",
+  confidence: "high" as const,
+  chosenReason: "najlepší nájdený",
+  verdict: "ok" as const,
+  chosenCandidate: { name: "Bunda Alfa", url: "https://dodavatel.example.com/bunda-alfa", rawScore: 1080.5, codeHit: true },
+  decision: null,
+};
+
+const UNMATCHED_ITEM = {
+  ...MATCHED_ITEM,
+  productKey: "PR-2",
+  chosenCandidate: null,
+  confidence: "none" as const,
+  verdict: null,
+};
+
+const DECIDED_UNAVAILABLE_ITEM = {
+  ...MATCHED_ITEM,
+  productKey: "PR-3",
+  decision: { status: "unavailable" as const, url: null, decidedAt: "2026-08-13T04:00:00.000Z" },
+};
+
+const DECIDED_GOOD_ITEM = {
+  ...MATCHED_ITEM,
+  productKey: "PR-4",
+  hasEffectiveLink: true,
+  decision: { status: "good" as const, url: "https://dodavatel.example.com/bunda-alfa", decidedAt: "2026-08-13T04:00:00.000Z" },
+};
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+it("'citanie' rola nevidí ŽIADNE akčné tlačidlo", async () => {
+  render(<PairingReviewCard item={MATCHED_ITEM} role="citanie" onDecided={() => {}} onSessionExpired={() => {}} />);
+  const card = await screen.findByTestId("pairing-review-card-PR-1");
+  expect(card.querySelectorAll("button")).toHaveLength(0);
+});
+
+it("napárovaný produkt bez rozhodnutia ukáže ✓ Dobré / ✗ Zlé; klik na ✓ Dobré odošle {status:'good'} a zavolá onDecided", async () => {
+  sendPairingDecision.mockResolvedValue(undefined);
+  const onDecided = vi.fn();
+  render(<PairingReviewCard item={MATCHED_ITEM} role="manazer" onDecided={onDecided} onSessionExpired={() => {}} />);
+
+  expect(screen.getByTestId("pairing-review-good-PR-1")).toBeDefined();
+  fireEvent.click(screen.getByTestId("pairing-review-good-PR-1"));
+
+  await waitFor(() => {
+    expect(sendPairingDecision).toHaveBeenCalledWith("PR-1", { status: "good" });
+  });
+  await waitFor(() => {
+    expect(onDecided).toHaveBeenCalledTimes(1);
+  });
+});
+
+it("klik na ✗ Zlé ROZBALÍ panel NA MIESTE (karta ostáva) a načíta kandidátov; 'Vybrať' odošle manual s URL toho kandidáta", async () => {
+  fetchPairingCandidates.mockResolvedValue([
+    { name: "Top kandidát", url: "https://dodavatel.example.com/top", rawScore: 90, codeHit: true },
+    { name: "Druhý kandidát", url: "https://dodavatel.example.com/druhy", rawScore: 60, codeHit: false },
+  ]);
+  sendPairingDecision.mockResolvedValue(undefined);
+
+  render(<PairingReviewCard item={MATCHED_ITEM} role="manazer" onDecided={() => {}} onSessionExpired={() => {}} />);
+  fireEvent.click(screen.getByTestId("pairing-review-open-panel-PR-1"));
+
+  // Karta samotná sa NEPRESÚVA/nezmizne — panel sa objaví NA TEJ ISTEJ karte.
+  expect(screen.getByTestId("pairing-review-card-PR-1")).toBeDefined();
+  const panel = await screen.findByTestId("pairing-review-panel-PR-1");
+  expect(panel.textContent).toContain("Top kandidát");
+  expect(panel.textContent).toContain("Druhý kandidát");
+
+  fireEvent.click(screen.getByTestId("pairing-review-panel-pick-PR-1-1"));
+  await waitFor(() => {
+    expect(sendPairingDecision).toHaveBeenCalledWith("PR-1", { status: "manual", url: "https://dodavatel.example.com/druhy" });
+  });
+});
+
+it("ručná URL: neplatná adresa sa NEODOŠLE (klientská validácia), platná sa odošle orezaná", async () => {
+  fetchPairingCandidates.mockResolvedValue([]);
+  sendPairingDecision.mockResolvedValue(undefined);
+
+  render(<PairingReviewCard item={UNMATCHED_ITEM} role="manazer" onDecided={() => {}} onSessionExpired={() => {}} />);
+  // UNMATCHED_ITEM (bez chosenCandidate, bez rozhodnutia) ukazuje panel PRIAMO.
+  const input = await screen.findByTestId("pairing-review-manual-input-PR-2");
+
+  fireEvent.change(input, { target: { value: "nie-je-url" } });
+  fireEvent.click(screen.getByTestId("pairing-review-manual-save-PR-2"));
+  expect(sendPairingDecision).not.toHaveBeenCalled();
+  expect(screen.getByRole("alert").textContent).toContain("http");
+
+  fireEvent.change(input, { target: { value: "  https://dodavatel.example.com/rucne  " } });
+  fireEvent.click(screen.getByTestId("pairing-review-manual-save-PR-2"));
+  await waitFor(() => {
+    expect(sendPairingDecision).toHaveBeenCalledWith("PR-2", { status: "manual", url: "https://dodavatel.example.com/rucne" });
+  });
+});
+
+it("📦 Nie je skladom / 🚫 Už sa nebude predávať odošlú príslušný terminálny status", async () => {
+  fetchPairingCandidates.mockResolvedValue([]);
+  sendPairingDecision.mockResolvedValue(undefined);
+
+  render(<PairingReviewCard item={UNMATCHED_ITEM} role="manazer" onDecided={() => {}} onSessionExpired={() => {}} />);
+  await screen.findByTestId("pairing-review-panel-PR-2");
+
+  fireEvent.click(screen.getByTestId("pairing-review-unavailable-PR-2"));
+  await waitFor(() => {
+    expect(sendPairingDecision).toHaveBeenCalledWith("PR-2", { status: "unavailable" });
+  });
+});
+
+it("už rozhodnutý produkt (terminálny stav) ukáže odznak + '↩ Vrátiť'; klik odošle {status:'revert'}", async () => {
+  sendPairingDecision.mockResolvedValue(undefined);
+  const onDecided = vi.fn();
+  render(<PairingReviewCard item={DECIDED_UNAVAILABLE_ITEM} role="manazer" onDecided={onDecided} onSessionExpired={() => {}} />);
+
+  expect(screen.getByTestId("pairing-review-decision-badge-PR-3").textContent).toContain("Nie je skladom");
+  // Terminálny stav (unavailable/discontinued) nemá "Zmeniť" tlačidlo —
+  // len napárované/manuálne rozhodnutia sa dajú "zmeniť na iný link".
+  expect(screen.queryByTestId("pairing-review-change-PR-3")).toBeNull();
+
+  fireEvent.click(screen.getByTestId("pairing-review-revert-PR-3"));
+  await waitFor(() => {
+    expect(sendPairingDecision).toHaveBeenCalledWith("PR-3", { status: "revert" });
+  });
+  await waitFor(() => {
+    expect(onDecided).toHaveBeenCalledTimes(1);
+  });
+});
+
+it("rozhodnutie 'good' ukáže AJ '✗ Zmeniť / iný link' — klik otvorí panel s kandidátmi", async () => {
+  fetchPairingCandidates.mockResolvedValue([{ name: "Top kandidát", url: "https://dodavatel.example.com/bunda-alfa", rawScore: 90, codeHit: true }]);
+
+  render(<PairingReviewCard item={DECIDED_GOOD_ITEM} role="manazer" onDecided={() => {}} onSessionExpired={() => {}} />);
+  fireEvent.click(screen.getByTestId("pairing-review-change-PR-4"));
+
+  await screen.findByTestId("pairing-review-panel-PR-4");
+  expect(fetchPairingCandidates).toHaveBeenCalledWith("PR-4");
+});
+
+it("busy guard: kým prvý zápis beží, ✓ Dobré AJ ✗ Zlé sú disabled (jeden zdieľaný guard)", async () => {
+  let resolveDecision: (() => void) | undefined;
+  sendPairingDecision.mockImplementation(
+    () =>
+      new Promise<void>((resolve) => {
+        resolveDecision = resolve;
+      }),
+  );
+
+  render(<PairingReviewCard item={MATCHED_ITEM} role="manazer" onDecided={() => {}} onSessionExpired={() => {}} />);
+  const good = screen.getByTestId<HTMLButtonElement>("pairing-review-good-PR-1");
+  const bad = screen.getByTestId<HTMLButtonElement>("pairing-review-open-panel-PR-1");
+  expect(good.disabled).toBe(false);
+  expect(bad.disabled).toBe(false);
+
+  fireEvent.click(good);
+  await waitFor(() => {
+    expect(good.disabled).toBe(true);
+  });
+  expect(bad.disabled).toBe(true);
+
+  resolveDecision?.();
+  await waitFor(() => {
+    expect(sendPairingDecision).toHaveBeenCalledTimes(1);
+  });
+});
+
+it("401 pri odoslaní rozhodnutia zavolá onSessionExpired namiesto zobrazenia všeobecnej chyby", async () => {
+  sendPairingDecision.mockRejectedValue(new PairingReviewUnauthorizedError());
+  const onSessionExpired = vi.fn();
+
+  render(<PairingReviewCard item={MATCHED_ITEM} role="manazer" onDecided={() => {}} onSessionExpired={onSessionExpired} />);
+  fireEvent.click(screen.getByTestId("pairing-review-good-PR-1"));
+
+  await waitFor(() => {
+    expect(onSessionExpired).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/PairingReviewCard.tsx
+++ b/apps/web/src/components/PairingReviewCard.tsx
@@ -1,11 +1,27 @@
-import type { JSX } from "react";
-import type { PairingReviewItem } from "../pairingReviewApi.js";
+import { useCallback, useRef, useState, type JSX } from "react";
+import type { Me } from "../api.js";
+import { validateSupplierLinkUrl } from "../ordersApi.js";
+import {
+  fetchPairingCandidates,
+  PairingReviewUnauthorizedError,
+  sendPairingDecision,
+  type PairingDecisionAction,
+  type PairingReviewCandidate,
+  type PairingReviewItem,
+} from "../pairingReviewApi.js";
 
 // issue 387 E5: karta jedného produktu, vyčlenená VOPRED z `PairingReviewSection.tsx`
 // (rovnaký princíp ako `OrderLineRow.tsx`/`UpozornenieCard.tsx` — dvojstĺpcová
 // karta má dosť JSX na prekročenie eslint `max-lines: 400` v jednom súbore,
-// `.claude/rules/frontend-design.md`). ČISTO zobrazovacia — E5 je LEN
-// čítanie, žiadne callbacky/akcie (tie prídu v E6).
+// `.claude/rules/frontend-design.md`).
+//
+// issue 387 E6: pridáva rozhodovanie — presne UX starej appky (design
+// komentár na tickete): ✓ Dobré / ✗ Zlé (✗ len ROZBALÍ panel na mieste,
+// NEPRESÚVA kartu), panel so zoznamom top-8 kandidátov ("Vybrať"), ručné URL
+// pole ("Uložiť"), 📦/🚫 terminálne stavy, ↩ Vrátiť + "Zmeniť" pri už
+// rozhodnutých. Panel je PER-KARTE lokálny stav (žiadny globálny
+// `editingXId` scalar) — issue 381's krížová strata konceptu sa netýka.
+// VŠETKY akčné tlačidlá zdieľajú JEDEN `busy` guard.
 
 const STATE_LABELS: Readonly<Record<PairingReviewItem["productState"], string>> = {
   sellable: "🟢 Skladom",
@@ -25,6 +41,15 @@ const VERDICT_LABELS: Readonly<Record<NonNullable<PairingReviewItem["verdict"]>,
   unsure: "kód sa na stránke nenašiel",
 };
 
+const DECISION_BADGE_LABELS: Readonly<Record<NonNullable<PairingReviewItem["decision"]>["status"], string>> = {
+  good: "✓ Dobré",
+  manual: "✓ Vybraný link",
+  unavailable: "📦 Nie je skladom",
+  discontinued: "🚫 Už sa nebude predávať",
+};
+
+const CAN_EDIT_ROLES: ReadonlySet<Me["role"]> = new Set(["admin", "manazer"]);
+
 function formatPriceRange(item: PairingReviewItem): string | null {
   if (item.priceMin === null || item.priceMax === null) return null;
   const currencySuffix = item.currency !== null && item.currency !== "" && item.currency !== "EUR" ? ` ${item.currency}` : " €";
@@ -32,9 +57,95 @@ function formatPriceRange(item: PairingReviewItem): string | null {
   return `${item.priceMin}–${item.priceMax}${currencySuffix}`;
 }
 
-export function PairingReviewCard({ item }: { readonly item: PairingReviewItem }): JSX.Element {
+export function PairingReviewCard({
+  item,
+  role,
+  onDecided,
+  onSessionExpired,
+}: {
+  readonly item: PairingReviewItem;
+  readonly role: Me["role"];
+  readonly onDecided: () => void;
+  readonly onSessionExpired: () => void;
+}): JSX.Element {
   const priceRange = formatPriceRange(item);
   const codes = item.externalCodes.length > 0 ? item.externalCodes.join(", ") : "—";
+  const canEdit = CAN_EDIT_ROLES.has(role);
+
+  const [panelOpen, setPanelOpen] = useState(false);
+  const [candidates, setCandidates] = useState<readonly PairingReviewCandidate[] | null>(null);
+  const [candidatesError, setCandidatesError] = useState("");
+  const [manualUrl, setManualUrl] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [actionError, setActionError] = useState("");
+
+  // "Latest ref" vzor (`.claude/rules/frontend-design.md`) — panel sa môže
+  // zavrieť/znovu otvoriť skôr, než dobehne pôvodný `fetchPairingCandidates`.
+  const openSeq = useRef(0);
+
+  const openPanel = useCallback(() => {
+    const seq = (openSeq.current += 1);
+    setPanelOpen(true);
+    setActionError("");
+    setCandidatesError("");
+    // Predvyplní vlastnú URL len keď ide o EXISTUJÚCE manuálne rozhodnutie,
+    // čo NESEDÍ so žiadnym kandidátom (rovnaký vzor ako stará appka's
+    // `resolutionPanel`) — inak prázdne, nikdy neuhádnuté.
+    setManualUrl(item.decision?.status === "manual" ? (item.decision.url ?? "") : "");
+    setCandidates(null);
+    fetchPairingCandidates(item.productKey)
+      .then((result) => {
+        if (seq !== openSeq.current) return;
+        setCandidates(result);
+      })
+      .catch((err: unknown) => {
+        if (seq !== openSeq.current) return;
+        if (err instanceof PairingReviewUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setCandidatesError("Zoznam kandidátov sa nepodarilo načítať.");
+      });
+  }, [item.productKey, item.decision, onSessionExpired]);
+
+  const closePanel = useCallback(() => {
+    openSeq.current += 1; // zahodí prípadnú ešte-bežiacu odpoveď na kandidátov
+    setPanelOpen(false);
+    setActionError("");
+  }, []);
+
+  const submit = useCallback(
+    (action: PairingDecisionAction) => {
+      setActionError("");
+      setBusy(true);
+      sendPairingDecision(item.productKey, action)
+        .then(() => {
+          setPanelOpen(false);
+          onDecided();
+        })
+        .catch((err: unknown) => {
+          if (err instanceof PairingReviewUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setActionError(err instanceof Error ? err.message : "Uloženie rozhodnutia sa nepodarilo.");
+        })
+        .finally(() => {
+          setBusy(false);
+        });
+    },
+    [item.productKey, onDecided, onSessionExpired],
+  );
+
+  const saveManual = useCallback(() => {
+    const trimmed = manualUrl.trim();
+    const validationError = validateSupplierLinkUrl(trimmed);
+    if (validationError !== null) {
+      setActionError(validationError);
+      return;
+    }
+    submit({ status: "manual", url: trimmed });
+  }, [manualUrl, submit]);
 
   return (
     <div className="card pairing-review-card" data-testid={`pairing-review-card-${item.productKey}`}>
@@ -97,7 +208,136 @@ export function PairingReviewCard({ item }: { readonly item: PairingReviewItem }
               )}
             </div>
           )}
-          <p className="pairing-review-placeholder">Rozhodovanie príde v ďalšej etape.</p>
+
+          {!canEdit ? (
+            item.decision !== null && (
+              <span className="pairing-review-decision-badge" data-testid={`pairing-review-decision-badge-${item.productKey}`}>
+                {DECISION_BADGE_LABELS[item.decision.status]}
+              </span>
+            )
+          ) : (
+            <>
+              {actionError !== "" && <p role="alert">{actionError}</p>}
+
+              {item.decision !== null && !panelOpen && (
+                <div className="pairing-review-actions">
+                  <span className="pairing-review-decision-badge" data-testid={`pairing-review-decision-badge-${item.productKey}`}>
+                    {DECISION_BADGE_LABELS[item.decision.status]}
+                  </span>
+                  {(item.decision.status === "good" || item.decision.status === "manual") && (
+                    <button type="button" className="btn ghost sm" disabled={busy} onClick={openPanel} data-testid={`pairing-review-change-${item.productKey}`}>
+                      ✗ Zmeniť / iný link
+                    </button>
+                  )}
+                  <button type="button" className="btn ghost sm" disabled={busy} onClick={() => { submit({ status: "revert" }); }} data-testid={`pairing-review-revert-${item.productKey}`}>
+                    ↩ Vrátiť
+                  </button>
+                </div>
+              )}
+
+              {item.decision === null && item.chosenCandidate !== null && !panelOpen && (
+                <div className="pairing-review-actions">
+                  <button
+                    type="button"
+                    className="btn good sm"
+                    disabled={busy}
+                    onClick={() => {
+                      submit({ status: "good" });
+                    }}
+                    data-testid={`pairing-review-good-${item.productKey}`}
+                  >
+                    ✓ Dobré
+                  </button>
+                  <button type="button" className="btn bad sm" disabled={busy} onClick={openPanel} data-testid={`pairing-review-open-panel-${item.productKey}`}>
+                    ✗ Zlé
+                  </button>
+                </div>
+              )}
+
+              {/* Bez kandidáta niet čo "prijať" — panel (kandidáti/manuál/terminálne stavy) sa ukazuje priamo, presne ako stará appka. */}
+              {(panelOpen || (item.decision === null && item.chosenCandidate === null)) && (
+                <div className="pairing-review-panel" data-testid={`pairing-review-panel-${item.productKey}`}>
+                  {candidatesError !== "" && <p role="alert">{candidatesError}</p>}
+                  {candidates === null && candidatesError === "" && <p>Načítavam kandidátov…</p>}
+                  {candidates !== null &&
+                    candidates.map((c, i) => (
+                      <div key={c.url} className="pairing-review-panel-candidate">
+                        <span>
+                          {c.name}: {c.url}
+                          {c.codeHit && " (kód sedí)"}
+                        </span>
+                        <button
+                          type="button"
+                          className="btn good sm"
+                          disabled={busy}
+                          onClick={() => {
+                            submit({ status: "manual", url: c.url });
+                          }}
+                          data-testid={`pairing-review-panel-pick-${item.productKey}-${String(i)}`}
+                        >
+                          Vybrať
+                        </button>
+                      </div>
+                    ))}
+
+                  <div className="pairing-review-manual-row">
+                    <input
+                      type="url"
+                      placeholder="Vlož vlastnú URL dodávateľa…"
+                      value={manualUrl}
+                      disabled={busy}
+                      data-testid={`pairing-review-manual-input-${item.productKey}`}
+                      onChange={(e) => {
+                        setManualUrl(e.target.value);
+                      }}
+                    />
+                    <button
+                      type="button"
+                      className="btn good sm"
+                      disabled={busy || manualUrl.trim() === ""}
+                      onClick={saveManual}
+                      data-testid={`pairing-review-manual-save-${item.productKey}`}
+                    >
+                      Uložiť URL
+                    </button>
+                  </div>
+
+                  <div className="pairing-review-terminal-row">
+                    <button
+                      type="button"
+                      className="btn warn sm"
+                      disabled={busy}
+                      onClick={() => {
+                        submit({ status: "unavailable" });
+                      }}
+                      data-testid={`pairing-review-unavailable-${item.productKey}`}
+                      title="visible + Vypredané, stock 0 — dočasne, ostáva na re-kontrolu"
+                    >
+                      📦 Nie je skladom
+                    </button>
+                    <button
+                      type="button"
+                      className="btn ghost sm"
+                      disabled={busy}
+                      onClick={() => {
+                        submit({ status: "discontinued" });
+                      }}
+                      data-testid={`pairing-review-discontinued-${item.productKey}`}
+                      title="detailOnly + Predaj výrobku skončil — link ostane pre Google"
+                    >
+                      🚫 Už sa nebude predávať
+                    </button>
+                  </div>
+
+                  {panelOpen && (
+                    <button type="button" className="btn ghost sm" disabled={busy} onClick={closePanel} data-testid={`pairing-review-panel-cancel-${item.productKey}`}>
+                      Zavrieť
+                    </button>
+                  )}
+                </div>
+              )}
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/apps/web/src/components/PairingReviewCard.tsx
+++ b/apps/web/src/components/PairingReviewCard.tsx
@@ -211,7 +211,10 @@ export function PairingReviewCard({
 
           {!canEdit ? (
             item.decision !== null && (
-              <span className="pairing-review-decision-badge" data-testid={`pairing-review-decision-badge-${item.productKey}`}>
+              <span
+                className={"pairing-review-decision-badge pairing-review-decision-" + item.decision.status}
+                data-testid={`pairing-review-decision-badge-${item.productKey}`}
+              >
                 {DECISION_BADGE_LABELS[item.decision.status]}
               </span>
             )
@@ -221,7 +224,10 @@ export function PairingReviewCard({
 
               {item.decision !== null && !panelOpen && (
                 <div className="pairing-review-actions">
-                  <span className="pairing-review-decision-badge" data-testid={`pairing-review-decision-badge-${item.productKey}`}>
+                  <span
+                    className={"pairing-review-decision-badge pairing-review-decision-" + item.decision.status}
+                    data-testid={`pairing-review-decision-badge-${item.productKey}`}
+                  >
                     {DECISION_BADGE_LABELS[item.decision.status]}
                   </span>
                   {(item.decision.status === "good" || item.decision.status === "manual") && (

--- a/apps/web/src/components/PairingReviewSection.test.tsx
+++ b/apps/web/src/components/PairingReviewSection.test.tsx
@@ -32,6 +32,7 @@ const MATCHED_ITEM = {
   chosenReason: "najlepší nájdený",
   verdict: "ok" as const,
   chosenCandidate: { name: "Bunda Alfa", url: "https://dodavatel.example.com/bunda-alfa", rawScore: 1080.5, codeHit: true },
+  decision: null,
 };
 
 const UNMATCHED_ITEM = {
@@ -52,6 +53,7 @@ const UNMATCHED_ITEM = {
   chosenReason: null,
   verdict: null,
   chosenCandidate: null,
+  decision: null,
 };
 
 afterEach(() => {
@@ -63,7 +65,7 @@ afterEach(() => {
 it("zobrazí karty pre napárovaný aj nenapárovaný produkt s progress počítadlom", async () => {
   searchPairingReview.mockResolvedValue({ total: 2, gatheredTotal: 5, linkedTotal: 3, items: [MATCHED_ITEM, UNMATCHED_ITEM] });
 
-  render(<PairingReviewSection onSessionExpired={() => {}} />);
+  render(<PairingReviewSection role="citanie" onSessionExpired={() => {}} />);
 
   const matchedCard = await screen.findByTestId("pairing-review-card-PR-1");
   expect(matchedCard.textContent).toContain("Bunda Alfa Zimná");
@@ -80,7 +82,7 @@ it("zobrazí karty pre napárovaný aj nenapárovaný produkt s progress počít
 it("keď zoznam nezodpovedá žiadnemu produktu, zobrazí informačnú vetu", async () => {
   searchPairingReview.mockResolvedValue({ total: 0, gatheredTotal: 0, linkedTotal: 0, items: [] });
 
-  render(<PairingReviewSection onSessionExpired={() => {}} />);
+  render(<PairingReviewSection role="citanie" onSessionExpired={() => {}} />);
 
   await screen.findByTestId("pairing-review-empty");
 });
@@ -89,7 +91,7 @@ it("pri 401 zavolá onSessionExpired namiesto zobrazenia všeobecnej chyby", asy
   searchPairingReview.mockRejectedValue(new PairingReviewUnauthorizedError());
   const onSessionExpired = vi.fn();
 
-  render(<PairingReviewSection onSessionExpired={onSessionExpired} />);
+  render(<PairingReviewSection role="citanie" onSessionExpired={onSessionExpired} />);
 
   await waitFor(() => {
     expect(onSessionExpired).toHaveBeenCalledTimes(1);
@@ -102,7 +104,7 @@ it("pri 401 zavolá onSessionExpired namiesto zobrazenia všeobecnej chyby", asy
 it("predvolený filter pri prvom otvorení je 'unreviewed'", async () => {
   searchPairingReview.mockResolvedValue({ total: 0, gatheredTotal: 0, linkedTotal: 0, items: [] });
 
-  render(<PairingReviewSection onSessionExpired={() => {}} />);
+  render(<PairingReviewSection role="citanie" onSessionExpired={() => {}} />);
 
   await waitFor(() => {
     expect(searchPairingReview).toHaveBeenCalledWith({ filter: "unreviewed", page: 1 });
@@ -112,7 +114,7 @@ it("predvolený filter pri prvom otvorení je 'unreviewed'", async () => {
 it("klik na iný filter znova načíta zoznam s novým filtrom a zapamätá si ho do localStorage", async () => {
   searchPairingReview.mockResolvedValue({ total: 0, gatheredTotal: 0, linkedTotal: 0, items: [] });
 
-  render(<PairingReviewSection onSessionExpired={() => {}} />);
+  render(<PairingReviewSection role="citanie" onSessionExpired={() => {}} />);
   await screen.findByTestId("pairing-review-empty");
 
   searchPairingReview.mockClear();
@@ -133,7 +135,7 @@ it("klik na iný filter znova načíta zoznam s novým filtrom a zapamätá si h
 it("hlavička karty 'Náš produkt' je odlíšená od 'Navrhnutý kandidát' — bez vlastného <h1>/<h2> obrazovky", async () => {
   searchPairingReview.mockResolvedValue({ total: 1, gatheredTotal: 1, linkedTotal: 0, items: [MATCHED_ITEM] });
 
-  render(<PairingReviewSection onSessionExpired={() => {}} />);
+  render(<PairingReviewSection role="citanie" onSessionExpired={() => {}} />);
   await screen.findByTestId("pairing-review-card-PR-1");
 
   expect(screen.queryByRole("heading")).toBeNull();

--- a/apps/web/src/components/PairingReviewSection.tsx
+++ b/apps/web/src/components/PairingReviewSection.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useRef, useState, type JSX } from "react";
+import { useCallback, useContext, useEffect, useRef, useState, type JSX } from "react";
+import type { Me } from "../api.js";
 import {
   PAGE_SIZE,
   PAIRING_REVIEW_FILTERS,
@@ -7,15 +8,20 @@ import {
   type PairingReviewFilter,
   type PairingReviewItem,
 } from "../pairingReviewApi.js";
+import { PairingReviewBadgeRefreshContext } from "../pairingReviewBadgeContext.js";
 import { useLoadMore } from "../useLoadMore.js";
 import { PairingReviewCard } from "./PairingReviewCard.js";
 
 // issue 387 E5: "Eshop → Párovanie" — čítacia obrazovka (karty + filtre) nad
-// tým, čo E3 (gather)/E4 (verify) zozbierali. LEN čítanie, žiadne akcie
-// (rozhodnutia prídu v E6). Design komentár na tickete (issue 387 E5):
-// "unreviewed" (default filter, aj badge v `App.tsx`) = "produkt z gather
-// populácie BEZ efektívnej dodávateľskej linky" — pairing_decision (E6) tu
-// ešte neexistuje.
+// tým, čo E3 (gather)/E4 (verify) zozbierali. Design komentár na tickete
+// (issue 387 E5): "unreviewed" (default filter, aj badge v `App.tsx`) =
+// "produkt z gather populácie BEZ efektívnej dodávateľskej linky".
+//
+// issue 387 E6: pridáva rozhodovanie (`PairingReviewCard`'s akčné tlačidlá).
+// Po úspešnom zápise karta zavolá `onDecided` (znova načíta AKTUÁLNY filter
+// na stranu 1 — rovnaký serverový zdroj pravdy ako pri zmene filtra, žiadna
+// duplicitná klientská filter-logika, design komentár na tickete) a
+// `PairingReviewBadgeRefreshContext.refresh()` (odznak v menu).
 //
 // Konvencie appky (`.claude/rules/frontend-design.md`): `useLoadMore` pre
 // stránkovanie, "latest ref" vzor pre `.then()`, `mountedRef` StrictMode-
@@ -46,12 +52,11 @@ function readStoredFilter(): PairingReviewFilter {
   return "unreviewed";
 }
 
-// issue 342 vzor (`DailyTasksSection.tsx`): obrazovka nemá žiadne rolové
-// rozlíšenie (E5 je čisto čítanie, bez akcií) — užší typ props než zdieľané
-// `SectionProps` je platný podtyp `ComponentType<SectionProps>` (nav.ts),
-// keďže `App.tsx` odovzdáva SKUTOČNÝ objekt, nie literál (žiadna "excess
-// property" kontrola).
-export function PairingReviewSection({ onSessionExpired }: { readonly onSessionExpired: () => void }): JSX.Element {
+// issue 387 E6: `role` teraz TREBA (rozhodovacie tlačidlá sa gatujú rovnako
+// ako `RestockLinkSuggestionsSection.tsx`'s `CAN_EDIT_ROLES`) — plný
+// `SectionProps` tvar (`nav.ts`), na rozdiel od E5's užšieho podtypu.
+export function PairingReviewSection({ role, onSessionExpired }: { readonly role: Me["role"]; readonly onSessionExpired: () => void }): JSX.Element {
+  const pairingReviewBadge = useContext(PairingReviewBadgeRefreshContext);
   const [filter, setFilter] = useState<PairingReviewFilter>(readStoredFilter);
   const [items, setItems] = useState<readonly PairingReviewItem[]>([]);
   const [total, setTotal] = useState(0);
@@ -122,6 +127,17 @@ export function PairingReviewSection({ onSessionExpired }: { readonly onSessionE
     // Filter sa mení LEN explicitným klikom nižšie (ktorý sám volá `load`) —
     // tento efekt beží iba raz pri mounte, presne ako sesterské obrazovky.
   }, []);
+
+  // issue 387 E6 — po úspešnom rozhodnutí: znova načítaj AKTUÁLNY filter na
+  // stranu 1 (rovnaký serverový zdroj pravdy, design komentár na tickete —
+  // žiadna duplicitná klientská filter-logika) + odznak v menu. `load()` je
+  // stabilné (prázdne závislosti), `loadedFilterRef` nesie filter, čo
+  // vyprodukoval AKTUÁLNE zobrazené `items` — čítanie `.current` v ceallbacku
+  // je zámerné, nie chýbajúca závislosť (ref).
+  const onDecided = useCallback(() => {
+    load(loadedFilterRef.current);
+    pairingReviewBadge.refresh();
+  }, [load, pairingReviewBadge]);
 
   const changeFilter = useCallback(
     (next: PairingReviewFilter) => {
@@ -214,7 +230,7 @@ export function PairingReviewSection({ onSessionExpired }: { readonly onSessionE
       ) : (
         <div className="pairing-review-list">
           {items.map((item) => (
-            <PairingReviewCard key={item.productKey} item={item} />
+            <PairingReviewCard key={item.productKey} item={item} role={role} onDecided={onDecided} onSessionExpired={onSessionExpired} />
           ))}
         </div>
       )}

--- a/apps/web/src/pairingReviewApi.ts
+++ b/apps/web/src/pairingReviewApi.ts
@@ -1,8 +1,9 @@
 import { z } from "zod";
 
 // issue 387 E5: "Eshop → Párovanie" — zrkadlí `GET /api/pairing-review`
-// (`apps/api/src/http/pairing-review-routes.ts`). LEN čítanie — rozhodnutia
-// (E6) tu ešte neexistujú, žiadna zapisovacia funkcia v tomto súbore.
+// (`apps/api/src/http/pairing-review-routes.ts`). issue 387 E6 pridáva
+// rozhodnutia: `sendPairingDecision`/`fetchPairingCandidates` + `decision`
+// pole v položke.
 
 export const PAIRING_REVIEW_FILTERS = ["unreviewed", "matched", "unmatched", "st1", "st2", "st3", "all"] as const;
 export type PairingReviewFilter = (typeof PAIRING_REVIEW_FILTERS)[number];
@@ -13,6 +14,16 @@ const chosenCandidateSchema = z.object({
   rawScore: z.number(),
   codeHit: z.boolean(),
 });
+
+export const PAIRING_DECISION_STATUSES = ["good", "manual", "unavailable", "discontinued"] as const;
+export type PairingDecisionStatus = (typeof PAIRING_DECISION_STATUSES)[number];
+
+const decisionSchema = z.object({
+  status: z.enum(PAIRING_DECISION_STATUSES),
+  url: z.string().nullable(),
+  decidedAt: z.string(),
+});
+export type PairingReviewDecision = z.infer<typeof decisionSchema>;
 
 const itemSchema = z.object({
   productKey: z.string(),
@@ -32,6 +43,7 @@ const itemSchema = z.object({
   chosenReason: z.string().nullable(),
   verdict: z.enum(["ok", "unsure"]).nullable(),
   chosenCandidate: chosenCandidateSchema.nullable(),
+  decision: decisionSchema.nullable(),
 });
 export type PairingReviewItem = z.infer<typeof itemSchema>;
 
@@ -91,4 +103,38 @@ export async function fetchPairingReviewUnreviewedCount(): Promise<number> {
   if (!response.ok) return 0;
   const parsed = countSchema.safeParse(await response.json());
   return parsed.success ? parsed.data.total : 0;
+}
+
+const candidateSchema = z.object({
+  name: z.string(),
+  url: z.string(),
+  rawScore: z.number(),
+  codeHit: z.boolean(),
+});
+export type PairingReviewCandidate = z.infer<typeof candidateSchema>;
+const candidatesSchema = z.object({ candidates: z.array(candidateSchema) });
+
+// issue 387 E6 — lazy top-8 kandidátov pre rozhodovací panel (design komentár
+// na tickete: volané AŽ pri otvorení panelu ✗ Zlé, nikdy vopred).
+export async function fetchPairingCandidates(productKey: string): Promise<readonly PairingReviewCandidate[]> {
+  const response = await fetch(`/api/pairing-review/${encodeURIComponent(productKey)}/candidates`);
+  return candidatesSchema.parse(await readJson(response, "Zoznam kandidátov sa nepodarilo načítať")).candidates;
+}
+
+// issue 387 E6 — diskriminovaná únia presne zrkadliaca server (`http/pairing-
+// review-routes.ts`'s `pairingDecisionBody`).
+export type PairingDecisionAction =
+  | { readonly status: "good" }
+  | { readonly status: "manual"; readonly url: string }
+  | { readonly status: "unavailable" }
+  | { readonly status: "discontinued" }
+  | { readonly status: "revert" };
+
+export async function sendPairingDecision(productKey: string, action: PairingDecisionAction): Promise<void> {
+  const response = await fetch(`/api/pairing-review/${encodeURIComponent(productKey)}/decision`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(action),
+  });
+  await readJson(response, "Uloženie rozhodnutia sa nepodarilo");
 }

--- a/apps/web/src/pairingReviewBadgeContext.ts
+++ b/apps/web/src/pairingReviewBadgeContext.ts
@@ -1,0 +1,19 @@
+import { createContext } from "react";
+
+// issue 387 E6 — most medzi `PairingReviewSection`/`PairingReviewCard`
+// (mutujú dáta — rozhodnutie o produkte) a `App.tsx` (vlastní odznak v
+// ľavom menu, `badgeCounts`) — presne rovnaký vzor a dôvod ako
+// `RestockLinksBadgeRefreshContext` (issue 331). `App.tsx` si count naďalej
+// načítava a vlastní SÁM (musí byť známy hneď po prihlásení, nie až po
+// prvom otvorení tejto záložky), tento context nesie LEN účinok "niečo sa
+// práve zmenilo".
+export interface PairingReviewBadgeRefreshContextValue {
+  readonly refresh: () => void;
+}
+
+export const PairingReviewBadgeRefreshContext = createContext<PairingReviewBadgeRefreshContextValue>({
+  refresh: () => {
+    // Predvolená hodnota mimo Provider-a (napr. test, čo rendruje
+    // PairingReviewSection samostatne bez App.tsx) — bezpečné no-op.
+  },
+});

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -3069,8 +3069,24 @@ a.upozornenie-title:hover {
   font-weight: var(--fs-weight-semibold);
   padding: var(--fs-space-1) var(--fs-space-3);
   border-radius: 999px;
+}
+/* Odlíšené farby PODĽA STATUSU (review nález, issue 387 E6) — rovnaký
+   princíp ako `.pairing-review-state-*` vyššie: "good"/"manual" (odkaz
+   potvrdený) je pozitívna zelená, "unavailable" (dočasný, čaká na
+   re-kontrolu) je varovná žltá, "discontinued" (konečný, žiadny odkaz už
+   netreba) je neutrálna sivá. */
+.pairing-review-decision-good,
+.pairing-review-decision-manual {
   background: var(--fs-success-bg);
   color: var(--fs-success);
+}
+.pairing-review-decision-unavailable {
+  background: var(--fs-warning-bg);
+  color: var(--fs-warning);
+}
+.pairing-review-decision-discontinued {
+  background: var(--fs-surface-alt);
+  color: var(--fs-ink-muted);
 }
 .pairing-review-panel {
   margin-top: var(--fs-space-3);

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -704,6 +704,25 @@ tr:last-child td {
 .btn.ghost:hover {
   background: var(--fs-border-soft);
 }
+/* issue 387 E6 — ✗ Zlé / terminálne rozhodnutia (`.claude/rules/frontend-
+   design.md`: nové varianty na EXISTUJÚCICH `--fs-danger`/`--fs-warning`
+   tokenoch, nikdy nová surová farba). */
+.btn.bad {
+  background: var(--fs-danger-bg);
+  color: var(--fs-danger);
+}
+.btn.bad:hover {
+  background: var(--fs-danger);
+  color: #fff;
+}
+.btn.warn {
+  background: var(--fs-warning-bg);
+  color: var(--fs-warning);
+}
+.btn.warn:hover {
+  background: var(--fs-warning);
+  color: #fff;
+}
 .btn:disabled {
   opacity: 0.55;
   cursor: not-allowed;
@@ -3035,9 +3054,50 @@ a.upozornenie-title:hover {
 .pairing-review-verdict-unsure {
   color: var(--fs-warning);
 }
-.pairing-review-placeholder {
-  font-size: var(--fs-text-xs);
-  color: var(--fs-ink-faint);
-  font-style: italic;
+/* issue 387 E6 — rozhodovacia UX (nahradzuje E5's statický "Rozhodovanie
+   príde v ďalšej etape" placeholder text). */
+.pairing-review-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--fs-space-2);
+  flex-wrap: wrap;
   margin-top: var(--fs-space-3);
+}
+.pairing-review-decision-badge {
+  display: inline-block;
+  font-size: var(--fs-text-xs);
+  font-weight: var(--fs-weight-semibold);
+  padding: var(--fs-space-1) var(--fs-space-3);
+  border-radius: 999px;
+  background: var(--fs-success-bg);
+  color: var(--fs-success);
+}
+.pairing-review-panel {
+  margin-top: var(--fs-space-3);
+  padding: var(--fs-space-3);
+  background: var(--fs-surface-alt);
+  border: 1px solid var(--fs-border);
+  border-radius: var(--fs-radius-sm);
+  display: flex;
+  flex-direction: column;
+  gap: var(--fs-space-2);
+}
+.pairing-review-panel-candidate {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--fs-space-2);
+  font-size: var(--fs-text-sm);
+  overflow-wrap: break-word;
+}
+.pairing-review-manual-row,
+.pairing-review-terminal-row {
+  display: flex;
+  align-items: center;
+  gap: var(--fs-space-2);
+  flex-wrap: wrap;
+}
+.pairing-review-manual-row input {
+  flex: 1 1 0%;
+  min-width: 12rem;
 }

--- a/apps/web/tests/e2e/catalog.spec.ts
+++ b/apps/web/tests/e2e/catalog.spec.ts
@@ -38,14 +38,19 @@ test("manažér vidí stav katalógu, vyhľadá variant a konzola je čistá", a
   // Skladom: návrhy odkazov" ("E2E-RL-CHYBA"/"E2E-RL-NAVRH"/"E2E-RL-CUDZI",
   // issue 311, `scripts/e2e-fixtures-restock-links.ts`)
   // + 60 seedovaných produktov pre "Načítať ďalšie" (issue 337, "E2E-PAGE-
-  // 001".."E2E-PAGE-060", `scripts/e2e-fixtures-pagination.ts`) = 103.
+  // 001".."E2E-PAGE-060", `scripts/e2e-fixtures-pagination.ts`)
+  // + 3 seedované produkty pre "Eshop → Párovanie" ("E2E-PR-CHYBA"/
+  // "E2E-PR-NENAJDENY"/"E2E-PR-SLINKOU", issue 387 E5,
+  // `scripts/e2e-fixtures-pairing-review.ts` — chýbalo tu pri E5, doplnené
+  // issue 387 E6 pri prvom behu CELEJ e2e sady proti tomuto fixtúrovému
+  // súboru) = 106.
   // Prví dvaja (PREP-1/PREP-2) aj "E2E-RL-CHYBA" sú `out_of_stock` (nemenia
-  // "sellable"/"missing" nižšie), zvyšných 5 aj všetkých 60 "E2E-PAGE-*" sú
-  // `sellable` (posúvajú filter "sellable" 7→72 nižšie), "missing"(1) sa
-  // nemení ani jedným z nich.
+  // "sellable"/"missing" nižšie), zvyšných 5, všetkých 60 "E2E-PAGE-*" aj
+  // všetky 3 "E2E-PR-*" sú `sellable` (posúvajú filter "sellable" 7→75
+  // nižšie), "missing"(1) sa nemení ani jedným z nich.
   await expect(page.getByTestId("snapshot")).toContainText("Posledný import: prijatý");
-  await expect(page.getByTestId("counts")).toContainText("Variantov v katalógu (vrátane chýbajúcich): 103");
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 103 (zobrazených prvých 50)");
+  await expect(page.getByTestId("counts")).toContainText("Variantov v katalógu (vrátane chýbajúcich): 106");
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 106 (zobrazených prvých 50)");
 
   await page.getByLabel("Kód alebo názov").fill("40237/3XL");
   await page.getByRole("button", { name: "Hľadať", exact: true }).click();
@@ -65,17 +70,19 @@ test("filter podľa stavu zúži zoznam na predajné varianty", async ({ page })
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 103 (zobrazených prvých 50)");
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 106 (zobrazených prvých 50)");
   await page.getByLabel("Stav", { exact: true }).selectOption("sellable");
   await page.getByRole("button", { name: "Hľadať", exact: true }).click();
 
-  // 72 = 7 od issue 219 (variant "40237/L" má oba texty dostupnosti prázdne,
+  // 75 = 7 od issue 219 (variant "40237/L" má oba texty dostupnosti prázdne,
   // čo znamená predvolenú dostupnosť Shoptetu — "Skladom", nie vypredané) +
   // 2 sellable produkty issue 239's fixtúry ("E2E-PL-CHYBA"/"E2E-PL-OPRAVA")
   // + 1 sellable produkt issue 240's fixtúry ("E2E-SEARCH-1") + 2 sellable
   // produkty issue 311's fixtúry ("E2E-RL-NAVRH"/"E2E-RL-CUDZI") + 60 sellable
-  // produktov issue 337's fixtúry ("E2E-PAGE-001".."E2E-PAGE-060").
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 72 (zobrazených prvých 50)");
+  // produktov issue 337's fixtúry ("E2E-PAGE-001".."E2E-PAGE-060") + 3
+  // sellable produkty issue 387 E5's fixtúry ("E2E-PR-CHYBA"/
+  // "E2E-PR-NENAJDENY"/"E2E-PR-SLINKOU").
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 75 (zobrazených prvých 50)");
   await expect(page.getByTestId("variant-40237/M")).toBeVisible();
 });
 
@@ -87,7 +94,7 @@ test("filter 'Chýbajúce' nájde presne označený variant a riadok ukazuje, od
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 103 (zobrazených prvých 50)");
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 106 (zobrazených prvých 50)");
   await page.getByLabel("Stav", { exact: true }).selectOption("missing");
   await page.getByRole("button", { name: "Hľadať", exact: true }).click();
 
@@ -144,7 +151,7 @@ test("import (ešte prebiehajúci) nesmie prepísať MEDZITÝM zmenený filter z
   await page.getByLabel("E-mail").fill(E2E_RACE_EMAIL);
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 103 (zobrazených prvých 50)");
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 106 (zobrazených prvých 50)");
 
   await page.getByRole("button", { name: "Stiahnuť a naimportovať export" }).click();
 

--- a/apps/web/tests/e2e/pairing-review.spec.ts
+++ b/apps/web/tests/e2e/pairing-review.spec.ts
@@ -16,6 +16,11 @@ const E2E_PAROVANIE_REVIEW_EMAIL = "e2e-parovanie-review@forestshop.sk";
 // len pri "Všetky"). Substring kolízia s "Párovanie produktov" (#239) —
 // `{ name: "Párovanie", exact: true }` je POVINNÉ na tejto záložke, presne
 // ako `nav.spec.ts`.
+//
+// issue 387 E6: pridáva rozhodovanie — "E2E-PR-CHYBA" (má kandidáta) a
+// "E2E-PR-NENAJDENY" (nemá kandidáta, panel je hneď otvorený) sú fixtúry E5,
+// zámerne dovtedy NEROZHODNUTÉ, aby E6 testy mali čerstvý "nezrevidovaný"
+// stav na začiatku behu (fixtúrový súbor sa medzi behmi znova naseeduje).
 
 test("predvolený filter 'Nezrevidované' ukáže produkty bez linky (s aj bez kandidáta), vylúči produkt, čo linku už má; konzola je čistá", async ({
   page,
@@ -40,12 +45,14 @@ test("predvolený filter 'Nezrevidované' ukáže produkty bez linky (s aj bez k
   await expect(page.getByRole("heading", { name: "Párovanie", exact: true })).toBeVisible();
 
   // Napárovaný produkt — karta ukazuje náš produkt aj navrhnutého kandidáta,
-  // BEZ akýchkoľvek akčných tlačidiel (E5 je len čítanie, E6 pridá rozhodovanie).
+  // s presne DVOMA akčnými tlačidlami (✓ Dobré / ✗ Zlé, issue 387 E6 —
+  // fixtúrový účet má rolu "manazer", teda smie rozhodovať).
   const chybaKarta = page.getByTestId("pairing-review-card-E2E-PR-CHYBA");
   await expect(chybaKarta).toBeVisible();
   await expect(chybaKarta).toContainText("E2E Bunda Alfa Nezrevidovaná");
   await expect(page.getByTestId("pairing-review-candidate-E2E-PR-CHYBA")).toContainText("E2E Bunda Alfa u dodávateľa");
-  await expect(chybaKarta.getByRole("button")).toHaveCount(0);
+  await expect(chybaKarta.getByTestId("pairing-review-good-E2E-PR-CHYBA")).toBeVisible();
+  await expect(chybaKarta.getByTestId("pairing-review-open-panel-E2E-PR-CHYBA")).toBeVisible();
 
   // Nenapárovaný produkt (gather nenašiel u dodávateľa nič) — vlastná hláška.
   const nenajdenyKarta = page.getByTestId("pairing-review-card-E2E-PR-NENAJDENY");
@@ -88,6 +95,89 @@ test("odznak v menu ukazuje počet nezrevidovaných HNEĎ po prihlásení, bez o
   const odznak = page.getByTestId("nav-badge-pairing-review");
   await expect(odznak).toBeVisible();
   await expect(odznak).toHaveText(/^\d+$/);
+
+  expect(chyby).toEqual([]);
+});
+
+// issue 387 E6 — "✓ Dobré": karta vypadne z predvoleného "Nezrevidované"
+// filtra (presne "unreviewed" definícia — bez efektívnej linky), dostane
+// odznak "✓ Dobré" pod filtrom "Všetky", A efektívny odkaz sa OKAMŽITE
+// prejaví aj na sesterskej obrazovke "Párovanie produktov" (#239) — obe
+// čítajú TÚ ISTÚ `product_supplier_link_override` tabuľku, zdieľaný zápis.
+test("'✓ Dobré' rozhodnutie zapíše efektívny odkaz — viditeľný na tejto AJ na 'Párovanie produktov' obrazovke; konzola je čistá", async ({ page }) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/");
+  await page.getByLabel("E-mail").fill(E2E_PAROVANIE_REVIEW_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await page.getByTestId("nav-tab-pairing-review").click();
+
+  const karta = page.getByTestId("pairing-review-card-E2E-PR-CHYBA");
+  await expect(karta).toBeVisible();
+  await karta.getByTestId("pairing-review-good-E2E-PR-CHYBA").click();
+
+  // Predvolený filter "Nezrevidované" (bez efektívnej linky) kartu vylúči
+  // hneď, ako appka potvrdí zápis — priama proxy pre "efektívny odkaz sa
+  // zmenil" (rovnaký princíp ako integračný test `.claude/rules/pairing-
+  // search.md`'s "unreviewed = bez efektívnej linky").
+  await expect(karta).toHaveCount(0);
+
+  await page.getByTestId("pairing-review-filter-all").click();
+  const kartaVsetky = page.getByTestId("pairing-review-card-E2E-PR-CHYBA");
+  await expect(kartaVsetky).toBeVisible();
+  await expect(kartaVsetky.getByTestId("pairing-review-decision-badge-E2E-PR-CHYBA")).toHaveText("✓ Dobré");
+
+  // Krížové overenie na "Párovanie produktov" (#239) — zdieľaná zapisovacia
+  // cesta, `.claude/rules/product-links.md`.
+  await page.getByTestId("nav-tab-supplier-links").click();
+  await page.getByLabel("Hľadať produkt (kód alebo názov)").fill("E2E-PR-CHYBA");
+  await page.getByLabel("Zobraziť produkty").selectOption("all");
+  await page.getByRole("button", { name: "Zobraziť" }).click();
+  await expect(page.getByTestId("product-link-url-E2E-PR-CHYBA")).toHaveText("https://e2e-dodavatel.example.com/bunda-alfa-navrh");
+
+  expect(chyby).toEqual([]);
+});
+
+// issue 387 E6 — "📦 Nie je skladom" (terminálny stav bez odkazu) + "↩
+// Vrátiť": produkt vypadne z "Nezrevidované" (je zrevidovaný, aj bez
+// efektívnej linky — E5's forward-kompat poznámka), Vrátiť ho vráti späť.
+test("'📦 Nie je skladom' vyradí produkt z 'Nezrevidované'; '↩ Vrátiť' ho vráti späť; konzola je čistá", async ({ page }) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/");
+  await page.getByLabel("E-mail").fill(E2E_PAROVANIE_REVIEW_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await page.getByTestId("nav-tab-pairing-review").click();
+
+  // "E2E-PR-NENAJDENY" nemá kandidáta — panel (📦/🚫/manuál) je vidno PRIAMO,
+  // bez ✓/✗ prepínača (nič na "prijatie").
+  const karta = page.getByTestId("pairing-review-card-E2E-PR-NENAJDENY");
+  await expect(karta).toBeVisible();
+  await karta.getByTestId("pairing-review-unavailable-E2E-PR-NENAJDENY").click();
+  await expect(karta).toHaveCount(0);
+
+  await page.getByTestId("pairing-review-filter-all").click();
+  const kartaVsetky = page.getByTestId("pairing-review-card-E2E-PR-NENAJDENY");
+  await expect(kartaVsetky).toBeVisible();
+  await expect(kartaVsetky.getByTestId("pairing-review-decision-badge-E2E-PR-NENAJDENY")).toHaveText("📦 Nie je skladom");
+  await kartaVsetky.getByTestId("pairing-review-revert-E2E-PR-NENAJDENY").click();
+
+  await page.getByTestId("pairing-review-filter-unreviewed").click();
+  await expect(page.getByTestId("pairing-review-card-E2E-PR-NENAJDENY")).toBeVisible();
 
   expect(chyby).toEqual([]);
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.230",
+  "version": "0.3.0-dev.231",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -263,7 +263,10 @@ await db.execute(
   // uvedenia — pridané ručne rovnako ako riadok vyššie. "pairing_search_
   // settings" je rovnaká situácia ako "restock_settings" (žiadny FK,
   // singleton id, žiadny migračný seed riadok — netreba reseed nižšie).
-  'TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, nedostupne_replacement_link, mail_template, mail_template_history, supplier_stock, restock_settings, restock_event, shop_product_url, theme_color, dpd_pickup_request, upozornenie, daily_task, mail_log, dpd_shipment, product_supplier_override, product_supplier_link_override, pairing_candidate, pairing_candidate_set, pairing_search_settings RESTART IDENTITY CASCADE',
+  // issue 387 E6: "pairing_decision" má reálny FK do "product" AJ "users"
+  // (TRUNCATE CASCADE ignoruje ON DELETE RESTRICT), pridané ručne rovnako
+  // ako riadok vyššie.
+  'TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, nedostupne_replacement_link, mail_template, mail_template_history, supplier_stock, restock_settings, restock_event, shop_product_url, theme_color, dpd_pickup_request, upozornenie, daily_task, mail_log, dpd_shipment, product_supplier_override, product_supplier_link_override, pairing_candidate, pairing_candidate_set, pairing_search_settings, pairing_decision RESTART IDENTITY CASCADE',
 );
 // Rovnaký dôvod ako `tests/helpers/db.ts`: bez tohto by "Na objednanie" bolo
 // v CELOM e2e behu prázdne pre KAŽDÚ objednávku (žiadny nastavený otvorený


### PR DESCRIPTION
Etapa E6 z issue 387 (profesionálne párovanie produktov, port starej appky @ 60b6164)
+ dokumentačná bodka za issue 376. Šiesta z ôsmich etáp — rozhodovanie na obrazovke
Eshop → Párovanie.

## Obsah (issue 387 E6)

- Migrácia: tabuľka `pairing_decision` (stav good/manual/unavailable/discontinued,
  CHECK na URL podľa stavu, kto a kedy rozhodol, `state_synced_at` pre E7).
- API `pairing-review/decisions.ts` + POST route: potvrdenie AI kandidáta, výber iného
  kandidáta, ručná URL (zod validácia), 📦 Nie je skladom, 🚫 Už sa nebude predávať,
  ↩ Vrátiť (DELETE rozhodnutia; uložený odkaz sa nemaže). Pri good/manual v JEDNEJ
  transakcii rozhodnutie + zdieľaný zápis odkazu (#239) — žiadna paralelná cesta.
  Súbežný prepis: posledný zápis vyhráva (konvencia repa, zdôvodnené na tikete).
- Web: akčné tlačidlá na kartách presne podľa starej appky — ✓ Dobré / ✗ Zlé (panel
  na mieste: kandidáti s „Vybrať", ručná URL, 📦, 🚫), pri rozhodnutých ↩ Vrátiť /
  Zmeniť; dodržané toggle-open pravidlá (seed-if-absent, busy guard). Filter
  „Nezrevidované" a badge v menu prepnuté na skutočnú definíciu cez rozhodnutia.

## Obsah (issue 376 — dokumentácia)

`.claude/rules/backups.md`: čas dev1-ovho sťahovania záloh je po prvej reálnej noci
OVERENÝ — denne 04:30 Europe/Bratislava (02:30 UTC), dôkaz Accepted publickey
2026-08-13T02:30:02Z; doplnená poznámka o ISO formáte timestampov v auth.log.
Ticket 376 už je zavretý s dôkazom.

## Testy

17 nových integračných (každý stav, CHECK obojsmerne, transakčnosť, revert) +
9 komponentových + 2 e2e; celkovo API 878 unit / 706 integračných (91 súborov),
web 621, celá e2e sada 61/61, typecheck aj lint čisté.
Review (čerstvý kontext): 0 🔴 0 🟡 2 🔵 — oba opravené v tej istej vetve.

Issue 387 zostáva otvorené — zavrie sa po poslednej etape a živom overení.
