### PR TITLE
Párovanie produktov E7: stavový zápis do Shoptetu, default vypnutý (issue 387)

### DIFF
--- a/.claude/rules/pairing-search.md
+++ b/.claude/rules/pairing-search.md
@@ -482,3 +482,30 @@ https://github.com/zbynekdrlik/forestshop-app/issues/387#issuecomment-5273377438
   lokálny e2e beh aspoň RAZ za pár etáp (nielen kolíznu dvojicu) — kolízna
   dvojica chytá len PRIAME substring/aria kolízie, nikdy vzdialené číselné
   závislosti ako `catalog.spec.ts`'s celkový počet.
+
+## E7 — Stavový writeback (`shoptet-writeback/{csv,select-states,mark-state-synced,run-state-writeback,run-writeback-sequence,state-writeback-settings}.ts`)
+
+- **`variants.code` je v tejto appke DB PRIMÁRNY KĽÚČ (`schema-catalog.ts`)
+  — starej appky's "dedup podľa code, first-wins" zákon je tu preto
+  ŠTRUKTÚROVANE nedosiahnuteľná situácia pri korektnom volajúcom, nikdy
+  reálna možnosť ako v starej appke (kde CSV-grouping raw Shoptet exportu
+  vedel produkovať skutočné duplikáty naprieč "produktmi").**
+  `dedupeStateRowsByCode`/`buildStatesCsv` napriek tomu implementujú dedup
+  doslovne (zadanie to explicitne žiada + je to obranná vrstva navyše) —
+  ale nikdy sa naň nespoliehaj ako na JEDINÚ ochranu proti duplicitnému
+  `code` v CSV; skutočná ochrana je DB unikátnosť. Pri ĎALŠOM porte
+  "dedup/first-wins" pravidla zo starej appky do tejto appky vždy over
+  najprv, či cieľový stĺpec tu má DB unikátnosť — ak áno, dedup kód je len
+  dokumentácia zámeru/obranná vrstva, nie skutočná nutnosť.
+- **Read-back kontrola bezpečných nastavení importu (`_ensure_safe_settings`
+  starej appky) UŽ existovala pred E7** — `playwright-import.ts`'s
+  `ensureSafeSettings` (zavedená issue 122) nastavuje AJ číta späť oba
+  prvky (`.isChecked()` po `.check()`/`.uncheck()`, abort pri nezhode) a je
+  zdieľaná KAŽDÝM importom cez `runShoptetImportIsolated` (linkový aj
+  stavový). Zadania bod "doplniť, ak chýba" bol teda "over, nie doplň" —
+  potvrdené v design komentári na tickete PRED kódovaním, nikdy netreba
+  znova písať/kontrolovať pri ĎALŠOM novom CSV type v tomto module.
+- **Sekvenčná nezávislosť dvoch Playwright importov v jednom scheduler
+  behu potrebuje VLASTNÝ `try`/`catch` v KAŽDOM podbehu** — plný
+  mechanizmus + review nález (`e6c2695`) zdokumentovaný v `.claude/rules/
+  shoptet-writeback.md` (hľadaj "VYHADZUJE"), nie duplikovaný tu.

--- a/.claude/rules/shoptet-writeback.md
+++ b/.claude/rules/shoptet-writeback.md
@@ -261,6 +261,39 @@ paths:
   úplne prázdneho súboru obchádza tento guard bez toho, aby sa oň muselo
   zasahovať, a je aj bližšie realistickej ceste, akou by appka skutočný
   import poslala.
+- **`runShoptetImportIsolated` VYHADZUJE (rejectne promise) na TVRDOM
+  zlyhaní — nenájde prihlasovací formulár, nenájde bezpečný radio
+  (`ensureSafeSettings`), dieťa proces skončí bez výsledku (`child-
+  runner.ts`) — nie len vracia `{ok:false}` (to je LEN pre mäkké zlyhania,
+  keď sa CSV reálne odoslalo, ale Log ukázal chybu/nejednoznačný text).**
+  Kým `run-writeback.ts` bolo JEDINÝM krokom celého behu (issue 122), táto
+  výnimka jednoducho zastavila celý job — `shoptetWritebackJob`
+  (`scheduler/jobs.ts`) ju odchytí a zapíše ako `job_run.status =
+  "failure"`, presne podľa zámeru. **Akonáhle vznikne DRUHÝ nezávislý
+  krok volajúci TÚ ISTÚ funkciu v sekvencii (issue 387 E7's `run-writeback-
+  sequence.ts`: linkový → stavový), táto výnimka by BEZ VLASTNÉHO
+  `try`/`catch` v KAŽDOM podbehu prešla priamo cez orchestrátor a
+  zastavila by aj pokus o ĎALŠÍ krok** — presný opak "nezávislosti", ktorú
+  taký orchestrátor sľubuje (review nález, opravené commitom `e6c2695`:
+  `run-writeback.ts`/`run-state-writeback.ts` teraz OBIDVA obaľujú svoje
+  `runShoptetImportIsolated` volanie a premieňajú výnimku na normálny
+  `{status:"failed", processed:null, failed:null, errorDetail:...}`
+  výsledok). **Pri KAŽDOM ďalšom orchestrátore, čo reťazí VIAC volaní
+  tejto (alebo `runOrderNoteWritebackIsolated`) funkcie za sebou:** over,
+  že KAŽDÉ volanie má VLASTNÝ `try`/`catch`, nikdy sa nespoliehaj na to, že
+  doterajší jediný-krokový vzor (bez `try`/`catch`) je bezpečný aj vo
+  viackrokovom kontexte.
+- **Testovanie "prvé z N sekvenčných volaní tvrdo zlyhá, druhé uspeje" BEZ
+  mockovania internej logiky (repo zakazuje mock reálneho kódu, len
+  externých sieťových hraníc):** `shoptet-fixture.ts`'s
+  `failNextImportFormOnce()` (issue 387 E7) — jednorazovo vynechá bezpečný
+  radio na ĎALŠOM `GET /admin/import-produktov/` (spotrebuje sa, ďalší
+  request je normálny). Na rozdiel od konštruktorového `omitSafeRadio`
+  (platí na KAŽDÝ request rovnako, takže dve sekvenčné volania by boli
+  nerozlíšiteľné — obe by zlyhali identicky), tento toggle robí presne
+  JEDNO volanie tvrdo zlyhať a nasledujúce prejsť normálne — jediný
+  spôsob, ako naživo (nie mockom) dokázať, že DRUHÉ volanie orchestrátora
+  sa SKUTOČNE spustilo, nielen že prvé zlyhalo.
 - **PÔVODNÝ (mylný) nález, ponechaný pre históriu — pozri opravu vyššie:**
   Ručný ("Spustiť teraz") beh Playwright login flow-u DO Shoptet
   administrácie cez DEŇ vie zlyhať s "prihlasovací formulár stále

--- a/apps/api/drizzle/0049_plain_metal_master.sql
+++ b/apps/api/drizzle/0049_plain_metal_master.sql
@@ -1,0 +1,5 @@
+CREATE TABLE "pairing_state_writeback_settings" (
+	"id" text PRIMARY KEY NOT NULL,
+	"enabled" boolean DEFAULT false NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL
+);

--- a/apps/api/drizzle/meta/0049_snapshot.json
+++ b/apps/api/drizzle/meta/0049_snapshot.json
@@ -1,0 +1,3513 @@
+{
+  "id": "08780281-0404-42c8-980e-f3456417b92a",
+  "prevId": "d137f6c9-6118-459f-820c-ee48ee774005",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_code": {
+          "name": "external_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_open_status": {
+      "name": "order_open_status",
+      "schema": "",
+      "columns": {
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Vybavuje sa'"
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop_remark": {
+          "name": "shop_remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shoptet_order_id": {
+          "name": "shoptet_order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_updated_at": {
+          "name": "comment_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_synced_at": {
+          "name": "comment_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_carrier_name": {
+          "name": "shipping_carrier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_price_with_vat": {
+          "name": "total_price_with_vat",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_marked_at": {
+          "name": "claim_marked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_note": {
+          "name": "claim_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_full_name": {
+          "name": "delivery_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_company": {
+          "name": "delivery_company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_street": {
+          "name": "delivery_street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_house_number": {
+          "name": "delivery_house_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_city": {
+          "name": "delivery_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_zip": {
+          "name": "delivery_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_country_name": {
+          "name": "delivery_country_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_name": {
+          "name": "payment_method_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_to_pay": {
+          "name": "price_to_pay",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_link_override": {
+      "name": "product_supplier_link_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_link_override_product_key_product_key_fk": {
+          "name": "product_supplier_link_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_link_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_override": {
+      "name": "product_supplier_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_override_product_key_product_key_fk": {
+          "name": "product_supplier_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing": {
+      "name": "pairing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_url": {
+          "name": "supplier_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "pairing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'navrhnute'"
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pairing_state_idx": {
+          "name": "pairing_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_confirmed_by_idx": {
+          "name": "pairing_confirmed_by_idx",
+          "columns": [
+            {
+              "expression": "confirmed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_variant_code_variant_code_fk": {
+          "name": "pairing_variant_code_variant_code_fk",
+          "tableFrom": "pairing",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pairing_confirmed_by_users_id_fk": {
+          "name": "pairing_confirmed_by_users_id_fk",
+          "tableFrom": "pairing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pairing_variant_code_unique": {
+          "name": "pairing_variant_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pairing_confirmation_ck": {
+          "name": "pairing_confirmation_ck",
+          "value": "(\"pairing\".\"state\" = 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)\n        OR (\"pairing\".\"state\" != 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NULL AND \"pairing\".\"confirmed_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier": {
+      "name": "supplier",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wholesale_base_url": {
+          "name": "wholesale_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_key": {
+          "name": "adapter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_settings": {
+      "name": "posta_uncollected_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_state": {
+      "name": "posta_uncollected_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notify_count": {
+          "name": "notify_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_state": {
+          "name": "terminal_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_settings": {
+      "name": "order_reminder_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_state": {
+      "name": "order_reminder_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_replacement_link": {
+      "name": "nedostupne_replacement_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nedostupne_replacement_link_variant_idx": {
+          "name": "nedostupne_replacement_link_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_state": {
+      "name": "nedostupne_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "nedostupne_email_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nedostupne_state_order_variant_type_uq": {
+          "name": "nedostupne_state_order_variant_type_uq",
+          "columns": [
+            {
+              "expression": "order_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template_history": {
+      "name": "mail_template_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "mail_template_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_template_history_key_idx": {
+          "name": "mail_template_history_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_template_history_changed_by_user_id_users_id_fk": {
+          "name": "mail_template_history_changed_by_user_id_users_id_fk",
+          "tableFrom": "mail_template_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template": {
+      "name": "mail_template",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail_template_updated_by_user_id_users_id_fk": {
+          "name": "mail_template_updated_by_user_id_users_id_fk",
+          "tableFrom": "mail_template",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_log": {
+      "name": "mail_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "mail_log_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_log_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "mail_log_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_log_created_idx": {
+          "name": "mail_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_log_source_created_idx": {
+          "name": "mail_log_source_created_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_log_actor_user_id_users_id_fk": {
+          "name": "mail_log_actor_user_id_users_id_fk",
+          "tableFrom": "mail_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_stock": {
+      "name": "supplier_stock",
+      "schema": "",
+      "columns": {
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "supplier_availability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "supplier_stock_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "supplier_stock_host_idx": {
+          "name": "supplier_stock_host_idx",
+          "columns": [
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "supplier_stock_avail_idx": {
+          "name": "supplier_stock_avail_idx",
+          "columns": [
+            {
+              "expression": "availability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "supplier_stock_link_size_label_pk": {
+          "name": "supplier_stock_link_size_label_pk",
+          "columns": [
+            "link",
+            "size_label"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_event": {
+      "name": "restock_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_link": {
+          "name": "supplier_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_availability_text": {
+          "name": "supplier_availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "supplier_price": {
+          "name": "supplier_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "restock_event_at_idx": {
+          "name": "restock_event_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "restock_event_variant_idx": {
+          "name": "restock_event_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_settings": {
+      "name": "restock_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shop_product_url": {
+      "name": "shop_product_url",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.theme_color": {
+      "name": "theme_color",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "theme_color_updated_by_user_id_users_id_fk": {
+          "name": "theme_color_updated_by_user_id_users_id_fk",
+          "tableFrom": "theme_color",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upozornenie": {
+      "name": "upozornenie",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "upozornenie_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "upozornenie_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedup_key": {
+          "name": "dedup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postponed_until": {
+          "name": "postponed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seen_at": {
+          "name": "seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "upozornenie_dedup_key_uq": {
+          "name": "upozornenie_dedup_key_uq",
+          "columns": [
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "resolved_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upozornenie_resolved_at_idx": {
+          "name": "upozornenie_resolved_at_idx",
+          "columns": [
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upozornenie_dedup_key_idx": {
+          "name": "upozornenie_dedup_key_idx",
+          "columns": [
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upozornenie_resolved_by_user_id_users_id_fk": {
+          "name": "upozornenie_resolved_by_user_id_users_id_fk",
+          "tableFrom": "upozornenie",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "upozornenie_created_by_user_id_users_id_fk": {
+          "name": "upozornenie_created_by_user_id_users_id_fk",
+          "tableFrom": "upozornenie",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dpd_pickup_request": {
+      "name": "dpd_pickup_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "pickup_date": {
+          "name": "pickup_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "dpd_operation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dpd_shipment": {
+      "name": "dpd_shipment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "dpd_operation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parcel_number": {
+          "name": "parcel_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cod_amount": {
+          "name": "cod_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dpd_shipment_order_uq": {
+          "name": "dpd_shipment_order_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dpd_shipment_order_id_order_id_fk": {
+          "name": "dpd_shipment_order_id_order_id_fk",
+          "tableFrom": "dpd_shipment",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_task": {
+      "name": "daily_task",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "done_at": {
+          "name": "done_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "daily_task_user_id_created_at_idx": {
+          "name": "daily_task_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_task_user_id_users_id_fk": {
+          "name": "daily_task_user_id_users_id_fk",
+          "tableFrom": "daily_task",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing_candidate_set": {
+      "name": "pairing_candidate_set",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gathered_at": {
+          "name": "gathered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "queries": {
+          "name": "queries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chosen_url": {
+          "name": "chosen_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chosen_reason": {
+          "name": "chosen_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "pairing_confidence",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "pairing_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verdict_checked_at": {
+          "name": "verdict_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pairing_candidate_set_product_key_product_key_fk": {
+          "name": "pairing_candidate_set_product_key_product_key_fk",
+          "tableFrom": "pairing_candidate_set",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing_candidate": {
+      "name": "pairing_candidate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_score": {
+          "name": "raw_score",
+          "type": "numeric(8, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_hit": {
+          "name": "code_hit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pairing_candidate_product_url_uq": {
+          "name": "pairing_candidate_product_url_uq",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_candidate_product_idx": {
+          "name": "pairing_candidate_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_candidate_product_key_fk": {
+          "name": "pairing_candidate_product_key_fk",
+          "tableFrom": "pairing_candidate",
+          "tableTo": "pairing_candidate_set",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "product_key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing_decision": {
+      "name": "pairing_decision",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "pairing_decision_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_synced_at": {
+          "name": "state_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pairing_decision_product_key_product_key_fk": {
+          "name": "pairing_decision_product_key_product_key_fk",
+          "tableFrom": "pairing_decision",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pairing_decision_decided_by_users_id_fk": {
+          "name": "pairing_decision_decided_by_users_id_fk",
+          "tableFrom": "pairing_decision",
+          "tableTo": "users",
+          "columnsFrom": [
+            "decided_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pairing_decision_url_ck": {
+          "name": "pairing_decision_url_ck",
+          "value": "(\"pairing_decision\".\"status\" IN ('good','manual') AND \"pairing_decision\".\"url\" IS NOT NULL) OR (\"pairing_decision\".\"status\" IN ('unavailable','discontinued') AND \"pairing_decision\".\"url\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pairing_search_settings": {
+      "name": "pairing_search_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing_state_writeback_settings": {
+      "name": "pairing_state_writeback_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne"
+      ]
+    },
+    "public.pairing_state": {
+      "name": "pairing_state",
+      "schema": "public",
+      "values": [
+        "navrhnute",
+        "potvrdene"
+      ]
+    },
+    "public.nedostupne_email_type": {
+      "name": "nedostupne_email_type",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "alternativa"
+      ]
+    },
+    "public.mail_template_action": {
+      "name": "mail_template_action",
+      "schema": "public",
+      "values": [
+        "save",
+        "reset"
+      ]
+    },
+    "public.mail_log_source": {
+      "name": "mail_log_source",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "posta_uncollected",
+        "order_reminder",
+        "supplier_order",
+        "order_merge"
+      ]
+    },
+    "public.mail_log_status": {
+      "name": "mail_log_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.mail_log_trigger": {
+      "name": "mail_log_trigger",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "manual"
+      ]
+    },
+    "public.supplier_availability": {
+      "name": "supplier_availability",
+      "schema": "public",
+      "values": [
+        "available",
+        "unavailable",
+        "unknown"
+      ]
+    },
+    "public.supplier_stock_source": {
+      "name": "supplier_stock_source",
+      "schema": "public",
+      "values": [
+        "json_ld",
+        "meta",
+        "text",
+        "size_list",
+        "none"
+      ]
+    },
+    "public.upozornenie_source": {
+      "name": "upozornenie_source",
+      "schema": "public",
+      "values": [
+        "vlastne",
+        "appka"
+      ]
+    },
+    "public.upozornenie_type": {
+      "name": "upozornenie_type",
+      "schema": "public",
+      "values": [
+        "vlastna_poznamka",
+        "nevyzdvihnuta_zasielka",
+        "vratenie",
+        "vratena_zasielka",
+        "objednavka_visi"
+      ]
+    },
+    "public.dpd_operation_status": {
+      "name": "dpd_operation_status",
+      "schema": "public",
+      "values": [
+        "submitted",
+        "failed"
+      ]
+    },
+    "public.pairing_confidence": {
+      "name": "pairing_confidence",
+      "schema": "public",
+      "values": [
+        "high",
+        "medium",
+        "low",
+        "none"
+      ]
+    },
+    "public.pairing_decision_status": {
+      "name": "pairing_decision_status",
+      "schema": "public",
+      "values": [
+        "good",
+        "manual",
+        "unavailable",
+        "discontinued"
+      ]
+    },
+    "public.pairing_verdict": {
+      "name": "pairing_verdict",
+      "schema": "public",
+      "values": [
+        "ok",
+        "unsure"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -344,6 +344,13 @@
       "when": 1786589109618,
       "tag": "0048_brave_iron_patriot",
       "breakpoints": true
+    },
+    {
+      "idx": 49,
+      "version": "7",
+      "when": 1786594123925,
+      "tag": "0049_plain_metal_master",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema-pairing-review.ts
+++ b/apps/api/src/db/schema-pairing-review.ts
@@ -98,6 +98,20 @@ export const pairingSearchSettings = pgTable("pairing_search_settings", {
 // tickete, issue 387 E5). "↩ Vrátiť" = DELETE riadku (nikdy status navyše).
 export const pairingDecisionStatus = pgEnum("pairing_decision_status", ["good", "manual", "unavailable", "discontinued"]);
 
+// issue 387 E7 — Singleton Štart/Stop prepínač PRE STAVOVÝ WRITEBACK
+// (rovnaký vzor ako `pairingSearchSettings`/`restock_settings` vyššie —
+// ŽIADEN migračný seed riadok, chýbajúci riadok = `false`, fail-closed).
+// Stavový zápis MENÍ VIDITEĽNOSŤ produktov na živom shope (na rozdiel od
+// linkového `internalNote` zápisu, ktorý žiadny prepínač nemá — issue
+// 122's zdôvodnenie: ten iba dopĺňa privátnu poznámku, nikdy nemení, čo
+// zákazník vidí), preto dostáva VLASTNÝ, defaultne VYPNUTÝ prepínač
+// (design komentár na tickete, E7 sekcia "Architektúra").
+export const pairingStateWritebackSettings = pgTable("pairing_state_writeback_settings", {
+  id: text("id").primaryKey(),
+  enabled: boolean("enabled").notNull().default(false),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull(),
+});
+
 export const pairingDecisions = pgTable(
   "pairing_decision",
   {

--- a/apps/api/src/http/pairing-review-routes.ts
+++ b/apps/api/src/http/pairing-review-routes.ts
@@ -3,9 +3,11 @@ import type { Hono } from "hono";
 import { z } from "zod";
 import type { Database } from "../db/client.js";
 import { log } from "../logger.js";
+import { record } from "../modules/audit/service.js";
 import { supplierLinkUrlBody } from "../modules/orders/supplier-link-assignment.js";
 import { setPairingDecision } from "../modules/pairing-review/decisions.js";
 import { listPairingCandidatesForProduct, listPairingReview } from "../modules/pairing-review/queries.js";
+import { isStateWritebackEnabled, setStateWritebackEnabled } from "../modules/shoptet-writeback/state-writeback-settings.js";
 import { requireRole, requireUser, type AppBindings } from "./middleware.js";
 import { requireSameOrigin } from "./origin-check.js";
 
@@ -13,7 +15,10 @@ import { requireSameOrigin } from "./origin-check.js";
 // E3/E4 zozbierali a overili). issue 387 E6: pridáva rozhodnutia (POST) +
 // lazy zoznam kandidátov pre panel (GET) — rovnaké oprávnenie ako
 // `product-links-routes.ts`'s zápisová trasa (`requireRole("admin",
-// "manazer")` + `requireSameOrigin()`).
+// "manazer")` + `requireSameOrigin()`). issue 387 E7: pridáva Štart/Stop
+// prepínač pre STAVOVÝ writeback (mení viditeľnosť produktov na živom
+// shope) — rovnaké miesto ako zvyšok obrazovky Párovanie, rovnaký vzor ako
+// existujúca `PUT /api/pairing-search/enabled`.
 
 // Prázdna hodnota (`page=`) sa má správať ako neprítomný parameter, rovnaký
 // vzor ako `restock-links-routes.ts`/`product-links-routes.ts`'s `pageParam`.
@@ -44,7 +49,42 @@ const pairingDecisionBody = z.discriminatedUnion("status", [
   z.object({ status: z.literal("revert") }),
 ]);
 
+const setStateWritebackEnabledBody = z.object({ enabled: z.boolean() });
+
 export function registerPairingReviewRoutes(app: Hono<AppBindings>, db: Database): void {
+  // issue 387 E7 — `/api/pairing-review/state-writeback-enabled` má INÝ
+  // segmentový tvar než `:productKey/candidates`/`:productKey/decision`
+  // nižšie (2 segmenty za prefixom, nie `:productKey` + ďalší literál), takže
+  // tu nehrozí `.claude/rules/http-routes.md`'s literal-vs-`:param` kolízia —
+  // ponechané na tomto mieste kvôli tematickému zoskupeniu (Štart/Stop je
+  // súčasťou tej istej obrazovky Párovanie).
+  app.get("/api/pairing-review/state-writeback-enabled", requireUser(db), async (c) =>
+    c.json({ enabled: await isStateWritebackEnabled(db) }),
+  );
+
+  app.put(
+    "/api/pairing-review/state-writeback-enabled",
+    requireSameOrigin(),
+    requireUser(db),
+    requireRole("admin", "manazer"),
+    zValidator("json", setStateWritebackEnabledBody),
+    async (c) => {
+      const { enabled } = c.req.valid("json");
+      const user = c.get("user");
+      const now = new Date();
+      await setStateWritebackEnabled(db, enabled, now);
+      await record(db, {
+        at: now,
+        actorUserId: user.userId,
+        action: "pairing_state_writeback.enabled.set",
+        entity: "pairing_state_writeback_settings",
+        data: { enabled },
+      });
+      log.info({ actorUserId: user.userId, enabled }, "Párovanie: Štart/Stop stavového writebacku");
+      return c.json({ ok: true as const, enabled });
+    },
+  );
+
   // Rovnaké oprávnenie ako `restock-links`/`product-links` čítanie
   // (`requireUser`, žiadne rolové obmedzenie) — každý prihlásený smie vidieť
   // stav párovania.

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -45,7 +45,7 @@ import { startScheduler } from "./modules/scheduler/scheduler.js";
 import { orderNoteWritebackConfigFromBaseUrl, shoptetImportConfigFromBaseUrl } from "./modules/shoptet-writeback/config.js";
 import { dpdPortalConfigFromBaseUrl } from "./modules/dpd/config.js";
 import { runOrderNoteWritebackJob } from "./modules/shoptet-writeback/run-order-note-writeback.js";
-import { runShoptetWriteback } from "./modules/shoptet-writeback/run-writeback.js";
+import { runShoptetWritebackSequence } from "./modules/shoptet-writeback/run-writeback-sequence.js";
 import { createShutdownHandler } from "./shutdown.js";
 import { appVersion } from "./version.js";
 
@@ -134,19 +134,22 @@ const sendSupplierMail =
         replyTo: env.MAIL_REPLY_TO,
       });
 
-// issue 122: spätný zápis odkazu na dodávateľa do Shoptetu — rovnaká úvaha
-// ako `runIngest`/`runOrdersIngest`/`sendSupplierMail` vyššie:
+// issue 122 + issue 387 E7: spätný zápis do Shoptetu — rovnaká úvaha ako
+// `runIngest`/`runOrdersIngest`/`sendSupplierMail` vyššie:
 // `SHOPTET_ADMIN_USER`/`PASSWORD` sú nepovinné (`env.ts`), appka beží ďalej
 // bez nich, len naplánovaná úloha zaznamená "nenakonfigurované"
 // (`scheduler/jobs.ts`'s `shoptetWritebackJob`). Žiadna HTTP cesta ich
 // nepotrebuje (na rozdiel od tamtých troch) — toto je LEN scheduler.
+// E7: `runShoptetWritebackSequence` robí OBIDVA podbehy (linkový + stavový,
+// ten druhý gatovaný vlastným Štart/Stop prepínačom) s TÝMITO ISTÝMI
+// prihlasovacími údajmi — žiadne nové premenné.
 const shoptetAdminUser = env.SHOPTET_ADMIN_USER;
 const shoptetAdminPassword = env.SHOPTET_ADMIN_PASSWORD;
 const runShoptetWritebackFn =
   shoptetAdminUser === undefined || shoptetAdminPassword === undefined
     ? undefined
     : (db2: typeof db, now: Date) =>
-        runShoptetWriteback(
+        runShoptetWritebackSequence(
           db2,
           shoptetImportConfigFromBaseUrl(env.SHOPTET_ADMIN_BASE_URL, shoptetAdminUser, shoptetAdminPassword),
           now,

--- a/apps/api/src/modules/scheduler/jobs.ts
+++ b/apps/api/src/modules/scheduler/jobs.ts
@@ -9,7 +9,7 @@ import type { PostaUncollectedRunResult } from "../posta-uncollected/run.js";
 import { isOrderReminderEnabled } from "../order-reminder/settings.js";
 import type { OrderReminderRunResult } from "../order-reminder/run.js";
 import type { OrderNoteWritebackRunResult } from "../shoptet-writeback/run-order-note-writeback.js";
-import type { WritebackRunResult } from "../shoptet-writeback/run-writeback.js";
+import type { ShoptetWritebackSequenceResult } from "../shoptet-writeback/run-writeback-sequence.js";
 import { RESTOCK_JOB_NAME } from "../restock/constants.js";
 import type { RestockRunResult } from "../restock/run.js";
 import { isRestockEnabled } from "../restock/run.js";
@@ -166,21 +166,26 @@ export function pruneRawOrdersJob(rawDir: string, keepDays = 30): ScheduledJob {
   };
 }
 
-export type RunShoptetWriteback = (db: Parameters<ScheduledJob["run"]>[0], now: Date) => Promise<WritebackRunResult>;
+export type RunShoptetWriteback = (
+  db: Parameters<ScheduledJob["run"]>[0],
+  now: Date,
+) => Promise<ShoptetWritebackSequenceResult>;
 
 /**
- * Spätný zápis odkazov na dodávateľa do Shoptetu (issue 122) — hodinovo, na
- * :50 (mimo kolízie s `ordersImportJob`'s :45). Rovnaký vzor ako
- * `catalogImportJob`/`ordersImportJob`: dostáva injektovanú `runWriteback`
- * closure (môže byť `undefined`, keď `SHOPTET_ADMIN_USER`/`PASSWORD` nie sú
- * nakonfigurované — `index.ts` ju zostaví z `runShoptetWriteback`
- * (`shoptet-writeback/run-writeback.ts`) + `shoptetImportConfigFromBaseUrl`),
- * nikdy si business logiku nezostavuje sama. Žiadny nový advisory lock
- * (rovnaký dôvod ako pri tamtých dvoch: v tomto tickete niet manuálneho
- * triggeru, teda niet s čím pretekať — `job_run` periodicita scheduler.ts
- * sama vylučuje duplicitný beh v tej istej hodine). Keď `runWriteback` je
- * `undefined`, job VYHODÍ — rovnaký vzor ako ostatné nepovinne-nakonfigurované
- * joby vyššie.
+ * Spätný zápis do Shoptetu (issue 122 + issue 387 E7) — hodinovo, na :50
+ * (mimo kolízie s `ordersImportJob`'s :45). Od E7 volá `run-writeback-
+ * sequence.ts`'s `runShoptetWritebackSequence` — DVA nezávislé importy v
+ * sekvencii (linkový, potom stavový, ten druhý gatovaný vlastným Štart/Stop
+ * prepínačom), nie priamo `runShoptetWriteback`. Rovnaký injektovaná-
+ * closure vzor ako `catalogImportJob`/`ordersImportJob`: `runWriteback` môže
+ * byť `undefined`, keď `SHOPTET_ADMIN_USER`/`PASSWORD` nie sú nakonfigurované
+ * (`index.ts` ju zostaví z `runShoptetWritebackSequence` +
+ * `shoptetImportConfigFromBaseUrl` — OBIDVA podbehy zdieľajú tie isté
+ * prihlasovacie údaje). Žiadny nový advisory lock (rovnaký dôvod ako pri
+ * tamtých dvoch: v tomto tickete niet manuálneho triggeru, teda niet s čím
+ * pretekať — `job_run` periodicita scheduler.ts sama vylučuje duplicitný
+ * beh v tej istej hodine). Keď `runWriteback` je `undefined`, job VYHODÍ —
+ * rovnaký vzor ako ostatné nepovinne-nakonfigurované joby vyššie.
  */
 export function shoptetWritebackJob(runWriteback: RunShoptetWriteback | undefined): ScheduledJob {
   return {

--- a/apps/api/src/modules/shoptet-writeback/csv.test.ts
+++ b/apps/api/src/modules/shoptet-writeback/csv.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildRestockCsv, buildWritebackCsv } from "./csv.js";
+import { buildRestockCsv, buildStatesCsv, buildWritebackCsv, dedupeStateRowsByCode } from "./csv.js";
 
 describe("buildWritebackCsv", () => {
   it("has the canonical Shoptet import header + BOM + CRLF + ';' delimiter", () => {
@@ -74,5 +74,89 @@ describe("buildRestockCsv", () => {
 
   it("odmietne prázdny zoznam — prázdny import do Shoptetu sa nikdy nenahráva", () => {
     expect(() => buildRestockCsv([])).toThrow(/žiadne riadky/);
+  });
+});
+
+// issue 387 E7: stavový writeback — druhý, samostatný import (nikdy
+// kombinovaný s linkovým `buildWritebackCsv` vyššie). Mapovanie stavov +
+// stĺpce presne podľa starej appky (`import_builder.py`'s `state_rows`):
+// unavailable → visible/0/Vypredané, discontinued → detailOnly/0/Predaj
+// výrobku skončil. Stĺpce sú DISJUNKTNÉ od linkového CSV — žiadny
+// `internalNote`, takže existujúce dodávateľské odkazy ostávajú nedotknuté.
+describe("buildStatesCsv", () => {
+  it("má stavovú hlavičku (disjunktnú od linkového CSV) + BOM + CRLF + ';' oddeľovač", () => {
+    const csv = buildStatesCsv([{ code: "123/S", pairCode: "456", status: "unavailable" }]);
+    const text = csv.toString("utf8");
+    expect(text.charCodeAt(0)).toBe(0xfeff);
+    const lines = text.slice(1).split("\r\n");
+    expect(lines[0]).toBe("code;pairCode;productVisibility;stock;availabilityInStock;availabilityOutOfStock");
+    expect(lines[1]).toBe("123/S;456;visible;0;Vypredané;Vypredané");
+    expect(lines.at(-1)).toBe("");
+  });
+
+  it("mapuje 'unavailable' na visible/0/Vypredané (oba dostupnostné texty rovnaké)", () => {
+    const csv = buildStatesCsv([{ code: "A", pairCode: "", status: "unavailable" }]);
+    const rows = csv.toString("utf8").slice(1).split("\r\n").filter(Boolean);
+    expect(rows[1]).toBe("A;;visible;0;Vypredané;Vypredané");
+  });
+
+  it("mapuje 'discontinued' na detailOnly/0/Predaj výrobku skončil (oba texty rovnaké)", () => {
+    const csv = buildStatesCsv([{ code: "B", pairCode: "77", status: "discontinued" }]);
+    const rows = csv.toString("utf8").slice(1).split("\r\n").filter(Boolean);
+    expect(rows[1]).toBe("B;77;detailOnly;0;Predaj výrobku skončil;Predaj výrobku skončil");
+  });
+
+  it("odmietne prázdny zoznam — prázdny import do Shoptetu sa nikdy nenahráva", () => {
+    expect(() => buildStatesCsv([])).toThrow(/žiadne riadky/i);
+  });
+
+  // issue 153: rovnaká CSV-injection ochrana ako `buildWritebackCsv` —
+  // `code`/`pairCode` prichádzajú z katalógového importu bez inej kontroly.
+  it("neutralizuje bunku začínajúcu znakom vzorca v KTOROMKOĽVEK stĺpci", () => {
+    const csv = buildStatesCsv([{ code: "=SUM(A1:A9)", pairCode: "+1", status: "unavailable" }]);
+    const rows = csv.toString("utf8").slice(1).split("\r\n").filter(Boolean);
+    expect(rows[1]).toBe("'=SUM(A1:A9);'+1;visible;0;Vypredané;Vypredané");
+  });
+
+  // Dedup podľa `code`, PRVÝ vyhráva — stará appka's zákon
+  // (`import_builder.py`'s `state_rows`/`link_rows`: Shoptet aborduje celý
+  // import na duplicitnom kóde). V tejto appke je `variants.code` DB
+  // primárny kľúč, takže skutočný duplikát je štrukturálne nedosiahnuteľný
+  // pri korektnom volajúcom — táto funkcia je obranná vrstva navyše.
+  it("dedupuje podľa 'code' — prvý výskyt vyhráva, druhý (aj s iným stavom) sa zahodí", () => {
+    const csv = buildStatesCsv([
+      { code: "DUP", pairCode: "1", status: "unavailable" },
+      { code: "DUP", pairCode: "2", status: "discontinued" },
+      { code: "OK", pairCode: "3", status: "discontinued" },
+    ]);
+    const rows = csv.toString("utf8").slice(1).split("\r\n").filter(Boolean);
+    expect(rows).toEqual([
+      "code;pairCode;productVisibility;stock;availabilityInStock;availabilityOutOfStock",
+      "DUP;1;visible;0;Vypredané;Vypredané",
+      "OK;3;detailOnly;0;Predaj výrobku skončil;Predaj výrobku skončil",
+    ]);
+  });
+});
+
+describe("dedupeStateRowsByCode", () => {
+  it("necháva neduplicitné riadky bezo zmeny (rovnaký poradie)", () => {
+    const rows = [
+      { code: "A", pairCode: "", status: "unavailable" as const },
+      { code: "B", pairCode: "", status: "discontinued" as const },
+    ];
+    expect(dedupeStateRowsByCode(rows)).toEqual(rows);
+  });
+
+  it("zahodí KAŽDÝ ďalší výskyt toho istého 'code', zachová prvý", () => {
+    const rows = [
+      { code: "X", pairCode: "1", status: "unavailable" as const },
+      { code: "X", pairCode: "2", status: "unavailable" as const },
+      { code: "X", pairCode: "3", status: "unavailable" as const },
+    ];
+    expect(dedupeStateRowsByCode(rows)).toEqual([{ code: "X", pairCode: "1", status: "unavailable" }]);
+  });
+
+  it("je no-op pre prázdny zoznam", () => {
+    expect(dedupeStateRowsByCode([])).toEqual([]);
   });
 });

--- a/apps/api/src/modules/shoptet-writeback/csv.ts
+++ b/apps/api/src/modules/shoptet-writeback/csv.ts
@@ -100,3 +100,71 @@ export function buildRestockCsv(rows: readonly RestockCsvRow[]): Buffer {
   const bom = "﻿";
   return Buffer.from(bom + lines.join("\r\n") + "\r\n", "utf8");
 }
+
+// issue 387 E7: stavový zápis (rozhodnutia "📦 Nie je skladom"/"🚫 Už sa
+// nebude predávať" z obrazovky Párovanie) — DRUHÝ, SAMOSTATNÝ CSV import,
+// nikdy kombinovaný s linkovým vyššie. Vlastný tvar riadku (stĺpce sú
+// DISJUNKTNÉ od `WritebackRow` — žiadny `internalNote`, takže existujúce
+// dodávateľské odkazy ostávajú nedotknuté), ale ZÁMERNE v tomto súbore a
+// cez to isté `dataRowToLine` — CSV-injection ochrana platí pre KAŽDÚ
+// cestu zápisu do Shoptetu.
+export type StateWritebackStatus = "unavailable" | "discontinued";
+
+export interface StateCsvRow {
+  readonly code: string;
+  readonly pairCode: string;
+  readonly status: StateWritebackStatus;
+}
+
+const STATE_HEADER = ["code", "pairCode", "productVisibility", "stock", "availabilityInStock", "availabilityOutOfStock"] as const;
+
+// Mapovanie stavov — presne stará appka's zákon (`import_builder.py`'s
+// `state_rows`/`export_helpers.py`'s `_VYPREDANE`/`_SKONCIL`): unavailable →
+// visible/Vypredané (produkt ostáva viditeľný, môže sa neskôr prepnúť späť —
+// `.claude/rules/supplier-stock.md`'s restock automatika naň smie zareagovať),
+// discontinued → detailOnly/Predaj výrobku skončil (stránka ostáva kvôli
+// Google, ale restock ho už nikdy neprepne späť — `detailOnly` je mimo
+// `HIDDEN_VISIBILITIES`, ale AJ mimo `SELLABLE_VISIBILITY`). `stock` sa
+// nezapisuje (issue 219's dôvod platí rovnako — majiteľ zásobu neudržiava),
+// oba dostupnostné texty sa zapisujú NARAZ (issue 219).
+const STATE_VISIBILITY: Record<StateWritebackStatus, string> = { unavailable: "visible", discontinued: "detailOnly" };
+const STATE_AVAILABILITY_TEXT: Record<StateWritebackStatus, string> = {
+  unavailable: "Vypredané",
+  discontinued: "Predaj výrobku skončil",
+};
+
+/**
+ * Dedup podľa `code`, PRVÝ výskyt vyhráva — stará appka's zákon ("Each code
+ * appears ONCE — Shoptet aborts the whole import on a duplicate code").
+ * `variants.code` je v tejto appke DB primárny kľúč (`schema-catalog.ts`),
+ * takže skutočný duplikát v `rows` je štrukturálne nedosiahnuteľný pri
+ * korektnom volajúcom — táto funkcia je obranná vrstva navyše, nikdy
+ * jediná ochrana. Exportovaná samostatne (nie len vnorená v
+ * `buildStatesCsv`), aby volajúci (`run-state-writeback.ts`) mohol z NEJ
+ * istej odvodiť presný `expectedRows` pre Log-overenie výsledku importu —
+ * jeden zdroj pravdy pre "koľko riadkov sa reálne zapíše".
+ */
+export function dedupeStateRowsByCode(rows: readonly StateCsvRow[]): readonly StateCsvRow[] {
+  const seen = new Set<string>();
+  return rows.filter((r) => {
+    if (seen.has(r.code)) return false;
+    seen.add(r.code);
+    return true;
+  });
+}
+
+export function buildStatesCsv(rows: readonly StateCsvRow[]): Buffer {
+  if (rows.length === 0) {
+    throw new Error("buildStatesCsv: žiadne riadky na zápis — CSV sa nesmie nahrať prázdne");
+  }
+  const deduped = dedupeStateRowsByCode(rows);
+  const lines = [
+    rowToLine(STATE_HEADER),
+    ...deduped.map((r) => {
+      const text = STATE_AVAILABILITY_TEXT[r.status];
+      return dataRowToLine([r.code, r.pairCode, STATE_VISIBILITY[r.status], "0", text, text]);
+    }),
+  ];
+  const bom = "﻿";
+  return Buffer.from(bom + lines.join("\r\n") + "\r\n", "utf8");
+}

--- a/apps/api/src/modules/shoptet-writeback/mark-state-synced.ts
+++ b/apps/api/src/modules/shoptet-writeback/mark-state-synced.ts
@@ -1,0 +1,23 @@
+import { and, inArray, lte } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { pairingDecisions } from "../../db/schema.js";
+
+/**
+ * Označí dané `productKey`s ako stavovo úspešne zapísané do Shoptetu — mirror
+ * `markSuppliersLinksSynced` (mark-synced.ts), len na `pairing_decision
+ * .state_synced_at`. Volaj LEN po POTVRDENOM úspechu stavového importu
+ * (Log ukázal presne toľko spracovaných riadkov, koľko sa poslalo, žiadne
+ * zlyhania, `run-state-writeback.ts`). `now` je čas ZAČIATKU celého behu
+ * (rovnaký race guard ako linkový zápis, `.claude/rules/shoptet-writeback
+ * .md`): keby sa rozhodnutie zmenilo znova MEDZI výberom a týmto zápisom
+ * (import cez prehliadač môže trvať desiatky sekúnd), `updated_at <= now`
+ * podmienka to rozpozná (nová hodnota má `updated_at` nutne neskôr než
+ * `now`) a NEoznačí ju ako synchronizovanú — nasledujúci beh ju pošle znova.
+ */
+export async function markStateSynced(db: Database, productKeys: readonly string[], now: Date): Promise<void> {
+  if (productKeys.length === 0) return;
+  await db
+    .update(pairingDecisions)
+    .set({ stateSyncedAt: now })
+    .where(and(inArray(pairingDecisions.productKey, [...productKeys]), lte(pairingDecisions.updatedAt, now)));
+}

--- a/apps/api/src/modules/shoptet-writeback/run-state-writeback.ts
+++ b/apps/api/src/modules/shoptet-writeback/run-state-writeback.ts
@@ -1,0 +1,59 @@
+import type { Database } from "../../db/client.js";
+import { buildStatesCsv, dedupeStateRowsByCode } from "./csv.js";
+import type { ShoptetImportConfig } from "./config.js";
+import { markStateSynced } from "./mark-state-synced.js";
+import { runShoptetImportIsolated } from "./playwright-import.js";
+import { selectChangedStateDecisions } from "./select-states.js";
+
+export type StateWritebackRunResult =
+  | { readonly status: "nothing_changed" }
+  | { readonly status: "ok"; readonly productCount: number; readonly rowCount: number }
+  | {
+      readonly status: "failed";
+      readonly productCount: number;
+      readonly rowCount: number;
+      readonly processed: number | null;
+      readonly failed: number | null;
+      readonly errorDetail: string | null;
+    };
+
+/**
+ * issue 387 E7 — DRUHÝ, SAMOSTATNÝ writeback beh (mirror `runShoptetWriteback`,
+ * run-writeback.ts): vyber terminálne rozhodnutia (unavailable/discontinued)
+ * bez čerstvého stavového syncu → postav stavový CSV → nahraj cez Playwright
+ * (ŽIADEN nový Playwright kód — ten istý `runShoptetImportIsolated`, teda
+ * aj tá istá `ensureSafeSettings` read-back kontrola) → LEN po POTVRDENOM
+ * úspechu označ dané produkty ako stavovo synchronizované. Pri chybe/
+ * nejednoznačnom výsledku sa `stateSyncedAt` NIKDY nezmení — nasledujúci
+ * beh (`shoptetWritebackJob`, cez `run-writeback-sequence.ts`) tie isté
+ * produkty pošle znova.
+ */
+export async function runShoptetStateWriteback(
+  db: Database,
+  config: ShoptetImportConfig,
+  now: Date,
+): Promise<StateWritebackRunResult> {
+  const { productKeys, rows } = await selectChangedStateDecisions(db);
+  if (rows.length === 0) return { status: "nothing_changed" };
+
+  // `dedupeStateRowsByCode` sa volá TU (nie len vnútri `buildStatesCsv`),
+  // aby `expectedRows` (Log-overenie výsledku importu, `log-attribution.ts`)
+  // sedelo s tým, čo `buildStatesCsv` skutočne zapíše — jeden zdroj pravdy.
+  const deduped = dedupeStateRowsByCode(rows);
+  const csv = buildStatesCsv(rows);
+  const outcome = await runShoptetImportIsolated({ config, csv, expectedRows: deduped.length });
+
+  if (!outcome.ok) {
+    return {
+      status: "failed",
+      productCount: productKeys.length,
+      rowCount: deduped.length,
+      processed: outcome.processed,
+      failed: outcome.failed,
+      errorDetail: outcome.errorDetail,
+    };
+  }
+
+  await markStateSynced(db, productKeys, now);
+  return { status: "ok", productCount: productKeys.length, rowCount: deduped.length };
+}

--- a/apps/api/src/modules/shoptet-writeback/run-state-writeback.ts
+++ b/apps/api/src/modules/shoptet-writeback/run-state-writeback.ts
@@ -2,7 +2,7 @@ import type { Database } from "../../db/client.js";
 import { buildStatesCsv, dedupeStateRowsByCode } from "./csv.js";
 import type { ShoptetImportConfig } from "./config.js";
 import { markStateSynced } from "./mark-state-synced.js";
-import { runShoptetImportIsolated } from "./playwright-import.js";
+import { runShoptetImportIsolated, type ShoptetImportOutcome } from "./playwright-import.js";
 import { selectChangedStateDecisions } from "./select-states.js";
 
 export type StateWritebackRunResult =
@@ -27,6 +27,12 @@ export type StateWritebackRunResult =
  * nejednoznačnom výsledku sa `stateSyncedAt` NIKDY nezmení — nasledujúci
  * beh (`shoptetWritebackJob`, cez `run-writeback-sequence.ts`) tie isté
  * produkty pošle znova.
+ *
+ * Review nález (rovnaký ako `run-writeback.ts`): `runShoptetImportIsolated`
+ * VYHADZUJE na tvrdom zlyhaní (nie len `{ok:false}`) — `try`/`catch` nižšie
+ * to premieňa na normálny `{status:"failed"}` výsledok, aby výnimka NIKDY
+ * neprešla do `run-writeback-sequence.ts` a nezastavila (v opačnom poradí
+ * volania) linkový podbeh.
  */
 export async function runShoptetStateWriteback(
   db: Database,
@@ -41,7 +47,19 @@ export async function runShoptetStateWriteback(
   // sedelo s tým, čo `buildStatesCsv` skutočne zapíše — jeden zdroj pravdy.
   const deduped = dedupeStateRowsByCode(rows);
   const csv = buildStatesCsv(rows);
-  const outcome = await runShoptetImportIsolated({ config, csv, expectedRows: deduped.length });
+  let outcome: ShoptetImportOutcome;
+  try {
+    outcome = await runShoptetImportIsolated({ config, csv, expectedRows: deduped.length });
+  } catch (error) {
+    return {
+      status: "failed",
+      productCount: productKeys.length,
+      rowCount: deduped.length,
+      processed: null,
+      failed: null,
+      errorDetail: error instanceof Error ? error.message : String(error),
+    };
+  }
 
   if (!outcome.ok) {
     return {

--- a/apps/api/src/modules/shoptet-writeback/run-writeback-sequence.ts
+++ b/apps/api/src/modules/shoptet-writeback/run-writeback-sequence.ts
@@ -1,0 +1,36 @@
+import type { Database } from "../../db/client.js";
+import type { ShoptetImportConfig } from "./config.js";
+import { isStateWritebackEnabled } from "./state-writeback-settings.js";
+import { runShoptetStateWriteback, type StateWritebackRunResult } from "./run-state-writeback.js";
+import { runShoptetWriteback, type WritebackRunResult } from "./run-writeback.js";
+
+export interface ShoptetWritebackSequenceResult {
+  readonly link: WritebackRunResult;
+  readonly state: StateWritebackRunResult | { readonly status: "disabled" };
+}
+
+/**
+ * issue 387 E7 — čo teraz beží na `:50` (`scheduler/jobs.ts`'s
+ * `shoptetWritebackJob`, cez `index.ts`'s `runShoptetWritebackFn`): DVA
+ * nezávislé importy v sekvencii, najprv linkový (existujúci, issue 122),
+ * potom stavový (nový — mení viditeľnosť produktov na živom shope, preto
+ * gatovaný vlastným Štart/Stop prepínačom, default VYPNUTÝ). Zámerne
+ * NEZÁVISLÉ (design komentár na tickete, "Zvažované prístupy" bod 2):
+ * zlyhanie linkového importu nesmie zabrániť POKUSU o stavový — ide o inú,
+ * disjunktnú množinu riadkov v inom súbore.
+ *
+ * `now` sa zachytí RAZ (job-level, `scheduler.ts`) a odovzdá OBOM
+ * podbehom — rovnaký "čas štartu CELÉHO behu" race guard vzor ako dnešný
+ * `syncedAt`, len teraz zdieľaný dvomi nezávislými race guardmi
+ * (`markSuppliersLinksSynced`/`markStateSynced`) naraz.
+ */
+export async function runShoptetWritebackSequence(
+  db: Database,
+  config: ShoptetImportConfig,
+  now: Date,
+): Promise<ShoptetWritebackSequenceResult> {
+  const link = await runShoptetWriteback(db, config, now);
+  const stateEnabled = await isStateWritebackEnabled(db);
+  const state = stateEnabled ? await runShoptetStateWriteback(db, config, now) : ({ status: "disabled" } as const);
+  return { link, state };
+}

--- a/apps/api/src/modules/shoptet-writeback/run-writeback-sequence.ts
+++ b/apps/api/src/modules/shoptet-writeback/run-writeback-sequence.ts
@@ -17,7 +17,11 @@ export interface ShoptetWritebackSequenceResult {
  * gatovaný vlastným Štart/Stop prepínačom, default VYPNUTÝ). Zámerne
  * NEZÁVISLÉ (design komentár na tickete, "Zvažované prístupy" bod 2):
  * zlyhanie linkového importu nesmie zabrániť POKUSU o stavový — ide o inú,
- * disjunktnú množinu riadkov v inom súbore.
+ * disjunktnú množinu riadkov v inom súbore. Nezávislosť platí AJ pre TVRDÉ
+ * zlyhanie (vyhodenú výnimku, nie len `{ok:false}` Log výsledok) — obe
+ * `runShoptetWriteback`/`runShoptetStateWriteback` majú VLASTNÝ `try`/`catch`
+ * okolo `runShoptetImportIsolated` (review nález, issue 387 E7), takže ani
+ * jeden podbeh sem výnimku nikdy nepošle.
  *
  * `now` sa zachytí RAZ (job-level, `scheduler.ts`) a odovzdá OBOM
  * podbehom — rovnaký "čas štartu CELÉHO behu" race guard vzor ako dnešný

--- a/apps/api/src/modules/shoptet-writeback/run-writeback.ts
+++ b/apps/api/src/modules/shoptet-writeback/run-writeback.ts
@@ -2,7 +2,7 @@ import type { Database } from "../../db/client.js";
 import { buildWritebackCsv } from "./csv.js";
 import type { ShoptetImportConfig } from "./config.js";
 import { markSuppliersLinksSynced } from "./mark-synced.js";
-import { runShoptetImportIsolated } from "./playwright-import.js";
+import { runShoptetImportIsolated, type ShoptetImportOutcome } from "./playwright-import.js";
 import { selectChangedSupplierLinks } from "./select-changes.js";
 
 export type WritebackRunResult =
@@ -24,6 +24,17 @@ export type WritebackRunResult =
  * nezmení — nasledujúci beh (naplánovaná úloha, `scheduler/jobs.ts`) tie isté
  * produkty pošle znova. `now` sa berie ako parameter (nie `new Date()` tu
  * vnútri), rovnaká disciplína ako `catalogImportJob`/`ordersImportJob`.
+ *
+ * issue 387 E7 (review nález): `runShoptetImportIsolated` VYHADZUJE (nie len
+ * vracia `{ok:false}`) na TVRDOM zlyhaní (nenájde prihlasovací formulár,
+ * nenájde bezpečný radio, dieťa proces skončí bez výsledku — `child-
+ * runner.ts`) — TENTO `try`/`catch` PREMIEŇA aj tento prípad na normálny
+ * `{status:"failed"}` výsledok (`processed`/`failed` `null`, keďže žiadny
+ * štruktúrovaný Log výsledok nebol získaný). Bez neho by výnimka prešla AŽ
+ * DO `run-writeback-sequence.ts`, kde by ZASTAVILA aj pokus o DRUHÝ
+ * (stavový) import — presne opak toho, čo `runShoptetWritebackSequence`
+ * sľubuje ("nezávislé"). Predtým sa toto nikdy neprejavilo, lebo `run-
+ * writeback.ts` bolo JEDINÝM krokom behu (issue 122) — teraz je PRVÝM z DVOCH.
  */
 export async function runShoptetWriteback(
   db: Database,
@@ -34,7 +45,19 @@ export async function runShoptetWriteback(
   if (rows.length === 0) return { status: "nothing_changed" };
 
   const csv = buildWritebackCsv(rows);
-  const outcome = await runShoptetImportIsolated({ config, csv, expectedRows: rows.length });
+  let outcome: ShoptetImportOutcome;
+  try {
+    outcome = await runShoptetImportIsolated({ config, csv, expectedRows: rows.length });
+  } catch (error) {
+    return {
+      status: "failed",
+      productCount: productKeys.length,
+      rowCount: rows.length,
+      processed: null,
+      failed: null,
+      errorDetail: error instanceof Error ? error.message : String(error),
+    };
+  }
 
   if (!outcome.ok) {
     return {

--- a/apps/api/src/modules/shoptet-writeback/select-states.ts
+++ b/apps/api/src/modules/shoptet-writeback/select-states.ts
@@ -1,0 +1,68 @@
+import { and, eq, inArray, isNull, lt, or } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { pairingDecisions, variants } from "../../db/schema.js";
+import { log } from "../../logger.js";
+import type { StateCsvRow, StateWritebackStatus } from "./csv.js";
+
+export interface SelectedStateWriteback {
+  /** productKey of every decision actually included below — used to mark
+   * `stateSyncedAt` after a CONFIRMED successful import (run-state-writeback.ts). */
+  readonly productKeys: readonly string[];
+  /** one row per variant of every changed decision, ready for buildStatesCsv. */
+  readonly rows: readonly StateCsvRow[];
+}
+
+/**
+ * "Zmenilo sa niečo od posledného úspešného stavového zápisu?" (issue 387 E7)
+ * — mirror `selectChangedSupplierLinks` (select-changes.ts), len nad
+ * `pairing_decision` namiesto `product_supplier_link_override`.
+ * `state_synced_at IS NULL` = ešte nikdy odoslané; `state_synced_at <
+ * updated_at` = odoslané, ale odvtedy rozhodnutie znova zmenené
+ * (`pairing-review/decisions.ts`'s `upsertPairingDecisionRow` nuluje
+ * `state_synced_at` pri KAŽDEJ zmene). LEN terminálne rozhodnutia
+ * (unavailable/discontinued) — `good`/`manual` nikdy stavovú CSV riadok
+ * nedostanú (idú cez existujúci `internalNote` zápis, issue 122).
+ */
+export async function selectChangedStateDecisions(db: Database): Promise<SelectedStateWriteback> {
+  const changedCondition = and(
+    inArray(pairingDecisions.status, ["unavailable", "discontinued"]),
+    or(isNull(pairingDecisions.stateSyncedAt), lt(pairingDecisions.stateSyncedAt, pairingDecisions.updatedAt)),
+  );
+
+  const rows = await db
+    .select({
+      code: variants.code,
+      pairCode: variants.pairCode,
+      status: pairingDecisions.status,
+      productKey: pairingDecisions.productKey,
+    })
+    .from(pairingDecisions)
+    .innerJoin(variants, eq(variants.productKey, pairingDecisions.productKey))
+    .where(changedCondition)
+    .orderBy(variants.code);
+
+  const productKeys = [...new Set(rows.map((r) => r.productKey))];
+
+  // rovnaký "anomália bez variantu" pozorovací log ako
+  // `selectChangedSupplierLinks` (select-changes.ts, review of PR 140) —
+  // produkt bez variantov je dátová anomália, nikdy normálny prípad.
+  const changedDecisions = await db
+    .select({ productKey: pairingDecisions.productKey })
+    .from(pairingDecisions)
+    .where(changedCondition);
+  const skipped = changedDecisions.map((d) => d.productKey).filter((key) => !productKeys.includes(key));
+  if (skipped.length > 0) {
+    log.warn(
+      { skippedProductKeys: skipped },
+      "shoptet stavový zápis: preskočené zmenené rozhodnutia bez žiadneho variantu (dátová anomália)",
+    );
+  }
+
+  return {
+    productKeys,
+    // `changedCondition`'s `inArray(status, ["unavailable","discontinued"])`
+    // zaručuje toto zúženie za behu — TS to sám odvodiť nevie (stĺpec je
+    // celý `pairing_decision_status` enum).
+    rows: rows.map((r) => ({ code: r.code, pairCode: r.pairCode ?? "", status: r.status as StateWritebackStatus })),
+  };
+}

--- a/apps/api/src/modules/shoptet-writeback/state-writeback-settings.ts
+++ b/apps/api/src/modules/shoptet-writeback/state-writeback-settings.ts
@@ -1,0 +1,27 @@
+import { eq } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { pairingStateWritebackSettings } from "../../db/schema.js";
+
+// issue 387 E7 — Štart/Stop prepínač pre stavový writeback (mení viditeľnosť
+// produktov na živom shope). Mirror `pairing-search/settings.ts`.
+export const PAIRING_STATE_WRITEBACK_SETTINGS_ID = "default";
+
+/** `true` len keď riadok existuje A `enabled = true` — chýbajúci riadok
+ * (žiadny migračný seed) sa berie ako VYPNUTÉ, nikdy ako zapnuté (rovnaká
+ * fail-closed disciplína ako `pairing_search_settings`/`restock_settings`:
+ * appka nezačne meniť viditeľnosť produktov na živom shope, kým ju niekto
+ * výslovne nezapne po prvom naživo overení). */
+export async function isStateWritebackEnabled(db: Database): Promise<boolean> {
+  const [row] = await db
+    .select({ enabled: pairingStateWritebackSettings.enabled })
+    .from(pairingStateWritebackSettings)
+    .where(eq(pairingStateWritebackSettings.id, PAIRING_STATE_WRITEBACK_SETTINGS_ID));
+  return row?.enabled ?? false;
+}
+
+export async function setStateWritebackEnabled(db: Database, enabled: boolean, now: Date): Promise<void> {
+  await db
+    .insert(pairingStateWritebackSettings)
+    .values({ id: PAIRING_STATE_WRITEBACK_SETTINGS_ID, enabled, updatedAt: now })
+    .onConflictDoUpdate({ target: pairingStateWritebackSettings.id, set: { enabled, updatedAt: now } });
+}

--- a/apps/api/tests/helpers/db.ts
+++ b/apps/api/tests/helpers/db.ts
@@ -90,8 +90,11 @@ export async function withCleanDb(): Promise<{ db: Database; close: () => Promis
     // ON DELETE actions, so this still cascades) — either alone already
     // reaches it transitively, listed explicitly anyway for the SAME
     // self-documenting consistency as "pairing_candidate_set" above.
+    // issue 387 E7: "pairing_state_writeback_settings" is the SAME situation
+    // as "pairing_search_settings"/"restock_settings" above — no FK in
+    // either direction (singleton id), no migration-seeded default row.
     await db.execute(
-      sql`TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, nedostupne_replacement_link, mail_template, mail_template_history, supplier_stock, restock_settings, restock_event, shop_product_url, theme_color, dpd_pickup_request, upozornenie, daily_task, mail_log, dpd_shipment, product_supplier_override, product_supplier_link_override, pairing_candidate, pairing_candidate_set, pairing_search_settings, pairing_decision RESTART IDENTITY CASCADE`,
+      sql`TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, nedostupne_replacement_link, mail_template, mail_template_history, supplier_stock, restock_settings, restock_event, shop_product_url, theme_color, dpd_pickup_request, upozornenie, daily_task, mail_log, dpd_shipment, product_supplier_override, product_supplier_link_override, pairing_candidate, pairing_candidate_set, pairing_search_settings, pairing_decision, pairing_state_writeback_settings RESTART IDENTITY CASCADE`,
     );
     // issue 59: `order_open_status` is a NEW table with real production
     // content (the migration seeds it) — TRUNCATE alone would leave every

--- a/apps/api/tests/helpers/shoptet-fixture.ts
+++ b/apps/api/tests/helpers/shoptet-fixture.ts
@@ -42,6 +42,16 @@ export interface ShoptetFixture {
    * seeding this, matching production instead of the never-happens "log
    * truly empty" edge case. */
   seedPastEntry(): void;
+  /** issue 387 E7: makes the NEXT import attempt's `/admin/import-produktov/`
+   * page render WITHOUT the safe-mode radio — one-shot (consumed on the next
+   * `GET`, then reverts to normal), so `ensureSafeSettings` (`playwright-
+   * import.ts`) throws (a genuine HARD failure, not a soft `{ok:false}` Log
+   * result) on that ONE attempt only. Lets a test prove that a hard failure
+   * in ONE of two sequential import calls (`run-writeback-sequence.ts`) does
+   * NOT prevent the OTHER from being genuinely attempted — a static
+   * `omitSafeRadio` (constructor option, above) would trip on EVERY attempt
+   * against the same fixture, making the two calls indistinguishable. */
+  failNextImportFormOnce(): void;
   close(): Promise<void>;
 }
 
@@ -96,6 +106,7 @@ export async function startShoptetFixture(options: ShoptetFixtureOptions): Promi
   let entries: string[] = [];
   let nextId = 100;
   let outcome: FixtureOutcomeMode = "success";
+  let failNextImportForm = false; // issue 387 E7 — one-shot, see failNextImportFormOnce() below
 
   app.get("/admin/", (c) => {
     const cookie = getCookie(c, COOKIE_NAME);
@@ -115,6 +126,10 @@ export async function startShoptetFixture(options: ShoptetFixtureOptions): Promi
 
   app.get("/admin/import-produktov/", (c) => {
     if (getCookie(c, COOKIE_NAME) !== "ok") return c.redirect("/admin/", 303);
+    if (failNextImportForm) {
+      failNextImportForm = false; // one-shot — consumed, next request is normal again
+      return c.html(importPage(true));
+    }
     return c.html(importPage(options.omitSafeRadio ?? false));
   });
 
@@ -161,6 +176,9 @@ export async function startShoptetFixture(options: ShoptetFixtureOptions): Promi
       const id = nextId;
       nextId += 1;
       entries = [`#${String(id)} 01.08.2026 09:00 Spracované: 9. Upravené: 9. Zlyhanie variantov: 0.`, ...entries];
+    },
+    failNextImportFormOnce: () => {
+      failNextImportForm = true;
     },
     close: () =>
       new Promise<void>((resolve, reject) => {

--- a/apps/api/tests/pairing-review-state-writeback-settings-http.integration.test.ts
+++ b/apps/api/tests/pairing-review-state-writeback-settings-http.integration.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, expect, it } from "vitest";
+import { users } from "../src/db/schema.js";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import type { UserRole } from "../src/modules/auth/service.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 387 E7: `GET`/`PUT /api/pairing-review/state-writeback-enabled` —
+// vyčlenené OD `pairing-review-decisions-http.integration.test.ts` (E6, už
+// na 316 riadkoch), aby ani jeden súbor nenarástol cez eslint `max-lines:
+// 400` (`.claude/rules/testing.md`'s zavedený vzor).
+
+const HESLO = "test-heslo-abc"; // testovacie údaje, nie tajomstvo
+
+let close: (() => Promise<void>) | undefined;
+
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  resetLoginRateLimit();
+});
+
+async function boot(role: UserRole) {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const [pouzivatel] = await ctx.db
+    .insert(users)
+    .values({ email: "manazer@forestshop.sk", passwordHash: await hashPassword(HESLO), displayName: "Manažér", role })
+    .returning({ id: users.id });
+  if (pouzivatel === undefined) throw new Error("testovací používateľ sa nepodarilo vložiť");
+
+  const app = createApp(ctx.db, { cookieSecure: false });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "manazer@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie };
+}
+
+it("GET vráti enabled=false hneď po migrácii (bezpečný default — nikdy zapnuté bez výslovného zásahu)", async () => {
+  const { app, cookie } = await boot("citanie");
+  const res = await app.request("/api/pairing-review/state-writeback-enabled", { headers: { cookie } });
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { enabled: boolean };
+  expect(body.enabled).toBe(false);
+});
+
+it("rola citanie NESMIE prepnúť Štart/Stop (403)", async () => {
+  const { app, cookie } = await boot("citanie");
+  const res = await app.request("/api/pairing-review/state-writeback-enabled", {
+    method: "PUT",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ enabled: true }),
+  });
+  expect(res.status).toBe(403);
+});
+
+it("manazer prepne Štart/Stop a GET to hneď odzrkadlí", async () => {
+  const { app, cookie } = await boot("manazer");
+  const put = await app.request("/api/pairing-review/state-writeback-enabled", {
+    method: "PUT",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ enabled: true }),
+  });
+  expect(put.status).toBe(200);
+
+  const res = await app.request("/api/pairing-review/state-writeback-enabled", { headers: { cookie } });
+  const body = (await res.json()) as { enabled: boolean };
+  expect(body.enabled).toBe(true);
+});

--- a/apps/api/tests/scheduler-jobs.integration.test.ts
+++ b/apps/api/tests/scheduler-jobs.integration.test.ts
@@ -206,7 +206,10 @@ it("shoptetWritebackJob bez nakonfigurovaného runWriteback VYHODÍ (zachytí ho
 });
 
 it("shoptetWritebackJob s nakonfigurovaným runWriteback naň deleguje a vráti jeho výsledok ako detail", async () => {
-  const fakeResult = { status: "nothing_changed" } as const;
+  // issue 387 E7: `runWriteback` teraz vracia KOMBINOVANÝ výsledok oboch
+  // podbehov (linkový + stavový) — `run-writeback-sequence.ts`'s
+  // `ShoptetWritebackSequenceResult`.
+  const fakeResult = { link: { status: "nothing_changed" }, state: { status: "disabled" } } as const;
   let receivedNow: Date | undefined;
   const job = shoptetWritebackJob((_db, now) => {
     receivedNow = now;

--- a/apps/api/tests/shoptet-writeback-mark-state-synced.integration.test.ts
+++ b/apps/api/tests/shoptet-writeback-mark-state-synced.integration.test.ts
@@ -1,0 +1,116 @@
+import { eq } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Database } from "../src/db/client.js";
+import { pairingDecisions, users } from "../src/db/schema.js";
+import { markStateSynced } from "../src/modules/shoptet-writeback/mark-state-synced.js";
+import { selectChangedStateDecisions } from "../src/modules/shoptet-writeback/select-states.js";
+import { withCleanDb } from "./helpers/db.js";
+import { insertTestVariantForProduct } from "./helpers/orders.js";
+
+// issue 387 E7: mirror `shoptet-writeback-mark-synced.integration.test.ts`
+// (issue 122's `markSuppliersLinksSynced`), teraz nad `pairing_decision
+// .state_synced_at`.
+
+describe("markStateSynced", () => {
+  let db: Database;
+  let close: () => Promise<void>;
+  let userId: string;
+
+  beforeEach(async () => {
+    ({ db, close } = await withCleanDb());
+    const [row] = await db
+      .insert(users)
+      .values({ email: "rozhodca@forestshop.sk", passwordHash: "x", displayName: "Rozhodca", role: "manazer" })
+      .returning({ id: users.id });
+    if (row === undefined) throw new Error("testovací používateľ sa nepodarilo vložiť");
+    userId = row.id;
+  });
+
+  afterEach(async () => {
+    await close();
+  });
+
+  it("sets stateSyncedAt on exactly the given productKeys, leaving an untouched sibling row alone", async () => {
+    await insertTestVariantForProduct(db, "P1", "P1", {});
+    await insertTestVariantForProduct(db, "P2", "P2", {});
+    await db.insert(pairingDecisions).values([
+      {
+        productKey: "P1",
+        status: "unavailable",
+        url: null,
+        decidedBy: userId,
+        decidedAt: new Date("2026-01-01T00:00:00Z"),
+        updatedAt: new Date("2026-01-01T00:00:00Z"),
+      },
+      {
+        productKey: "P2",
+        status: "unavailable",
+        url: null,
+        decidedBy: userId,
+        decidedAt: new Date("2026-01-01T00:00:00Z"),
+        updatedAt: new Date("2026-01-01T00:00:00Z"),
+      },
+    ]);
+
+    await markStateSynced(db, ["P1"], new Date("2026-02-01T00:00:00Z"));
+
+    const [p1] = await db.select({ v: pairingDecisions.stateSyncedAt }).from(pairingDecisions).where(eq(pairingDecisions.productKey, "P1"));
+    const [p2] = await db.select({ v: pairingDecisions.stateSyncedAt }).from(pairingDecisions).where(eq(pairingDecisions.productKey, "P2"));
+    expect(p1?.v?.toISOString()).toBe("2026-02-01T00:00:00.000Z");
+    expect(p2?.v).toBeNull();
+  });
+
+  it("removes the marked products from the next selectChangedStateDecisions() result", async () => {
+    await insertTestVariantForProduct(db, "P3", "P3", {});
+    await db.insert(pairingDecisions).values({
+      productKey: "P3",
+      status: "discontinued",
+      url: null,
+      decidedBy: userId,
+      decidedAt: new Date("2026-01-01T00:00:00Z"),
+      updatedAt: new Date("2026-01-01T00:00:00Z"),
+    });
+
+    expect((await selectChangedStateDecisions(db)).productKeys).toEqual(["P3"]);
+    await markStateSynced(db, ["P3"], new Date("2026-01-02T00:00:00Z"));
+    expect((await selectChangedStateDecisions(db)).productKeys).toEqual([]);
+  });
+
+  it("is a no-op for an empty productKeys list", async () => {
+    await insertTestVariantForProduct(db, "P4", "P4", {});
+    await db.insert(pairingDecisions).values({
+      productKey: "P4",
+      status: "unavailable",
+      url: null,
+      decidedBy: userId,
+      decidedAt: new Date("2026-01-01T00:00:00Z"),
+      updatedAt: new Date("2026-01-01T00:00:00Z"),
+    });
+
+    await markStateSynced(db, [], new Date("2026-01-02T00:00:00Z"));
+    expect((await selectChangedStateDecisions(db)).productKeys).toEqual(["P4"]);
+  });
+
+  it("does NOT mark a row synced if it was edited AGAIN after the run started (race window) — the next run must still pick it up", async () => {
+    await insertTestVariantForProduct(db, "P5", "P5", {});
+    // The run started at 10:00 (selected this row with updatedAt 09:00 — not
+    // modelled here directly, only the END state matters); while the
+    // (possibly slow, browser-driven) import was still in flight, the
+    // decision was changed AGAIN at 10:05 — AFTER the run's start time but
+    // BEFORE this markStateSynced call actually executes.
+    await db.insert(pairingDecisions).values({
+      productKey: "P5",
+      status: "discontinued",
+      url: null,
+      decidedBy: userId,
+      decidedAt: new Date("2026-01-01T10:05:00Z"),
+      updatedAt: new Date("2026-01-01T10:05:00Z"),
+    });
+
+    await markStateSynced(db, ["P5"], new Date("2026-01-01T10:00:00Z"));
+
+    const [row] = await db.select({ v: pairingDecisions.stateSyncedAt }).from(pairingDecisions).where(eq(pairingDecisions.productKey, "P5"));
+    expect(row?.v).toBeNull();
+    expect((await selectChangedStateDecisions(db)).productKeys).toEqual(["P5"]);
+  });
+});

--- a/apps/api/tests/shoptet-writeback-select-states.integration.test.ts
+++ b/apps/api/tests/shoptet-writeback-select-states.integration.test.ts
@@ -1,0 +1,181 @@
+import { eq } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Database } from "../src/db/client.js";
+import { pairingDecisions, products, users } from "../src/db/schema.js";
+import { selectChangedStateDecisions } from "../src/modules/shoptet-writeback/select-states.js";
+import { insertTestSnapshot } from "./helpers/catalog.js";
+import { withCleanDb } from "./helpers/db.js";
+import { insertTestVariantForProduct } from "./helpers/orders.js";
+
+// issue 387 E7: mirror `shoptet-writeback-select.integration.test.ts` (issue
+// 122's `selectChangedSupplierLinks`), teraz nad `pairing_decision`'s
+// terminálne stavy (unavailable/discontinued) namiesto `product_supplier_
+// link_override`.
+
+describe("selectChangedStateDecisions", () => {
+  let db: Database;
+  let close: () => Promise<void>;
+  let userId: string;
+
+  beforeEach(async () => {
+    ({ db, close } = await withCleanDb());
+    const [row] = await db
+      .insert(users)
+      .values({ email: "rozhodca@forestshop.sk", passwordHash: "x", displayName: "Rozhodca", role: "manazer" })
+      .returning({ id: users.id });
+    if (row === undefined) throw new Error("testovací používateľ sa nepodarilo vložiť");
+    userId = row.id;
+  });
+
+  afterEach(async () => {
+    await close();
+  });
+
+  it("returns no rows when there are no decisions at all", async () => {
+    const result = await selectChangedStateDecisions(db);
+    expect(result.productKeys).toEqual([]);
+    expect(result.rows).toEqual([]);
+  });
+
+  it("emits ONE row per variant of a never-synced unavailable decision, mapping code+pairCode+status", async () => {
+    await insertTestVariantForProduct(db, "P1", "P1/S", { pairCode: "1001" });
+    await insertTestVariantForProduct(db, "P1", "P1/M", { pairCode: "1002" });
+    await db.insert(pairingDecisions).values({
+      productKey: "P1",
+      status: "unavailable",
+      url: null,
+      decidedBy: userId,
+      decidedAt: new Date("2026-01-02T00:00:00Z"),
+      updatedAt: new Date("2026-01-02T00:00:00Z"),
+    });
+
+    const result = await selectChangedStateDecisions(db);
+    expect(result.productKeys).toEqual(["P1"]);
+    expect(result.rows).toHaveLength(2);
+    expect(result.rows).toEqual(
+      expect.arrayContaining([
+        { code: "P1/S", pairCode: "1001", status: "unavailable" },
+        { code: "P1/M", pairCode: "1002", status: "unavailable" },
+      ]),
+    );
+  });
+
+  it("emits a discontinued decision's variants with status 'discontinued'", async () => {
+    await insertTestVariantForProduct(db, "P2", "P2", {});
+    await db.insert(pairingDecisions).values({
+      productKey: "P2",
+      status: "discontinued",
+      url: null,
+      decidedBy: userId,
+      decidedAt: new Date("2026-01-02T00:00:00Z"),
+      updatedAt: new Date("2026-01-02T00:00:00Z"),
+    });
+
+    const result = await selectChangedStateDecisions(db);
+    expect(result.rows).toEqual([{ code: "P2", pairCode: "", status: "discontinued" }]);
+  });
+
+  it("excludes 'good'/'manual' decisions — those go through the existing internalNote path, never a stavová CSV riadok", async () => {
+    await insertTestVariantForProduct(db, "P3", "P3", {});
+    await db.insert(pairingDecisions).values({
+      productKey: "P3",
+      status: "good",
+      url: "https://dodavatel.example/p3",
+      decidedBy: userId,
+      decidedAt: new Date("2026-01-02T00:00:00Z"),
+      updatedAt: new Date("2026-01-02T00:00:00Z"),
+    });
+
+    const result = await selectChangedStateDecisions(db);
+    expect(result.productKeys).toEqual([]);
+  });
+
+  it("excludes a decision already state-synced AFTER its last update (nothing changed since)", async () => {
+    await insertTestVariantForProduct(db, "P4", "P4", {});
+    await db.insert(pairingDecisions).values({
+      productKey: "P4",
+      status: "unavailable",
+      url: null,
+      decidedBy: userId,
+      decidedAt: new Date("2026-01-01T00:00:00Z"),
+      updatedAt: new Date("2026-01-01T00:00:00Z"),
+      stateSyncedAt: new Date("2026-01-02T00:00:00Z"),
+    });
+
+    const result = await selectChangedStateDecisions(db);
+    expect(result.productKeys).toEqual([]);
+  });
+
+  it("includes a decision whose updatedAt moved PAST its last stateSyncedAt (changed again after a sync)", async () => {
+    await insertTestVariantForProduct(db, "P5", "P5", {});
+    await db.insert(pairingDecisions).values({
+      productKey: "P5",
+      status: "discontinued",
+      url: null,
+      decidedBy: userId,
+      decidedAt: new Date("2026-01-03T00:00:00Z"),
+      updatedAt: new Date("2026-01-03T00:00:00Z"),
+      stateSyncedAt: new Date("2026-01-01T00:00:00Z"),
+    });
+
+    const result = await selectChangedStateDecisions(db);
+    expect(result.productKeys).toEqual(["P5"]);
+  });
+
+  it("skips (never crashes on) a changed decision whose product has zero variants — a data anomaly", async () => {
+    // A pairing_decision row requires the referenced product to already
+    // exist (FK) — insert one directly with no variant, mirroring
+    // `shoptet-writeback-select.integration.test.ts`'s equivalent case.
+    const snapshotId = await insertTestSnapshot(db);
+    await db.insert(products).values({
+      key: "P6-NO-VARIANTS",
+      name: "Produkt bez variantu (anomália)",
+      supplier: null,
+      firstSeenAt: new Date("2026-01-01T00:00:00Z"),
+      lastSeenAt: new Date("2026-01-01T00:00:00Z"),
+      lastSeenSnapshotId: snapshotId,
+    });
+    await db.insert(pairingDecisions).values({
+      productKey: "P6-NO-VARIANTS",
+      status: "unavailable",
+      url: null,
+      decidedBy: userId,
+      decidedAt: new Date("2026-01-01T00:00:00Z"),
+      updatedAt: new Date("2026-01-01T00:00:00Z"),
+    });
+
+    const result = await selectChangedStateDecisions(db);
+    expect(result.productKeys).toEqual([]);
+    expect(result.rows).toEqual([]);
+  });
+
+  it("only reports the productKeys of rows actually selected — a synced-and-unchanged sibling stays excluded", async () => {
+    await insertTestVariantForProduct(db, "P7", "P7", {});
+    await insertTestVariantForProduct(db, "P8", "P8", {});
+    await db.insert(pairingDecisions).values([
+      {
+        productKey: "P7",
+        status: "unavailable",
+        url: null,
+        decidedBy: userId,
+        decidedAt: new Date("2026-01-01T00:00:00Z"),
+        updatedAt: new Date("2026-01-01T00:00:00Z"),
+        stateSyncedAt: new Date("2026-01-02T00:00:00Z"),
+      },
+      {
+        productKey: "P8",
+        status: "unavailable",
+        url: null,
+        decidedBy: userId,
+        decidedAt: new Date("2026-01-02T00:00:00Z"),
+        updatedAt: new Date("2026-01-02T00:00:00Z"),
+      },
+    ]);
+
+    const result = await selectChangedStateDecisions(db);
+    expect(result.productKeys).toEqual(["P8"]);
+
+    const all = await db.select().from(pairingDecisions).where(eq(pairingDecisions.productKey, "P7"));
+    expect(all).toHaveLength(1);
+  });
+});

--- a/apps/api/tests/shoptet-writeback-sequence.integration.test.ts
+++ b/apps/api/tests/shoptet-writeback-sequence.integration.test.ts
@@ -1,0 +1,141 @@
+import { eq } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Database } from "../src/db/client.js";
+import { pairingDecisions, productSupplierLinkOverrides, users } from "../src/db/schema.js";
+import { runShoptetWritebackSequence } from "../src/modules/shoptet-writeback/run-writeback-sequence.js";
+import { setStateWritebackEnabled } from "../src/modules/shoptet-writeback/state-writeback-settings.js";
+import { withCleanDb } from "./helpers/db.js";
+import { insertTestVariantForProduct } from "./helpers/orders.js";
+import { startShoptetFixture, type ShoptetFixture } from "./helpers/shoptet-fixture.js";
+
+const TEST_TIMEOUT_MS = 60_000;
+
+// issue 387 E7: `runShoptetWritebackSequence` is what the `:50` scheduler
+// job now runs — a REAL fixture (not a hand-rolled fake) so both writeback
+// paths (linkový + stavový) exercise the exact same Playwright/Log
+// attribution machinery a production run does, one after the other against
+// the SAME accumulating Log, exactly like production.
+describe("runShoptetWritebackSequence (end-to-end proti fixture)", () => {
+  let db: Database;
+  let closeDb: () => Promise<void>;
+  let fixture: ShoptetFixture;
+  let userId: string;
+
+  beforeEach(async () => {
+    ({ db, close: closeDb } = await withCleanDb());
+    fixture = await startShoptetFixture({ user: "manager", password: "tajneheslo" });
+    fixture.seedPastEntry();
+    const [row] = await db
+      .insert(users)
+      .values({ email: "rozhodca@forestshop.sk", passwordHash: "x", displayName: "Rozhodca", role: "manazer" })
+      .returning({ id: users.id });
+    if (row === undefined) throw new Error("testovací používateľ sa nepodarilo vložiť");
+    userId = row.id;
+  });
+
+  afterEach(async () => {
+    await closeDb();
+    await fixture.close();
+  });
+
+  function fixtureConfig(): {
+    loginUrl: string;
+    importUrl: string;
+    logUrl: string;
+    user: string;
+    password: string;
+  } {
+    return {
+      loginUrl: `${fixture.baseUrl}/admin/`,
+      importUrl: `${fixture.baseUrl}/admin/import-produktov/`,
+      logUrl: `${fixture.baseUrl}/admin/import-produktov/log/`,
+      user: "manager",
+      password: "tajneheslo",
+    };
+  }
+
+  it(
+    "state writeback disabled (default) — only the link import runs, state stays 'disabled'",
+    async () => {
+      const result = await runShoptetWritebackSequence(db, fixtureConfig(), new Date("2026-02-01T00:00:00Z"));
+      expect(result).toEqual({ link: { status: "nothing_changed" }, state: { status: "disabled" } });
+      expect(fixture.logEntryCount()).toBe(1); // only the seed
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "state writeback enabled — runs BOTH imports as TWO separate uploads against the same Log, and sets stateSyncedAt only on confirmed success",
+    async () => {
+      await setStateWritebackEnabled(db, true, new Date("2026-01-01T00:00:00Z"));
+      await insertTestVariantForProduct(db, "P1", "P1/S", { pairCode: "1" });
+      await db
+        .insert(productSupplierLinkOverrides)
+        .values({ productKey: "P1", url: "https://x.example/p1", updatedAt: new Date("2026-01-01T00:00:00Z") });
+      await insertTestVariantForProduct(db, "P2", "P2", {});
+      await db.insert(pairingDecisions).values({
+        productKey: "P2",
+        status: "unavailable",
+        url: null,
+        decidedBy: userId,
+        decidedAt: new Date("2026-01-01T00:00:00Z"),
+        updatedAt: new Date("2026-01-01T00:00:00Z"),
+      });
+
+      const result = await runShoptetWritebackSequence(db, fixtureConfig(), new Date("2026-02-01T00:00:00Z"));
+      expect(result).toEqual({
+        link: { status: "ok", productCount: 1, rowCount: 1 },
+        state: { status: "ok", productCount: 1, rowCount: 1 },
+      });
+      // TWO separate uploads happened — one per import, never a combined file.
+      expect(fixture.logEntryCount()).toBe(3); // seed + link + state
+
+      const [link] = await db
+        .select({ syncedAt: productSupplierLinkOverrides.syncedAt })
+        .from(productSupplierLinkOverrides)
+        .where(eq(productSupplierLinkOverrides.productKey, "P1"));
+      expect(link?.syncedAt?.toISOString()).toBe("2026-02-01T00:00:00.000Z");
+
+      const [decision] = await db.select({ v: pairingDecisions.stateSyncedAt }).from(pairingDecisions).where(eq(pairingDecisions.productKey, "P2"));
+      expect(decision?.v?.toISOString()).toBe("2026-02-01T00:00:00.000Z");
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "a hard failure on the LINK import does not block the STATE import from being attempted — the two are independent",
+    async () => {
+      await setStateWritebackEnabled(db, true, new Date("2026-01-01T00:00:00Z"));
+      await insertTestVariantForProduct(db, "P3", "P3", {});
+      await db
+        .insert(productSupplierLinkOverrides)
+        .values({ productKey: "P3", url: "https://x.example/p3", updatedAt: new Date("2026-01-01T00:00:00Z") });
+      await insertTestVariantForProduct(db, "P4", "P4", {});
+      await db.insert(pairingDecisions).values({
+        productKey: "P4",
+        status: "discontinued",
+        url: null,
+        decidedBy: userId,
+        decidedAt: new Date("2026-01-01T00:00:00Z"),
+        updatedAt: new Date("2026-01-01T00:00:00Z"),
+      });
+      fixture.setOutcome("hard-error");
+
+      const result = await runShoptetWritebackSequence(db, fixtureConfig(), new Date("2026-02-01T00:00:00Z"));
+      expect(result.link.status).toBe("failed");
+      expect(result.state.status).toBe("failed");
+      // BOTH imports were actually attempted (seed + 2 failed attempts) —
+      // the state import was never skipped because the link one failed.
+      expect(fixture.logEntryCount()).toBe(3);
+
+      const [link] = await db
+        .select({ syncedAt: productSupplierLinkOverrides.syncedAt })
+        .from(productSupplierLinkOverrides)
+        .where(eq(productSupplierLinkOverrides.productKey, "P3"));
+      expect(link?.syncedAt).toBeNull();
+      const [decision] = await db.select({ v: pairingDecisions.stateSyncedAt }).from(pairingDecisions).where(eq(pairingDecisions.productKey, "P4"));
+      expect(decision?.v).toBeNull();
+    },
+    TEST_TIMEOUT_MS,
+  );
+});

--- a/apps/api/tests/shoptet-writeback-sequence.integration.test.ts
+++ b/apps/api/tests/shoptet-writeback-sequence.integration.test.ts
@@ -138,4 +138,53 @@ describe("runShoptetWritebackSequence (end-to-end proti fixture)", () => {
     },
     TEST_TIMEOUT_MS,
   );
+
+  it(
+    "a HARD failure (thrown exception, not a soft ok:false Log result) on the LINK import genuinely does NOT prevent the STATE import from being attempted",
+    async () => {
+      // review finding: the previous test above only proved independence for
+      // a SOFT failure (fixture.setOutcome("hard-error") still completes the
+      // HTTP round-trip and returns a Log page with error TEXT, which
+      // runShoptetImport parses into an ordinary {ok:false} return — it never
+      // throws). A genuine HARD failure (ensureSafeSettings throwing because
+      // the safe-mode radio is missing, playwright-import.ts) rejects the
+      // whole promise — this test proves the SECOND (state) import call
+      // still genuinely runs when that happens on the FIRST (link) call.
+      await setStateWritebackEnabled(db, true, new Date("2026-01-01T00:00:00Z"));
+      await insertTestVariantForProduct(db, "P5", "P5", {});
+      await db
+        .insert(productSupplierLinkOverrides)
+        .values({ productKey: "P5", url: "https://x.example/p5", updatedAt: new Date("2026-01-01T00:00:00Z") });
+      await insertTestVariantForProduct(db, "P6", "P6", {});
+      await db.insert(pairingDecisions).values({
+        productKey: "P6",
+        status: "unavailable",
+        url: null,
+        decidedBy: userId,
+        decidedAt: new Date("2026-01-01T00:00:00Z"),
+        updatedAt: new Date("2026-01-01T00:00:00Z"),
+      });
+      fixture.failNextImportFormOnce(); // trips ONLY the link import (runs first)
+
+      const result = await runShoptetWritebackSequence(db, fixtureConfig(), new Date("2026-02-01T00:00:00Z"));
+
+      // LINK hard-failed (converted to a "failed" result, never thrown out of
+      // the sequence) — nothing was ever uploaded for it (fail-closed,
+      // ensureSafeSettings throws BEFORE the file is submitted).
+      expect(result.link.status).toBe("failed");
+      if (result.link.status === "failed") {
+        expect(result.link.errorDetail).toMatch(/bezpečn/i);
+      }
+      // STATE genuinely ran (was NOT skipped because link threw) and
+      // succeeded — the one-shot fixture toggle only affected the FIRST
+      // import page load, not the second.
+      expect(result.state).toEqual({ status: "ok", productCount: 1, rowCount: 1 });
+      // Exactly ONE real upload happened (the state one) — seed + state.
+      expect(fixture.logEntryCount()).toBe(2);
+
+      const [decision] = await db.select({ v: pairingDecisions.stateSyncedAt }).from(pairingDecisions).where(eq(pairingDecisions.productKey, "P6"));
+      expect(decision?.v?.toISOString()).toBe("2026-02-01T00:00:00.000Z");
+    },
+    TEST_TIMEOUT_MS,
+  );
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.231",
+  "version": "0.3.0-dev.232",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -266,7 +266,10 @@ await db.execute(
   // issue 387 E6: "pairing_decision" má reálny FK do "product" AJ "users"
   // (TRUNCATE CASCADE ignoruje ON DELETE RESTRICT), pridané ručne rovnako
   // ako riadok vyššie.
-  'TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, nedostupne_replacement_link, mail_template, mail_template_history, supplier_stock, restock_settings, restock_event, shop_product_url, theme_color, dpd_pickup_request, upozornenie, daily_task, mail_log, dpd_shipment, product_supplier_override, product_supplier_link_override, pairing_candidate, pairing_candidate_set, pairing_search_settings, pairing_decision RESTART IDENTITY CASCADE',
+  // issue 387 E7: "pairing_state_writeback_settings" je rovnaká situácia ako
+  // "pairing_search_settings"/"restock_settings" (žiadny FK, singleton id,
+  // žiadny migračný seed riadok).
+  'TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, nedostupne_replacement_link, mail_template, mail_template_history, supplier_stock, restock_settings, restock_event, shop_product_url, theme_color, dpd_pickup_request, upozornenie, daily_task, mail_log, dpd_shipment, product_supplier_override, product_supplier_link_override, pairing_candidate, pairing_candidate_set, pairing_search_settings, pairing_decision, pairing_state_writeback_settings RESTART IDENTITY CASCADE',
 );
 // Rovnaký dôvod ako `tests/helpers/db.ts`: bez tohto by "Na objednanie" bolo
 // v CELOM e2e behu prázdne pre KAŽDÚ objednávku (žiadny nastavený otvorený


### PR DESCRIPTION
Etapa E7 z issue 387 (profesionálne párovanie produktov, port starej appky @ 60b6164).
Siedma z ôsmich etáp — zápis stavov z rozhodnutí naspäť do Shoptetu.

## Obsah

- `buildStatesCsv` v shoptet-writeback: rozhodnutie „Nie je skladom" →
  `visible;0;Vypredané`, „Už sa nebude predávať" → `detailOnly;0;Predaj výrobku
  skončil` — presne kontrakt starej appky; oddelený súbor od linkového importu
  (Shoptet maže stĺpce s prázdnou bunkou), dedup kódov first-wins, rovnaký
  formula-guard ako linkový CSV.
- Nočný :50 beh teraz robí DVA nezávislé importy v sekvencii (linkový, potom
  stavový); `state_synced_at` sa nastavuje len po úspechu, s race guardom.
- Prepínač Start/Stop (nová tabuľka nastavení + API), default VYPNUTÝ — stavový
  zápis mení viditeľnosť produktov na živom shope, zapne sa až po živom overení.
- Read-back kontrola bezpečných volieb importného formulára už existovala — overené,
  bez zmeny.

Review (čerstvý kontext) chytilo 1 🔴: tvrdé zlyhanie linkového importu by zhodilo aj
stavový krok — opravené (try/catch + RED→GREEN regresný test, že druhý import beží aj
pri páde prvého).

## Testy

API integračné 725 testov v 95 súboroch zelené, unit + web bez regresií, typecheck
aj lint čisté. Živý zápis do Shoptetu sa zámerne neskúšal (prepínač vypnutý) —
overí sa po nasadení samostatne.

Issue 387 zostáva otvorené — zavrie sa po poslednej etape a živom overení.
