### PR TITLE
Párovanie produktov: dolaďovačky z prvého ostrého behu (issue 387)

### DIFF
--- a/.claude/rules/scheduler.md
+++ b/.claude/rules/scheduler.md
@@ -13,7 +13,16 @@ paths:
 
 - **Pridanie ŠTVRTEJ naplánovanej úlohy = jedna nová `ScheduledJob` v
   `modules/scheduler/jobs.ts` + jeden riadok v `index.ts`'s
-  `startScheduler(db, [...])` zozname.** Job's `run(db, now)` MUSÍ volať
+  `startScheduler(db, [...])` zozname + jeden riadok v `apps/web/src/
+  schedulerLabels.ts`'s `JOB_LABELS`.** Tretí krok sa oddeľuje ĽAHKO —
+  žiadny typecheck/build ho nevynúti (mapa má fallback na surový
+  `jobName`), takže appka bez neho ticho ukazuje technický názov namiesto
+  slovenského popisu v "Plánovač"/"Sync zo Shoptetu"'s histórii behov.
+  Stalo sa to UŽ DVAKRÁT (issue 185 pre štyri joby naraz, issue 387 pre
+  `pairing-search`) — pri KAŽDOM ďalšom novom jobe (naplánovanom AJ
+  čisto manuálnom "Spustiť teraz") skontroluj `JOB_LABELS` HNEĎ vedľa
+  týchto dvoch krokov, nie až keď si niekto všimne surový názov na
+  obrazovke. Job's `run(db, now)` MUSÍ volať
   existujúcu, už otestovanú business-logickú funkciu (rovnaký vzor ako
   `catalogImportJob`/`pruneRawExportsJob`/`sessionCleanupJob`) — scheduler
   sám žiadnu doménovú logiku nemá a nemá ju ani získať. `run()` nikdy

--- a/apps/api/src/http/pairing-search-routes.ts
+++ b/apps/api/src/http/pairing-search-routes.ts
@@ -34,6 +34,18 @@ function isRunResult(detail: unknown): detail is PairingSearchRunResult {
  * `posta-uncollected-routes.ts`/`restock-routes.ts`'s vlastné
  * `runAndRecord`) — aby `GET /api/pairing-search/status` videl ručný beh
  * HNEĎ, nielen po ďalšom nočnom ticku.
+ *
+ * SYNCHRÓNNE ZÁMERNE (issue 387, overené po prvom ostrom ~21-min behu):
+ * appka NEMÁ v sebe žiadny background/fire-and-forget vzor pre `run-now` —
+ * VŠETKY existujúce trasy (`posta-uncollected`, `restock`,
+ * `supplier-stock`, `order-reminder`) sú rovnako synchrónne. Cloudflare
+ * tunel má vlastný ~100s proxy timeout (`.claude/rules/deploy.md`, issue
+ * 227) — dlhý beh cez tunel dostane klientsky HTTP 524, hoci appka beh na
+ * `app:3000` dokončí normálne (`job_run` sa zapíše `success`). Toto NIE JE
+ * prehliadnutý bug, je to zdieľané, zdokumentované a majiteľom akceptované
+ * správanie naprieč VŠETKÝMI päť automatizáciami — never meň LEN túto trasu
+ * na async bez toho, aby sa zmenili aj ostatné štyri (inak appka získa dva
+ * nekonzistentné vzory naraz).
  */
 async function runAndRecord(db: Database, now: Date): Promise<PairingSearchRunResult> {
   const [inserted] = await db

--- a/apps/web/src/schedulerLabels.test.ts
+++ b/apps/web/src/schedulerLabels.test.ts
@@ -17,6 +17,15 @@ it("jobLabel vráti holý technický názov pre naozaj neznámy job (fallback ne
   expect(jobLabel("neexistujuci-job")).toBe("neexistujuci-job");
 });
 
-it("JOB_LABELS pozná presne 9 jobov (5 pôvodných + 4 z issue 185) — žiadny sa nestratil", () => {
-  expect(Object.keys(JOB_LABELS)).toHaveLength(9);
+// Issue 387 (dolaďovačka z prvého ostrého behu): "pairing-search"
+// (`PAIRING_SEARCH_JOB_NAME`, apps/api/src/modules/pairing-search/
+// constants.ts) chýbalo v JOB_LABELS, takže Plánovač ukazoval surový
+// technický názov namiesto slovenského popisu — presne ten istý nález
+// ako issue 185, len o job neskôr.
+it("jobLabel pozná pairing-search (issue 387) — nevracia holý technický názov", () => {
+  expect(jobLabel("pairing-search")).toBe("Párovanie: nočný zber kandidátov u dodávateľov");
+});
+
+it("JOB_LABELS pozná presne 10 jobov (5 pôvodných + 4 z issue 185 + 1 z issue 387) — žiadny sa nestratil", () => {
+  expect(Object.keys(JOB_LABELS)).toHaveLength(10);
 });

--- a/apps/web/src/schedulerLabels.ts
+++ b/apps/web/src/schedulerLabels.ts
@@ -10,7 +10,11 @@ import type { JobRun } from "./schedulerApi.js";
 // (rovnaké slovenské názvy ako ich `NavTab.label` v `nav.ts`) a
 // "shoptet-writeback"/"order-note-writeback" (skrátené znenie ich
 // "*_NOT_CONFIGURED" hlášok v `modules/scheduler/jobs.ts` — sem sa zmestí
-// len krátky popis stĺpca "Úloha", nie celá veta).
+// len krátky popis stĺpca "Úloha", nie celá veta). Issue 387 (dolaďovačka
+// z prvého ostrého behu párovania): doplnené "pairing-search"
+// (`PAIRING_SEARCH_JOB_NAME`, apps/api/src/modules/pairing-search/
+// constants.ts, E3) — presne ten istý typ medzery ako issue 185, len o
+// job neskôr.
 export const JOB_LABELS: Readonly<Record<string, string>> = {
   "catalog-import": "Import katalógu",
   "prune-raw-exports": "Mazanie starých surových exportov (katalóg)",
@@ -21,6 +25,7 @@ export const JOB_LABELS: Readonly<Record<string, string>> = {
   "order-reminder": "Pripomienky objednávok",
   "shoptet-writeback": "Spätný zápis dodávateľa do Shoptetu",
   "order-note-writeback": "Spätný zápis poznámky do Shoptetu",
+  "pairing-search": "Párovanie: nočný zber kandidátov u dodávateľov",
 };
 
 export const STATUS_LABELS: Record<JobRun["status"], string> = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.233",
+  "version": "0.3.0-dev.234",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Záverečný PR k issue 387 (profesionálne párovanie produktov) — dolaďovačky z prvého
ostrého behu, ktorý už prebehol na produkcii (185 produktov, 1309 kandidátov, živé
overenie rozhodnutí aj vrátenia; dôkazy v komentároch na tikete).

## Obsah

- Slovenský popis jobu `pairing-search` v plánovači („Párovanie: nočný zber kandidátov
  u dodávateľov") — RED→GREEN test na úplnosť JOB_LABELS.
- Zdokumentované, že synchrónny run-now je zámerný zdieľaný vzor celej appky (rovnaký
  ako pri ostatných štyroch automatizáciách; známe 524 správanie tunela, issue 227) —
  žiadna zmena správania.
- Playbook: nový job potrebuje aj riadok v JOB_LABELS (chytené už druhýkrát).

## Testy

Web 609 unit testov (vrátane nového), API 887, typecheck aj lint čisté.

Issue 387 sa po tomto PR zavrie — všetkých 8 stavebných etáp je nasadených a naživo
overených; otvorené zostávajú len dve rozhodnutia majiteľa zapísané na tikete
(zapnutie stavového zápisu do Shoptetu; prípadné odstránenie starých obrazoviek E9).
