### PR TITLE
Prerobená obrazovka Úlohy na dnes (issue 403)

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -1325,3 +1325,31 @@ paths:
   NOT work once the badge is populated (only works for a badge-less tab,
   the `restock-links.md`'s "Vypredané → Skladom" precedent) — reach for the
   `data-testid` instead of trying to out-clever the accessible-name string.
+- **A bare single-class selector styling a NEW `<input>` (e.g.
+  `.my-checkbox { width: 1rem; }`) silently LOSES to this file's own
+  global reset `input:not([type="hidden"]) { width: 100%; ... }` (line
+  ~161) — regardless of source order.** CSS specificity: the global
+  reset is `input` (1 element) + `:not([type="hidden"])`'s attribute
+  argument (1 attribute/class-level) = (0,0,1,1); a bare
+  `.my-checkbox` is (0,0,1,0) — ONE class-level component, strictly
+  lower, so it loses even though it's defined LATER in the file (tie-
+  breaking by source order only applies when specificity is EQUAL).
+  Issue 403's `.uloha-done-toggle` hit this converting a `<button>`
+  (Unicode ☐/☑) to a real `<input type="checkbox">`: the checkbox
+  silently got `width:100%`, stealing nearly the whole flex row and
+  squeezing the sibling text span to a computed `width:0` — found via
+  live Playwright DOM inspection (`getComputedStyle`/
+  `getBoundingClientRect` on a local dev server, not by reading the CSS,
+  since a screenshot alone doesn't reveal a 0-width element sitting
+  behind a stretched sibling) after a Playwright e2e test reported the
+  text as unexpectedly `"hidden"` (a 0-width bounding box reads as not
+  visible). **Fix: scope with a PARENT class, not just the element's
+  own** — `.uloha-row .uloha-done-toggle` = 2 class-level components =
+  (0,0,2,0), which beats (0,0,1,1) unconditionally (class-count 2>1
+  decides before the element-count tiebreak is even reached). This is
+  the SAME shape as the pre-existing `.order-group input[type="checkbox"]`
+  precedent (`app.css` ~line 1202, (0,0,2,1)) — any FUTURE new
+  `<input>` styled in this codebase needs AT LEAST 2 class-level
+  selector components (a parent-scoped class, or `.class[type="..."]`),
+  never a bare single class, or it silently inherits the global
+  `width:100%`/border/padding/background reset instead of its own CSS.

--- a/.claude/rules/local-dev.md
+++ b/.claude/rules/local-dev.md
@@ -127,3 +127,30 @@ paths:
   behu identické (rovnaký kód); jediný rozdiel sú zdrojové dáta v
   tabuľkách, čo neovplyvňuje výšku/rozloženie blokov závislých len od CSS a
   počtu položiek.
+- **Keď lokálny e2e beh proti zdieľanej `forestshop_app-postgres-1` (5433)
+  padá NEVYSVETLITEĽNE (zlé heslo pri overene správnom účte, FK porušenie
+  na tabuľke, ktorú si sám nesiahol) A na boxe bežia SÚBEŽNÉ worktree
+  relácie (iné autopilot-worker tikety), podozrievaj NAJPRV kolíziu so
+  `scripts/e2e-setup.ts`'s nezamknutým TRUNCATE (`.claude/rules/testing.md`)
+  — a najspoľahlivejší fix nie je čakať na tiché okno, ale spustiť si
+  ÚPLNE VLASTNÚ, izolovanú Postgres inštanciu.** Issue 403: `ps aux | grep
+  -E "vitest|playwright|e2e-setup"` ukázalo prázdno, no `pnpm exec tsx
+  scripts/e2e-setup.ts` napriek tomu spadol na `insert or update on table
+  "order_line" violates foreign key constraint` (`order_id` odkazoval na
+  medzičasom zmazaný `order` riadok) — klasický odtlačok TRUNCATE-u
+  bežiaceho SÚBEŽNE s INOU reláciou (krátkodobý proces, čo `ps aux`
+  jednoducho nestihol zachytiť). Namiesto opakovaného čakania/skúšania:
+  `docker run -d --name <unikátny-názov> -p 127.0.0.1:<voľný-port>:5432 -e
+  POSTGRES_USER=forestshop -e POSTGRES_PASSWORD=forestshop -e
+  POSTGRES_DB=forestshop postgres:18` → `DATABASE_URL=postgres://forestshop
+  :forestshop@127.0.0.1:<port>/forestshop pnpm --filter @forestshop/api
+  db:migrate` → `pnpm --filter @forestshop/web e2e` s tým istým
+  `DATABASE_URL` (Playwright's vlastný `webServer` si `e2e-setup.ts` aj
+  API spustí sám). Presne táto ISTÁ izolácia, akú CI dostáva zadarmo
+  (vlastný efemérny Postgres kontajner na job) — 59/59 e2e testov prešlo
+  načisto po prechode na izolovanú inštanciu, zatiaľ čo DVA po sebe idúce
+  pokusy proti zdieľanej 5433 zlyhali z DÔVODOV NESÚVISIACICH s
+  testovaným diffom. `docker rm -f <unikátny-názov>` po overení — jednorazová
+  inštancia, žiadny cleanup skript netreba. Použi UNIKÁTNY názov kontajnera
+  a VOĽNÝ port (`ss -ltnp | grep :<port>` najprv) — súbežný worktree môže
+  robiť to isté.

--- a/apps/web/src/components/DailyTasksSection.test.tsx
+++ b/apps/web/src/components/DailyTasksSection.test.tsx
@@ -122,6 +122,19 @@ it("označí úlohu ako vybavenú — riadok dostane triedu 'done'", async () =>
   });
 });
 
+// Issue 403: prepínač je teraz skutočný `<input type="checkbox">` (predtým
+// `<button>` s Unicode ☐/☑) — regresný test na skutočnú rolu/`checked`
+// atribút, nielen na testid (ten by prešiel pre hocijaký element).
+it("prepínač 'vybavené' je skutočný checkbox s rolou a atribútom checked, nie textové tlačidlo", async () => {
+  fetchDailyTasks.mockResolvedValueOnce([ROW_A]);
+  render(<DailyTasksSection onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("uloha-row-task-a");
+
+  const checkbox = screen.getByRole<HTMLInputElement>("checkbox", { name: "Označiť ako vybavené" });
+  expect(checkbox.type).toBe("checkbox");
+  expect(checkbox.checked).toBe(false);
+});
+
 it("vybavená úloha OSTÁVA v zozname (nezmizne), len je stlmená", async () => {
   fetchDailyTasks.mockResolvedValueOnce([ROW_DONE]);
   render(<DailyTasksSection onSessionExpired={vi.fn()} />);

--- a/apps/web/src/components/DailyTasksSection.tsx
+++ b/apps/web/src/components/DailyTasksSection.tsx
@@ -35,7 +35,9 @@ import {
 //    namiesto `<button>`u s Unicode ☐/☑ — jediné miesto v appke, kde hlavný
 //    ovládací prvok obrazovky bol len text namiesto skutočného UI prvku
 //    (OrderLineRow.tsx/UpozorneniaSection.tsx/DpdSection.tsx majú všade
-//    skutočný checkbox).
+//    skutočný checkbox — CSS špecificitu proti globálnemu resetu, pozri
+//    app.css, si však rieši výslovne len OrderLineRow.tsx's
+//    `.order-group input[type="checkbox"]`, viď fix nižšie).
 // 3) `.uloha-row`'s `align-items` je `flex-start` namiesto `center` — pri
 //    zalomení textu na užšom okne (viac riadkov) drží checkbox/ikony pri
 //    PRVOM riadku textu namiesto stredu celého zalomeného bloku.

--- a/apps/web/src/components/DailyTasksSection.tsx
+++ b/apps/web/src/components/DailyTasksSection.tsx
@@ -21,6 +21,25 @@ import {
 // `ComponentType<SectionProps>` (`nav.ts`), lebo objekt s VIAC poľami (role
 // navyše) sa dá vždy odovzdať tam, kde sa čaká len podmnožina.
 
+// Issue 403 (majiteľ: "stale to je otras" — naživo pomenované na tickete):
+// tri štrukturálne opravy, žiadna zmena funkčnosti/testid.
+// 1) `.ulohy-panel` (JSX nižšie) obmedzuje šírku pridávacieho riadku aj
+//    zoznamu na `max-width: 40rem` (app.css) — bez neho sa `.uloha-text`ov
+//    `flex:1 1 auto` naťahoval cez CELÚ neohraničenú `<section>` a
+//    `.uloha-actions`ov `margin-left:auto` odsúval ikony (✏️😊🗑) na
+//    vzdialený pravý okraj, s priemernou nameranou mŕtvou medzerou 771px pri
+//    1440px okne (komentár na tickete). Ohraničenie na 40rem (rovnaký
+//    ustálený vzor ako `.ord-supplier-link-edit`, issue 162) zníži ju na
+//    ~338px bez zmeny riadkovej výšky.
+// 2) Prepínač "vybavené" je teraz skutočný `<input type="checkbox">`
+//    namiesto `<button>`u s Unicode ☐/☑ — jediné miesto v appke, kde hlavný
+//    ovládací prvok obrazovky bol len text namiesto skutočného UI prvku
+//    (OrderLineRow.tsx/UpozorneniaSection.tsx/DpdSection.tsx majú všade
+//    skutočný checkbox).
+// 3) `.uloha-row`'s `align-items` je `flex-start` namiesto `center` — pri
+//    zalomení textu na užšom okne (viac riadkov) drží checkbox/ikony pri
+//    PRVOM riadku textu namiesto stredu celého zalomeného bloku.
+
 // Issue 381: odstráni draft PRE JEDEN riadok z `emojiDraft` bez `delete`
 // operátora (`@typescript-eslint/no-dynamic-delete` zakazuje `delete
 // next[dynamickýKľúč]`) — filtrovanie cez `Object.entries` je funkčne
@@ -256,8 +275,10 @@ export function DailyTasksSection({ onSessionExpired }: { readonly onSessionExpi
     return (
       <section>
         {intro}
-        {addRow}
-        <p role="alert">{error}</p>
+        <div className="ulohy-panel">
+          {addRow}
+          <p role="alert">{error}</p>
+        </div>
       </section>
     );
   }
@@ -265,8 +286,10 @@ export function DailyTasksSection({ onSessionExpired }: { readonly onSessionExpi
     return (
       <section>
         {intro}
-        {addRow}
-        <p>Načítavam…</p>
+        <div className="ulohy-panel">
+          {addRow}
+          <p>Načítavam…</p>
+        </div>
       </section>
     );
   }
@@ -274,180 +297,180 @@ export function DailyTasksSection({ onSessionExpired }: { readonly onSessionExpi
   return (
     <section>
       {intro}
-      {addRow}
-      {error !== "" && <p role="alert">{error}</p>}
+      <div className="ulohy-panel">
+        {addRow}
+        {error !== "" && <p role="alert">{error}</p>}
 
-      {rows.length === 0 ? (
-        <p data-testid="ulohy-empty">Žiadne úlohy — napíš prvú vyššie.</p>
-      ) : (
-        <div className="ulohy-list" data-testid="ulohy-list">
-          {rows.map((row) => {
-            const isDone = row.doneAt !== null;
-            const busy = busyId === row.id;
-            return (
-              <div className={"uloha-row" + (isDone ? " done" : "")} key={row.id} data-testid={`uloha-row-${row.id}`}>
-                <button
-                  type="button"
-                  className="uloha-done-toggle"
-                  aria-pressed={isDone}
-                  aria-label={isDone ? "Označiť ako nevybavené" : "Označiť ako vybavené"}
-                  title={isDone ? "Označiť ako nevybavené" : "Označiť ako vybavené"}
-                  disabled={busy}
-                  onClick={() => {
-                    toggleDone(row);
-                  }}
-                  data-testid={`uloha-done-${row.id}`}
-                >
-                  {isDone ? "☑" : "☐"}
-                </button>
+        {rows.length === 0 ? (
+          <p data-testid="ulohy-empty">Žiadne úlohy — napíš prvú vyššie.</p>
+        ) : (
+          <div className="ulohy-list" data-testid="ulohy-list">
+            {rows.map((row) => {
+              const isDone = row.doneAt !== null;
+              const busy = busyId === row.id;
+              return (
+                <div className={"uloha-row" + (isDone ? " done" : "")} key={row.id} data-testid={`uloha-row-${row.id}`}>
+                  <input
+                    type="checkbox"
+                    className="uloha-done-toggle"
+                    checked={isDone}
+                    aria-label={isDone ? "Označiť ako nevybavené" : "Označiť ako vybavené"}
+                    title={isDone ? "Označiť ako nevybavené" : "Označiť ako vybavené"}
+                    disabled={busy}
+                    onChange={() => {
+                      toggleDone(row);
+                    }}
+                    data-testid={`uloha-done-${row.id}`}
+                  />
 
-                {row.emoji !== null && editingEmojiId !== row.id && (
-                  <span className="uloha-emoji" aria-hidden="true">
-                    {row.emoji}
-                  </span>
-                )}
+                  {row.emoji !== null && editingEmojiId !== row.id && (
+                    <span className="uloha-emoji" aria-hidden="true">
+                      {row.emoji}
+                    </span>
+                  )}
 
-                {editingTextId === row.id ? (
-                  <>
-                    <input
-                      className="uloha-edit-input"
-                      value={textDraft[row.id] ?? row.text}
-                      onChange={(e) => {
-                        const value = e.target.value;
-                        setTextDraft((d) => ({ ...d, [row.id]: value }));
-                      }}
-                      aria-label="Upraviť text úlohy"
-                      data-testid={`uloha-edit-input-${row.id}`}
-                      autoFocus
-                    />
-                    <button
-                      type="button"
-                      className="uloha-icon-btn"
-                      disabled={busy}
-                      onClick={() => {
-                        saveText(row.id);
-                      }}
-                      title="Uložiť"
-                      aria-label="Uložiť text"
-                      data-testid={`uloha-edit-save-${row.id}`}
-                    >
-                      💾
-                    </button>
-                    <button
-                      type="button"
-                      className="uloha-icon-btn"
-                      onClick={() => {
-                        setEditingTextId(null);
-                      }}
-                      title="Zrušiť"
-                      aria-label="Zrušiť úpravu textu"
-                    >
-                      ✕
-                    </button>
-                  </>
-                ) : (
-                  <span className="uloha-text" data-testid={`uloha-text-${row.id}`}>
-                    {row.text}
-                  </span>
-                )}
-
-                {editingEmojiId === row.id && (
-                  <>
-                    <input
-                      className="uloha-emoji-input-field"
-                      value={emojiDraft[row.id] ?? row.emoji ?? ""}
-                      onChange={(e) => {
-                        const value = e.target.value;
-                        setEmojiDraft((d) => ({ ...d, [row.id]: value }));
-                      }}
-                      aria-label="Emoji úlohy"
-                      placeholder="😊"
-                      data-testid={`uloha-emoji-input-${row.id}`}
-                      autoFocus
-                    />
-                    <button
-                      type="button"
-                      className="uloha-icon-btn"
-                      disabled={busy}
-                      onClick={() => {
-                        saveEmoji(row.id);
-                      }}
-                      title="Uložiť emoji"
-                      aria-label="Uložiť emoji"
-                      data-testid={`uloha-emoji-save-${row.id}`}
-                    >
-                      💾
-                    </button>
-                    {/* Review dispatch (issue 381): bez `disabled={busy}` by Zrušiť
-                        počas ROZBEHNUTÉHO uloženia TOHO ISTÉHO riadku otvorilo
-                        okno na race — zrušenie + nový rozpis medzitým a
-                        následné doručenie PÔVODNEJ (už "zrušenej") odpovede
-                        by ten nový rozpis ticho zahodilo cez `saveEmoji`'s
-                        `forgetEmojiDraft`. Rovnaký `busy` guard ako má Save. */}
-                    <button
-                      type="button"
-                      className="uloha-icon-btn"
-                      disabled={busy}
-                      onClick={() => {
-                        cancelEmojiEdit(row.id);
-                      }}
-                      title="Zrušiť"
-                      aria-label="Zrušiť úpravu emoji"
-                      data-testid={`uloha-emoji-cancel-${row.id}`}
-                    >
-                      ✕
-                    </button>
-                  </>
-                )}
-
-                {editingTextId !== row.id && (
-                  <div className="uloha-actions">
-                    <button
-                      type="button"
-                      className="uloha-icon-btn"
-                      onClick={() => {
-                        openTextEditor(row);
-                      }}
-                      title="Upraviť text"
-                      aria-label={`Upraviť text úlohy ${row.text}`}
-                      data-testid={`uloha-edit-${row.id}`}
-                    >
-                      ✏️
-                    </button>
-                    {editingEmojiId !== row.id && (
+                  {editingTextId === row.id ? (
+                    <>
+                      <input
+                        className="uloha-edit-input"
+                        value={textDraft[row.id] ?? row.text}
+                        onChange={(e) => {
+                          const value = e.target.value;
+                          setTextDraft((d) => ({ ...d, [row.id]: value }));
+                        }}
+                        aria-label="Upraviť text úlohy"
+                        data-testid={`uloha-edit-input-${row.id}`}
+                        autoFocus
+                      />
+                      <button
+                        type="button"
+                        className="uloha-icon-btn"
+                        disabled={busy}
+                        onClick={() => {
+                          saveText(row.id);
+                        }}
+                        title="Uložiť"
+                        aria-label="Uložiť text"
+                        data-testid={`uloha-edit-save-${row.id}`}
+                      >
+                        💾
+                      </button>
                       <button
                         type="button"
                         className="uloha-icon-btn"
                         onClick={() => {
-                          openEmojiEditor(row);
+                          setEditingTextId(null);
                         }}
-                        title="Pridať/zmeniť emoji"
-                        aria-label={`Pridať/zmeniť emoji úlohy ${row.text}`}
-                        data-testid={`uloha-emoji-${row.id}`}
+                        title="Zrušiť"
+                        aria-label="Zrušiť úpravu textu"
                       >
-                        😊
+                        ✕
                       </button>
-                    )}
-                    <button
-                      type="button"
-                      className="uloha-icon-btn"
-                      disabled={busy}
-                      onClick={() => {
-                        removeTask(row.id);
-                      }}
-                      title="Odstrániť"
-                      aria-label={`Odstrániť úlohu ${row.text}`}
-                      data-testid={`uloha-delete-${row.id}`}
-                    >
-                      🗑
-                    </button>
-                  </div>
-                )}
-              </div>
-            );
-          })}
-        </div>
-      )}
+                    </>
+                  ) : (
+                    <span className="uloha-text" data-testid={`uloha-text-${row.id}`}>
+                      {row.text}
+                    </span>
+                  )}
+
+                  {editingEmojiId === row.id && (
+                    <>
+                      <input
+                        className="uloha-emoji-input-field"
+                        value={emojiDraft[row.id] ?? row.emoji ?? ""}
+                        onChange={(e) => {
+                          const value = e.target.value;
+                          setEmojiDraft((d) => ({ ...d, [row.id]: value }));
+                        }}
+                        aria-label="Emoji úlohy"
+                        placeholder="😊"
+                        data-testid={`uloha-emoji-input-${row.id}`}
+                        autoFocus
+                      />
+                      <button
+                        type="button"
+                        className="uloha-icon-btn"
+                        disabled={busy}
+                        onClick={() => {
+                          saveEmoji(row.id);
+                        }}
+                        title="Uložiť emoji"
+                        aria-label="Uložiť emoji"
+                        data-testid={`uloha-emoji-save-${row.id}`}
+                      >
+                        💾
+                      </button>
+                      {/* Review dispatch (issue 381): bez `disabled={busy}` by Zrušiť
+                          počas ROZBEHNUTÉHO uloženia TOHO ISTÉHO riadku otvorilo
+                          okno na race — zrušenie + nový rozpis medzitým a
+                          následné doručenie PÔVODNEJ (už "zrušenej") odpovede
+                          by ten nový rozpis ticho zahodilo cez `saveEmoji`'s
+                          `forgetEmojiDraft`. Rovnaký `busy` guard ako má Save. */}
+                      <button
+                        type="button"
+                        className="uloha-icon-btn"
+                        disabled={busy}
+                        onClick={() => {
+                          cancelEmojiEdit(row.id);
+                        }}
+                        title="Zrušiť"
+                        aria-label="Zrušiť úpravu emoji"
+                        data-testid={`uloha-emoji-cancel-${row.id}`}
+                      >
+                        ✕
+                      </button>
+                    </>
+                  )}
+
+                  {editingTextId !== row.id && (
+                    <div className="uloha-actions">
+                      <button
+                        type="button"
+                        className="uloha-icon-btn"
+                        onClick={() => {
+                          openTextEditor(row);
+                        }}
+                        title="Upraviť text"
+                        aria-label={`Upraviť text úlohy ${row.text}`}
+                        data-testid={`uloha-edit-${row.id}`}
+                      >
+                        ✏️
+                      </button>
+                      {editingEmojiId !== row.id && (
+                        <button
+                          type="button"
+                          className="uloha-icon-btn"
+                          onClick={() => {
+                            openEmojiEditor(row);
+                          }}
+                          title="Pridať/zmeniť emoji"
+                          aria-label={`Pridať/zmeniť emoji úlohy ${row.text}`}
+                          data-testid={`uloha-emoji-${row.id}`}
+                        >
+                          😊
+                        </button>
+                      )}
+                      <button
+                        type="button"
+                        className="uloha-icon-btn"
+                        disabled={busy}
+                        onClick={() => {
+                          removeTask(row.id);
+                        }}
+                        title="Odstrániť"
+                        aria-label={`Odstrániť úlohu ${row.text}`}
+                        data-testid={`uloha-delete-${row.id}`}
+                      >
+                        🗑
+                      </button>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
     </section>
   );
 }

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2419,6 +2419,10 @@ a.upozornenie-title:hover {
 .uloha-row:first-child {
   border-top: 1px solid var(--fs-border-soft);
 }
+/* issue 403: nenápadné zvýraznenie riadku pod kurzorom — teraz, keď je
+   ovládanie ohraničené na `.ulohy-panel`'s 640px (nie roztiahnuté cez
+   celú stránku), pomáha oku pri prehľadávaní dlhšieho zoznamu spojiť
+   text riadku s jeho vlastnými ikonami vpravo. */
 .uloha-row:hover {
   background: var(--fs-surface-alt);
 }

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2371,6 +2371,20 @@ a.upozornenie-title:hover {
    Majiteľova požiadavka: "space-effective", "nieže dám 4 na stranu" — riadky
    sú preto ÚZKE (žiadne karty s tieňom/rámikom ako Upozornenia, len tenká
    deliaca čiara), aby sa na obrazovku zmestilo veľa úloh naraz. */
+/* issue 403 (majiteľ: "stale to je otras"): `.uloha-text`ov `flex:1 1 auto`
+   + `.uloha-actions`ov `margin-left:auto` (nižšie) sa bez OHRANIČENIA šírky
+   rodiča naťahovali cez CELÚ neohraničenú `<section>` — pri 1440px okne
+   nameraná priemerná mŕtva medzera medzi textom a ikonami (✏️😊🗑) bola
+   771px. `.ulohy-panel` (obaľuje `addRow` + zoznam/empty/error stavy,
+   `DailyTasksSection.tsx`) obmedzuje šírku na `max-width: 40rem` — rovnaký
+   ustálený vzor ako `.ord-supplier-link-edit` (issue 162's komentár vyššie
+   v tomto súbore). Naživo overené na produkcii: mŕtva medzera klesla na
+   priemerne 338px (-56 %), riadková výška ostala nezmenená (30-31px) —
+   ide o šírku PANELU, nie o "karty", takže vyššie zaznamenané rozhodnutie
+   proti Upozornenia-štýlu kartám ostáva v platnosti.  */
+.ulohy-panel {
+  max-width: 40rem;
+}
 .ulohy-add-row {
   display: flex;
   gap: var(--fs-space-2);
@@ -2391,7 +2405,12 @@ a.upozornenie-title:hover {
 }
 .uloha-row {
   display: flex;
-  align-items: center;
+  /* issue 403: `flex-start`, nie `center` — pri zalomení textu na užšom
+     okne (viac riadkov) drží checkbox/ikony pri PRVOM riadku textu, nie v
+     strede celého zalomeného bloku. Pri bežnom jednoriadkovom texte (drvivá
+     väčšina úloh) je vizuálny rozdiel nulový — všetky flex-item majú
+     rovnakú výšku ako jediný riadok textu. */
+  align-items: flex-start;
   gap: var(--fs-space-2);
   padding: var(--fs-space-1) var(--fs-space-2);
   border-bottom: 1px solid var(--fs-border-soft);
@@ -2399,6 +2418,9 @@ a.upozornenie-title:hover {
 }
 .uloha-row:first-child {
   border-top: 1px solid var(--fs-border-soft);
+}
+.uloha-row:hover {
+  background: var(--fs-surface-alt);
 }
 /* Vybavené úlohy OSTÁVAJÚ v zozname (design rozhodnutie na tickete — poradie
    je čisto chronologické), len vizuálne stlmené: prečiarknutý text + nižší
@@ -2410,14 +2432,32 @@ a.upozornenie-title:hover {
 .uloha-row.done .uloha-text {
   text-decoration: line-through;
 }
-.uloha-done-toggle {
+/* issue 403: skutočný `<input type="checkbox">` namiesto `<button>`u s
+   Unicode ☐/☑ (13.5×15px, tenké) — jediné miesto v appke, kde hlavný
+   ovládací prvok obrazovky bol len text namiesto skutočného UI prvku.
+   Rovnaký `accent-color` token ako `.order-group input[type="checkbox"]`
+   (Objednávky), o niečo menšia veľkosť (1.125rem vs. 1.375rem), aby sa
+   zmestila do 30px riadku bez zvýšenia jeho výšky. `margin-top` opticky
+   zarovná checkbox s prvým riadkom textu pod `.uloha-row`ov nový
+   `align-items: flex-start`.
+   Selektor MUSÍ byť `.uloha-row .uloha-done-toggle` (nie bare
+   `.uloha-done-toggle`) — globálny reset `input:not([type="hidden"])`
+   (tento súbor, riadok ~161: `width:100%`) má špecificitu (0,0,1,1)
+   (1 trieda z `:not([...])` + `input` element), zatiaľ čo samotná
+   `.uloha-done-toggle` má len (0,0,1,0) a globálny reset by ju PREBIL —
+   naživo reprodukované: checkbox dostal `width:100%`, ukradol takmer celú
+   šírku riadku a `.uloha-text` skončil s vypočítanou šírkou 0px (Playwright
+   e2e to nahlásilo ako "hidden"). Vzor s rodičovskou triedou (`.uloha-row
+   .uloha-done-toggle` = (0,0,2,0)) porazí globálny reset BEZPODMIENEČNE,
+   rovnako ako existujúci vzor `.order-group input[type="checkbox"]`
+   ((0,0,2,1)) o kus vyššie v tomto súbore. */
+.uloha-row .uloha-done-toggle {
   flex: 0 0 auto;
-  background: none;
-  border: none;
+  width: 1.125rem;
+  height: 1.125rem;
+  margin: 0.1rem 0 0;
+  accent-color: var(--fs-brand);
   cursor: pointer;
-  font-size: var(--fs-text-md);
-  line-height: 1;
-  padding: 0;
 }
 .uloha-done-toggle:disabled {
   opacity: 0.5;

--- a/apps/web/tests/e2e/daily-tasks.spec.ts
+++ b/apps/web/tests/e2e/daily-tasks.spec.ts
@@ -66,7 +66,9 @@ test("napísať jedno za druhým, upraviť, pridať emoji, vybaviť (ostáva vid
   await expect(upravenyRiadok.locator(".uloha-emoji")).toHaveText("🛍️");
 
   // Označiť ako vybavené — úloha OSTÁVA v zozname (nezmizne), len stlmená.
-  await upravenyRiadok.getByRole("button", { name: "Označiť ako vybavené" }).click();
+  // issue 403: skutočný `<input type="checkbox">` namiesto `<button>`u —
+  // rola je teraz "checkbox", nie "button" (meno ostáva rovnaké).
+  await upravenyRiadok.getByRole("checkbox", { name: "Označiť ako vybavené" }).click();
   await expect(upravenyRiadok).toHaveClass(/done/);
   await expect(riadky).toHaveCount(2); // stále obe, žiadna nezmizla
 

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -3642,3 +3642,42 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   zálohovacia varianta pre forestshop-dev).
 - Issue 366 zavretý ručne po naživo overení (nie cez `Closes #N` v PR —
   overenie prišlo AŽ po merge/deploy).
+
+## Issue 403 — Úlohy na dnes: naživo pomenované problémy + prerobenie hustoty/ovládania
+
+- Naživo overené na produkcii (Playwright, `vychod@varos.sk`, 11 úloh):
+  4 pomenované problémy (komentár na tickete) — falošný Unicode ☐/☑
+  checkbox namiesto skutočného `<input>`, priemerná mŕtva medzera 771px
+  medzi textom a ikonami (`.uloha-text` neohraničený `flex:1 1 auto` cez
+  celú stránku), žiadna vizuálna hranica zoznamu, checkbox/ikony
+  center-ované voči celému zalomenému textu na užšom okne namiesto
+  prvého riadku. Počet klikov na bežné úkony bol už predtým minimálny —
+  potvrdené, nemenené.
+- Fix: `commit 5e6b7eb` — `.ulohy-panel` (max-width 40rem, ustálený vzor
+  `.ord-supplier-link-edit`), skutočný `<input type="checkbox">` namiesto
+  `<button>`u, `.uloha-row`'s `align-items: flex-start`. Cestou nájdený
+  SKUTOČNÝ bug: bare `.uloha-done-toggle` prehrával špecificitou proti
+  globálnemu `input:not([type="hidden"])` resetu (width:100%) — checkbox
+  kradol takmer celú šírku riadku, `.uloha-text` mal vypočítanú šírku 0px.
+  Fix: `.uloha-row .uloha-done-toggle` (vyššia špecificita).
+- Merané PRED→PO (1440px, 11 úloh, Range-nad-textovým-uzlom metodika):
+  priemerná mŕtva medzera 771px → 327px (-58 %), checkbox 13.5×15px
+  Unicode glyph → 18×18px skutočný `<input>`, riadková výška nezmenená
+  30-31px, panel šírka 640px (predtým neohraničená ~1072px).
+  `commit 033f3be` — review dispatch našiel 2 🔵 (chýbajúci komentár na
+  `:hover`, nepresné tvrdenie o precedente) — oba opravené.
+- Testy: nový vitest regresný test na `role=checkbox`+`checked` (overený
+  RED proti starému `<button>` markupu cez review dispatch); `daily-tasks
+  .spec.ts` aktualizovaný na `getByRole("checkbox", ...)`. Celá
+  web+api unit sada (887+610) aj celá lokálna e2e sada (59/59) zelené.
+- **Vedľajší nález (nie tejto zmeny bug, ale AKTÍVNY súbežný jav počas
+  tejto relácie):** dva po sebe idúce lokálne e2e behy proti zdieľanej
+  `forestshop_app-postgres-1` (5433) zlyhali z dôvodov NESÚVISIACICH s
+  týmto diffom — súbežné worktree relácie (issues 397/400) races-ovali
+  `scripts/e2e-setup.ts`'s nezamknutý TRUNCATE. Vyriešené izolovanou
+  throwaway `docker run postgres:18` inštanciou (port 5555) namiesto
+  čakania na tiché okno — 59/59 zelené. Playbook: `.claude/rules/
+  local-dev.md` (izolovaná Postgres technika), `.claude/rules/
+  frontend-design.md` (CSS špecificita vs. globálny `input` reset).
+- Worktree mode (izolácia #317) — commit ostáva na vlastnej vetve,
+  supervisor mergne + spustí CI pri round-integrácii.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.234",
+  "version": "0.3.0-dev.237",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
issue 403 — majiteľ: „a tie ulohy na dnes si nejako vylepsil lebo stale to je otras".

## Obsah

- Obrazovka **Dôležité → Úlohy na dnes** prerobená po naživo pomenovaných problémoch
  (komentár s číslami na tickete): falošný checkbox (Unicode ☐/☑ 13,5×15 px),
  neohraničený riadok s ~771 px mŕtvej medzery medzi textom a ikonami, žiadne
  vizuálne ohraničenie sekcie, zlé centrovanie pri zalomenom texte.
- Fix: skutočný `<input type="checkbox">`, `.ulohy-panel{max-width:40rem}`,
  `align-items:flex-start`; cestou opravený reálny bug špecificity CSS (globálny
  `input:not([type="hidden"])` reset dával checkboxu `width:100%` a textu `width:0`).
- Funkcie zachované (vrátane emoji z issue 381).
- PRED→PO (1440 px, 11 úloh): mŕtva medzera 771→327 px (−58 %), checkbox 18×18
  skutočný input, výška riadku nezmenená 30–31 px, panel 640 px.

## Testy

typecheck+lint čisté, unit 887 API + 610 web, celá lokálna e2e sada 59/59
(izolovaný jednorazový Postgres kvôli súbežným worktree). Review: 0 🔴 0 🟡 2 🔵
(opravené v 033f3be).
