### PR TITLE
Obrázky nášho produktu aj kandidáta na karte Párovanie (issue 397)

### DIFF
--- a/.claude/rules/pairing-search.md
+++ b/.claude/rules/pairing-search.md
@@ -543,3 +543,65 @@ vyradilo #311 aj jeho playbook súbor (návrh, sekcia 4); router v
   `restock-waiting.spec.ts`/`restock-events.spec.ts`) je priamy dôkaz.
   Použi rovnaký vzor pri E9 (vyradenie starého #239 UI + F4) na dôkaz, že
   `/api/product-links` route a jej zapisovacia cesta ostali nedotknuté.
+
+## issue 397 — Obrázok kandidáta na karte (mimo E1-E9 sériovej reťaze)
+
+- **Stará appka NIKDY neparsovala kandidátov obrázok z výsledkovej karty —
+  ťahala ho AŽ naživo z DETAILU (`og:image`, LEN pri otvorení karty vo
+  webreview, disk-cache).** Dispatch predpokladal opak; skutočnosť je
+  LEPŠIA — živé overenie (curl + cookie warm-up, 13. 8. 2026) ukázalo, že
+  VŠETKY TRI dodávateľské výsledkové karty DNES reálne obrázok nesú, len
+  ho žiadny parser doteraz nečítal. `PairingCandidate.imageUrl` sa preto
+  pľní PRIAMO v E2's adaptéroch (žiadny extra network request), s `og:image`
+  fallback (`verify.ts`) len ako defenzívna posledná záchrana pre CHOSEN
+  kandidáta, keď E4 aj tak beží (confidence high/medium).
+- **Per-dodávateľ selektor + past, živo overené 13. 8. 2026:**
+  - WETLAND: `img.product-miniature__image` v `<picture>` vnútri
+    `a.product-miniature__link`, SÚRODENEC (nie predok/potomok) title-
+    anchoru — treba `.closest(".product-miniature")` na spoločnú kartu,
+    potom `.find(...)`. `data-full-size-image-url` (plná veľkosť)
+    uprednostnené pred menším `src`.
+  - BETALOV: `img.product-image` v `a.mh-100` vnútri TEJ ISTEJ `.product-col`
+    karty, čo už dnes dáva `href` — priamy `card.find(...)`, žiadny
+    `.closest()` netreba. **PASCA: jej DETAILNEJ stránky `og:image` je
+    VŽDY stránkové logo (`/svg/logo2.svg`), nikdy produkt** — fallback
+    preň preto reálne nikdy nič neprinesie (šumový filter ho vyfiltruje),
+    zámerne, nie medzera.
+  - ODIMON: `img` vnútri `a.product-card`, TEN ISTÝ element, čo už dnes dáva
+    `alt`/`title` pre meno. **KRITICKÁ PASCA: `src` je na tejto doméne
+    VŽDY `.../no-image.png` placeholder (lazy-load cez JS) — skutočný
+    obrázok je LEN v `data-src`.** `resolveImageUrl`'s poradie
+    (`data-src` pred `src`) preto nie je štylistická preferencia, je nutná
+    správnosť.
+- **`resolveImageUrl` (`adapters/url.ts`, zdieľaná adaptérmi AJ `verify.ts`'s
+  `og:image` fallbackom) je doslovný port starej appka's `_IMG_NOISE`
+  (`webreview/app.py`) — `logo`/`/producer/`/`.svg`/`/svg/`/`placeholder`/
+  `no-image`/`banner`/`/img/m/` substring filter (case-insensitive), na
+  REZOLVOVANEJ (nie surovej) URL.** Vyberá prvý NEPRÁZDNY, nespracovateľný/
+  šumový sa PRESKOČÍ (fallback na ĎALŠIEHO kandidáta v poli, nikdy hneď
+  `null`). Test pri KAŽDOM ĎALŠOM dodávateľovi/zdroji obrázka: over živo,
+  či jeho "očividný" zdroj (og:image, hlavný `<img>`) nie je v skutočnosti
+  logo/placeholder/ikonka — mikrodáta aj obrázky vedia klamať rovnako ako
+  `supplier-stock.md`'s dostupnostné JSON-LD.
+- **Backfill existujúcich kandidátov BEZ obrázka (1309 riadkov, 177 s
+  `chosen_url` v čase merge) je DEDIKOVANÝ idempotentný CLI
+  (`backfill.ts` + `cli/pairing-backfill-images.ts` + `scripts/` alias,
+  presne vzor `catalog-prune-raw.ts`), NIKDY `input_hash` bump/plný
+  re-gather.** Scope = LEN `pairing_candidate` riadky, kde `url =
+  candidate_set.chosen_url` (karta ukazuje LEN chosenCandidate, top-8
+  panel obrázok nepotrebuje) `AND image_url IS NULL` — jeden
+  `SearchClient.fetchPage` na produkt, žiadne query-variant vyhľadávanie
+  navyše. Zdieľa `PAIRING_SEARCH_RUN_LOCK_KEY` (žiadny nový kľúč), aby sa
+  nikdy nepretínal s nočným gather behom nad TÝMI ISTÝMI riadkami. Príkaz
+  na produkcii: `docker compose -f docker-compose.prod.yml exec app node
+  apps/api/dist/cli/pairing-backfill-images.js` (bezpečné spustiť
+  kedykoľvek znova — WHERE-om idempotentný).
+- **Pokrytie NÁŠHO obrázka (`ourImageUrl`, `shop_product_url`) zmerané
+  priamo na produkcii (13. 8. 2026): 185 gathered produktov, LEN 28 má
+  zodpovedajúci `shop_product_url` riadok (26 s vyplneným obrázkom) — teda
+  159/185 (86 %) ukáže na ĽAVEJ strane "bez obrázka".** 157 z týchto 159
+  NEMÁ vôbec žiadny `shop_product_url` riadok — presne už zdokumentovaná
+  medzera issue 220 (626 viditeľných variantov mimo `google.xml` feedu,
+  `.claude/rules/shop-feed.md`), NIE bug tejto appky ani tohto tiketu.
+  Zlepšenie by znamenalo vylepšiť Shoptet feed/vyhľadávací fallback —
+  samostatný tiket, mimo rozsahu "ukáž oba obrázky".

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -20,6 +20,24 @@ paths:
   (obrazovky→e2e, DB/prihlásenie→integration), nikdy obe naraz, nikdy
   súbežne s ničím iným. Plný dôvod + namerané čísla: `.claude/rules/local-
   dev.md`.
+- **Worktree-izolovaný autopilot dispatch (issue #317) pre tento repo môže
+  reálne bežať PRIAMO na `forestshop-dev` (zdieľaný produkčný stroj), nie
+  na `dev1` — over `hostname` PRED spustením ťažkej lokálnej sady, nikdy
+  to nepredpokladaj len z projektového CLAUDE.md.** Zistené issue 397: `ps
+  aux`/`hostname` ukázali, že worktree bežal na `forestshop-dev`, s
+  DVOMA súbežnými sesterskými procesmi (background lint job + `pnpm
+  install` iného paralelného worktree workera) — presne tá istá "preťažený
+  zdieľaný box" kolízna trieda nižšie v tomto súbore, len s DOPLNKOVOU
+  stávkou, že ten istý box beží aj ŽIVÚ PRODUKCIU (`.claude/rules/
+  deploy.md`'s "Vývoj a produkcia bežia na TOM ISTOM 2-jadrovom stroji" —
+  ťažký lokálny beh tam vie zhodiť produkčný Cloudflare tunel cez
+  hladovanie po CPU, aj keď to cgroup `CPUWeight` mitigácia od 12. 8. 2026
+  výrazne obmedzuje). Pri červenom e2e/integration výsledku na TOMTO repe
+  over VŽDY najprv `hostname` + `ps aux | grep -E "vitest|playwright
+  test|npm run|pnpm install"` (nielen `ps aux | grep vitest`, ako
+  existujúci vzor nižšie predpokladá) — sesterský worktree worker nemusí
+  spúšťať vitest/playwright priamo, môže bežať lint/install/iný unrelated
+  príkaz, čo tiež zaberá CPU na 2-jadrovom stroji.
 - **`apps/api` má dve úrovne testov, oddelené priečinkom aj scriptom:**
   - `src/**/*.test.ts` → `pnpm --filter @forestshop/api test` (`vitest run
     src`) — bežia BEZ databázy, čisto unit (napr. rate-limiter, password

--- a/apps/api/drizzle/0050_dusty_marrow.sql
+++ b/apps/api/drizzle/0050_dusty_marrow.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "pairing_candidate" ADD COLUMN "image_url" text;

--- a/apps/api/drizzle/meta/0050_snapshot.json
+++ b/apps/api/drizzle/meta/0050_snapshot.json
@@ -1,0 +1,3519 @@
+{
+  "id": "dde4f0b7-c9a8-498f-a4ef-65585ddc8fd1",
+  "prevId": "08780281-0404-42c8-980e-f3456417b92a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_code": {
+          "name": "external_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_open_status": {
+      "name": "order_open_status",
+      "schema": "",
+      "columns": {
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Vybavuje sa'"
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop_remark": {
+          "name": "shop_remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shoptet_order_id": {
+          "name": "shoptet_order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_updated_at": {
+          "name": "comment_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_synced_at": {
+          "name": "comment_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_carrier_name": {
+          "name": "shipping_carrier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_price_with_vat": {
+          "name": "total_price_with_vat",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_marked_at": {
+          "name": "claim_marked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_note": {
+          "name": "claim_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_full_name": {
+          "name": "delivery_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_company": {
+          "name": "delivery_company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_street": {
+          "name": "delivery_street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_house_number": {
+          "name": "delivery_house_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_city": {
+          "name": "delivery_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_zip": {
+          "name": "delivery_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_country_name": {
+          "name": "delivery_country_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_name": {
+          "name": "payment_method_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_to_pay": {
+          "name": "price_to_pay",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_link_override": {
+      "name": "product_supplier_link_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_link_override_product_key_product_key_fk": {
+          "name": "product_supplier_link_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_link_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_override": {
+      "name": "product_supplier_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_override_product_key_product_key_fk": {
+          "name": "product_supplier_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing": {
+      "name": "pairing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_url": {
+          "name": "supplier_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "pairing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'navrhnute'"
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pairing_state_idx": {
+          "name": "pairing_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_confirmed_by_idx": {
+          "name": "pairing_confirmed_by_idx",
+          "columns": [
+            {
+              "expression": "confirmed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_variant_code_variant_code_fk": {
+          "name": "pairing_variant_code_variant_code_fk",
+          "tableFrom": "pairing",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pairing_confirmed_by_users_id_fk": {
+          "name": "pairing_confirmed_by_users_id_fk",
+          "tableFrom": "pairing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pairing_variant_code_unique": {
+          "name": "pairing_variant_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pairing_confirmation_ck": {
+          "name": "pairing_confirmation_ck",
+          "value": "(\"pairing\".\"state\" = 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)\n        OR (\"pairing\".\"state\" != 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NULL AND \"pairing\".\"confirmed_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier": {
+      "name": "supplier",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wholesale_base_url": {
+          "name": "wholesale_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_key": {
+          "name": "adapter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_settings": {
+      "name": "posta_uncollected_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_state": {
+      "name": "posta_uncollected_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notify_count": {
+          "name": "notify_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_state": {
+          "name": "terminal_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_settings": {
+      "name": "order_reminder_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_state": {
+      "name": "order_reminder_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_replacement_link": {
+      "name": "nedostupne_replacement_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nedostupne_replacement_link_variant_idx": {
+          "name": "nedostupne_replacement_link_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_state": {
+      "name": "nedostupne_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "nedostupne_email_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nedostupne_state_order_variant_type_uq": {
+          "name": "nedostupne_state_order_variant_type_uq",
+          "columns": [
+            {
+              "expression": "order_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template_history": {
+      "name": "mail_template_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "mail_template_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_template_history_key_idx": {
+          "name": "mail_template_history_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_template_history_changed_by_user_id_users_id_fk": {
+          "name": "mail_template_history_changed_by_user_id_users_id_fk",
+          "tableFrom": "mail_template_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template": {
+      "name": "mail_template",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail_template_updated_by_user_id_users_id_fk": {
+          "name": "mail_template_updated_by_user_id_users_id_fk",
+          "tableFrom": "mail_template",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_log": {
+      "name": "mail_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "mail_log_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_log_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "mail_log_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_log_created_idx": {
+          "name": "mail_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_log_source_created_idx": {
+          "name": "mail_log_source_created_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_log_actor_user_id_users_id_fk": {
+          "name": "mail_log_actor_user_id_users_id_fk",
+          "tableFrom": "mail_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_stock": {
+      "name": "supplier_stock",
+      "schema": "",
+      "columns": {
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "supplier_availability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "supplier_stock_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "supplier_stock_host_idx": {
+          "name": "supplier_stock_host_idx",
+          "columns": [
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "supplier_stock_avail_idx": {
+          "name": "supplier_stock_avail_idx",
+          "columns": [
+            {
+              "expression": "availability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "supplier_stock_link_size_label_pk": {
+          "name": "supplier_stock_link_size_label_pk",
+          "columns": [
+            "link",
+            "size_label"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_event": {
+      "name": "restock_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_link": {
+          "name": "supplier_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_availability_text": {
+          "name": "supplier_availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "supplier_price": {
+          "name": "supplier_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "restock_event_at_idx": {
+          "name": "restock_event_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "restock_event_variant_idx": {
+          "name": "restock_event_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_settings": {
+      "name": "restock_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shop_product_url": {
+      "name": "shop_product_url",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.theme_color": {
+      "name": "theme_color",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "theme_color_updated_by_user_id_users_id_fk": {
+          "name": "theme_color_updated_by_user_id_users_id_fk",
+          "tableFrom": "theme_color",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upozornenie": {
+      "name": "upozornenie",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "upozornenie_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "upozornenie_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedup_key": {
+          "name": "dedup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postponed_until": {
+          "name": "postponed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seen_at": {
+          "name": "seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "upozornenie_dedup_key_uq": {
+          "name": "upozornenie_dedup_key_uq",
+          "columns": [
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "resolved_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upozornenie_resolved_at_idx": {
+          "name": "upozornenie_resolved_at_idx",
+          "columns": [
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upozornenie_dedup_key_idx": {
+          "name": "upozornenie_dedup_key_idx",
+          "columns": [
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upozornenie_resolved_by_user_id_users_id_fk": {
+          "name": "upozornenie_resolved_by_user_id_users_id_fk",
+          "tableFrom": "upozornenie",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "upozornenie_created_by_user_id_users_id_fk": {
+          "name": "upozornenie_created_by_user_id_users_id_fk",
+          "tableFrom": "upozornenie",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dpd_pickup_request": {
+      "name": "dpd_pickup_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "pickup_date": {
+          "name": "pickup_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "dpd_operation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dpd_shipment": {
+      "name": "dpd_shipment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "dpd_operation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parcel_number": {
+          "name": "parcel_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cod_amount": {
+          "name": "cod_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dpd_shipment_order_uq": {
+          "name": "dpd_shipment_order_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dpd_shipment_order_id_order_id_fk": {
+          "name": "dpd_shipment_order_id_order_id_fk",
+          "tableFrom": "dpd_shipment",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_task": {
+      "name": "daily_task",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "done_at": {
+          "name": "done_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "daily_task_user_id_created_at_idx": {
+          "name": "daily_task_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_task_user_id_users_id_fk": {
+          "name": "daily_task_user_id_users_id_fk",
+          "tableFrom": "daily_task",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing_candidate_set": {
+      "name": "pairing_candidate_set",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gathered_at": {
+          "name": "gathered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "queries": {
+          "name": "queries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chosen_url": {
+          "name": "chosen_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chosen_reason": {
+          "name": "chosen_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "pairing_confidence",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "pairing_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verdict_checked_at": {
+          "name": "verdict_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pairing_candidate_set_product_key_product_key_fk": {
+          "name": "pairing_candidate_set_product_key_product_key_fk",
+          "tableFrom": "pairing_candidate_set",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing_candidate": {
+      "name": "pairing_candidate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_score": {
+          "name": "raw_score",
+          "type": "numeric(8, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_hit": {
+          "name": "code_hit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pairing_candidate_product_url_uq": {
+          "name": "pairing_candidate_product_url_uq",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_candidate_product_idx": {
+          "name": "pairing_candidate_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_candidate_product_key_fk": {
+          "name": "pairing_candidate_product_key_fk",
+          "tableFrom": "pairing_candidate",
+          "tableTo": "pairing_candidate_set",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "product_key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing_decision": {
+      "name": "pairing_decision",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "pairing_decision_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_synced_at": {
+          "name": "state_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pairing_decision_product_key_product_key_fk": {
+          "name": "pairing_decision_product_key_product_key_fk",
+          "tableFrom": "pairing_decision",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pairing_decision_decided_by_users_id_fk": {
+          "name": "pairing_decision_decided_by_users_id_fk",
+          "tableFrom": "pairing_decision",
+          "tableTo": "users",
+          "columnsFrom": [
+            "decided_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pairing_decision_url_ck": {
+          "name": "pairing_decision_url_ck",
+          "value": "(\"pairing_decision\".\"status\" IN ('good','manual') AND \"pairing_decision\".\"url\" IS NOT NULL) OR (\"pairing_decision\".\"status\" IN ('unavailable','discontinued') AND \"pairing_decision\".\"url\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pairing_search_settings": {
+      "name": "pairing_search_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing_state_writeback_settings": {
+      "name": "pairing_state_writeback_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne"
+      ]
+    },
+    "public.pairing_state": {
+      "name": "pairing_state",
+      "schema": "public",
+      "values": [
+        "navrhnute",
+        "potvrdene"
+      ]
+    },
+    "public.nedostupne_email_type": {
+      "name": "nedostupne_email_type",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "alternativa"
+      ]
+    },
+    "public.mail_template_action": {
+      "name": "mail_template_action",
+      "schema": "public",
+      "values": [
+        "save",
+        "reset"
+      ]
+    },
+    "public.mail_log_source": {
+      "name": "mail_log_source",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "posta_uncollected",
+        "order_reminder",
+        "supplier_order",
+        "order_merge"
+      ]
+    },
+    "public.mail_log_status": {
+      "name": "mail_log_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.mail_log_trigger": {
+      "name": "mail_log_trigger",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "manual"
+      ]
+    },
+    "public.supplier_availability": {
+      "name": "supplier_availability",
+      "schema": "public",
+      "values": [
+        "available",
+        "unavailable",
+        "unknown"
+      ]
+    },
+    "public.supplier_stock_source": {
+      "name": "supplier_stock_source",
+      "schema": "public",
+      "values": [
+        "json_ld",
+        "meta",
+        "text",
+        "size_list",
+        "none"
+      ]
+    },
+    "public.upozornenie_source": {
+      "name": "upozornenie_source",
+      "schema": "public",
+      "values": [
+        "vlastne",
+        "appka"
+      ]
+    },
+    "public.upozornenie_type": {
+      "name": "upozornenie_type",
+      "schema": "public",
+      "values": [
+        "vlastna_poznamka",
+        "nevyzdvihnuta_zasielka",
+        "vratenie",
+        "vratena_zasielka",
+        "objednavka_visi"
+      ]
+    },
+    "public.dpd_operation_status": {
+      "name": "dpd_operation_status",
+      "schema": "public",
+      "values": [
+        "submitted",
+        "failed"
+      ]
+    },
+    "public.pairing_confidence": {
+      "name": "pairing_confidence",
+      "schema": "public",
+      "values": [
+        "high",
+        "medium",
+        "low",
+        "none"
+      ]
+    },
+    "public.pairing_decision_status": {
+      "name": "pairing_decision_status",
+      "schema": "public",
+      "values": [
+        "good",
+        "manual",
+        "unavailable",
+        "discontinued"
+      ]
+    },
+    "public.pairing_verdict": {
+      "name": "pairing_verdict",
+      "schema": "public",
+      "values": [
+        "ok",
+        "unsure"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -351,6 +351,13 @@
       "when": 1786594123925,
       "tag": "0049_plain_metal_master",
       "breakpoints": true
+    },
+    {
+      "idx": 50,
+      "version": "7",
+      "when": 1786605379430,
+      "tag": "0050_dusty_marrow",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/cli/pairing-backfill-images.ts
+++ b/apps/api/src/cli/pairing-backfill-images.ts
@@ -1,0 +1,35 @@
+// Backfill obrázka CHOSEN kandidáta pre `pairing_candidate` riadky bez neho
+// (issue 397) — kanonická implementácia, presne vzor `cli/catalog-prune-
+// raw.ts`. Tento súbor žije PRIAMO v `apps/api/src`, takže ho `pnpm
+// --filter @forestshop/api build` (tsc -b) skompiluje do
+// `apps/api/dist/cli/pairing-backfill-images.js` — Dockerfile už kopíruje
+// celý `apps/api/dist` do produkčného obrazu, takže žiadna zmena
+// Dockerfile nie je potrebná. `scripts/pairing-backfill-images.ts` je len
+// jej tenký re-export alias pre lokálne/CI spustenie (`pnpm pairing:
+// backfill-images`).
+//
+// IDEMPOTENTNÝ — bezpečné spustiť KEDYKOĽVEK znova (dotkne sa len riadkov,
+// čo ešte nemajú obrázok). Berie `PAIRING_SEARCH_RUN_LOCK_KEY` (rovnaký
+// zámok ako nočný gather beh), takže sa NIKDY nesmie/nemôže pretínať s
+// ním — spúšťaj mimo očakávaného behu nočného jobu, ak chceš, aby doňho
+// backfill sám nečakal.
+//
+// Príkaz na produkcii (viď `.claude/rules/deploy.md`):
+//   docker compose -f docker-compose.prod.yml exec app node apps/api/dist/cli/pairing-backfill-images.js
+import { createDb } from "../db/client.js";
+import { loadEnv } from "../env.js";
+import { backfillCandidateImages } from "../modules/pairing-search/backfill.js";
+
+const env = loadEnv();
+const { db, pool } = createDb(env.DATABASE_URL);
+let result: Awaited<ReturnType<typeof backfillCandidateImages>>;
+try {
+  result = await backfillCandidateImages({ db });
+} finally {
+  await pool.end();
+}
+
+console.log(
+  `Obrázok kandidáta doplnený pre ${String(result.updated)} z ${String(result.checked)} skontrolovaných (${String(result.failed)} zlyhaní).`,
+);
+console.log(JSON.stringify(result));

--- a/apps/api/src/cli/pairing-backfill-images.ts
+++ b/apps/api/src/cli/pairing-backfill-images.ts
@@ -32,4 +32,14 @@ try {
 console.log(
   `Obrázok kandidáta doplnený pre ${String(result.updated)} z ${String(result.checked)} skontrolovaných (${String(result.failed)} zlyhaní).`,
 );
+for (const [host, count] of Object.entries(result.noImageFoundByHost)) {
+  console.log(`  ${host}: ${String(count)} riadkov bez použiteľného og:image (stránka sa stiahla, ale nemala čo ponúknuť).`);
+}
 console.log(JSON.stringify(result));
+
+// Review nález, issue 397: predtým vždy exit 0 aj keď VŠETKO zlyhalo —
+// operátor/wrapper skript pod `set -e` by to prečítal ako úspech.
+// `failed > 0` je vždy SIEŤOVÁ/parse chyba (nikdy "stránka bez obrázka" —
+// to sa počíta do `checked - updated - failed`, viď `BackfillCandidateImagesResult`
+// dokumentácia v `backfill.ts`), teda skutočný dôvod na nenulový exit kód.
+if (result.failed > 0) process.exitCode = 1;

--- a/apps/api/src/db/schema-pairing-review.ts
+++ b/apps/api/src/db/schema-pairing-review.ts
@@ -63,6 +63,12 @@ export const pairingCandidates = pgTable(
     // AŽ E4's overenie na detaile kandidáta.
     code: text("code"),
     price: numeric("price", { precision: 12, scale: 2 }),
+    // issue 397 (mimo doslovného portu — stará appka obrázok kandidáta z
+    // výsledkovej karty nikdy neparsovala) — adaptéry ho na rozdiel od
+    // `code`/`price` NAPĹŇAJÚ priamo pri parsovaní výsledkov, keď ho karta
+    // nesie; `verify.ts`'s `og:image` fallback (LEN pre chosen kandidáta)
+    // ho vie doplniť dodatočne v TOM ISTOM upserte (`run.ts`).
+    imageUrl: text("image_url"),
     // Repo konvencia: numeric floaty sa ukladajú cez `numeric` (string na
     // JS strane), nikdy `real`/`doublePrecision` (`.claude/rules/
     // database.md`) — `raw_score` nie je peniaze, ale konzistencia s

--- a/apps/api/src/modules/pairing-review/queries.ts
+++ b/apps/api/src/modules/pairing-review/queries.ts
@@ -42,6 +42,9 @@ const OWN_SHOP_SEARCH_BASE = "https://www.forestshop.sk/vyhladavanie/?string=";
 export interface PairingReviewChosenCandidate {
   readonly name: string;
   readonly url: string;
+  /** issue 397 — obrázok kandidáta (z adaptéra, alebo `verify.ts`'s
+   *  `og:image` fallback), `null` keď žiadny zdroj neposkytol použiteľný. */
+  readonly imageUrl: string | null;
   readonly rawScore: number;
   readonly codeHit: boolean;
 }
@@ -188,6 +191,7 @@ export async function listPairingReview(db: Database, input: PairingReviewSearch
       productKey: pairingCandidates.productKey,
       name: pairingCandidates.name,
       url: pairingCandidates.url,
+      imageUrl: pairingCandidates.imageUrl,
       rawScore: pairingCandidates.rawScore,
       codeHit: pairingCandidates.codeHit,
     })
@@ -263,7 +267,13 @@ export async function listPairingReview(db: Database, input: PairingReviewSearch
     const chosenCandidate: PairingReviewChosenCandidate | null =
       chosenCandidateRow === undefined
         ? null
-        : { name: chosenCandidateRow.name, url: chosenCandidateRow.url, rawScore: Number(chosenCandidateRow.rawScore), codeHit: chosenCandidateRow.codeHit };
+        : {
+            name: chosenCandidateRow.name,
+            url: chosenCandidateRow.url,
+            imageUrl: chosenCandidateRow.imageUrl,
+            rawScore: Number(chosenCandidateRow.rawScore),
+            codeHit: chosenCandidateRow.codeHit,
+          };
 
     const decisionRow = decisionByProduct.get(set.productKey);
     const decision: PairingReviewDecision | null =

--- a/apps/api/src/modules/pairing-search/adapters/betalov.test.ts
+++ b/apps/api/src/modules/pairing-search/adapters/betalov.test.ts
@@ -21,11 +21,16 @@ describe("parseBetalovSearch", () => {
       url: "https://www.huntingshop.eu/detske-outdoorove-nohavice-combi-14695",
       code: null,
       price: null,
+      // issue 397: `img.product-image` je REÁLNE prítomný v tejto naživo
+      // zachytenej fixtúre (nebolo treba dopĺňať).
+      imageUrl: "https://www.huntingshop.eu/upload/images/product/md__14695-detske-outdoorove-nohavice-combi-1.webp",
       rawScore: 0,
       codeHit: false,
     });
     expect(candidates[1]?.name).toBe("Armotion Class-T dámske nohavice");
+    expect(candidates[1]?.imageUrl).toBe("https://www.huntingshop.eu/upload/images/product/md__14306-armotion-class-t-damske-nohavice-1.webp");
     expect(candidates[2]?.name).toBe("WADERA - Detské krátke nohavice - Hnedé");
+    expect(candidates[2]?.imageUrl).toBe("https://www.huntingshop.eu/upload/images/product/md__14266-wadera-detske-kratke-nohavice-hnede-1.webp");
   });
 
   it("dedups the repeated card by canonical URL", () => {
@@ -56,6 +61,7 @@ describe("parseBetalovSearch", () => {
         url: "https://www.huntingshop.eu/len-title-odkaz",
         code: null,
         price: null,
+        imageUrl: null,
         rawScore: 0,
         codeHit: false,
       },
@@ -72,6 +78,7 @@ describe("parseBetalovSearch", () => {
         url: "https://www.huntingshop.eu/x",
         code: null,
         price: null,
+        imageUrl: null,
         rawScore: 0,
         codeHit: false,
       },
@@ -90,10 +97,18 @@ describe("parseBetalovSearch", () => {
         url: "https://www.huntingshop.eu/dobra",
         code: null,
         price: null,
+        imageUrl: null,
         rawScore: 0,
         codeHit: false,
       },
     ]);
+  });
+
+  it("issue 397: šumový obrázok (.svg ikonka) sa filtruje na imageUrl null, aj keď path nie je vylúčená", () => {
+    const html =
+      '<div class="product-col"><a href="/x" class="mh-100"><img class="product-image" src="/upload/images/icons/cart.svg"></a>' +
+      '<h3 class="product-title"><a href="x">Produkt s ikonkou namiesto fotky</a></h3></div>';
+    expect(parseBetalovSearch(html)[0]?.imageUrl).toBeNull();
   });
 });
 

--- a/apps/api/src/modules/pairing-search/adapters/betalov.ts
+++ b/apps/api/src/modules/pairing-search/adapters/betalov.ts
@@ -21,11 +21,21 @@
 // `fixtures/betalov-prazdne-vysledky.html`) — selektory aj `#snippet--
 // productList`/`.product-col` tvar sa zhodujú so starou appka's
 // dokumentáciou z 27. 6. 2026.
+//
+// issue 397: obrázok kandidáta (MIMO doslovného portu). Karta nesie
+// `<div class="product-thumb-nail"><a class="mh-100"><img class="product-
+// image" src="/upload/images/product/md__…"></a></div>` — `img.product-
+// image` v tej istej `.product-col` karte, čo už dnes dáva `a.mh-100`'s
+// `href`. **`og:image` na DETAILNEJ stránke je na tejto doméne VŽDY
+// stránkové logo (`/svg/logo2.svg`), nikdy produktová fotka** (živo
+// overené) — presne prípad, na ktorý `resolveImageUrl`'s šumový filter
+// existuje; `verify.ts`'s fallback ho preto na tomto dodávateľovi nikdy
+// neuplatní.
 
 import * as cheerio from "cheerio";
 import type { PairingCandidate } from "../types.js";
 import type { SupplierAdapter } from "./types.js";
-import { belongsToBase, resolveAndStripFragment } from "./url.js";
+import { belongsToBase, resolveAndStripFragment, resolveImageUrl } from "./url.js";
 
 const BASE_URL = "https://www.huntingshop.eu";
 
@@ -86,7 +96,9 @@ export function parseBetalovSearch(html: string): PairingCandidate[] {
     seen.add(url);
 
     const name = card.find(".product-title a").first().text().trim();
-    out.push({ name, url, code: null, price: null, rawScore: 0, codeHit: false });
+    const img = card.find("img.product-image").first();
+    const imageUrl = resolveImageUrl([img.attr("src")], BASE_URL);
+    out.push({ name, url, code: null, price: null, imageUrl, rawScore: 0, codeHit: false });
   });
 
   return out;

--- a/apps/api/src/modules/pairing-search/adapters/odimon.test.ts
+++ b/apps/api/src/modules/pairing-search/adapters/odimon.test.ts
@@ -20,11 +20,19 @@ describe("parseOdimonSearch", () => {
       url: "https://www.odimon.sk/obuv-a-oblecenie/polovnicke-oblecenie/polovnicke-termopradlo/termopradlo-nohavice-modal-termovel",
       code: null,
       price: null,
+      // issue 397: `data-src` (skutočný lazy-load obrázok) uprednostnené
+      // pred `src` (na tejto doméne VŽDY `no-image.png` placeholder).
+      imageUrl:
+        "https://www.odimon.sk/buxus/images/cache/product_catalog.eshop_product_list/produkty/katalog_produktov/obuv_a_oblecenie/polovnicke_termopradlo/termopradlo_nohavice_modal_termovel/20161611121146-termovelspodky.jpg",
       rawScore: 0,
       codeHit: false,
     });
     expect(candidates[1]?.name).toBe("Pánske poľovnícke nohavice Michal");
+    // issue 397: karty 2-3 nemajú `data-src`/`src` vo fixtúre (zámerne) ->
+    // žiadny obrázok sa nájsť nedá.
+    expect(candidates[1]?.imageUrl).toBeNull();
     expect(candidates[2]?.name).toBe("Poľovnícke nohavice Deerhunter Ram");
+    expect(candidates[2]?.imageUrl).toBeNull();
   });
 
   it("dedups the repeated card by canonical URL", () => {
@@ -47,6 +55,7 @@ describe("parseOdimonSearch", () => {
         url: "https://www.odimon.sk/x",
         code: null,
         price: null,
+        imageUrl: null,
         rawScore: 0,
         codeHit: false,
       },
@@ -65,10 +74,18 @@ describe("parseOdimonSearch", () => {
         url: "https://www.odimon.sk/dobra",
         code: null,
         price: null,
+        imageUrl: null,
         rawScore: 0,
         codeHit: false,
       },
     ]);
+  });
+
+  it("issue 397: samotný src bez data-src (no-image.png placeholder) sa NIKDY nezoberie ako obrázok", () => {
+    const html =
+      '<a class="product-card" href="https://www.odimon.sk/bez-obrazka">' +
+      '<img alt="Bez obrázka" src="/buxus/images/cache/product_catalog.eshop_product_list/no-image.png"></a>';
+    expect(parseOdimonSearch(html)[0]?.imageUrl).toBeNull();
   });
 });
 

--- a/apps/api/src/modules/pairing-search/adapters/odimon.ts
+++ b/apps/api/src/modules/pairing-search/adapters/odimon.ts
@@ -17,11 +17,19 @@
 // `fixtures/odimon-prazdne-vysledky.html`) — selektory aj `.product-
 // list__results`/`a.product-card` tvar sa zhodujú so starou appka's
 // dokumentáciou z 27. 6. 2026.
+//
+// issue 397: obrázok kandidáta (MIMO doslovného portu) — z TOHO ISTÉHO
+// `img` elementu, čo už dnes dáva `alt`/`title` pre meno. **KRITICKÉ: `src`
+// je na tejto doméne VŽDY `.../no-image.png` placeholder (lazy-load cez
+// JS) — skutočný obrázok nesie `data-src`.** Živo overené: `data-src`
+// ukazuje na TEN ISTÝ súbor, čo aj detailnej stránky `og:image`.
+// `resolveImageUrl`'s poradie (`data-src` pred `src`) je preto nutné, nie
+// len štylistická preferencia.
 
 import * as cheerio from "cheerio";
 import type { PairingCandidate } from "../types.js";
 import type { SupplierAdapter } from "./types.js";
-import { belongsToBase, resolveAndStripFragment } from "./url.js";
+import { belongsToBase, resolveAndStripFragment, resolveImageUrl } from "./url.js";
 
 const BASE_URL = "https://www.odimon.sk";
 
@@ -47,7 +55,8 @@ export function parseOdimonSearch(html: string): PairingCandidate[] {
 
     const img = anchor.find("img").first();
     const name = (img.attr("alt") ?? img.attr("title") ?? "").trim();
-    out.push({ name, url, code: null, price: null, rawScore: 0, codeHit: false });
+    const imageUrl = resolveImageUrl([img.attr("data-src"), img.attr("src")], BASE_URL);
+    out.push({ name, url, code: null, price: null, imageUrl, rawScore: 0, codeHit: false });
   });
 
   return out;

--- a/apps/api/src/modules/pairing-search/adapters/url.test.ts
+++ b/apps/api/src/modules/pairing-search/adapters/url.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { belongsToBase, resolveAndStripFragment } from "./url.js";
+import { belongsToBase, resolveAndStripFragment, resolveImageUrl } from "./url.js";
 
 describe("resolveAndStripFragment", () => {
   it("resolves a relative href against the base and strips the fragment", () => {
@@ -39,5 +39,45 @@ describe("belongsToBase", () => {
 
   it("rejects an unrelated host", () => {
     expect(belongsToBase("https://evil.example/x", "https://www.wetland.sk")).toBe(false);
+  });
+});
+
+// issue 397 (mimo doslovného portu — port starej appka's `_IMG_NOISE`,
+// `webreview/app.py`) — zdieľaná pomôcka pre všetky tri adaptéry aj
+// `verify.ts`'s `og:image` fallback.
+describe("resolveImageUrl", () => {
+  it("resolves the FIRST non-empty candidate and stops (never checks later ones)", () => {
+    expect(resolveImageUrl(["/a.jpg", "/b.jpg"], "https://www.wetland.sk")).toBe("https://www.wetland.sk/a.jpg");
+  });
+
+  it("skips undefined/empty candidates and falls through to the next", () => {
+    expect(resolveImageUrl([undefined, "", "  ", "/b.jpg"], "https://www.wetland.sk")).toBe("https://www.wetland.sk/b.jpg");
+  });
+
+  it("returns null when every candidate is undefined/empty", () => {
+    expect(resolveImageUrl([undefined, ""], "https://www.wetland.sk")).toBeNull();
+  });
+
+  it("returns null when every candidate is unresolvable (malformed URL)", () => {
+    expect(resolveImageUrl(["http://["], "https://www.wetland.sk")).toBeNull();
+  });
+
+  it("filters out a noise marker (logo/placeholder/…) and falls through to the next candidate", () => {
+    expect(resolveImageUrl(["/logo.png", "/product.jpg"], "https://www.wetland.sk")).toBe("https://www.wetland.sk/product.jpg");
+  });
+
+  it.each(["logo", "/producer/", ".svg", "/svg/", "placeholder", "no-image", "banner", "/img/m/"])(
+    "filters a candidate whose resolved URL contains the noise marker %j",
+    (marker) => {
+      expect(resolveImageUrl([`/${marker}/x.jpg`], "https://www.wetland.sk")).toBeNull();
+    },
+  );
+
+  it("noise matching is case-insensitive", () => {
+    expect(resolveImageUrl(["/LOGO/x.jpg"], "https://www.wetland.sk")).toBeNull();
+  });
+
+  it("trims whitespace before resolving", () => {
+    expect(resolveImageUrl(["  /a.jpg  "], "https://www.wetland.sk")).toBe("https://www.wetland.sk/a.jpg");
   });
 });

--- a/apps/api/src/modules/pairing-search/adapters/url.test.ts
+++ b/apps/api/src/modules/pairing-search/adapters/url.test.ts
@@ -80,4 +80,17 @@ describe("resolveImageUrl", () => {
   it("trims whitespace before resolving", () => {
     expect(resolveImageUrl(["  /a.jpg  "], "https://www.wetland.sk")).toBe("https://www.wetland.sk/a.jpg");
   });
+
+  // Review nález, issue 397: rezolvovaná URL sa priamo ukladá do DB a
+  // renderuje do `<img src>` na prihlásenej review obrazovke — len
+  // `http:`/`https:` je platný scheme, aj keď je inak nespracovateľný.
+  it("rejects a non-http(s) scheme (e.g. data:) and falls through to the next candidate", () => {
+    expect(resolveImageUrl(["data:image/png;base64,AAAA", "/product.jpg"], "https://www.wetland.sk")).toBe(
+      "https://www.wetland.sk/product.jpg",
+    );
+  });
+
+  it("returns null when the ONLY candidate is a non-http(s) scheme", () => {
+    expect(resolveImageUrl(["javascript:alert(1)"], "https://www.wetland.sk")).toBeNull();
+  });
 });

--- a/apps/api/src/modules/pairing-search/adapters/url.ts
+++ b/apps/api/src/modules/pairing-search/adapters/url.ts
@@ -42,3 +42,38 @@ export function resolveAndStripFragment(href: string, baseUrl: string): string |
 export function belongsToBase(url: string, baseUrl: string): boolean {
   return url === baseUrl || url.startsWith(`${baseUrl}/`);
 }
+
+// Doslovný port starej appka's `_IMG_NOISE` (`webreview/app.py`) — URL
+// fragmenty, ktoré NIKDY nie sú produktová fotka, aj keď sedia v inak
+// platnom obrázkovom atribúte. Živo overené (issue 397): BETALOV's
+// (huntingshop.eu) detailná `og:image` je VŽDY stránkové logo
+// (`.../svg/logo2.svg`) — presne dôvod, prečo starú appku tento filter
+// mal už pred rokom, nie len teoretická obrana.
+const IMAGE_NOISE_MARKERS = ["logo", "/producer/", ".svg", "/svg/", "placeholder", "no-image", "banner", "/img/m/"] as const;
+
+function isNoiseImage(url: string): boolean {
+  const low = url.toLowerCase();
+  return IMAGE_NOISE_MARKERS.some((marker) => low.includes(marker));
+}
+
+/**
+ * Vyberie prvý NEPRÁZDNY, nie-šumový obrázkový atribút z `candidates` (v
+ * poradí priority — napr. `[data-src, src]`, keď `src` je na danej doméne
+ * lazy-load placeholder) a vyrieši ho na absolútnu URL voči `baseUrl`.
+ * `null`, keď žiadny kandidát nenesie použiteľnú hodnotu — chýbajúca/
+ * prázdna, nespracovateľná (`resolveAndStripFragment`), alebo šumová
+ * (`IMAGE_NOISE_MARKERS` vyššie). Živo overené (issue 397): ODIMON's
+ * výsledková karta má `src="…/no-image.png"` VŽDY (skutočný obrázok je len
+ * v `data-src`, lazy-load) — bez tohto poradia by sa placeholder bral ako
+ * platný obrázok.
+ */
+export function resolveImageUrl(candidates: readonly (string | undefined)[], baseUrl: string): string | null {
+  for (const raw of candidates) {
+    const trimmed = raw?.trim();
+    if (trimmed === undefined || trimmed === "") continue;
+    const resolved = resolveAndStripFragment(trimmed, baseUrl);
+    if (resolved === null || isNoiseImage(resolved)) continue;
+    return resolved;
+  }
+  return null;
+}

--- a/apps/api/src/modules/pairing-search/adapters/url.ts
+++ b/apps/api/src/modules/pairing-search/adapters/url.ts
@@ -57,22 +57,40 @@ function isNoiseImage(url: string): boolean {
 }
 
 /**
+ * `true` LEN pre `http:`/`https:` — obranná vrstva navyše (review nález,
+ * issue 397): rezolvovaná obrázková URL sa priamo ukladá do DB a renderuje
+ * do `<img src>` na prihlásenej review obrazovke (`PairingReviewCard.tsx`),
+ * bez akéhokoľvek ďalšieho scheme obmedzenia. Dodávateľská karta by teoreticky
+ * mohla niesť `data:`/iný neobrázkový scheme v inak platnom atribúte — `img
+ * src` `javascript:`/`data:` nie je XSS vektor, ale nie je dôvod ukladať
+ * niečo iné, než skutočne stiahnuteľný obrázok.
+ */
+function isHttpUrl(url: string): boolean {
+  try {
+    const protocol = new URL(url).protocol;
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Vyberie prvý NEPRÁZDNY, nie-šumový obrázkový atribút z `candidates` (v
  * poradí priority — napr. `[data-src, src]`, keď `src` je na danej doméne
  * lazy-load placeholder) a vyrieši ho na absolútnu URL voči `baseUrl`.
  * `null`, keď žiadny kandidát nenesie použiteľnú hodnotu — chýbajúca/
- * prázdna, nespracovateľná (`resolveAndStripFragment`), alebo šumová
- * (`IMAGE_NOISE_MARKERS` vyššie). Živo overené (issue 397): ODIMON's
- * výsledková karta má `src="…/no-image.png"` VŽDY (skutočný obrázok je len
- * v `data-src`, lazy-load) — bez tohto poradia by sa placeholder bral ako
- * platný obrázok.
+ * prázdna, nespracovateľná (`resolveAndStripFragment`), šumová
+ * (`IMAGE_NOISE_MARKERS` vyššie), alebo nie-`http(s)` scheme (`isHttpUrl`).
+ * Živo overené (issue 397): ODIMON's výsledková karta má `src="…/no-image
+ * .png"` VŽDY (skutočný obrázok je len v `data-src`, lazy-load) — bez tohto
+ * poradia by sa placeholder bral ako platný obrázok.
  */
 export function resolveImageUrl(candidates: readonly (string | undefined)[], baseUrl: string): string | null {
   for (const raw of candidates) {
     const trimmed = raw?.trim();
     if (trimmed === undefined || trimmed === "") continue;
     const resolved = resolveAndStripFragment(trimmed, baseUrl);
-    if (resolved === null || isNoiseImage(resolved)) continue;
+    if (resolved === null || isNoiseImage(resolved) || !isHttpUrl(resolved)) continue;
     return resolved;
   }
   return null;

--- a/apps/api/src/modules/pairing-search/adapters/wetland.test.ts
+++ b/apps/api/src/modules/pairing-search/adapters/wetland.test.ts
@@ -21,11 +21,18 @@ describe("parseWetlandSearch", () => {
       url: "https://www.wetland.sk/nohavice/deerhunter-pro-gamekeeper-boot-trousers-polovnicke-nohavice-111-592",
       code: null,
       price: null,
+      // issue 397: prvá karta má REÁLNU `.product-miniature` obal-struktúru
+      // (`data-full-size-image-url` uprednostnené pred menším `src`).
+      imageUrl: "https://www.wetland.sk/7593-home_default/deerhunter-pro-gamekeeper-boot-trousers-polovnicke-nohavice.jpg",
       rawScore: 0,
       codeHit: false,
     });
     expect(candidates[1]?.name).toBe("DEERHUNTER Strike Extreme Pull-Over Trousers - ochranné nohavice");
+    // issue 397: karty 2-3 nemajú `.product-miniature` obal vo fixtúre
+    // (zámerne, viď fixtúrov komentár) -> žiadny obrázok sa nájsť nedá.
+    expect(candidates[1]?.imageUrl).toBeNull();
     expect(candidates[2]?.name).toBe("DEERHUNTER Lady Excape Winter Trousers - dámske nohavice");
+    expect(candidates[2]?.imageUrl).toBeNull();
   });
 
   it("strips the #/variant fragment and dedups the two occurrences by canonical URL", () => {
@@ -51,7 +58,7 @@ describe("parseWetlandSearch", () => {
       '<a class="product-miniature__link" href="/x" title="Miniatúra produktu">' +
       '<img alt="obrázok"></a>';
     expect(parseWetlandSearch(html)).toEqual([
-      { name: "Miniatúra produktu", url: "https://www.wetland.sk/x", code: null, price: null, rawScore: 0, codeHit: false },
+      { name: "Miniatúra produktu", url: "https://www.wetland.sk/x", code: null, price: null, imageUrl: null, rawScore: 0, codeHit: false },
     ]);
   });
 
@@ -65,6 +72,7 @@ describe("parseWetlandSearch", () => {
         url: "https://www.wetland.sk/nohavice/dobra",
         code: null,
         price: null,
+        imageUrl: null,
         rawScore: 0,
         codeHit: false,
       },

--- a/apps/api/src/modules/pairing-search/adapters/wetland.ts
+++ b/apps/api/src/modules/pairing-search/adapters/wetland.ts
@@ -14,11 +14,21 @@
 // Živo overené 13. 8. 2026 (`fixtures/wetland-vysledky-nohavice.html`,
 // `fixtures/wetland-prazdne-vysledky.html`) — selektory aj tvar URL sa
 // zhodujú so starou appka's dokumentáciou z 27. 6. 2026.
+//
+// issue 397: obrázok kandidáta (MIMO doslovného portu — stará appka ho z
+// výsledkovej karty nikdy nečítala). Karta nesie `<picture><img
+// class="product-miniature__image" data-full-size-image-url="…"
+// src="…_default_md/…">` vnútri `a.product-miniature__link`, ktorý je
+// SÚRODENEC (nie predok/potomok) title-anchoru — preto `.closest(".product-
+// miniature")` na spoločného predka karty, potom `.find(...)` naň. Živo
+// overené (13. 8. 2026): OBAJA atribúty nesú REÁLNY, nie-placeholder
+// obrázok — `data-full-size-image-url` (plná veľkosť) sa uprednostní pred
+// menším `src`.
 
 import * as cheerio from "cheerio";
 import type { PairingCandidate } from "../types.js";
 import type { SupplierAdapter } from "./types.js";
-import { belongsToBase, resolveAndStripFragment } from "./url.js";
+import { belongsToBase, resolveAndStripFragment, resolveImageUrl } from "./url.js";
 
 const BASE_URL = "https://www.wetland.sk";
 
@@ -43,7 +53,13 @@ export function parseWetlandSearch(html: string): PairingCandidate[] {
     seen.add(url);
 
     const name = (anchor.text().trim() || anchor.attr("title") || "").trim();
-    out.push({ name, url, code: null, price: null, rawScore: 0, codeHit: false });
+    // `.closest()`/`.find()` na PRÁZDNEJ zhode (žiadny "product-miniature"
+    // predok) vracajú ĎALŠIU prázdnu zhodu, nikdy nevyhodia — `.attr()` na
+    // nej je bezpečne `undefined`, žiadny osobitný "chýbajúci obal" vetva
+    // netreba.
+    const img = anchor.closest(".product-miniature").find("img.product-miniature__image").first();
+    const imageUrl = resolveImageUrl([img.attr("data-full-size-image-url"), img.attr("src")], BASE_URL);
+    out.push({ name, url, code: null, price: null, imageUrl, rawScore: 0, codeHit: false });
   });
 
   return out;

--- a/apps/api/src/modules/pairing-search/backfill.ts
+++ b/apps/api/src/modules/pairing-search/backfill.ts
@@ -1,0 +1,104 @@
+// issue 397 — jednorazový/opakovateľný backfill obrázka CHOSEN kandidáta
+// pre `pairing_candidate` riadky, ktoré ho ešte nemajú. Design komentár na
+// tickete ("Zvolený prístup — existujúcich 1309 kandidátov bez obrázka"):
+// cielený backfill namiesto plného re-gatheru (`input_hash` bump) —
+// zamietnuté, lebo (a) `input_hash` je "zmenila sa identita produktu?",
+// nikdy "má appka všetky assety?", (b) plný re-gather by stál
+// query_variants×dodávatelia×throttle na produkt len na doplnenie JEDNÉHO
+// poľa, kým cielený fetch stojí PRESNE JEDEN request na produkt, (c)
+// re-rankovanie by mohlo (zriedkavo) zvoliť iného `chosen_url` kandidáta.
+//
+// Karta ukazuje LEN `chosenCandidate` (top-8 panel obrázok nepotrebuje,
+// mimo rozsahu tiketu) — scope je preto `pairing_candidate` riadky, ktorých
+// `url` sa zhoduje s `pairing_candidate_set.chosen_url` toho istého
+// produktu, s `image_url IS NULL`. IDEMPOTENTNÝ (WHERE-om), bezpečné
+// spustiť KEDYKOĽVEK znova — nielen jednorazová migrácia, ale trvalý
+// nástroj na budúce medzery (markup drift na jednom produkte a pod.).
+//
+// Zdieľa `runPairingSearch`'s advisory zámok (`PAIRING_SEARCH_RUN_LOCK_KEY`)
+// — nikdy nový kľúč — aby sa backfill nikdy nepretínal s nočným gather
+// behom nad TÝMI ISTÝMI riadkami (ten by mohol medzitým delete+insert-núť
+// presne tie riadky, čo backfill práve aktualizuje).
+
+import { and, eq, isNull } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { pairingCandidates, pairingCandidateSets } from "../../db/schema.js";
+import { log } from "../../logger.js";
+import { SearchClient } from "./client.js";
+import { PAIRING_SEARCH_RUN_LOCK_KEY } from "./constants.js";
+import { extractPage } from "./verify.js";
+
+export interface BackfillCandidateImagesError {
+  readonly productKey: string;
+  readonly url: string;
+  readonly message: string;
+}
+
+export interface BackfillCandidateImagesResult {
+  /** Koľko chosen-kandidátových riadkov bez obrázka backfill našiel. */
+  readonly checked: number;
+  /** Koľko z nich reálne dostalo obrázok (stránka niesla použiteľný
+   *  `og:image` — `checked - updated - failed` je "stránka sa stiahla, ale
+   *  žiadny použiteľný obrázok nenašla", nie chyba). */
+  readonly updated: number;
+  readonly failed: number;
+  readonly errors: readonly BackfillCandidateImagesError[];
+}
+
+export interface BackfillCandidateImagesOptions {
+  readonly db: Database;
+  /** Iba pre testy — nahradí skutočný sieťový `SearchClient`. */
+  readonly searchClient?: SearchClient;
+}
+
+export async function backfillCandidateImages(options: BackfillCandidateImagesOptions): Promise<BackfillCandidateImagesResult> {
+  const { db } = options;
+  const lockClient = await db.$client.connect();
+  try {
+    await lockClient.query("select pg_advisory_lock($1)", [PAIRING_SEARCH_RUN_LOCK_KEY]);
+    return await backfillCandidateImagesLocked(options);
+  } finally {
+    await lockClient.query("select pg_advisory_unlock($1)", [PAIRING_SEARCH_RUN_LOCK_KEY]);
+    lockClient.release();
+  }
+}
+
+async function backfillCandidateImagesLocked(options: BackfillCandidateImagesOptions): Promise<BackfillCandidateImagesResult> {
+  const { db } = options;
+  const client = options.searchClient ?? new SearchClient();
+
+  const rows = await db
+    .select({ productKey: pairingCandidates.productKey, url: pairingCandidates.url })
+    .from(pairingCandidates)
+    .innerJoin(
+      pairingCandidateSets,
+      and(eq(pairingCandidateSets.productKey, pairingCandidates.productKey), eq(pairingCandidateSets.chosenUrl, pairingCandidates.url)),
+    )
+    .where(isNull(pairingCandidates.imageUrl));
+
+  let updated = 0;
+  const errors: BackfillCandidateImagesError[] = [];
+
+  for (const row of rows) {
+    try {
+      const html = await client.fetchPage(row.url);
+      const { image } = extractPage(html, row.url);
+      if (image !== null) {
+        await db
+          .update(pairingCandidates)
+          .set({ imageUrl: image })
+          .where(and(eq(pairingCandidates.productKey, row.productKey), eq(pairingCandidates.url, row.url)));
+        updated += 1;
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      log.warn(
+        { productKey: row.productKey, url: row.url, message },
+        "pairing-search: backfill obrázka zlyhal pre kandidáta, pokračujem ďalším",
+      );
+      errors.push({ productKey: row.productKey, url: row.url, message });
+    }
+  }
+
+  return { checked: rows.length, updated, failed: errors.length, errors };
+}

--- a/apps/api/src/modules/pairing-search/backfill.ts
+++ b/apps/api/src/modules/pairing-search/backfill.ts
@@ -43,6 +43,14 @@ export interface BackfillCandidateImagesResult {
   readonly updated: number;
   readonly failed: number;
   readonly errors: readonly BackfillCandidateImagesError[];
+  /** Review nález (issue 397): PRE KAŽDÝ HOST, koľko riadkov malo stránku
+   *  stiahnuteľnú, ale BEZ použiteľného `og:image` (šumový/chýbajúci —
+   *  `resolveImageUrl`). Toto NIE JE náhodné — BETALOV (huntingshop.eu) je
+   *  tu ŠTRUKTÚROVANE VŽDY 100 % (jeho detailná `og:image` je vždy stránkové
+   *  logo, živo overené, playbook), takže operátor musí vedieť "60 z 177
+   *  doplnených" znamená AJ "zvyšok je z domény, kde to backfill nikdy
+   *  nevie splniť", nie len "náhodné zlyhania". */
+  readonly noImageFoundByHost: Readonly<Record<string, number>>;
 }
 
 export interface BackfillCandidateImagesOptions {
@@ -51,14 +59,32 @@ export interface BackfillCandidateImagesOptions {
   readonly searchClient?: SearchClient;
 }
 
+/**
+ * Review nález (issue 397): pôvodne `pg_advisory_lock` (BLOKUJÚCI) — keď
+ * nočný gather beh zámok už držal, tento interaktívny CLI by ticho visel
+ * (177 riadkov × throttle/retry v gather behu môže trvať hodiny) bez
+ * akéhokoľvek výstupu. `pg_try_advisory_lock` (NEBLOKUJÚCI) zlyhá NAHLAS
+ * hneď — operátor vie okamžite, že má skúsiť neskôr, namiesto zaseknutého
+ * terminálu.
+ */
 export async function backfillCandidateImages(options: BackfillCandidateImagesOptions): Promise<BackfillCandidateImagesResult> {
   const { db } = options;
   const lockClient = await db.$client.connect();
   try {
-    await lockClient.query("select pg_advisory_lock($1)", [PAIRING_SEARCH_RUN_LOCK_KEY]);
-    return await backfillCandidateImagesLocked(options);
+    const acquired = await lockClient.query<{ pg_try_advisory_lock: boolean }>("select pg_try_advisory_lock($1)", [
+      PAIRING_SEARCH_RUN_LOCK_KEY,
+    ]);
+    if (acquired.rows[0]?.pg_try_advisory_lock !== true) {
+      throw new Error(
+        "backfill obrázkov kandidáta: advisory zámok (PAIRING_SEARCH_RUN_LOCK_KEY) je obsadený — pravdepodobne beží nočný gather beh. Skús znova neskôr.",
+      );
+    }
+    try {
+      return await backfillCandidateImagesLocked(options);
+    } finally {
+      await lockClient.query("select pg_advisory_unlock($1)", [PAIRING_SEARCH_RUN_LOCK_KEY]);
+    }
   } finally {
-    await lockClient.query("select pg_advisory_unlock($1)", [PAIRING_SEARCH_RUN_LOCK_KEY]);
     lockClient.release();
   }
 }
@@ -78,6 +104,7 @@ async function backfillCandidateImagesLocked(options: BackfillCandidateImagesOpt
 
   let updated = 0;
   const errors: BackfillCandidateImagesError[] = [];
+  const noImageFoundByHost: Record<string, number> = {};
 
   for (const row of rows) {
     try {
@@ -89,6 +116,12 @@ async function backfillCandidateImagesLocked(options: BackfillCandidateImagesOpt
           .set({ imageUrl: image })
           .where(and(eq(pairingCandidates.productKey, row.productKey), eq(pairingCandidates.url, row.url)));
         updated += 1;
+      } else {
+        // `new URL(row.url).host` nikdy nevyhodí — `row.url` je vždy
+        // predtým uložená, už-validovaná absolútna URL (adaptér/`og:image`
+        // fallback ju cez `resolveAndStripFragment` vytvorili).
+        const host = new URL(row.url).host;
+        noImageFoundByHost[host] = (noImageFoundByHost[host] ?? 0) + 1;
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -100,5 +133,12 @@ async function backfillCandidateImagesLocked(options: BackfillCandidateImagesOpt
     }
   }
 
-  return { checked: rows.length, updated, failed: errors.length, errors };
+  for (const [host, count] of Object.entries(noImageFoundByHost)) {
+    log.warn(
+      { host, count },
+      "pairing-search: backfill nenašiel použiteľný og:image pre tento host — over, či doména vôbec obrázok v og:image ponúka (napr. BETALOV ho tam nikdy nemá, je to vždy stránkové logo)",
+    );
+  }
+
+  return { checked: rows.length, updated, failed: errors.length, errors, noImageFoundByHost };
 }

--- a/apps/api/src/modules/pairing-search/client.test.ts
+++ b/apps/api/src/modules/pairing-search/client.test.ts
@@ -91,7 +91,7 @@ describe("SearchClient", () => {
     const candidates = await client.search("odimon", "test");
 
     expect(candidates).toEqual<readonly PairingCandidate[]>([
-      { name: "Test produkt", url: "https://www.odimon.sk/p", code: null, price: null, rawScore: 0, codeHit: false },
+      { name: "Test produkt", url: "https://www.odimon.sk/p", code: null, price: null, imageUrl: null, rawScore: 0, codeHit: false },
     ]);
   });
 });

--- a/apps/api/src/modules/pairing-search/fixtures/odimon-vysledky-nohavice.html
+++ b/apps/api/src/modules/pairing-search/fixtures/odimon-vysledky-nohavice.html
@@ -10,6 +10,12 @@
   nohavice.html`). `.claude/rules/supplier-stock.md` potvrdzuje, že
   `odimon.sk` je BUXUS a JSON-LD na tejto doméne nie je pre stránku
   vyhľadávania relevantné (parser meno berie z `img[alt]`).
+
+  issue 397: PRVÁ karta má naviac naživo overené `data-src`/`src` atribúty
+  (13. 8. 2026) — `src` je na tejto doméne VŽDY `no-image.png` placeholder
+  (lazy-load cez JS), skutočný obrázok je len v `data-src`. Karty 2-4
+  ZÁMERNE ostávajú bez obrázkových atribútov (mechanizmus "chýbajúci
+  data-src/src -> imageUrl null", nie chyba).
 -->
 <html lang="sk">
 <head><title>Výsledky vyhľadávania: nohavice | odimon.sk</title></head>
@@ -24,7 +30,9 @@
       <div class="product tag-product-card">
         <div class="image">
           <a href="https://www.odimon.sk/obuv-a-oblecenie/polovnicke-oblecenie/polovnicke-termopradlo/termopradlo-nohavice-modal-termovel" class="product-card">
-            <img class="img-responsive lazy" alt="Termoprádlo nohavice modal Termovel">
+            <img class="img-responsive lazy" alt="Termoprádlo nohavice modal Termovel"
+                 data-src="/buxus/images/cache/product_catalog.eshop_product_list/produkty/katalog_produktov/obuv_a_oblecenie/polovnicke_termopradlo/termopradlo_nohavice_modal_termovel/20161611121146-termovelspodky.jpg"
+                 src="/buxus/images/cache/product_catalog.eshop_product_list/no-image.png">
           </a>
         </div>
       </div>

--- a/apps/api/src/modules/pairing-search/fixtures/wetland-vysledky-nohavice.html
+++ b/apps/api/src/modules/pairing-search/fixtures/wetland-vysledky-nohavice.html
@@ -9,13 +9,35 @@
   jav, ktorý `urldefrag` + dedup podľa URL musí zvládnuť (mechanizmus, nie
   naživo nájdená vzorka — rovnaký princíp ako `supplier-stock/fixtures/
   rosler-vypredane-noz-entita.html`).
+
+  issue 397: PRVÁ karta má naviac plný `article.product-miniature` obal so
+  `<picture><img>` (doslovne skopírované z reálnej odpovede, 13. 8. 2026) —
+  overuje `.closest(".product-miniature")` obrázkovú extrakciu naživo
+  overenou štruktúrou. Karty 2-4 ZÁMERNE ostávajú bez obalu (mechanizmus
+  "žiadny .product-miniature predok -> imageUrl null", nie chyba).
 -->
 <html lang="sk">
 <head><title>Vyhľadávanie: nohavice | wetland.sk</title></head>
 <body>
-  <div class="product-miniature__title">
-    <a class="link" href="https://www.wetland.sk/nohavice/deerhunter-pro-gamekeeper-boot-trousers-polovnicke-nohavice-111-592#/9-velkost-48">DEERHUNTER Pro Gamekeeper Boot Trousers - poľovnícke nohavice</a>
-  </div>
+  <article class="product-miniature js-product-miniature col-6 col-md-4 col-xl-3" data-id-product="111" data-id-product-attribute="592">
+    <div class="product-miniature__inner">
+      <a href="https://www.wetland.sk/nohavice/deerhunter-pro-gamekeeper-boot-trousers-polovnicke-nohavice-111-592#/9-velkost-48" class="product-miniature__link">
+        <div class="product-miniature__image-container thumbnail-container">
+          <picture>
+            <img
+              class="product-miniature__image card-img-top"
+              src="https://www.wetland.sk/7593-default_md/deerhunter-pro-gamekeeper-boot-trousers-polovnicke-nohavice.jpg"
+              alt="Obrázok"
+              data-full-size-image-url="https://www.wetland.sk/7593-home_default/deerhunter-pro-gamekeeper-boot-trousers-polovnicke-nohavice.jpg"
+            >
+          </picture>
+        </div>
+      </a>
+      <div class="product-miniature__title">
+        <a class="link" href="https://www.wetland.sk/nohavice/deerhunter-pro-gamekeeper-boot-trousers-polovnicke-nohavice-111-592#/9-velkost-48">DEERHUNTER Pro Gamekeeper Boot Trousers - poľovnícke nohavice</a>
+      </div>
+    </div>
+  </article>
   <div class="product-miniature__title">
     <a class="link" href="https://www.wetland.sk/nohavice/deerhunter-strike-extreme-pull-over-trousers-ochranne-nohavice-60-19897#/46-velkost-l_xl">DEERHUNTER Strike Extreme Pull-Over Trousers - ochranné nohavice</a>
   </div>

--- a/apps/api/src/modules/pairing-search/ranking.test.ts
+++ b/apps/api/src/modules/pairing-search/ranking.test.ts
@@ -7,7 +7,7 @@ function product(name: string, externalCodes: readonly string[] = []): PairingPr
 }
 
 function candidate(name: string, url: string, code: string | null = null): PairingCandidate {
-  return { name, url, code, price: null, rawScore: 0, codeHit: false };
+  return { name, url, code, price: null, imageUrl: null, rawScore: 0, codeHit: false };
 }
 
 // Fixtúry prevzaté z `tests/test_ranking.py` starej appky (commit 60b6164,

--- a/apps/api/src/modules/pairing-search/run.ts
+++ b/apps/api/src/modules/pairing-search/run.ts
@@ -106,7 +106,7 @@ async function runPairingSearchLocked(options: RunPairingSearchOptions): Promise
     try {
       const { queries, candidates } = await gatherCandidates(searchClient, item);
       const pick = pickBest(item.product, candidates);
-      const { verdict, verdictCheckedAt } = await verifyPickIfWarranted(searchClient, item.product, pick, now);
+      const { verdict, verdictCheckedAt, fallbackImageUrl } = await verifyPickIfWarranted(searchClient, item.product, pick, now);
       await upsertCandidateSet(db, {
         productKey: item.product.productKey,
         gatheredAt: now,
@@ -117,7 +117,7 @@ async function runPairingSearchLocked(options: RunPairingSearchOptions): Promise
         confidence: pick.confidence,
         verdict,
         verdictCheckedAt,
-        candidates,
+        candidates: applyImageFallback(candidates, pick.candidate?.url ?? null, fallbackImageUrl),
       });
       succeeded += 1;
     } catch (error) {
@@ -164,6 +164,11 @@ async function gatherCandidates(
 interface VerifyOutcomeFields {
   readonly verdict: PairingVerdict | null;
   readonly verdictCheckedAt: Date | null;
+  /** issue 397 — `og:image` z TEJ ISTEJ overovacej stránky, keď verify vôbec
+   *  fetchol (nulový extra request). `null`, keď sa neoverovalo VÔBEC, ALEBO
+   *  keď stránka žiadny použiteľný obrázok neniesla — `applyImageFallback`
+   *  nižšie ho použije LEN ako doplnok k chýbajúcemu adaptérovmu obrázku. */
+  readonly fallbackImageUrl: string | null;
 }
 
 /**
@@ -179,10 +184,29 @@ async function verifyPickIfWarranted(
   now: Date,
 ): Promise<VerifyOutcomeFields> {
   if (pick.candidate === null || (pick.confidence !== "high" && pick.confidence !== "medium")) {
-    return { verdict: null, verdictCheckedAt: null };
+    return { verdict: null, verdictCheckedAt: null, fallbackImageUrl: null };
   }
   const outcome = await verifyCandidateCode(client, pick.candidate.url, product);
-  return { verdict: outcome.verdict, verdictCheckedAt: now };
+  return { verdict: outcome.verdict, verdictCheckedAt: now, fallbackImageUrl: outcome.imageUrl };
+}
+
+/**
+ * issue 397: keď E4's overenie vrátilo `og:image` fallback, doplní ho LEN
+ * do CHOSEN kandidátovho riadku v top-8 poli (`chosenUrl` zhoda) A LEN keď
+ * ten riadok ešte NEMÁ vlastný obrázok z adaptéra — fallback fetch prebehol
+ * VÝHRADNE preň, ostatných top-8 kandidátov sa netýka. Vracia NOVÉ pole
+ * (vstupné `candidates` ostáva nedotknuté, rovnaká disciplína ako
+ * `ranking.ts`'s `rank()`).
+ */
+function applyImageFallback(
+  candidates: readonly PairingCandidate[],
+  chosenUrl: string | null,
+  fallbackImageUrl: string | null,
+): readonly PairingCandidate[] {
+  if (chosenUrl === null || fallbackImageUrl === null) return candidates;
+  return candidates.map((candidate) =>
+    candidate.url === chosenUrl && candidate.imageUrl === null ? { ...candidate, imageUrl: fallbackImageUrl } : candidate,
+  );
 }
 
 /** Krátky ľudsky čitateľný dôvod voľby — nová appka's pole, stará appka ho
@@ -239,6 +263,7 @@ async function upsertCandidateSet(db: Database, input: UpsertCandidateSetInput):
           url: candidate.url,
           code: candidate.code,
           price: candidate.price,
+          imageUrl: candidate.imageUrl,
           rawScore: candidate.rawScore.toFixed(4),
           codeHit: candidate.codeHit,
         })),

--- a/apps/api/src/modules/pairing-search/types.ts
+++ b/apps/api/src/modules/pairing-search/types.ts
@@ -34,12 +34,20 @@ export interface PairingProduct {
  * `rawScore`/`codeHit` sú diagnostické polia, ktoré dopĺňa `ranking.ts`'s
  * `rank()` (a zodpovedajú `pairing_candidate`'s `raw_score`/`code_hit`
  * stĺpcom z návrhu, sekcia „DB schéma" — pripravené na E3).
+ *
+ * `imageUrl` (issue 397, MIMO doslovného portu — stará appka obrázok
+ * kandidáta z výsledkovej karty nikdy neparsovala, ťahala ho až naživo z
+ * detailu pri otvorení webreview) — adaptéry ho čítajú priamo z výsledkovej
+ * karty (`adapters/url.ts`'s `resolveImageUrl`), `verify.ts` ho pri overení
+ * kódu vie doplniť z `og:image` detailu ako fallback (LEN pre chosen
+ * kandidáta, viď design komentár na tickete).
  */
 export interface PairingCandidate {
   readonly name: string;
   readonly url: string;
   readonly code: string | null;
   readonly price: string | null;
+  readonly imageUrl: string | null;
   readonly rawScore: number;
   readonly codeHit: boolean;
 }

--- a/apps/api/src/modules/pairing-search/verify.test.ts
+++ b/apps/api/src/modules/pairing-search/verify.test.ts
@@ -13,25 +13,32 @@ const WETLAND_DETAIL = fixture("wetland-detail-nohavice.html");
 const BETALOV_DETAIL = fixture("betalov-detail-nohavice.html");
 const ODIMON_DETAIL = fixture("odimon-detail-nohavice.html");
 
+// Detailná URL potrebná pre `extractPage`'s `og:image` rezolúciu (issue
+// 397) — žiadna z troch fixtúr vyššie `og:image` nenesie (živo overené
+// `grep`om, `apps/api/src/modules/pairing-search/fixtures/`), takže
+// `.image` na nich je vždy `null`; `og:image` správanie sa testuje
+// samostatne nižšie na syntetickom HTML.
+const DETAIL_URL = "https://www.wetland.sk/x";
+
 function product(externalCodes: readonly string[], name = "Testovací produkt"): PairingProduct {
   return { productKey: "P1", name, supplier: "WETLAND", externalCodes };
 }
 
 describe("extractPage — kódová kaskáda (issue 387 E4, port verify.py's extract_page)", () => {
   it("WETLAND (PrestaShop): preskočí .detail__title 'Značka' a nájde .detail__title 'Kód' -> .detail__right", () => {
-    const page = extractPage(WETLAND_DETAIL);
+    const page = extractPage(WETLAND_DETAIL, DETAIL_URL);
     expect(page.code).toBe("3726-391-48@");
     expect(page.title).toBe("DEERHUNTER Pro Gamekeeper Boot Trousers - poľovnícke nohavice");
   });
 
   it("BETALOV (Nette): .fs-5 regex 'Katalógové číslo: X'", () => {
-    const page = extractPage(BETALOV_DETAIL);
+    const page = extractPage(BETALOV_DETAIL, DETAIL_URL);
     expect(page.code).toBe("OB3022");
     expect(page.title).toBe("Detské outdoorové nohavice - Combi");
   });
 
   it("ODIMON (BUXUS, odchýlka od doslovného portu): preskočí 'Kategória' a nájde .product-property-item s 'kód' v popisku", () => {
-    const page = extractPage(ODIMON_DETAIL);
+    const page = extractPage(ODIMON_DETAIL, DETAIL_URL);
     expect(page.code).toBe("PO22811");
     expect(page.title).toBe("Termoprádlo nohavice modal Termovel");
   });
@@ -40,23 +47,23 @@ describe("extractPage — kódová kaskáda (issue 387 E4, port verify.py's extr
     const html =
       '<html><head><title>Produkt XY | Forestshop</title></head><body>' +
       '<span itemprop="sku">ABC123</span></body></html>';
-    const page = extractPage(html);
+    const page = extractPage(html, DETAIL_URL);
     expect(page.title).toBe("Produkt XY");
     expect(page.code).toBe("ABC123");
   });
 
   it("title-tag so ' - ' oddeľovačom (bez '|') sa tiež strihá na prvú časť", () => {
     const html = "<html><head><title>Produkt XY - Forestshop</title></head><body></body></html>";
-    expect(extractPage(html).title).toBe("Produkt XY");
+    expect(extractPage(html, DETAIL_URL).title).toBe("Produkt XY");
   });
 
   it("žiadny <h1> ani <title> -> prázdny title", () => {
-    expect(extractPage("<html><head></head><body><p>nič</p></body></html>").title).toBe("");
+    expect(extractPage("<html><head></head><body><p>nič</p></body></html>", DETAIL_URL).title).toBe("");
   });
 
   it("kód sa nikde na stránke nenašiel -> code je null", () => {
     const html = "<html><body><h1>Nejaký produkt</h1><p>bez akéhokoľvek kódu</p></body></html>";
-    expect(extractPage(html).code).toBeNull();
+    expect(extractPage(html, DETAIL_URL).code).toBeNull();
   });
 
   it(".detail__title bez slova 'kód' v texte (napr. len 'Značka') sa nikdy nepoužije ako zdroj kódu", () => {
@@ -64,53 +71,84 @@ describe("extractPage — kódová kaskáda (issue 387 E4, port verify.py's extr
       '<html><body><h1>X</h1><ul><li class="detail">' +
       '<div class="detail__left"><span class="detail__title">Značka</span></div>' +
       '<div class="detail__right">DEERHUNTER</div></li></ul></body></html>';
-    expect(extractPage(html).code).toBeNull();
+    expect(extractPage(html, DETAIL_URL).code).toBeNull();
+  });
+});
+
+describe("extractPage — og:image fallback (issue 397, mimo doslovného portu)", () => {
+  it("prítomný og:image sa resolvuje na absolútnu URL", () => {
+    const html = '<html><head><meta property="og:image" content="/img/produkt.jpg"></head><body></body></html>';
+    expect(extractPage(html, "https://www.odimon.sk/x").image).toBe("https://www.odimon.sk/img/produkt.jpg");
+  });
+
+  it("absolútny og:image content ostáva nezmenený", () => {
+    const html = '<html><head><meta property="og:image" content="https://www.odimon.sk/img/produkt.jpg"></head></html>';
+    expect(extractPage(html, DETAIL_URL).image).toBe("https://www.odimon.sk/img/produkt.jpg");
+  });
+
+  it("žiadny og:image -> image je null", () => {
+    expect(extractPage("<html><head></head><body></body></html>", DETAIL_URL).image).toBeNull();
+  });
+
+  it("šumový og:image (BETALOV's stránkové logo, živo overené 13. 8. 2026) sa filtruje na null", () => {
+    const html = '<html><head><meta property="og:image" content="https://www.huntingshop.eu/assets2/front/svg/logo2.svg"></head></html>';
+    expect(extractPage(html, "https://www.huntingshop.eu/x").image).toBeNull();
+  });
+
+  it("prázdny og:image content -> image je null", () => {
+    const html = '<html><head><meta property="og:image" content=""></head></html>';
+    expect(extractPage(html, DETAIL_URL).image).toBeNull();
   });
 });
 
 describe("codeVerdict — port verify.py's code_verdict (viac-kódová adaptácia)", () => {
   it("produkt bez external kódu je VŽDY unsure — nikdy false-ok", () => {
-    const result = codeVerdict(product([]), { title: "čokoľvek", code: null });
+    const result = codeVerdict(product([]), { title: "čokoľvek", code: null, image: null });
     expect(result.verdict).toBe("unsure");
   });
 
   it("kód sa nachádza priamo v extrahovanom .code poli -> ok", () => {
-    const result = codeVerdict(product(["OB570"]), { title: "HART RANDO XHP OB570", code: "OB570" });
+    const result = codeVerdict(product(["OB570"]), { title: "HART RANDO XHP OB570", code: "OB570", image: null });
     expect(result.verdict).toBe("ok");
     expect(result.reason).toContain("OB570");
   });
 
   it("kód sa nenašiel na stránke -> unsure", () => {
-    const result = codeVerdict(product(["OB570"]), { title: "Iný produkt", code: "ZZ9" });
+    const result = codeVerdict(product(["OB570"]), { title: "Iný produkt", code: "ZZ9", image: null });
     expect(result.verdict).toBe("unsure");
   });
 
   it("regresia: kód '376' sa nezhoduje ako podreťazec '3760' (code_present hranica)", () => {
-    const result = codeVerdict(product(["376"]), { title: "Lampáš model 3760", code: null });
+    const result = codeVerdict(product(["376"]), { title: "Lampáš model 3760", code: null, image: null });
     expect(result.verdict).toBe("unsure");
   });
 
   it("kód '376' sedí, keď je ohraničený (nie súčasť dlhšieho behu)", () => {
-    const result = codeVerdict(product(["376"]), { title: "Lampáš model 376 LED", code: "376" });
+    const result = codeVerdict(product(["376"]), { title: "Lampáš model 376 LED", code: "376", image: null });
     expect(result.verdict).toBe("ok");
   });
 
   it("viac external kódov (adaptácia na per-variant kódy): zhoda platí, keď sedí HOCIKTORÝ z nich", () => {
-    const result = codeVerdict(product(["NESEDI1", "SEDI2", "NESEDI3"]), { title: "Produkt SEDI2 model", code: null });
+    const result = codeVerdict(product(["NESEDI1", "SEDI2", "NESEDI3"]), { title: "Produkt SEDI2 model", code: null, image: null });
     expect(result.verdict).toBe("ok");
     expect(result.reason).toContain("SEDI2");
   });
 
   it("žiadny z viacerých kódov nesedí -> unsure, dôvod cituje všetky", () => {
-    const result = codeVerdict(product(["A1", "B2"]), { title: "Nič také tu nie je", code: null });
+    const result = codeVerdict(product(["A1", "B2"]), { title: "Nič také tu nie je", code: null, image: null });
     expect(result.verdict).toBe("unsure");
     expect(result.reason).toContain("A1");
     expect(result.reason).toContain("B2");
   });
+
+  it("issue 397: image z page sa NESIE do výsledku bez ohľadu na kódový verdikt", () => {
+    const result = codeVerdict(product(["OB570"]), { title: "HART RANDO XHP OB570", code: "OB570", image: "https://x/img.jpg" });
+    expect(result.imageUrl).toBe("https://x/img.jpg");
+  });
 });
 
 describe("verifyCandidateCode — sieťový wrapper (SearchClient.fetchPage)", () => {
-  it("produkt bez external kódu sa NIKDY nefetchuje (šetrí requesty) a vráti unsure", async () => {
+  it("produkt bez external kódu sa NIKDY nefetchuje (šetrí requesty) a vráti unsure, imageUrl null", async () => {
     let called = false;
     const fetcher: Fetcher = () => {
       called = true;
@@ -119,6 +157,7 @@ describe("verifyCandidateCode — sieťový wrapper (SearchClient.fetchPage)", (
     const client = new SearchClient({ fetcher });
     const result = await verifyCandidateCode(client, "https://www.wetland.sk/x", product([]));
     expect(result.verdict).toBe("unsure");
+    expect(result.imageUrl).toBeNull();
     expect(called).toBe(false);
   });
 
@@ -129,11 +168,20 @@ describe("verifyCandidateCode — sieťový wrapper (SearchClient.fetchPage)", (
     expect(result.verdict).toBe("ok");
   });
 
-  it("zlyhaný fetch (sieťová chyba) sa NIKDY nevyhodí ďalej -> unsure s dôvodom", async () => {
+  it("issue 397: úspešný fetch vráti imageUrl z og:image TEJ ISTEJ stránky (žiadny extra fetch)", async () => {
+    const html = '<html><head><meta property="og:image" content="/img/x.jpg"></head><body><h1>H</h1></body></html>';
+    const fetcher: Fetcher = () => Promise.resolve(html);
+    const client = new SearchClient({ fetcher });
+    const result = await verifyCandidateCode(client, "https://www.wetland.sk/produkt-x", product(["KOD1"]));
+    expect(result.imageUrl).toBe("https://www.wetland.sk/img/x.jpg");
+  });
+
+  it("zlyhaný fetch (sieťová chyba) sa NIKDY nevyhodí ďalej -> unsure s dôvodom, imageUrl null", async () => {
     const fetcher: Fetcher = () => Promise.reject(new Error("simulovaný sieťový pád"));
     const client = new SearchClient({ fetcher });
     const result = await verifyCandidateCode(client, "https://www.wetland.sk/x", product(["KOD1"]));
     expect(result.verdict).toBe("unsure");
     expect(result.reason).toContain("simulovaný sieťový pád");
+    expect(result.imageUrl).toBeNull();
   });
 });

--- a/apps/api/src/modules/pairing-search/verify.ts
+++ b/apps/api/src/modules/pairing-search/verify.ts
@@ -23,23 +23,36 @@
 // Krok 2b nižšie (`.product-property-item`) je NOVÝ, pridaný medzi Nette a
 // generický fallback — bez neho by ODIMON kandidáti VŽDY skončili na
 // `unsure` (bezpečné, ale zbytočne slabé pokrytie tretiny dodávateľov).
+//
+// issue 397: `image` — `og:image` z TEJ ISTEJ detailnej HTML, čo táto
+// funkcia aj tak sťahuje na kódovú kaskádu (ŽIADEN extra request). Použité
+// v `run.ts` LEN ako fallback, keď adaptér vlastný obrázok z výsledkovej
+// karty nenašiel — filtrovaný cez `resolveImageUrl`'s šumový zoznam
+// (`adapters/url.ts`), lebo BETALOV's `og:image` je na tejto doméne VŽDY
+// stránkové logo (živo overené, design komentár na tickete).
 
 import * as cheerio from "cheerio";
+import { resolveImageUrl } from "./adapters/url.js";
 import { codePresent } from "./normalize.js";
 import type { SearchClient } from "./client.js";
 import type { PairingProduct, PairingVerdict } from "./types.js";
 import { log } from "../../logger.js";
 
 /** Výstup kódovej kaskády — port `extract_page`'s title+code polí (price sa
- *  neportuje, viď komentár vyššie). */
+ *  neportuje, viď komentár vyššie) + `image` (issue 397, mimo portu). */
 export interface PageExtract {
   readonly title: string;
   readonly code: string | null;
+  readonly image: string | null;
 }
 
 export interface VerifyOutcome {
   readonly verdict: PairingVerdict;
   readonly reason: string;
+  /** issue 397 — `og:image` fallback z tej istej stránky, `null` keď
+   *  chýba/je šumový (`resolveImageUrl`). Volajúci (`run.ts`) ho použije
+   *  LEN keď adaptér vlastný obrázok kandidáta nenašiel. */
+  readonly imageUrl: string | null;
 }
 
 const WHITESPACE_RUN = /\s+/g;
@@ -137,10 +150,28 @@ function extractCode($: cheerio.CheerioAPI): string | null {
   );
 }
 
-/** Port `extract_page` (title+code časť — price sa neportuje). */
-export function extractPage(html: string): PageExtract {
+/**
+ * issue 397 (mimo doslovného portu): `<meta property="og:image">` —
+ * jediný obrázkový zdroj tohto fallbacku (dispatch: "fallback og:image z
+ * detailu", nikdy celá stará appka's gallery-selektorová kaskáda —
+ * `adaptéry` už dnes reálne dávajú obrázok priamo z výsledkovej karty pre
+ * všetkých troch dodávateľov, toto je len defenzívna posledná záchrana).
+ * `resolveImageUrl` (zdieľané s adaptérmi) rieši relatívny `content` voči
+ * `detailUrl` A filtruje šumové obrázky (logo/placeholder/…) — bez tohto
+ * by BETALOV's stránkové logo (`og:image` je tam VŽDY logo, živo overené)
+ * skončilo ako "obrázok kandidáta".
+ */
+function extractOgImage($: cheerio.CheerioAPI, detailUrl: string): string | null {
+  const content = $('meta[property="og:image"]').first().attr("content");
+  return resolveImageUrl([content], detailUrl);
+}
+
+/** Port `extract_page` (title+code časť — price sa neportuje) + `image`
+ *  (issue 397). `detailUrl` je stránka, z ktorej `html` pochádza —
+ *  potrebná na rezolúciu relatívnej `og:image` URL (`resolveImageUrl`). */
+export function extractPage(html: string, detailUrl: string): PageExtract {
   const $ = cheerio.load(html);
-  return { title: collapseWhitespace(extractTitle($)), code: extractCode($) };
+  return { title: collapseWhitespace(extractTitle($)), code: extractCode($), image: extractOgImage($, detailUrl) };
 }
 
 /**
@@ -152,16 +183,17 @@ export function extractPage(html: string): PageExtract {
  */
 export function codeVerdict(product: PairingProduct, page: PageExtract): VerifyOutcome {
   if (product.externalCodes.length === 0) {
-    return { verdict: "unsure", reason: "produkt nemá žiadny external kód na overenie" };
+    return { verdict: "unsure", reason: "produkt nemá žiadny external kód na overenie", imageUrl: page.image };
   }
   const hay = [page.title, page.code ?? ""].filter((part) => part.length > 0).join(" ");
   const matchedCode = product.externalCodes.find((code) => codePresent(code, hay));
   if (matchedCode !== undefined) {
-    return { verdict: "ok", reason: `kód ${matchedCode} sa nachádza na stránke kandidáta` };
+    return { verdict: "ok", reason: `kód ${matchedCode} sa nachádza na stránke kandidáta`, imageUrl: page.image };
   }
   return {
     verdict: "unsure",
     reason: `žiadny z kódov produktu (${product.externalCodes.join(", ")}) sa na stránke kandidáta nenašiel`,
+    imageUrl: page.image,
   };
 }
 
@@ -178,7 +210,9 @@ export async function verifyCandidateCode(
   product: PairingProduct,
 ): Promise<VerifyOutcome> {
   if (product.externalCodes.length === 0) {
-    return { verdict: "unsure", reason: "produkt nemá žiadny external kód na overenie" };
+    // Žiadny fetch (šetrí requesty, nezmenené E4 správanie) — teda ani
+    // žiadna šanca na `og:image` fallback, `imageUrl` ostáva `null`.
+    return { verdict: "unsure", reason: "produkt nemá žiadny external kód na overenie", imageUrl: null };
   }
   // Sieťová ANI parse chyba sa nikdy nevyhodí ďalej — obe (fetch aj
   // extractPage/codeVerdict) sú v JEDNOM try, aby zlyhanie overenia nikdy
@@ -187,10 +221,10 @@ export async function verifyCandidateCode(
   // len fetch, nie parsovanie).
   try {
     const html = await client.fetchPage(url);
-    return codeVerdict(product, extractPage(html));
+    return codeVerdict(product, extractPage(html, url));
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     log.warn({ url, message }, "pairing-search: verify zlyhal, verdikt unsure");
-    return { verdict: "unsure", reason: `overenie kandidáta zlyhalo (${message})` };
+    return { verdict: "unsure", reason: `overenie kandidáta zlyhalo (${message})`, imageUrl: null };
   }
 }

--- a/apps/api/tests/helpers/pairing-review.ts
+++ b/apps/api/tests/helpers/pairing-review.ts
@@ -66,7 +66,14 @@ export async function seedPairingCandidateSet(
     readonly chosenUrl?: string | null;
     readonly confidence?: "high" | "medium" | "low" | "none";
     readonly verdict?: "ok" | "unsure" | null;
-    readonly candidates?: readonly { readonly url: string; readonly name: string; readonly rawScore: string; readonly codeHit: boolean }[];
+    readonly candidates?: readonly {
+      readonly url: string;
+      readonly name: string;
+      readonly rawScore: string;
+      readonly codeHit: boolean;
+      /** issue 397 — voliteľné, `undefined`/chýbajúce necháva DB default (`null`). */
+      readonly imageUrl?: string | null;
+    }[];
   } = {},
 ): Promise<void> {
   await db.insert(pairingCandidateSets).values({
@@ -86,6 +93,7 @@ export async function seedPairingCandidateSet(
       position: i,
       name: c.name,
       url: c.url,
+      imageUrl: c.imageUrl ?? null,
       rawScore: c.rawScore,
       codeHit: c.codeHit,
     });

--- a/apps/api/tests/pairing-review-http.integration.test.ts
+++ b/apps/api/tests/pairing-review-http.integration.test.ts
@@ -61,7 +61,13 @@ interface Telo {
     readonly hasEffectiveLink: boolean;
     readonly confidence: "high" | "medium" | "low" | "none";
     readonly verdict: "ok" | "unsure" | null;
-    readonly chosenCandidate: { readonly name: string; readonly url: string; readonly rawScore: number; readonly codeHit: boolean } | null;
+    readonly chosenCandidate: {
+      readonly name: string;
+      readonly url: string;
+      readonly imageUrl: string | null;
+      readonly rawScore: number;
+      readonly codeHit: boolean;
+    } | null;
   }[];
 }
 
@@ -92,7 +98,15 @@ it("napárovaný produkt (chosenUrl) nesie navrhnutého kandidáta so skóre/ist
     chosenUrl: "https://dodavatel.example.com/bunda-alfa",
     confidence: "high",
     verdict: "ok",
-    candidates: [{ url: "https://dodavatel.example.com/bunda-alfa", name: "Bunda Alfa", rawScore: "1080.5000", codeHit: true }],
+    candidates: [
+      {
+        url: "https://dodavatel.example.com/bunda-alfa",
+        name: "Bunda Alfa",
+        rawScore: "1080.5000",
+        codeHit: true,
+        imageUrl: "https://dodavatel.example.com/img/bunda-alfa.jpg",
+      },
+    ],
   });
 
   const telo = (await (await app.request("/api/pairing-review?filter=matched", { headers: { cookie } })).json()) as Telo;
@@ -100,7 +114,13 @@ it("napárovaný produkt (chosenUrl) nesie navrhnutého kandidáta so skóre/ist
   expect(item).toBeDefined();
   expect(item?.confidence).toBe("high");
   expect(item?.verdict).toBe("ok");
-  expect(item?.chosenCandidate).toMatchObject({ name: "Bunda Alfa", url: "https://dodavatel.example.com/bunda-alfa", rawScore: 1080.5, codeHit: true });
+  expect(item?.chosenCandidate).toMatchObject({
+    name: "Bunda Alfa",
+    url: "https://dodavatel.example.com/bunda-alfa",
+    imageUrl: "https://dodavatel.example.com/img/bunda-alfa.jpg",
+    rawScore: 1080.5,
+    codeHit: true,
+  });
 });
 
 it("nenapárovaný produkt (confidence none, žiadny kandidát) má chosenCandidate null a padne do filtra 'unmatched'", async () => {

--- a/apps/api/tests/pairing-search-backfill.integration.test.ts
+++ b/apps/api/tests/pairing-search-backfill.integration.test.ts
@@ -1,0 +1,186 @@
+// issue 397 — backfill obrázka CHOSEN kandidáta pre existujúcich `pairing_
+// candidate` riadkov bez neho. Design komentár na tickete ("Zvolený prístup
+// — existujúcich 1309 kandidátov bez obrázka"): cielený backfill (JEDEN
+// fetch na produkt), nikdy `input_hash` bump/plný re-gather.
+
+import { eq } from "drizzle-orm";
+import { afterEach, describe, expect, it } from "vitest";
+import type { Database } from "../src/db/client.js";
+import { pairingCandidates } from "../src/db/schema.js";
+import { SearchClient, type Fetcher } from "../src/modules/pairing-search/client.js";
+import { backfillCandidateImages } from "../src/modules/pairing-search/backfill.js";
+import { insertTestSnapshot } from "./helpers/catalog.js";
+import { withCleanDb } from "./helpers/db.js";
+import { seedPairingCandidateSet as seedCandidateSet, seedPairingReviewProduct as seedProduct } from "./helpers/pairing-review.js";
+
+let close: (() => Promise<void>) | undefined;
+
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+});
+
+async function boot(): Promise<Database> {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  return ctx.db;
+}
+
+function ogImageHtml(imageUrl: string): string {
+  return `<html><head><meta property="og:image" content="${imageUrl}"></head><body></body></html>`;
+}
+
+describe("backfillCandidateImages (issue 397)", () => {
+  it("backfills the CHOSEN candidate's image from og:image, leaves other top-8 rows untouched", async () => {
+    const db = await boot();
+    const snapshotId = await insertTestSnapshot(db);
+    await seedProduct(db, snapshotId, "P1", { name: "Bunda P1" });
+    await seedCandidateSet(db, "P1", {
+      chosenUrl: "https://dodavatel.example.com/chosen",
+      confidence: "high",
+      candidates: [
+        { url: "https://dodavatel.example.com/chosen", name: "Chosen", rawScore: "1050.0000", codeHit: true },
+        { url: "https://dodavatel.example.com/other", name: "Other (nie chosen)", rawScore: "60.0000", codeHit: false },
+      ],
+    });
+
+    let calls = 0;
+    const fetcher: Fetcher = (url) => {
+      calls += 1;
+      expect(url).toBe("https://dodavatel.example.com/chosen"); // NIKDY non-chosen top-8 riadok
+      return Promise.resolve(ogImageHtml("https://dodavatel.example.com/img/chosen.jpg"));
+    };
+    const searchClient = new SearchClient({ fetcher });
+
+    const result = await backfillCandidateImages({ db, searchClient });
+
+    expect(result).toMatchObject({ checked: 1, updated: 1, failed: 0 });
+    expect(calls).toBe(1);
+
+    const rows = await db.select().from(pairingCandidates).where(eq(pairingCandidates.productKey, "P1"));
+    expect(rows.find((r) => r.url === "https://dodavatel.example.com/chosen")?.imageUrl).toBe(
+      "https://dodavatel.example.com/img/chosen.jpg",
+    );
+    expect(rows.find((r) => r.url === "https://dodavatel.example.com/other")?.imageUrl).toBeNull();
+  });
+
+  it("skips a candidate that ALREADY has an image (adaptér ho už našiel pri gathere)", async () => {
+    const db = await boot();
+    const snapshotId = await insertTestSnapshot(db);
+    await seedProduct(db, snapshotId, "P1", { name: "Bunda P1" });
+    await seedCandidateSet(db, "P1", {
+      chosenUrl: "https://dodavatel.example.com/chosen",
+      candidates: [
+        {
+          url: "https://dodavatel.example.com/chosen",
+          name: "Chosen",
+          rawScore: "1050.0000",
+          codeHit: true,
+          imageUrl: "https://dodavatel.example.com/uz-mam-obrazok.jpg",
+        },
+      ],
+    });
+
+    let called = false;
+    const fetcher: Fetcher = () => {
+      called = true;
+      return Promise.resolve(ogImageHtml("https://dodavatel.example.com/nikdy-pouzity.jpg"));
+    };
+    const result = await backfillCandidateImages({ db, searchClient: new SearchClient({ fetcher }) });
+
+    expect(result).toMatchObject({ checked: 0, updated: 0, failed: 0 });
+    expect(called).toBe(false);
+
+    const [row] = await db.select().from(pairingCandidates).where(eq(pairingCandidates.url, "https://dodavatel.example.com/chosen"));
+    expect(row?.imageUrl).toBe("https://dodavatel.example.com/uz-mam-obrazok.jpg");
+  });
+
+  it("stránka bez použiteľného og:image (šumový/chýbajúci) sa NEPOČÍTA ako chyba, len ostáva null", async () => {
+    const db = await boot();
+    const snapshotId = await insertTestSnapshot(db);
+    await seedProduct(db, snapshotId, "P1", { name: "Bunda P1" });
+    await seedCandidateSet(db, "P1", {
+      chosenUrl: "https://dodavatel.example.com/chosen",
+      candidates: [{ url: "https://dodavatel.example.com/chosen", name: "Chosen", rawScore: "1050.0000", codeHit: true }],
+    });
+
+    const fetcher: Fetcher = () => Promise.resolve("<html><head></head><body>bez og:image</body></html>");
+    const result = await backfillCandidateImages({ db, searchClient: new SearchClient({ fetcher }) });
+
+    expect(result).toMatchObject({ checked: 1, updated: 0, failed: 0 });
+    const [row] = await db.select().from(pairingCandidates).where(eq(pairingCandidates.url, "https://dodavatel.example.com/chosen"));
+    expect(row?.imageUrl).toBeNull();
+  });
+
+  it("zlyhaný fetch pre JEDEN produkt sa zaloguje do errors a POKRAČUJE ďalším produktom", async () => {
+    const db = await boot();
+    const snapshot1 = await insertTestSnapshot(db);
+    await seedProduct(db, snapshot1, "FAIL", { name: "Bunda FAIL" });
+    await seedCandidateSet(db, "FAIL", {
+      chosenUrl: "https://dodavatel.example.com/fail",
+      candidates: [{ url: "https://dodavatel.example.com/fail", name: "Fail", rawScore: "1050.0000", codeHit: true }],
+    });
+    const snapshot2 = await insertTestSnapshot(db);
+    await seedProduct(db, snapshot2, "OK", { name: "Bunda OK" });
+    await seedCandidateSet(db, "OK", {
+      chosenUrl: "https://dodavatel.example.com/ok",
+      candidates: [{ url: "https://dodavatel.example.com/ok", name: "OK", rawScore: "1050.0000", codeHit: true }],
+    });
+
+    const fetcher: Fetcher = (url) => {
+      if (url.includes("fail")) return Promise.reject(new Error("simulovaný sieťový pád"));
+      return Promise.resolve(ogImageHtml("https://dodavatel.example.com/img/ok.jpg"));
+    };
+    const result = await backfillCandidateImages({ db, searchClient: new SearchClient({ fetcher }) });
+
+    expect(result).toMatchObject({ checked: 2, updated: 1, failed: 1 });
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]?.productKey).toBe("FAIL");
+    expect(result.errors[0]?.message).toContain("simulovaný sieťový pád");
+
+    const [okRow] = await db.select().from(pairingCandidates).where(eq(pairingCandidates.url, "https://dodavatel.example.com/ok"));
+    expect(okRow?.imageUrl).toBe("https://dodavatel.example.com/img/ok.jpg");
+  });
+
+  it("idempotentný: druhý beh po úspešnom prvom nenájde už nič na doplnenie", async () => {
+    const db = await boot();
+    const snapshotId = await insertTestSnapshot(db);
+    await seedProduct(db, snapshotId, "P1", { name: "Bunda P1" });
+    await seedCandidateSet(db, "P1", {
+      chosenUrl: "https://dodavatel.example.com/chosen",
+      candidates: [{ url: "https://dodavatel.example.com/chosen", name: "Chosen", rawScore: "1050.0000", codeHit: true }],
+    });
+
+    let calls = 0;
+    const fetcher: Fetcher = () => {
+      calls += 1;
+      return Promise.resolve(ogImageHtml("https://dodavatel.example.com/img/x.jpg"));
+    };
+    const searchClient = new SearchClient({ fetcher });
+
+    const first = await backfillCandidateImages({ db, searchClient });
+    expect(first).toMatchObject({ checked: 1, updated: 1 });
+    expect(calls).toBe(1);
+
+    const second = await backfillCandidateImages({ db, searchClient });
+    expect(second).toMatchObject({ checked: 0, updated: 0, failed: 0 });
+    expect(calls).toBe(1); // žiadny ďalší fetch
+  });
+
+  it("produkt BEZ chosen_url (confidence none) sa nikdy nezoberie do backfillu", async () => {
+    const db = await boot();
+    const snapshotId = await insertTestSnapshot(db);
+    await seedProduct(db, snapshotId, "P1", { name: "Bunda P1" });
+    await seedCandidateSet(db, "P1", { confidence: "none" });
+
+    let called = false;
+    const fetcher: Fetcher = () => {
+      called = true;
+      return Promise.resolve(ogImageHtml("https://x/never.jpg"));
+    };
+    const result = await backfillCandidateImages({ db, searchClient: new SearchClient({ fetcher }) });
+
+    expect(result).toMatchObject({ checked: 0, updated: 0, failed: 0 });
+    expect(called).toBe(false);
+  });
+});

--- a/apps/api/tests/pairing-search-backfill.integration.test.ts
+++ b/apps/api/tests/pairing-search-backfill.integration.test.ts
@@ -4,18 +4,26 @@
 // fetch na produkt), nikdy `input_hash` bump/plný re-gather.
 
 import { eq } from "drizzle-orm";
+import pg from "pg";
 import { afterEach, describe, expect, it } from "vitest";
 import type { Database } from "../src/db/client.js";
 import { pairingCandidates } from "../src/db/schema.js";
 import { SearchClient, type Fetcher } from "../src/modules/pairing-search/client.js";
 import { backfillCandidateImages } from "../src/modules/pairing-search/backfill.js";
+import { PAIRING_SEARCH_RUN_LOCK_KEY } from "../src/modules/pairing-search/constants.js";
 import { insertTestSnapshot } from "./helpers/catalog.js";
 import { withCleanDb } from "./helpers/db.js";
 import { seedPairingCandidateSet as seedCandidateSet, seedPairingReviewProduct as seedProduct } from "./helpers/pairing-review.js";
 
 let close: (() => Promise<void>) | undefined;
+let lockHolder: pg.Client | undefined;
 
 afterEach(async () => {
+  if (lockHolder !== undefined) {
+    await lockHolder.query("select pg_advisory_unlock($1)", [PAIRING_SEARCH_RUN_LOCK_KEY]);
+    await lockHolder.end();
+    lockHolder = undefined;
+  }
   await close?.();
   close = undefined;
 });
@@ -167,11 +175,24 @@ describe("backfillCandidateImages (issue 397)", () => {
     expect(calls).toBe(1); // žiadny ďalší fetch
   });
 
-  it("produkt BEZ chosen_url (confidence none) sa nikdy nezoberie do backfillu", async () => {
+  // Review nález (issue 397): predošlá verzia tohto testu nesedela s ničím
+  // — `seedCandidateSet(db, "P1", { confidence: "none" })` vloží NULU
+  // `pairing_candidate` riadkov (`helpers/pairing-review.ts`'s `(over.
+  // candidates ?? [])`), takže `checked: 0` by platilo aj keby `innerJoin`
+  // bol `leftJoin`, alebo keby `eq(chosenUrl, url)` podmienka vôbec
+  // chýbala. TERAZ produkt SKUTOČNE nesie top-8 kandidátov (žiadny z nich
+  // `chosenUrl`, ktorý je `null`) — dokazuje, že `eq(pairingCandidateSets
+  // .chosenUrl, pairingCandidates.url)` proti `NULL` skutočne nikdy
+  // nezhodí ŽIADEN riadok (SQL `NULL = 'x'` je `NULL`, nikdy `true`).
+  it("produkt BEZ chosen_url (confidence none), ale S top-8 kandidátmi, sa nikdy nezoberie do backfillu", async () => {
     const db = await boot();
     const snapshotId = await insertTestSnapshot(db);
     await seedProduct(db, snapshotId, "P1", { name: "Bunda P1" });
-    await seedCandidateSet(db, "P1", { confidence: "none" });
+    await seedCandidateSet(db, "P1", {
+      chosenUrl: null,
+      confidence: "none",
+      candidates: [{ url: "https://dodavatel.example.com/nechosen", name: "Nikdy chosen", rawScore: "10.0000", codeHit: false }],
+    });
 
     let called = false;
     const fetcher: Fetcher = () => {
@@ -181,6 +202,107 @@ describe("backfillCandidateImages (issue 397)", () => {
     const result = await backfillCandidateImages({ db, searchClient: new SearchClient({ fetcher }) });
 
     expect(result).toMatchObject({ checked: 0, updated: 0, failed: 0 });
+    expect(called).toBe(false);
+
+    const [row] = await db.select().from(pairingCandidates).where(eq(pairingCandidates.url, "https://dodavatel.example.com/nechosen"));
+    expect(row?.imageUrl).toBeNull(); // ostal nedotknutý, nikdy nebol ani "checked"
+  });
+
+  // Review nález (issue 397): oba guardy v `applyImageFallback` (run.ts) —
+  // "nikdy neprepíš existujúci adaptérov obrázok" a "dotkni sa LEN chosen
+  // riadku" — sa dajú vymazať bez toho, aby padol JEDINÝ existujúci test.
+  // Toto je zámerne backfillov EKVIVALENT tej istej dvojice invariantov:
+  // backfill sa dotkne LEN riadkov s `image_url IS NULL` (`WHERE` klauzula,
+  // nikdy "prepíš aj existujúci"), a LEN chosen riadku (`INNER JOIN` na
+  // `chosenUrl = url`, nikdy iný top-8 riadok toho istého produktu).
+  it("issue 397: druhý top-8 kandidát BEZ obrázka, ktorý NIE JE chosen, ostáva nedotknutý (backfill sa ho ani nepýta)", async () => {
+    const db = await boot();
+    const snapshotId = await insertTestSnapshot(db);
+    await seedProduct(db, snapshotId, "P1", { name: "Bunda P1" });
+    await seedCandidateSet(db, "P1", {
+      chosenUrl: "https://dodavatel.example.com/chosen",
+      candidates: [
+        {
+          url: "https://dodavatel.example.com/chosen",
+          name: "Chosen",
+          rawScore: "1050.0000",
+          codeHit: true,
+          imageUrl: "https://dodavatel.example.com/uz-mam-obrazok.jpg",
+        },
+        { url: "https://dodavatel.example.com/druhy-bez-obrazka", name: "Druhý (nie chosen, bez obrázka)", rawScore: "60.0000", codeHit: false },
+      ],
+    });
+
+    let called = false;
+    const fetcher: Fetcher = () => {
+      called = true;
+      return Promise.resolve(ogImageHtml("https://dodavatel.example.com/nikdy-pouzity.jpg"));
+    };
+    const result = await backfillCandidateImages({ db, searchClient: new SearchClient({ fetcher }) });
+
+    // Chosen riadok je preskočený (už má obrázok), "druhý" riadok je
+    // preskočený (nie je chosen) — spolu `checked: 0`, ŽIADEN fetch.
+    expect(result).toMatchObject({ checked: 0, updated: 0, failed: 0 });
+    expect(called).toBe(false);
+
+    const [druhy] = await db.select().from(pairingCandidates).where(eq(pairingCandidates.url, "https://dodavatel.example.com/druhy-bez-obrazka"));
+    expect(druhy?.imageUrl).toBeNull();
+  });
+
+  // Review nález (issue 397): per-host prehľad (`noImageFoundByHost`) —
+  // operátor musí vedieť, KTORÝ host stránku stiahol, ale nedal žiadny
+  // použiteľný obrázok (napr. BETALOV, kde detailná og:image je VŽDY
+  // stránkové logo — šumový filter ho vyfiltruje na null KAŽDÝKRÁT).
+  it("issue 397: per-host prehľad ráta riadky, kde sa stránka stiahla, ale og:image nebol použiteľný", async () => {
+    const db = await boot();
+    const snapshotId = await insertTestSnapshot(db);
+    await seedProduct(db, snapshotId, "P1", { name: "Bunda P1", supplier: "BETALOV" });
+    await seedCandidateSet(db, "P1", {
+      chosenUrl: "https://www.huntingshop.eu/produkt-1",
+      candidates: [{ url: "https://www.huntingshop.eu/produkt-1", name: "Produkt 1", rawScore: "1050.0000", codeHit: true }],
+    });
+    const snapshot2 = await insertTestSnapshot(db);
+    await seedProduct(db, snapshot2, "P2", { name: "Bunda P2", supplier: "BETALOV" });
+    await seedCandidateSet(db, "P2", {
+      chosenUrl: "https://www.huntingshop.eu/produkt-2",
+      candidates: [{ url: "https://www.huntingshop.eu/produkt-2", name: "Produkt 2", rawScore: "1050.0000", codeHit: true }],
+    });
+
+    // BETALOV's detail og:image je VŽDY stránkové logo (živo overené,
+    // playbook) — `resolveImageUrl` ho vyfiltruje na null pre OBA riadky.
+    const fetcher: Fetcher = () =>
+      Promise.resolve('<html><head><meta property="og:image" content="https://www.huntingshop.eu/assets2/front/svg/logo2.svg"></head></html>');
+    const result = await backfillCandidateImages({ db, searchClient: new SearchClient({ fetcher }) });
+
+    expect(result).toMatchObject({ checked: 2, updated: 0, failed: 0 });
+    expect(result.noImageFoundByHost).toEqual({ "www.huntingshop.eu": 2 });
+  });
+
+  // Review nález (issue 397): `pg_advisory_lock` (BLOKUJÚCI) by tu ticho
+  // VISEL, kým `lockHolder` zámok nedrží — `pg_try_advisory_lock`
+  // (NEBLOKUJÚCI) musí zlyhať NAHLAS a okamžite namiesto zaseknutia.
+  it("issue 397: keď advisory zámok drží iné pripojenie (napr. nočný gather beh), backfill zlyhá NAHLAS namiesto ticheho zaseknutia", async () => {
+    const db = await boot();
+    const snapshotId = await insertTestSnapshot(db);
+    await seedProduct(db, snapshotId, "P1", { name: "Bunda P1" });
+    await seedCandidateSet(db, "P1", {
+      chosenUrl: "https://dodavatel.example.com/chosen",
+      candidates: [{ url: "https://dodavatel.example.com/chosen", name: "Chosen", rawScore: "1050.0000", codeHit: true }],
+    });
+
+    const databaseUrl = process.env["DATABASE_URL"];
+    if (databaseUrl === undefined || databaseUrl === "") throw new Error("DATABASE_URL chýba");
+    lockHolder = new pg.Client({ connectionString: databaseUrl });
+    await lockHolder.connect();
+    await lockHolder.query("select pg_advisory_lock($1)", [PAIRING_SEARCH_RUN_LOCK_KEY]);
+
+    let called = false;
+    const fetcher: Fetcher = () => {
+      called = true;
+      return Promise.resolve(ogImageHtml("https://nikdy-pouzity.example.com/x.jpg"));
+    };
+
+    await expect(backfillCandidateImages({ db, searchClient: new SearchClient({ fetcher }) })).rejects.toThrow(/advisory zámok/);
     expect(called).toBe(false);
   });
 });

--- a/apps/api/tests/pairing-search-run.integration.test.ts
+++ b/apps/api/tests/pairing-search-run.integration.test.ts
@@ -82,6 +82,18 @@ function wetlandCard(name: string, href: string): string {
   return `<div class="product-miniature__title"><a class="link" href="${href}">${name}</a></div>`;
 }
 
+/** issue 397 — plná `.product-miniature` obal-štruktúra s obrázkom, presne
+ * ako `wetland.ts`'s `.closest(".product-miniature")` obrázková extrakcia
+ * očakáva. */
+function wetlandCardWithImage(name: string, href: string, imageSrc: string): string {
+  return (
+    `<article class="product-miniature">` +
+    `<a class="product-miniature__link"><img class="product-miniature__image" src="${imageSrc}"></a>` +
+    `<div class="product-miniature__title"><a class="link" href="${href}">${name}</a></div>` +
+    `</article>`
+  );
+}
+
 function fakeWetlandFetcher(html: string, onCall?: (url: string) => void): Fetcher {
   return (url) => {
     onCall?.(url);
@@ -112,6 +124,23 @@ describe("pairing-search: gather beh (issue 387 E3)", () => {
     const candidates = await db.select().from(pairingCandidates).where(eq(pairingCandidates.productKey, "P1"));
     expect(candidates).toHaveLength(2);
     expect(candidates.find((c) => c.position === 0)?.url).toBe("https://www.wetland.sk/p/1");
+  });
+
+  // issue 397: adaptér už NAPĺŇA `imageUrl` priamo z výsledkovej karty —
+  // over, že sa nesie AŽ do DB, žiadny extra fetch navyše (dispatch, "adaptéry
+  // čítajú obrázok priamo z výsledkovej karty").
+  it("issue 397: obrázok kandidáta z výsledkovej karty (adaptér) sa uloží do pairing_candidate.image_url", async () => {
+    const db = await boot();
+    await seedSupplier(db, "WETLAND", "wetland");
+    await seedProduct(db, "P1", { name: "Bunda Wetland" });
+
+    const html = `<div>${wetlandCardWithImage("Bunda Wetland", "https://www.wetland.sk/p/1", "/img/bunda.jpg")}</div>`;
+    const searchClient = new SearchClient({ fetcher: fakeWetlandFetcher(html) });
+
+    await runPairingSearch({ db, now: NOW, searchClient });
+
+    const [candidate] = await db.select().from(pairingCandidates).where(eq(pairingCandidates.productKey, "P1"));
+    expect(candidate?.imageUrl).toBe("https://www.wetland.sk/img/bunda.jpg");
   });
 
   it("kódová zhoda vždy vyhrá nad menovou (confidence high, aj keď meno nesedí)", async () => {

--- a/apps/api/tests/pairing-search-verify.integration.test.ts
+++ b/apps/api/tests/pairing-search-verify.integration.test.ts
@@ -6,7 +6,7 @@
 import { eq } from "drizzle-orm";
 import { afterEach, describe, expect, it } from "vitest";
 import type { Database } from "../src/db/client.js";
-import { pairingCandidateSets, products, suppliers, variants } from "../src/db/schema.js";
+import { pairingCandidates, pairingCandidateSets, products, suppliers, variants } from "../src/db/schema.js";
 import { SearchClient, type Fetcher } from "../src/modules/pairing-search/client.js";
 import { runPairingSearch } from "../src/modules/pairing-search/run.js";
 import { insertTestSnapshot } from "./helpers/catalog.js";
@@ -84,6 +84,17 @@ function wetlandDetailPage(code: string | null): string {
       ? ""
       : `<li class="detail"><div class="detail__left"><span class="detail__title">Kód</span></div><div class="detail__right"><span>${code}</span></div></li>`;
   return `<html><body><h1>Detail kandidáta</h1><ul class="product__details">${codeBlock}</ul></body></html>`;
+}
+
+/** issue 397 — rovnaká detailná stránka, naviac s `og:image` — dokazuje
+ *  fallback (`applyImageFallback`, `run.ts`) na TEJ ISTEJ HTML, čo E4 aj
+ *  tak sťahuje na kódovú kaskádu. */
+function wetlandDetailPageWithImage(code: string | null, imageContent: string): string {
+  const codeBlock =
+    code === null
+      ? ""
+      : `<li class="detail"><div class="detail__left"><span class="detail__title">Kód</span></div><div class="detail__right"><span>${code}</span></div></li>`;
+  return `<html><head><meta property="og:image" content="${imageContent}"></head><body><h1>Detail kandidáta</h1><ul class="product__details">${codeBlock}</ul></body></html>`;
 }
 
 /** Smeruje podľa URL: `vyhladavanie` -> search výsledky, inak (kandidátova
@@ -172,5 +183,43 @@ describe("pairing-search: kódové overenie (issue 387 E4)", () => {
     // externalCodes.length === 0`) — žiadne ĎALŠIE volanie na
     // "/p/medium" nad rámec search dopytov.
     expect(calls.some((url) => url === "https://www.wetland.sk/p/medium")).toBe(false);
+  });
+
+  // issue 397 (mimo doslovného portu) — `og:image` fallback z TEJ ISTEJ
+  // detailnej stránky, čo E4 už aj tak fetchuje na kódovú kaskádu. Design
+  // komentár na tickete: fallback platí LEN pre CHOSEN kandidáta (adaptér
+  // vlastný obrázok z `wetlandCard` helperu tu nikdy nedostane, keďže ten
+  // nenesie žiadny `.product-miniature` obal — presne prípad, kde fallback
+  // musí zaskočiť).
+  it("issue 397: vysoká istota + adaptér bez obrázka -> chosen kandidát dostane og:image fallback z detailu", async () => {
+    const db = await boot();
+    await seedSupplier(db);
+    await seedProduct(db, "P1", { name: "Nohavice X", externalCode: "KOD777" });
+
+    const searchHtml = wetlandCard("Úplne iný text KOD777 model", "https://www.wetland.sk/p/kod");
+    const calls: string[] = [];
+    const detailHtml = wetlandDetailPageWithImage("KOD777", "/img/kod777.jpg");
+    const client = new SearchClient({ fetcher: routingFetcher(searchHtml, detailHtml, calls) });
+
+    await runPairingSearch({ db, now: NOW, searchClient: client });
+
+    const [chosen] = await db.select().from(pairingCandidates).where(eq(pairingCandidates.url, "https://www.wetland.sk/p/kod"));
+    expect(chosen?.imageUrl).toBe("https://www.wetland.sk/img/kod777.jpg");
+  });
+
+  it("issue 397: fallback sa NIKDY neuplatní, keď verify vôbec nebeží (low confidence)", async () => {
+    const db = await boot();
+    await seedSupplier(db);
+    await seedProduct(db, "P1", { name: "Bunda Wetland" });
+
+    const searchHtml = wetlandCard("Úplne nesúvisiaci produkt XYZ", "https://www.wetland.sk/p/low");
+    const calls: string[] = [];
+    const detailHtml = wetlandDetailPageWithImage("HOCICO", "/img/nikdy-pouzity.jpg");
+    const client = new SearchClient({ fetcher: routingFetcher(searchHtml, detailHtml, calls) });
+
+    await runPairingSearch({ db, now: NOW, searchClient: client });
+
+    const [chosen] = await db.select().from(pairingCandidates).where(eq(pairingCandidates.url, "https://www.wetland.sk/p/low"));
+    expect(chosen?.imageUrl).toBeNull();
   });
 });

--- a/apps/api/tests/pairing-search-verify.integration.test.ts
+++ b/apps/api/tests/pairing-search-verify.integration.test.ts
@@ -86,6 +86,19 @@ function wetlandDetailPage(code: string | null): string {
   return `<html><body><h1>Detail kandidáta</h1><ul class="product__details">${codeBlock}</ul></body></html>`;
 }
 
+/** issue 397 — plná `.product-miniature` obal-štruktúra s obrázkom
+ *  (mirror `pairing-search-run.integration.test.ts`'s rovnomenného
+ *  helperu) — pre karty, kde chceme dokázať, že adaptérov OBRÁZOK vyhráva
+ *  nad `og:image` fallbackom, nikdy naopak. */
+function wetlandCardWithImage(name: string, href: string, imageSrc: string): string {
+  return (
+    `<article class="product-miniature">` +
+    `<a class="product-miniature__link"><img class="product-miniature__image" src="${imageSrc}"></a>` +
+    `<div class="product-miniature__title"><a class="link" href="${href}">${name}</a></div>` +
+    `</article>`
+  );
+}
+
 /** issue 397 — rovnaká detailná stránka, naviac s `og:image` — dokazuje
  *  fallback (`applyImageFallback`, `run.ts`) na TEJ ISTEJ HTML, čo E4 aj
  *  tak sťahuje na kódovú kaskádu. */
@@ -205,6 +218,34 @@ describe("pairing-search: kódové overenie (issue 387 E4)", () => {
 
     const [chosen] = await db.select().from(pairingCandidates).where(eq(pairingCandidates.url, "https://www.wetland.sk/p/kod"));
     expect(chosen?.imageUrl).toBe("https://www.wetland.sk/img/kod777.jpg");
+  });
+
+  // Review nález (issue 397): oba guardy vnútri `applyImageFallback`
+  // (run.ts) — "nikdy neprepíš adaptérov obrázok" a "dotkni sa LEN chosen
+  // riadku top-8 poľa" — sa dali vymazať bez toho, aby padol ktorýkoľvek
+  // existujúci test (predošlý fallback test mal LEN JEDNÉHO kandidáta bez
+  // vlastného obrázka). Tento test má DVOCH kandidátov naraz: chosen (kód
+  // sedí) UŽ MÁ adaptérov obrázok, druhý (nie chosen) obrázok nemá vôbec —
+  // dokazuje OBE vlastnosti v jednom behu.
+  it("issue 397: og:image fallback NIKDY neprepíše existujúci adaptérov obrázok chosen kandidáta, ani sa nedotkne iného top-8 riadku", async () => {
+    const db = await boot();
+    await seedSupplier(db);
+    await seedProduct(db, "P1", { name: "Nohavice X", externalCode: "KOD777" });
+
+    const searchHtml = `<div>${wetlandCardWithImage("Úplne iný text KOD777 model", "https://www.wetland.sk/p/kod", "/img/adapter-kod.jpg")}${wetlandCard("Úplne nesúvisiaci iný produkt", "https://www.wetland.sk/p/other")}</div>`;
+    const calls: string[] = [];
+    // og:image fallback by (nesprávne) ponúklo TENTO obrázok — dôkaz, že sa
+    // NIKDY nepoužije, keďže chosen už má vlastný adaptérov obrázok.
+    const detailHtml = wetlandDetailPageWithImage("KOD777", "/img/og-image-fallback-nikdy-pouzity.jpg");
+    const client = new SearchClient({ fetcher: routingFetcher(searchHtml, detailHtml, calls) });
+
+    await runPairingSearch({ db, now: NOW, searchClient: client });
+
+    const [chosen] = await db.select().from(pairingCandidates).where(eq(pairingCandidates.url, "https://www.wetland.sk/p/kod"));
+    expect(chosen?.imageUrl).toBe("https://www.wetland.sk/img/adapter-kod.jpg"); // adaptérov, nikdy og:image
+
+    const [other] = await db.select().from(pairingCandidates).where(eq(pairingCandidates.url, "https://www.wetland.sk/p/other"));
+    expect(other?.imageUrl).toBeNull(); // NIE chosen -> fallback sa ho vôbec netýka
   });
 
   it("issue 397: fallback sa NIKDY neuplatní, keď verify vôbec nebeží (low confidence)", async () => {

--- a/apps/web/src/components/PairingReviewCard.test.tsx
+++ b/apps/web/src/components/PairingReviewCard.test.tsx
@@ -38,7 +38,13 @@ const MATCHED_ITEM = {
   confidence: "high" as const,
   chosenReason: "najlepší nájdený",
   verdict: "ok" as const,
-  chosenCandidate: { name: "Bunda Alfa", url: "https://dodavatel.example.com/bunda-alfa", rawScore: 1080.5, codeHit: true },
+  chosenCandidate: {
+    name: "Bunda Alfa",
+    url: "https://dodavatel.example.com/bunda-alfa",
+    imageUrl: "https://dodavatel.example.com/img/bunda-alfa.jpg",
+    rawScore: 1080.5,
+    codeHit: true,
+  },
   decision: null,
 };
 
@@ -88,6 +94,22 @@ it("napárovaný produkt bez rozhodnutia ukáže ✓ Dobré / ✗ Zlé; klik na 
   await waitFor(() => {
     expect(onDecided).toHaveBeenCalledTimes(1);
   });
+});
+
+it("issue 397: karta ukazuje obrázok kandidáta AJ nášho produktu vedľa seba; chýbajúci obrázok kandidáta ukáže 'bez obrázka'", async () => {
+  render(<PairingReviewCard item={MATCHED_ITEM} role="citanie" onDecided={() => {}} onSessionExpired={() => {}} />);
+  const card = await screen.findByTestId("pairing-review-card-PR-1");
+  const images = card.querySelectorAll("img");
+  expect(images).toHaveLength(2);
+  expect(images[0]?.getAttribute("src")).toBe(MATCHED_ITEM.ourImageUrl);
+  expect(images[1]?.getAttribute("src")).toBe(MATCHED_ITEM.chosenCandidate.imageUrl);
+
+  cleanup();
+  const bezObrazka = { ...MATCHED_ITEM, productKey: "PR-NOIMG", chosenCandidate: { ...MATCHED_ITEM.chosenCandidate, imageUrl: null } };
+  render(<PairingReviewCard item={bezObrazka} role="citanie" onDecided={() => {}} onSessionExpired={() => {}} />);
+  const cardBezObrazka = await screen.findByTestId("pairing-review-card-PR-NOIMG");
+  expect(cardBezObrazka.querySelectorAll("img")).toHaveLength(1); // len naša strana
+  expect(cardBezObrazka.querySelectorAll(".pairing-review-noimg")).toHaveLength(1);
 });
 
 it("klik na ✗ Zlé ROZBALÍ panel NA MIESTE (karta ostáva) a načíta kandidátov; 'Vybrať' odošle manual s URL toho kandidáta", async () => {

--- a/apps/web/src/components/PairingReviewCard.tsx
+++ b/apps/web/src/components/PairingReviewCard.tsx
@@ -206,6 +206,13 @@ export function PairingReviewCard({
                   {VERDICT_LABELS[item.verdict]}
                 </div>
               )}
+              <div className="pairing-review-imgbox">
+                {item.chosenCandidate.imageUrl !== null ? (
+                  <img src={item.chosenCandidate.imageUrl} alt={item.chosenCandidate.name} loading="lazy" />
+                ) : (
+                  <span className="pairing-review-noimg">bez obrázka</span>
+                )}
+              </div>
             </div>
           )}
 

--- a/apps/web/src/pairingReviewApi.ts
+++ b/apps/web/src/pairingReviewApi.ts
@@ -11,6 +11,8 @@ export type PairingReviewFilter = (typeof PAIRING_REVIEW_FILTERS)[number];
 const chosenCandidateSchema = z.object({
   name: z.string(),
   url: z.string(),
+  // issue 397 — obrázok kandidáta (adaptér, alebo `og:image` fallback).
+  imageUrl: z.string().nullable(),
   rawScore: z.number(),
   codeHit: z.boolean(),
 });

--- a/apps/web/tests/e2e/pairing-review.spec.ts
+++ b/apps/web/tests/e2e/pairing-review.spec.ts
@@ -6,6 +6,15 @@ const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáz
 // na hranici `MAX_ATTEMPTS`. Musí sa zhodovať s `scripts/e2e-fixtures-
 // pairing-review.ts`'s `E2E_PAROVANIE_REVIEW_EMAIL`.
 const E2E_PAROVANIE_REVIEW_EMAIL = "e2e-parovanie-review@forestshop.sk";
+// issue 397 — musia sa zhodovať s `E2E_OUR_IMAGE_DATA_URI`/`E2E_CANDIDATE_
+// IMAGE_DATA_URI` v `scripts/e2e-fixtures-pairing-review.ts` (rovnaký
+// "musí sa zhodovať" vzor ako heslo/email vyššie — `data:` URI, nikdy
+// skutočná `https://` adresa, inak prehliadač reálne skúsi obrázok
+// stiahnuť a zapíše `net::ERR_NAME_NOT_RESOLVED`/404 do konzoly).
+const E2E_OUR_IMAGE_DATA_URI =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC";
+const E2E_CANDIDATE_IMAGE_DATA_URI =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGNgYPgPAAEDAQAIicLsAAAAAElFTkSuQmCC";
 
 // issue 387 E5: "Eshop → Párovanie" — VIDITEĽNÁ záložka (`nav.ts`, priečinok
 // Eshop). Fixtúry (`scripts/e2e-fixtures-pairing-review.ts`): "E2E-PR-CHYBA"
@@ -53,6 +62,13 @@ test("predvolený filter 'Nezrevidované' ukáže produkty bez linky (s aj bez k
   await expect(page.getByTestId("pairing-review-candidate-E2E-PR-CHYBA")).toContainText("E2E Bunda Alfa u dodávateľa");
   await expect(chybaKarta.getByTestId("pairing-review-good-E2E-PR-CHYBA")).toBeVisible();
   await expect(chybaKarta.getByTestId("pairing-review-open-panel-E2E-PR-CHYBA")).toBeVisible();
+
+  // issue 397 — karta ukazuje OBA obrázky vedľa seba (náš produkt aj
+  // navrhnutý kandidát), nielen text okolo nich (`scripts/e2e-fixtures-
+  // pairing-review.ts` seeduje OBE obrázkové URL pre "E2E-PR-CHYBA").
+  await expect(chybaKarta.locator("img")).toHaveCount(2);
+  await expect(chybaKarta.locator("img").nth(0)).toHaveAttribute("src", E2E_OUR_IMAGE_DATA_URI);
+  await expect(chybaKarta.locator("img").nth(1)).toHaveAttribute("src", E2E_CANDIDATE_IMAGE_DATA_URI);
 
   // Nenapárovaný produkt (gather nenašiel u dodávateľa nič) — vlastná hláška.
   const nenajdenyKarta = page.getByTestId("pairing-review-card-E2E-PR-NENAJDENY");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.234",
+  "version": "0.3.0-dev.235",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "gates:local": "pnpm typecheck && pnpm lint && pnpm test",
     "catalog:ingest": "tsx scripts/catalog-ingest.ts",
     "catalog:prune-raw": "tsx scripts/catalog-prune-raw.ts",
-    "orders:ingest": "tsx scripts/orders-ingest.ts"
+    "orders:ingest": "tsx scripts/orders-ingest.ts",
+    "pairing:backfill-images": "tsx scripts/pairing-backfill-images.ts"
   },
   "devDependencies": {
     "@eslint/js": "^9.0.0",

--- a/scripts/e2e-fixtures-pairing-review.ts
+++ b/scripts/e2e-fixtures-pairing-review.ts
@@ -9,13 +9,29 @@
 // (dokazuje, že "unreviewed" filter/odznak ho vylúči — design komentár na
 // tickete, issue 387 E5).
 import type { Database } from "../apps/api/src/db/client.js";
-import { pairingCandidates, pairingCandidateSets, products, users, variants } from "../apps/api/src/db/schema.js";
+import { pairingCandidates, pairingCandidateSets, products, shopProductUrl, users, variants } from "../apps/api/src/db/schema.js";
 import { hashPassword } from "../apps/api/src/modules/auth/passwords.js";
 
 // Musí sa zhodovať s hodnotou v `apps/web/tests/e2e/pairing-review.spec.ts` —
 // VLASTNÝ izolovaný účet (rovnaký mechanizmus ako `E2E_NAVRHY_ODKAZOV_EMAIL` —
 // zdieľaný `e2e@forestshop.sk` je už na hranici `MAX_ATTEMPTS`).
 export const E2E_PAROVANIE_REVIEW_EMAIL = "e2e-parovanie-review@forestshop.sk";
+
+// issue 397 — `<img src>` obrázkové URL pre e2e fixtúry MUSIA byť `data:`
+// URI, nikdy skutočná (aj keď zámerne neplatná) `https://` adresa —
+// prehliadač sa REÁLNE pokúsi obrázok stiahnuť (Playwright beží proti
+// skutočnému Chromiu), takže vymyslená `https://e2e-*.example.com/img/…`
+// URL vyrobí skutočnú `net::ERR_NAME_NOT_RESOLVED`/404 konzolovú chybu —
+// presne to, čo `.claude/rules/testing.md`'s "konzola je čistá" zákaz
+// rozširovania výnimiek zakazuje. `data:` URI sa vykreslí OKAMŽITE, bez
+// akéhokoľvek sieťového volania. DVE ODLIŠNÉ 1×1px PNG (červená/modrá) —
+// nikdy tá istá hodnota pre obe strany, inak by test prešiel aj keby appka
+// omylom zamenila náš a kandidátov obrázok. Musia sa zhodovať s hodnotami
+// v `apps/web/tests/e2e/pairing-review.spec.ts`.
+export const E2E_OUR_IMAGE_DATA_URI =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC";
+export const E2E_CANDIDATE_IMAGE_DATA_URI =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGNgYPgPAAEDAQAIicLsAAAAAElFTkSuQmCC";
 
 export async function seedPairingReviewFixtures(db: Database, teraz: Date, snapshotId: string, heslo: string): Promise<void> {
   await db.insert(users).values({
@@ -69,8 +85,21 @@ export async function seedPairingReviewFixtures(db: Database, teraz: Date, snaps
     position: 0,
     name: "E2E Bunda Alfa u dodávateľa",
     url: "https://e2e-dodavatel.example.com/bunda-alfa-navrh",
+    // issue 397 — OBA obrázky na karte: kandidátov (tu) aj náš vlastný
+    // (shopProductUrl riadok nižšie) — presne to, čo `pairing-review.spec
+    // .ts`'s nová kontrola overuje.
+    imageUrl: E2E_CANDIDATE_IMAGE_DATA_URI,
     rawScore: "85.0000",
     codeHit: false,
+  });
+  // issue 397 — náš vlastný obrázok (`shop_product_url`, feed google.xml,
+  // `.claude/rules/shop-feed.md`) kľúčovaný podľa variant.code (= `key`,
+  // `seedProdukt` vyššie).
+  await db.insert(shopProductUrl).values({
+    code: "E2E-PR-CHYBA",
+    url: "https://www.forestshop.sk/e2e-bunda-alfa",
+    imageUrl: E2E_OUR_IMAGE_DATA_URI,
+    fetchedAt: teraz,
   });
 
   await seedProdukt("E2E-PR-NENAJDENY", "E2E Produkt Bez Kandidáta");

--- a/scripts/pairing-backfill-images.ts
+++ b/scripts/pairing-backfill-images.ts
@@ -1,0 +1,7 @@
+// Tenký alias pre `pnpm pairing:backfill-images` (tsx, mimo produkčného
+// kontajnera). Skutočná logika žije v `apps/api/src/cli/pairing-backfill-
+// images.ts` — TÁ istá implementácia sa skompiluje aj do `apps/api/dist/
+// cli/pairing-backfill-images.js`, ktorý beží priamo v produkčnom obraze
+// (Docker CMD spúšťa skompilovaný kód, nie tsx). Rovnaký vzor ako
+// `scripts/catalog-prune-raw.ts`.
+import "../apps/api/src/cli/pairing-backfill-images.js";


### PR DESCRIPTION
issue 397 — majiteľ: „pri tom parovani tam maju byt obrazky nasho produktu a produktu dodavatela tak to bolo aj pred tym".

## Obsah

- Karta **Párovanie** ukazuje obrázok nášho produktu AJ kandidáta dodávateľa vedľa seba.
- Obrázok kandidáta sa berie priamo z kariet výsledkov vyhľadávania dodávateľa pri
  zbere (WETLAND `data-full-size-image-url`, BETALOV `img.product-image`, ODIMON
  `data-src` — lazy-load pasce zdokumentované v playbooku) + `og:image` fallback
  pre zvoleného kandidáta (BETALOV šum-filtrovaný: jeho og:image je vždy logo).
- Idempotentný backfill CLI pre 177 existujúcich riadkov (rovnaký vzor ako
  catalog-prune-raw; zdieľa advisory zámok, fail-fast).
- Migrácia: `pairing_candidate.image_url` — pri integrácii prečíslovaná na 0051
  (kolízia s 0050 z issue 402, ktorá už je nasadená); snapshot chain opravený
  a migrácia overená na čistom Postgrese.
- Pokrytie našich obrázkov zmerané: 159/185 „bez obrázka" — 157 z nich nemá
  žiadny feed riadok (známa medzera issue 220), mimo rozsah tohto ticketu.
- Follow-up: #409 (top-8 panel kandidátov bez obrázkov, needs-user-decision) —
  rieši sa v balíku s issue 398.

## Testy

typecheck+lint čisté; 913 API + 610 web unit; 26 integračných pairing-search;
e2e vlastný spec 4/4 + celá sada 59/59. Review: 10 nálezov, 9 opravených
(d228cbe), 1 vyčlenený ako #409. Migrácia overená: `db:migrate` OK na čistej DB.
