### PR TITLE
Párovanie: možnosti rovno na karte, plná populácia, obrázky v paneli (issues 398, 401, 409)

### DIFF
--- a/.claude/rules/pairing-search.md
+++ b/.claude/rules/pairing-search.md
@@ -605,3 +605,63 @@ vyradilo #311 aj jeho playbook súbor (návrh, sekcia 4); router v
   `.claude/rules/shop-feed.md`), NIE bug tejto appky ani tohto tiketu.
   Zlepšenie by znamenalo vylepšiť Shoptet feed/vyhľadávací fallback —
   samostatný tiket, mimo rozsahu "ukáž oba obrázky".
+
+## issues 398/401/409 — všetky možnosti priamo na karte, plná populácia, obrázky v paneli
+
+- **Populácia obrazovky sa zmenila z "INNER JOIN na `pairing_candidate_set`"
+  (E5's pôvodná hranica) na ÚNIU troch množín** (`listPairingReview`,
+  `queries.ts`): (1) má `pairing_candidate_set` riadok, ALEBO (2) nemá
+  efektívnu dodávateľskú linku, ALEBO (3) má `pairing_decision` riadok.
+  Bod (2) je to, čo produkty dodávateľov BEZ automatického adaptéra vôbec
+  prvýkrát sprístupní na tejto obrazovke; bod (3) drží produkt viditeľný
+  aj POTOM, čo "manual"/"good" rozhodnutie medzitým získa efektívnu linku
+  (inak by zmizol skôr, než ho reviewer stihne skontrolovať/zmeniť). Celý
+  katalóg sa načíta do JS a filtruje tam (rovnaký MVP vzor ako `select.ts`/
+  `product-links`/`restock-links` — `resolveEffectiveSupplierLink` je
+  čistá JS funkcia, nedá sa vyjadriť ako SQL predikát bez duplicity).
+- **`supplierHasAdapter` (nové pole) je vlastnosť DODÁVATEĽA
+  (`suppliers.adapter_key !== null`), NIE vlastnosť "má/nemá gather
+  riadok".** Karta ho používa na rozlíšenie "dodávateľ zatiaľ nemá
+  automatické vyhľadávanie" (`pairing-review-no-adapter-*`) od "adaptér
+  MÁ, gather prehľadal a nič nenašiel" (`pairing-review-no-candidate-*`)
+  — pozor, TEORETICKY existuje tretí, nepokrytý stav (adaptérový
+  dodávateľ, čo ešte NIKDY negatheroval — `gatheredAt === null` aj
+  `supplierHasAdapter === true` naraz), vtedy karta ukáže "Nenašiel sa
+  žiadny kandidát" hlášku, hoci presnejšie by bolo "ešte nebehalo" —
+  zámerné zjednodušenie (dizajnová poznámka na tickete), keďže nočný beh
+  tento stav prakticky vždy vyrieši do 24 h.
+- **`withCleanDb()` (integračné testy) AJ `scripts/e2e-setup.ts` (e2e)
+  TRUNCATE-ujú `supplier` tabuľku BEZ reseedu migračného WETLAND/BETALOV/
+  ODIMON seedu (`0047_brief_yellowjacket.sql`)** — `supplierHasAdapter`
+  preto vyjde `false` pre ÚPLNE VŠETKY produkty, pokiaľ si test/fixtúra
+  VLASTNÝ `suppliers` riadok sám nevloží. Zavedený vzor (`pairing-search-
+  run.integration.test.ts`/`pairing-search-verify.integration.test.ts`,
+  teraz aj `e2e-fixtures-pairing-review.ts`): `db.insert(suppliers)
+  .values({name, currency:"EUR", wholesaleBaseUrl, adapterKey})` priamo v
+  seed/setup kóde — nikdy sa nespoliehaj na migračný seed prežívajúci
+  TRUNCATE.
+- **Review nález (opravené pred mergom): panel, čo sa ukazuje AUTOMATICKY
+  (karta bez kandidáta, nič na "prijatie"), musí SÁM zavolať
+  `fetchPairingCandidates` — inak "Načítavam kandidátov…" ostáva navždy
+  zobrazené.** Pôvodný E6 kód volal fetch LEN z `openPanel`u (explicitný
+  klik "vyber url"/"Zmeniť"), nikdy z auto-show vetvy. Bug existoval od
+  E6, ale #401 ho spravil OVEĽA bežnejším (každý produkt bez adaptéra ho
+  má). Fix: zdieľaná `loadCandidates()` funkcia + `useEffect` sledujúci
+  `item.decision === null && item.chosenCandidate === null` (spustí sa
+  PRI MOUNTE aj pri KAŽDOM neskoršom false→true prechode na TEJ ISTEJ
+  inštancii — napr. "↩ Vrátiť" na produkte bez kandidáta). **Test pri
+  KAŽDOM ďalšom "panel/sekcia sa ukáže bez explicitného kliku" vzore v
+  tejto appke: over, či dátový fetch, čo by normálne vyvolal explicitný
+  handler, MÁ AJ svoj vlastný `useEffect` spúšťač pre auto-show cestu —
+  jeden UI stav vie mať DVA rôzne spôsoby, ako sa zobrazí, a fetch
+  potrebuje pokrytie OBOCH.**
+- **Nové priame 📦/🚫 tlačidlá (kolektívny riadok na karte, #398) ZDIEĽAJÚ
+  `data-testid` s panelovými verziami TÝCH ISTÝCH tlačidiel** (`Terminal
+  Buttons`, `PairingReviewPanelParts.tsx`) — bezpečné, lebo obe vetvy sú
+  vzájomne VYLUČUJÚCE (priamy riadok len keď `chosenCandidate !== null &&
+  decision === null && !panelOpen`, panel len keď `panelOpen || (decision
+  === null && chosenCandidate === null)`) — nikdy oba naraz pre ten istý
+  produkt. Pri ĎALŠOM podobnom "tá istá akcia na DVOCH miestach karty"
+  vzore: zdieľaj testid len PO overení, že podmienky sú GENUINELY
+  disjunktné (nie len "vyzerá to tak"), inak dvojznačný Playwright/RTL
+  dotaz.

--- a/apps/api/src/http/pairing-review-routes.ts
+++ b/apps/api/src/http/pairing-review-routes.ts
@@ -28,7 +28,7 @@ const pageParam = z.preprocess(
 );
 
 const pairingReviewQuery = z.object({
-  filter: z.enum(["unreviewed", "matched", "unmatched", "st1", "st2", "st3", "all"]).default("unreviewed"),
+  filter: z.enum(["unreviewed", "matched", "unmatched", "st1", "st2", "st3", "decided", "terminal", "all"]).default("unreviewed"),
   page: pageParam,
   pageSize: z.coerce.number().int().min(1).max(200).default(50),
 });

--- a/apps/api/src/modules/pairing-review/queries.ts
+++ b/apps/api/src/modules/pairing-review/queries.ts
@@ -1,7 +1,5 @@
 // issue 387 E5: "Eshop → Párovanie" — čítacia obrazovka nad tým, čo E3
-// (gather) + E4 (verify) už zozbierali a overili. Populácia je "produkty S
-// KANDIDÁTMI" (INNER JOIN na `pairing_candidate_set` — produkt, ktorý gather
-// ešte nespracoval, sa tu nezobrazuje vôbec, presne ako zadanie žiada).
+// (gather) + E4 (verify) už zozbierali a overili.
 //
 // issue 387 E6: `pairing_decision` (E5's forward-kompat poznámka) teraz
 // EXISTUJE — "unreviewed" ostáva PRIMÁRNE "bez efektívnej linky" (E5's
@@ -9,11 +7,18 @@
 // TERMINÁLNE rozhodnutie (`unavailable`/`discontinued` — tie linku NIKDY
 // nedostanú, ale SÚ zrevidované, netreba na ne ďalej upozorňovať). Design
 // komentár na tickete (issue 387 E6): API kontrakt sa nemení, len sa
-// definícia SPRESŇUJE. Rovnaký MVP vzor ako `product-links/queries.ts`/
-// `restock-links/queries.ts`/`pairing-search/select.ts` — celá relevantná
-// populácia (rádovo stovky, nie celý katalóg) sa načíta a filtruje/triedi/
-// stránkuje v JS, keďže `resolveEffectiveSupplierLink` je čistá JS funkcia
-// nad `internalNote`, nedá sa vyjadriť ako SQL predikát bez duplicity.
+// definícia SPRESŇUJE.
+//
+// issue 401: populácia UŽ NIE JE len "produkty S KANDIDÁTMI" (E5's pôvodná
+// INNER JOIN hranica) — majiteľ chcel VŠETKY produkty bez napárovaného
+// odkazu, bez ohľadu na dodávateľa. `listPairingReview` preto teraz iteruje
+// ÚNIU troch množín (má `pairing_candidate_set` riadok, ALEBO nemá efektívnu
+// linku, ALEBO má `pairing_decision` riadok) — pozri design komentár na
+// #398/#401 pre plné odôvodnenie. Rovnaký MVP vzor ako
+// `product-links/queries.ts`/`restock-links/queries.ts`/`pairing-search/
+// select.ts` — celý katalóg sa načíta a filtruje/triedi/stránkuje v JS,
+// keďže `resolveEffectiveSupplierLink` je čistá JS funkcia nad
+// `internalNote`, nedá sa vyjadriť ako SQL predikát bez duplicity.
 
 import { eq, inArray } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
@@ -24,14 +29,16 @@ import {
   productSupplierLinkOverrides,
   products,
   shopProductUrl,
+  suppliers,
   variants,
 } from "../../db/schema.js";
 import { resolveEffectiveSupplierLink } from "../orders/effective-supplier-link.js";
+import { normalizeSupplierKeyJs } from "../orders/supplier-key.js";
 import type { PairingConfidence, PairingVerdict } from "../pairing-search/types.js";
 import { SELLABLE_VISIBILITY } from "../restock/constants.js";
 import type { PairingDecisionStatus } from "./decisions.js";
 
-export type PairingReviewFilter = "unreviewed" | "matched" | "unmatched" | "st1" | "st2" | "st3" | "all";
+export type PairingReviewFilter = "unreviewed" | "matched" | "unmatched" | "st1" | "st2" | "st3" | "decided" | "terminal" | "all";
 export type PairingReviewProductState = "sellable" | "out_of_stock" | "discontinued";
 
 // Fallback presne ako stará appka (`webreview/app.js`'s `renderCard`) — keď
@@ -77,7 +84,16 @@ export interface PairingReviewItem {
   /** `true` = appka už pozná EFEKTÍVNU dodávateľskú linku (override alebo
    * extrahovaná z `internalNote`) — toto JE "unreviewed" predikát (viď hlavička súboru). */
   readonly hasEffectiveLink: boolean;
-  readonly gatheredAt: string;
+  /** issue 401 — `true` = `product.supplier` sa normalizuje na `suppliers`
+   * riadok s vyplneným `adapter_key` (WETLAND/BETALOV/ODIMON). Karta podľa
+   * toho rozlišuje "dodávateľ zatiaľ nemá automatické vyhľadávanie" (false)
+   * od "gather zatiaľ nič nenašiel/nebehol" (true, ale `gatheredAt === null`
+   * alebo `chosenCandidate === null`). */
+  readonly supplierHasAdapter: boolean;
+  /** issue 401 — `null` keď pre produkt ešte NEEXISTUJE `pairing_candidate_set`
+   * riadok (nikdy nebol gatherovaný — typicky dodávateľ bez adaptéra, alebo
+   * adaptérový produkt, čo ešte nočný beh nestihol spracovať). */
+  readonly gatheredAt: string | null;
   readonly confidence: PairingConfidence;
   readonly chosenReason: string | null;
   readonly verdict: PairingVerdict | null;
@@ -95,8 +111,10 @@ export interface PairingReviewSearchInput {
 
 export interface PairingReviewSearchResult {
   readonly total: number;
-  /** Celá gather populácia (počet `pairing_candidate_set` riadkov), nezávisle
-   * od `filter` — menovateľ pre progress. */
+  /** issue 401 — CELÁ populácia tejto obrazovky (únia: gatherované produkty +
+   * produkty bez efektívnej linky + rozhodnuté produkty, viď `listPairingReview`),
+   * nezávisle od `filter` — menovateľ pre progress. Meno poľa ostalo z E5
+   * (kedy populácia = "len gatherované"), význam sa odvtedy rozšíril. */
   readonly gatheredTotal: number;
   /** Koľko z `gatheredTotal` už MÁ efektívnu linku — čitateľ pre progress
    * (doplnok `unreviewed` počtu, ktorý číta rovnaký endpoint s `filter=unreviewed`). */
@@ -131,8 +149,41 @@ function rollupProductState(rows: readonly VariantRow[]): PairingReviewProductSt
   return "discontinued";
 }
 
+// issue 401 — dodávateľ SO ZNÁMYM adaptérom (WETLAND/BETALOV/ODIMON), presne
+// rovnaký zdroj/normalizácia ako `pairing-search/select.ts`'s
+// `selectEligibleProducts` (zámerne duplikované — malá, 5-riadková mapa,
+// zdieľanie by tu pridalo len ďalší modul navyše bez skutočného úžitku).
+async function loadAdapterByNormalizedSupplier(db: Database): Promise<ReadonlyMap<string, string>> {
+  const supplierRows = await db.select({ name: suppliers.name, adapterKey: suppliers.adapterKey }).from(suppliers);
+  const map = new Map<string, string>();
+  for (const row of supplierRows) {
+    if (row.adapterKey !== null) map.set(normalizeSupplierKeyJs(row.name), row.adapterKey);
+  }
+  return map;
+}
+
 export async function listPairingReview(db: Database, input: PairingReviewSearchInput): Promise<PairingReviewSearchResult> {
-  const setRows = await db
+  // issue 401 — populácia je ÚNIA troch množín (design komentár na tickete
+  // 398/401): (1) produkty S `pairing_candidate_set` riadkom (gatherované,
+  // akéhokoľvek dodávateľa), (2) produkty BEZ efektívnej dodávateľskej linky
+  // (akéhokoľvek dodávateľa — adaptér alebo nie), (3) produkty S
+  // `pairing_decision` riadkom (rozhodnuté cez TÚTO obrazovku — zostávajú
+  // viditeľné aj keď medzitým získajú efektívnu linku, napr. "manual").
+  // Rovnaký MVP vzor ako `pairing-search/select.ts`/`product-links`/
+  // `restock-links` — celý katalóg do JS, filtrovanie/spájanie tam
+  // (`resolveEffectiveSupplierLink` je čistá JS funkcia, nedá sa vyjadriť
+  // ako SQL predikát bez duplicity — súborová hlavička).
+  const productRows = await db
+    .select({ key: products.key, name: products.name, supplier: products.supplier, internalNote: products.internalNote })
+    .from(products);
+  if (productRows.length === 0) return { total: 0, gatheredTotal: 0, linkedTotal: 0, items: [] };
+
+  const overrideRowsAll = await db
+    .select({ productKey: productSupplierLinkOverrides.productKey, url: productSupplierLinkOverrides.url })
+    .from(productSupplierLinkOverrides);
+  const overrideByProduct = new Map(overrideRowsAll.map((r) => [r.productKey, r.url]));
+
+  const setRowsAll = await db
     .select({
       productKey: pairingCandidateSets.productKey,
       gatheredAt: pairingCandidateSets.gatheredAt,
@@ -142,21 +193,30 @@ export async function listPairingReview(db: Database, input: PairingReviewSearch
       verdict: pairingCandidateSets.verdict,
     })
     .from(pairingCandidateSets);
-  if (setRows.length === 0) return { total: 0, gatheredTotal: 0, linkedTotal: 0, items: [] };
+  const setByProduct = new Map(setRowsAll.map((r) => [r.productKey, r]));
 
-  const productKeys = setRows.map((r) => r.productKey);
+  const decisionRowsAll = await db
+    .select({
+      productKey: pairingDecisions.productKey,
+      status: pairingDecisions.status,
+      url: pairingDecisions.url,
+      decidedAt: pairingDecisions.decidedAt,
+    })
+    .from(pairingDecisions);
+  const decisionByProduct = new Map(decisionRowsAll.map((r) => [r.productKey, r]));
 
-  const productRows = await db
-    .select({ key: products.key, name: products.name, supplier: products.supplier, internalNote: products.internalNote })
-    .from(products)
-    .where(inArray(products.key, productKeys));
+  const adapterByNormalizedSupplier = await loadAdapterByNormalizedSupplier(db);
+
+  const productKeys: string[] = [];
+  for (const product of productRows) {
+    const effective = resolveEffectiveSupplierLink(product.internalNote, overrideByProduct.get(product.key) ?? null);
+    const hasCandidateSet = setByProduct.has(product.key);
+    const hasDecision = decisionByProduct.has(product.key);
+    if (hasCandidateSet || effective.url === null || hasDecision) productKeys.push(product.key);
+  }
+  if (productKeys.length === 0) return { total: 0, gatheredTotal: 0, linkedTotal: 0, items: [] };
+
   const productByKey = new Map(productRows.map((r) => [r.key, r]));
-
-  const overrideRows = await db
-    .select({ productKey: productSupplierLinkOverrides.productKey, url: productSupplierLinkOverrides.url })
-    .from(productSupplierLinkOverrides)
-    .where(inArray(productSupplierLinkOverrides.productKey, productKeys));
-  const overrideByProduct = new Map(overrideRows.map((r) => [r.productKey, r.url]));
 
   const variantRows: VariantRow[] = await db
     .select({
@@ -205,30 +265,15 @@ export async function listPairingReview(db: Database, input: PairingReviewSearch
   // (E5 ukazuje LEN navrhnutého kandidáta, nie všetkých top-8 — design komentár).
   const candidateByKey = new Map(candidateRows.map((r) => [`${r.productKey} ${r.url}`, r]));
 
-  // issue 387 E6 — posledné rozhodnutie na produkt, `undefined` keď žiadne.
-  // Samostatný dopyt + Mapa (nie SQL JOIN), rovnaký MVP vzor ako každý iný
-  // spájaný zdroj v tejto funkcii — appka vždy spája v JS, nikdy v SQL, keď
-  // ide o odvodenú/filtrovanú obrazovkovú logiku (hlavička súboru).
-  const decisionRows = await db
-    .select({
-      productKey: pairingDecisions.productKey,
-      status: pairingDecisions.status,
-      url: pairingDecisions.url,
-      decidedAt: pairingDecisions.decidedAt,
-    })
-    .from(pairingDecisions)
-    .where(inArray(pairingDecisions.productKey, productKeys));
-  const decisionByProduct = new Map(decisionRows.map((r) => [r.productKey, r]));
-
   const allItems: PairingReviewItem[] = [];
-  for (const set of setRows) {
-    const product = productByKey.get(set.productKey);
-    // Osirotený `pairing_candidate_set` riadok (produkt medzičasom zmizol z
-    // katalógu) — nikdy sa nezobrazí, rovnaká disciplína ako `select.ts`'s
-    // review-nález o `missingSince` (informačná poznámka, nie porušenie).
+  for (const productKey of productKeys) {
+    const product = productByKey.get(productKey);
+    // Nedosiahnuteľné (`productKey` vzišlo priamo z `productRows` vyššie) —
+    // len na uspokojenie `noUncheckedIndexedAccess`/typovej kontroly.
     if (product === undefined) continue;
 
-    const productVariants = variantsByProduct.get(set.productKey) ?? [];
+    const set = setByProduct.get(productKey);
+    const productVariants = variantsByProduct.get(productKey) ?? [];
 
     const seenCodes = new Set<string>();
     const externalCodes: string[] = [];
@@ -268,9 +313,10 @@ export async function listPairingReview(db: Database, input: PairingReviewSearch
     const priceMax = prices.length > 0 ? Math.max(...prices).toFixed(2) : null;
     const currency = productVariants.find((v) => v.currency !== null)?.currency ?? null;
 
-    const effective = resolveEffectiveSupplierLink(product.internalNote, overrideByProduct.get(set.productKey) ?? null);
+    const effective = resolveEffectiveSupplierLink(product.internalNote, overrideByProduct.get(productKey) ?? null);
 
-    const chosenCandidateRow = set.chosenUrl === null ? undefined : candidateByKey.get(`${set.productKey} ${set.chosenUrl}`);
+    const chosenUrl = set?.chosenUrl ?? null;
+    const chosenCandidateRow = chosenUrl === null ? undefined : candidateByKey.get(`${productKey} ${chosenUrl}`);
     const chosenCandidate: PairingReviewChosenCandidate | null =
       chosenCandidateRow === undefined
         ? null
@@ -282,12 +328,12 @@ export async function listPairingReview(db: Database, input: PairingReviewSearch
             codeHit: chosenCandidateRow.codeHit,
           };
 
-    const decisionRow = decisionByProduct.get(set.productKey);
+    const decisionRow = decisionByProduct.get(productKey);
     const decision: PairingReviewDecision | null =
       decisionRow === undefined ? null : { status: decisionRow.status, url: decisionRow.url, decidedAt: decisionRow.decidedAt.toISOString() };
 
     allItems.push({
-      productKey: set.productKey,
+      productKey,
       productName: product.name,
       supplier: product.supplier,
       externalCodes,
@@ -300,15 +346,22 @@ export async function listPairingReview(db: Database, input: PairingReviewSearch
       ourUrlIsSearchFallback,
       ourImageUrl,
       hasEffectiveLink: effective.url !== null,
-      gatheredAt: set.gatheredAt.toISOString(),
-      confidence: set.confidence,
-      chosenReason: set.chosenReason,
-      verdict: set.verdict,
+      supplierHasAdapter: adapterByNormalizedSupplier.has(normalizeSupplierKeyJs(product.supplier ?? "")),
+      gatheredAt: set !== undefined ? set.gatheredAt.toISOString() : null,
+      confidence: set?.confidence ?? "none",
+      chosenReason: set?.chosenReason ?? null,
+      verdict: set?.verdict ?? null,
       chosenCandidate,
       decision,
     });
   }
 
+  // issue 401 — mená polí (`gatheredTotal`/`linkedTotal`) ostávajú NEZMENENÉ
+  // (API kontrakt), ale VÝZNAM sa rozšíril spolu s populáciou vyššie —
+  // `gatheredTotal` je teraz "koľko produktov appka na tejto obrazovke
+  // sleduje" (nie len "koľko bolo gatherovaných"), badge/progress bar
+  // (`PairingReviewSection.tsx`) tak automaticky počítajú novú, plnú
+  // populáciu bez zmeny na strane frontendu.
   const gatheredTotal = allItems.length;
   const linkedTotal = allItems.filter((item) => item.hasEffectiveLink).length;
 
@@ -338,6 +391,10 @@ export async function listPairingReview(db: Database, input: PairingReviewSearch
         return item.productState === "out_of_stock";
       case "st3":
         return item.productState === "discontinued";
+      case "decided":
+        return item.decision !== null && (item.decision.status === "good" || item.decision.status === "manual");
+      case "terminal":
+        return item.decision !== null && (item.decision.status === "unavailable" || item.decision.status === "discontinued");
       case "all":
         return true;
     }
@@ -362,14 +419,19 @@ export async function listPairingReview(db: Database, input: PairingReviewSearch
 export interface PairingReviewCandidate {
   readonly name: string;
   readonly url: string;
+  /** issue 409 — obrázok kandidáta (z adaptéra pri gatheri, presne ako
+   * `PairingReviewChosenCandidate.imageUrl` vyššie), `null` keď žiadny zdroj
+   * neposkytol použiteľný. Dáta sú UŽ perzistované (žiadny live-fetch pri
+   * otvorení panelu) — pozri design komentár na #398/#409. */
+  readonly imageUrl: string | null;
   readonly rawScore: number;
   readonly codeHit: boolean;
 }
 
-// issue 387 E6 — top-8 kandidátov produktu pre rozhodovací panel ("✗ Zlé" →
-// zoznam s "Vybrať"). LAZY (volá sa AŽ pri otvorení panelu, design komentár
-// na tickete) — hlavný zoznam vyššie ukazuje len `chosenCandidate`, nikdy
-// všetkých 8, aby sa nezaťažoval payload každej karty, čo sa nikdy
+// issue 387 E6 — top-8 kandidátov produktu pre rozhodovací panel ("vyber
+// url" → zoznam s "Vybrať"). LAZY (volá sa AŽ pri otvorení panelu, design
+// komentár na tickete) — hlavný zoznam vyššie ukazuje len `chosenCandidate`,
+// nikdy všetkých 8, aby sa nezaťažoval payload každej karty, čo sa nikdy
 // nerozbalí. Dáta sú UŽ perzistované z E2-E4 (`pairing_candidate`), žiadny
 // živý fetch (E5 to explicitne zamietla, kým to nebolo treba).
 export async function listPairingCandidatesForProduct(db: Database, productKey: string): Promise<readonly PairingReviewCandidate[]> {
@@ -377,6 +439,7 @@ export async function listPairingCandidatesForProduct(db: Database, productKey: 
     .select({
       name: pairingCandidates.name,
       url: pairingCandidates.url,
+      imageUrl: pairingCandidates.imageUrl,
       rawScore: pairingCandidates.rawScore,
       codeHit: pairingCandidates.codeHit,
       position: pairingCandidates.position,
@@ -386,5 +449,5 @@ export async function listPairingCandidatesForProduct(db: Database, productKey: 
 
   return rows
     .sort((a, b) => a.position - b.position)
-    .map((r) => ({ name: r.name, url: r.url, rawScore: Number(r.rawScore), codeHit: r.codeHit }));
+    .map((r) => ({ name: r.name, url: r.url, imageUrl: r.imageUrl, rawScore: Number(r.rawScore), codeHit: r.codeHit }));
 }

--- a/apps/api/tests/pairing-review-decisions-http.integration.test.ts
+++ b/apps/api/tests/pairing-review-decisions-http.integration.test.ts
@@ -105,6 +105,10 @@ it("'good': v JEDNEJ transakcii zapíše override AJ pairing_decision, okamžite
   expect(item?.hasEffectiveLink).toBe(true);
   expect(item?.decision).toEqual({ status: "good", url: "https://dodavatel.example.com/bunda-alfa", decidedAt: expect.any(String) as string });
   expect(await unreviewedKeys(app, cookie)).not.toContain("PR-GOOD");
+
+  // issue 398 — nový "✓ Dobré/Vybrané" filter ho zahŕňa.
+  const decidedTelo = (await (await app.request("/api/pairing-review?filter=decided", { headers: { cookie } })).json()) as { readonly items: { readonly productKey: string }[] };
+  expect(decidedTelo.items.some((i) => i.productKey === "PR-GOOD")).toBe(true);
 });
 
 it("'good' bez navrhnutého kandidáta (confidence none) vráti 400 a NIČ nezapíše", async () => {

--- a/apps/api/tests/pairing-review-http.integration.test.ts
+++ b/apps/api/tests/pairing-review-http.integration.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, expect, it } from "vitest";
-import { productSupplierLinkOverrides, shopProductUrl, users } from "../src/db/schema.js";
+import { productSupplierLinkOverrides, shopProductUrl, suppliers, users } from "../src/db/schema.js";
 import { createApp } from "../src/http/app.js";
 import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
 import { hashPassword } from "../src/modules/auth/passwords.js";
@@ -60,6 +60,8 @@ interface Telo {
     readonly ourUrlIsSearchFallback: boolean;
     readonly ourImageUrl: string | null;
     readonly hasEffectiveLink: boolean;
+    readonly supplierHasAdapter: boolean;
+    readonly gatheredAt: string | null;
     readonly confidence: "high" | "medium" | "low" | "none";
     readonly verdict: "ok" | "unsure" | null;
     readonly chosenCandidate: {
@@ -77,14 +79,57 @@ it("bez prihlásenia vráti 401", async () => {
   expect((await app.request("/api/pairing-review")).status).toBe(401);
 });
 
-it("produkt BEZ pairing_candidate_set riadku (gather ho ešte nespracoval) sa v zozname vôbec nezobrazí", async () => {
+// issue 401 — populácia je teraz ÚNIA (gatherované ∪ bez efektívnej linky ∪
+// rozhodnuté), nie len INNER JOIN na `pairing_candidate_set` (E5's pôvodná
+// hranica). Produkt bez gather riadku, ale AJ BEZ efektívnej linky (typicky
+// dodávateľ bez adaptéra — tu žiadny `suppliers` riadok vôbec neexistuje) sa
+// TERAZ zobrazí, s `gatheredAt: null` a `supplierHasAdapter: false`.
+it("issue 401: produkt BEZ pairing_candidate_set riadku A BEZ efektívnej linky SA ZOBRAZÍ (dodávateľ bez adaptéra) — plná populácia", async () => {
   const { app, cookie, db } = await boot("citanie");
   const snapshotId = await insertTestSnapshot(db);
-  await seedProduct(db, snapshotId, "PR-NEGATHER", { name: "Negatherovaný produkt" });
+  await seedProduct(db, snapshotId, "PR-NEGATHER", { name: "Negatherovaný produkt", supplier: "DODAVATEL-BEZ-ADAPTERA" });
 
   const telo = (await (await app.request("/api/pairing-review?filter=all", { headers: { cookie } })).json()) as Telo;
-  expect(telo.items.some((i) => i.productKey === "PR-NEGATHER")).toBe(false);
+  const item = telo.items.find((i) => i.productKey === "PR-NEGATHER");
+  expect(item).toBeDefined();
+  expect(item?.gatheredAt).toBeNull();
+  expect(item?.supplierHasAdapter).toBe(false);
+  expect(item?.chosenCandidate).toBeNull();
+  expect(item?.confidence).toBe("none");
+  expect(telo.gatheredTotal).toBe(1);
+
+  // "unreviewed" (bez efektívnej linky, bez terminálneho rozhodnutia) ho tiež zahŕňa.
+  const unreviewedTelo = (await (await app.request("/api/pairing-review?filter=unreviewed", { headers: { cookie } })).json()) as Telo;
+  expect(unreviewedTelo.items.some((i) => i.productKey === "PR-NEGATHER")).toBe(true);
+});
+
+// Prevrátený prípad — produkt BEZ gather riadku, ktorý UŽ MÁ efektívnu linku
+// (napr. založenú cez #239/#240 predtým, než sem raz zavítal gather) sa
+// NEZOBRAZÍ — netreba naň upozorňovať (rovnaká "má odkaz, netreba upozorniť"
+// zásada ako E6's `unreviewed` predikát).
+it("issue 401: produkt BEZ pairing_candidate_set riadku, ktorý UŽ MÁ efektívnu linku (mimo tejto obrazovky), sa NEZOBRAZÍ", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedProduct(db, snapshotId, "PR-LINKED-NOGATHER", { name: "Produkt s linkou bez gatheru", internalNote: "https://dodavatel.example.com/uz-ma-linku" });
+
+  const telo = (await (await app.request("/api/pairing-review?filter=all", { headers: { cookie } })).json()) as Telo;
+  expect(telo.items.some((i) => i.productKey === "PR-LINKED-NOGATHER")).toBe(false);
   expect(telo.gatheredTotal).toBe(0);
+});
+
+// issue 401 — `supplierHasAdapter` je `true` PRIAMO pre dodávateľa s
+// registrovaným `suppliers.adapter_key`, nezávisle od toho, či preň gather
+// UŽ prebehol (rovnaká `suppliers` tabuľka ako `pairing-search/select.ts`).
+it("issue 401: supplierHasAdapter je true pre dodávateľa s registrovaným adaptérom, aj keď preň gather ešte nebehal", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const snapshotId = await insertTestSnapshot(db);
+  await db.insert(suppliers).values({ name: "WETLAND", currency: "EUR", wholesaleBaseUrl: "https://www.wetland.sk", adapterKey: "wetland" });
+  await seedProduct(db, snapshotId, "PR-ADAPTER-NEGATHER", { name: "Adaptérový, ešte negatherovaný", supplier: "WETLAND" });
+
+  const telo = (await (await app.request("/api/pairing-review?filter=all", { headers: { cookie } })).json()) as Telo;
+  const item = telo.items.find((i) => i.productKey === "PR-ADAPTER-NEGATHER");
+  expect(item?.supplierHasAdapter).toBe(true);
+  expect(item?.gatheredAt).toBeNull();
 });
 
 it("napárovaný produkt (chosenUrl) nesie navrhnutého kandidáta so skóre/istotou/kódovým overením", async () => {

--- a/apps/web/src/components/PairingReviewCard.test.tsx
+++ b/apps/web/src/components/PairingReviewCard.test.tsx
@@ -6,6 +6,9 @@ import { PairingReviewCard } from "./PairingReviewCard.js";
 // toggle-open panel vzor). Vyčlenené OD `PairingReviewSection.test.tsx` (E5,
 // list-rendering), rovnaký princíp ako `OrderLineRow.*.test.tsx`/
 // `UpozornenieCard.*.test.ts` — karta má VLASTNÝ test súbor.
+//
+// issue 398/401/409 — testy prerobené na novú UX (žiadne "✗ Zlé", priamy
+// riadok ✓ Dobré/„vyber url"/📦/🚫, adapterless hláška, obrázky v paneli).
 
 const { fetchPairingCandidates, sendPairingDecision } = vi.hoisted(() => ({
   fetchPairingCandidates: vi.fn(),
@@ -35,6 +38,7 @@ const MATCHED_ITEM = {
   ourUrlIsSearchFallback: false,
   ourImageUrl: "https://www.forestshop.sk/img/bunda.jpg",
   hasEffectiveLink: false,
+  supplierHasAdapter: true,
   gatheredAt: "2026-08-13T03:35:00.000Z",
   confidence: "high" as const,
   chosenReason: "najlepší nájdený",
@@ -55,6 +59,16 @@ const UNMATCHED_ITEM = {
   chosenCandidate: null,
   confidence: "none" as const,
   verdict: null,
+};
+
+// issue 401 — dodávateľ BEZ adaptéra: rovnaký tvar ako UNMATCHED_ITEM
+// (žiadny kandidát), ale gather pre TAKÝTO produkt nikdy nebeží vôbec.
+const NO_ADAPTER_ITEM = {
+  ...UNMATCHED_ITEM,
+  productKey: "PR-NOADAPTER",
+  supplier: "DODAVATEL-BEZ-ADAPTERA",
+  supplierHasAdapter: false,
+  gatheredAt: null,
 };
 
 const DECIDED_UNAVAILABLE_ITEM = {
@@ -97,12 +111,20 @@ it("'citanie' rola nevidí ŽIADNE akčné tlačidlo", async () => {
   expect(card.querySelectorAll("button")).toHaveLength(0);
 });
 
-it("napárovaný produkt bez rozhodnutia ukáže ✓ Dobré / ✗ Zlé; klik na ✓ Dobré odošle {status:'good'} a zavolá onDecided", async () => {
+// issue 398 — posledná podoba starej appky: žiadny "✗ Zlé" medzikrok, VŠETKY
+// štyri možnosti (✓ Dobré / „vyber url" / 📦 / 🚫) sú priamo na karte naraz.
+it("napárovaný produkt bez rozhodnutia ukáže priamo VŠETKY štyri možnosti (✓ Dobré/vyber url/📦/🚫); klik na ✓ Dobré odošle {status:'good'} a zavolá onDecided", async () => {
   sendPairingDecision.mockResolvedValue(undefined);
   const onDecided = vi.fn();
   render(<PairingReviewCard item={MATCHED_ITEM} role="manazer" onDecided={onDecided} onSessionExpired={() => {}} />);
 
   expect(screen.getByTestId("pairing-review-good-PR-1")).toBeDefined();
+  expect(screen.getByTestId("pairing-review-open-panel-PR-1").textContent).toBe("vyber url");
+  expect(screen.getByTestId("pairing-review-unavailable-PR-1")).toBeDefined();
+  expect(screen.getByTestId("pairing-review-discontinued-PR-1")).toBeDefined();
+  // Panel NIE JE otvorený — žiadny z jeho prvkov (napr. "Zavrieť") ešte neexistuje.
+  expect(screen.queryByTestId("pairing-review-panel-cancel-PR-1")).toBeNull();
+
   fireEvent.click(screen.getByTestId("pairing-review-good-PR-1"));
 
   await waitFor(() => {
@@ -111,6 +133,20 @@ it("napárovaný produkt bez rozhodnutia ukáže ✓ Dobré / ✗ Zlé; klik na 
   await waitFor(() => {
     expect(onDecided).toHaveBeenCalledTimes(1);
   });
+});
+
+// issue 398 — priame 📦/🚫 tlačidlá v riadku (nie len v paneli) skutočne
+// fungujú, bez toho, že by treba najprv otvoriť panel.
+it("priame 📦 tlačidlo (bez otvorenia panelu) odošle {status:'unavailable'}", async () => {
+  sendPairingDecision.mockResolvedValue(undefined);
+  render(<PairingReviewCard item={MATCHED_ITEM} role="manazer" onDecided={() => {}} onSessionExpired={() => {}} />);
+
+  fireEvent.click(screen.getByTestId("pairing-review-unavailable-PR-1"));
+  await waitFor(() => {
+    expect(sendPairingDecision).toHaveBeenCalledWith("PR-1", { status: "unavailable" });
+  });
+  // Panel sa NIKDY neotvoril — `fetchPairingCandidates` sa nezavolalo.
+  expect(fetchPairingCandidates).not.toHaveBeenCalled();
 });
 
 it("issue 397: karta ukazuje obrázok kandidáta AJ nášho produktu vedľa seba; chýbajúci obrázok kandidáta ukáže 'bez obrázka'", async () => {
@@ -129,10 +165,30 @@ it("issue 397: karta ukazuje obrázok kandidáta AJ nášho produktu vedľa seba
   expect(cardBezObrazka.querySelectorAll(".pairing-review-noimg")).toHaveLength(1);
 });
 
-it("klik na ✗ Zlé ROZBALÍ panel NA MIESTE (karta ostáva) a načíta kandidátov; 'Vybrať' odošle manual s URL toho kandidáta", async () => {
+// issue 401 — dodávateľ bez adaptéra dostáva VLASTNÚ hlášku, nie "Nenašiel
+// sa žiadny kandidát" (tá je vyhradená pre "gather behal, nič nenašiel").
+it("issue 401: dodávateľ BEZ adaptéra ukáže 'zatiaľ nemá automatické vyhľadávanie', nikdy 'Nenašiel sa žiadny kandidát'", async () => {
+  fetchPairingCandidates.mockResolvedValue([]);
+  render(<PairingReviewCard item={NO_ADAPTER_ITEM} role="manazer" onDecided={() => {}} onSessionExpired={() => {}} />);
+
+  expect(screen.getByTestId("pairing-review-no-adapter-PR-NOADAPTER").textContent).toContain("nemá automatické vyhľadávanie");
+  expect(screen.queryByTestId("pairing-review-no-candidate-PR-NOADAPTER")).toBeNull();
+  // Bez kandidáta -> panel (manuálne URL pole + 📦/🚫) je vidno priamo.
+  expect(await screen.findByTestId("pairing-review-manual-input-PR-NOADAPTER")).toBeDefined();
+});
+
+it("issue 401: naopak — adaptérový dodávateľ, ktorý gather prehľadal a nič nenašiel, ukáže 'Nenašiel sa žiadny kandidát'", () => {
+  fetchPairingCandidates.mockResolvedValue([]);
+  render(<PairingReviewCard item={UNMATCHED_ITEM} role="manazer" onDecided={() => {}} onSessionExpired={() => {}} />);
+
+  expect(screen.getByTestId("pairing-review-no-candidate-PR-2").textContent).toContain("Nenašiel sa žiadny kandidát");
+  expect(screen.queryByTestId("pairing-review-no-adapter-PR-2")).toBeNull();
+});
+
+it("klik na „vyber url\" ROZBALÍ panel NA MIESTE (karta ostáva) a načíta kandidátov S OBRÁZKAMI; 'Vybrať' odošle manual s URL toho kandidáta", async () => {
   fetchPairingCandidates.mockResolvedValue([
-    { name: "Top kandidát", url: "https://dodavatel.example.com/top", rawScore: 90, codeHit: true },
-    { name: "Druhý kandidát", url: "https://dodavatel.example.com/druhy", rawScore: 60, codeHit: false },
+    { name: "Top kandidát", url: "https://dodavatel.example.com/top", imageUrl: "https://dodavatel.example.com/img/top.jpg", rawScore: 90, codeHit: true },
+    { name: "Druhý kandidát", url: "https://dodavatel.example.com/druhy", imageUrl: null, rawScore: 60, codeHit: false },
   ]);
   sendPairingDecision.mockResolvedValue(undefined);
 
@@ -144,6 +200,11 @@ it("klik na ✗ Zlé ROZBALÍ panel NA MIESTE (karta ostáva) a načíta kandid�
   const panel = await screen.findByTestId("pairing-review-panel-PR-1");
   expect(panel.textContent).toContain("Top kandidát");
   expect(panel.textContent).toContain("Druhý kandidát");
+
+  // issue 409 — prvý kandidát MÁ obrázok (vlastný <img>), druhý nemá (fallback "bez obrázka").
+  expect(panel.querySelectorAll("img")).toHaveLength(1);
+  expect(panel.querySelector("img")?.getAttribute("src")).toBe("https://dodavatel.example.com/img/top.jpg");
+  expect(panel.querySelectorAll(".pairing-review-noimg")).toHaveLength(1);
 
   fireEvent.click(screen.getByTestId("pairing-review-panel-pick-PR-1-1"));
   await waitFor(() => {
@@ -171,7 +232,7 @@ it("ručná URL: neplatná adresa sa NEODOŠLE (klientská validácia), platná 
   });
 });
 
-it("📦 Nie je skladom / 🚫 Už sa nebude predávať odošlú príslušný terminálny status", async () => {
+it("📦 Nie je skladom / 🚫 Už sa nebude predávať v PANELI odošlú príslušný terminálny status", async () => {
   fetchPairingCandidates.mockResolvedValue([]);
   sendPairingDecision.mockResolvedValue(undefined);
 
@@ -184,7 +245,7 @@ it("📦 Nie je skladom / 🚫 Už sa nebude predávať odošlú príslušný te
   });
 });
 
-it("už rozhodnutý produkt (terminálny stav) ukáže odznak + '↩ Vrátiť'; klik odošle {status:'revert'}", async () => {
+it("už rozhodnutý produkt (terminálny stav) ukáže odznak + vysvetľujúcu poznámku o nočnej automatike + '↩ Vrátiť'; klik odošle {status:'revert'}", async () => {
   sendPairingDecision.mockResolvedValue(undefined);
   const onDecided = vi.fn();
   render(<PairingReviewCard item={DECIDED_UNAVAILABLE_ITEM} role="manazer" onDecided={onDecided} onSessionExpired={() => {}} />);
@@ -193,6 +254,8 @@ it("už rozhodnutý produkt (terminálny stav) ukáže odznak + '↩ Vrátiť'; 
   // Terminálny stav (unavailable/discontinued) nemá "Zmeniť" tlačidlo —
   // len napárované/manuálne rozhodnutia sa dajú "zmeniť na iný link".
   expect(screen.queryByTestId("pairing-review-change-PR-3")).toBeNull();
+  // issue 398 — vysvetlenie, že reálne prepnutie robí nočná automatika.
+  expect(screen.getByTestId("pairing-review-terminal-note-PR-3").textContent).toContain("nočná automatika");
 
   fireEvent.click(screen.getByTestId("pairing-review-revert-PR-3"));
   await waitFor(() => {
@@ -203,17 +266,18 @@ it("už rozhodnutý produkt (terminálny stav) ukáže odznak + '↩ Vrátiť'; 
   });
 });
 
-it("rozhodnutie 'good' ukáže AJ '✗ Zmeniť / iný link' — klik otvorí panel s kandidátmi", async () => {
-  fetchPairingCandidates.mockResolvedValue([{ name: "Top kandidát", url: "https://dodavatel.example.com/bunda-alfa", rawScore: 90, codeHit: true }]);
+it("rozhodnutie 'good' ukáže AJ '✗ Zmeniť / iný link' — klik otvorí panel s kandidátmi, ŽIADNA terminálna poznámka", async () => {
+  fetchPairingCandidates.mockResolvedValue([{ name: "Top kandidát", url: "https://dodavatel.example.com/bunda-alfa", imageUrl: null, rawScore: 90, codeHit: true }]);
 
   render(<PairingReviewCard item={DECIDED_GOOD_ITEM} role="manazer" onDecided={() => {}} onSessionExpired={() => {}} />);
+  expect(screen.queryByTestId("pairing-review-terminal-note-PR-4")).toBeNull();
   fireEvent.click(screen.getByTestId("pairing-review-change-PR-4"));
 
   await screen.findByTestId("pairing-review-panel-PR-4");
   expect(fetchPairingCandidates).toHaveBeenCalledWith("PR-4");
 });
 
-it("busy guard: kým prvý zápis beží, ✓ Dobré AJ ✗ Zlé sú disabled (jeden zdieľaný guard)", async () => {
+it("busy guard: kým prvý zápis beží, VŠETKY štyri priame tlačidlá (✓ Dobré/vyber url/📦/🚫) sú disabled (jeden zdieľaný guard)", async () => {
   let resolveDecision: (() => void) | undefined;
   sendPairingDecision.mockImplementation(
     () =>
@@ -224,15 +288,21 @@ it("busy guard: kým prvý zápis beží, ✓ Dobré AJ ✗ Zlé sú disabled (j
 
   render(<PairingReviewCard item={MATCHED_ITEM} role="manazer" onDecided={() => {}} onSessionExpired={() => {}} />);
   const good = screen.getByTestId<HTMLButtonElement>("pairing-review-good-PR-1");
-  const bad = screen.getByTestId<HTMLButtonElement>("pairing-review-open-panel-PR-1");
+  const chooseUrl = screen.getByTestId<HTMLButtonElement>("pairing-review-open-panel-PR-1");
+  const unavailable = screen.getByTestId<HTMLButtonElement>("pairing-review-unavailable-PR-1");
+  const discontinued = screen.getByTestId<HTMLButtonElement>("pairing-review-discontinued-PR-1");
   expect(good.disabled).toBe(false);
-  expect(bad.disabled).toBe(false);
+  expect(chooseUrl.disabled).toBe(false);
+  expect(unavailable.disabled).toBe(false);
+  expect(discontinued.disabled).toBe(false);
 
   fireEvent.click(good);
   await waitFor(() => {
     expect(good.disabled).toBe(true);
   });
-  expect(bad.disabled).toBe(true);
+  expect(chooseUrl.disabled).toBe(true);
+  expect(unavailable.disabled).toBe(true);
+  expect(discontinued.disabled).toBe(true);
 
   resolveDecision?.();
   await waitFor(() => {

--- a/apps/web/src/components/PairingReviewCard.test.tsx
+++ b/apps/web/src/components/PairingReviewCard.test.tsx
@@ -177,6 +177,24 @@ it("issue 401: dodávateľ BEZ adaptéra ukáže 'zatiaľ nemá automatické vyh
   expect(await screen.findByTestId("pairing-review-manual-input-PR-NOADAPTER")).toBeDefined();
 });
 
+// Review nález (issue 398/401 review): panel, čo sa ukazuje AUTOMATICKY (bez
+// kliku na "vyber url", keď karta nemá kandidáta), musí SÁM zavolať
+// `fetchPairingCandidates` — predtým sa to volalo LEN z `openPanel`u, takže
+// "Načítavam kandidátov…" ostávalo navždy zobrazené. issue 401 tento stav
+// spraví oveľa bežnejším (každý produkt bez adaptéra ho má), preto je
+// regresný test tu.
+it("panel, čo sa ukáže AUTOMATICKY (bez kandidáta), SÁM zavolá fetchPairingCandidates — 'Načítavam kandidátov…' zmizne", async () => {
+  fetchPairingCandidates.mockResolvedValue([]);
+  render(<PairingReviewCard item={NO_ADAPTER_ITEM} role="manazer" onDecided={() => {}} onSessionExpired={() => {}} />);
+
+  await waitFor(() => {
+    expect(fetchPairingCandidates).toHaveBeenCalledWith("PR-NOADAPTER");
+  });
+  await waitFor(() => {
+    expect(screen.queryByText("Načítavam kandidátov…")).toBeNull();
+  });
+});
+
 it("issue 401: naopak — adaptérový dodávateľ, ktorý gather prehľadal a nič nenašiel, ukáže 'Nenašiel sa žiadny kandidát'", () => {
   fetchPairingCandidates.mockResolvedValue([]);
   render(<PairingReviewCard item={UNMATCHED_ITEM} role="manazer" onDecided={() => {}} onSessionExpired={() => {}} />);

--- a/apps/web/src/components/PairingReviewCard.tsx
+++ b/apps/web/src/components/PairingReviewCard.tsx
@@ -9,19 +9,34 @@ import {
   type PairingReviewCandidate,
   type PairingReviewItem,
 } from "../pairingReviewApi.js";
+import { PanelCandidateRow, TerminalButtons } from "./PairingReviewPanelParts.js";
 
 // issue 387 E5: karta jedného produktu, vyčlenená VOPRED z `PairingReviewSection.tsx`
 // (rovnaký princíp ako `OrderLineRow.tsx`/`UpozornenieCard.tsx` — dvojstĺpcová
 // karta má dosť JSX na prekročenie eslint `max-lines: 400` v jednom súbore,
 // `.claude/rules/frontend-design.md`).
 //
-// issue 387 E6: pridáva rozhodovanie — presne UX starej appky (design
-// komentár na tickete): ✓ Dobré / ✗ Zlé (✗ len ROZBALÍ panel na mieste,
-// NEPRESÚVA kartu), panel so zoznamom top-8 kandidátov ("Vybrať"), ručné URL
-// pole ("Uložiť"), 📦/🚫 terminálne stavy, ↩ Vrátiť + "Zmeniť" pri už
-// rozhodnutých. Panel je PER-KARTE lokálny stav (žiadny globálny
-// `editingXId` scalar) — issue 381's krížová strata konceptu sa netýka.
-// VŠETKY akčné tlačidlá zdieľajú JEDEN `busy` guard.
+// issue 398: posledná podoba starej appky (`parovanie-produktov` @ f76cafa,
+// commit `f45af65`) nahradila mätúci medzikrok „✗ Zlé" priamymi tlačidlami
+// NA KARTE — nerozhodnutá karta s kandidátom ukazuje VŠETKY možnosti naraz
+// (✓ Dobré / „vyber url" / 📦 / 🚫), žiadny medzikrok. „vyber url" (predtým
+// „✗ Zlé") má PRESNE rovnaké správanie ako predtým — len ROZBALÍ panel na
+// mieste (NEPRESÚVA kartu, NEMENÍ stav), teraz len s iným labelom a bez
+// zbytočného "zlé" rámovania. Panel (kandidáti/manuál/📦/🚫/Zavrieť) sa
+// ukazuje aj priamo, keď karta nemá kandidáta vôbec. Panel je PER-KARTE
+// lokálny stav (žiadny globálny `editingXId` scalar) — issue 381's krížová
+// strata konceptu sa netýka. VŠETKY akčné tlačidlá zdieľajú JEDEN `busy` guard.
+//
+// issue 401: `item.supplierHasAdapter === false` (dodávateľ bez
+// automatického adaptéra WETLAND/BETALOV/ODIMON) dostáva VLASTNÚ hlášku
+// namiesto "Nenašiel sa žiadny kandidát" — karta inak vyzerá identicky
+// (manuálne URL pole + 📦/🚫 sú tie isté možnosti z #398).
+//
+// issue 409: panel kandidátov ukazuje obrázok KAŽDÉHO z top-8 (dáta sú UŽ
+// perzistované z gather behu — žiadny live-fetch navyše, design komentár).
+//
+// Design komentár (root cause/prístup/zamietnutá alternatíva/Architektúra)
+// pre #398/#401/#409: https://github.com/zbynekdrlik/forestshop-app/issues/398
 
 const STATE_LABELS: Readonly<Record<PairingReviewItem["productState"], string>> = {
   sellable: "🟢 Skladom",
@@ -193,9 +208,18 @@ export function PairingReviewCard({
         <div className="pairing-review-side">
           <div className="pairing-review-label">Navrhnutý kandidát</div>
           {item.chosenCandidate === null ? (
-            <p className="pairing-review-nocandidate" data-testid={`pairing-review-no-candidate-${item.productKey}`}>
-              Nenašiel sa žiadny kandidát u dodávateľa.
-            </p>
+            item.supplierHasAdapter ? (
+              <p className="pairing-review-nocandidate" data-testid={`pairing-review-no-candidate-${item.productKey}`}>
+                Nenašiel sa žiadny kandidát u dodávateľa.
+              </p>
+            ) : (
+              // issue 401 — dodávateľ NEMÁ automatický adaptér (nie
+              // WETLAND/BETALOV/ODIMON) — gather preň vôbec nebehal, na
+              // rozdiel od "gather behal, nič nenašiel" vyššie.
+              <p className="pairing-review-nocandidate" data-testid={`pairing-review-no-adapter-${item.productKey}`}>
+                Tento dodávateľ zatiaľ nemá automatické vyhľadávanie — link treba zadať ručne.
+              </p>
+            )
           ) : (
             <div data-testid={`pairing-review-candidate-${item.productKey}`}>
               <a
@@ -258,6 +282,17 @@ export function PairingReviewCard({
                 </div>
               )}
 
+              {/* issue 398 — vysvetlenie dôsledku pri už rozhodnutom
+                  terminálnom stave: appka SAMA nič na eshope nemení hneď,
+                  reálne prepnutie robí nočná automatika (E7 stavový writeback). */}
+              {item.decision !== null && !panelOpen && (item.decision.status === "unavailable" || item.decision.status === "discontinued") && (
+                <p className="pairing-review-terminal-note" data-testid={`pairing-review-terminal-note-${item.productKey}`}>
+                  Reálne prepnutie viditeľnosti na eshope urobí nočná automatika (stavový zápis) — toto rozhodnutie je len príprava naň.
+                </p>
+              )}
+
+              {/* issue 398 — posledná podoba starej appky: KOLEKTÍVNY riadok
+                  všetkých možností priamo na karte, žiadny "✗ Zlé" medzikrok. */}
               {item.decision === null && item.chosenCandidate !== null && !panelOpen && (
                 <div className="pairing-review-actions">
                   <button
@@ -271,9 +306,10 @@ export function PairingReviewCard({
                   >
                     ✓ Dobré
                   </button>
-                  <button type="button" className="btn bad sm" disabled={busy} onClick={openPanel} data-testid={`pairing-review-open-panel-${item.productKey}`}>
-                    ✗ Zlé
+                  <button type="button" className="btn ghost sm" disabled={busy} onClick={openPanel} data-testid={`pairing-review-open-panel-${item.productKey}`}>
+                    vyber url
                   </button>
+                  <TerminalButtons busy={busy} submit={submit} productKey={item.productKey} />
                 </div>
               )}
 
@@ -284,23 +320,7 @@ export function PairingReviewCard({
                   {candidates === null && candidatesError === "" && <p>Načítavam kandidátov…</p>}
                   {candidates !== null &&
                     candidates.map((c, i) => (
-                      <div key={c.url} className="pairing-review-panel-candidate">
-                        <span>
-                          {c.name}: {c.url}
-                          {c.codeHit && " (kód sedí)"}
-                        </span>
-                        <button
-                          type="button"
-                          className="btn good sm"
-                          disabled={busy}
-                          onClick={() => {
-                            submit({ status: "manual", url: c.url });
-                          }}
-                          data-testid={`pairing-review-panel-pick-${item.productKey}-${String(i)}`}
-                        >
-                          Vybrať
-                        </button>
-                      </div>
+                      <PanelCandidateRow key={c.url} candidate={c} index={i} busy={busy} submit={submit} productKey={item.productKey} />
                     ))}
 
                   <div className="pairing-review-manual-row">
@@ -326,30 +346,7 @@ export function PairingReviewCard({
                   </div>
 
                   <div className="pairing-review-terminal-row">
-                    <button
-                      type="button"
-                      className="btn warn sm"
-                      disabled={busy}
-                      onClick={() => {
-                        submit({ status: "unavailable" });
-                      }}
-                      data-testid={`pairing-review-unavailable-${item.productKey}`}
-                      title="visible + Vypredané, stock 0 — dočasne, ostáva na re-kontrolu"
-                    >
-                      📦 Nie je skladom
-                    </button>
-                    <button
-                      type="button"
-                      className="btn ghost sm"
-                      disabled={busy}
-                      onClick={() => {
-                        submit({ status: "discontinued" });
-                      }}
-                      data-testid={`pairing-review-discontinued-${item.productKey}`}
-                      title="detailOnly + Predaj výrobku skončil — link ostane pre Google"
-                    >
-                      🚫 Už sa nebude predávať
-                    </button>
+                    <TerminalButtons busy={busy} submit={submit} productKey={item.productKey} />
                   </div>
 
                   {panelOpen && (

--- a/apps/web/src/components/PairingReviewCard.tsx
+++ b/apps/web/src/components/PairingReviewCard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState, type JSX } from "react";
+import { useCallback, useEffect, useRef, useState, type JSX } from "react";
 import type { Me } from "../api.js";
 import { validateSupplierLinkUrl } from "../ordersApi.js";
 import {
@@ -98,15 +98,17 @@ export function PairingReviewCard({
   // zavrieť/znovu otvoriť skôr, než dobehne pôvodný `fetchPairingCandidates`.
   const openSeq = useRef(0);
 
-  const openPanel = useCallback(() => {
+  // issue 398/401 review nález: panel sa ukazuje AJ AUTOMATICKY (bez kliku na
+  // "vyber url"), keď karta nemá kandidáta vôbec — pred touto opravou sa v
+  // tom prípade `fetchPairingCandidates` NIKDY nezavolalo (volalo sa len z
+  // `openPanel`u), takže "Načítavam kandidátov…" ostávalo navždy zobrazené aj
+  // keď v skutočnosti niet čo načítať (item.chosenCandidate === null vždy
+  // znamená `confidence === "none"`, teda top-8 zoznam je prázdny — `.claude/
+  // rules/pairing-search.md`'s E5 sekcia). issue 401 tento stav sprístupnilo
+  // OVEĽA ČASTEJŠIE (každý produkt bez adaptéra ho má), preto oprava patrí sem.
+  const loadCandidates = useCallback(() => {
     const seq = (openSeq.current += 1);
-    setPanelOpen(true);
-    setActionError("");
     setCandidatesError("");
-    // Predvyplní vlastnú URL len keď ide o EXISTUJÚCE manuálne rozhodnutie,
-    // čo NESEDÍ so žiadnym kandidátom (rovnaký vzor ako stará appka's
-    // `resolutionPanel`) — inak prázdne, nikdy neuhádnuté.
-    setManualUrl(item.decision?.status === "manual" ? (item.decision.url ?? "") : "");
     setCandidates(null);
     fetchPairingCandidates(item.productKey)
       .then((result) => {
@@ -121,7 +123,30 @@ export function PairingReviewCard({
         }
         setCandidatesError("Zoznam kandidátov sa nepodarilo načítať.");
       });
-  }, [item.productKey, item.decision, onSessionExpired]);
+  }, [item.productKey, onSessionExpired]);
+
+  const openPanel = useCallback(() => {
+    setPanelOpen(true);
+    setActionError("");
+    // Predvyplní vlastnú URL len keď ide o EXISTUJÚCE manuálne rozhodnutie,
+    // čo NESEDÍ so žiadnym kandidátom (rovnaký vzor ako stará appka's
+    // `resolutionPanel`) — inak prázdne, nikdy neuhádnuté.
+    setManualUrl(item.decision?.status === "manual" ? (item.decision.url ?? "") : "");
+    loadCandidates();
+  }, [item.decision, loadCandidates]);
+
+  const autoShowsPanel = item.decision === null && item.chosenCandidate === null;
+  // Beží pri MOUNTE (keď karta odrazu štartuje v "bez kandidáta" stave) AJ
+  // pri KAŽDOM prechode false→true PO mounte (napr. "↩ Vrátiť" na produkte
+  // bez kandidáta vráti `decision` na `null`, karta ostáva TOU ISTOU
+  // inštanciou — žiadny remount, žiadny iný spúšťač by fetch nespustil).
+  // Pole závislostí je ÚPLNÉ (tento repo nemá `eslint-plugin-react-hooks`,
+  // `.claude/rules/frontend-design.md` — kontrola je ručná, nie lintová):
+  // `loadCandidates` je stabilné (memoizované na `[item.productKey,
+  // onSessionExpired]`, oboje stabilné hodnoty).
+  useEffect(() => {
+    if (autoShowsPanel) loadCandidates();
+  }, [autoShowsPanel, loadCandidates]);
 
   const closePanel = useCallback(() => {
     openSeq.current += 1; // zahodí prípadnú ešte-bežiacu odpoveď na kandidátov

--- a/apps/web/src/components/PairingReviewPanelParts.test.tsx
+++ b/apps/web/src/components/PairingReviewPanelParts.test.tsx
@@ -1,0 +1,73 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { PanelCandidateRow, TerminalButtons } from "./PairingReviewPanelParts.js";
+
+// issue 398/409 review nález (🔵) — `PairingReviewPanelParts.tsx` je extrahovaný
+// súbor bez VLASTNÉHO test súboru (repo's zavedený vzor pre takéto extrakcie,
+// napr. `OrderLineRow.*.test.tsx`); správanie bolo dovtedy pokryté len
+// nepriamo cez `PairingReviewCard.test.tsx`. Tento súbor testuje OBIDVE
+// zložky v izolácii, s vlastnými (nie karta-odvodenými) props.
+
+const CANDIDATE = {
+  name: "Top kandidát",
+  url: "https://dodavatel.example.com/top",
+  imageUrl: "https://dodavatel.example.com/img/top.jpg",
+  rawScore: 90,
+  codeHit: true,
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+it("TerminalButtons: 📦 odošle {status:'unavailable'}, 🚫 odošle {status:'discontinued'}, oboje nesú testid podľa productKey", () => {
+  const submit = vi.fn();
+  render(<TerminalButtons busy={false} submit={submit} productKey="PR-X" />);
+
+  fireEvent.click(screen.getByTestId("pairing-review-unavailable-PR-X"));
+  expect(submit).toHaveBeenCalledWith({ status: "unavailable" });
+
+  fireEvent.click(screen.getByTestId("pairing-review-discontinued-PR-X"));
+  expect(submit).toHaveBeenCalledWith({ status: "discontinued" });
+  expect(submit).toHaveBeenCalledTimes(2);
+});
+
+it("TerminalButtons: busy=true disabluje OBE tlačidlá", () => {
+  render(<TerminalButtons busy={true} submit={vi.fn()} productKey="PR-X" />);
+
+  expect(screen.getByTestId<HTMLButtonElement>("pairing-review-unavailable-PR-X").disabled).toBe(true);
+  expect(screen.getByTestId<HTMLButtonElement>("pairing-review-discontinued-PR-X").disabled).toBe(true);
+});
+
+it("PanelCandidateRow: kandidát S obrázkom ukáže <img>, klik na 'Vybrať' odošle {status:'manual', url} tohto kandidáta", () => {
+  const submit = vi.fn();
+  render(<PanelCandidateRow candidate={CANDIDATE} index={2} busy={false} submit={submit} productKey="PR-X" />);
+
+  const img = screen.getByRole("img");
+  expect(img.getAttribute("src")).toBe(CANDIDATE.imageUrl);
+  expect(screen.queryByText("bez obrázka")).toBeNull();
+
+  fireEvent.click(screen.getByTestId("pairing-review-panel-pick-PR-X-2"));
+  expect(submit).toHaveBeenCalledWith({ status: "manual", url: CANDIDATE.url });
+});
+
+it("PanelCandidateRow: kandidát BEZ obrázka (imageUrl null) ukáže 'bez obrázka' fallback, nikdy <img>", () => {
+  render(<PanelCandidateRow candidate={{ ...CANDIDATE, imageUrl: null }} index={0} busy={false} submit={vi.fn()} productKey="PR-X" />);
+
+  expect(screen.queryByRole("img")).toBeNull();
+  expect(screen.getByText("bez obrázka")).toBeDefined();
+});
+
+it("PanelCandidateRow: text ukazuje meno, URL aj '(kód sedí)' len keď codeHit je true", () => {
+  const { unmount } = render(<PanelCandidateRow candidate={CANDIDATE} index={0} busy={false} submit={vi.fn()} productKey="PR-X" />);
+  expect(screen.getByText(/Top kandidát/).textContent).toContain("(kód sedí)");
+  unmount();
+
+  render(<PanelCandidateRow candidate={{ ...CANDIDATE, codeHit: false }} index={0} busy={false} submit={vi.fn()} productKey="PR-X" />);
+  expect(screen.getByText(/Top kandidát/).textContent).not.toContain("(kód sedí)");
+});
+
+it("PanelCandidateRow: busy=true disabluje tlačidlo 'Vybrať'", () => {
+  render(<PanelCandidateRow candidate={CANDIDATE} index={0} busy={true} submit={vi.fn()} productKey="PR-X" />);
+  expect(screen.getByTestId<HTMLButtonElement>("pairing-review-panel-pick-PR-X-0").disabled).toBe(true);
+});

--- a/apps/web/src/components/PairingReviewPanelParts.tsx
+++ b/apps/web/src/components/PairingReviewPanelParts.tsx
@@ -1,0 +1,90 @@
+import type { JSX } from "react";
+import type { PairingDecisionAction, PairingReviewCandidate } from "../pairingReviewApi.js";
+
+// issue 398/409 — vyčlenené z `PairingReviewCard.tsx` (eslint `max-lines: 400`,
+// `.claude/rules/frontend-design.md`'s zavedený vzor "component file that grows
+// past the cap gets its repeated per-item rendering unit extracted"). Dve malé,
+// bezstavové zložky zdieľané DVOMA miestami v `PairingReviewCard.tsx`:
+// `TerminalButtons` (priamy riadok na karte AJ panel — vzájomne vylučujúce v
+// DOM-e, zdieľajú testid) a `PanelCandidateRow` (jeden riadok top-8 zoznamu v
+// rozbaľovacom paneli, teraz s obrázkom kandidáta — issue 409).
+
+export function TerminalButtons({
+  busy,
+  submit,
+  productKey,
+}: {
+  readonly busy: boolean;
+  readonly submit: (action: PairingDecisionAction) => void;
+  readonly productKey: string;
+}): JSX.Element {
+  return (
+    <>
+      <button
+        type="button"
+        className="btn warn sm"
+        disabled={busy}
+        onClick={() => {
+          submit({ status: "unavailable" });
+        }}
+        data-testid={`pairing-review-unavailable-${productKey}`}
+        title="visible + Vypredané, stock 0 — dočasne, ostáva na re-kontrolu"
+      >
+        📦 Nie je skladom
+      </button>
+      <button
+        type="button"
+        className="btn ghost sm"
+        disabled={busy}
+        onClick={() => {
+          submit({ status: "discontinued" });
+        }}
+        data-testid={`pairing-review-discontinued-${productKey}`}
+        title="detailOnly + Predaj výrobku skončil — link ostane pre Google"
+      >
+        🚫 Už sa nebude predávať
+      </button>
+    </>
+  );
+}
+
+export function PanelCandidateRow({
+  candidate,
+  index,
+  busy,
+  submit,
+  productKey,
+}: {
+  readonly candidate: PairingReviewCandidate;
+  readonly index: number;
+  readonly busy: boolean;
+  readonly submit: (action: PairingDecisionAction) => void;
+  readonly productKey: string;
+}): JSX.Element {
+  return (
+    <div className="pairing-review-panel-candidate">
+      <div className="pairing-review-panel-candidate-imgbox">
+        {candidate.imageUrl !== null ? (
+          <img src={candidate.imageUrl} alt={candidate.name} loading="lazy" />
+        ) : (
+          <span className="pairing-review-noimg">bez obrázka</span>
+        )}
+      </div>
+      <span className="pairing-review-panel-candidate-text">
+        {candidate.name}: {candidate.url}
+        {candidate.codeHit && " (kód sedí)"}
+      </span>
+      <button
+        type="button"
+        className="btn good sm"
+        disabled={busy}
+        onClick={() => {
+          submit({ status: "manual", url: candidate.url });
+        }}
+        data-testid={`pairing-review-panel-pick-${productKey}-${String(index)}`}
+      >
+        Vybrať
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/PairingReviewSection.test.tsx
+++ b/apps/web/src/components/PairingReviewSection.test.tsx
@@ -28,11 +28,12 @@ const MATCHED_ITEM = {
   ourUrlIsSearchFallback: false,
   ourImageUrl: "https://www.forestshop.sk/img/bunda.jpg",
   hasEffectiveLink: false,
+  supplierHasAdapter: true,
   gatheredAt: "2026-08-13T03:35:00.000Z",
   confidence: "high" as const,
   chosenReason: "najlepší nájdený",
   verdict: "ok" as const,
-  chosenCandidate: { name: "Bunda Alfa", url: "https://dodavatel.example.com/bunda-alfa", rawScore: 1080.5, codeHit: true },
+  chosenCandidate: { name: "Bunda Alfa", url: "https://dodavatel.example.com/bunda-alfa", imageUrl: null, rawScore: 1080.5, codeHit: true },
   decision: null,
 };
 
@@ -50,6 +51,7 @@ const UNMATCHED_ITEM = {
   ourUrlIsSearchFallback: true,
   ourImageUrl: null,
   hasEffectiveLink: false,
+  supplierHasAdapter: true,
   gatheredAt: "2026-08-13T03:35:00.000Z",
   confidence: "none" as const,
   chosenReason: null,
@@ -128,6 +130,26 @@ it("klik na iný filter znova načíta zoznam s novým filtrom a zapamätá si h
     expect(searchPairingReview).toHaveBeenCalledWith({ filter: "matched", page: 1 });
   });
   expect(window.localStorage.getItem("pairingReviewFilter")).toBe("matched");
+});
+
+// issue 398 — plný zoznam z majiteľovho komentára na tickete musí byť
+// naozaj VYKRESLENÝ, nielen definovaný v type/kóde.
+it("issue 398: filtre '✓ Dobré/Vybrané' a '⛔ Vyriešené-vypnuté' sú vykreslené a fungujú", async () => {
+  searchPairingReview.mockResolvedValue({ total: 0, gatheredTotal: 0, linkedTotal: 0, items: [] });
+
+  render(<PairingReviewSection role="citanie" onSessionExpired={() => {}} />);
+  await screen.findByTestId("pairing-review-empty");
+
+  expect(screen.getByTestId("pairing-review-filter-decided").textContent).toBe("✓ Dobré/Vybrané");
+  expect(screen.getByTestId("pairing-review-filter-terminal").textContent).toBe("⛔ Vyriešené-vypnuté");
+
+  searchPairingReview.mockClear();
+  searchPairingReview.mockResolvedValue({ total: 0, gatheredTotal: 0, linkedTotal: 0, items: [] });
+  screen.getByTestId("pairing-review-filter-terminal").click();
+
+  await waitFor(() => {
+    expect(searchPairingReview).toHaveBeenCalledWith({ filter: "terminal", page: 1 });
+  });
 });
 
 // Substring kolízia s "Párovanie produktov" (#239) — pozri design komentár

--- a/apps/web/src/components/PairingReviewSection.tsx
+++ b/apps/web/src/components/PairingReviewSection.tsx
@@ -196,9 +196,10 @@ export function PairingReviewSection({ role, onSessionExpired }: { readonly role
   return (
     <section data-testid="pairing-review-section">
       <p>
-        Produkty, ktoré appka už porovnala s ponukou dodávateľov (WETLAND/BETALOV/ODIMON) — vľavo náš produkt, vpravo
-        najlepší nájdený kandidát. Rozhodovanie (potvrdenie odkazu, „Nie je skladom“, „Už sa nebude predávať“) príde v
-        ďalšej etape; táto obrazovka zatiaľ len ukazuje stav.
+        Produkty bez napárovaného odkazu na dodávateľa — vľavo náš produkt, vpravo najlepší nájdený kandidát (ak ho
+        appka u dodávateľa s automatickým vyhľadávaním našla). Na karte priamo potvrdíš navrhnutý odkaz, vyberieš
+        iného kandidáta alebo zadáš vlastnú URL, prípadne označíš produkt ako „Nie je skladom“/„Už sa nebude
+        predávať“.
       </p>
 
       <div className="pairing-review-progress" data-testid="pairing-review-progress">

--- a/apps/web/src/components/PairingReviewSection.tsx
+++ b/apps/web/src/components/PairingReviewSection.tsx
@@ -29,6 +29,10 @@ import { PairingReviewCard } from "./PairingReviewCard.js";
 // efektu, nielen v `useRef` počiatočnej hodnote). Viditeľná záložka v `NAV`
 // (`nav.ts`) — ŽIADEN vlastný `<h1>`/`<h2>`, `App.tsx`/`Topbar` ho vykreslí sám.
 
+// issue 398 — plný zoznam z majiteľovho komentára na tickete (poslednej
+// podoby starej appky): Nezrevidované · Napárované (AI) · Nenapárované ·
+// 🟢 Skladom · 📦 Nie skladom · 🚫 Nepredáva sa · ✓ Dobré/Vybrané ·
+// ⛔ Vyriešené-vypnuté · Všetky — presne v tomto poradí.
 const FILTER_LABELS: Readonly<Record<PairingReviewFilter, string>> = {
   unreviewed: "Nezrevidované",
   matched: "Napárované (AI)",
@@ -36,6 +40,8 @@ const FILTER_LABELS: Readonly<Record<PairingReviewFilter, string>> = {
   st1: "🟢 Skladom",
   st2: "📦 Nie skladom",
   st3: "🚫 Nepredáva sa",
+  decided: "✓ Dobré/Vybrané",
+  terminal: "⛔ Vyriešené-vypnuté",
   all: "Všetky",
 };
 

--- a/apps/web/src/pairingReviewApi.ts
+++ b/apps/web/src/pairingReviewApi.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 // rozhodnutia: `sendPairingDecision`/`fetchPairingCandidates` + `decision`
 // pole v položke.
 
-export const PAIRING_REVIEW_FILTERS = ["unreviewed", "matched", "unmatched", "st1", "st2", "st3", "all"] as const;
+export const PAIRING_REVIEW_FILTERS = ["unreviewed", "matched", "unmatched", "st1", "st2", "st3", "decided", "terminal", "all"] as const;
 export type PairingReviewFilter = (typeof PAIRING_REVIEW_FILTERS)[number];
 
 const chosenCandidateSchema = z.object({
@@ -41,7 +41,10 @@ const itemSchema = z.object({
   ourUrlIsSearchFallback: z.boolean(),
   ourImageUrl: z.string().nullable(),
   hasEffectiveLink: z.boolean(),
-  gatheredAt: z.string(),
+  // issue 401 — `true` = dodávateľ MÁ automatický adaptér (WETLAND/BETALOV/ODIMON).
+  supplierHasAdapter: z.boolean(),
+  // issue 401 — `null` keď produkt ešte nikdy nebol gatherovaný.
+  gatheredAt: z.string().nullable(),
   confidence: z.enum(["high", "medium", "low", "none"]),
   chosenReason: z.string().nullable(),
   verdict: z.enum(["ok", "unsure"]).nullable(),
@@ -111,6 +114,8 @@ export async function fetchPairingReviewUnreviewedCount(): Promise<number> {
 const candidateSchema = z.object({
   name: z.string(),
   url: z.string(),
+  // issue 409 — obrázok kandidáta, `null` keď žiadny zdroj neposkytol použiteľný.
+  imageUrl: z.string().nullable(),
   rawScore: z.number(),
   codeHit: z.boolean(),
 });
@@ -118,7 +123,7 @@ export type PairingReviewCandidate = z.infer<typeof candidateSchema>;
 const candidatesSchema = z.object({ candidates: z.array(candidateSchema) });
 
 // issue 387 E6 — lazy top-8 kandidátov pre rozhodovací panel (design komentár
-// na tickete: volané AŽ pri otvorení panelu ✗ Zlé, nikdy vopred).
+// na tickete: volané AŽ pri otvorení panelu „vyber url"/„✗ Zmeniť", nikdy vopred).
 export async function fetchPairingCandidates(productKey: string): Promise<readonly PairingReviewCandidate[]> {
   const response = await fetch(`/api/pairing-review/${encodeURIComponent(productKey)}/candidates`);
   return candidatesSchema.parse(await readJson(response, "Zoznam kandidátov sa nepodarilo načítať")).candidates;

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -3149,6 +3149,14 @@ a.upozornenie-title:hover {
   background: var(--fs-surface-alt);
   color: var(--fs-ink-muted);
 }
+/* issue 398 — vysvetlenie pod terminálnym odznakom (unavailable/discontinued),
+   že reálne prepnutie na eshope robí nočná automatika, nie táto obrazovka. */
+.pairing-review-terminal-note {
+  font-size: var(--fs-text-xs);
+  color: var(--fs-ink-faint);
+  font-style: italic;
+  margin-top: var(--fs-space-1);
+}
 .pairing-review-panel {
   margin-top: var(--fs-space-3);
   padding: var(--fs-space-3);
@@ -3162,10 +3170,25 @@ a.upozornenie-title:hover {
 .pairing-review-panel-candidate {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: var(--fs-space-2);
   font-size: var(--fs-text-sm);
   overflow-wrap: break-word;
+}
+/* issue 409 — malý náhľad obrázka na KAŽDOM riadku panelu (nie len chosenCandidate). */
+.pairing-review-panel-candidate-imgbox {
+  flex: 0 0 auto;
+}
+.pairing-review-panel-candidate-imgbox img {
+  width: 40px;
+  height: 40px;
+  object-fit: contain;
+  background: var(--fs-surface);
+  border: 1px solid var(--fs-border);
+  border-radius: var(--fs-radius-sm);
+}
+.pairing-review-panel-candidate-text {
+  flex: 1 1 auto;
+  min-width: 0;
 }
 .pairing-review-manual-row,
 .pairing-review-terminal-row {

--- a/apps/web/tests/e2e/catalog.spec.ts
+++ b/apps/web/tests/e2e/catalog.spec.ts
@@ -41,16 +41,19 @@ test("manažér vidí stav katalógu, vyhľadá variant a konzola je čistá", a
   // "E2E-PR-NENAJDENY"/"E2E-PR-SLINKOU", issue 387 E5,
   // `scripts/e2e-fixtures-pairing-review.ts` — chýbalo tu pri E5, doplnené
   // issue 387 E6 pri prvom behu CELEJ e2e sady proti tomuto fixtúrovému
-  // súboru) = 103. (issue 311's 3 seedované produkty "E2E-RL-*" — issue 387
-  // E8 ich fixtúru odstránilo spolu s celou obrazovkou "Vypredané → Skladom:
+  // súboru) + 2 ĎALŠIE seedované produkty pre TÚ ISTÚ obrazovku (issue
+  // 398/401: "E2E-PR-BEZADAPTERA" — dodávateľ bez adaptéra, "E2E-PR-PANEL"
+  // — druhý/alternatívny kandidát s vlastným obrázkom v paneli) = 105.
+  // (issue 311's 3 seedované produkty "E2E-RL-*" — issue 387 E8 ich
+  // fixtúru odstránilo spolu s celou obrazovkou "Vypredané → Skladom:
   // návrhy odkazov" — z tohto súčtu preto vypadli, pôvodný súčet bol 106.)
   // Prví dvaja (PREP-1/PREP-2) sú `out_of_stock` (nemenia "sellable"/
-  // "missing" nižšie), zvyšných 5, všetkých 60 "E2E-PAGE-*" aj všetky 3
-  // "E2E-PR-*" sú `sellable` (posúvajú filter "sellable" 7→73 nižšie),
+  // "missing" nižšie), zvyšných 5, všetkých 60 "E2E-PAGE-*" aj všetkých 5
+  // "E2E-PR-*" sú `sellable` (posúvajú filter "sellable" 7→75 nižšie),
   // "missing"(1) sa nemení ani jedným z nich.
   await expect(page.getByTestId("snapshot")).toContainText("Posledný import: prijatý");
-  await expect(page.getByTestId("counts")).toContainText("Variantov v katalógu (vrátane chýbajúcich): 103");
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 103 (zobrazených prvých 50)");
+  await expect(page.getByTestId("counts")).toContainText("Variantov v katalógu (vrátane chýbajúcich): 105");
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 105 (zobrazených prvých 50)");
 
   await page.getByLabel("Kód alebo názov").fill("40237/3XL");
   await page.getByRole("button", { name: "Hľadať", exact: true }).click();
@@ -70,20 +73,21 @@ test("filter podľa stavu zúži zoznam na predajné varianty", async ({ page })
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 103 (zobrazených prvých 50)");
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 105 (zobrazených prvých 50)");
   await page.getByLabel("Stav", { exact: true }).selectOption("sellable");
   await page.getByRole("button", { name: "Hľadať", exact: true }).click();
 
-  // 73 = 7 od issue 219 (variant "40237/L" má oba texty dostupnosti prázdne,
+  // 75 = 7 od issue 219 (variant "40237/L" má oba texty dostupnosti prázdne,
   // čo znamená predvolenú dostupnosť Shoptetu — "Skladom", nie vypredané) +
   // 2 sellable produkty issue 239's fixtúry ("E2E-PL-CHYBA"/"E2E-PL-OPRAVA")
   // + 1 sellable produkt issue 240's fixtúry ("E2E-SEARCH-1") + 60 sellable
-  // produktov issue 337's fixtúry ("E2E-PAGE-001".."E2E-PAGE-060") + 3
-  // sellable produkty issue 387 E5's fixtúry ("E2E-PR-CHYBA"/
-  // "E2E-PR-NENAJDENY"/"E2E-PR-SLINKOU"). (issue 311's 2 sellable "E2E-RL-
-  // NAVRH"/"E2E-RL-CUDZI" vypadli — issue 387 E8 fixtúru odstránilo, pôvodný
-  // súčet bol 75.)
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 73 (zobrazených prvých 50)");
+  // produktov issue 337's fixtúry ("E2E-PAGE-001".."E2E-PAGE-060") + 5
+  // sellable produkty issue 387/398/401's fixtúry ("E2E-PR-CHYBA"/
+  // "E2E-PR-NENAJDENY"/"E2E-PR-SLINKOU"/"E2E-PR-BEZADAPTERA"/"E2E-PR-PANEL").
+  // (issue 311's 2 sellable "E2E-RL-NAVRH"/"E2E-RL-CUDZI" vypadli skôr —
+  // issue 387 E8 fixtúru odstránilo — a 2 nové issue 398/401 produkty vyššie
+  // súčet znova zdvihli presne o 2, na náhodne rovnaké číslo 75.)
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 75 (zobrazených prvých 50)");
   await expect(page.getByTestId("variant-40237/M")).toBeVisible();
 });
 
@@ -95,7 +99,7 @@ test("filter 'Chýbajúce' nájde presne označený variant a riadok ukazuje, od
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 103 (zobrazených prvých 50)");
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 105 (zobrazených prvých 50)");
   await page.getByLabel("Stav", { exact: true }).selectOption("missing");
   await page.getByRole("button", { name: "Hľadať", exact: true }).click();
 
@@ -152,7 +156,7 @@ test("import (ešte prebiehajúci) nesmie prepísať MEDZITÝM zmenený filter z
   await page.getByLabel("E-mail").fill(E2E_RACE_EMAIL);
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 103 (zobrazených prvých 50)");
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 105 (zobrazených prvých 50)");
 
   await page.getByRole("button", { name: "Stiahnuť a naimportovať export" }).click();
 

--- a/apps/web/tests/e2e/pairing-review.spec.ts
+++ b/apps/web/tests/e2e/pairing-review.spec.ts
@@ -7,14 +7,17 @@ const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáz
 // pairing-review.ts`'s `E2E_PAROVANIE_REVIEW_EMAIL`.
 const E2E_PAROVANIE_REVIEW_EMAIL = "e2e-parovanie-review@forestshop.sk";
 // issue 397 — musia sa zhodovať s `E2E_OUR_IMAGE_DATA_URI`/`E2E_CANDIDATE_
-// IMAGE_DATA_URI` v `scripts/e2e-fixtures-pairing-review.ts` (rovnaký
-// "musí sa zhodovať" vzor ako heslo/email vyššie — `data:` URI, nikdy
-// skutočná `https://` adresa, inak prehliadač reálne skúsi obrázok
-// stiahnuť a zapíše `net::ERR_NAME_NOT_RESOLVED`/404 do konzoly).
+// IMAGE_DATA_URI`/`E2E_ALT_CANDIDATE_IMAGE_DATA_URI` v `scripts/e2e-fixtures-
+// pairing-review.ts` (rovnaký "musí sa zhodovať" vzor ako heslo/email
+// vyššie — `data:` URI, nikdy skutočná `https://` adresa, inak prehliadač
+// reálne skúsi obrázok stiahnuť a zapíše `net::ERR_NAME_NOT_RESOLVED`/404
+// do konzoly).
 const E2E_OUR_IMAGE_DATA_URI =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC";
 const E2E_CANDIDATE_IMAGE_DATA_URI =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGNgYPgPAAEDAQAIicLsAAAAAElFTkSuQmCC";
+const E2E_ALT_CANDIDATE_IMAGE_DATA_URI =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==";
 
 // issue 387 E5: "Eshop → Párovanie" — VIDITEĽNÁ záložka (`nav.ts`, priečinok
 // Eshop). Fixtúry (`scripts/e2e-fixtures-pairing-review.ts`): "E2E-PR-CHYBA"
@@ -31,6 +34,15 @@ const E2E_CANDIDATE_IMAGE_DATA_URI =
 // "E2E-PR-NENAJDENY" (nemá kandidáta, panel je hneď otvorený) sú fixtúry E5,
 // zámerne dovtedy NEROZHODNUTÉ, aby E6 testy mali čerstvý "nezrevidovaný"
 // stav na začiatku behu (fixtúrový súbor sa medzi behmi znova naseeduje).
+//
+// issue 398: žiadny "✗ Zlé" medzikrok — nerozhodnutá karta s kandidátom
+// ukazuje ŠTYRI možnosti priamo (✓ Dobré / „vyber url" / 📦 / 🚫).
+// issue 401: "E2E-PR-BEZADAPTERA" (dodávateľ BEZ registrovaného adaptéra,
+// žiadny `pairing_candidate_set` riadok) — dokazuje plnú populáciu + vlastnú
+// "zatiaľ nemá automatické vyhľadávanie" hlášku.
+// issue 409: "E2E-PR-PANEL" (DRUHÝ/alternatívny, nevybraný kandidát s
+// VLASTNÝM obrázkom) — dokazuje, že panel ukazuje obrázok KAŽDÉHO z top-8,
+// zámerne dovtedy nerozhodnutý produkt, čo žiadny INÝ test v súbore netrafí.
 
 test("predvolený filter 'Nezrevidované' ukáže produkty bez linky (s aj bez kandidáta), vylúči produkt, čo linku už má; konzola je čistá", async ({
   page,
@@ -54,15 +66,19 @@ test("predvolený filter 'Nezrevidované' ukáže produkty bez linky (s aj bez k
   await page.getByTestId("nav-tab-pairing-review").click();
   await expect(page.getByRole("heading", { name: "Párovanie", exact: true })).toBeVisible();
 
-  // Napárovaný produkt — karta ukazuje náš produkt aj navrhnutého kandidáta,
-  // s presne DVOMA akčnými tlačidlami (✓ Dobré / ✗ Zlé, issue 387 E6 —
-  // fixtúrový účet má rolu "manazer", teda smie rozhodovať).
+  // issue 398 — napárovaný produkt: karta ukazuje náš produkt aj navrhnutého
+  // kandidáta, so ŠTYRMI akčnými tlačidlami PRIAMO na karte (✓ Dobré / vyber
+  // url / 📦 / 🚫), žiadny "✗ Zlé" medzikrok.
   const chybaKarta = page.getByTestId("pairing-review-card-E2E-PR-CHYBA");
   await expect(chybaKarta).toBeVisible();
   await expect(chybaKarta).toContainText("E2E Bunda Alfa Nezrevidovaná");
   await expect(page.getByTestId("pairing-review-candidate-E2E-PR-CHYBA")).toContainText("E2E Bunda Alfa u dodávateľa");
   await expect(chybaKarta.getByTestId("pairing-review-good-E2E-PR-CHYBA")).toBeVisible();
-  await expect(chybaKarta.getByTestId("pairing-review-open-panel-E2E-PR-CHYBA")).toBeVisible();
+  await expect(chybaKarta.getByTestId("pairing-review-open-panel-E2E-PR-CHYBA")).toHaveText("vyber url");
+  await expect(chybaKarta.getByTestId("pairing-review-unavailable-E2E-PR-CHYBA")).toBeVisible();
+  await expect(chybaKarta.getByTestId("pairing-review-discontinued-E2E-PR-CHYBA")).toBeVisible();
+  // Panel NIE JE otvorený automaticky — "vyber url" ho len ponúka.
+  await expect(chybaKarta.getByTestId("pairing-review-panel-E2E-PR-CHYBA")).toHaveCount(0);
 
   // issue 397 — karta ukazuje OBA obrázky vedľa seba (náš produkt aj
   // navrhnutý kandidát), nielen text okolo nich (`scripts/e2e-fixtures-
@@ -75,6 +91,13 @@ test("predvolený filter 'Nezrevidované' ukáže produkty bez linky (s aj bez k
   const nenajdenyKarta = page.getByTestId("pairing-review-card-E2E-PR-NENAJDENY");
   await expect(nenajdenyKarta).toBeVisible();
   await expect(page.getByTestId("pairing-review-no-candidate-E2E-PR-NENAJDENY")).toContainText("Nenašiel sa žiadny kandidát");
+
+  // issue 401 — produkt dodávateľa BEZ adaptéra: VLASTNÁ hláška, NIKDY
+  // "Nenašiel sa žiadny kandidát" (gather preň vôbec nebehal).
+  const bezAdapteraKarta = page.getByTestId("pairing-review-card-E2E-PR-BEZADAPTERA");
+  await expect(bezAdapteraKarta).toBeVisible();
+  await expect(page.getByTestId("pairing-review-no-adapter-E2E-PR-BEZADAPTERA")).toContainText("nemá automatické vyhľadávanie");
+  await expect(page.getByTestId("pairing-review-no-candidate-E2E-PR-BEZADAPTERA")).toHaveCount(0);
 
   // Produkt, čo UŽ MÁ efektívnu linku — "Nezrevidované" ho vylúči.
   await expect(page.getByTestId("pairing-review-card-E2E-PR-SLINKOU")).toHaveCount(0);
@@ -118,8 +141,9 @@ test("odznak v menu ukazuje počet nezrevidovaných HNEĎ po prihlásení, bez o
 
 // issue 387 E6 — "✓ Dobré": karta vypadne z predvoleného "Nezrevidované"
 // filtra (presne "unreviewed" definícia — bez efektívnej linky), dostane
-// odznak "✓ Dobré" pod filtrom "Všetky", A efektívny odkaz sa OKAMŽITE
-// prejaví aj na obrazovke "Vyhľadať" (#240) — obe čítajú TÚ ISTÚ
+// odznak "✓ Dobré" pod filtrom "Všetky" AJ pod novým "✓ Dobré/Vybrané"
+// filtrom (issue 398), A efektívny odkaz sa OKAMŽITE prejaví aj na
+// obrazovke "Vyhľadať" (#240) — obe čítajú TÚ ISTÚ
 // `product_supplier_link_override` tabuľku, zdieľaný zápis
 // (`.claude/rules/product-links.md`). Pôvodne toto krížové overenie
 // išlo cez sesterskú obrazovku "Párovanie produktov" (#239) — issue 400
@@ -155,6 +179,10 @@ test("'✓ Dobré' rozhodnutie zapíše efektívny odkaz — viditeľný na tejt
   await expect(kartaVsetky).toBeVisible();
   await expect(kartaVsetky.getByTestId("pairing-review-decision-badge-E2E-PR-CHYBA")).toHaveText("✓ Dobré");
 
+  // issue 398 — nový "✓ Dobré/Vybrané" filter ho zahŕňa.
+  await page.getByTestId("pairing-review-filter-decided").click();
+  await expect(page.getByTestId("pairing-review-card-E2E-PR-CHYBA")).toBeVisible();
+
   // Krížové overenie na "Vyhľadať" (#240) — zdieľaná zapisovacia cesta,
   // rovnaký vzor ako `search.spec.ts`'s "Hľadať produkt".
   await page.getByRole("button", { name: "Vyhľadať" }).click();
@@ -169,7 +197,11 @@ test("'✓ Dobré' rozhodnutie zapíše efektívny odkaz — viditeľný na tejt
 // issue 387 E6 — "📦 Nie je skladom" (terminálny stav bez odkazu) + "↩
 // Vrátiť": produkt vypadne z "Nezrevidované" (je zrevidovaný, aj bez
 // efektívnej linky — E5's forward-kompat poznámka), Vrátiť ho vráti späť.
-test("'📦 Nie je skladom' vyradí produkt z 'Nezrevidované'; '↩ Vrátiť' ho vráti späť; konzola je čistá", async ({ page }) => {
+// issue 398 pridáva vysvetľujúcu poznámku o nočnej automatike + nový
+// "⛔ Vyriešené-vypnuté" filter.
+test("'📦 Nie je skladom' vyradí produkt z 'Nezrevidované', ukáže poznámku o nočnej automatike a je v '⛔ Vyriešené-vypnuté'; '↩ Vrátiť' ho vráti späť; konzola je čistá", async ({
+  page,
+}) => {
   const chyby: string[] = [];
   page.on("console", (m) => {
     if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
@@ -185,7 +217,7 @@ test("'📦 Nie je skladom' vyradí produkt z 'Nezrevidované'; '↩ Vrátiť' h
   await page.getByTestId("nav-tab-pairing-review").click();
 
   // "E2E-PR-NENAJDENY" nemá kandidáta — panel (📦/🚫/manuál) je vidno PRIAMO,
-  // bez ✓/✗ prepínača (nič na "prijatie").
+  // bez ✓/vyber url prepínača (nič na "prijatie").
   const karta = page.getByTestId("pairing-review-card-E2E-PR-NENAJDENY");
   await expect(karta).toBeVisible();
   await karta.getByTestId("pairing-review-unavailable-E2E-PR-NENAJDENY").click();
@@ -195,10 +227,98 @@ test("'📦 Nie je skladom' vyradí produkt z 'Nezrevidované'; '↩ Vrátiť' h
   const kartaVsetky = page.getByTestId("pairing-review-card-E2E-PR-NENAJDENY");
   await expect(kartaVsetky).toBeVisible();
   await expect(kartaVsetky.getByTestId("pairing-review-decision-badge-E2E-PR-NENAJDENY")).toHaveText("📦 Nie je skladom");
-  await kartaVsetky.getByTestId("pairing-review-revert-E2E-PR-NENAJDENY").click();
+  await expect(kartaVsetky.getByTestId("pairing-review-terminal-note-E2E-PR-NENAJDENY")).toContainText("nočná automatika");
+
+  // issue 398 — nový "⛔ Vyriešené-vypnuté" filter ho zahŕňa.
+  await page.getByTestId("pairing-review-filter-terminal").click();
+  await expect(page.getByTestId("pairing-review-card-E2E-PR-NENAJDENY")).toBeVisible();
+
+  await page.getByTestId("pairing-review-filter-all").click();
+  await page.getByTestId("pairing-review-card-E2E-PR-NENAJDENY").getByTestId("pairing-review-revert-E2E-PR-NENAJDENY").click();
 
   await page.getByTestId("pairing-review-filter-unreviewed").click();
   await expect(page.getByTestId("pairing-review-card-E2E-PR-NENAJDENY")).toBeVisible();
+
+  expect(chyby).toEqual([]);
+});
+
+// issue 401 — dodávateľ BEZ adaptéra: karta bez kandidátov, vlastná hláška,
+// manuálne URL pole + 📦/🚫 (rovnaké možnosti z #398) — ručne zadaná URL sa
+// zapíše cez ZDIEĽANÚ zapisovaciu cestu presne ako pri adaptérovom produkte.
+test("issue 401: produkt dodávateľa BEZ adaptéra — vlastná hláška, ručne zadaná URL sa uloží a produkt vypadne z 'Nezrevidované'; konzola je čistá", async ({
+  page,
+}) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/");
+  await page.getByLabel("E-mail").fill(E2E_PAROVANIE_REVIEW_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await page.getByTestId("nav-tab-pairing-review").click();
+
+  const karta = page.getByTestId("pairing-review-card-E2E-PR-BEZADAPTERA");
+  await expect(karta).toBeVisible();
+  await expect(page.getByTestId("pairing-review-no-adapter-E2E-PR-BEZADAPTERA")).toBeVisible();
+
+  await karta.getByTestId("pairing-review-manual-input-E2E-PR-BEZADAPTERA").fill("https://dodavatel-bez-adaptera.example.com/rucne-zadana");
+  await karta.getByTestId("pairing-review-manual-save-E2E-PR-BEZADAPTERA").click();
+  await expect(karta).toHaveCount(0);
+
+  await page.getByTestId("pairing-review-filter-all").click();
+  const kartaVsetky = page.getByTestId("pairing-review-card-E2E-PR-BEZADAPTERA");
+  await expect(kartaVsetky).toBeVisible();
+  await expect(kartaVsetky.getByTestId("pairing-review-decision-badge-E2E-PR-BEZADAPTERA")).toHaveText("✓ Vybraný link");
+
+  expect(chyby).toEqual([]);
+});
+
+// issue 409 — panel ukazuje obrázok KAŽDÉHO z top-8, nielen navrhnutého
+// kandidáta: dva kandidáti s DVOMA ODLIŠNÝMI obrázkami, výber alternatívneho
+// (nevybraného) kandidáta zapíše JEHO url, nie chosenUrl.
+test("issue 409: panel kandidátov ukazuje obrázok KAŽDÉHO kandidáta; výber alternatívneho zapíše jeho URL; konzola je čistá", async ({ page }) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/");
+  await page.getByLabel("E-mail").fill(E2E_PAROVANIE_REVIEW_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await page.getByTestId("nav-tab-pairing-review").click();
+  await page.getByTestId("pairing-review-filter-all").click();
+
+  const karta = page.getByTestId("pairing-review-card-E2E-PR-PANEL");
+  await expect(karta).toBeVisible();
+  await karta.getByTestId("pairing-review-open-panel-E2E-PR-PANEL").click();
+
+  const panel = karta.getByTestId("pairing-review-panel-E2E-PR-PANEL");
+  await expect(panel).toBeVisible();
+  await expect(panel.locator("img")).toHaveCount(2);
+  await expect(panel.locator("img").nth(0)).toHaveAttribute("src", E2E_CANDIDATE_IMAGE_DATA_URI);
+  await expect(panel.locator("img").nth(1)).toHaveAttribute("src", E2E_ALT_CANDIDATE_IMAGE_DATA_URI);
+
+  await panel.getByTestId("pairing-review-panel-pick-E2E-PR-PANEL-1").click();
+  // Filter "Všetky" ukazuje kartu ĎALEJ (na rozdiel od "Nezrevidované") — teraz
+  // s odznakom rozhodnutia namiesto akčných tlačidiel/panelu.
+  await expect(karta.getByTestId("pairing-review-decision-badge-E2E-PR-PANEL")).toHaveText("✓ Vybraný link");
+
+  // Krížové overenie na "Vyhľadať" (#240) — dokazuje, že sa zapísala URL
+  // ALTERNATÍVNEHO kandidáta (druhá pozícia), nie navrhnutého ("chosenUrl").
+  await page.getByRole("button", { name: "Vyhľadať" }).click();
+  await page.getByLabel("Produkt").fill("E2E-PR-PANEL");
+  await page.getByRole("button", { name: "Hľadať produkt" }).click();
+  await page.getByTestId("search-product-open-E2E-PR-PANEL").click();
+  await expect(page.getByTestId("search-detail-link-value")).toHaveText("https://e2e-dodavatel.example.com/bunda-beta-alt");
 
   expect(chyby).toEqual([]);
 });

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -3681,3 +3681,43 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   frontend-design.md` (CSS špecificita vs. globálny `input` reset).
 - Worktree mode (izolácia #317) — commit ostáva na vlastnej vetve,
   supervisor mergne + spustí CI pri round-integrácii.
+
+## 2026-08-13 — #398 + #401 + #409 (Parovanie: vsetky moznosti na karte, plna populacia, obrazky v paneli)
+
+- Batch (worktree isolation, #317), version bump `d504053` (0.3.0-dev.239→.241).
+- Design comment BEFORE first code commit (root cause/pristup/zamietnuta
+  alternativa/Architektura, spolocny pre vsetky tri tikety):
+  https://github.com/zbynekdrlik/forestshop-app/issues/398#issuecomment-5278355746
+  (link z #401/#409).
+- Implementacia `3779235`:
+  - #398: `PairingReviewCard.tsx` — zrusenie "Zle" medzikroku, kolektivny
+    riadok (Dobre/vyber url/Nie skladom/Uz nepredava) priamo na karte,
+    vysvetlujuca poznamka pri terminalnom rozhodnuti (nocna automatika),
+    filtre rozsirene o "decided"/"terminal" (API zod enum + web).
+  - #401: `queries.ts`'s `listPairingReview` — populacia = unia (ma
+    candidate_set RIADOK, ALEBO nema efektivnu linku, ALEBO ma
+    pairing_decision riadok), nove pole `supplierHasAdapter`, `gatheredAt`
+    nullable.
+  - #409: `listPairingCandidatesForProduct` vracia `imageUrl` pre kazdeho
+    z top-8 (uz perzistovane z gather behu, ziadny live-fetch).
+  - Novy subor `PairingReviewPanelParts.tsx` (extrakcia `TerminalButtons`/
+    `PanelCandidateRow` — eslint `max-lines: 400`).
+- Review (`fa22d5d`, jeden samostatny `general-purpose` subagent nad celym
+  diffom): 2 🟡 opravene — auto-show panel nikdy nevolal
+  `fetchPairingCandidates` (bug od E6, #401 ho spravil bezneho), stary
+  intro odstavec tvrdil "rozhodovanie pride neskor".
+- Testy: unit (web `PairingReviewCard.test.tsx`/`PairingReviewSection
+  .test.tsx`, +regresny test na auto-fetch), integration (2 nove testy v
+  `pairing-review-http.integration.test.ts` pre plnu populaciu +
+  `supplierHasAdapter`, 2 nove v `-decisions-http` pre rozhodnutie na
+  produkte bez candidateSet), e2e (2 nove testy — E2E-PR-BEZADAPTERA,
+  E2E-PR-PANEL, + 3 existujuce testy rozsirene). Cely lokalny beh (web
+  607/607, api 960/960 unit + 744/744 integration, e2e 57/57) zeleny —
+  izolovany throwaway Postgres (port 5442→5443), box zdielany s inymi
+  worktree workermi (forestshop-dev).
+- Playbook: `.claude/rules/pairing-search.md` — nova sekcia "issues
+  398/401/409" (populacna unia, `supplierHasAdapter` vs. gather stav,
+  `suppliers` TRUNCATE-bez-reseedu past, auto-show fetch gotcha, zdielany
+  testid vzor).
+- Worktree mode (izolacia #317) — commit ostava na vlastnej vetve,
+  supervisor mergne + spusti CI pri round-integracii.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.239",
+  "version": "0.3.0-dev.241",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-fixtures-pairing-review.ts
+++ b/scripts/e2e-fixtures-pairing-review.ts
@@ -1,15 +1,19 @@
 // issue 387 E5: "Eshop → Párovanie" — vyčlenené z `e2e-setup.ts` (eslint
 // `max-lines: 400`, `.claude/rules/testing.md`), rovnaký vzor ako existujúci
-// `e2e-fixtures-restock-links.ts` (#311). TRI VLASTNÉ, dovtedy nepoužité
-// jednovariantné produkty, každý s vlastným `pairing_candidate_set` riadkom
-// (E5's populácia = "produkty S kandidátmi", INNER JOIN): jeden BEZ
-// efektívnej linky s napárovaným kandidátom ("unreviewed" + "matched"),
-// jeden BEZ efektívnej linky bez kandidáta ("unreviewed" + "unmatched" —
-// dokazuje "Nenašiel sa žiadny kandidát" stav), a jeden UŽ S linkou
-// (dokazuje, že "unreviewed" filter/odznak ho vylúči — design komentár na
-// tickete, issue 387 E5).
+// `e2e-fixtures-restock-links.ts` (#311).
+//
+// issue 398/401/409 — fixtúry rozšírené o: `suppliers` riadok pre "E2E
+// Dodávateľ Párovanie" (adapterKey vyplnený — bez neho by `supplierHasAdapter`
+// vyšlo `false` pre VŠETKY existujúce fixtúry, keďže `withCleanDb`/
+// `e2e-setup.ts` truncatuje `supplier` tabuľku a NEreseeduje migračný
+// WETLAND/BETALOV/ODIMON seed — rovnaký ustálený vzor, aký `pairing-search
+// -run.integration.test.ts`/`pairing-search-verify.integration.test.ts` už
+// používajú: test si vlastný `suppliers` riadok vloží SÁM, nikdy sa
+// nespolieha na migračný seed), produkt BEZ adaptéra (#401 — nová plná
+// populácia) a produkt s DRUHÝM (nevybraným) kandidátom s vlastným
+// obrázkom (#409 — panel ukazuje obrázok KAŽDÉHO z top-8).
 import type { Database } from "../apps/api/src/db/client.js";
-import { pairingCandidates, pairingCandidateSets, products, shopProductUrl, users, variants } from "../apps/api/src/db/schema.js";
+import { pairingCandidates, pairingCandidateSets, products, shopProductUrl, suppliers, users, variants } from "../apps/api/src/db/schema.js";
 import { hashPassword } from "../apps/api/src/modules/auth/passwords.js";
 
 // Musí sa zhodovať s hodnotou v `apps/web/tests/e2e/pairing-review.spec.ts` —
@@ -32,6 +36,15 @@ export const E2E_OUR_IMAGE_DATA_URI =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC";
 export const E2E_CANDIDATE_IMAGE_DATA_URI =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGNgYPgPAAEDAQAIicLsAAAAAElFTkSuQmCC";
+// issue 409 — TRETÍ, odlišný obrázok pre ALTERNATÍVNEHO (nevybraného)
+// kandidáta v paneli (E2E-PR-PANEL nižšie) — zelený 1×1px PNG.
+export const E2E_ALT_CANDIDATE_IMAGE_DATA_URI =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==";
+
+const ADAPTER_SUPPLIER_NAME = "E2E Dodávateľ Párovanie";
+// issue 401 — dodávateľ ZÁMERNE bez `suppliers` riadku vôbec — presne
+// scenár "dodávateľ zatiaľ nemá automatické vyhľadávanie".
+const NO_ADAPTER_SUPPLIER_NAME = "E2E Dodávateľ Bez Adaptéra";
 
 export async function seedPairingReviewFixtures(db: Database, teraz: Date, snapshotId: string, heslo: string): Promise<void> {
   await db.insert(users).values({
@@ -41,11 +54,18 @@ export async function seedPairingReviewFixtures(db: Database, teraz: Date, snaps
     role: "manazer",
   });
 
-  async function seedProdukt(key: string, name: string, over: { readonly internalNote?: string | null } = {}): Promise<void> {
+  await db.insert(suppliers).values({
+    name: ADAPTER_SUPPLIER_NAME,
+    currency: "EUR",
+    wholesaleBaseUrl: "https://e2e-dodavatel.example.com",
+    adapterKey: "wetland",
+  });
+
+  async function seedProdukt(key: string, name: string, over: { readonly internalNote?: string | null; readonly supplier?: string } = {}): Promise<void> {
     await db.insert(products).values({
       key,
       name,
-      supplier: "E2E Dodávateľ Párovanie",
+      supplier: over.supplier ?? ADAPTER_SUPPLIER_NAME,
       internalNote: over.internalNote ?? null,
       firstSeenAt: teraz,
       lastSeenAt: teraz,
@@ -127,4 +147,46 @@ export async function seedPairingReviewFixtures(db: Database, teraz: Date, snaps
     confidence: "none",
     verdict: null,
   });
+
+  // issue 401 — dodávateľ BEZ adaptéra: ŽIADEN `pairing_candidate_set`
+  // riadok vôbec (gather preň nikdy nebeží), ŽIADNA efektívna linka —
+  // ukazuje kartu bez kandidátov, s hláškou "zatiaľ nemá automatické
+  // vyhľadávanie" (nie "Nenašiel sa žiadny kandidát").
+  await seedProdukt("E2E-PR-BEZADAPTERA", "E2E Produkt Bez Adaptéra", { supplier: NO_ADAPTER_SUPPLIER_NAME });
+
+  // issue 409 — DVA kandidáti: prvý (chosen) MÁ obrázok, druhý (alternatívny,
+  // nevybraný) MÁ VLASTNÝ iný obrázok — panel musí ukázať OBA nezávisle.
+  // Vlastný, dovtedy nepoužitý produkt (nikdy sa nerozhoduje inde v súbore),
+  // aby ho žiadny INÝ test v behu netrafil/nezmenil.
+  await seedProdukt("E2E-PR-PANEL", "E2E Bunda Beta Panel");
+  await db.insert(pairingCandidateSets).values({
+    productKey: "E2E-PR-PANEL",
+    gatheredAt: teraz,
+    queries: ["e2e bunda beta"],
+    inputHash: "e2e-hash-panel",
+    chosenUrl: "https://e2e-dodavatel.example.com/bunda-beta-navrh",
+    chosenReason: "najlepší nájdený",
+    confidence: "medium",
+    verdict: null,
+  });
+  await db.insert(pairingCandidates).values([
+    {
+      productKey: "E2E-PR-PANEL",
+      position: 0,
+      name: "E2E Bunda Beta u dodávateľa",
+      url: "https://e2e-dodavatel.example.com/bunda-beta-navrh",
+      imageUrl: E2E_CANDIDATE_IMAGE_DATA_URI,
+      rawScore: "85.0000",
+      codeHit: false,
+    },
+    {
+      productKey: "E2E-PR-PANEL",
+      position: 1,
+      name: "E2E Bunda Beta Alternatíva",
+      url: "https://e2e-dodavatel.example.com/bunda-beta-alt",
+      imageUrl: E2E_ALT_CANDIDATE_IMAGE_DATA_URI,
+      rawScore: "60.0000",
+      codeHit: false,
+    },
+  ]);
 }


### PR DESCRIPTION
issues 398 + 401 + 409 — majiteľ: možnosti rovno na karte bez mätúceho „Zlé"
(posledná podoba starej appky) + všetky produkty bez linku + obrázky v paneli.

## Obsah

- **issue 398**: „✗ Zlé" medzikrok odstránený — nerozhodnutá karta ukazuje rovno
  ✓ Dobré / vyber url / 📦 Nie je skladom / 🚫 Už sa nebude predávať; panel so
  všetkými kandidátmi + vlastná URL ostávajú; vyriešená karta má „✗ Zmeniť" a
  „↩ Vrátiť" s poznámkou o nočnej automatizácii. Filtre rozšírené o
  Rozhodnuté/Vyriešené-vypnuté (mapovanie zdokumentované na tickete).
- **issue 401**: populácia obrazovky prepísaná z INNER JOIN na zjednotenie
  (zber ∪ bez efektívneho linku ∪ s rozhodnutím) — obrazovka ukazuje VŠETKY
  produkty bez napárovaného odkazu, aj od dodávateľov bez adaptéra (karta
  s jasným označením + ručná URL + 📦/🚫). Badge a progres rátajú novú populáciu.
- **issue 409**: panel top-8 kandidátov ukazuje obrázky (pole z issue 397,
  žiadne živé sťahovanie).
- Opravený nájdený bug: automaticky otvorený panel „bez kandidáta" nikdy
  nespustil fetch kandidátov („Načítavam…" navždy).

## Testy

typecheck+lint čisté; unit 960 API + 613 web; integračné 744; e2e 57/57
(izolovaný Postgres). Review: 0 🔴 2 🟡 1 🔵 — všetko opravené vo vetve.
