### PR TITLE
run-now asynchrónne (202, bez duplicitných behov) + čistenie osirotených job_run (issue 413)

### DIFF
--- a/.claude/rules/local-dev.md
+++ b/.claude/rules/local-dev.md
@@ -212,3 +212,19 @@ paths:
   (`../../../../../package.json` alebo podobný dlhý reťazec `../`)
   ukazuje MIMO worktree — over ju `readlink -f`/počítaním `../` PRED tým,
   než začneš ladiť vlastný `vitest.config.ts`.
+- **`git diff <base>..HEAD` (dvojbodkový tvar) v salvage/pokračovacom
+  worktree-i, ktorý PRED implementáciou robil `git merge origin/dev`,
+  zahŕňa AJ zmeny z toho mergu — nielen prácu na aktuálnom tikete.**
+  Issue 413 (salvage): `<base>` bol commit PRED `git merge origin/dev`
+  (ktorý priniesol issue 412's samostatnú prácu), takže `git diff
+  <base>..HEAD` ukázal issue 412's súbory (`modules/orders/`, `cli/
+  orders-ingest.ts`, ...) POMIEŠANÉ s issue 413's reálnym diffom — dvojbodkové
+  `diff` je čistá stromová diferencia dvoch commitov, nerozlišuje "reachable
+  vs. ancestor" tak, ako to robí `git log A..B`. Dispatch pre nezávislý
+  review subagent, čo dostal tento zlý rozsah, musel byť opravený `SendMessage`-om
+  s presným príkazom `git diff <merge-commit>..HEAD` (rozsah AŽ OD merge
+  commitu, nie od pôvodného base). Pri KAŽDOM ĎALŠOM "recenzuj rozsah
+  A..B" dispatch-i na vetve, čo obsahovala `git merge origin/<base>`
+  UPROSTRED práce: over `git log --oneline A..B` NAJPRV (mal by ukázať LEN
+  commity tohto tiketu), a ak zoznam obsahuje cudzie SHA, posuň `A` na
+  merge commit samotný.

--- a/.claude/rules/scheduler.md
+++ b/.claude/rules/scheduler.md
@@ -89,6 +89,9 @@ paths:
   `787_878_002` (`SCHEDULER_ADVISORY_LOCK_KEY`, `scheduler.ts`),
   `787_878_003` (`INGEST_ORDERS_ADVISORY_LOCK_KEY`, `orders/ingest.ts`, #21),
   `787_878_100` (`TEST_DB_ISOLATION_LOCK_KEY`, `tests/helpers/db.ts`),
+  `787_878_101` (`TEST_RUN_NOW_LOCK_KEY`, `tests/run-now.integration.test.ts`,
+  issue 413 — vlastný testovací kľúč pre `startRunNow`u priame testy, mimo
+  produkčného rozsahu presne ako `787_878_100`),
   `787_878_004` (`POSTA_UNCOLLECTED_RUN_LOCK_KEY`, `posta-uncollected/run.ts`,
   issue 172 — pozri nižšie), `787_878_005` (`ORDER_REMINDER_RUN_LOCK_KEY`,
   `order-reminder/constants.ts`, issue 173), `787_878_006`
@@ -145,3 +148,50 @@ paths:
   ingest.ts` vedľa `CatalogIngestResult`, `catalog-routes.ts` ho odtiaľ
   len re-exportuje. Rovnaký test pri KAŽDOM ďalšom type zdieľanom medzi
   vrstvami: ktorá vrstva ho logicky vlastní?
+- **"Spustiť teraz" (manuálny HTTP trigger) je od issue 413 ASYNC pre
+  VŠETKÝCH šesť automatizácií s `job_run`-based stavom** (`shop-sitemap`,
+  `pairing-search`, `posta-uncollected`, `order-reminder`, `supplier-stock`,
+  `restock`) — **PRED touto zmenou bol synchrónny, zámerne a zdokumentovane
+  (issue 387's "appka NEMÁ v sebe žiadny background/fire-and-forget vzor
+  pre run-now"), kým prvý ostrý ~72-min beh (`supplier-stock`) a opakovaný
+  ~21-min beh (`pairing-search`) neukázali, že Cloudflare tunel's ~100s
+  proxy timeout (`.claude/rules/deploy.md`) spôsobuje klientsky HTTP 524 +
+  ZOPAKOVANÝ POST od klienta/proxy — a druhý pokus predtým ČAKAL (blokujúci
+  `pg_advisory_lock` vnútri `runXxx()`) na uvoľnenie zámku prvým behom a
+  POTOM spustil DRUHÝ, úplne zbytočný beh** (naživo pozorované na
+  shop-sitemap, issue 402: 08:55 aj 09:01 v ten istý deň). **Nový vzor
+  (`modules/scheduler/run-now.ts`'s `startRunNow`, zdieľaný naprieč
+  všetkými šiestimi):** `pg_try_advisory_lock` (NEBLOKUJÚCI) — keď zámok
+  drží niekto iný, HNEĎ 200 `{error: "Beh už prebieha…"}` (nikdy 4xx/5xx,
+  `.claude/rules/testing.md`'s "bežný doménový výsledok" disciplína) BEZ
+  vloženia `job_run` riadku a BEZ volania `run()`; keď zámok získa, vloží
+  "running" riadok, vráti 202 `{ok:true, started:true}` HNEĎ a `run()`
+  spustí BEZ `await`-u v HTTP handleri (fire-and-forget) — zámok DRŽÍ PO
+  CELÝ ČAS behu (nie peek-a-pusti), takže `run()` MUSÍ byť "odomknutý"
+  jadrový variant (`runXxxLocked`, teraz `export`-nutý zo všetkých šiestich
+  `run.ts` súborov) — inak by si vnútri seba skúsil vziať TEN ISTÝ zámok
+  znova (na inom pripojení) a deadlockol by proti `startRunNow`, čo ho už
+  drží. NAPLÁNOVANÝ beh (`scheduler/jobs.ts` cez `index.ts`) POUŽÍVA
+  NEZMENENÝ pôvodný `runXxx()` export (vlastný zámok dnu) — scheduler↔
+  run-now serializácia (druhý sa ČAKAJÚCO zaradí) ostáva pre TÚTO cestu
+  úplne nedotknutá. Frontend (4 zo 6 majú tlačidlo — `pairing-search`/
+  `shop-sitemap` nemajú vlastné UI) prestal čítať výsledok priamo z POST
+  odpovede a namiesto toho volá zdieľaný `apps/web/src/pollJobRun.ts`'s
+  `pollUntilJobDone` (opakovaný `fetchXxxStatus()`, kým `lastRun.status
+  === "running"`, ohraničené ~2 min) — presne rovnaký DRY dôvod ako
+  `useLoadMore.ts` (issue 337). **Ďalšia budúca automatizácia s manuálnym
+  HTTP run-now triggerom** (nová `{X}_RUN_LOCK_KEY` + `job_run` vzor) MÁ
+  ísť ROVNO cez `startRunNow` (export-ni `runXxxLocked`, volaj `startRunNow`
+  z routes súboru) — nikdy nekopíruj pôvodný pred-413 `runAndRecord` vzor,
+  ten je odstránený zo všetkých šiestich `http/*-routes.ts` súborov.
+- **Osirotené `job_run` riadky (appka reštart/deploy zabije rozbehnutý beh,
+  `status='running'` ostane navždy — issue 413, nález b) sa čistia
+  `modules/scheduler/startup-cleanup.ts`'s `cleanOrphanedJobRuns`, volanou
+  RAZ z `index.ts` HNEĎ PO migráciách, PRED `createApp`/`startScheduler`/
+  `serve()`.** `UPDATE job_run SET status='failure' WHERE status='running'
+  AND started_at < <čas štartu procesu>` — appka beží vždy ako PRESNE JEDNA
+  inštancia (`.claude/rules/database.md`), takže "running" riadok STARŠÍ
+  než štart TOHOTO procesu patrí nevyhnutne MŔTVEMU procesu; poradie v
+  `index.ts` (cleanup PRED čímkoľvek, čo by mohlo vložiť NOVÝ riadok)
+  garantuje nulový race. Platí VŠEOBECNE pre KAŽDÝ job (plánovaný aj
+  run-now), nielen tých šesť s manuálnym HTTP triggerom.

--- a/.claude/rules/scheduler.md
+++ b/.claude/rules/scheduler.md
@@ -195,3 +195,32 @@ paths:
   `index.ts` (cleanup PRED čímkoľvek, čo by mohlo vložiť NOVÝ riadok)
   garantuje nulový race. Platí VŠEOBECNE pre KAŽDÝ job (plánovaný aj
   run-now), nielen tých šesť s manuálnym HTTP triggerom.
+- **Každý krok medzi `pg_try_advisory_lock`-om a bodom, kde je uvoľnenie
+  zámku GARANTOVANÉ cez `.finally()` (`startRunNow`, `run-now.ts`), musí
+  mať VLASTNÝ `try/catch` uvoľňujúci zámok pred `throw`/`return` — inak
+  zámok ostane držaný NAVŽDY.** Dva takéto nálezy počas review issue 413
+  (oba opravené, oba s regresným testom): (1) `db.insert(jobRuns)` vkladajúci
+  "running" riadok — bez `try/catch` by jeho zlyhanie nechalo zámok
+  navždy zablokovaný (aj pre NAPLÁNOVANÝ beh s tým istým kľúčom); (2)
+  samotný ZÁPIS konečného stavu (`db.update(...)` v `.then()`'s success/
+  failure vetve) — bez ochrany by jeho zlyhanie NEuniklo zámok (ten sa aj
+  tak uvoľní v `.finally()`), ale nechalo by `job_run` riadok navždy
+  `status: "running"`, hoci beh v skutočnosti dobehol; fix je
+  `writeTerminalOutcome` helper, čo skúsi JEDEN núdzový zápis `failure` s
+  vysvetľujúcou správou, keď hlavný zápis zlyhá. Test na KAŽDÝ ĎALŠÍ krok
+  pridaný medzi zámok a garantované uvoľnenie: čo sa stane, ak TENTO krok
+  vyhodí? Zámok aj riadok musia oba dosiahnuť definovaný koncový stav,
+  nikdy nie "zostane visieť napospas".
+- **HTTP-level test na "Spustiť teraz" endpoint NEPOTREBUJE fixtúru ani
+  fake override, keď zdrojová funkcia má vlastný "0 kandidátov" skorý
+  návrat PRED prvým dotykom reálnej externej závislosti** (Shoptet
+  prihlásenie, sitemap fetch, search provider, dodávateľská stránka) —
+  over to PRIAMO v zdrojovom kóde funkcie (nie predpokladom), potom stačí
+  úplne PRÁZDNA `withCleanDb()` databáza. Issue 413 review nález: len 2 zo
+  6 run-now trás mali skutočný `app.request()` test dokazujúci 202/busy
+  kontrakt na HTTP úrovni (`order-reminder`/`posta-uncollected`-http.
+  integration.test.ts) — `restock-run-now-http`/`shop-sitemap-run-now-http`/
+  `pairing-search-run-now-http`.integration.test.ts (nové súbory) a
+  `supplier-stock-http.integration.test.ts` (rozšírený, `boot()` dostal
+  parameter role namiesto natvrdo "citanie") to doplnili presne týmto
+  vzorom — žiadny z nich nikdy nedotkne živú tretiu stranu.

--- a/apps/api/src/http/order-reminder-routes.ts
+++ b/apps/api/src/http/order-reminder-routes.ts
@@ -10,8 +10,10 @@ import { resolveTemplate } from "../modules/mail-templates/store.js";
 import { buildReminderEmail } from "../modules/order-reminder/logic.js";
 import { ORDER_REMINDER_JOB_NAME } from "../modules/scheduler/jobs.js";
 import { getLatestJobRun } from "../modules/scheduler/queries.js";
+import { startRunNow, type RunNowStart } from "../modules/scheduler/run-now.js";
+import { ORDER_REMINDER_RUN_LOCK_KEY } from "../modules/order-reminder/constants.js";
 import type { OrderReminderRow, OrderReminderRunResult, RunOrderReminderOptions } from "../modules/order-reminder/run.js";
-import { runOrderReminder, runOrderReminderOverride } from "../modules/order-reminder/run.js";
+import { runOrderReminderLocked, runOrderReminderOverride } from "../modules/order-reminder/run.js";
 import { isOrderReminderEnabled, setOrderReminderEnabled } from "../modules/order-reminder/settings.js";
 import { requireRole, requireUser, type AppBindings } from "./middleware.js";
 import { requireSameOrigin } from "./origin-check.js";
@@ -30,33 +32,12 @@ function isRunResult(detail: unknown): detail is OrderReminderRunResult {
   return typeof detail === "object" && detail !== null && "noNote" in detail;
 }
 
-/**
- * Manuálne "Spustiť teraz" aj naplánovaný beh zapisujú job_run TÝM ISTÝM
- * vzorom, aký #172's `runAndRecord` používa — `GET /api/order-reminder` tak
- * vidí manuálny beh HNEĎ, nielen po ďalšom pravidelnom ticku.
- */
-async function runAndRecord(db: Database, deps: OrderReminderRunDeps, now: Date, actorUserId: string): Promise<OrderReminderRunResult> {
-  const [inserted] = await db
-    .insert(jobRuns)
-    .values({ jobName: ORDER_REMINDER_JOB_NAME, startedAt: now, status: "running" })
-    .returning({ id: jobRuns.id });
-  const runId = inserted?.id;
-  try {
-    // issue 193: "Spustiť teraz" je RUČNÁ akcia (kniha odoslaných e-mailov).
-    const result = await runOrderReminder({ db, now, ...deps, trigger: "manual", actorUserId });
-    if (runId !== undefined) {
-      await db.update(jobRuns).set({ status: "success", finishedAt: new Date(), detail: result }).where(eq(jobRuns.id, runId));
-    }
-    return result;
-  } catch (error) {
-    const rawErrorMessage = error instanceof Error ? error.message : String(error);
-    log.error({ rawErrorMessage }, "Pripomienky objednávok: ručný beh zlyhal");
-    if (runId !== undefined) {
-      await db.update(jobRuns).set({ status: "failure", finishedAt: new Date(), errorMessage: rawErrorMessage }).where(eq(jobRuns.id, runId));
-    }
-    throw error;
-  }
-}
+// issue 413: manuálne "Spustiť teraz" ide cez zdieľaný `startRunNow`
+// (`modules/scheduler/run-now.ts`) — vloží "running" riadok HNEĎ a vráti
+// odpoveď BEZ čakania na celý beh (predtým synchrónne; Cloudflare tunel
+// 100s timeout spôsoboval 524 + duplicitný beh). `GET /api/order-reminder`
+// tak vidí manuálny beh HNEĎ AKO ZAČAL (status "running"), nielen po
+// dobehnutí.
 
 function findRow(result: OrderReminderRunResult | null, orderCode: string): OrderReminderRow | undefined {
   if (result === null) return undefined;
@@ -179,21 +160,36 @@ export function registerOrderReminderRoutes(app: Hono<AppBindings>, db: Database
     async (c) => {
       const user = c.get("user");
       const now = new Date();
-      let result: OrderReminderRunResult;
+      let outcome: RunNowStart;
       try {
-        result = await runAndRecord(db, deps, now, user.userId);
+        outcome = await startRunNow(
+          db,
+          {
+            jobName: ORDER_REMINDER_JOB_NAME,
+            lockKey: ORDER_REMINDER_RUN_LOCK_KEY,
+            // issue 193: "Spustiť teraz" je RUČNÁ akcia (kniha odoslaných e-mailov).
+            run: (runNow) => runOrderReminderLocked({ db, now: runNow, ...deps, trigger: "manual", actorUserId: user.userId }),
+          },
+          now,
+          async (settled) => {
+            if (settled.status !== "success") return;
+            await record(db, {
+              at: now,
+              actorUserId: user.userId,
+              action: "order_reminder.run_now",
+              entity: "job_run",
+              data: { stats: settled.result.stats },
+            });
+            log.info({ actorUserId: user.userId, stats: settled.result.stats }, "Pripomienky objednávok: ručné spustenie");
+          },
+        );
       } catch {
-        return c.json({ error: "Beh zlyhal — skúste to znova o chvíľu." }, 502);
+        return c.json({ error: "Beh sa nepodarilo spustiť — skúste to znova o chvíľu." }, 500);
       }
-      await record(db, {
-        at: now,
-        actorUserId: user.userId,
-        action: "order_reminder.run_now",
-        entity: "job_run",
-        data: { stats: result.stats },
-      });
-      log.info({ actorUserId: user.userId, stats: result.stats }, "Pripomienky objednávok: ručné spustenie");
-      return c.json({ ok: true as const, result });
+      // issue 413: "busy" je bežný, očakávaný doménový výsledok — 200, nikdy
+      // 4xx/5xx (`.claude/rules/testing.md`).
+      if (outcome.status === "busy") return c.json({ error: outcome.message }, 200);
+      return c.json({ ok: true as const, started: true as const }, 202);
     },
   );
 

--- a/apps/api/src/http/pairing-search-routes.ts
+++ b/apps/api/src/http/pairing-search-routes.ts
@@ -7,18 +7,17 @@
 // `order-reminder-routes.ts`).
 
 import { zValidator } from "@hono/zod-validator";
-import { eq } from "drizzle-orm";
 import type { Hono } from "hono";
 import { z } from "zod";
 import type { Database } from "../db/client.js";
-import { jobRuns } from "../db/schema.js";
 import { log } from "../logger.js";
 import { record } from "../modules/audit/service.js";
-import { PAIRING_SEARCH_JOB_NAME } from "../modules/pairing-search/constants.js";
+import { PAIRING_SEARCH_JOB_NAME, PAIRING_SEARCH_RUN_LOCK_KEY } from "../modules/pairing-search/constants.js";
 import type { PairingSearchRunResult } from "../modules/pairing-search/run.js";
-import { runPairingSearch } from "../modules/pairing-search/run.js";
+import { runPairingSearchLocked } from "../modules/pairing-search/run.js";
 import { isPairingSearchEnabled, setPairingSearchEnabled } from "../modules/pairing-search/settings.js";
 import { getLatestJobRun } from "../modules/scheduler/queries.js";
+import { startRunNow, type RunNowStart } from "../modules/scheduler/run-now.js";
 import { requireRole, requireUser, type AppBindings } from "./middleware.js";
 import { requireSameOrigin } from "./origin-check.js";
 
@@ -28,46 +27,14 @@ function isRunResult(detail: unknown): detail is PairingSearchRunResult {
   return typeof detail === "object" && detail !== null && "eligible" in detail;
 }
 
-/**
- * Manuálne "Spustiť teraz" zapisuje `job_run` TÝM ISTÝM vzorom, aký
- * `scheduler.ts`'s interná `executeJob` používa (rovnaká kópia ako
- * `posta-uncollected-routes.ts`/`restock-routes.ts`'s vlastné
- * `runAndRecord`) — aby `GET /api/pairing-search/status` videl ručný beh
- * HNEĎ, nielen po ďalšom nočnom ticku.
- *
- * SYNCHRÓNNE ZÁMERNE (issue 387, overené po prvom ostrom ~21-min behu):
- * appka NEMÁ v sebe žiadny background/fire-and-forget vzor pre `run-now` —
- * VŠETKY existujúce trasy (`posta-uncollected`, `restock`,
- * `supplier-stock`, `order-reminder`) sú rovnako synchrónne. Cloudflare
- * tunel má vlastný ~100s proxy timeout (`.claude/rules/deploy.md`, issue
- * 227) — dlhý beh cez tunel dostane klientsky HTTP 524, hoci appka beh na
- * `app:3000` dokončí normálne (`job_run` sa zapíše `success`). Toto NIE JE
- * prehliadnutý bug, je to zdieľané, zdokumentované a majiteľom akceptované
- * správanie naprieč VŠETKÝMI päť automatizáciami — never meň LEN túto trasu
- * na async bez toho, aby sa zmenili aj ostatné štyri (inak appka získa dva
- * nekonzistentné vzory naraz).
- */
-async function runAndRecord(db: Database, now: Date): Promise<PairingSearchRunResult> {
-  const [inserted] = await db
-    .insert(jobRuns)
-    .values({ jobName: PAIRING_SEARCH_JOB_NAME, startedAt: now, status: "running" })
-    .returning({ id: jobRuns.id });
-  const runId = inserted?.id;
-  try {
-    const result = await runPairingSearch({ db, now });
-    if (runId !== undefined) {
-      await db.update(jobRuns).set({ status: "success", finishedAt: new Date(), detail: result }).where(eq(jobRuns.id, runId));
-    }
-    return result;
-  } catch (error) {
-    const rawErrorMessage = error instanceof Error ? error.message : String(error);
-    log.error({ rawErrorMessage }, "Profesionálne párovanie: ručný beh zlyhal");
-    if (runId !== undefined) {
-      await db.update(jobRuns).set({ status: "failure", finishedAt: new Date(), errorMessage: rawErrorMessage }).where(eq(jobRuns.id, runId));
-    }
-    throw error;
-  }
-}
+// issue 413: manuálne "Spustiť teraz" ide odteraz cez ZDIEĽANÝ `startRunNow`
+// (`modules/scheduler/run-now.ts`) — pôvodný komentár tu (nižšie citovaný v
+// design komentári na tikete) výslovne dokumentoval SYNCHRÓNNE ako zámerné,
+// zdieľané správanie naprieč VŠETKÝMI šiestimi automatizáciami po prvom
+// ostrom ~21-min behu (issue 387) — presne preto sa teraz menia VŠETKÝCH
+// šesť naraz, jedným zdieľaným mechanizmom, nikdy len táto trasa osamote.
+// `GET /api/pairing-search/status` vidí manuálny beh HNEĎ AKO ZAČAL (status
+// "running"), nielen po dobehnutí.
 
 export function registerPairingSearchRoutes(app: Hono<AppBindings>, db: Database): void {
   app.get("/api/pairing-search/status", requireUser(db), async (c) => {
@@ -128,29 +95,42 @@ export function registerPairingSearchRoutes(app: Hono<AppBindings>, db: Database
     async (c) => {
       const user = c.get("user");
       const now = new Date();
-      let result: PairingSearchRunResult;
+      let outcome: RunNowStart;
       try {
-        result = await runAndRecord(db, now);
+        outcome = await startRunNow(
+          db,
+          {
+            jobName: PAIRING_SEARCH_JOB_NAME,
+            lockKey: PAIRING_SEARCH_RUN_LOCK_KEY,
+            run: (runNow) => runPairingSearchLocked({ db, now: runNow }),
+          },
+          now,
+          async (settled) => {
+            if (settled.status !== "success") return;
+            const { result } = settled;
+            await record(db, {
+              at: now,
+              actorUserId: user.userId,
+              action: "pairing_search.run_now",
+              entity: "job_run",
+              data: {
+                eligible: result.eligible,
+                processed: result.processed,
+                succeeded: result.succeeded,
+                failed: result.failed,
+              },
+            });
+            log.info(
+              { actorUserId: user.userId, eligible: result.eligible, processed: result.processed, succeeded: result.succeeded, failed: result.failed },
+              "Profesionálne párovanie: ručné spustenie",
+            );
+          },
+        );
       } catch {
-        return c.json({ ok: false as const, error: "Beh zlyhal." }, 500);
+        return c.json({ ok: false as const, error: "Beh sa nepodarilo spustiť." }, 500);
       }
-      await record(db, {
-        at: now,
-        actorUserId: user.userId,
-        action: "pairing_search.run_now",
-        entity: "job_run",
-        data: {
-          eligible: result.eligible,
-          processed: result.processed,
-          succeeded: result.succeeded,
-          failed: result.failed,
-        },
-      });
-      log.info(
-        { actorUserId: user.userId, eligible: result.eligible, processed: result.processed, succeeded: result.succeeded, failed: result.failed },
-        "Profesionálne párovanie: ručné spustenie",
-      );
-      return c.json({ ok: true as const, result });
+      if (outcome.status === "busy") return c.json({ ok: false as const, error: outcome.message }, 200);
+      return c.json({ ok: true as const, started: true as const }, 202);
     },
   );
 }

--- a/apps/api/src/http/posta-uncollected-routes.ts
+++ b/apps/api/src/http/posta-uncollected-routes.ts
@@ -1,9 +1,7 @@
 import { zValidator } from "@hono/zod-validator";
 import type { Hono } from "hono";
-import { eq } from "drizzle-orm";
 import { z } from "zod";
 import type { Database } from "../db/client.js";
-import { jobRuns } from "../db/schema.js";
 import { log } from "../logger.js";
 import { record } from "../modules/audit/service.js";
 import { MAX_EMAILS } from "../modules/posta-uncollected/constants.js";
@@ -11,8 +9,9 @@ import { resolveTemplate } from "../modules/mail-templates/store.js";
 import { buildEmail, postaTemplateKey } from "../modules/posta-uncollected/logic.js";
 import { POSTA_UNCOLLECTED_JOB_NAME } from "../modules/scheduler/jobs.js";
 import { getLatestJobRun } from "../modules/scheduler/queries.js";
+import { startRunNow, type RunNowStart } from "../modules/scheduler/run-now.js";
 import type { PostaUncollectedRunResult, RunPostaUncollectedOptions } from "../modules/posta-uncollected/run.js";
-import { runPostaUncollected } from "../modules/posta-uncollected/run.js";
+import { POSTA_UNCOLLECTED_RUN_LOCK_KEY, runPostaUncollectedLocked } from "../modules/posta-uncollected/run.js";
 import { isPostaUncollectedEnabled, setPostaUncollectedEnabled } from "../modules/posta-uncollected/settings.js";
 import { requireRole, requireUser, type AppBindings } from "./middleware.js";
 import { requireSameOrigin } from "./origin-check.js";
@@ -30,36 +29,13 @@ function isRunResult(detail: unknown): detail is PostaUncollectedRunResult {
   return typeof detail === "object" && detail !== null && "uncollected" in detail;
 }
 
-/**
- * Manuálne "Spustiť teraz" aj naplánovaný beh zapisujú job_run TÝM ISTÝM
- * vzorom, aký `scheduler.ts`'s `executeJob` používa interne — tá funkcia nie
- * je exportovaná (scheduler-interná), takže táto malá kópia zapisuje
- * rovnaký tvar riadku priamo, aby `GET /api/posta-uncollected` videl
- * manuálny beh HNEĎ, nielen po ďalšom pravidelnom ticku.
- */
-async function runAndRecord(db: Database, deps: PostaUncollectedRunDeps, now: Date, actorUserId: string): Promise<PostaUncollectedRunResult> {
-  const [inserted] = await db
-    .insert(jobRuns)
-    .values({ jobName: POSTA_UNCOLLECTED_JOB_NAME, startedAt: now, status: "running" })
-    .returning({ id: jobRuns.id });
-  const runId = inserted?.id;
-  try {
-    // issue 193: "Spustiť teraz" je RUČNÁ akcia — kniha odoslaných e-mailov
-    // to musí odlíšiť od nočného behu (`trigger`), aj s menom zamestnanca.
-    const result = await runPostaUncollected({ db, now, ...deps, trigger: "manual", actorUserId });
-    if (runId !== undefined) {
-      await db.update(jobRuns).set({ status: "success", finishedAt: new Date(), detail: result }).where(eq(jobRuns.id, runId));
-    }
-    return result;
-  } catch (error) {
-    const rawErrorMessage = error instanceof Error ? error.message : String(error);
-    log.error({ rawErrorMessage }, "Nevyzdvihnuté zásielky: ručný beh zlyhal");
-    if (runId !== undefined) {
-      await db.update(jobRuns).set({ status: "failure", finishedAt: new Date(), errorMessage: rawErrorMessage }).where(eq(jobRuns.id, runId));
-    }
-    throw error;
-  }
-}
+// issue 413: `startRunNow` (zdieľané naprieč všetkými 6 run-now
+// automatizáciami) — vloží "running" riadok HNEĎ a vráti odpoveď BEZ
+// čakania na celý beh (predtým synchrónne, viď design komentár na tikete —
+// Cloudflare tunel 100s timeout spôsoboval 524 + duplicitný beh). Audit
+// (`record()`) sa zapisuje AŽ keď beh na pozadí dobehne úspešne — presne
+// TÁ ISTÁ podmienka, akú mal pôvodný synchrónny kód (žiadny audit riadok
+// pri zlyhaní, len `job_run.status = "failure"`).
 
 export function registerPostaUncollectedRoutes(app: Hono<AppBindings>, db: Database, deps: PostaUncollectedRunDeps): void {
   // Čítanie — každý prihlásený zamestnanec (rovnaká úroveň ako "Sync zo
@@ -125,21 +101,43 @@ export function registerPostaUncollectedRoutes(app: Hono<AppBindings>, db: Datab
     async (c) => {
       const user = c.get("user");
       const now = new Date();
-      let result: PostaUncollectedRunResult;
+      let outcome: RunNowStart;
       try {
-        result = await runAndRecord(db, deps, now, user.userId);
+        outcome = await startRunNow(
+          db,
+          {
+            jobName: POSTA_UNCOLLECTED_JOB_NAME,
+            lockKey: POSTA_UNCOLLECTED_RUN_LOCK_KEY,
+            // issue 193: "Spustiť teraz" je RUČNÁ akcia — kniha odoslaných
+            // e-mailov to musí odlíšiť od nočného behu (`trigger`), aj s
+            // menom zamestnanca.
+            run: (runNow) => runPostaUncollectedLocked({ db, now: runNow, ...deps, trigger: "manual", actorUserId: user.userId }),
+          },
+          now,
+          async (settled) => {
+            // Audit sa zapisuje LEN pri úspechu — presne ako pôvodný
+            // synchrónny kód (žiadny audit riadok pri zlyhaní, len
+            // `job_run.status = "failure"`, ktoré `startRunNow` už zapísalo).
+            if (settled.status !== "success") return;
+            await record(db, {
+              at: now,
+              actorUserId: user.userId,
+              action: "posta_uncollected.run_now",
+              entity: "job_run",
+              data: { stats: settled.result.stats },
+            });
+            log.info({ actorUserId: user.userId, stats: settled.result.stats }, "Nevyzdvihnuté zásielky: ručné spustenie");
+          },
+        );
       } catch {
-        return c.json({ error: "Beh zlyhal — skúste to znova o chvíľu." }, 502);
+        return c.json({ error: "Beh sa nepodarilo spustiť — skúste to znova o chvíľu." }, 500);
       }
-      await record(db, {
-        at: now,
-        actorUserId: user.userId,
-        action: "posta_uncollected.run_now",
-        entity: "job_run",
-        data: { stats: result.stats },
-      });
-      log.info({ actorUserId: user.userId, stats: result.stats }, "Nevyzdvihnuté zásielky: ručné spustenie");
-      return c.json({ ok: true as const, result });
+      // issue 413: "busy" je BEŽNÝ, OČAKÁVANÝ doménový výsledok (druhý klik/
+      // Cloudflare retry počas prebiehajúceho behu) — 200, nikdy 4xx/5xx
+      // (`.claude/rules/testing.md`'s "Chromium loguje KAŽDÚ 4xx/5xx do
+      // konzoly" disciplína).
+      if (outcome.status === "busy") return c.json({ error: outcome.message }, 200);
+      return c.json({ ok: true as const, started: true as const }, 202);
     },
   );
 

--- a/apps/api/src/http/restock-routes.ts
+++ b/apps/api/src/http/restock-routes.ts
@@ -1,17 +1,16 @@
 import { zValidator } from "@hono/zod-validator";
-import { eq } from "drizzle-orm";
 import type { Hono } from "hono";
 import { z } from "zod";
 import type { Database } from "../db/client.js";
-import { jobRuns } from "../db/schema.js";
 import { log } from "../logger.js";
 import { record } from "../modules/audit/service.js";
 import { findFeedStateConflicts } from "../modules/catalog/feed-cross-check.js";
-import { MAX_PER_RUN, RESTOCK_JOB_NAME } from "../modules/restock/constants.js";
+import { MAX_PER_RUN, RESTOCK_JOB_NAME, RESTOCK_RUN_LOCK_KEY } from "../modules/restock/constants.js";
 import { listRestockEvents, listRestockWaiting, selectRestockCandidates } from "../modules/restock/queries.js";
 import type { RestockRunResult, RunRestockOptions } from "../modules/restock/run.js";
-import { isRestockEnabled, runRestock, setRestockEnabled } from "../modules/restock/run.js";
+import { isRestockEnabled, runRestockLocked, setRestockEnabled } from "../modules/restock/run.js";
 import { getLatestJobRun } from "../modules/scheduler/queries.js";
+import { startRunNow, type RunNowStart } from "../modules/scheduler/run-now.js";
 import { requireRole, requireUser, type AppBindings } from "./middleware.js";
 import { requireSameOrigin } from "./origin-check.js";
 
@@ -33,33 +32,9 @@ function isRunResult(detail: unknown): detail is RestockRunResult {
   return typeof detail === "object" && detail !== null && "status" in detail;
 }
 
-async function runAndRecord(db: Database, deps: RestockRunDeps, now: Date): Promise<RestockRunResult> {
-  const [inserted] = await db
-    .insert(jobRuns)
-    .values({ jobName: RESTOCK_JOB_NAME, startedAt: now, status: "running" })
-    .returning({ id: jobRuns.id });
-  const runId = inserted?.id;
-  try {
-    const result = await runRestock({ db, now, ...deps });
-    if (runId !== undefined) {
-      await db
-        .update(jobRuns)
-        .set({ status: "success", finishedAt: new Date(), detail: result })
-        .where(eq(jobRuns.id, runId));
-    }
-    return result;
-  } catch (error) {
-    const rawErrorMessage = error instanceof Error ? error.message : String(error);
-    log.error({ rawErrorMessage }, "Vypredané → Skladom: ručný beh zlyhal");
-    if (runId !== undefined) {
-      await db
-        .update(jobRuns)
-        .set({ status: "failure", finishedAt: new Date(), errorMessage: rawErrorMessage })
-        .where(eq(jobRuns.id, runId));
-    }
-    throw error;
-  }
-}
+// issue 413: manuálne "Spustiť teraz" ide cez zdieľaný `startRunNow`
+// (`modules/scheduler/run-now.ts`) — vloží "running" riadok HNEĎ a vráti
+// odpoveď BEZ čakania na celý beh, viď design komentár na tikete.
 
 export function registerRestockRoutes(app: Hono<AppBindings>, db: Database, deps: RestockRunDeps): void {
   app.get("/api/restock", requireUser(db), async (c) => {
@@ -150,21 +125,33 @@ export function registerRestockRoutes(app: Hono<AppBindings>, db: Database, deps
     async (c) => {
       const user = c.get("user");
       const now = new Date();
-      let result: RestockRunResult;
+      let outcome: RunNowStart;
       try {
-        result = await runAndRecord(db, deps, now);
+        outcome = await startRunNow(
+          db,
+          {
+            jobName: RESTOCK_JOB_NAME,
+            lockKey: RESTOCK_RUN_LOCK_KEY,
+            run: (runNow) => runRestockLocked({ db, now: runNow, ...deps }),
+          },
+          now,
+          async (settled) => {
+            if (settled.status !== "success") return;
+            await record(db, {
+              at: now,
+              actorUserId: user.userId,
+              action: "restock.run_now",
+              entity: "restock_event",
+              data: { status: settled.result.status },
+            });
+            log.info({ actorUserId: user.userId, ...settled.result }, "Vypredané → Skladom: ručný beh");
+          },
+        );
       } catch {
-        return c.json({ ok: false as const, error: "Beh zlyhal." }, 500);
+        return c.json({ ok: false as const, error: "Beh sa nepodarilo spustiť." }, 500);
       }
-      await record(db, {
-        at: now,
-        actorUserId: user.userId,
-        action: "restock.run_now",
-        entity: "restock_event",
-        data: { status: result.status },
-      });
-      log.info({ actorUserId: user.userId, ...result }, "Vypredané → Skladom: ručný beh");
-      return c.json({ ok: true as const, result });
+      if (outcome.status === "busy") return c.json({ ok: false as const, error: outcome.message }, 200);
+      return c.json({ ok: true as const, started: true as const }, 202);
     },
   );
 }

--- a/apps/api/src/http/shop-sitemap-routes.ts
+++ b/apps/api/src/http/shop-sitemap-routes.ts
@@ -5,15 +5,14 @@
 // (design komentár na tickete) — trasa slúži pre ops/smoke-test/budúce UI,
 // rovnaké zdôvodnenie ako `shop-feed`u chýbajúci manuálny spúšťač úplne.
 
-import { eq } from "drizzle-orm";
 import type { Hono } from "hono";
 import type { Database } from "../db/client.js";
-import { jobRuns } from "../db/schema.js";
 import { log } from "../logger.js";
 import { record } from "../modules/audit/service.js";
-import { SHOP_SITEMAP_JOB_NAME } from "../modules/shop-sitemap/constants.js";
-import { runShopSitemap, type ShopSitemapRunResult } from "../modules/shop-sitemap/run.js";
+import { SHOP_SITEMAP_JOB_NAME, SHOP_SITEMAP_RUN_LOCK_KEY } from "../modules/shop-sitemap/constants.js";
+import { runShopSitemapLocked, type ShopSitemapRunResult } from "../modules/shop-sitemap/run.js";
 import { getLatestJobRun } from "../modules/scheduler/queries.js";
+import { startRunNow, type RunNowStart } from "../modules/scheduler/run-now.js";
 import { requireRole, requireUser, type AppBindings } from "./middleware.js";
 import { requireSameOrigin } from "./origin-check.js";
 
@@ -21,31 +20,10 @@ function isRunResult(detail: unknown): detail is ShopSitemapRunResult {
   return typeof detail === "object" && detail !== null && "missingProducts" in detail;
 }
 
-/**
- * Manuálne "Spustiť teraz" zapisuje `job_run` TÝM ISTÝM vzorom ako
- * `scheduler.ts`'s interná `executeJob` (rovnaká kópia ako `pairing-search-
- * routes.ts`'s `runAndRecord`) — SYNCHRÓNNE zámerne, rovnaký dôvod
- * zdokumentovaný tam (appka nemá v sebe žiadny fire-and-forget vzor pre
- * run-now trasy).
- */
-async function runAndRecord(db: Database, now: Date): Promise<ShopSitemapRunResult> {
-  const [inserted] = await db.insert(jobRuns).values({ jobName: SHOP_SITEMAP_JOB_NAME, startedAt: now, status: "running" }).returning({ id: jobRuns.id });
-  const runId = inserted?.id;
-  try {
-    const result = await runShopSitemap({ db, now });
-    if (runId !== undefined) {
-      await db.update(jobRuns).set({ status: "success", finishedAt: new Date(), detail: result }).where(eq(jobRuns.id, runId));
-    }
-    return result;
-  } catch (error) {
-    const rawErrorMessage = error instanceof Error ? error.message : String(error);
-    log.error({ rawErrorMessage }, "Adresy z sitemapy: ručný beh zlyhal");
-    if (runId !== undefined) {
-      await db.update(jobRuns).set({ status: "failure", finishedAt: new Date(), errorMessage: rawErrorMessage }).where(eq(jobRuns.id, runId));
-    }
-    throw error;
-  }
-}
+// issue 413: manuálne "Spustiť teraz" ide cez zdieľaný `startRunNow`
+// (`modules/scheduler/run-now.ts`) — vloží "running" riadok HNEĎ a vráti
+// odpoveď BEZ čakania na celý beh (predtým synchrónne — presne TENTO job
+// bol nálezom (a) na tikete: druhý beh 08:55 aj 09:01 z Cloudflare retry).
 
 export function registerShopSitemapRoutes(app: Hono<AppBindings>, db: Database): void {
   app.get("/api/shop-sitemap/status", requireUser(db), async (c) => {
@@ -67,28 +45,41 @@ export function registerShopSitemapRoutes(app: Hono<AppBindings>, db: Database):
   app.post("/api/shop-sitemap/run-now", requireSameOrigin(), requireUser(db), requireRole("admin", "manazer"), async (c) => {
     const user = c.get("user");
     const now = new Date();
-    let result: ShopSitemapRunResult;
+    let outcome: RunNowStart;
     try {
-      result = await runAndRecord(db, now);
+      outcome = await startRunNow(
+        db,
+        {
+          jobName: SHOP_SITEMAP_JOB_NAME,
+          lockKey: SHOP_SITEMAP_RUN_LOCK_KEY,
+          run: (runNow) => runShopSitemapLocked({ db, now: runNow }),
+        },
+        now,
+        async (settled) => {
+          if (settled.status !== "success") return;
+          const { result } = settled;
+          await record(db, {
+            at: now,
+            actorUserId: user.userId,
+            action: "shop_sitemap.run_now",
+            entity: "job_run",
+            data: {
+              missingProducts: result.missingProducts,
+              resolvedBySitemap: result.resolvedBySitemap,
+              resolvedByProbe: result.resolvedByProbe,
+              codesAttempted: result.codesAttempted,
+            },
+          });
+          log.info(
+            { actorUserId: user.userId, missingProducts: result.missingProducts, resolvedBySitemap: result.resolvedBySitemap, resolvedByProbe: result.resolvedByProbe },
+            "Adresy z sitemapy: ručné spustenie",
+          );
+        },
+      );
     } catch {
-      return c.json({ ok: false as const, error: "Beh zlyhal." }, 500);
+      return c.json({ ok: false as const, error: "Beh sa nepodarilo spustiť." }, 500);
     }
-    await record(db, {
-      at: now,
-      actorUserId: user.userId,
-      action: "shop_sitemap.run_now",
-      entity: "job_run",
-      data: {
-        missingProducts: result.missingProducts,
-        resolvedBySitemap: result.resolvedBySitemap,
-        resolvedByProbe: result.resolvedByProbe,
-        codesAttempted: result.codesAttempted,
-      },
-    });
-    log.info(
-      { actorUserId: user.userId, missingProducts: result.missingProducts, resolvedBySitemap: result.resolvedBySitemap, resolvedByProbe: result.resolvedByProbe },
-      "Adresy z sitemapy: ručné spustenie",
-    );
-    return c.json({ ok: true as const, result });
+    if (outcome.status === "busy") return c.json({ ok: false as const, error: outcome.message }, 200);
+    return c.json({ ok: true as const, started: true as const }, 202);
   });
 }

--- a/apps/api/src/http/supplier-stock-routes.ts
+++ b/apps/api/src/http/supplier-stock-routes.ts
@@ -1,11 +1,10 @@
-import { eq } from "drizzle-orm";
 import type { Hono } from "hono";
 import type { Database } from "../db/client.js";
-import { jobRuns } from "../db/schema.js";
 import { log } from "../logger.js";
 import { record } from "../modules/audit/service.js";
 import { getLatestJobRun } from "../modules/scheduler/queries.js";
-import { SUPPLIER_STOCK_JOB_NAME } from "../modules/supplier-stock/constants.js";
+import { startRunNow, type RunNowStart } from "../modules/scheduler/run-now.js";
+import { SUPPLIER_STOCK_JOB_NAME, SUPPLIER_STOCK_RUN_LOCK_KEY } from "../modules/supplier-stock/constants.js";
 import type { PageFetcher } from "../modules/supplier-stock/page-fetcher.js";
 import {
   getSupplierStockHostOverview,
@@ -14,7 +13,7 @@ import {
   listUnreadableHosts,
 } from "../modules/supplier-stock/queries.js";
 import type { SupplierStockRunResult } from "../modules/supplier-stock/run.js";
-import { countOwnShopLinks, runSupplierStock } from "../modules/supplier-stock/run.js";
+import { countOwnShopLinks, runSupplierStockLocked } from "../modules/supplier-stock/run.js";
 import { requireRole, requireUser, type AppBindings } from "./middleware.js";
 import { requireSameOrigin } from "./origin-check.js";
 
@@ -22,43 +21,10 @@ function isRunResult(detail: unknown): detail is SupplierStockRunResult {
   return typeof detail === "object" && detail !== null && "checked" in detail;
 }
 
-/**
- * Manuálny beh zapisuje `job_run` tým istým tvarom ako scheduler, aby
- * obrazovka videla ručné spustenie HNEĎ (rovnaký vzor a rovnaký dôvod ako
- * `posta-uncollected-routes.ts`'s `runAndRecord` — `executeJob` nie je
- * exportované).
- */
-async function runAndRecord(
-  db: Database,
-  fetchPage: PageFetcher,
-  now: Date,
-): Promise<SupplierStockRunResult> {
-  const [inserted] = await db
-    .insert(jobRuns)
-    .values({ jobName: SUPPLIER_STOCK_JOB_NAME, startedAt: now, status: "running" })
-    .returning({ id: jobRuns.id });
-  const runId = inserted?.id;
-  try {
-    const result = await runSupplierStock({ db, now, fetchPage });
-    if (runId !== undefined) {
-      await db
-        .update(jobRuns)
-        .set({ status: "success", finishedAt: new Date(), detail: result })
-        .where(eq(jobRuns.id, runId));
-    }
-    return result;
-  } catch (error) {
-    const rawErrorMessage = error instanceof Error ? error.message : String(error);
-    log.error({ rawErrorMessage }, "Dodávateľský sklad: ručný beh zlyhal");
-    if (runId !== undefined) {
-      await db
-        .update(jobRuns)
-        .set({ status: "failure", finishedAt: new Date(), errorMessage: rawErrorMessage })
-        .where(eq(jobRuns.id, runId));
-    }
-    throw error;
-  }
-}
+// issue 413: manuálne "Spustiť teraz" ide cez zdieľaný `startRunNow`
+// (`modules/scheduler/run-now.ts`) — vloží "running" riadok HNEĎ a vráti
+// odpoveď BEZ čakania na celý ~72-minútový beh (predtým synchrónne,
+// `.claude/rules/supplier-stock.md`), viď design komentár na tikete.
 
 export function registerSupplierStockRoutes(
   app: Hono<AppBindings>,
@@ -105,23 +71,36 @@ export function registerSupplierStockRoutes(
     async (c) => {
       const user = c.get("user");
       const now = new Date();
-      let result: SupplierStockRunResult;
+      let outcome: RunNowStart;
       try {
-        result = await runAndRecord(db, fetchPage, now);
+        outcome = await startRunNow(
+          db,
+          {
+            jobName: SUPPLIER_STOCK_JOB_NAME,
+            lockKey: SUPPLIER_STOCK_RUN_LOCK_KEY,
+            run: (runNow) => runSupplierStockLocked({ db, now: runNow, fetchPage }),
+          },
+          now,
+          async (settled) => {
+            if (settled.status !== "success") return;
+            await record(db, {
+              at: now,
+              actorUserId: user.userId,
+              action: "supplier_stock.run_now",
+              entity: "supplier_stock",
+              data: { checked: settled.result.checked, failed: settled.result.failed },
+            });
+            log.info({ actorUserId: user.userId, ...settled.result }, "Dodávateľský sklad: ručný beh");
+          },
+        );
       } catch {
         // Presné znenie chyby je už v logu aj v `job_run` — používateľovi sa
-        // vracia len to, že beh zlyhal (rovnako ako ostatné "Spustiť teraz").
-        return c.json({ ok: false as const, error: "Beh zlyhal." }, 500);
+        // vracia len to, že beh sa nepodarilo spustiť (rovnako ako ostatné
+        // "Spustiť teraz").
+        return c.json({ ok: false as const, error: "Beh sa nepodarilo spustiť." }, 500);
       }
-      await record(db, {
-        at: now,
-        actorUserId: user.userId,
-        action: "supplier_stock.run_now",
-        entity: "supplier_stock",
-        data: { checked: result.checked, failed: result.failed },
-      });
-      log.info({ actorUserId: user.userId, ...result }, "Dodávateľský sklad: ručný beh");
-      return c.json({ ok: true as const, result });
+      if (outcome.status === "busy") return c.json({ ok: false as const, error: outcome.message }, 200);
+      return c.json({ ok: true as const, started: true as const }, 202);
     },
   );
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -48,6 +48,7 @@ import { orderNoteWritebackConfigFromBaseUrl, shoptetImportConfigFromBaseUrl } f
 import { dpdPortalConfigFromBaseUrl } from "./modules/dpd/config.js";
 import { runOrderNoteWritebackJob } from "./modules/shoptet-writeback/run-order-note-writeback.js";
 import { runShoptetWritebackSequence } from "./modules/shoptet-writeback/run-writeback-sequence.js";
+import { cleanOrphanedJobRuns } from "./modules/scheduler/startup-cleanup.js";
 import { createShutdownHandler } from "./shutdown.js";
 import { appVersion } from "./version.js";
 
@@ -61,6 +62,12 @@ const { db, pool } = createDb(env.DATABASE_URL);
 // a jeden z nich zlyhá na kolízii (napr. "already exists"). Nasadenie beží ako
 // jedna inštancia (docker-compose.prod.yml), takže to dnes nehrozí.
 await migrate(db, { migrationsFolder: fileURLToPath(new URL("../drizzle", import.meta.url)) });
+
+// issue 413: osirotené `job_run` riadky (predošlý reštart/deploy zabil
+// rozbehnutý beh, `status='running'` ostal navždy) sa vyčistia HNEĎ TU —
+// PRED `createApp`/`startScheduler`/`serve()`, takže ešte NIKTO nemohol
+// vložiť NOVÝ "running" riadok (žiadny race s čerstvo vloženým riadkom).
+await cleanOrphanedJobRuns(db, new Date());
 
 // `SHOPTET_EXPORT_URL` je nepovinná (env.ts) — bez nej appka beží ďalej, len
 // ručný import vráti 503 (catalog-routes.ts). `exactOptionalPropertyTypes` je

--- a/apps/api/src/modules/order-reminder/run.ts
+++ b/apps/api/src/modules/order-reminder/run.ts
@@ -98,7 +98,13 @@ export async function runOrderReminder(options: RunOrderReminderOptions): Promis
   }
 }
 
-async function runOrderReminderLocked(options: RunOrderReminderOptions): Promise<OrderReminderRunResult> {
+// issue 413: exportované pre `startRunNow` (`modules/scheduler/run-now.ts`)
+// z rovnakého dôvodu ako `posta-uncollected/run.ts`'s `runPostaUncollectedLocked`
+// — `startRunNow` drží `ORDER_REMINDER_RUN_LOCK_KEY` SÁM po celý čas behu.
+// `runOrderReminderOverrideLocked` (samostatný per-riadkový zámok nižšie)
+// NEEXPORTUJEME — override je rýchla akcia (jeden e-mail), nemá CF 524 riziko,
+// jej HTTP trasa zostáva nezmenená (`http/order-reminder-routes.ts`).
+export async function runOrderReminderLocked(options: RunOrderReminderOptions): Promise<OrderReminderRunResult> {
   const { db, now, classifyClient, mailTransport, bccEmail, adminBaseUrl } = options;
   const eligible = await loadEligibleOrders(db);
   const candidates = eligible.filter((o) => isOldEnough(o.placedAt, now));

--- a/apps/api/src/modules/pairing-search/run.ts
+++ b/apps/api/src/modules/pairing-search/run.ts
@@ -83,7 +83,9 @@ export async function runPairingSearch(options: RunPairingSearchOptions): Promis
   }
 }
 
-async function runPairingSearchLocked(options: RunPairingSearchOptions): Promise<PairingSearchRunResult> {
+// issue 413: exportované pre `startRunNow` (`modules/scheduler/run-now.ts`),
+// rovnaký dôvod ako `posta-uncollected/run.ts`'s `runPostaUncollectedLocked`.
+export async function runPairingSearchLocked(options: RunPairingSearchOptions): Promise<PairingSearchRunResult> {
   const { db, now } = options;
   const searchClient = options.searchClient ?? new SearchClient();
   const timeBudgetMs = options.timeBudgetMs ?? RUN_TIME_BUDGET_MS;

--- a/apps/api/src/modules/posta-uncollected/run.ts
+++ b/apps/api/src/modules/posta-uncollected/run.ts
@@ -128,7 +128,13 @@ export async function runPostaUncollected(options: RunPostaUncollectedOptions): 
   }
 }
 
-async function runPostaUncollectedLocked(options: RunPostaUncollectedOptions): Promise<PostaUncollectedRunResult> {
+// issue 413: exportované, aby `startRunNow` (`modules/scheduler/run-now.ts`)
+// mohlo zavolať odomknuté jadro PRIAMO — `startRunNow` drží
+// `POSTA_UNCOLLECTED_RUN_LOCK_KEY` SÁM po celý čas run-now behu, takže
+// volanie `runPostaUncollected` (jej zámkový obal vyššie) by tu skončilo v
+// deadlocku (čakalo by na zámok, ktorý drží volajúci). Naplánovaný beh
+// (`scheduler/jobs.ts`) naďalej volá `runPostaUncollected` (obal), nezmenené.
+export async function runPostaUncollectedLocked(options: RunPostaUncollectedOptions): Promise<PostaUncollectedRunResult> {
   const { db, now, trackingClient, mailTransport, bccEmail, adminBaseUrl, actorUserId } = options;
   const trigger = options.trigger ?? "scheduled";
   const adminOrderUrl = (order: { readonly externalOrderId: string; readonly shoptetOrderId: number | null }): string =>

--- a/apps/api/src/modules/restock/run.ts
+++ b/apps/api/src/modules/restock/run.ts
@@ -54,7 +54,9 @@ export async function runRestock(options: RunRestockOptions): Promise<RestockRun
   }
 }
 
-async function runRestockLocked(options: RunRestockOptions): Promise<RestockRunResult> {
+// issue 413: exportované pre `startRunNow` (`modules/scheduler/run-now.ts`),
+// rovnaký dôvod ako `posta-uncollected/run.ts`'s `runPostaUncollectedLocked`.
+export async function runRestockLocked(options: RunRestockOptions): Promise<RestockRunResult> {
   const { db, now, config } = options;
   const importToShoptet = options.importToShoptet ?? runShoptetImportIsolated;
   const limit = options.limit ?? MAX_PER_RUN;

--- a/apps/api/src/modules/scheduler/run-now.ts
+++ b/apps/api/src/modules/scheduler/run-now.ts
@@ -1,0 +1,141 @@
+import { eq } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { jobRuns } from "../../db/schema.js";
+import { log } from "../../logger.js";
+import { getZonedDateParts } from "../../timezone.js";
+import { getLatestJobRun } from "./queries.js";
+
+/**
+ * Zdieľaný "Spustiť teraz" (run-now) mechanizmus pre AKÚKOĽVEK automatizáciu s
+ * `job_run`-based stavom (issue 413). PRED touto zmenou mala každá zo šiestich
+ * automatizácií (shop-sitemap/pairing-search/posta-uncollected/order-reminder/
+ * supplier-stock/restock) VLASTNÚ takmer identickú kópiu `runAndRecord` v
+ * `http/*-routes.ts`, ktorá SYNCHRÓNNE `await`-ovala CELÝ beh predtým, než
+ * HTTP odpoveď odišla. Cloudflare tunel má ~100s proxy timeout
+ * (`.claude/rules/deploy.md`) — beh dlhší než to (supplier-stock ~72 min,
+ * pairing-search ~21 min) dostal klientsky HTTP 524 a klient/proxy POŽIADAVKU
+ * ZOPAKOVAL, hoci appka beh na pozadí dokončila normálne. Druhý pokus predtým
+ * ČAKAL (blokujúci `pg_advisory_lock` vnútri `runXxx()`) na uvoľnenie zámku
+ * prvým behom a POTOM spustil DRUHÝ, úplne zbytočný beh (naživo pozorované na
+ * shop-sitemap, issue 402 — beh 13. 8. 2026 o 08:55 aj 09:01).
+ *
+ * `startRunNow` rieši oba nálezy z issue 413 naraz:
+ *
+ * 1. `pg_try_advisory_lock` (NEBLOKUJÚCI) na `job.lockKey` — keď zámok už
+ *    niekto drží, HNEĎ vráti `{status:"busy"}` BEZ vloženia ďalšieho
+ *    `job_run` riadku a BEZ volania `job.run()` vôbec (HTTP vrstva to premení
+ *    na 409). Žiadne čakanie, žiadny druhý beh po dobehnutí prvého.
+ * 2. Keď zámok získa, DRŽÍ HO PO CELÝ ČAS BEHU (na tom istom pripojení, cez
+ *    ktoré ho získal) — vloží "running" `job_run` riadok, HNEĎ vráti
+ *    `{status:"started"}` (HTTP vrstva 202) a `job.run(now)` spustí BEZ
+ *    `await`-u v HTTP handleri (fire-and-forget); jeho výsledok/chyba sa
+ *    zapíše do TOHO ISTÉHO `job_run` riadku, keď dobehne, a zámok sa uvoľní
+ *    AŽ VTEDY.
+ *
+ * `job.run` MUSÍ byť "odomknutý" jadrový variant business funkcie (napr.
+ * `runPostaUncollectedLocked`, nie `runPostaUncollected`) — inak by si beh
+ * vnútri seba skúsil vziať TEN ISTÝ zámok znova (na inom pripojení) a
+ * navždy by čakal na `startRunNow`, ktoré ho už drží (deadlock). Každý zo
+ * šiestich modulov MÁ tento "Locked" variant interne od začiatku (`runXxx()`
+ * ho volá PO získaní zámku) — stačí ho `export`-núť, žiadna zmena
+ * správania. NAPLÁNOVANÝ beh (`scheduler/jobs.ts` cez `index.ts`) POUŽÍVA
+ * NEZMENENÝ pôvodný `runXxx()` export (vlastný zámok dnu, presne ako
+ * doteraz) — scheduler↔run-now serializácia (druhý sa ČAKAJÚCO zaradí)
+ * ostáva pre TÚTO cestu úplne nedotknutá, mení sa len HTTP run-now tlačidlo.
+ *
+ * Zvažovaná a zamietnutá alternatíva ("peek": `pg_try_advisory_lock` →
+ * okamžité `pg_advisory_unlock` → spustiť pôvodný, blokujúci `runXxx()`)
+ * necháva TOCTOU race okno medzi uvoľnením peek-zámku a opätovným získaním
+ * vnútri `runXxx()` — issue 413 explicitne žiada "never blocking-wait" ako
+ * ZÁRUKU, nie len pravdepodobnosť, viď design komentár na tikete.
+ */
+export interface RunNowJob<T> {
+  readonly jobName: string;
+  readonly lockKey: number;
+  /** Odomknuté jadro (`runXxxLocked`) — pozri modulový komentár vyššie. */
+  readonly run: (now: Date) => Promise<T>;
+}
+
+export type RunNowOutcome<T> =
+  | { readonly status: "success"; readonly result: T }
+  | { readonly status: "failure"; readonly error: unknown };
+
+export type RunNowStart = { readonly status: "started" } | { readonly status: "busy"; readonly message: string };
+
+function formatBratislavaTime(instant: Date): string {
+  const { hour, minute } = getZonedDateParts(instant);
+  const pad = (n: number): string => String(n).padStart(2, "0");
+  return `${pad(hour)}:${pad(minute)}`;
+}
+
+async function buildBusyMessage(db: Database, jobName: string): Promise<string> {
+  const currentRun = await getLatestJobRun(db, jobName);
+  if (currentRun !== null && currentRun.status === "running") {
+    return `Beh už prebieha (spustený o ${formatBratislavaTime(new Date(currentRun.startedAt))}) — počkajte na jeho dokončenie.`;
+  }
+  // Zámok drží niekto, koho `job_run` riadok si (race medzi peek a týmto
+  // dopytom) tento dopyt ešte nevidel, alebo ho vôbec nevkladá — všeobecná
+  // správa je stále pravdivá a nikdy neluže operátorovi presný, no zastaraný čas.
+  return "Beh už prebieha — počkajte na jeho dokončenie.";
+}
+
+export async function startRunNow<T>(
+  db: Database,
+  job: RunNowJob<T>,
+  now: Date,
+  onSettled: (outcome: RunNowOutcome<T>) => void | Promise<void>,
+): Promise<RunNowStart> {
+  const lockClient = await db.$client.connect();
+  const lockResult = await lockClient.query<{ locked: boolean }>("select pg_try_advisory_lock($1) as locked", [job.lockKey]);
+  const acquired = lockResult.rows[0]?.locked === true;
+
+  if (!acquired) {
+    lockClient.release();
+    return { status: "busy", message: await buildBusyMessage(db, job.jobName) };
+  }
+
+  const [inserted] = await db.insert(jobRuns).values({ jobName: job.jobName, startedAt: now, status: "running" }).returning({ id: jobRuns.id });
+  const runId = inserted?.id;
+
+  // Fire-and-forget — HTTP handler NIKDY nečaká na toto (issue 413's hlavná
+  // oprava). `lockClient` zostáva pripojený/zamknutý po CELÝ beh, uvoľní sa
+  // AŽ v poslednom `.finally()` nižšie.
+  void job
+    .run(now)
+    .then(
+      async (result) => {
+        if (runId !== undefined) {
+          await db.update(jobRuns).set({ status: "success", finishedAt: new Date(), detail: result }).where(eq(jobRuns.id, runId));
+        }
+        await onSettled({ status: "success", result });
+      },
+      async (error: unknown) => {
+        const rawErrorMessage = error instanceof Error ? error.message : String(error);
+        log.error({ jobName: job.jobName, rawErrorMessage }, "run-now: beh na pozadí zlyhal");
+        if (runId !== undefined) {
+          await db.update(jobRuns).set({ status: "failure", finishedAt: new Date(), errorMessage: rawErrorMessage }).where(eq(jobRuns.id, runId));
+        }
+        await onSettled({ status: "failure", error });
+      },
+    )
+    .catch((residualError: unknown) => {
+      // Obranná sieť — nemala by nikdy vystreliť (obe vetvy vyššie sa už
+      // snažia zapísať výsledok), ale zvyškové zlyhanie tu (napr. samotný
+      // UPDATE `job_run` vyhodí) nesmie nikdy uniknúť ako unhandled rejection.
+      const rawErrorMessage = residualError instanceof Error ? residualError.message : String(residualError);
+      log.error({ jobName: job.jobName, rawErrorMessage }, "run-now: zápis výsledku behu zlyhal");
+    })
+    .finally(() => {
+      void lockClient
+        .query("select pg_advisory_unlock($1)", [job.lockKey])
+        .catch((unlockError: unknown) => {
+          const rawErrorMessage = unlockError instanceof Error ? unlockError.message : String(unlockError);
+          log.error({ jobName: job.jobName, rawErrorMessage }, "run-now: uvoľnenie advisory zámku zlyhalo");
+        })
+        .finally(() => {
+          lockClient.release();
+        });
+    });
+
+  return { status: "started" };
+}

--- a/apps/api/src/modules/scheduler/run-now.ts
+++ b/apps/api/src/modules/scheduler/run-now.ts
@@ -94,8 +94,22 @@ export async function startRunNow<T>(
     return { status: "busy", message: await buildBusyMessage(db, job.jobName) };
   }
 
-  const [inserted] = await db.insert(jobRuns).values({ jobName: job.jobName, startedAt: now, status: "running" }).returning({ id: jobRuns.id });
-  const runId = inserted?.id;
+  let runId: string | undefined;
+  try {
+    const [inserted] = await db.insert(jobRuns).values({ jobName: job.jobName, startedAt: now, status: "running" }).returning({ id: jobRuns.id });
+    runId = inserted?.id;
+  } catch (insertError) {
+    // Zámok bol UŽ získaný, ale "running" riadok sa nepodarilo vložiť —
+    // `job.run()` sa NIKDY nespustí, takže fire-and-forget reťaz nižšie (a
+    // jej `.finally()`, ktoré by inak zámok uvoľnilo) sa vôbec nezostaví.
+    // Bez tohto by zámok ostal držaný NAVŽDY (rovnaký kľúč používa aj
+    // NAPLÁNOVANÝ beh, takže by sa zablokoval tiež) — uvoľni ho TU a
+    // vyhoď ďalej, presne ako "busy" vetva vyššie robí `lockClient
+    // .release()` pred návratom.
+    await lockClient.query("select pg_advisory_unlock($1)", [job.lockKey]).catch(() => undefined);
+    lockClient.release();
+    throw insertError;
+  }
 
   // Fire-and-forget — HTTP handler NIKDY nečaká na toto (issue 413's hlavná
   // oprava). `lockClient` zostáva pripojený/zamknutý po CELÝ beh, uvoľní sa

--- a/apps/api/src/modules/scheduler/run-now.ts
+++ b/apps/api/src/modules/scheduler/run-now.ts
@@ -68,6 +68,48 @@ function formatBratislavaTime(instant: Date): string {
   return `${pad(hour)}:${pad(minute)}`;
 }
 
+/**
+ * Zapíše KONEČNÝ stav `job_run` riadku — NIKDY sama nevyhodí (review nález,
+ * issue 413). Pôvodná verzia mala priamy `db.update(...)` v oboch vetvách
+ * (`.then()`'s success aj failure) BEZ vlastnej ochrany — keby TENTO zápis
+ * zlyhal (napr. krátky sieťový výpadok DB tesne po tom, čo beh sám dobehol),
+ * chyba spadla do vonkajšieho obranného `.catch()`, ktorý len loguje —
+ * riadok ostal navždy `status: "running"`, hoci proces, čo ho vložil, stále
+ * žije. Po ĎALŠOM reštarte appky by `startup-cleanup.ts`'s
+ * `cleanOrphanedJobRuns` takýto riadok navyše NESPRÁVNE označil za
+ * "prerušený reštartom", hoci v skutočnosti dobehol — len sa nepodarilo
+ * zapísať výsledok.
+ *
+ * Fix: keď hlavný zápis zlyhá, skús JEDEN núdzový zápis `failure` s
+ * vysvetľujúcou správou — riadok sa tak VŽDY dostane do konečného stavu
+ * (nikdy nezostane "running" navždy), aj keď stratí presný pôvodný
+ * výsledok/chybu. Keby zlyhal AJ núdzový zápis (dvojnásobný DB výpadok),
+ * len sa zaloguje — to je jediný prípad, keď riadok skutočne môže ostať
+ * "running" (rovnaká zvyšková miera rizika, akú má KAŽDÝ DB zápis v appke).
+ */
+async function writeTerminalOutcome(
+  db: Database,
+  jobName: string,
+  runId: string,
+  patch: { readonly status: "success" | "failure"; readonly finishedAt: Date; readonly detail?: unknown; readonly errorMessage?: string },
+): Promise<void> {
+  try {
+    await db.update(jobRuns).set(patch).where(eq(jobRuns.id, runId));
+  } catch (writeError) {
+    const rawErrorMessage = writeError instanceof Error ? writeError.message : String(writeError);
+    log.error({ jobName, rawErrorMessage }, "run-now: zápis konečného stavu behu zlyhal — skúšam núdzový zápis 'failure'");
+    try {
+      await db
+        .update(jobRuns)
+        .set({ status: "failure", finishedAt: new Date(), errorMessage: `Beh dobehol, ale zápis výsledku zlyhal: ${rawErrorMessage}` })
+        .where(eq(jobRuns.id, runId));
+    } catch (fallbackError) {
+      const fallbackMessage = fallbackError instanceof Error ? fallbackError.message : String(fallbackError);
+      log.error({ jobName, fallbackMessage }, "run-now: NÚDZOVÝ zápis konečného stavu TIEŽ zlyhal — riadok ostáva 'running'");
+    }
+  }
+}
+
 async function buildBusyMessage(db: Database, jobName: string): Promise<string> {
   const currentRun = await getLatestJobRun(db, jobName);
   if (currentRun !== null && currentRun.status === "running") {
@@ -119,7 +161,7 @@ export async function startRunNow<T>(
     .then(
       async (result) => {
         if (runId !== undefined) {
-          await db.update(jobRuns).set({ status: "success", finishedAt: new Date(), detail: result }).where(eq(jobRuns.id, runId));
+          await writeTerminalOutcome(db, job.jobName, runId, { status: "success", finishedAt: new Date(), detail: result });
         }
         await onSettled({ status: "success", result });
       },
@@ -127,7 +169,7 @@ export async function startRunNow<T>(
         const rawErrorMessage = error instanceof Error ? error.message : String(error);
         log.error({ jobName: job.jobName, rawErrorMessage }, "run-now: beh na pozadí zlyhal");
         if (runId !== undefined) {
-          await db.update(jobRuns).set({ status: "failure", finishedAt: new Date(), errorMessage: rawErrorMessage }).where(eq(jobRuns.id, runId));
+          await writeTerminalOutcome(db, job.jobName, runId, { status: "failure", finishedAt: new Date(), errorMessage: rawErrorMessage });
         }
         await onSettled({ status: "failure", error });
       },

--- a/apps/api/src/modules/scheduler/startup-cleanup.ts
+++ b/apps/api/src/modules/scheduler/startup-cleanup.ts
@@ -1,0 +1,42 @@
+import { and, eq, lt } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { jobRuns } from "../../db/schema.js";
+import { log } from "../../logger.js";
+
+/**
+ * Osirotené `job_run` riadky (issue 413, nález b): reštart appky (nasadenie
+ * novej verzie) posiela SIGTERM, `shutdown.ts` zastaví BUDÚCE naplánované
+ * ticky, ale UŽ ROZBEHNUTÝ beh (`job.run()`/`runXxx()`) sa NEPRERUŠÍ — proces
+ * jednoducho zanikne (`forceExitAfterMs` force-exit po 8 s, alebo Dockerov
+ * SIGKILL po `stop_grace_period`), kým `job_run` riadok ostáva navždy
+ * `status: "running"`. Nič v appke ho po reštarte nikdy nedohľadá — obrazovka
+ * Automatizácie/Plánovač ukazuje "Beží" donekonečna, hoci proces, čo riadok
+ * vložil, už dávno neexistuje.
+ *
+ * `cleanOrphanedJobRuns` sa volá RAZ pri štarte appky (`index.ts`, HNEĎ PO
+ * migráciách, PRED `createApp`/`startScheduler`/`serve()`) — v tomto okamihu
+ * ešte NIKTO nemohol vložiť NOVÝ "running" riadok (ani HTTP run-now, ani
+ * scheduler ešte nebežia), takže žiadny race medzi cleanup-om a čerstvo
+ * vloženým riadkom nehrozí. Platí VŠEOBECNE pre KAŽDÝ job (plánovaný aj
+ * run-now, nielen tých šesť s manuálnym HTTP triggerom z issue 413) — appka
+ * beží vždy ako presne JEDNA inštancia (`.claude/rules/database.md`), takže
+ * `status='running'` riadok so `started_at` STARŠÍM než štart TOHOTO procesu
+ * patrí nevyhnutne MŔTVEMU procesu, nikdy práve bežiacemu.
+ */
+export const ORPHANED_JOB_RUN_MESSAGE = "Beh bol prerušený reštartom aplikácie (nasadenie novej verzie) — appka to zistila pri štarte.";
+
+export async function cleanOrphanedJobRuns(db: Database, processStartedAt: Date): Promise<number> {
+  const orphaned = await db
+    .update(jobRuns)
+    .set({ status: "failure", finishedAt: processStartedAt, errorMessage: ORPHANED_JOB_RUN_MESSAGE })
+    .where(and(eq(jobRuns.status, "running"), lt(jobRuns.startedAt, processStartedAt)))
+    .returning({ id: jobRuns.id, jobName: jobRuns.jobName });
+
+  if (orphaned.length > 0) {
+    log.warn(
+      { count: orphaned.length, jobNames: orphaned.map((r) => r.jobName) },
+      "osirotené job_run riadky (prerušené predošlým reštartom appky) označené ako failure",
+    );
+  }
+  return orphaned.length;
+}

--- a/apps/api/src/modules/shop-sitemap/run.ts
+++ b/apps/api/src/modules/shop-sitemap/run.ts
@@ -66,7 +66,9 @@ export async function runShopSitemap(options: RunShopSitemapOptions): Promise<Sh
   }
 }
 
-async function runShopSitemapLocked(options: RunShopSitemapOptions): Promise<ShopSitemapRunResult> {
+// issue 413: exportované pre `startRunNow` (`modules/scheduler/run-now.ts`),
+// rovnaký dôvod ako `posta-uncollected/run.ts`'s `runPostaUncollectedLocked`.
+export async function runShopSitemapLocked(options: RunShopSitemapOptions): Promise<ShopSitemapRunResult> {
   const { db, now } = options;
   const fetchSitemap = options.fetchSitemap ?? createHttpSitemapFetcher();
   const fetchCandidate = options.fetchCandidate ?? createHttpProbeFetcher();

--- a/apps/api/src/modules/supplier-stock/run.ts
+++ b/apps/api/src/modules/supplier-stock/run.ts
@@ -156,7 +156,9 @@ interface StockRowInput {
   readonly source: SupplierStockSource;
 }
 
-async function runSupplierStockLocked(options: RunSupplierStockOptions): Promise<SupplierStockRunResult> {
+// issue 413: exportované pre `startRunNow` (`modules/scheduler/run-now.ts`),
+// rovnaký dôvod ako `posta-uncollected/run.ts`'s `runPostaUncollectedLocked`.
+export async function runSupplierStockLocked(options: RunSupplierStockOptions): Promise<SupplierStockRunResult> {
   const { db, now, fetchPage } = options;
   const sleep = options.sleep ?? defaultSleep;
 

--- a/apps/api/tests/helpers/job-run.ts
+++ b/apps/api/tests/helpers/job-run.ts
@@ -1,0 +1,22 @@
+import type { Database } from "../../src/db/client.js";
+import { getLatestJobRun, type JobRunSummary } from "../../src/modules/scheduler/queries.js";
+
+/**
+ * issue 413: run-now beží odteraz ASYNC (server vráti 202 hneď, beh
+ * pokračuje na pozadí, mimo `await`-u HTTP handlera) — integračný test,
+ * čo predtým čítal výsledok priamo z POST odpovede, musí namiesto toho
+ * počkať, kým sa `job_run` riadok posunie z "running" do konečného stavu.
+ * Bounded poll (nikdy nekonečné čakanie) — testovaný beh v týchto testoch
+ * je vždy s fejkovanými/rýchlymi závislosťami, takže reálne dobehne za pár
+ * milisekúnd; strop je len obranná poistka proti zaseknutému testu.
+ */
+export async function waitForJobRunSettled(db: Database, jobName: string, maxAttempts = 100): Promise<JobRunSummary> {
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    const run = await getLatestJobRun(db, jobName);
+    if (run !== null && run.status !== "running") return run;
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 20);
+    });
+  }
+  throw new Error(`job_run "${jobName}" sa nedostal do konečného stavu do ${String(maxAttempts)} pokusov`);
+}

--- a/apps/api/tests/order-reminder-http.integration.test.ts
+++ b/apps/api/tests/order-reminder-http.integration.test.ts
@@ -5,7 +5,9 @@ import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
 import { hashPassword } from "../src/modules/auth/passwords.js";
 import type { UserRole } from "../src/modules/auth/service.js";
 import type { MailMessage } from "../src/modules/mail/transport.js";
+import { ORDER_REMINDER_JOB_NAME } from "../src/modules/scheduler/jobs.js";
 import { withCleanDb } from "./helpers/db.js";
+import { waitForJobRunSettled } from "./helpers/job-run.js";
 
 // issue 173: HTTP vrstva pre "Pripomienky objednávok". Falošný AI
 // klasifikátor + falošný mail transport — NIKDY skutočné OpenAI ani
@@ -96,6 +98,9 @@ it("manazer prepne Štart/Stop a GET to hneď odzrkadlí", async () => {
   expect(body.enabled).toBe(true);
 });
 
+// issue 413: run-now je odteraz ASYNC — POST vráti 202 HNEĎ (beh pokračuje
+// na pozadí), výsledok sa overuje AŽ po dobehnutí (`waitForJobRunSettled`),
+// nie priamo z POST odpovede.
 it("'Spustiť teraz' funguje BEZ ohľadu na enabled=false, ale bez BCC neposlé nič", async () => {
   const sent: MailMessage[] = [];
   const { app, cookie, db } = await boot("manazer", { sent });
@@ -109,15 +114,33 @@ it("'Spustiť teraz' funguje BEZ ohľadu na enabled=false, ale bez BCC neposlé 
   });
 
   const res = await app.request("/api/order-reminder/run-now", { method: "POST", headers: { cookie } });
-  expect(res.status).toBe(200);
-  const body = (await res.json()) as { ok: boolean; result: { pending: unknown[] } };
-  expect(body.ok).toBe(true);
-  expect(body.result.pending).toHaveLength(1); // chýba BCC → čaká
+  expect(res.status).toBe(202);
+  const body = (await res.json()) as { ok: boolean; started: boolean };
+  expect(body).toEqual({ ok: true, started: true });
+
+  const finished = await waitForJobRunSettled(db, ORDER_REMINDER_JOB_NAME);
+  expect(finished.status).toBe("success");
+  const detail = finished.detail as { pending: unknown[] };
+  expect(detail.pending).toHaveLength(1); // chýba BCC → čaká
   expect(sent).toHaveLength(0);
 
   const status = await app.request("/api/order-reminder", { headers: { cookie } });
   const statusBody = (await status.json()) as { lastRun: { result: { pending: unknown[] } } | null };
   expect(statusBody.lastRun?.result.pending).toHaveLength(1);
+});
+
+it("'Spustiť teraz' druhý raz PRESNE počas prebiehajúceho behu vráti 200 'beh už prebieha'", async () => {
+  const { app, cookie, db } = await boot("manazer");
+
+  const first = app.request("/api/order-reminder/run-now", { method: "POST", headers: { cookie } });
+  const second = await app.request("/api/order-reminder/run-now", { method: "POST", headers: { cookie } });
+  expect(second.status).toBe(200);
+  const secondBody = (await second.json()) as { error: string };
+  expect(secondBody.error).toContain("Beh už prebieha");
+
+  const firstResponse = await first;
+  expect(firstResponse.status).toBe(202);
+  await waitForJobRunSettled(db, ORDER_REMINDER_JOB_NAME);
 });
 
 it("s BCC adresou 'Spustiť teraz' pošle e-mail zákazníkovi", async () => {
@@ -133,6 +156,7 @@ it("s BCC adresou 'Spustiť teraz' pošle e-mail zákazníkovi", async () => {
   });
 
   await app.request("/api/order-reminder/run-now", { method: "POST", headers: { cookie } });
+  await waitForJobRunSettled(db, ORDER_REMINDER_JOB_NAME);
   expect(sent).toHaveLength(1);
   expect(sent[0]?.bcc).toBe("majitel@forestshop.sk");
 });
@@ -149,6 +173,7 @@ it("náhľad e-mailu (preview) vráti presne to, čo by odišlo — bez odoslani
     shopRemark: "volať zákazníka",
   });
   await app.request("/api/order-reminder/run-now", { method: "POST", headers: { cookie } });
+  await waitForJobRunSettled(db, ORDER_REMINDER_JOB_NAME);
   expect(sent).toHaveLength(1);
 
   const preview = await app.request("/api/order-reminder/preview/20600103", { headers: { cookie } });
@@ -218,6 +243,7 @@ it("ručná akcia 'kontaktované' PRESUNIE riadok z 'bez poznámky' do 'preskoč
     shopRemark: null,
   });
   await app.request("/api/order-reminder/run-now", { method: "POST", headers: { cookie } });
+  await waitForJobRunSettled(db, ORDER_REMINDER_JOB_NAME);
   const before = await app.request("/api/order-reminder", { headers: { cookie } });
   const beforeBody = (await before.json()) as { lastRun: { result: { noNote: { orderCode: string }[] } } | null };
   expect(beforeBody.lastRun?.result.noNote.map((r) => r.orderCode)).toContain("20600106");

--- a/apps/api/tests/pairing-search-run-now-http.integration.test.ts
+++ b/apps/api/tests/pairing-search-run-now-http.integration.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, expect, it } from "vitest";
+import { users } from "../src/db/schema.js";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import { PAIRING_SEARCH_JOB_NAME } from "../src/modules/pairing-search/constants.js";
+import { withCleanDb } from "./helpers/db.js";
+import { waitForJobRunSettled } from "./helpers/job-run.js";
+
+// issue 413 (review finding — reviewer's 🟡 #2): closes the missing
+// HTTP-level run-now coverage for `pairing-search`, same reasoning as
+// `restock-run-now-http.integration.test.ts` — the shared `startRunNow`
+// core is already covered generically, this proves the ROUTE itself is
+// wired to the 202/busy contract.
+//
+// A completely EMPTY database is deliberate: `runPairingSearchLocked`
+// (`pairing-search/run.ts`) iterates `selectEligibleProducts(db)` and never
+// enters the loop body (the only place `searchClient` — defaulting to the
+// REAL `new SearchClient()`, `.claude/rules/testing.md`'s "never touch a
+// real external system in a test" rule — is actually used) when there are
+// zero eligible products. No fixture needed — the empty-DB short-circuit is
+// what keeps this test from ever reaching a live search provider.
+const HESLO = "test-heslo-abc";
+
+let close: (() => Promise<void>) | undefined;
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  resetLoginRateLimit();
+});
+
+async function boot() {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await ctx.db.insert(users).values({
+    email: "pouzivatel@forestshop.sk",
+    passwordHash: await hashPassword(HESLO),
+    displayName: "Test",
+    role: "manazer",
+  });
+  const app = createApp(ctx.db, { cookieSecure: false });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "pouzivatel@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie, db: ctx.db };
+}
+
+it("POST /api/pairing-search/run-now vráti 202 {ok:true,started:true} HNEĎ a job_run dobehne s eligible:0", async () => {
+  const { app, cookie, db } = await boot();
+
+  const res = await app.request("/api/pairing-search/run-now", { method: "POST", headers: { cookie } });
+  expect(res.status).toBe(202);
+  const body = (await res.json()) as { ok: boolean; started: boolean };
+  expect(body).toEqual({ ok: true, started: true });
+
+  const finished = await waitForJobRunSettled(db, PAIRING_SEARCH_JOB_NAME);
+  expect(finished.status).toBe("success");
+  const detail = finished.detail as { eligible: number; processed: number };
+  expect(detail.eligible).toBe(0);
+  expect(detail.processed).toBe(0);
+});
+
+it("druhý POST PRESNE počas prebiehajúceho behu vráti 200 {ok:false,error} 'beh už prebieha'", async () => {
+  const { app, cookie, db } = await boot();
+
+  const first = app.request("/api/pairing-search/run-now", { method: "POST", headers: { cookie } });
+  const second = await app.request("/api/pairing-search/run-now", { method: "POST", headers: { cookie } });
+  expect(second.status).toBe(200);
+  const secondBody = (await second.json()) as { ok: boolean; error: string };
+  expect(secondBody.ok).toBe(false);
+  expect(secondBody.error).toContain("Beh už prebieha");
+
+  const firstResponse = await first;
+  expect(firstResponse.status).toBe(202);
+  await waitForJobRunSettled(db, PAIRING_SEARCH_JOB_NAME);
+});

--- a/apps/api/tests/posta-uncollected-http.integration.test.ts
+++ b/apps/api/tests/posta-uncollected-http.integration.test.ts
@@ -5,7 +5,9 @@ import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
 import { hashPassword } from "../src/modules/auth/passwords.js";
 import type { UserRole } from "../src/modules/auth/service.js";
 import type { MailMessage } from "../src/modules/mail/transport.js";
+import { POSTA_UNCOLLECTED_JOB_NAME } from "../src/modules/scheduler/jobs.js";
 import { withCleanDb } from "./helpers/db.js";
+import { waitForJobRunSettled } from "./helpers/job-run.js";
 
 // issue 172: HTTP vrstva pre "Nevyzdvihnuté zásielky". Falošný tracking klient
 // + falošný mail transport — NIKDY skutočné api.posta.sk ani skutočný SMTP
@@ -95,6 +97,9 @@ it("manazer prepne Štart/Stop a GET to hneď odzrkadlí", async () => {
   expect(body.enabled).toBe(true);
 });
 
+// issue 413: run-now je odteraz ASYNC — POST vráti 202 HNEĎ (beh pokračuje
+// na pozadí), výsledok sa overuje AŽ po dobehnutí (`waitForJobRunSettled`),
+// nie priamo z POST odpovede.
 it("'Spustiť teraz' funguje BEZ ohľadu na enabled=false, ale bez BCC neposlé nič", async () => {
   const sent: MailMessage[] = [];
   const { app, cookie, db } = await boot("manazer", { sent });
@@ -112,16 +117,51 @@ it("'Spustiť teraz' funguje BEZ ohľadu na enabled=false, ale bez BCC neposlé 
     method: "POST",
     headers: { cookie },
   });
-  expect(res.status).toBe(200);
-  const body = (await res.json()) as { ok: boolean; result: { stats: { emailsBlocked: number }; uncollected: unknown[] } };
-  expect(body.ok).toBe(true);
-  expect(body.result.stats.emailsBlocked).toBe(1);
+  expect(res.status).toBe(202);
+  const body = (await res.json()) as { ok: boolean; started: boolean };
+  expect(body).toEqual({ ok: true, started: true });
+
+  const finished = await waitForJobRunSettled(db, POSTA_UNCOLLECTED_JOB_NAME);
+  expect(finished.status).toBe("success");
+  const detail = finished.detail as { stats: { emailsBlocked: number } };
+  expect(detail.stats.emailsBlocked).toBe(1);
   expect(sent).toHaveLength(0);
 
-  // GET hneď odzrkadlí manuálny beh (žiadny ďalší tick netreba čakať).
+  // GET odzrkadlí manuálny beh AKO DOBEHNUTÝ (žiadny ďalší tick netreba čakať).
   const status = await app.request("/api/posta-uncollected", { headers: { cookie } });
   const statusBody = (await status.json()) as { lastRun: { result: { uncollected: unknown[] } } | null };
   expect(statusBody.lastRun?.result.uncollected).toHaveLength(1);
+});
+
+it("'Spustiť teraz' druhý raz PRESNE počas prebiehajúceho behu vráti 200 'beh už prebieha' (žiadny duplicitný e-mail)", async () => {
+  const sent: MailMessage[] = [];
+  const { app, cookie, db } = await boot("manazer", { sent, bccEmail: "majitel@forestshop.sk" });
+  await db.insert(orders).values({
+    externalOrderId: "20600004",
+    customerName: "Test",
+    statusName: "Vybavená",
+    placedAt: new Date("2026-07-25T00:00:00Z"),
+    email: "zakaznik@example.sk",
+    packageNumber: "EF4SK",
+    shippingCarrierName: "Kuriér",
+  });
+
+  const first = app.request("/api/posta-uncollected/run-now", { method: "POST", headers: { cookie } });
+  // Druhý pokus IHNEĎ, bez čakania na prvý — advisory zámok (nie časovanie)
+  // je to, čo garantuje, že tento vidí "busy", nie náhoda v poradí promises.
+  const second = await app.request("/api/posta-uncollected/run-now", { method: "POST", headers: { cookie } });
+  expect(second.status).toBe(200);
+  const secondBody = (await second.json()) as { error: string };
+  expect(secondBody.error).toContain("Beh už prebieha");
+
+  const firstResponse = await first;
+  expect(firstResponse.status).toBe(202);
+
+  await waitForJobRunSettled(db, POSTA_UNCOLLECTED_JOB_NAME);
+  // Presne JEDEN e-mail sa poslal — druhý (odmietnutý) pokus nikdy nespustil
+  // vlastný beh, takže nikdy nemohol poslať duplicitný e-mail (issue 402's
+  // pôvodný nález, kde CF retry spôsobil práve toto).
+  expect(sent).toHaveLength(1);
 });
 
 it("s BCC adresou 'Spustiť teraz' pošle e-mail zákazníkovi", async () => {
@@ -138,6 +178,7 @@ it("s BCC adresou 'Spustiť teraz' pošle e-mail zákazníkovi", async () => {
   });
 
   await app.request("/api/posta-uncollected/run-now", { method: "POST", headers: { cookie } });
+  await waitForJobRunSettled(db, POSTA_UNCOLLECTED_JOB_NAME);
   expect(sent).toHaveLength(1);
   expect(sent[0]?.bcc).toBe("majitel@forestshop.sk");
 });
@@ -155,6 +196,7 @@ it("náhľad e-mailu (preview) vráti presne to, čo by odišlo — bez odoslani
     shippingCarrierName: "Kuriér",
   });
   await app.request("/api/posta-uncollected/run-now", { method: "POST", headers: { cookie } });
+  await waitForJobRunSettled(db, POSTA_UNCOLLECTED_JOB_NAME);
   expect(sent).toHaveLength(1); // prvý e-mail sa reálne poslal
 
   const preview = await app.request("/api/posta-uncollected/preview/EF3SK", { headers: { cookie } });

--- a/apps/api/tests/restock-run-now-http.integration.test.ts
+++ b/apps/api/tests/restock-run-now-http.integration.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, expect, it } from "vitest";
+import { users } from "../src/db/schema.js";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import { RESTOCK_JOB_NAME } from "../src/modules/restock/constants.js";
+import { withCleanDb } from "./helpers/db.js";
+import { waitForJobRunSettled } from "./helpers/job-run.js";
+
+// issue 413 (review finding — reviewer's 🟡 #2): every one of the six
+// run-now automations shares ONE core (`startRunNow`), already covered
+// generically by `run-now.integration.test.ts`, but only 2 of 6 routes had
+// an HTTP-level test proving the ACTUAL route is wired to the new 202/busy
+// contract (not still the old synchronous shape). This file closes that gap
+// for `restock` — separate from `restock-run.integration.test.ts` (business
+// logic, calls `runRestock` directly) so this one file stays a thin,
+// route-only proof.
+//
+// A completely EMPTY database (no seeded products/variants/supplier_stock)
+// is deliberate, not an oversight: `runRestockLocked` (`restock/run.ts`)
+// returns `{status:"nothing_to_do"}` the moment `selectRestockCandidates`
+// finds zero candidates — BEFORE it ever calls `importToShoptet` (which
+// defaults to the REAL `runShoptetImportIsolated`, `.claude/rules/
+// testing.md`'s "never touch a real external system in a test" rule). No
+// fixture, no `createApp(... {restock: {...}})` override needed — the
+// empty-DB short-circuit is what keeps this test from ever reaching
+// Shoptet.
+const HESLO = "test-heslo-abc";
+
+let close: (() => Promise<void>) | undefined;
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  resetLoginRateLimit();
+});
+
+async function boot() {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await ctx.db.insert(users).values({
+    email: "pouzivatel@forestshop.sk",
+    passwordHash: await hashPassword(HESLO),
+    displayName: "Test",
+    role: "manazer",
+  });
+  const app = createApp(ctx.db, { cookieSecure: false });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "pouzivatel@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie, db: ctx.db };
+}
+
+it("POST /api/restock/run-now vráti 202 {ok:true,started:true} HNEĎ a job_run dobehne 'nothing_to_do'", async () => {
+  const { app, cookie, db } = await boot();
+
+  const res = await app.request("/api/restock/run-now", { method: "POST", headers: { cookie } });
+  expect(res.status).toBe(202);
+  const body = (await res.json()) as { ok: boolean; started: boolean };
+  expect(body).toEqual({ ok: true, started: true });
+
+  const finished = await waitForJobRunSettled(db, RESTOCK_JOB_NAME);
+  expect(finished.status).toBe("success");
+  expect(finished.detail).toEqual({ status: "nothing_to_do", overLimit: 0 });
+});
+
+it("druhý POST PRESNE počas prebiehajúceho behu vráti 200 {ok:false,error} 'beh už prebieha'", async () => {
+  const { app, cookie, db } = await boot();
+
+  const first = app.request("/api/restock/run-now", { method: "POST", headers: { cookie } });
+  const second = await app.request("/api/restock/run-now", { method: "POST", headers: { cookie } });
+  expect(second.status).toBe(200);
+  const secondBody = (await second.json()) as { ok: boolean; error: string };
+  expect(secondBody.ok).toBe(false);
+  expect(secondBody.error).toContain("Beh už prebieha");
+
+  const firstResponse = await first;
+  expect(firstResponse.status).toBe(202);
+  await waitForJobRunSettled(db, RESTOCK_JOB_NAME);
+});

--- a/apps/api/tests/run-now.integration.test.ts
+++ b/apps/api/tests/run-now.integration.test.ts
@@ -118,6 +118,64 @@ describe("startRunNow — zlyhaný beh", () => {
   });
 });
 
+describe("startRunNow — zápis KONEČNÉHO stavu (po dobehnutí behu) zlyhá", () => {
+  // Independent reviewer's finding (issue 413): the original success/failure
+  // `.then()` branches wrote the terminal status with a bare `db.update(...)`
+  // — if THAT specific write throws (a transient DB blip right after the
+  // job itself finished normally), the rejection fell into the outer
+  // defensive `.catch()`, which only logs. The row stayed "running" forever
+  // — and a LATER restart's `cleanOrphanedJobRuns` would then mislabel it
+  // as "interrupted by a deploy", which it never was.
+  it("úspešný beh, ale zápis 'success' zlyhá → NÚDZOVÝ zápis 'failure' to zachráni, riadok NEOSTANE 'running' navždy", async () => {
+    const ctx = await withCleanDb();
+    close = ctx.close;
+    let updateAttempts = 0;
+    // Atrapa: PRVÉ volanie `db.update` (skutočný zápis výsledku) synchrónne
+    // vyhodí, KAŽDÉ ĎALŠIE (núdzový zápis) sa prepustí na skutočnú `db`
+    // (naviazané späť na `target`, nie na proxy, aby drizzle-ov interný
+    // `this` ostal správny). Všetko OSTATNÉ (vrátane `$client`u pre zámok)
+    // ide priamo na skutočnú `db`.
+    const flakyOnceUpdateDb = new Proxy(ctx.db, {
+      get(target, prop, receiver: unknown) {
+        if (prop === "update") {
+          return (...args: unknown[]) => {
+            updateAttempts += 1;
+            if (updateAttempts === 1) {
+              throw new Error("simulované zlyhanie zápisu výsledku behu");
+            }
+            const real = Reflect.get(target, prop, receiver) as (...a: unknown[]) => unknown;
+            const value: unknown = real.apply(target, args);
+            return value;
+          };
+        }
+        const value: unknown = Reflect.get(target, prop, receiver);
+        if (typeof value === "function") {
+          const bound: unknown = value.bind(target);
+          return bound;
+        }
+        return value;
+      },
+    });
+
+    const outcome = await startRunNow(
+      flakyOnceUpdateDb,
+      { jobName: TEST_JOB_NAME, lockKey: TEST_RUN_NOW_LOCK_KEY, run: () => Promise.resolve({ marker: "hotovo" }) },
+      new Date(),
+      () => undefined,
+    );
+    expect(outcome).toEqual({ status: "started" });
+
+    const finalRun = await waitForJobRunSettled(ctx.db, TEST_JOB_NAME);
+    expect(finalRun.status).toBe("failure");
+    expect(finalRun.errorMessage).toContain("Beh dobehol, ale zápis výsledku zlyhal");
+    expect(updateAttempts).toBe(2);
+
+    // Zámok sa aj tak uvoľnil — táto oprava sa netýka zámku (ten bol
+    // vždy uvoľnený v `.finally()`u), len konečného stavu riadku.
+    expect(await tryLockFromSeparateConnection(process.env["DATABASE_URL"] ?? "")).toBe(true);
+  });
+});
+
 describe("startRunNow — zlyhanie PRI VKLADANÍ 'running' riadku (zámok už bol získaný)", () => {
   // Code review nález (issue 413): zámok sa berie PRED `db.insert(jobRuns)`.
   // Bez explicitného try/catch okolo insertu by JEHO zlyhanie (napr.

--- a/apps/api/tests/run-now.integration.test.ts
+++ b/apps/api/tests/run-now.integration.test.ts
@@ -1,0 +1,204 @@
+import pg from "pg";
+import { afterEach, describe, expect, it } from "vitest";
+import { getLatestJobRun } from "../src/modules/scheduler/queries.js";
+import { startRunNow, type RunNowOutcome } from "../src/modules/scheduler/run-now.js";
+import { withCleanDb } from "./helpers/db.js";
+import { waitForJobRunSettled } from "./helpers/job-run.js";
+
+// issue 413: `startRunNow` je zdieľané jadro pre VŠETKÝCH šesť run-now
+// automatizácií (shop-sitemap/pairing-search/posta-uncollected/
+// order-reminder/supplier-stock/restock) — tieto testy overujú JEHO
+// správanie priamo (nie cez HTTP), aby jedno pokrytie chránilo všetkých
+// šesť volajúcich naraz. Vlastný, testovací lock kľúč (787_878_101) —
+// mimo produkčného registra (`.claude/rules/scheduler.md`: 001-010 + 100
+// obsadené), aby test nikdy nekolidoval so skutočným jobom.
+const TEST_RUN_NOW_LOCK_KEY = 787_878_101;
+const TEST_JOB_NAME = "run-now-test-job";
+
+function deferred<T>(): { readonly promise: Promise<T>; readonly resolve: (value: T) => void; readonly reject: (error: unknown) => void } {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function tryLockFromSeparateConnection(databaseUrl: string): Promise<boolean> {
+  const client = new pg.Client({ connectionString: databaseUrl });
+  await client.connect();
+  try {
+    const result = await client.query<{ locked: boolean }>("select pg_try_advisory_lock($1) as locked", [TEST_RUN_NOW_LOCK_KEY]);
+    const acquired = result.rows[0]?.locked === true;
+    if (acquired) {
+      await client.query("select pg_advisory_unlock($1)", [TEST_RUN_NOW_LOCK_KEY]);
+    }
+    return acquired;
+  } finally {
+    await client.end();
+  }
+}
+
+let close: (() => Promise<void>) | undefined;
+let checker: pg.Client | undefined;
+afterEach(async () => {
+  await checker?.end().catch(() => undefined);
+  checker = undefined;
+  await close?.();
+  close = undefined;
+});
+
+describe("startRunNow — úspešný beh", () => {
+  it("vloží 'running' riadok HNEĎ, vráti started BEZ čakania na dokončenie behu, a zapíše success PO dobehnutí", async () => {
+    const ctx = await withCleanDb();
+    close = ctx.close;
+    const work = deferred<{ readonly marker: string }>();
+    const settled: RunNowOutcome<{ readonly marker: string }>[] = [];
+    const now = new Date("2026-08-13T09:00:00Z");
+
+    const outcome = await startRunNow(
+      ctx.db,
+      { jobName: TEST_JOB_NAME, lockKey: TEST_RUN_NOW_LOCK_KEY, run: () => work.promise },
+      now,
+      (o) => {
+        settled.push(o);
+      },
+    );
+
+    // HNEĎ po `startRunNow` (bez čakania na `work` dobehnutie) je odpoveď
+    // "started" a job_run už existuje ako "running".
+    expect(outcome).toEqual({ status: "started" });
+    const runningRow = await getLatestJobRun(ctx.db, TEST_JOB_NAME);
+    expect(runningRow?.status).toBe("running");
+    expect(settled).toHaveLength(0);
+
+    // Zámok je držaný počas celého behu — druhé pripojenie ho nedostane.
+    expect(await tryLockFromSeparateConnection(process.env["DATABASE_URL"] ?? "")).toBe(false);
+
+    work.resolve({ marker: "hotovo" });
+    const finalRun = await waitForJobRunSettled(ctx.db, TEST_JOB_NAME);
+    expect(finalRun.status).toBe("success");
+    expect(finalRun.detail).toEqual({ marker: "hotovo" });
+    expect(settled).toEqual([{ status: "success", result: { marker: "hotovo" } }]);
+
+    // Zámok sa po dobehnutí uvoľnil.
+    expect(await tryLockFromSeparateConnection(process.env["DATABASE_URL"] ?? "")).toBe(true);
+  });
+});
+
+describe("startRunNow — zlyhaný beh", () => {
+  it("zapíše failure s errorMessage a uvoľní zámok, aj keď beh vyhodí", async () => {
+    const ctx = await withCleanDb();
+    close = ctx.close;
+    const settled: RunNowOutcome<never>[] = [];
+    const now = new Date("2026-08-13T09:10:00Z");
+
+    const outcome = await startRunNow(
+      ctx.db,
+      {
+        jobName: TEST_JOB_NAME,
+        lockKey: TEST_RUN_NOW_LOCK_KEY,
+        run: () => Promise.reject(new Error("simulované zlyhanie")),
+      },
+      now,
+      (o) => {
+        settled.push(o);
+      },
+    );
+    expect(outcome).toEqual({ status: "started" });
+
+    const finalRun = await waitForJobRunSettled(ctx.db, TEST_JOB_NAME);
+    expect(finalRun.status).toBe("failure");
+    expect(finalRun.errorMessage).toBe("simulované zlyhanie");
+    expect(settled).toHaveLength(1);
+    expect(settled[0]?.status).toBe("failure");
+
+    expect(await tryLockFromSeparateConnection(process.env["DATABASE_URL"] ?? "")).toBe(true);
+  });
+});
+
+describe("startRunNow — busy (zámok už drží niekto iný)", () => {
+  it("keď zámok drží MANUÁLNE vzatý zámok (žiadny job_run riadok), vráti busy so VŠEOBECNOU správou a NIKDY nezavolá run()", async () => {
+    const ctx = await withCleanDb();
+    close = ctx.close;
+    checker = new pg.Client({ connectionString: process.env["DATABASE_URL"] ?? "" });
+    await checker.connect();
+    await checker.query("select pg_advisory_lock($1)", [TEST_RUN_NOW_LOCK_KEY]);
+
+    let runCalled = false;
+    const outcome = await startRunNow(
+      ctx.db,
+      {
+        jobName: TEST_JOB_NAME,
+        lockKey: TEST_RUN_NOW_LOCK_KEY,
+        run: () => {
+          runCalled = true;
+          return Promise.resolve({ marker: "nikdy" });
+        },
+      },
+      new Date(),
+      () => {
+        throw new Error("onSettled sa pri busy nikdy nemá zavolať");
+      },
+    );
+
+    expect(outcome.status).toBe("busy");
+    if (outcome.status === "busy") {
+      expect(outcome.message).toContain("Beh už prebieha");
+      expect(outcome.message).not.toContain("spustený o");
+    }
+    expect(runCalled).toBe(false);
+    expect(await getLatestJobRun(ctx.db, TEST_JOB_NAME)).toBeNull();
+  });
+
+  it("keď zámok drží PRÁVE PREBIEHAJÚCI run-now beh, druhý súbežný pokus dostane busy s ČASOM prvého behu a job_run ostáva NEDOTKNUTÝ", async () => {
+    const ctx = await withCleanDb();
+    close = ctx.close;
+    const work = deferred<{ readonly marker: string }>();
+    const now1 = new Date("2026-08-13T11:23:00Z");
+
+    const outcome1 = await startRunNow(
+      ctx.db,
+      { jobName: TEST_JOB_NAME, lockKey: TEST_RUN_NOW_LOCK_KEY, run: () => work.promise },
+      now1,
+      () => undefined,
+    );
+    expect(outcome1).toEqual({ status: "started" });
+
+    let secondRunCalled = false;
+    const outcome2 = await startRunNow(
+      ctx.db,
+      {
+        jobName: TEST_JOB_NAME,
+        lockKey: TEST_RUN_NOW_LOCK_KEY,
+        run: () => {
+          secondRunCalled = true;
+          return Promise.resolve({ marker: "nikdy" });
+        },
+      },
+      new Date("2026-08-13T11:23:05Z"),
+      () => {
+        throw new Error("onSettled druhého (odmietnutého) behu sa nikdy nemá zavolať");
+      },
+    );
+
+    expect(outcome2.status).toBe("busy");
+    if (outcome2.status === "busy") {
+      // 11:23 UTC = 13:23 Europe/Bratislava (letný čas) — presný formát
+      // overuje `formatBratislavaTime` (`run-now.ts`), nie len prítomnosť
+      // nejakého textu.
+      expect(outcome2.message).toBe("Beh už prebieha (spustený o 13:23) — počkajte na jeho dokončenie.");
+    }
+    expect(secondRunCalled).toBe(false);
+
+    // job_run riadok PRVÉHO behu ostal nedotknutý ("running", žiadny
+    // druhý riadok nevznikol) — druhý pokus sa naň vôbec nepokúsil zapísať.
+    const stillRunning = await getLatestJobRun(ctx.db, TEST_JOB_NAME);
+    expect(stillRunning?.status).toBe("running");
+    expect(stillRunning?.startedAt).toBe(now1.toISOString());
+
+    work.resolve({ marker: "hotovo" });
+    await waitForJobRunSettled(ctx.db, TEST_JOB_NAME);
+  });
+});

--- a/apps/api/tests/run-now.integration.test.ts
+++ b/apps/api/tests/run-now.integration.test.ts
@@ -1,6 +1,5 @@
 import pg from "pg";
 import { afterEach, describe, expect, it } from "vitest";
-import type { Database } from "../src/db/client.js";
 import { getLatestJobRun } from "../src/modules/scheduler/queries.js";
 import { startRunNow, type RunNowOutcome } from "../src/modules/scheduler/run-now.js";
 import { withCleanDb } from "./helpers/db.js";
@@ -141,9 +140,10 @@ describe("startRunNow — zlyhanie PRI VKLADANÍ 'running' riadku (zámok už bo
             throw new Error("simulované zlyhanie vloženia job_run riadku");
           };
         }
-        return Reflect.get(target, prop, receiver);
+        const value: unknown = Reflect.get(target, prop, receiver);
+        return value;
       },
-    }) as Database;
+    });
 
     await expect(
       startRunNow(

--- a/apps/api/tests/run-now.integration.test.ts
+++ b/apps/api/tests/run-now.integration.test.ts
@@ -1,5 +1,6 @@
 import pg from "pg";
 import { afterEach, describe, expect, it } from "vitest";
+import type { Database } from "../src/db/client.js";
 import { getLatestJobRun } from "../src/modules/scheduler/queries.js";
 import { startRunNow, type RunNowOutcome } from "../src/modules/scheduler/run-now.js";
 import { withCleanDb } from "./helpers/db.js";
@@ -115,6 +116,50 @@ describe("startRunNow — zlyhaný beh", () => {
     expect(settled[0]?.status).toBe("failure");
 
     expect(await tryLockFromSeparateConnection(process.env["DATABASE_URL"] ?? "")).toBe(true);
+  });
+});
+
+describe("startRunNow — zlyhanie PRI VKLADANÍ 'running' riadku (zámok už bol získaný)", () => {
+  // Code review nález (issue 413): zámok sa berie PRED `db.insert(jobRuns)`.
+  // Bez explicitného try/catch okolo insertu by JEHO zlyhanie (napr.
+  // dočasný sieťový výpadok DB) nechalo zámok NAVŽDY držaný — `job.run()` sa
+  // nikdy nespustí, takže fire-and-forget reťaz (a jej `.finally()`, čo by
+  // inak zámok uvoľnilo) sa vôbec nezostaví. Rovnaký kľúč používa aj
+  // NAPLÁNOVANÝ beh (`scheduler/jobs.ts`), takže by sa zablokoval tiež, až
+  // do reštartu procesu.
+  it("uvoľní zámok a vyhodí ĎALEJ — zámok NEOSTANE navždy držaný", async () => {
+    const ctx = await withCleanDb();
+    close = ctx.close;
+    // Atrapa, ktorá prepustí VŠETKO na skutočnú `db` (vrátane `$client`u
+    // potrebného na získanie zámku) okrem `.insert`, ktoré synchrónne
+    // vyhodí — rovnaký `Proxy`-vzor ako `shop-feed/run.test.ts`'s
+    // `forbiddenDb`.
+    const insertFailingDb = new Proxy(ctx.db, {
+      get(target, prop, receiver: unknown) {
+        if (prop === "insert") {
+          return () => {
+            throw new Error("simulované zlyhanie vloženia job_run riadku");
+          };
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+    }) as Database;
+
+    await expect(
+      startRunNow(
+        insertFailingDb,
+        { jobName: TEST_JOB_NAME, lockKey: TEST_RUN_NOW_LOCK_KEY, run: () => Promise.resolve({ marker: "nikdy" }) },
+        new Date(),
+        () => {
+          throw new Error("onSettled sa nikdy nemá zavolať, keď insert zlyhá PRED spustením run()");
+        },
+      ),
+    ).rejects.toThrow("simulované zlyhanie vloženia job_run riadku");
+
+    // Zámok sa uvoľnil aj napriek zlyhaniu insertu — druhé pripojenie ho
+    // dostane HNEĎ, nikdy nezostane navždy zablokovaný.
+    expect(await tryLockFromSeparateConnection(process.env["DATABASE_URL"] ?? "")).toBe(true);
+    expect(await getLatestJobRun(ctx.db, TEST_JOB_NAME)).toBeNull();
   });
 });
 

--- a/apps/api/tests/scheduler-startup-cleanup.integration.test.ts
+++ b/apps/api/tests/scheduler-startup-cleanup.integration.test.ts
@@ -1,0 +1,89 @@
+import { eq } from "drizzle-orm";
+import { afterEach, expect, it } from "vitest";
+import { jobRuns } from "../src/db/schema.js";
+import { cleanOrphanedJobRuns, ORPHANED_JOB_RUN_MESSAGE } from "../src/modules/scheduler/startup-cleanup.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 413 (nález b): appka reštart (SIGTERM/SIGKILL pri deploy) zabije
+// rozbehnutý beh a jeho `job_run` riadok ostane navždy "running" — tieto
+// testy overujú `cleanOrphanedJobRuns`, ktoré `index.ts` volá RAZ pri
+// štarte, HNEĎ po migráciách.
+
+let close: (() => Promise<void>) | undefined;
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+});
+
+it("označí 'running' riadok STARŠÍ než štart procesu ako failure s vysvetľujúcou správou", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const [inserted] = await ctx.db
+    .insert(jobRuns)
+    .values({ jobName: "orphaned-before-restart", startedAt: new Date("2026-08-13T09:00:00Z"), status: "running" })
+    .returning({ id: jobRuns.id });
+  const runId = inserted?.id;
+  expect(runId).toBeDefined();
+
+  const processStartedAt = new Date("2026-08-13T09:12:00Z");
+  const count = await cleanOrphanedJobRuns(ctx.db, processStartedAt);
+  expect(count).toBe(1);
+
+  const [row] = await ctx.db.select().from(jobRuns).where(eq(jobRuns.id, runId ?? ""));
+  expect(row?.status).toBe("failure");
+  expect(row?.errorMessage).toBe(ORPHANED_JOB_RUN_MESSAGE);
+  expect(row?.finishedAt?.toISOString()).toBe(processStartedAt.toISOString());
+});
+
+it("NEDOTKNE SA 'running' riadku vloženého AŽ PO štarte procesu (nový, skutočne bežiaci beh)", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const processStartedAt = new Date("2026-08-13T09:12:00Z");
+  const [inserted] = await ctx.db
+    .insert(jobRuns)
+    .values({ jobName: "genuinely-running-now", startedAt: new Date("2026-08-13T09:15:00Z"), status: "running" })
+    .returning({ id: jobRuns.id });
+  const runId = inserted?.id;
+
+  const count = await cleanOrphanedJobRuns(ctx.db, processStartedAt);
+  expect(count).toBe(0);
+
+  const [row] = await ctx.db.select().from(jobRuns).where(eq(jobRuns.id, runId ?? ""));
+  expect(row?.status).toBe("running");
+  expect(row?.errorMessage).toBeNull();
+});
+
+it("NEDOTKNE SA riadku, ktorý už má konečný stav (success/failure)", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const [inserted] = await ctx.db
+    .insert(jobRuns)
+    .values({
+      jobName: "already-succeeded",
+      startedAt: new Date("2026-08-13T08:00:00Z"),
+      finishedAt: new Date("2026-08-13T08:05:00Z"),
+      status: "success",
+      detail: { ok: true },
+    })
+    .returning({ id: jobRuns.id });
+  const runId = inserted?.id;
+
+  const count = await cleanOrphanedJobRuns(ctx.db, new Date("2026-08-13T09:00:00Z"));
+  expect(count).toBe(0);
+
+  const [row] = await ctx.db.select().from(jobRuns).where(eq(jobRuns.id, runId ?? ""));
+  expect(row?.status).toBe("success");
+  expect(row?.detail).toEqual({ ok: true });
+});
+
+it("vyčistí VIACERO osirotených riadkov naraz, každý s vlastným jobName", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await ctx.db.insert(jobRuns).values([
+    { jobName: "orphan-a", startedAt: new Date("2026-08-13T08:00:00Z"), status: "running" },
+    { jobName: "orphan-b", startedAt: new Date("2026-08-13T08:30:00Z"), status: "running" },
+  ]);
+
+  const count = await cleanOrphanedJobRuns(ctx.db, new Date("2026-08-13T09:00:00Z"));
+  expect(count).toBe(2);
+});

--- a/apps/api/tests/shop-sitemap-run-now-http.integration.test.ts
+++ b/apps/api/tests/shop-sitemap-run-now-http.integration.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, expect, it } from "vitest";
+import { users } from "../src/db/schema.js";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import { SHOP_SITEMAP_JOB_NAME } from "../src/modules/shop-sitemap/constants.js";
+import { withCleanDb } from "./helpers/db.js";
+import { waitForJobRunSettled } from "./helpers/job-run.js";
+
+// issue 413 (review finding — reviewer's 🟡 #2): closes the missing
+// HTTP-level run-now coverage for `shop-sitemap`, same reasoning as
+// `restock-run-now-http.integration.test.ts` — the shared `startRunNow`
+// core is already covered generically, this proves the ROUTE itself is
+// wired to the 202/busy contract.
+//
+// A completely EMPTY database is deliberate: `runShopSitemapLocked`
+// (`shop-sitemap/run.ts`) returns early (`missingProducts:0`) the moment
+// `selectMissingProducts` finds nothing — BEFORE it ever calls
+// `fetchSitemap()` (which defaults to the REAL `createHttpSitemapFetcher()`,
+// `.claude/rules/testing.md`'s "never touch a real external system in a
+// test" rule). No fixture needed — the empty-DB short-circuit is what keeps
+// this test from ever reaching the live e-shop.
+const HESLO = "test-heslo-abc";
+
+let close: (() => Promise<void>) | undefined;
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  resetLoginRateLimit();
+});
+
+async function boot() {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await ctx.db.insert(users).values({
+    email: "pouzivatel@forestshop.sk",
+    passwordHash: await hashPassword(HESLO),
+    displayName: "Test",
+    role: "manazer",
+  });
+  const app = createApp(ctx.db, { cookieSecure: false });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "pouzivatel@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie, db: ctx.db };
+}
+
+it("POST /api/shop-sitemap/run-now vráti 202 {ok:true,started:true} HNEĎ a job_run dobehne s missingProducts:0", async () => {
+  const { app, cookie, db } = await boot();
+
+  const res = await app.request("/api/shop-sitemap/run-now", { method: "POST", headers: { cookie } });
+  expect(res.status).toBe(202);
+  const body = (await res.json()) as { ok: boolean; started: boolean };
+  expect(body).toEqual({ ok: true, started: true });
+
+  const finished = await waitForJobRunSettled(db, SHOP_SITEMAP_JOB_NAME);
+  expect(finished.status).toBe("success");
+  const detail = finished.detail as { missingProducts: number };
+  expect(detail.missingProducts).toBe(0);
+});
+
+it("druhý POST PRESNE počas prebiehajúceho behu vráti 200 {ok:false,error} 'beh už prebieha'", async () => {
+  const { app, cookie, db } = await boot();
+
+  const first = app.request("/api/shop-sitemap/run-now", { method: "POST", headers: { cookie } });
+  const second = await app.request("/api/shop-sitemap/run-now", { method: "POST", headers: { cookie } });
+  expect(second.status).toBe(200);
+  const secondBody = (await second.json()) as { ok: boolean; error: string };
+  expect(secondBody.ok).toBe(false);
+  expect(secondBody.error).toContain("Beh už prebieha");
+
+  const firstResponse = await first;
+  expect(firstResponse.status).toBe(202);
+  await waitForJobRunSettled(db, SHOP_SITEMAP_JOB_NAME);
+});

--- a/apps/api/tests/supplier-stock-http.integration.test.ts
+++ b/apps/api/tests/supplier-stock-http.integration.test.ts
@@ -3,9 +3,12 @@ import { users } from "../src/db/schema.js";
 import { createApp } from "../src/http/app.js";
 import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
 import { hashPassword } from "../src/modules/auth/passwords.js";
+import type { UserRole } from "../src/modules/auth/service.js";
+import { SUPPLIER_STOCK_JOB_NAME } from "../src/modules/supplier-stock/constants.js";
 import type { PageFetchResult } from "../src/modules/supplier-stock/page-fetcher.js";
 import { runSupplierStock } from "../src/modules/supplier-stock/run.js";
 import { withCleanDb } from "./helpers/db.js";
+import { waitForJobRunSettled } from "./helpers/job-run.js";
 import { insertTestVariant } from "./helpers/orders.js";
 
 // issue 227: HTTP vrstva pre prehľad podľa domény + vylúčenie vlastného
@@ -23,14 +26,14 @@ const IN_STOCK = `<script type="application/ld+json">
   {"@type":"Product","offers":{"@type":"Offer","availability":"https://schema.org/InStock"}}
 </script>`;
 
-async function boot() {
+async function boot(role: UserRole = "citanie") {
   const ctx = await withCleanDb();
   close = ctx.close;
   await ctx.db.insert(users).values({
     email: "pouzivatel@forestshop.sk",
     passwordHash: await hashPassword(HESLO),
     displayName: "Test",
-    role: "citanie",
+    role,
   });
   const app = createApp(ctx.db, {
     cookieSecure: false,
@@ -81,4 +84,49 @@ it("prehľad podľa domény je zoradený podľa počtu klesajúco a NEobsahuje v
   expect(body.hostOverview.map((r) => r.host)).toEqual(["huntingshop.eu", "wetland.sk"]);
   expect(body.hostOverview[0]).toMatchObject({ host: "huntingshop.eu", total: 2, readable: 2, unknown: 0, failed: 0 });
   expect(body.ownShopLinksCount).toBe(1);
+});
+
+// issue 413 (review finding — reviewer's 🟡 #2): closes the missing
+// HTTP-level run-now coverage for `supplier-stock` — the one of the six
+// automations the ticket itself names as the worst offender (~72-minute
+// real runs, `.claude/rules/supplier-stock.md`). The shared `startRunNow`
+// core is already covered generically (`run-now.integration.test.ts`); this
+// proves the ROUTE itself is wired to the 202/busy contract, not still the
+// old synchronous shape.
+//
+// No variant is inserted for these two tests (unlike the GET test above) —
+// `runSupplierStockLocked` (`supplier-stock/run.ts`) only ever calls
+// `fetchPage` inside its per-link loop, so an empty `variant`/`internal
+// _note` population means `collectSupplierLinks` returns zero links and the
+// loop body — hence `fetchPage` — never runs at all; `boot()`'s fake
+// `fetchSupplierPage` is a belt-and-suspenders safety net on top of that,
+// never a live dependency of this specific short-circuit.
+it("POST /api/supplier-stock/run-now vráti 202 {ok:true,started:true} HNEĎ a job_run dobehne checked:0", async () => {
+  const { app, cookie, db } = await boot("manazer");
+
+  const res = await app.request("/api/supplier-stock/run-now", { method: "POST", headers: { cookie } });
+  expect(res.status).toBe(202);
+  const body = (await res.json()) as { ok: boolean; started: boolean };
+  expect(body).toEqual({ ok: true, started: true });
+
+  const finished = await waitForJobRunSettled(db, SUPPLIER_STOCK_JOB_NAME);
+  expect(finished.status).toBe("success");
+  const detail = finished.detail as { checked: number; failed: number };
+  expect(detail.checked).toBe(0);
+  expect(detail.failed).toBe(0);
+});
+
+it("druhý POST PRESNE počas prebiehajúceho behu vráti 200 {ok:false,error} 'beh už prebieha'", async () => {
+  const { app, cookie, db } = await boot("manazer");
+
+  const first = app.request("/api/supplier-stock/run-now", { method: "POST", headers: { cookie } });
+  const second = await app.request("/api/supplier-stock/run-now", { method: "POST", headers: { cookie } });
+  expect(second.status).toBe(200);
+  const secondBody = (await second.json()) as { ok: boolean; error: string };
+  expect(secondBody.ok).toBe(false);
+  expect(secondBody.error).toContain("Beh už prebieha");
+
+  const firstResponse = await first;
+  expect(firstResponse.status).toBe(202);
+  await waitForJobRunSettled(db, SUPPLIER_STOCK_JOB_NAME);
 });

--- a/apps/web/src/components/OrderReminderSection.test.tsx
+++ b/apps/web/src/components/OrderReminderSection.test.tsx
@@ -188,8 +188,12 @@ it("preskočený riadok (AI kontaktovaný) má náhľad a klik zobrazí presne t
 });
 
 it("'Spustiť teraz' zavolá beh a obnoví stav", async () => {
+  // issue 413: run-now je ASYNC — `runOrderReminderNow()` už neresolvuje
+  // výsledok priamo (server 202-ne hneď), komponent ho PREBERIE
+  // opakovaným čítaním stavu (`pollUntilJobDone`), preto tu netreba mock
+  // rozlíšenej hodnoty niesť.
   fetchOrderReminderStatus.mockResolvedValueOnce({ enabled: true, lastRun: null }).mockResolvedValue(STATUS_WITH_RESULT);
-  runOrderReminderNow.mockResolvedValue(RUN_RESULT);
+  runOrderReminderNow.mockResolvedValue(undefined);
 
   render(<OrderReminderSection role="manazer" onSessionExpired={() => {}} />);
   await screen.findByTestId("order-reminder-run-now");

--- a/apps/web/src/components/OrderReminderSection.tsx
+++ b/apps/web/src/components/OrderReminderSection.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState, type JSX } from "react";
 import type { Me } from "../api.js";
 import { formatSkDateTime } from "../formatDate.js";
+import { pollUntilJobDone } from "../pollJobRun.js";
 import {
   fetchOrderReminderPreview,
   fetchOrderReminderStatus,
@@ -72,15 +73,31 @@ export function OrderReminderSection({
       });
   }, [status, load, onSessionExpired]);
 
+  // issue 413: "Spustiť teraz" beží odteraz ASYNC — server vráti 202 hneď
+  // (beh pokračuje na pozadí), výsledok sa PREBERIE opakovaným čítaním
+  // stavu (`pollUntilJobDone`), nie z priamej POST odpovede.
   const runNow = useCallback(() => {
     setRunBusy(true);
-    setRunNotice("");
+    setRunNotice("Beh spustený na pozadí…");
     runOrderReminderNow()
-      .then((result) => {
-        setRunNotice(
-          `Skontrolovaných ${String(result.stats.candidates)}, e-mailov odoslaných ${String(result.stats.emailedNow)}, kontaktovaných (AI) ${String(result.stats.contactedNow)}.`,
-        );
-        load();
+      .then(() => pollUntilJobDone(fetchOrderReminderStatus))
+      .then((polled) => {
+        setStatus(polled);
+        const { lastRun } = polled;
+        if (lastRun === null) {
+          setRunNotice("");
+        } else if (lastRun.status === "failure") {
+          setRunNotice(lastRun.errorMessage ?? "Beh zlyhal.");
+        } else if (lastRun.status === "running") {
+          setRunNotice("Beh stále prebieha — skúste obnoviť stránku o chvíľu.");
+        } else if (lastRun.result !== null) {
+          const { result } = lastRun;
+          setRunNotice(
+            `Skontrolovaných ${String(result.stats.candidates)}, e-mailov odoslaných ${String(result.stats.emailedNow)}, kontaktovaných (AI) ${String(result.stats.contactedNow)}.`,
+          );
+        } else {
+          setRunNotice("");
+        }
       })
       .catch((err: unknown) => {
         if (err instanceof OrderReminderUnauthorizedError) {
@@ -92,7 +109,7 @@ export function OrderReminderSection({
       .finally(() => {
         setRunBusy(false);
       });
-  }, [load, onSessionExpired]);
+  }, [onSessionExpired]);
 
   const runAction = useCallback(
     (orderCode: string, action: "contact" | "send") => {

--- a/apps/web/src/components/PostaUncollectedSection.test.tsx
+++ b/apps/web/src/components/PostaUncollectedSection.test.tsx
@@ -179,8 +179,12 @@ it("klik na 'Náhľad' zobrazí presne to, čo by odišlo, bez odoslania", async
 });
 
 it("'Spustiť teraz' zavolá beh a obnoví stav", async () => {
+  // issue 413: run-now je ASYNC — `runPostaUncollectedNow()` už neresolvuje
+  // výsledok priamo (server 202-ne hneď), komponent ho PREBERIE opakovaným
+  // čítaním stavu (`pollUntilJobDone`), preto tu netreba mock rozlíšenej
+  // hodnoty niesť.
   fetchPostaUncollectedStatus.mockResolvedValueOnce({ enabled: true, lastRun: null }).mockResolvedValue(STATUS_WITH_RESULT);
-  runPostaUncollectedNow.mockResolvedValue(RUN_RESULT);
+  runPostaUncollectedNow.mockResolvedValue(undefined);
 
   render(<PostaUncollectedSection role="manazer" onSessionExpired={() => {}} />);
   await screen.findByTestId("posta-run-now");

--- a/apps/web/src/components/PostaUncollectedSection.tsx
+++ b/apps/web/src/components/PostaUncollectedSection.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState, type JSX } from "react";
 import type { Me } from "../api.js";
 import { formatSkDateTime } from "../formatDate.js";
+import { pollUntilJobDone } from "../pollJobRun.js";
 import {
   fetchPostaUncollectedPreview,
   fetchPostaUncollectedStatus,
@@ -71,15 +72,31 @@ export function PostaUncollectedSection({
       });
   }, [status, load, onSessionExpired]);
 
+  // issue 413: "Spustiť teraz" beží odteraz ASYNC — server vráti 202 hneď
+  // (beh pokračuje na pozadí), výsledok sa PREBERIE opakovaným čítaním
+  // stavu (`pollUntilJobDone`), nie z priamej POST odpovede.
   const runNow = useCallback(() => {
     setRunBusy(true);
-    setRunNotice("");
+    setRunNotice("Beh spustený na pozadí…");
     runPostaUncollectedNow()
-      .then((result) => {
-        setRunNotice(
-          `Skontrolovaných ${String(result.stats.checked)}, nevyzdvihnutých ${String(result.stats.uncollectedCount)}, e-mailov odoslaných ${String(result.stats.emailsSent)}.`,
-        );
-        load();
+      .then(() => pollUntilJobDone(fetchPostaUncollectedStatus))
+      .then((polled) => {
+        setStatus(polled);
+        const { lastRun } = polled;
+        if (lastRun === null) {
+          setRunNotice("");
+        } else if (lastRun.status === "failure") {
+          setRunNotice(lastRun.errorMessage ?? "Beh zlyhal.");
+        } else if (lastRun.status === "running") {
+          setRunNotice("Beh stále prebieha — skúste obnoviť stránku o chvíľu.");
+        } else if (lastRun.result !== null) {
+          const { result } = lastRun;
+          setRunNotice(
+            `Skontrolovaných ${String(result.stats.checked)}, nevyzdvihnutých ${String(result.stats.uncollectedCount)}, e-mailov odoslaných ${String(result.stats.emailsSent)}.`,
+          );
+        } else {
+          setRunNotice("");
+        }
       })
       .catch((err: unknown) => {
         if (err instanceof PostaUncollectedUnauthorizedError) {
@@ -91,7 +108,7 @@ export function PostaUncollectedSection({
       .finally(() => {
         setRunBusy(false);
       });
-  }, [load, onSessionExpired]);
+  }, [onSessionExpired]);
 
   const openPreview = useCallback(
     (packageNumber: string) => {

--- a/apps/web/src/components/RestockSection.test.tsx
+++ b/apps/web/src/components/RestockSection.test.tsx
@@ -169,14 +169,22 @@ it("Štart/Stop prepne automatizáciu a znovu načíta stav", async () => {
 
 // Zlyhanie zápisu do Shoptetu sa NESMIE tváriť ako úspech — obsluha musí
 // vidieť, že sa nič nepreplo.
+// issue 413: run-now je odteraz ASYNC — `runRestockNow()` už nevracia
+// výsledok priamo (server 202-ne hneď), obrazovka ho PREBERIE opakovaným
+// `fetchRestockStatus()` volaním (`pollUntilJobDone`). Mock preto nesie
+// zlyhaný DOMÉNOVÝ výsledok (`result.status === "failed"`) na `lastRun`,
+// nie na `runRestockNow`'s rozlíšenej hodnote — `lastRun.status` samotné
+// zostáva "success" (beh ako job doiel bez výnimky, len zápis do
+// Shoptetu vnútri neuspel).
 it("po zlyhaní zápisu povie, že sa nič neprepínalo", async () => {
-  fetchRestockStatus.mockResolvedValue(STATUS);
-  runRestockNow.mockResolvedValue({
-    status: "failed",
-    attempted: 3,
-    overLimit: 0,
-    errorDetail: "prihlásenie zlyhalo",
+  fetchRestockStatus.mockResolvedValue({
+    ...STATUS,
+    lastRun: {
+      ...STATUS.lastRun,
+      result: { status: "failed", attempted: 3, overLimit: 0, errorDetail: "prihlásenie zlyhalo" },
+    },
   });
+  runRestockNow.mockResolvedValue(undefined);
   render(<RestockSection role="admin" onSessionExpired={vi.fn()} />);
 
   fireEvent.click(await screen.findByTestId("restock-run-now"));

--- a/apps/web/src/components/RestockSection.tsx
+++ b/apps/web/src/components/RestockSection.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState, type JSX } from "react";
 import type { Me } from "../api.js";
 import { formatSkDateTime } from "../formatDate.js";
+import { pollUntilJobDone } from "../pollJobRun.js";
 import {
   fetchRestockStatus,
   fetchRestockWaiting,
@@ -100,23 +101,41 @@ export function RestockSection({
       });
   }, [status, load, onSessionExpired]);
 
+  // issue 413: "Spustiť teraz" beží odteraz ASYNC — server vráti 202 hneď
+  // (beh pokračuje na pozadí), výsledok sa PREBERIE opakovaným čítaním
+  // stavu (`pollUntilJobDone`), nie z priamej POST odpovede. Vrátený
+  // `polled` stav nesie AJ obnovené `events`/`waiting`, takže samostatné
+  // `load()` volanie navyše netreba.
   const runNow = useCallback(() => {
     setRunBusy(true);
-    setRunNotice("");
+    setRunNotice("Beh spustený na pozadí…");
     runRestockNow()
-      .then((result) => {
-        if (result.status === "ok") {
-          setRunNotice(
-            result.overLimit > 0
-              ? `Prepnutých ${String(result.switched)} produktov, ďalších ${String(result.overLimit)} čaká na ďalší beh (strop).`
-              : `Prepnutých ${String(result.switched)} produktov.`,
-          );
-        } else if (result.status === "nothing_to_do") {
-          setRunNotice("Nebolo čo prepnúť — žiadny vypredaný produkt nemá čerstvé potvrdenie od dodávateľa.");
+      .then(() => pollUntilJobDone(fetchRestockStatus))
+      .then((polled) => {
+        setStatus(polled);
+        const { lastRun } = polled;
+        if (lastRun === null) {
+          setRunNotice("");
+        } else if (lastRun.status === "failure") {
+          setRunNotice(lastRun.errorMessage ?? "Beh zlyhal.");
+        } else if (lastRun.status === "running") {
+          setRunNotice("Beh stále prebieha — skúste obnoviť stránku o chvíľu.");
+        } else if (lastRun.result !== null) {
+          const { result } = lastRun;
+          if (result.status === "ok") {
+            setRunNotice(
+              result.overLimit > 0
+                ? `Prepnutých ${String(result.switched)} produktov, ďalších ${String(result.overLimit)} čaká na ďalší beh (strop).`
+                : `Prepnutých ${String(result.switched)} produktov.`,
+            );
+          } else if (result.status === "nothing_to_do") {
+            setRunNotice("Nebolo čo prepnúť — žiadny vypredaný produkt nemá čerstvé potvrdenie od dodávateľa.");
+          } else {
+            setRunNotice(`Zápis do Shoptetu zlyhal (${result.errorDetail}). Nič sa nepreplo, skúsi sa znova.`);
+          }
         } else {
-          setRunNotice(`Zápis do Shoptetu zlyhal (${result.errorDetail}). Nič sa nepreplo, skúsi sa znova.`);
+          setRunNotice("");
         }
-        load();
       })
       .catch((err: unknown) => {
         if (err instanceof RestockUnauthorizedError) {
@@ -128,7 +147,7 @@ export function RestockSection({
       .finally(() => {
         setRunBusy(false);
       });
-  }, [load, onSessionExpired]);
+  }, [onSessionExpired]);
 
   if (!loaded) return <p role="status">Načítavam…</p>;
   if (status === null) return <p role="alert">{error === "" ? "Nepodarilo sa načítať." : error}</p>;

--- a/apps/web/src/components/SupplierStockSection.test.tsx
+++ b/apps/web/src/components/SupplierStockSection.test.tsx
@@ -153,8 +153,12 @@ it("bez odkazov na vlastný e-shop sa upozornenie nezobrazí", async () => {
 });
 
 it("„Spustiť teraz\" spustí kontrolu a znovu načíta prehľad", async () => {
+  // issue 413: run-now je ASYNC — `runSupplierStockNow()` už neresolvuje
+  // výsledok priamo (server 202-ne hneď), komponent ho PREBERIE opakovaným
+  // čítaním stavu (`pollUntilJobDone`, tu ihneď "success" — `STATUS` slúži
+  // zároveň ako počiatočný AJ polovaný stav).
   fetchSupplierStockStatus.mockResolvedValue(STATUS);
-  runSupplierStockNow.mockResolvedValue(STATUS.lastRun.result);
+  runSupplierStockNow.mockResolvedValue(undefined);
   render(<SupplierStockSection role="admin" onSessionExpired={vi.fn()} />);
 
   fireEvent.click(await screen.findByTestId("ss-run-now"));

--- a/apps/web/src/components/SupplierStockSection.tsx
+++ b/apps/web/src/components/SupplierStockSection.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState, type JSX } from "react";
 import type { Me } from "../api.js";
 import { formatSkDateTime } from "../formatDate.js";
+import { pollUntilJobDone } from "../pollJobRun.js";
 import {
   fetchSupplierStockStatus,
   runSupplierStockNow,
@@ -53,19 +54,40 @@ export function SupplierStockSection({
 
   useEffect(load, [load]);
 
+  // issue 413: "Spustiť teraz" beží odteraz ASYNC — server vráti 202 hneď
+  // (beh pokračuje na pozadí), výsledok sa PREBERIE opakovaným čítaním
+  // stavu (`pollUntilJobDone`), nie z priamej POST odpovede. Tento beh
+  // trvá reálne desiatky minút (`.claude/rules/supplier-stock.md`) —
+  // `pollUntilJobDone`'s predvolený strop (~2 min) sa preto ČASTO vyčerpá
+  // skôr, než beh dobehne, a ukáže "Beh stále prebieha" hlášku namiesto
+  // čísel; to je ZÁMER (poctivá informácia, nie chyba) — obsluha si stav
+  // pozrie neskôr na obrazovke Automatizácie/obnovením stránky.
   const runNow = useCallback(() => {
     setRunBusy(true);
-    setRunNotice("");
+    setRunNotice("Beh spustený na pozadí…");
     runSupplierStockNow()
-      .then((result) => {
-        // issue 224: `checked` je počet ODKAZOV, ale skladom/vypredané/neviem
-        // sú počty ZÁZNAMOV (odkaz × veľkosť) — odkaz s viacerými veľkosťami
-        // prispieva do rozpisu viac než raz, takže sa nesmú tváriť ako súčet
-        // rovnakej jednotky.
-        setRunNotice(
-          `Skontrolovaných ${String(result.checked)} odkazov · zlyhalo ${String(result.failed)}. Záznamy: skladom ${String(result.available)} · vypredané ${String(result.unavailable)} · neviem ${String(result.unknown)}.`,
-        );
-        load();
+      .then(() => pollUntilJobDone(fetchSupplierStockStatus))
+      .then((polled) => {
+        setStatus(polled);
+        const { lastRun } = polled;
+        if (lastRun === null) {
+          setRunNotice("");
+        } else if (lastRun.status === "failure") {
+          setRunNotice(lastRun.errorMessage ?? "Beh zlyhal.");
+        } else if (lastRun.status === "running") {
+          setRunNotice("Beh stále prebieha — skúste obnoviť stránku o chvíľu.");
+        } else if (lastRun.result !== null) {
+          // issue 224: `checked` je počet ODKAZOV, ale skladom/vypredané/
+          // neviem sú počty ZÁZNAMOV (odkaz × veľkosť) — odkaz s viacerými
+          // veľkosťami prispieva do rozpisu viac než raz, takže sa nesmú
+          // tváriť ako súčet rovnakej jednotky.
+          const { result } = lastRun;
+          setRunNotice(
+            `Skontrolovaných ${String(result.checked)} odkazov · zlyhalo ${String(result.failed)}. Záznamy: skladom ${String(result.available)} · vypredané ${String(result.unavailable)} · neviem ${String(result.unknown)}.`,
+          );
+        } else {
+          setRunNotice("");
+        }
       })
       .catch((err: unknown) => {
         if (err instanceof SupplierStockUnauthorizedError) {
@@ -77,7 +99,7 @@ export function SupplierStockSection({
       .finally(() => {
         setRunBusy(false);
       });
-  }, [load, onSessionExpired]);
+  }, [onSessionExpired]);
 
   if (!loaded) return <p role="status">Načítavam…</p>;
   if (status === null) return <p role="alert">{error === "" ? "Nepodarilo sa načítať." : error}</p>;

--- a/apps/web/src/orderReminderApi.ts
+++ b/apps/web/src/orderReminderApi.ts
@@ -61,8 +61,11 @@ export type OrderReminderStatus = z.infer<typeof statusSchema>;
 
 const setEnabledResultSchema = z.object({ ok: z.literal(true), enabled: z.boolean() });
 
+// issue 413: run-now beží odteraz ASYNC — 202 `{ok:true, started:true}`
+// namiesto pôvodného synchrónneho `{ok:true, result}`, "beh už prebieha"
+// je 200 `{error}` (`.claude/rules/testing.md`).
 const runNowResultSchema = z.union([
-  z.object({ ok: z.literal(true), result: runResultSchema }),
+  z.object({ ok: z.literal(true), started: z.literal(true) }),
   z.object({ error: z.string() }),
 ]);
 
@@ -117,11 +120,10 @@ export async function setOrderReminderEnabled(enabled: boolean): Promise<boolean
   return parsed.enabled;
 }
 
-export async function runOrderReminderNow(): Promise<OrderReminderRunResult> {
+export async function runOrderReminderNow(): Promise<void> {
   const response = await fetch("/api/order-reminder/run-now", { method: "POST" });
   const parsed = runNowResultSchema.parse(await readJson(response, "Beh sa nepodarilo spustiť"));
   if ("error" in parsed) throw new Error(parsed.error);
-  return parsed.result;
 }
 
 export async function overrideOrderReminder(orderCode: string, action: "contact" | "send"): Promise<OrderReminderOverrideResult> {

--- a/apps/web/src/pollJobRun.test.ts
+++ b/apps/web/src/pollJobRun.test.ts
@@ -1,0 +1,69 @@
+import { expect, it, vi } from "vitest";
+import { pollUntilJobDone } from "./pollJobRun.js";
+
+// issue 413: run-now beží ASYNC — táto funkcia je to, čo obrazovky použijú
+// na PREBRATIE výsledku namiesto priamej POST odpovede. `maxIntervalMs`
+// tu drží testy rýchle (malý strop na exponenciálny rast), žiadny
+// `vi.useFakeTimers()` netreba — rovnaký vzor ako iné čisto asynchrónne
+// testy v tomto repe.
+
+it("vráti stav hneď, keď prvý beh nie je running", async () => {
+  const fetchStatus = vi.fn().mockResolvedValue({ lastRun: { status: "success" as const } });
+  const result = await pollUntilJobDone(fetchStatus, { maxIntervalMs: 5 });
+  expect(result).toEqual({ lastRun: { status: "success" as const } });
+  expect(fetchStatus).toHaveBeenCalledTimes(1);
+});
+
+it("vráti stav hneď, keď lastRun je null", async () => {
+  const fetchStatus = vi.fn().mockResolvedValue({ lastRun: null });
+  const result = await pollUntilJobDone(fetchStatus, { maxIntervalMs: 5 });
+  expect(result).toEqual({ lastRun: null });
+  expect(fetchStatus).toHaveBeenCalledTimes(1);
+});
+
+it("opakuje volanie, kým beh ešte running, a vráti finálny stav", async () => {
+  const fetchStatus = vi
+    .fn()
+    .mockResolvedValueOnce({ lastRun: { status: "running" as const } })
+    .mockResolvedValueOnce({ lastRun: { status: "running" as const } })
+    .mockResolvedValueOnce({ lastRun: { status: "failure" as const } });
+
+  const result = await pollUntilJobDone(fetchStatus, { maxIntervalMs: 5 });
+  expect(result).toEqual({ lastRun: { status: "failure" as const } });
+  expect(fetchStatus).toHaveBeenCalledTimes(3);
+});
+
+it("vzdá sa po maxAttempts a vráti posledný (stále running) stav — nikdy nečaká navždy", async () => {
+  const fetchStatus = vi.fn().mockResolvedValue({ lastRun: { status: "running" as const } });
+  const result = await pollUntilJobDone(fetchStatus, { maxIntervalMs: 2, maxAttempts: 3 });
+  expect(result).toEqual({ lastRun: { status: "running" as const } });
+  // 1 prvotné volanie + 3 opakovania = 4.
+  expect(fetchStatus).toHaveBeenCalledTimes(4);
+});
+
+it("interval medzi pokusmi RASTIE (exponenciálne, orezaný stropom maxIntervalMs)", async () => {
+  vi.useFakeTimers();
+  try {
+    const fetchStatus = vi
+      .fn()
+      .mockResolvedValueOnce({ lastRun: { status: "running" as const } })
+      .mockResolvedValueOnce({ lastRun: { status: "running" as const } })
+      .mockResolvedValueOnce({ lastRun: { status: "running" as const } })
+      .mockResolvedValueOnce({ lastRun: { status: "success" as const } });
+
+    const promise = pollUntilJobDone(fetchStatus, { maxIntervalMs: 1000 });
+    // 500, min(1000,1000), min(2000,1000) — presne tri čakania medzi
+    // štyrmi volaniami `fetchStatus`.
+    await vi.advanceTimersByTimeAsync(500);
+    expect(fetchStatus).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(fetchStatus).toHaveBeenCalledTimes(3);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(fetchStatus).toHaveBeenCalledTimes(4);
+
+    const result = await promise;
+    expect(result).toEqual({ lastRun: { status: "success" as const } });
+  } finally {
+    vi.useRealTimers();
+  }
+});

--- a/apps/web/src/pollJobRun.ts
+++ b/apps/web/src/pollJobRun.ts
@@ -1,0 +1,51 @@
+// issue 413: "Spustiť teraz" beží odteraz ASYNC — server vráti 202 hneď (beh
+// pokračuje na pozadí), nie synchrónny výsledok priamo v POST odpovedi.
+// Obrazovka preto musí VÝSLEDOK DOČÍTAŤ opakovaným `fetchStatus()`, kým
+// posledný beh ešte `status === "running"`. Zdieľaný helper (rovnaký DRY
+// dôvod ako `useLoadMore.ts`, issue 337) — každá zo štyroch obrazoviek s
+// run-now tlačidlom (`PostaUncollectedSection`/`OrderReminderSection`/
+// `RestockSection`/`SupplierStockSection`) ho volá po úspešnom "started"
+// namiesto vlastnej kópie poll slučky.
+export interface PolledStatus {
+  readonly lastRun: { readonly status: "running" | "success" | "failure" } | null;
+}
+
+export interface PollUntilJobDoneOptions {
+  /** Horná hranica intervalu medzi pokusmi (predvolene 3000ms). */
+  readonly maxIntervalMs?: number;
+  readonly maxAttempts?: number;
+}
+
+/**
+ * Opakovane zavolá `fetchStatus()`, kým `lastRun.status === "running"` (alebo
+ * kým sa vyčerpá `maxAttempts`) — vracia POSLEDNE načítaný stav (buď
+ * skutočne dokončený beh, alebo stav po vyčerpaní pokusov, keď beh trvá
+ * neobvykle dlho — volajúci to rozpozná podľa `lastRun.status === "running"`
+ * na vrátenej hodnote).
+ *
+ * Interval medzi pokusmi RASTIE exponenciálne (500ms, 1s, 2s, potom stropom
+ * na `maxIntervalMs`) — posta-uncollected/order-reminder sú v praxi takmer
+ * OKAMŽITÉ (žiadny e2e fixtúrový riadok nemá čo reálne kontrolovať, viď
+ * `.claude/rules/posta-uncollected.md`), takže obsluha vidí výsledok skoro
+ * hneď, zatiaľ čo supplier-stock (~72 min, `.claude/rules/supplier-
+ * stock.md`) po pár pokusoch prejde na 3s krok a nikdy nezbytočne
+ * "nebombarduje" server počas skutočne dlhého behu.
+ */
+export async function pollUntilJobDone<S extends PolledStatus>(
+  fetchStatus: () => Promise<S>,
+  options: PollUntilJobDoneOptions = {},
+): Promise<S> {
+  const maxIntervalMs = options.maxIntervalMs ?? 3000;
+  const maxAttempts = options.maxAttempts ?? 40;
+  let status = await fetchStatus();
+  let attempts = 0;
+  while (status.lastRun !== null && status.lastRun.status === "running" && attempts < maxAttempts) {
+    const delayMs = Math.min(500 * 2 ** attempts, maxIntervalMs);
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, delayMs);
+    });
+    status = await fetchStatus();
+    attempts += 1;
+  }
+  return status;
+}

--- a/apps/web/src/postaUncollectedApi.ts
+++ b/apps/web/src/postaUncollectedApi.ts
@@ -79,8 +79,14 @@ export type PostaUncollectedStatus = z.infer<typeof statusSchema>;
 
 const setEnabledResultSchema = z.object({ ok: z.literal(true), enabled: z.boolean() });
 
+// issue 413: run-now beží odteraz ASYNC — server vráti 202 `{ok:true,
+// started:true}` HNEĎ (beh pokračuje na pozadí) namiesto pôvodného
+// synchrónneho `{ok:true, result}`. "Beh už prebieha" (druhý klik/
+// Cloudflare retry) je BEŽNÝ doménový výsledok, server ho vracia s 200
+// `{error: "..."}` (`.claude/rules/testing.md`), nikdy 4xx/5xx — ten istý
+// tvar, aký táto schéma už mala pre skutočné zlyhania.
 const runNowResultSchema = z.union([
-  z.object({ ok: z.literal(true), result: runResultSchema }),
+  z.object({ ok: z.literal(true), started: z.literal(true) }),
   z.object({ error: z.string() }),
 ]);
 
@@ -140,11 +146,10 @@ export async function setPostaUncollectedEnabled(enabled: boolean): Promise<bool
   return parsed.enabled;
 }
 
-export async function runPostaUncollectedNow(): Promise<PostaUncollectedRunResult> {
+export async function runPostaUncollectedNow(): Promise<void> {
   const response = await fetch("/api/posta-uncollected/run-now", { method: "POST" });
   const parsed = runNowResultSchema.parse(await readJson(response, "Beh sa nepodarilo spustiť"));
   if ("error" in parsed) throw new Error(parsed.error);
-  return parsed.result;
 }
 
 export async function fetchPostaUncollectedPreview(packageNumber: string): Promise<PostaUncollectedPreview> {

--- a/apps/web/src/restockApi.ts
+++ b/apps/web/src/restockApi.ts
@@ -72,8 +72,11 @@ const statusSchema = z.object({
 export type RestockStatus = z.infer<typeof statusSchema>;
 
 const setEnabledResultSchema = z.object({ ok: z.literal(true), enabled: z.boolean() });
+// issue 413: run-now beží odteraz ASYNC — 202 `{ok:true, started:true}`
+// namiesto pôvodného synchrónneho `{ok:true, result}`, "beh už prebieha"
+// je 200 `{ok:false, error}` (`.claude/rules/testing.md`).
 const runNowResultSchema = z.union([
-  z.object({ ok: z.literal(true), result: runResultSchema }),
+  z.object({ ok: z.literal(true), started: z.literal(true) }),
   z.object({ ok: z.literal(false), error: z.string() }),
 ]);
 
@@ -152,9 +155,8 @@ export async function setRestockEnabled(enabled: boolean): Promise<boolean> {
   return parsed.enabled;
 }
 
-export async function runRestockNow(): Promise<RestockRunResult> {
+export async function runRestockNow(): Promise<void> {
   const response = await fetch("/api/restock/run-now", { method: "POST" });
   const parsed = runNowResultSchema.parse(await readJson(response, "Beh sa nepodarilo spustiť"));
   if (!parsed.ok) throw new Error(parsed.error);
-  return parsed.result;
 }

--- a/apps/web/src/supplierStockApi.ts
+++ b/apps/web/src/supplierStockApi.ts
@@ -84,8 +84,11 @@ const statusSchema = z.object({
 });
 export type SupplierStockStatus = z.infer<typeof statusSchema>;
 
+// issue 413: run-now beží odteraz ASYNC — 202 `{ok:true, started:true}`
+// namiesto pôvodného synchrónneho `{ok:true, result}`, "beh už prebieha"
+// je 200 `{ok:false, error}` (`.claude/rules/testing.md`).
 const runNowResultSchema = z.union([
-  z.object({ ok: z.literal(true), result: runResultSchema }),
+  z.object({ ok: z.literal(true), started: z.literal(true) }),
   z.object({ ok: z.literal(false), error: z.string() }),
 ]);
 
@@ -118,9 +121,8 @@ export async function fetchSupplierStockStatus(): Promise<SupplierStockStatus> {
   return statusSchema.parse(await readJson(response, "Dodávateľský sklad sa nepodarilo načítať"));
 }
 
-export async function runSupplierStockNow(): Promise<SupplierStockRunResult> {
+export async function runSupplierStockNow(): Promise<void> {
   const response = await fetch("/api/supplier-stock/run-now", { method: "POST" });
   const parsed = runNowResultSchema.parse(await readJson(response, "Beh sa nepodarilo spustiť"));
   if (!parsed.ok) throw new Error(parsed.error);
-  return parsed.result;
 }

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -3836,3 +3836,53 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   journal záznamom).
 - Worktree mode (#317) — commit ostáva na vlastnej vetve `worktree-agent-aeefd434be27ba402`,
   supervisor mergne priamo z tejto REF-y a spustí CI pri round-integrácii.
+
+## Issue 413 — run-now joby: async 202 + advisory try-lock, orphaned job_run cleanup pri štarte
+
+- Salvage worker (predošlý worker zomrel na session limit, práca ostala necommitnutá v
+  existujúcom worktree `worktree-agent-a702ceb9bd8f82553`). Verzia zlúčená na 0.3.0-dev.248
+  (merge `4c5927b` — dev medzitým postúpil na .247 issue 412's integráciou; konflikt
+  vyriešený priamo na .248, žiadny amend).
+- Design komentár + STEP 0 validácia (obe posunuté PRED prvým code commitom, oba PÔVODNÝM
+  workerom): https://github.com/zbynekdrlik/forestshop-app/issues/413#issuecomment-5279794989
+  (validácia) a https://github.com/zbynekdrlik/forestshop-app/issues/413#issuecomment-5279795618
+  (Triage: non-trivial, 3 zvážené prístupy, Architektúra sekcia).
+- Jadro (commity `568bb65` RED / `f29cd77` GREEN): nový zdieľaný `modules/scheduler/
+  run-now.ts`'s `startRunNow` — `pg_try_advisory_lock` (neblokujúci), busy=200 bez zápisu,
+  acquired=202 hneď + fire-and-forget `job.run()` (držiaci zámok po celý beh, uvoľní sa až
+  v `.finally()`). Všetkých šesť `run.ts` súborov (`shop-sitemap`/`pairing-search`/
+  `posta-uncollected`/`order-reminder`/`supplier-stock`/`restock`) exportuje svoj interný
+  "Locked" variant; `http/*-routes.ts` nahradili vlastnú kópiu `runAndRecord` volaním
+  `startRunNow`. Naplánovaný beh (`scheduler/jobs.ts`) beží nezmenene cez pôvodný `runXxx()`.
+  Frontend: nový `apps/web/src/pollJobRun.ts`'s `pollUntilJobDone` (exponenciálny backoff,
+  ~2 min strop) namiesto priameho čítania POST odpovede, na 4 obrazovkách s tlačidlom.
+  Osirotené `job_run` riadky: nový `modules/scheduler/startup-cleanup.ts`'s
+  `cleanOrphanedJobRuns`, volaná raz z `index.ts` hneď po migráciách.
+- Vlastný review nález počas salvage (commity `0bbb6ee` RED / `3801692` GREEN, `37d8061`
+  lint-fix): `db.insert(jobRuns)` vkladajúci "running" riadok nemal `try/catch` — zlyhanie by
+  nechalo advisory zámok navždy držaný (aj pre naplánovaný beh s tým istým kľúčom). RED→GREEN
+  overené priamo (dočasné odstránenie fixu → beh → hang/cascade timeout na ďalších testoch v
+  súbore → fix vrátený → 5/5 čisto).
+- Nezávislý fresh-context `general-purpose` review dispatch (rozsah `4c5927b..HEAD`, opravený
+  cez `SendMessage` po počiatočnom zlom `cc4ba84..HEAD` rozsahu, čo omylom zahŕňal issue 412's
+  zlúčenú prácu): 0🔴, 2🟡 (oba opravené), 2🔵 (pred-existujúce, nedotknuté). 🟡#1 (commity
+  `3c977f5` RED / `19c7999` GREEN): zápis KONEČNÉHO stavu (`db.update` v `.then()`u) mohol
+  zlyhať a nechať riadok navždy "running" — fix `writeTerminalOutcome` s núdzovým `failure`
+  zápisom. 🟡#2 (commit `1fb856d`): len 2 zo 6 trás mali HTTP-úrovňový test na 202/busy
+  kontrakt — doplnené 3 nové súbory (`restock`/`shop-sitemap`/`pairing-search`-run-now-http)
+  + rozšírený `supplier-stock-http.integration.test.ts`, všetky proti PRÁZDNEJ DB (každá
+  business funkcia má vlastný "0 kandidátov" skorý návrat pred prvým dotykom reálnej externej
+  závislosti — overené priamo v zdroji, nie predpokladom). Review komentár:
+  https://github.com/zbynekdrlik/forestshop-app/issues/413#issuecomment-5281136318 (aj s
+  poznámkou, že design komentár spomína 409 pre busy — implementácia správne skončila na 200,
+  `.claude/rules/testing.md`'s konvencia).
+- Plný lokálny beh na FINÁLNOM commitnutom stave: typecheck + lint čisté, unit web 630 + api
+  962 zelené, CELÁ integračná sada 104 súborov/786 testov zelená (2 nezávislé behy), CELÁ e2e
+  sada 57/57 zelená (2 behy). Overené na izolovanej throwaway Postgres inštancii (port 5440).
+- Playbook: addendum do `.claude/rules/scheduler.md` (zámok-medzi-acquire-a-finally
+  disciplína — KAŽDÝ krok potrebuje vlastný try/catch; prázdna-DB HTTP test vzor pre run-now)
+  a `.claude/rules/local-dev.md` (dvojbodkový `git diff A..B` cez merge commit zahŕňa cudziu
+  prácu — over `git log --oneline A..B` najprv).
+- Worktree mode (#317) — commit ostáva na vlastnej vetve `worktree-agent-a702ceb9bd8f82553`,
+  supervisor mergne priamo z tejto REF-y a spustí CI pri round-integrácii. Throwaway Postgres
+  kontajner (`agent-a702ceb9-pg`, port 5440) odstránený na konci.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.245",
+  "version": "0.3.0-dev.246",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
issue 413 — dva nálezy z prvého ostrého behu shop-sitemap na produkcii.

## Obsah

- **run-now 202**: všetkých 6 run-now endpointov (shop-sitemap, posta-
  uncollected, order-reminder, supplier-stock, pairing-search, restock)
  vracia 202 okamžite cez zdieľaný `startRunNow` (`modules/scheduler/
  run-now.ts`) — beh pokračuje asynchrónne, výsledok v `job_run`. Žiadne
  Cloudflare 524, žiadny duplicitný beh: `pg_try_advisory_lock` (nikdy
  blokujúce čakanie) — držaný zámok vráti „beží" (HTTP 200 s info, podľa
  konvencie repa žiadne 4xx pre bežný doménový výsledok).
- **Čistenie osirotených behov**: pri štarte appky sa `job_run` riadky
  `running` staršie než štart procesu označia `failure` so slovenskou
  vysvetľujúcou správou — obrazovka Automatizácie už neukazuje večné „Beží".
- Frontend: run-now tlačidlá prešli na polling `job_run` (`pollJobRun.ts`).
- Opravené počas záchrany (pôvodný worker padol na limite relácie; práca
  prevzatá z worktree a dokončená): únik zámku pri zlyhaní insertu,
  odolnosť zápisu terminálneho stavu, HTTP pokrytie 202/busy kontraktu
  pre všetkých 6 endpointov.

## Testy

typecheck+lint čisté; unit 962 API + 630 web; integračné 786; e2e 57/57
(izolovaný Postgres, 2 nezávislé behy). Review: 0 🔴 2 🟡 (opravené) 2 🔵
(preexistujúce, mimo diff).
