### PR TITLE
Párovanie: ✂ Rozdeliť na veľkosti + záložka Hľadať/opraviť (issue 399)

### DIFF
--- a/.claude/rules/pairing-search.md
+++ b/.claude/rules/pairing-search.md
@@ -674,3 +674,111 @@ vyradilo #311 aj jeho playbook súbor (návrh, sekcia 4); router v
   session cookie aj same-origin sú splnené. Ak niekedy pribudne požiadavka
   na vypínač v UI, je to nový ticket (endpoint je hotový, chýba len
   komponent).
+
+## issue 399 — ✂ Rozdeliť na veľkosti + Hľadať/opraviť (mimo E1-E9)
+
+- **`pairing_decision_status` enum + jej CHECK constraint POUŽÍVAJÚCI novú
+  hodnotu MUSIA byť DVE SAMOSTATNÉ migrácie, nikdy jedna.** Naživo overené
+  na throwaway Postgrese 18: `ALTER TYPE ... ADD VALUE 'split'` a CHECK
+  constraint/INSERT používajúci `'split'` v TEJ ISTEJ transakcii vyhodí
+  `unsafe use of new value "split" ... New enum values must be committed
+  before they can be used` — KEĎ sa príkazy posielajú ako samostatné
+  príkazy v transakcii (presne to, čo `drizzle-kit`'s migrátor aj `psql`
+  skript robia). Jediný spôsob, ako to naživo prejde v JEDNEJ session, je
+  poslať VŠETKY príkazy naraz ako JEDNU multi-statement `simple query`
+  protokolovú správu (`psql -c "a; b; c;"`) — nikdy sa na to nespoliehaj,
+  to nie je tvar, akým appka migrácie reálne aplikuje. Postup na vyrobenie
+  dvoch migrácií z jednej schéma zmeny: dočasne zakomentuj/vráť CHECK a
+  novú tabuľku, `db:generate` (dá enum-only migráciu), obnov plnú schému,
+  `db:generate` znova (dá zvyšok). Test pri KAŽDEJ ĎALŠEJ novej hodnote
+  existujúceho `pgEnum`u, ktorú POUŽIJE aj CHECK constraint/iná DDL v tej
+  istej zmene: over TÝMTO postupom na throwaway Postgrese PRED tým, než sa
+  jedna migrácia s oboma príkazmi vôbec commitne.
+- **Nová `pairing_variant_link` tabuľka (PK `variant.code`) je ÚPLNE
+  NEZÁVISLÁ od `product_supplier_link_override` (#121/#239) aj od
+  existujúcej `pairing` tabuľky (F4, `schema-pairing.ts`) — design komentár
+  na tickete zdôvodňuje OBIDVE zamietnuté alternatívy.** `pairing` (F4)
+  vyzerá ako najbližší kandidát na reuse (je UŽ `variant.code`-kľúčovaná,
+  má UŽ URL pole) — ale jej dátový model (`navrhnute`/`potvrdene` stavy)
+  patrí BUDÚCEMU auto-matching automatu (#46/#48), NIKDY sa nezapisuje do
+  Shoptetu, a zlúčenie s "chýbajúce linky" bolo na tickete #239 UŽ RAZ
+  explicitne zamietnuté (`.claude/rules/product-links.md`). Reuse `pairing`
+  tabuľky pre split by resuscitoval presne to zamietnuté zlúčenie.
+- **`isUnreviewed` (queries.ts) MUSÍ zahrnúť `split` do TERMINÁLNEJ vetvy**
+  (spolu s `unavailable`/`discontinued`) — split produkt má `hasEffectiveLink
+  === false` NAVŽDY (jeho reálne linky žijú v `pairing_variant_link`, nikdy
+  v `product_supplier_link_override`), takže bez tejto výnimky by sa NIKDY
+  neprestal hlásiť ako "nezrevidovaný" napriek tomu, že JE vyriešený.
+- **`getPairingReviewItem`/`buildPairingReviewItems` (jednoproduktová
+  verzia `listPairingReview`, "Hľadať / opraviť") je ZÁMERNE SCOPED
+  (`inArray`), nikdy nenačíta celý katalóg** — na rozdiel od
+  `listPairingReview`'s vlastnej `determineReviewPopulationKeys` (tá MUSÍ
+  prejsť celý katalóg, aby zistila populáciu). Refaktor vyčlenil ITEM-
+  BUILDING (per-kľúč, scoped) od POPULATION-DETERMINATION (celý katalóg) —
+  `listPairingReview` teraz volá OBOJE (najprv určí kľúče, potom postaví
+  karty len pre ne), `getPairingReviewItem` volá LEN item-building s
+  `[productKey]`. Test pri ĎALŠEJ zmene tejto oblasti: nepridávaj žiadnu
+  ďalšiu čítaciu cestu, čo by znova načítala celý katalóg len na
+  vyhľadanie JEDNÉHO produktu — scoped dopyt je vždy lacnejší aj správnejší.
+- **"Hľadať / opraviť" ZDIEĽA `PairingReviewCard.tsx` NEZMENENÚ** (klik na
+  výsledok vyhľadávania → `fetchPairingReviewItem` → tá istá karta, čo
+  vidno na "Prehľad") — žiadna druhá kópia rozhodovacej/terminálnej/split
+  UI. `GET /api/search` vracia PER-VARIANT riadky (search modul, #240),
+  preto `PairingSearchFixTab.tsx` dedupuje podľa `productKey` (prvý výskyt
+  vyhráva) predtým, než ich zobrazí — Párovanie je produktovo-úrovňová
+  obrazovka, na rozdiel od "Vyhľadať", čo per-variant riadky ukazuje priamo.
+- **Karta bola vyčlenená na TRI súbory kvôli eslint `max-lines: 400`**
+  (pridanie split trigger + branch by inak `PairingReviewCard.tsx` poslalo
+  cez limit, rovnaký vzor ako issue 60/398/409 pred týmto): panel
+  (kandidáti/manuál/terminál/Zavrieť) → `PairingReviewDecisionPanel.tsx`
+  (čisto presentational, celý stav ostáva v `PairingReviewCard.tsx`); split
+  editor → `PairingReviewSplitPanel.tsx` (VLASTNÝ stav — `variants`
+  fetchnuté vo `useEffect`, per-riadok `busy`/draft — ale `candidates`/
+  `busy`/`submit` dostáva ako props z karty, žiadny druhý fetch top-8
+  kandidátov).
+- **Split editor NAHRADÍ celú pravú stranu karty** (`showSplitPanel =
+  splitOpen || item.decision?.status === "split"`), presne ako stará
+  appka's `renderCard`'s `splitOpen.has(p.key) || s === 'split'` early
+  return — "Navrhnutý kandidát" blok aj kolektívny riadok akcií SA
+  NEVYKRESLIA súčasne so split panelom, nikdy oba naraz.
+- **"✂ Rozdeliť na veľkosti" trigger je dostupný VŽDY, keď `item.decision
+  === null && item.variantCount > 1`, NEZÁVISLE od toho, či produkt má
+  navrhnutého kandidáta** (rovnaký zámer ako stará appky's `splitButton` —
+  žiadna podmienka na `chosenCandidate`). Trigger aj "vyber url" zdieľajú
+  TEN ISTÝ `loadCandidates()` (žiadny druhý fetch top-8 zoznamu) —
+  `openSplit`/`openPanel` sa navzájom VYLUČUJÚ (`setSplitOpen(false)`
+  v `openPanel`, `setPanelOpen(false)` v `openSplit`).
+- **"↩ Zrušiť rozdelenie" (revert na `split`) NIKDY nemaže per-veľkosť
+  linky** (`pairing_variant_link` riadky) — presne rovnaká asymetria/
+  konvencia ako "↩ Vrátiť" na `unavailable`/`discontinued` nikdy nemaže
+  `product_supplier_link_override`. Opätovné rozdelenie ukáže predtým
+  uložené hodnoty, integračný test (`pairing-review-variant-links-http
+  .integration.test.ts`) dokazuje explicitne.
+- **E2E fixtúra "E2E-PR-SPLIT" (2 varianty S/M) je JEDINÝ viacveľkostný
+  produkt v `scripts/e2e-fixtures-pairing-review.ts`** — `seedProdukt`
+  helper vytvára VŽDY presne jeden variant (`code === productKey`), takže
+  split test potreboval VLASTNÉ (nie helperom vyrobené) vloženie
+  `products`/`variants` s dvomi riadkami. Posunulo `catalog.spec.ts`'s
+  pevné počty o +2 (total 107→109, "sellable" 77→79) — zdokumentované
+  priamo tam (`.claude/rules/testing.md`'s "nový variant posunie počty" past).
+- **E2E testy zdieľajúce TEN ISTÝ fixtúrový produkt v jednom spec súbore
+  potrebujú VEDOMÉ PORADIE, nielen izolovaný účet.** `scripts/
+  e2e-setup.ts` sa seeduje LEN RAZ pri štarte `webServer`u (nie pred
+  KAŽDÝM testom) — `pairing-review-split.spec.ts`'s dva split testy oba
+  mutujú "E2E-PR-SPLIT"'s `decision`, takže test bežiaci DRUHÝ vidí stav,
+  aký zanechal PRVÝ. Riešenie: test, čo KONČÍ s `decision === null`
+  (revert), musí bežať PRED testom, čo očakáva split TRIGGER tlačidlo
+  (zobrazí sa len keď `decision === null`) — poradie v súbore = poradie
+  behu. Druhý test navyše explicitne PREPÍŠE obe veľkosti vlastnými
+  hodnotami, nezávisle od toho, čo prvý test zanechal v `pairing_variant_link`.
+- **`window.confirm()` (missing-link varovanie pri "✓ Hotovo") potrebuje
+  `page.on("dialog", d => void d.accept())` v e2e teste — Playwright BEZ
+  registrovaného handlera dialóg AUTOMATICKY ZAMIETNE**, takže test bez
+  neho by tichoTIMEOUTol/nezapísal rozhodnutie namiesto skutočného
+  overenia "potvrdenie prejde ďalej".
+- **Bare `getByRole("button", {name: "Hľadať"})` na obrazovke "Párovanie"
+  koliduje s DVOMA inými prvkami naraz** (`.claude/rules/testing.md`'s
+  zdokumentovaná trieda) — sidebarov "Vyhľadať" nav tab (case-insensitive
+  substring "hľadať" ⊂ "vyhľadať") AJ VLASTNÁ "Hľadať / opraviť" pod-
+  záložka (prefix). `{ name: "Hľadať", exact: true }` je jediná
+  jednoznačná cesta k skutočnému submit tlačidlu.

--- a/.claude/rules/pairing-search.md
+++ b/.claude/rules/pairing-search.md
@@ -782,3 +782,24 @@ vyradilo #311 aj jeho playbook súbor (návrh, sekcia 4); router v
   substring "hľadať" ⊂ "vyhľadať") AJ VLASTNÁ "Hľadať / opraviť" pod-
   záložka (prefix). `{ name: "Hľadať", exact: true }` je jediná
   jednoznačná cesta k skutočnému submit tlačidlu.
+- **Súhrnné "Hotovo"/potvrdzovacie tlačidlo NAD viacerými NEZÁVISLE
+  ukladajúcimi sa RIADKAMI (každý riadok VLASTný `rowBusy` `useState`)
+  potrebuje tento stav VYZDVIHNUTÝ do rodiča — nestačí len rodičov
+  spoločný `busy` prop.** Nájdené v self-review (nie testom):
+  `PairingReviewSplitPanel.tsx`'s "✓ Hotovo – rozdelené" kontrolovalo len
+  `busy` (karta-úrovňová) a `variants === null`, nie `rowBusy` VNÚTRI
+  `VariantRow`u (súkromný, rodičovi neviditeľný stav) — klik počas
+  rozbehnutého zápisu JEDNÉHO riadku mohol vidieť ešte-nezapísaný
+  (starý) stav a zbytočne ukázať konzervatívny potvrdzovací dialóg. Fix:
+  rodič drží `Set<string>` kódov s bežiacim zápisom (`busyRowCodes`), dieťa
+  (`VariantRow`) hlási zmenu cez `onBusyChange(code, busy)` callback pri
+  `setRowBusy` (oba smery — `true` aj `false`, symetricky), rodičovo
+  tlačidlo pridá `anyRowBusy = busyRowCodes.size > 0` do svojej `disabled`
+  podmienky. Iný tvar ako existujúci "per-item vs. group busy-guard,
+  disabled v OBOCH smeroch" vzor (`.claude/rules/frontend-design.md`,
+  issue 60) — TAM sú dva SÚRODENECKÉ akcie (jedna na riadku, jedna nad
+  skupinou), TU je to N nezávislých DETÍ hlásiacich svoj stav JEDNÉMU
+  rodičovmu tlačidlu — pri KAŽDOM ĎALŠOM "spoločné Hotovo/Uložiť nad
+  zoznamom nezávisle sa ukladajúcich riadkov" v tejto appke over, či
+  riadky majú VLASTNÝ busy stav, ktorý treba vyzdvihnúť rovnakým
+  callback vzorom.

--- a/.claude/rules/pairing-search.md
+++ b/.claude/rules/pairing-search.md
@@ -665,3 +665,12 @@ vyradilo #311 aj jeho playbook súbor (návrh, sekcia 4); router v
   vzore: zdieľaj testid len PO overení, že podmienky sú GENUINELY
   disjunktné (nie len "vyzerá to tak"), inak dvojznačný Playwright/RTL
   dotaz.
+- **Prepínač spätného zápisu stavov NEMÁ UI — zapína sa LEN cez API** (issue
+  418, 13. 8. 2026, zapnuté rozhodnutím majiteľa): `PUT /api/pairing-review/
+  state-writeback-enabled` s telom `{"enabled": true|false}` (same-origin +
+  rola admin/manazer; read-back GET vráti `{"enabled": ...}`). Singleton
+  riadok `pairing_state_writeback_settings` id=`default` (upsert). Z
+  prihláseného Playwright sedenia stačí `fetch()` v `browser_evaluate` —
+  session cookie aj same-origin sú splnené. Ak niekedy pribudne požiadavka
+  na vypínač v UI, je to nový ticket (endpoint je hotový, chýba len
+  komponent).

--- a/apps/api/drizzle/0053_pale_epoch.sql
+++ b/apps/api/drizzle/0053_pale_epoch.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."pairing_decision_status" ADD VALUE 'split';

--- a/apps/api/drizzle/0054_zippy_invisible_woman.sql
+++ b/apps/api/drizzle/0054_zippy_invisible_woman.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "pairing_variant_link" (
+	"code" text PRIMARY KEY NOT NULL,
+	"url" text NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "pairing_decision" DROP CONSTRAINT "pairing_decision_url_ck";--> statement-breakpoint
+ALTER TABLE "pairing_variant_link" ADD CONSTRAINT "pairing_variant_link_code_variant_code_fk" FOREIGN KEY ("code") REFERENCES "public"."variant"("code") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pairing_decision" ADD CONSTRAINT "pairing_decision_url_ck" CHECK (("pairing_decision"."status" IN ('good','manual') AND "pairing_decision"."url" IS NOT NULL) OR ("pairing_decision"."status" IN ('unavailable','discontinued','split') AND "pairing_decision"."url" IS NULL));

--- a/apps/api/drizzle/meta/0053_snapshot.json
+++ b/apps/api/drizzle/meta/0053_snapshot.json
@@ -1,0 +1,3738 @@
+{
+  "id": "1411fdfc-26c2-45cd-b005-f2e4156070fe",
+  "prevId": "4d7210b2-7922-4efc-a5f7-30acb016efcd",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_code": {
+          "name": "external_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_open_status": {
+      "name": "order_open_status",
+      "schema": "",
+      "columns": {
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Vybavuje sa'"
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop_remark": {
+          "name": "shop_remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shoptet_order_id": {
+          "name": "shoptet_order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_updated_at": {
+          "name": "comment_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_synced_at": {
+          "name": "comment_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_carrier_name": {
+          "name": "shipping_carrier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_price_with_vat": {
+          "name": "total_price_with_vat",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_marked_at": {
+          "name": "claim_marked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_note": {
+          "name": "claim_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_full_name": {
+          "name": "delivery_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_company": {
+          "name": "delivery_company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_street": {
+          "name": "delivery_street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_house_number": {
+          "name": "delivery_house_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_city": {
+          "name": "delivery_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_zip": {
+          "name": "delivery_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_country_name": {
+          "name": "delivery_country_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_name": {
+          "name": "payment_method_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_to_pay": {
+          "name": "price_to_pay",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_link_override": {
+      "name": "product_supplier_link_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_link_override_product_key_product_key_fk": {
+          "name": "product_supplier_link_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_link_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_override": {
+      "name": "product_supplier_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_override_product_key_product_key_fk": {
+          "name": "product_supplier_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing": {
+      "name": "pairing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_url": {
+          "name": "supplier_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "pairing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'navrhnute'"
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pairing_state_idx": {
+          "name": "pairing_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_confirmed_by_idx": {
+          "name": "pairing_confirmed_by_idx",
+          "columns": [
+            {
+              "expression": "confirmed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_variant_code_variant_code_fk": {
+          "name": "pairing_variant_code_variant_code_fk",
+          "tableFrom": "pairing",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pairing_confirmed_by_users_id_fk": {
+          "name": "pairing_confirmed_by_users_id_fk",
+          "tableFrom": "pairing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pairing_variant_code_unique": {
+          "name": "pairing_variant_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pairing_confirmation_ck": {
+          "name": "pairing_confirmation_ck",
+          "value": "(\"pairing\".\"state\" = 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)\n        OR (\"pairing\".\"state\" != 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NULL AND \"pairing\".\"confirmed_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier": {
+      "name": "supplier",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wholesale_base_url": {
+          "name": "wholesale_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_key": {
+          "name": "adapter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_settings": {
+      "name": "posta_uncollected_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_state": {
+      "name": "posta_uncollected_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notify_count": {
+          "name": "notify_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_state": {
+          "name": "terminal_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_settings": {
+      "name": "order_reminder_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_state": {
+      "name": "order_reminder_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_replacement_link": {
+      "name": "nedostupne_replacement_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nedostupne_replacement_link_variant_idx": {
+          "name": "nedostupne_replacement_link_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_state": {
+      "name": "nedostupne_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "nedostupne_email_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nedostupne_state_order_variant_type_uq": {
+          "name": "nedostupne_state_order_variant_type_uq",
+          "columns": [
+            {
+              "expression": "order_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template_history": {
+      "name": "mail_template_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "mail_template_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_template_history_key_idx": {
+          "name": "mail_template_history_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_template_history_changed_by_user_id_users_id_fk": {
+          "name": "mail_template_history_changed_by_user_id_users_id_fk",
+          "tableFrom": "mail_template_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template": {
+      "name": "mail_template",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail_template_updated_by_user_id_users_id_fk": {
+          "name": "mail_template_updated_by_user_id_users_id_fk",
+          "tableFrom": "mail_template",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_log": {
+      "name": "mail_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "mail_log_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_log_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "mail_log_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_log_created_idx": {
+          "name": "mail_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_log_source_created_idx": {
+          "name": "mail_log_source_created_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_log_actor_user_id_users_id_fk": {
+          "name": "mail_log_actor_user_id_users_id_fk",
+          "tableFrom": "mail_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_stock": {
+      "name": "supplier_stock",
+      "schema": "",
+      "columns": {
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "supplier_availability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "supplier_stock_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "supplier_stock_host_idx": {
+          "name": "supplier_stock_host_idx",
+          "columns": [
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "supplier_stock_avail_idx": {
+          "name": "supplier_stock_avail_idx",
+          "columns": [
+            {
+              "expression": "availability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "supplier_stock_link_size_label_pk": {
+          "name": "supplier_stock_link_size_label_pk",
+          "columns": [
+            "link",
+            "size_label"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_event": {
+      "name": "restock_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_link": {
+          "name": "supplier_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_availability_text": {
+          "name": "supplier_availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "supplier_price": {
+          "name": "supplier_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "restock_event_at_idx": {
+          "name": "restock_event_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "restock_event_variant_idx": {
+          "name": "restock_event_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_settings": {
+      "name": "restock_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shop_product_url": {
+      "name": "shop_product_url",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "shop_product_url_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'feed'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.theme_color": {
+      "name": "theme_color",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "theme_color_updated_by_user_id_users_id_fk": {
+          "name": "theme_color_updated_by_user_id_users_id_fk",
+          "tableFrom": "theme_color",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upozornenie": {
+      "name": "upozornenie",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "upozornenie_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "upozornenie_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedup_key": {
+          "name": "dedup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postponed_until": {
+          "name": "postponed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seen_at": {
+          "name": "seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "upozornenie_dedup_key_uq": {
+          "name": "upozornenie_dedup_key_uq",
+          "columns": [
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "resolved_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upozornenie_resolved_at_idx": {
+          "name": "upozornenie_resolved_at_idx",
+          "columns": [
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upozornenie_dedup_key_idx": {
+          "name": "upozornenie_dedup_key_idx",
+          "columns": [
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upozornenie_resolved_by_user_id_users_id_fk": {
+          "name": "upozornenie_resolved_by_user_id_users_id_fk",
+          "tableFrom": "upozornenie",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "upozornenie_created_by_user_id_users_id_fk": {
+          "name": "upozornenie_created_by_user_id_users_id_fk",
+          "tableFrom": "upozornenie",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dpd_pickup_request": {
+      "name": "dpd_pickup_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "pickup_date": {
+          "name": "pickup_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "dpd_operation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dpd_shipment": {
+      "name": "dpd_shipment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "dpd_operation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parcel_number": {
+          "name": "parcel_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cod_amount": {
+          "name": "cod_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dpd_shipment_order_uq": {
+          "name": "dpd_shipment_order_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dpd_shipment_order_id_order_id_fk": {
+          "name": "dpd_shipment_order_id_order_id_fk",
+          "tableFrom": "dpd_shipment",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_task": {
+      "name": "daily_task",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "done_at": {
+          "name": "done_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "daily_task_user_id_created_at_idx": {
+          "name": "daily_task_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_task_user_id_users_id_fk": {
+          "name": "daily_task_user_id_users_id_fk",
+          "tableFrom": "daily_task",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing_candidate_set": {
+      "name": "pairing_candidate_set",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gathered_at": {
+          "name": "gathered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "queries": {
+          "name": "queries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chosen_url": {
+          "name": "chosen_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chosen_reason": {
+          "name": "chosen_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "pairing_confidence",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "pairing_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verdict_checked_at": {
+          "name": "verdict_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pairing_candidate_set_product_key_product_key_fk": {
+          "name": "pairing_candidate_set_product_key_product_key_fk",
+          "tableFrom": "pairing_candidate_set",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing_candidate": {
+      "name": "pairing_candidate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_score": {
+          "name": "raw_score",
+          "type": "numeric(8, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_hit": {
+          "name": "code_hit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pairing_candidate_product_url_uq": {
+          "name": "pairing_candidate_product_url_uq",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_candidate_product_idx": {
+          "name": "pairing_candidate_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_candidate_product_key_fk": {
+          "name": "pairing_candidate_product_key_fk",
+          "tableFrom": "pairing_candidate",
+          "tableTo": "pairing_candidate_set",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "product_key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing_decision": {
+      "name": "pairing_decision",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "pairing_decision_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_synced_at": {
+          "name": "state_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pairing_decision_product_key_product_key_fk": {
+          "name": "pairing_decision_product_key_product_key_fk",
+          "tableFrom": "pairing_decision",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pairing_decision_decided_by_users_id_fk": {
+          "name": "pairing_decision_decided_by_users_id_fk",
+          "tableFrom": "pairing_decision",
+          "tableTo": "users",
+          "columnsFrom": [
+            "decided_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pairing_decision_url_ck": {
+          "name": "pairing_decision_url_ck",
+          "value": "(\"pairing_decision\".\"status\" IN ('good','manual') AND \"pairing_decision\".\"url\" IS NOT NULL) OR (\"pairing_decision\".\"status\" IN ('unavailable','discontinued') AND \"pairing_decision\".\"url\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pairing_search_settings": {
+      "name": "pairing_search_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing_state_writeback_settings": {
+      "name": "pairing_state_writeback_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.floor_note_product": {
+      "name": "floor_note_product",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "floor_note_id": {
+          "name": "floor_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "floor_note_product_note_idx": {
+          "name": "floor_note_product_note_idx",
+          "columns": [
+            {
+              "expression": "floor_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "floor_note_product_note_variant_uq": {
+          "name": "floor_note_product_note_variant_uq",
+          "columns": [
+            {
+              "expression": "floor_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "floor_note_product_floor_note_id_floor_note_id_fk": {
+          "name": "floor_note_product_floor_note_id_floor_note_id_fk",
+          "tableFrom": "floor_note_product",
+          "tableTo": "floor_note",
+          "columnsFrom": [
+            "floor_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "floor_note_product_variant_code_variant_code_fk": {
+          "name": "floor_note_product_variant_code_variant_code_fk",
+          "tableFrom": "floor_note_product",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.floor_note": {
+      "name": "floor_note",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "resolved": {
+          "name": "resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "called": {
+          "name": "called",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "floor_note_created_at_idx": {
+          "name": "floor_note_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "floor_note_created_by_user_id_users_id_fk": {
+          "name": "floor_note_created_by_user_id_users_id_fk",
+          "tableFrom": "floor_note",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne"
+      ]
+    },
+    "public.pairing_state": {
+      "name": "pairing_state",
+      "schema": "public",
+      "values": [
+        "navrhnute",
+        "potvrdene"
+      ]
+    },
+    "public.nedostupne_email_type": {
+      "name": "nedostupne_email_type",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "alternativa"
+      ]
+    },
+    "public.mail_template_action": {
+      "name": "mail_template_action",
+      "schema": "public",
+      "values": [
+        "save",
+        "reset"
+      ]
+    },
+    "public.mail_log_source": {
+      "name": "mail_log_source",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "posta_uncollected",
+        "order_reminder",
+        "supplier_order",
+        "order_merge"
+      ]
+    },
+    "public.mail_log_status": {
+      "name": "mail_log_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.mail_log_trigger": {
+      "name": "mail_log_trigger",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "manual"
+      ]
+    },
+    "public.supplier_availability": {
+      "name": "supplier_availability",
+      "schema": "public",
+      "values": [
+        "available",
+        "unavailable",
+        "unknown"
+      ]
+    },
+    "public.supplier_stock_source": {
+      "name": "supplier_stock_source",
+      "schema": "public",
+      "values": [
+        "json_ld",
+        "meta",
+        "text",
+        "size_list",
+        "none"
+      ]
+    },
+    "public.shop_product_url_source": {
+      "name": "shop_product_url_source",
+      "schema": "public",
+      "values": [
+        "feed",
+        "sitemap",
+        "probe"
+      ]
+    },
+    "public.upozornenie_source": {
+      "name": "upozornenie_source",
+      "schema": "public",
+      "values": [
+        "vlastne",
+        "appka"
+      ]
+    },
+    "public.upozornenie_type": {
+      "name": "upozornenie_type",
+      "schema": "public",
+      "values": [
+        "vlastna_poznamka",
+        "nevyzdvihnuta_zasielka",
+        "vratenie",
+        "vratena_zasielka",
+        "objednavka_visi"
+      ]
+    },
+    "public.dpd_operation_status": {
+      "name": "dpd_operation_status",
+      "schema": "public",
+      "values": [
+        "submitted",
+        "failed"
+      ]
+    },
+    "public.pairing_confidence": {
+      "name": "pairing_confidence",
+      "schema": "public",
+      "values": [
+        "high",
+        "medium",
+        "low",
+        "none"
+      ]
+    },
+    "public.pairing_decision_status": {
+      "name": "pairing_decision_status",
+      "schema": "public",
+      "values": [
+        "good",
+        "manual",
+        "unavailable",
+        "discontinued",
+        "split"
+      ]
+    },
+    "public.pairing_verdict": {
+      "name": "pairing_verdict",
+      "schema": "public",
+      "values": [
+        "ok",
+        "unsure"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/0054_snapshot.json
+++ b/apps/api/drizzle/meta/0054_snapshot.json
@@ -1,0 +1,3784 @@
+{
+  "id": "e278a653-afad-4028-8d05-45fc03196490",
+  "prevId": "1411fdfc-26c2-45cd-b005-f2e4156070fe",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_code": {
+          "name": "external_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_open_status": {
+      "name": "order_open_status",
+      "schema": "",
+      "columns": {
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Vybavuje sa'"
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop_remark": {
+          "name": "shop_remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shoptet_order_id": {
+          "name": "shoptet_order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_updated_at": {
+          "name": "comment_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_synced_at": {
+          "name": "comment_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_carrier_name": {
+          "name": "shipping_carrier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_price_with_vat": {
+          "name": "total_price_with_vat",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_marked_at": {
+          "name": "claim_marked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_note": {
+          "name": "claim_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_full_name": {
+          "name": "delivery_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_company": {
+          "name": "delivery_company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_street": {
+          "name": "delivery_street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_house_number": {
+          "name": "delivery_house_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_city": {
+          "name": "delivery_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_zip": {
+          "name": "delivery_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_country_name": {
+          "name": "delivery_country_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_name": {
+          "name": "payment_method_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_to_pay": {
+          "name": "price_to_pay",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_link_override": {
+      "name": "product_supplier_link_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_link_override_product_key_product_key_fk": {
+          "name": "product_supplier_link_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_link_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_override": {
+      "name": "product_supplier_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_override_product_key_product_key_fk": {
+          "name": "product_supplier_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing": {
+      "name": "pairing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_url": {
+          "name": "supplier_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "pairing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'navrhnute'"
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pairing_state_idx": {
+          "name": "pairing_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_confirmed_by_idx": {
+          "name": "pairing_confirmed_by_idx",
+          "columns": [
+            {
+              "expression": "confirmed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_variant_code_variant_code_fk": {
+          "name": "pairing_variant_code_variant_code_fk",
+          "tableFrom": "pairing",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pairing_confirmed_by_users_id_fk": {
+          "name": "pairing_confirmed_by_users_id_fk",
+          "tableFrom": "pairing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pairing_variant_code_unique": {
+          "name": "pairing_variant_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pairing_confirmation_ck": {
+          "name": "pairing_confirmation_ck",
+          "value": "(\"pairing\".\"state\" = 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)\n        OR (\"pairing\".\"state\" != 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NULL AND \"pairing\".\"confirmed_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier": {
+      "name": "supplier",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wholesale_base_url": {
+          "name": "wholesale_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_key": {
+          "name": "adapter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_settings": {
+      "name": "posta_uncollected_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_state": {
+      "name": "posta_uncollected_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notify_count": {
+          "name": "notify_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_state": {
+          "name": "terminal_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_settings": {
+      "name": "order_reminder_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_state": {
+      "name": "order_reminder_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_replacement_link": {
+      "name": "nedostupne_replacement_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nedostupne_replacement_link_variant_idx": {
+          "name": "nedostupne_replacement_link_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_state": {
+      "name": "nedostupne_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "nedostupne_email_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nedostupne_state_order_variant_type_uq": {
+          "name": "nedostupne_state_order_variant_type_uq",
+          "columns": [
+            {
+              "expression": "order_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template_history": {
+      "name": "mail_template_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "mail_template_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_template_history_key_idx": {
+          "name": "mail_template_history_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_template_history_changed_by_user_id_users_id_fk": {
+          "name": "mail_template_history_changed_by_user_id_users_id_fk",
+          "tableFrom": "mail_template_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template": {
+      "name": "mail_template",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail_template_updated_by_user_id_users_id_fk": {
+          "name": "mail_template_updated_by_user_id_users_id_fk",
+          "tableFrom": "mail_template",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_log": {
+      "name": "mail_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "mail_log_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_log_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "mail_log_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_log_created_idx": {
+          "name": "mail_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_log_source_created_idx": {
+          "name": "mail_log_source_created_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_log_actor_user_id_users_id_fk": {
+          "name": "mail_log_actor_user_id_users_id_fk",
+          "tableFrom": "mail_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_stock": {
+      "name": "supplier_stock",
+      "schema": "",
+      "columns": {
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "supplier_availability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "supplier_stock_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "supplier_stock_host_idx": {
+          "name": "supplier_stock_host_idx",
+          "columns": [
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "supplier_stock_avail_idx": {
+          "name": "supplier_stock_avail_idx",
+          "columns": [
+            {
+              "expression": "availability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "supplier_stock_link_size_label_pk": {
+          "name": "supplier_stock_link_size_label_pk",
+          "columns": [
+            "link",
+            "size_label"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_event": {
+      "name": "restock_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_link": {
+          "name": "supplier_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_availability_text": {
+          "name": "supplier_availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "supplier_price": {
+          "name": "supplier_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "restock_event_at_idx": {
+          "name": "restock_event_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "restock_event_variant_idx": {
+          "name": "restock_event_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_settings": {
+      "name": "restock_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shop_product_url": {
+      "name": "shop_product_url",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "shop_product_url_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'feed'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.theme_color": {
+      "name": "theme_color",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "theme_color_updated_by_user_id_users_id_fk": {
+          "name": "theme_color_updated_by_user_id_users_id_fk",
+          "tableFrom": "theme_color",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upozornenie": {
+      "name": "upozornenie",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "upozornenie_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "upozornenie_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedup_key": {
+          "name": "dedup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postponed_until": {
+          "name": "postponed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seen_at": {
+          "name": "seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "upozornenie_dedup_key_uq": {
+          "name": "upozornenie_dedup_key_uq",
+          "columns": [
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "resolved_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upozornenie_resolved_at_idx": {
+          "name": "upozornenie_resolved_at_idx",
+          "columns": [
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upozornenie_dedup_key_idx": {
+          "name": "upozornenie_dedup_key_idx",
+          "columns": [
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upozornenie_resolved_by_user_id_users_id_fk": {
+          "name": "upozornenie_resolved_by_user_id_users_id_fk",
+          "tableFrom": "upozornenie",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "upozornenie_created_by_user_id_users_id_fk": {
+          "name": "upozornenie_created_by_user_id_users_id_fk",
+          "tableFrom": "upozornenie",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dpd_pickup_request": {
+      "name": "dpd_pickup_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "pickup_date": {
+          "name": "pickup_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "dpd_operation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dpd_shipment": {
+      "name": "dpd_shipment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "dpd_operation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parcel_number": {
+          "name": "parcel_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cod_amount": {
+          "name": "cod_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dpd_shipment_order_uq": {
+          "name": "dpd_shipment_order_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dpd_shipment_order_id_order_id_fk": {
+          "name": "dpd_shipment_order_id_order_id_fk",
+          "tableFrom": "dpd_shipment",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_task": {
+      "name": "daily_task",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "done_at": {
+          "name": "done_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "daily_task_user_id_created_at_idx": {
+          "name": "daily_task_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_task_user_id_users_id_fk": {
+          "name": "daily_task_user_id_users_id_fk",
+          "tableFrom": "daily_task",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing_candidate_set": {
+      "name": "pairing_candidate_set",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gathered_at": {
+          "name": "gathered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "queries": {
+          "name": "queries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chosen_url": {
+          "name": "chosen_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chosen_reason": {
+          "name": "chosen_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "pairing_confidence",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "pairing_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verdict_checked_at": {
+          "name": "verdict_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pairing_candidate_set_product_key_product_key_fk": {
+          "name": "pairing_candidate_set_product_key_product_key_fk",
+          "tableFrom": "pairing_candidate_set",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing_candidate": {
+      "name": "pairing_candidate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_score": {
+          "name": "raw_score",
+          "type": "numeric(8, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_hit": {
+          "name": "code_hit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pairing_candidate_product_url_uq": {
+          "name": "pairing_candidate_product_url_uq",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_candidate_product_idx": {
+          "name": "pairing_candidate_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_candidate_product_key_fk": {
+          "name": "pairing_candidate_product_key_fk",
+          "tableFrom": "pairing_candidate",
+          "tableTo": "pairing_candidate_set",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "product_key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing_decision": {
+      "name": "pairing_decision",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "pairing_decision_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_synced_at": {
+          "name": "state_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pairing_decision_product_key_product_key_fk": {
+          "name": "pairing_decision_product_key_product_key_fk",
+          "tableFrom": "pairing_decision",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pairing_decision_decided_by_users_id_fk": {
+          "name": "pairing_decision_decided_by_users_id_fk",
+          "tableFrom": "pairing_decision",
+          "tableTo": "users",
+          "columnsFrom": [
+            "decided_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pairing_decision_url_ck": {
+          "name": "pairing_decision_url_ck",
+          "value": "(\"pairing_decision\".\"status\" IN ('good','manual') AND \"pairing_decision\".\"url\" IS NOT NULL) OR (\"pairing_decision\".\"status\" IN ('unavailable','discontinued','split') AND \"pairing_decision\".\"url\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pairing_search_settings": {
+      "name": "pairing_search_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing_state_writeback_settings": {
+      "name": "pairing_state_writeback_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing_variant_link": {
+      "name": "pairing_variant_link",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pairing_variant_link_code_variant_code_fk": {
+          "name": "pairing_variant_link_code_variant_code_fk",
+          "tableFrom": "pairing_variant_link",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.floor_note_product": {
+      "name": "floor_note_product",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "floor_note_id": {
+          "name": "floor_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "floor_note_product_note_idx": {
+          "name": "floor_note_product_note_idx",
+          "columns": [
+            {
+              "expression": "floor_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "floor_note_product_note_variant_uq": {
+          "name": "floor_note_product_note_variant_uq",
+          "columns": [
+            {
+              "expression": "floor_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "floor_note_product_floor_note_id_floor_note_id_fk": {
+          "name": "floor_note_product_floor_note_id_floor_note_id_fk",
+          "tableFrom": "floor_note_product",
+          "tableTo": "floor_note",
+          "columnsFrom": [
+            "floor_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "floor_note_product_variant_code_variant_code_fk": {
+          "name": "floor_note_product_variant_code_variant_code_fk",
+          "tableFrom": "floor_note_product",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.floor_note": {
+      "name": "floor_note",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "resolved": {
+          "name": "resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "called": {
+          "name": "called",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "floor_note_created_at_idx": {
+          "name": "floor_note_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "floor_note_created_by_user_id_users_id_fk": {
+          "name": "floor_note_created_by_user_id_users_id_fk",
+          "tableFrom": "floor_note",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne"
+      ]
+    },
+    "public.pairing_state": {
+      "name": "pairing_state",
+      "schema": "public",
+      "values": [
+        "navrhnute",
+        "potvrdene"
+      ]
+    },
+    "public.nedostupne_email_type": {
+      "name": "nedostupne_email_type",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "alternativa"
+      ]
+    },
+    "public.mail_template_action": {
+      "name": "mail_template_action",
+      "schema": "public",
+      "values": [
+        "save",
+        "reset"
+      ]
+    },
+    "public.mail_log_source": {
+      "name": "mail_log_source",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "posta_uncollected",
+        "order_reminder",
+        "supplier_order",
+        "order_merge"
+      ]
+    },
+    "public.mail_log_status": {
+      "name": "mail_log_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.mail_log_trigger": {
+      "name": "mail_log_trigger",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "manual"
+      ]
+    },
+    "public.supplier_availability": {
+      "name": "supplier_availability",
+      "schema": "public",
+      "values": [
+        "available",
+        "unavailable",
+        "unknown"
+      ]
+    },
+    "public.supplier_stock_source": {
+      "name": "supplier_stock_source",
+      "schema": "public",
+      "values": [
+        "json_ld",
+        "meta",
+        "text",
+        "size_list",
+        "none"
+      ]
+    },
+    "public.shop_product_url_source": {
+      "name": "shop_product_url_source",
+      "schema": "public",
+      "values": [
+        "feed",
+        "sitemap",
+        "probe"
+      ]
+    },
+    "public.upozornenie_source": {
+      "name": "upozornenie_source",
+      "schema": "public",
+      "values": [
+        "vlastne",
+        "appka"
+      ]
+    },
+    "public.upozornenie_type": {
+      "name": "upozornenie_type",
+      "schema": "public",
+      "values": [
+        "vlastna_poznamka",
+        "nevyzdvihnuta_zasielka",
+        "vratenie",
+        "vratena_zasielka",
+        "objednavka_visi"
+      ]
+    },
+    "public.dpd_operation_status": {
+      "name": "dpd_operation_status",
+      "schema": "public",
+      "values": [
+        "submitted",
+        "failed"
+      ]
+    },
+    "public.pairing_confidence": {
+      "name": "pairing_confidence",
+      "schema": "public",
+      "values": [
+        "high",
+        "medium",
+        "low",
+        "none"
+      ]
+    },
+    "public.pairing_decision_status": {
+      "name": "pairing_decision_status",
+      "schema": "public",
+      "values": [
+        "good",
+        "manual",
+        "unavailable",
+        "discontinued",
+        "split"
+      ]
+    },
+    "public.pairing_verdict": {
+      "name": "pairing_verdict",
+      "schema": "public",
+      "values": [
+        "ok",
+        "unsure"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -372,6 +372,20 @@
       "when": 1786614855370,
       "tag": "0052_thankful_invisible_woman",
       "breakpoints": true
+    },
+    {
+      "idx": 53,
+      "version": "7",
+      "when": 1786649276310,
+      "tag": "0053_pale_epoch",
+      "breakpoints": true
+    },
+    {
+      "idx": 54,
+      "version": "7",
+      "when": 1786649301861,
+      "tag": "0054_zippy_invisible_woman",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema-pairing-review.ts
+++ b/apps/api/src/db/schema-pairing-review.ts
@@ -5,7 +5,7 @@
 
 import { sql } from "drizzle-orm";
 import { boolean, check, foreignKey, index, integer, jsonb, numeric, pgEnum, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
-import { products } from "./schema-catalog.js";
+import { products, variants } from "./schema-catalog.js";
 // `users` sa importuje PRIAMO zo svojho sibling súboru, nikdy cez barrel
 // `schema.js` — ten by vytvoril kruhový import (`.claude/rules/database.md`).
 import { users } from "./schema-users.js";
@@ -102,7 +102,46 @@ export const pairingSearchSettings = pgTable("pairing_search_settings", {
 // riadku = "nezrevidované" (`pairing-review/queries.ts`'s `unreviewed`
 // filter, forward-kompat rozšírené o TENTO stĺpec — design komentár na
 // tickete, issue 387 E5). "↩ Vrátiť" = DELETE riadku (nikdy status navyše).
-export const pairingDecisionStatus = pgEnum("pairing_decision_status", ["good", "manual", "unavailable", "discontinued"]);
+//
+// issue 399 — piaty stav `split`: produkt s VIAC veľkosťami, ktorý má
+// KAŽDÁ svoj vlastný link u dodávateľa namiesto jedného spoločného. Rovnaký
+// tvar ako `unavailable`/`discontinued` (žiadna `url` na TOMTO riadku —
+// per-veľkosť linky žijú vo `pairingVariantLinks` nižšie, design komentár
+// na tickete, sekcia "Prístup 1"). **Pridanie hodnoty `split` MUSÍ byť
+// SAMOSTATNÁ migrácia (0053) od CHECK constraintu, čo ju používa (0054) —
+// naživo overené proti Postgresu 18 (throwaway kontajner): `ALTER TYPE ...
+// ADD VALUE` v tej istej transakcii ako CHECK constraint POUŽÍVAJÚCI novú
+// hodnotu vyhadzuje `unsafe use of new value "split" ... New enum values
+// must be committed before they can be used`, KEĎ sa príkazy posielajú
+// ako samostatné príkazy v rámci transakcie (presne to, čo drizzle-kit's
+// migrátor aj `psql` skript robia) — jediný spôsob, ako to naživo prejde v
+// JEDNEJ session, je poslať VŠETKY príkazy naraz ako JEDNU multi-statement
+// `simple query` protokolovú správu (`psql -c "a; b; c;"`), čo NIE JE tvar,
+// akým appka migrácie reálne aplikuje. `.claude/rules/database.md`'s
+// "nová pgEnum hodnota" bod sa netýka tohto — ten je o LOKÁLNOM `db:migrate`
+// zabudnutom kroku, nie o tomto DVOJTRANZAKČNOM obmedzení.**
+export const pairingDecisionStatus = pgEnum("pairing_decision_status", ["good", "manual", "unavailable", "discontinued", "split"]);
+
+// issue 399 — per-VEĽKOSŤ manuálny override odkazu na dodávateľa, pre
+// produkty rozdelené cez `pairing_decision.status = 'split'`. ÚPLNE
+// NEZÁVISLÁ od `product_supplier_link_override` (#121/#239, produktová
+// úroveň) — design komentár na tickete zdôvodňuje, prečo NIE syntetický
+// kľúč v tamtej tabuľke (rozbilo by to nočný Shoptet writeback aj
+// #212/#213's "Vypredané → Skladom" prepínanie, obe predpokladajú "jeden
+// riadok = celý produkt") a prečo NIE reuse existujúcej `pairing` tabuľky
+// (F4, `schema-pairing.ts` — zámerne SAMOSTATNÝ dátový model pre BUDÚCI
+// auto-matching automat, zlúčenie bolo na tickete #239 už raz zamietnuté,
+// `.claude/rules/product-links.md`). Chýbajúci riadok pre daný variant =
+// appka o jeho per-veľkosť linku ešte nevie. `url NOT NULL` (na rozdiel od
+// `pairingDecisions.url`) — riadok existuje len VTEDY, keď manažér reálne
+// niečo zadal; vymazanie linku = DELETE riadku, nikdy `url = null`.
+export const pairingVariantLinks = pgTable("pairing_variant_link", {
+  code: text("code")
+    .primaryKey()
+    .references(() => variants.code, { onDelete: "cascade" }),
+  url: text("url").notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+});
 
 // issue 387 E7 — Singleton Štart/Stop prepínač PRE STAVOVÝ WRITEBACK
 // (rovnaký vzor ako `pairingSearchSettings`/`restock_settings` vyššie —
@@ -158,7 +197,9 @@ export const pairingDecisions = pgTable(
   (t) => [
     check(
       "pairing_decision_url_ck",
-      sql`(${t.status} IN ('good','manual') AND ${t.url} IS NOT NULL) OR (${t.status} IN ('unavailable','discontinued') AND ${t.url} IS NULL)`,
+      // issue 399 — `split` pridané do NULOVEJ vetvy (žiadna URL na tomto
+      // riadku, per-veľkosť linky žijú v `pairingVariantLinks`).
+      sql`(${t.status} IN ('good','manual') AND ${t.url} IS NOT NULL) OR (${t.status} IN ('unavailable','discontinued','split') AND ${t.url} IS NULL)`,
     ),
   ],
 );

--- a/apps/api/src/http/pairing-review-routes.ts
+++ b/apps/api/src/http/pairing-review-routes.ts
@@ -153,6 +153,7 @@ export function registerPairingReviewRoutes(app: Hono<AppBindings>, db: Database
       const result = await setPairingDecision(db, { ...body, productKey, actorUserId: user.userId, now });
       if (result === "not_found") return c.json({ error: "Produkt sa nenašiel" }, 404);
       if (result === "no_candidate") return c.json({ error: "Tento produkt nemá navrhnutého kandidáta na potvrdenie" }, 400);
+      if (result === "not_multi_variant") return c.json({ error: "Tento produkt má len jednu veľkosť — rozdelenie na veľkosti nedáva zmysel" }, 400);
 
       log.info({ actorUserId: user.userId, productKey, status: body.status }, "rozhodnutie o párovaní produktu");
       return c.json({ ok: true as const, status: body.status });

--- a/apps/api/src/http/pairing-review-routes.ts
+++ b/apps/api/src/http/pairing-review-routes.ts
@@ -6,7 +6,8 @@ import { log } from "../logger.js";
 import { record } from "../modules/audit/service.js";
 import { supplierLinkUrlBody } from "../modules/orders/supplier-link-assignment.js";
 import { setPairingDecision } from "../modules/pairing-review/decisions.js";
-import { listPairingCandidatesForProduct, listPairingReview } from "../modules/pairing-review/queries.js";
+import { getPairingReviewItem, listPairingCandidatesForProduct, listPairingReview } from "../modules/pairing-review/queries.js";
+import { listPairingVariantLinks, setPairingVariantLink } from "../modules/pairing-review/variant-links.js";
 import { isStateWritebackEnabled, setStateWritebackEnabled } from "../modules/shoptet-writeback/state-writeback-settings.js";
 import { requireRole, requireUser, type AppBindings } from "./middleware.js";
 import { requireSameOrigin } from "./origin-check.js";
@@ -40,16 +41,29 @@ const pairingReviewProductParam = z.object({ productKey: z.string().min(1).max(2
 // issue 387 E6 — diskriminovaná únia presne podľa design komentára:
 // `good` nenesie žiadne telo (server sám dohľadá `chosenUrl`), `manual`
 // nesie `url` (zdieľaná zod validácia `supplierLinkUrlBody`, rovnaká ako
-// `product-links`), zvyšné tri nenesú nič.
+// `product-links`), zvyšné (`unavailable`/`discontinued`/`split`/`revert`) nenesú nič.
 const pairingDecisionBody = z.discriminatedUnion("status", [
   z.object({ status: z.literal("good") }),
   z.object({ status: z.literal("manual"), url: supplierLinkUrlBody.shape.url }),
   z.object({ status: z.literal("unavailable") }),
   z.object({ status: z.literal("discontinued") }),
+  // issue 399 — manažér už uložil per-veľkosť linky cez `variant-link`
+  // trasu nižšie (samostatné volania); toto len OZNAČÍ produkt rozdelený.
+  z.object({ status: z.literal("split") }),
   z.object({ status: z.literal("revert") }),
 ]);
 
 const setStateWritebackEnabledBody = z.object({ enabled: z.boolean() });
+
+// issue 399 — `code` v TELE (nie ceste), rovnaký dôvod ako `pairing.md`'s
+// `variantCode`-v-tele pravidlo (kód variantu nesie lomku, napr.
+// "40237/3XL" — necháva sa neoverené, či by prešiel cez URL cestový
+// segment). `url`: validovaná http(s) adresa (zdieľaná `supplierLinkUrlBody`),
+// ALEBO prázdny reťazec/`null` = vymazať per-veľkosť link.
+const pairingVariantLinkBody = z.object({
+  code: z.string().min(1).max(200),
+  url: z.union([supplierLinkUrlBody.shape.url, z.literal("")]).nullable(),
+});
 
 export function registerPairingReviewRoutes(app: Hono<AppBindings>, db: Database): void {
   // issue 387 E7 — `/api/pairing-review/state-writeback-enabled` má INÝ
@@ -92,6 +106,23 @@ export function registerPairingReviewRoutes(app: Hono<AppBindings>, db: Database
     c.json(await listPairingReview(db, c.req.valid("query"))),
   );
 
+  // issue 399 — "Hľadať / opraviť" tab: jedna karta pre AKÝKOĽVEK produkt
+  // (nájdený cez `GET /api/search`), nezávisle od `listPairingReview`'s
+  // populácie (design komentár na tickete). `:productKey` je JEDINÝ
+  // segment za prefixom (rovnaká hĺbka ako literálne `state-writeback-
+  // enabled` GET vyššie, registrované PRED touto trasou — `.claude/rules/
+  // http-routes.md`'s literal-pred-param pravidlo).
+  app.get(
+    "/api/pairing-review/:productKey",
+    requireUser(db),
+    zValidator("param", pairingReviewProductParam),
+    async (c) => {
+      const item = await getPairingReviewItem(db, c.req.valid("param").productKey);
+      if (item === null) return c.json({ error: "Produkt sa nenašiel" }, 404);
+      return c.json({ item });
+    },
+  );
+
   // issue 387 E6 — lazy top-8 kandidátov pre rozhodovací panel (design
   // komentár: volané AŽ pri otvorení panelu, nikdy vložené do hlavného
   // zoznamu). Rovnaké oprávnenie ako čítanie vyššie — panel smie OTVORIŤ
@@ -125,6 +156,41 @@ export function registerPairingReviewRoutes(app: Hono<AppBindings>, db: Database
 
       log.info({ actorUserId: user.userId, productKey, status: body.status }, "rozhodnutie o párovaní produktu");
       return c.json({ ok: true as const, status: body.status });
+    },
+  );
+
+  // issue 399 — "✂ Rozdeliť na veľkosti": zoznam variantov produktu s ich
+  // AKTUÁLNYM per-veľkosť linkom. Rovnaké oprávnenie ako kandidáti vyššie
+  // (`requireUser`, panel smie otvoriť ktokoľvek prihlásený).
+  app.get(
+    "/api/pairing-review/:productKey/variants",
+    requireUser(db),
+    zValidator("param", pairingReviewProductParam),
+    async (c) => c.json({ variants: await listPairingVariantLinks(db, c.req.valid("param").productKey) }),
+  );
+
+  // issue 399 — nastavenie/vymazanie PER-VEĽKOSŤ linku (SAMOSTATNÝ zápis,
+  // nezdieľanú transakciu s `.../decision` vyššie — design komentár na
+  // tickete). Rovnaké oprávnenie ako rozhodnutie (`requireRole("admin",
+  // "manazer")`).
+  app.post(
+    "/api/pairing-review/:productKey/variant-link",
+    requireSameOrigin(),
+    requireUser(db),
+    requireRole("admin", "manazer"),
+    zValidator("param", pairingReviewProductParam),
+    zValidator("json", pairingVariantLinkBody),
+    async (c) => {
+      const { productKey } = c.req.valid("param");
+      const { code, url } = c.req.valid("json");
+      const user = c.get("user");
+      const now = new Date();
+
+      const result = await setPairingVariantLink(db, { productKey, code, url: url === "" ? null : url, actorUserId: user.userId, now });
+      if (result === "not_found") return c.json({ error: "Variant sa nenašiel u tohto produktu" }, 404);
+
+      log.info({ actorUserId: user.userId, productKey, code, cleared: url === null || url === "" }, "úprava per-veľkosť linku (Párovanie)");
+      return c.json({ ok: true as const, code, url: url === "" ? null : url });
     },
   );
 }

--- a/apps/api/src/modules/pairing-review/decisions.ts
+++ b/apps/api/src/modules/pairing-review/decisions.ts
@@ -11,7 +11,7 @@ import { upsertProductSupplierLink, type UpsertExecutor } from "../orders/suppli
 // zámok — konflikt sa zaznamenáva SPÄTNE cez audit (`previousStatus`/
 // `previousUrl`), nikdy sa mu nepredchádza zamykaním.
 
-export type PairingDecisionStatus = "good" | "manual" | "unavailable" | "discontinued";
+export type PairingDecisionStatus = "good" | "manual" | "unavailable" | "discontinued" | "split";
 
 interface BaseInput {
   readonly productKey: string;
@@ -25,11 +25,19 @@ interface BaseInput {
 // vybraný kandidát ALEBO ručne vpísaná adresa, zod validácia na HTTP hranici
 // rovnaká ako `product-links`), `unavailable`/`discontinued` (žiadna URL),
 // `revert` (DELETE riadku).
+//
+// issue 399 — `split` (žiadna URL, rovnaký tvar ako `unavailable`/
+// `discontinued`): manažér už nastavil per-veľkosť linky cez
+// `POST .../variant-link` (`variant-links.ts`, samostatná zápisová cesta,
+// NEZDIEĽANÁ transakcia — per-veľkosť riadky sa ukladajú NEZÁVISLE, jeden
+// po druhom, PRED týmto rozhodnutím) — toto len OZNAČÍ produkt ako
+// rozdelený/zrevidovaný. Design komentár na tickete, sekcia "Prístup 1".
 export type SetPairingDecisionInput =
   | (BaseInput & { readonly status: "good" })
   | (BaseInput & { readonly status: "manual"; readonly url: string })
   | (BaseInput & { readonly status: "unavailable" })
   | (BaseInput & { readonly status: "discontinued" })
+  | (BaseInput & { readonly status: "split" })
   | (BaseInput & { readonly status: "revert" });
 
 export type SetPairingDecisionResult = "ok" | "not_found" | "no_candidate";
@@ -172,7 +180,9 @@ export async function setPairingDecision(db: Database, input: SetPairingDecision
       return "ok";
     }
 
-    // "unavailable" | "discontinued" — žiadna URL, žiadny link-override zápis.
+    // "unavailable" | "discontinued" | "split" — žiadna URL, žiadny
+    // link-override zápis (issue 399: split's per-veľkosť linky žijú v
+    // `pairingVariantLinks`, zapísané samostatne cez `variant-links.ts`).
     const [product] = await tx.select({ key: products.key }).from(products).where(eq(products.key, input.productKey)).limit(1);
     if (product === undefined) return "not_found";
 

--- a/apps/api/src/modules/pairing-review/decisions.ts
+++ b/apps/api/src/modules/pairing-review/decisions.ts
@@ -1,6 +1,6 @@
-import { eq } from "drizzle-orm";
+import { count, eq } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
-import { pairingCandidateSets, pairingDecisions, products } from "../../db/schema.js";
+import { pairingCandidateSets, pairingDecisions, products, variants } from "../../db/schema.js";
 import { record } from "../audit/service.js";
 import { upsertProductSupplierLink, type UpsertExecutor } from "../orders/supplier-link-assignment.js";
 
@@ -40,7 +40,7 @@ export type SetPairingDecisionInput =
   | (BaseInput & { readonly status: "split" })
   | (BaseInput & { readonly status: "revert" });
 
-export type SetPairingDecisionResult = "ok" | "not_found" | "no_candidate";
+export type SetPairingDecisionResult = "ok" | "not_found" | "no_candidate" | "not_multi_variant";
 
 interface UpsertDecisionRowInput {
   readonly productKey: string;
@@ -185,6 +185,17 @@ export async function setPairingDecision(db: Database, input: SetPairingDecision
     // `pairingVariantLinks`, zapísané samostatne cez `variant-links.ts`).
     const [product] = await tx.select({ key: products.key }).from(products).where(eq(products.key, input.productKey)).limit(1);
     if (product === undefined) return "not_found";
+
+    // issue 399 (review finding, #423 self-review) — obranná kontrola:
+    // frontend zobrazuje "✂ Rozdeliť na veľkosti" LEN pri `variantCount >
+    // 1` (`PairingReviewCard.tsx`), ale server nikdy nedôveruje klientovmu
+    // UI stavu (rovnaký princíp ako "good"'s `chosenUrl === null` kontrola
+    // vyššie) — priame API volanie nesmie označiť jednovariantný produkt
+    // ako "split".
+    if (input.status === "split") {
+      const [variantCountRow] = await tx.select({ n: count() }).from(variants).where(eq(variants.productKey, input.productKey));
+      if ((variantCountRow?.n ?? 0) <= 1) return "not_multi_variant";
+    }
 
     await upsertPairingDecisionRow(tx, {
       productKey: input.productKey,

--- a/apps/api/src/modules/pairing-review/queries.ts
+++ b/apps/api/src/modules/pairing-review/queries.ts
@@ -162,25 +162,58 @@ async function loadAdapterByNormalizedSupplier(db: Database): Promise<ReadonlyMa
   return map;
 }
 
-export async function listPairingReview(db: Database, input: PairingReviewSearchInput): Promise<PairingReviewSearchResult> {
-  // issue 401 — populácia je ÚNIA troch množín (design komentár na tickete
-  // 398/401): (1) produkty S `pairing_candidate_set` riadkom (gatherované,
-  // akéhokoľvek dodávateľa), (2) produkty BEZ efektívnej dodávateľskej linky
-  // (akéhokoľvek dodávateľa — adaptér alebo nie), (3) produkty S
-  // `pairing_decision` riadkom (rozhodnuté cez TÚTO obrazovku — zostávajú
-  // viditeľné aj keď medzitým získajú efektívnu linku, napr. "manual").
-  // Rovnaký MVP vzor ako `pairing-search/select.ts`/`product-links`/
-  // `restock-links` — celý katalóg do JS, filtrovanie/spájanie tam
-  // (`resolveEffectiveSupplierLink` je čistá JS funkcia, nedá sa vyjadriť
-  // ako SQL predikát bez duplicity — súborová hlavička).
+// issue 401 — populácia obrazovky je ÚNIA troch množín (design komentár na
+// tickete 398/401): (1) produkty S `pairing_candidate_set` riadkom
+// (gatherované, akéhokoľvek dodávateľa), (2) produkty BEZ efektívnej
+// dodávateľskej linky (akéhokoľvek dodávateľa — adaptér alebo nie), (3)
+// produkty S `pairing_decision` riadkom (rozhodnuté cez TÚTO obrazovku —
+// zostávajú viditeľné aj keď medzitým získajú efektívnu linku, napr.
+// "manual"). Rovnaký MVP vzor ako `pairing-search/select.ts`/`product-links`/
+// `restock-links` — celý katalóg do JS, filtrovanie/spájanie tam
+// (`resolveEffectiveSupplierLink` je čistá JS funkcia, nedá sa vyjadriť ako
+// SQL predikát bez duplicity). Vyčlenené z `listPairingReview` (issue 399) —
+// TOTO je jediné miesto, čo naozaj potrebuje CELÝ katalóg; `getPairingReviewItem`
+// nižšie (jednoproduktové vyhľadanie pre "Hľadať / opraviť") ho nepotrebuje.
+async function determineReviewPopulationKeys(db: Database): Promise<string[]> {
+  const productRows = await db.select({ key: products.key, internalNote: products.internalNote }).from(products);
+  if (productRows.length === 0) return [];
+
+  const overrideRowsAll = await db.select({ productKey: productSupplierLinkOverrides.productKey, url: productSupplierLinkOverrides.url }).from(productSupplierLinkOverrides);
+  const overrideByProduct = new Map(overrideRowsAll.map((r) => [r.productKey, r.url]));
+
+  const setKeyRows = await db.select({ productKey: pairingCandidateSets.productKey }).from(pairingCandidateSets);
+  const setKeys = new Set(setKeyRows.map((r) => r.productKey));
+
+  const decisionKeyRows = await db.select({ productKey: pairingDecisions.productKey }).from(pairingDecisions);
+  const decisionKeys = new Set(decisionKeyRows.map((r) => r.productKey));
+
+  const productKeys: string[] = [];
+  for (const product of productRows) {
+    const effective = resolveEffectiveSupplierLink(product.internalNote, overrideByProduct.get(product.key) ?? null);
+    if (setKeys.has(product.key) || effective.url === null || decisionKeys.has(product.key)) productKeys.push(product.key);
+  }
+  return productKeys;
+}
+
+// issue 399 — zdieľané budovanie karty(-diet) pre KONKRÉTNU množinu
+// `productKeys` — SCOPED dopyty (`inArray`), nikdy celý katalóg. Používané
+// AJ z `listPairingReview` (nad populáciou určenou vyššie), AJ z
+// `getPairingReviewItem` (jeden kľúč, "Hľadať / opraviť" tab — produkt MIMO
+// dnešnej populácie, napr. už s efektívnou linkou bez kandidáta/rozhodnutia,
+// sa tak dá otvoriť/opraviť rovnako ako ktorýkoľvek iný).
+async function buildPairingReviewItems(db: Database, productKeys: string[]): Promise<PairingReviewItem[]> {
+  if (productKeys.length === 0) return [];
+
   const productRows = await db
     .select({ key: products.key, name: products.name, supplier: products.supplier, internalNote: products.internalNote })
-    .from(products);
-  if (productRows.length === 0) return { total: 0, gatheredTotal: 0, linkedTotal: 0, items: [] };
+    .from(products)
+    .where(inArray(products.key, productKeys));
+  const productByKey = new Map(productRows.map((r) => [r.key, r]));
 
   const overrideRowsAll = await db
     .select({ productKey: productSupplierLinkOverrides.productKey, url: productSupplierLinkOverrides.url })
-    .from(productSupplierLinkOverrides);
+    .from(productSupplierLinkOverrides)
+    .where(inArray(productSupplierLinkOverrides.productKey, productKeys));
   const overrideByProduct = new Map(overrideRowsAll.map((r) => [r.productKey, r.url]));
 
   const setRowsAll = await db
@@ -192,7 +225,8 @@ export async function listPairingReview(db: Database, input: PairingReviewSearch
       confidence: pairingCandidateSets.confidence,
       verdict: pairingCandidateSets.verdict,
     })
-    .from(pairingCandidateSets);
+    .from(pairingCandidateSets)
+    .where(inArray(pairingCandidateSets.productKey, productKeys));
   const setByProduct = new Map(setRowsAll.map((r) => [r.productKey, r]));
 
   const decisionRowsAll = await db
@@ -202,21 +236,11 @@ export async function listPairingReview(db: Database, input: PairingReviewSearch
       url: pairingDecisions.url,
       decidedAt: pairingDecisions.decidedAt,
     })
-    .from(pairingDecisions);
+    .from(pairingDecisions)
+    .where(inArray(pairingDecisions.productKey, productKeys));
   const decisionByProduct = new Map(decisionRowsAll.map((r) => [r.productKey, r]));
 
   const adapterByNormalizedSupplier = await loadAdapterByNormalizedSupplier(db);
-
-  const productKeys: string[] = [];
-  for (const product of productRows) {
-    const effective = resolveEffectiveSupplierLink(product.internalNote, overrideByProduct.get(product.key) ?? null);
-    const hasCandidateSet = setByProduct.has(product.key);
-    const hasDecision = decisionByProduct.has(product.key);
-    if (hasCandidateSet || effective.url === null || hasDecision) productKeys.push(product.key);
-  }
-  if (productKeys.length === 0) return { total: 0, gatheredTotal: 0, linkedTotal: 0, items: [] };
-
-  const productByKey = new Map(productRows.map((r) => [r.key, r]));
 
   const variantRows: VariantRow[] = await db
     .select({
@@ -268,8 +292,8 @@ export async function listPairingReview(db: Database, input: PairingReviewSearch
   const allItems: PairingReviewItem[] = [];
   for (const productKey of productKeys) {
     const product = productByKey.get(productKey);
-    // Nedosiahnuteľné (`productKey` vzišlo priamo z `productRows` vyššie) —
-    // len na uspokojenie `noUncheckedIndexedAccess`/typovej kontroly.
+    // Produkt so zadaným kľúčom neexistuje (napr. neplatný `getPairingReviewItem`
+    // vstup) — jednoducho sa preskočí, volajúci to rieši ako "nenájdené".
     if (product === undefined) continue;
 
     const set = setByProduct.get(productKey);
@@ -356,12 +380,36 @@ export async function listPairingReview(db: Database, input: PairingReviewSearch
     });
   }
 
+  return allItems;
+}
+
+// issue 399 — jednoproduktová verzia `buildPairingReviewItems` pre "Hľadať /
+// opraviť" tab: nájde/postaví kartu pre AKÝKOĽVEK produkt (kód/názov/
+// dodávateľ, `GET /api/search`), NEZÁVISLE od toho, či je v `listPairingReview`'s
+// populácii (design komentár na tickete, sekcia "Prístup 1" — únia troch
+// množín vylučuje napr. produkt, čo už má efektívnu linku, ale žiadny
+// `pairing_candidate_set`/`pairing_decision` riadok). `null` = neznámy `productKey`.
+export async function getPairingReviewItem(db: Database, productKey: string): Promise<PairingReviewItem | null> {
+  const items = await buildPairingReviewItems(db, [productKey]);
+  return items[0] ?? null;
+}
+
+export async function listPairingReview(db: Database, input: PairingReviewSearchInput): Promise<PairingReviewSearchResult> {
+  const productKeys = await determineReviewPopulationKeys(db);
+  if (productKeys.length === 0) return { total: 0, gatheredTotal: 0, linkedTotal: 0, items: [] };
+
+  const allItems = await buildPairingReviewItems(db, productKeys);
+
   // issue 401 — mená polí (`gatheredTotal`/`linkedTotal`) ostávajú NEZMENENÉ
   // (API kontrakt), ale VÝZNAM sa rozšíril spolu s populáciou vyššie —
   // `gatheredTotal` je teraz "koľko produktov appka na tejto obrazovke
   // sleduje" (nie len "koľko bolo gatherovaných"), badge/progress bar
   // (`PairingReviewSection.tsx`) tak automaticky počítajú novú, plnú
-  // populáciu bez zmeny na strane frontendu.
+  // populáciu bez zmeny na strane frontendu. issue 399: `linkedTotal` zostáva
+  // ZÁMERNE VÝHRADNE `hasEffectiveLink` (produktová úroveň) — split produkt sa
+  // sem NEPOČÍTA, hoci má reálne per-veľkosť linky (`pairingVariantLinks`);
+  // jeho vlastný stav je viditeľný cez `decision.status === "split"` na karte
+  // samej, tento súčet zostáva o produktovej linke, nie o "je vyriešené".
   const gatheredTotal = allItems.length;
   const linkedTotal = allItems.filter((item) => item.hasEffectiveLink).length;
 
@@ -371,9 +419,12 @@ export async function listPairingReview(db: Database, input: PairingReviewSearch
   // `good`/`manual` rozhodnutia VŽDY produkujú `hasEffectiveLink === true`
   // (zdieľaný zápis vždy nastaví override), takže pre ne je táto podmienka
   // redundantná s prvou časťou — ponechaná explicitne pre čitateľnosť.
+  // issue 399: `split` PRIDANÉ do TERMINÁLNEJ vetvy — rozdelený produkt má
+  // svoje linky uložené per veľkosť (nikdy `hasEffectiveLink`), ale JE
+  // zrevidovaný, netreba naň ďalej upozorňovať v "Nezrevidované".
   function isUnreviewed(item: PairingReviewItem): boolean {
     if (item.hasEffectiveLink) return false;
-    if (item.decision !== null && (item.decision.status === "unavailable" || item.decision.status === "discontinued")) return false;
+    if (item.decision !== null && (item.decision.status === "unavailable" || item.decision.status === "discontinued" || item.decision.status === "split")) return false;
     return true;
   }
 

--- a/apps/api/src/modules/pairing-review/variant-links.ts
+++ b/apps/api/src/modules/pairing-review/variant-links.ts
@@ -1,0 +1,99 @@
+import { asc, eq } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { pairingVariantLinks, variants } from "../../db/schema.js";
+import { record } from "../audit/service.js";
+
+// issue 399 — per-VEĽKOSŤ manuálny override odkazu na dodávateľa (karta's
+// "✂ Rozdeliť na veľkosti"). ÚPLNE nezávislý zápis od `decisions.ts`'s
+// `setPairingDecision` (žiadna zdieľaná transakcia — každý riadok sa uloží
+// SAMOSTATNE, presne ako stará appka's `saveVariantLink` per-riadok save,
+// design komentár na tickete).
+
+export interface PairingVariantLinkRow {
+  readonly code: string;
+  readonly sizeLabel: string | null;
+  readonly url: string | null;
+}
+
+// Zoznam variantov produktu s ich AKTUÁLNYM per-veľkosť linkom (`null` = appka
+// ešte nič nevie). Zoradené podľa `sizeLabel` (prázdne/`null` naposledy),
+// potom podľa `code` — stabilné, čitateľné poradie na paneli.
+export async function listPairingVariantLinks(db: Database, productKey: string): Promise<readonly PairingVariantLinkRow[]> {
+  const rows = await db
+    .select({ code: variants.code, sizeLabel: variants.sizeLabel, url: pairingVariantLinks.url })
+    .from(variants)
+    .leftJoin(pairingVariantLinks, eq(pairingVariantLinks.code, variants.code))
+    .where(eq(variants.productKey, productKey))
+    .orderBy(asc(variants.code));
+
+  return rows
+    .slice()
+    .sort((a, b) => {
+      const aLabel = a.sizeLabel ?? "";
+      const bLabel = b.sizeLabel ?? "";
+      if (aLabel === "" && bLabel !== "") return 1;
+      if (bLabel === "" && aLabel !== "") return -1;
+      if (aLabel !== bLabel) return aLabel.localeCompare(bLabel, "sk");
+      return a.code.localeCompare(b.code, "sk");
+    })
+    .map((r) => ({ code: r.code, sizeLabel: r.sizeLabel, url: r.url }));
+}
+
+export type SetPairingVariantLinkResult = "ok" | "not_found";
+
+export interface SetPairingVariantLinkInput {
+  readonly productKey: string;
+  readonly code: string;
+  /** `null`/prázdne = vymazať (DELETE riadku, nikdy `url = null` — schéma to ani nedovolí). */
+  readonly url: string | null;
+  readonly actorUserId: string;
+  readonly now: Date;
+}
+
+// `code` MUSÍ patriť `productKey` — bez tejto kontroly by omylom (alebo
+// zlomyseľne) poslaný cudzí kód zapísal link pod NESÚVISIACI variant iného
+// produktu. `not_found` pokrýva OBA prípady (kód neexistuje AJ kód patrí
+// inému produktu) — rovnaká disciplína ako `pairing-routes.ts`'s
+// `variantCode` telo-parameter kontrola (`.claude/rules/pairing.md`).
+export async function setPairingVariantLink(db: Database, input: SetPairingVariantLinkInput): Promise<SetPairingVariantLinkResult> {
+  return db.transaction(async (tx) => {
+    const [variant] = await tx.select({ productKey: variants.productKey }).from(variants).where(eq(variants.code, input.code)).limit(1);
+    if (variant === undefined || variant.productKey !== input.productKey) return "not_found";
+
+    const [previous] = await tx.select({ url: pairingVariantLinks.url }).from(pairingVariantLinks).where(eq(pairingVariantLinks.code, input.code)).limit(1);
+
+    const trimmed = input.url?.trim() ?? "";
+    if (trimmed === "") {
+      // Idempotentné vymazanie — kód bez riadku (dvojklik/žiadna zmena) je
+      // no-op ok, žiadny audit záznam (rovnaký princíp ako
+      // `setPairingDecision`'s "revert" no-op vetva).
+      if (previous === undefined) return "ok";
+
+      await tx.delete(pairingVariantLinks).where(eq(pairingVariantLinks.code, input.code));
+      await record(tx, {
+        at: input.now,
+        actorUserId: input.actorUserId,
+        action: "pairing_variant_link.cleared",
+        entity: "pairing_variant_link",
+        entityId: input.code,
+        data: { productKey: input.productKey, code: input.code, previousUrl: previous.url },
+      });
+      return "ok";
+    }
+
+    await tx
+      .insert(pairingVariantLinks)
+      .values({ code: input.code, url: trimmed, updatedAt: input.now })
+      .onConflictDoUpdate({ target: pairingVariantLinks.code, set: { url: trimmed, updatedAt: input.now } });
+
+    await record(tx, {
+      at: input.now,
+      actorUserId: input.actorUserId,
+      action: "pairing_variant_link.changed",
+      entity: "pairing_variant_link",
+      entityId: input.code,
+      data: { productKey: input.productKey, code: input.code, previousUrl: previous?.url ?? null, newUrl: trimmed },
+    });
+    return "ok";
+  });
+}

--- a/apps/api/tests/helpers/db.ts
+++ b/apps/api/tests/helpers/db.ts
@@ -93,8 +93,12 @@ export async function withCleanDb(): Promise<{ db: Database; close: () => Promis
     // issue 387 E7: "pairing_state_writeback_settings" is the SAME situation
     // as "pairing_search_settings"/"restock_settings" above — no FK in
     // either direction (singleton id), no migration-seeded default row.
+    // issue 399: "pairing_variant_link" DOES have a real FK into "variant"
+    // (cascade), so `TRUNCATE variant CASCADE` already reaches it — listed
+    // explicitly anyway for the SAME self-documenting consistency as
+    // "pairing" above.
     await db.execute(
-      sql`TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, nedostupne_replacement_link, mail_template, mail_template_history, supplier_stock, restock_settings, restock_event, shop_product_url, theme_color, dpd_pickup_request, upozornenie, daily_task, mail_log, dpd_shipment, product_supplier_override, product_supplier_link_override, pairing_candidate, pairing_candidate_set, pairing_search_settings, pairing_decision, pairing_state_writeback_settings, floor_note, floor_note_product RESTART IDENTITY CASCADE`,
+      sql`TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, nedostupne_replacement_link, mail_template, mail_template_history, supplier_stock, restock_settings, restock_event, shop_product_url, theme_color, dpd_pickup_request, upozornenie, daily_task, mail_log, dpd_shipment, product_supplier_override, product_supplier_link_override, pairing_candidate, pairing_candidate_set, pairing_search_settings, pairing_decision, pairing_state_writeback_settings, pairing_variant_link, floor_note, floor_note_product RESTART IDENTITY CASCADE`,
     );
     // issue 59: `order_open_status` is a NEW table with real production
     // content (the migration seeds it) — TRUNCATE alone would leave every

--- a/apps/api/tests/pairing-review-item-http.integration.test.ts
+++ b/apps/api/tests/pairing-review-item-http.integration.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, expect, it } from "vitest";
+import { productSupplierLinkOverrides, users } from "../src/db/schema.js";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import type { UserRole } from "../src/modules/auth/service.js";
+import { insertTestSnapshot } from "./helpers/catalog.js";
+import { withCleanDb } from "./helpers/db.js";
+import { seedPairingCandidateSet as seedCandidateSet, seedPairingReviewProduct as seedProduct } from "./helpers/pairing-review.js";
+
+// issue 399 — "Hľadať / opraviť" tab: `GET /api/pairing-review/:productKey`
+// nájde/postaví kartu pre AKÝKOĽVEK produkt, NEZÁVISLE od `listPairingReview`'s
+// populácie (design komentár na tickete, sekcia "Prístup 1"). Vyčlenené do
+// vlastného súboru (rovnaký `.claude/rules/testing.md` split vzor ako
+// `pairing-review-http.integration.test.ts`/`pairing-review-decisions-http
+// .integration.test.ts`), aby ani jeden nenarástol cez eslint `max-lines: 400`.
+
+const HESLO = "test-heslo-abc"; // testovacie údaje, nie tajomstvo
+
+let close: (() => Promise<void>) | undefined;
+
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  resetLoginRateLimit();
+});
+
+async function boot(role: UserRole) {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const [pouzivatel] = await ctx.db
+    .insert(users)
+    .values({ email: "manazer@forestshop.sk", passwordHash: await hashPassword(HESLO), displayName: "Manažér", role })
+    .returning({ id: users.id });
+  if (pouzivatel === undefined) throw new Error("testovací používateľ sa nepodarilo vložiť");
+
+  const app = createApp(ctx.db, { cookieSecure: false });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "manazer@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie, db: ctx.db, userId: pouzivatel.id };
+}
+
+it("bez prihlásenia vráti 401", async () => {
+  const { app } = await boot("manazer");
+  expect((await app.request("/api/pairing-review/X")).status).toBe(401);
+});
+
+it("neznámy productKey vráti 404", async () => {
+  const { app, cookie } = await boot("citanie");
+  const res = await app.request("/api/pairing-review/NEEXISTUJE", { headers: { cookie } });
+  expect(res.status).toBe(404);
+});
+
+it("produkt VNÚTRI listPairingReview's populácie (bez linky, s kandidátom) — rovnaký tvar ako zoznamová položka", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedProduct(db, snapshotId, "PR-ITEM-1", { name: "Bunda Alfa" });
+  await seedCandidateSet(db, "PR-ITEM-1", {
+    chosenUrl: "https://dodavatel.example.com/bunda-alfa",
+    candidates: [{ url: "https://dodavatel.example.com/bunda-alfa", name: "Bunda Alfa u dodávateľa", rawScore: "85.0000", codeHit: true }],
+  });
+
+  const res = await app.request("/api/pairing-review/PR-ITEM-1", { headers: { cookie } });
+  expect(res.status).toBe(200);
+  const telo = (await res.json()) as { readonly item: { readonly productKey: string; readonly productName: string; readonly chosenCandidate: { readonly name: string } | null } };
+  expect(telo.item.productKey).toBe("PR-ITEM-1");
+  expect(telo.item.productName).toBe("Bunda Alfa");
+  expect(telo.item.chosenCandidate?.name).toBe("Bunda Alfa u dodávateľa");
+});
+
+// issue 399 — TOTO je presne dôvod, prečo tento endpoint existuje (design
+// komentár, sekcia "Prístup 1"): produkt s efektívnou linkou z
+// `internalNote`, ale BEZ `pairing_candidate_set`/`pairing_decision` riadku,
+// NIE JE v `listPairingReview`'s populácii vôbec — `filter=all` ho nikdy
+// nevráti, ale "Hľadať / opraviť" ho tu stále musí nájsť a otvoriť.
+it("produkt MIMO listPairingReview's populácie (má efektívnu linku, žiadny candidate_set/decision) sa NÁJDE tu, hoci NIE JE v zozname", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedProduct(db, snapshotId, "PR-ITEM-MIMO", { name: "Produkt s vlastnou linkou", internalNote: "https://dodavatel.example.com/uz-mam-link" });
+
+  const zoznam = (await (await app.request("/api/pairing-review?filter=all&pageSize=200", { headers: { cookie } })).json()) as {
+    readonly items: { readonly productKey: string }[];
+  };
+  expect(zoznam.items.some((i) => i.productKey === "PR-ITEM-MIMO")).toBe(false);
+
+  const res = await app.request("/api/pairing-review/PR-ITEM-MIMO", { headers: { cookie } });
+  expect(res.status).toBe(200);
+  const telo = (await res.json()) as { readonly item: { readonly productKey: string; readonly hasEffectiveLink: boolean } };
+  expect(telo.item.productKey).toBe("PR-ITEM-MIMO");
+  expect(telo.item.hasEffectiveLink).toBe(true);
+});
+
+it("manuálny override (product_supplier_link_override) sa premietne do hasEffectiveLink cez jednoproduktový endpoint rovnako ako v zozname", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedProduct(db, snapshotId, "PR-ITEM-OVERRIDE", { name: "Produkt s override" });
+  await db.insert(productSupplierLinkOverrides).values({ productKey: "PR-ITEM-OVERRIDE", url: "https://dodavatel.example.com/override", updatedAt: new Date() });
+
+  const res = await app.request("/api/pairing-review/PR-ITEM-OVERRIDE", { headers: { cookie } });
+  expect(res.status).toBe(200);
+  const telo = (await res.json()) as { readonly item: { readonly hasEffectiveLink: boolean } };
+  expect(telo.item.hasEffectiveLink).toBe(true);
+});

--- a/apps/api/tests/pairing-review-variant-links-http.integration.test.ts
+++ b/apps/api/tests/pairing-review-variant-links-http.integration.test.ts
@@ -1,0 +1,266 @@
+import { eq } from "drizzle-orm";
+import { afterEach, expect, it } from "vitest";
+import { auditEvents, pairingDecisions, pairingVariantLinks, productSupplierLinkOverrides, users, variants } from "../src/db/schema.js";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import type { UserRole } from "../src/modules/auth/service.js";
+import { insertTestSnapshot } from "./helpers/catalog.js";
+import { withCleanDb } from "./helpers/db.js";
+import { seedPairingCandidateSet as seedCandidateSet, seedPairingReviewProduct as seedProduct } from "./helpers/pairing-review.js";
+
+// issue 399 — "✂ Rozdeliť na veľkosti": `GET/POST /api/pairing-review/
+// :productKey/variants`/`variant-link` (per-veľkosť linky) + `pairing_decision
+// .status = 'split'` (`POST .../decision`). Vyčlenené do vlastného súboru
+// (rovnaký `.claude/rules/testing.md` split vzor ako sesterské pairing-review
+// integračné testy), aby ani jeden nenarástol cez eslint `max-lines: 400`.
+
+const HESLO = "test-heslo-abc"; // testovacie údaje, nie tajomstvo
+
+let close: (() => Promise<void>) | undefined;
+
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  resetLoginRateLimit();
+});
+
+async function boot(role: UserRole) {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const [pouzivatel] = await ctx.db
+    .insert(users)
+    .values({ email: "manazer@forestshop.sk", passwordHash: await hashPassword(HESLO), displayName: "Manažér", role })
+    .returning({ id: users.id });
+  if (pouzivatel === undefined) throw new Error("testovací používateľ sa nepodarilo vložiť");
+
+  const app = createApp(ctx.db, { cookieSecure: false });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "manazer@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie, db: ctx.db, userId: pouzivatel.id };
+}
+
+function setVariantLink(app: ReturnType<typeof createApp>, cookie: string, productKey: string, body: unknown) {
+  return app.request(`/api/pairing-review/${productKey}/variant-link`, {
+    method: "POST",
+    headers: { "content-type": "application/json", cookie },
+    body: JSON.stringify(body),
+  });
+}
+
+function decide(app: ReturnType<typeof createApp>, cookie: string, productKey: string, body: unknown) {
+  return app.request(`/api/pairing-review/${productKey}/decision`, {
+    method: "POST",
+    headers: { "content-type": "application/json", cookie },
+    body: JSON.stringify(body),
+  });
+}
+
+async function seedTwoSizeProduct(db: Awaited<ReturnType<typeof boot>>["db"], snapshotId: string, productKey: string): Promise<void> {
+  await seedProduct(db, snapshotId, productKey, {
+    name: "Bunda viacveľkostná",
+    variants: [
+      { code: `${productKey}/S` },
+      { code: `${productKey}/M` },
+    ],
+  });
+}
+
+it("GET .../variants bez prihlásenia vráti 401", async () => {
+  const { app } = await boot("manazer");
+  expect((await app.request("/api/pairing-review/X/variants")).status).toBe(401);
+});
+
+it("GET .../variants vráti KAŽDÝ variant produktu s null linkom, kým nič nie je uložené", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedTwoSizeProduct(db, snapshotId, "PR-SPLIT-LIST");
+
+  const res = await app.request("/api/pairing-review/PR-SPLIT-LIST/variants", { headers: { cookie } });
+  expect(res.status).toBe(200);
+  const telo = (await res.json()) as { readonly variants: { readonly code: string; readonly url: string | null }[] };
+  expect(telo.variants.map((v) => v.code).sort()).toEqual(["PR-SPLIT-LIST/M", "PR-SPLIT-LIST/S"]);
+  expect(telo.variants.every((v) => v.url === null)).toBe(true);
+});
+
+it("rola 'citanie' nemá právo zapísať variant-link (403)", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedTwoSizeProduct(db, snapshotId, "PR-SPLIT-403");
+
+  const res = await setVariantLink(app, cookie, "PR-SPLIT-403", { code: "PR-SPLIT-403/S", url: "https://dodavatel.example.com/s" });
+  expect(res.status).toBe(403);
+});
+
+it("POST .../variant-link uloží per-veľkosť URL, nezapíše product_supplier_link_override, audit záznam existuje", async () => {
+  const { app, cookie, db, userId } = await boot("manazer");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedTwoSizeProduct(db, snapshotId, "PR-SPLIT-SAVE");
+
+  const res = await setVariantLink(app, cookie, "PR-SPLIT-SAVE", { code: "PR-SPLIT-SAVE/S", url: "https://dodavatel.example.com/velkost-s" });
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ ok: true, code: "PR-SPLIT-SAVE/S", url: "https://dodavatel.example.com/velkost-s" });
+
+  const [row] = await db.select().from(pairingVariantLinks).where(eq(pairingVariantLinks.code, "PR-SPLIT-SAVE/S"));
+  expect(row?.url).toBe("https://dodavatel.example.com/velkost-s");
+
+  const overrides = await db.select().from(productSupplierLinkOverrides).where(eq(productSupplierLinkOverrides.productKey, "PR-SPLIT-SAVE"));
+  expect(overrides).toHaveLength(0);
+
+  const events = await db.select().from(auditEvents).where(eq(auditEvents.entityId, "PR-SPLIT-SAVE/S"));
+  expect(events.some((e) => e.action === "pairing_variant_link.changed" && e.actorUserId === userId)).toBe(true);
+});
+
+it("POST .../variant-link s kódom PATRIACIM INÉMU produktu vráti 404, nič sa nezapíše", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedTwoSizeProduct(db, snapshotId, "PR-SPLIT-A");
+  await seedProduct(db, snapshotId, "PR-SPLIT-B", { name: "Iný produkt" });
+
+  const res = await setVariantLink(app, cookie, "PR-SPLIT-B", { code: "PR-SPLIT-A/S", url: "https://dodavatel.example.com/x" });
+  expect(res.status).toBe(404);
+
+  const rows = await db.select().from(pairingVariantLinks).where(eq(pairingVariantLinks.code, "PR-SPLIT-A/S"));
+  expect(rows).toHaveLength(0);
+});
+
+it("POST .../variant-link s prázdnym url VYMAŽE existujúci riadok (idempotentné, no-op keď už nič nie je)", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedTwoSizeProduct(db, snapshotId, "PR-SPLIT-CLEAR");
+  expect((await setVariantLink(app, cookie, "PR-SPLIT-CLEAR", { code: "PR-SPLIT-CLEAR/S", url: "https://dodavatel.example.com/s" })).status).toBe(200);
+
+  const res = await setVariantLink(app, cookie, "PR-SPLIT-CLEAR", { code: "PR-SPLIT-CLEAR/S", url: "" });
+  expect(res.status).toBe(200);
+  const rows = await db.select().from(pairingVariantLinks).where(eq(pairingVariantLinks.code, "PR-SPLIT-CLEAR/S"));
+  expect(rows).toHaveLength(0);
+
+  // Druhý raz na už-prázdnom riadku je no-op ok, nikdy chyba.
+  const res2 = await setVariantLink(app, cookie, "PR-SPLIT-CLEAR", { code: "PR-SPLIT-CLEAR/S", url: null });
+  expect(res2.status).toBe(200);
+});
+
+it("POST .../variant-link s neplatnou URL (nie http) zlyhá na zod validácii, nič sa nezapíše", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedTwoSizeProduct(db, snapshotId, "PR-SPLIT-BADURL");
+
+  const res = await setVariantLink(app, cookie, "PR-SPLIT-BADURL", { code: "PR-SPLIT-BADURL/S", url: "nie-je-to-url" });
+  expect(res.status).toBe(400);
+  const rows = await db.select().from(pairingVariantLinks).where(eq(pairingVariantLinks.code, "PR-SPLIT-BADURL/S"));
+  expect(rows).toHaveLength(0);
+});
+
+// issue 399 — jadro celej funkcie: decision status "split" OZNAČÍ produkt
+// rozdelený (žiadny override zápis, produkt je zrevidovaný AJ bez efektívnej
+// linky — rovnaký princíp ako "unavailable"/"discontinued", ale "split" MÁ
+// per-veľkosť linky uložené v `pairingVariantLinks`, nie v `pairing_decision.url`).
+it("decision 'split': žiadny override, produkt vypadne z 'unreviewed' aj bez efektívnej linky; per-veľkosť linky ostávajú NEDOTKNUTÉ", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedTwoSizeProduct(db, snapshotId, "PR-SPLIT-DECIDE");
+  await seedCandidateSet(db, "PR-SPLIT-DECIDE", { confidence: "none" });
+  expect((await setVariantLink(app, cookie, "PR-SPLIT-DECIDE", { code: "PR-SPLIT-DECIDE/S", url: "https://dodavatel.example.com/s" })).status).toBe(200);
+  expect((await setVariantLink(app, cookie, "PR-SPLIT-DECIDE", { code: "PR-SPLIT-DECIDE/M", url: "https://dodavatel.example.com/m" })).status).toBe(200);
+
+  const unreviewedBefore = (await (await app.request("/api/pairing-review?filter=unreviewed&pageSize=200", { headers: { cookie } })).json()) as {
+    readonly items: { readonly productKey: string }[];
+  };
+  expect(unreviewedBefore.items.some((i) => i.productKey === "PR-SPLIT-DECIDE")).toBe(true);
+
+  const res = await decide(app, cookie, "PR-SPLIT-DECIDE", { status: "split" });
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ ok: true, status: "split" });
+
+  const [decision] = await db.select().from(pairingDecisions).where(eq(pairingDecisions.productKey, "PR-SPLIT-DECIDE"));
+  expect(decision?.status).toBe("split");
+  expect(decision?.url).toBeNull();
+
+  const overrides = await db.select().from(productSupplierLinkOverrides).where(eq(productSupplierLinkOverrides.productKey, "PR-SPLIT-DECIDE"));
+  expect(overrides).toHaveLength(0);
+
+  const unreviewedAfter = (await (await app.request("/api/pairing-review?filter=unreviewed&pageSize=200", { headers: { cookie } })).json()) as {
+    readonly items: { readonly productKey: string }[];
+  };
+  expect(unreviewedAfter.items.some((i) => i.productKey === "PR-SPLIT-DECIDE")).toBe(false);
+
+  // Per-veľkosť linky uložené PRED rozhodnutím zostávajú nedotknuté.
+  const links = await db.select().from(pairingVariantLinks).where(eq(pairingVariantLinks.code, "PR-SPLIT-DECIDE/S"));
+  expect(links[0]?.url).toBe("https://dodavatel.example.com/s");
+});
+
+// issue 399 — "↩ Vrátiť" (revert) na 'split' NIKDY nemaže per-veľkosť linky
+// (rovnaká asymetria/konvencia ako "Vrátiť" na 'unavailable'/'discontinued'
+// nikdy nemaže `product_supplier_link_override`, `.claude/rules/pairing-
+// search.md`'s E6 sekcia) — opätovné rozdelenie ukáže predtým uložené hodnoty.
+it("revert na 'split' zmaže LEN decision riadok — per-veľkosť linky prežijú, produkt sa vráti do 'unreviewed'", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedTwoSizeProduct(db, snapshotId, "PR-SPLIT-REVERT");
+  expect((await setVariantLink(app, cookie, "PR-SPLIT-REVERT", { code: "PR-SPLIT-REVERT/S", url: "https://dodavatel.example.com/s" })).status).toBe(200);
+  expect((await decide(app, cookie, "PR-SPLIT-REVERT", { status: "split" })).status).toBe(200);
+
+  const res = await decide(app, cookie, "PR-SPLIT-REVERT", { status: "revert" });
+  expect(res.status).toBe(200);
+
+  const decisionRows = await db.select().from(pairingDecisions).where(eq(pairingDecisions.productKey, "PR-SPLIT-REVERT"));
+  expect(decisionRows).toHaveLength(0);
+
+  const linkRows = await db.select().from(pairingVariantLinks).where(eq(pairingVariantLinks.code, "PR-SPLIT-REVERT/S"));
+  expect(linkRows).toHaveLength(1);
+  expect(linkRows[0]?.url).toBe("https://dodavatel.example.com/s");
+
+  const unreviewed = (await (await app.request("/api/pairing-review?filter=unreviewed&pageSize=200", { headers: { cookie } })).json()) as {
+    readonly items: { readonly productKey: string }[];
+  };
+  expect(unreviewed.items.some((i) => i.productKey === "PR-SPLIT-REVERT")).toBe(true);
+});
+
+it("CHECK obmedzenie: 'split' s VYPLNENOU url zlyhá na DB úrovni", async () => {
+  const { db, userId } = await boot("manazer");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedProduct(db, snapshotId, "PR-SPLIT-CHECK", { name: "Produkt" });
+  const now = new Date();
+  await expect(
+    db.insert(pairingDecisions).values({ productKey: "PR-SPLIT-CHECK", status: "split", url: "https://x.example.com", decidedBy: userId, decidedAt: now, updatedAt: now }),
+  ).rejects.toThrow();
+});
+
+// issue 399 — poradie panela je podľa `sizeLabel` (sk locale), NIE podľa
+// poradia vloženia/`code` — "L" < "S" abecedne, takže A (sizeLabel "L")
+// predchádza B (sizeLabel "S") bez ohľadu na to, že B bol vložený PRVÝ.
+it("GET .../variants zoradí podľa sizeLabel (sk locale), nie podľa poradia vloženia", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedProduct(db, snapshotId, "PR-SPLIT-ORDER", {
+    name: "Produkt s veľkosťami",
+    variants: [{ code: "PR-SPLIT-ORDER/B" }, { code: "PR-SPLIT-ORDER/A" }],
+  });
+  await db.update(variants).set({ sizeLabel: "L" }).where(eq(variants.code, "PR-SPLIT-ORDER/A"));
+  await db.update(variants).set({ sizeLabel: "S" }).where(eq(variants.code, "PR-SPLIT-ORDER/B"));
+
+  const res = await app.request("/api/pairing-review/PR-SPLIT-ORDER/variants", { headers: { cookie } });
+  const telo = (await res.json()) as { readonly variants: { readonly code: string; readonly sizeLabel: string | null }[] };
+  expect(telo.variants.map((v) => v.code)).toEqual(["PR-SPLIT-ORDER/A", "PR-SPLIT-ORDER/B"]);
+});
+
+// issue 399 — variant BEZ sizeLabel (`null`) sa zoradí NAPOSLEDY, nikdy pred
+// pomenovanými veľkosťami (rovnaký princíp ako existujúci "prázdne/`null`
+// naposledy" komentár v `variant-links.ts`).
+it("GET .../variants dá variant BEZ sizeLabel na koniec zoznamu", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedProduct(db, snapshotId, "PR-SPLIT-NOLABEL", {
+    name: "Produkt s aj bez veľkosti",
+    variants: [{ code: "PR-SPLIT-NOLABEL/UNI" }, { code: "PR-SPLIT-NOLABEL/M" }],
+  });
+  await db.update(variants).set({ sizeLabel: "M" }).where(eq(variants.code, "PR-SPLIT-NOLABEL/M"));
+
+  const res = await app.request("/api/pairing-review/PR-SPLIT-NOLABEL/variants", { headers: { cookie } });
+  const telo = (await res.json()) as { readonly variants: { readonly code: string }[] };
+  expect(telo.variants.map((v) => v.code)).toEqual(["PR-SPLIT-NOLABEL/M", "PR-SPLIT-NOLABEL/UNI"]);
+});

--- a/apps/api/tests/pairing-review-variant-links-http.integration.test.ts
+++ b/apps/api/tests/pairing-review-variant-links-http.integration.test.ts
@@ -230,6 +230,24 @@ it("CHECK obmedzenie: 'split' s VYPLNENOU url zlyhá na DB úrovni", async () =>
   ).rejects.toThrow();
 });
 
+// issue 399 (review finding, #423 self-review) — server nikdy nedôveruje
+// klientovmu UI stavu: frontend zobrazuje trigger "✂ Rozdeliť na veľkosti"
+// LEN pri `variantCount > 1`, ale priame API volanie musí byť odmietnuté aj
+// pre jednovariantný produkt — rovnaký princíp ako "good"'s `chosenUrl ===
+// null` obranná kontrola.
+it("decision 'split' na produkte s JEDNÝM variantom vráti 400, žiadny riadok sa nezapíše", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedProduct(db, snapshotId, "PR-SPLIT-SINGLEVARIANT", { name: "Jednovariantný produkt" });
+
+  const res = await decide(app, cookie, "PR-SPLIT-SINGLEVARIANT", { status: "split" });
+  expect(res.status).toBe(400);
+  expect((await res.json()) as { readonly error: string }).toEqual({ error: "Tento produkt má len jednu veľkosť — rozdelenie na veľkosti nedáva zmysel" });
+
+  const decisionRows = await db.select().from(pairingDecisions).where(eq(pairingDecisions.productKey, "PR-SPLIT-SINGLEVARIANT"));
+  expect(decisionRows).toHaveLength(0);
+});
+
 // issue 399 — poradie panela je podľa `sizeLabel` (sk locale), NIE podľa
 // poradia vloženia/`code` — "L" < "S" abecedne, takže A (sizeLabel "L")
 // predchádza B (sizeLabel "S") bez ohľadu na to, že B bol vložený PRVÝ.

--- a/apps/web/src/components/PairingReviewCard.test.tsx
+++ b/apps/web/src/components/PairingReviewCard.test.tsx
@@ -20,8 +20,9 @@ const { fetchPairingCandidates, sendPairingDecision, fetchPairingVariantLinks, s
 // `PairingReviewUnauthorizedError` ostáva SKUTOČNÁ trieda (rovnaký dôvod ako
 // `PairingReviewSection.test.tsx` — `instanceof` v komponente musí fungovať).
 // issue 399 — `fetchPairingVariantLinks`/`savePairingVariantLink` mockované
-// TU (nie len v `PairingReviewSplitPanel.test.tsx`), lebo `PairingReviewCard`
-// vykresľuje `PairingReviewSplitPanel` priamo (rovnaký modul, rovnaký mock).
+// TU, lebo `PairingReviewCard` vykresľuje `PairingReviewSplitPanel` priamo
+// (rovnaký modul, rovnaký mock) — `PairingReviewSplitPanel` samo nemá
+// vlastný test súbor, jeho pokrytie je celé cez tento súbor.
 vi.mock("../pairingReviewApi.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../pairingReviewApi.js")>();
   return { ...actual, fetchPairingCandidates, sendPairingDecision, fetchPairingVariantLinks, savePairingVariantLink };
@@ -399,6 +400,42 @@ it("split riadok: uloženie manuálnej URL zavolá savePairingVariantLink a prep
   });
   await waitFor(() => {
     expect(screen.getByTestId("pairing-review-split-state-PR-1/S").textContent).toBe("✓ link nastavený");
+  });
+});
+
+// issue 399 (review finding, #423 self-review) — "✓ Hotovo" musí zostať
+// disabled, kým NIEKTORÝ riadok ešte čaká na svoj VLASTNÝ zápis, inak by
+// klik mohol vidieť ešte-nezapísaný (starý) stav a zbytočne (konzervatívne)
+// ukázať potvrdzovací dialóg o chýbajúcom linku napriek zápisu v letu.
+it("'✓ Hotovo – rozdelené' je disabled, kým beží zápis JEDNÉHO riadku (rowBusy), aj keď hlavný 'busy' guard je voľný", async () => {
+  fetchPairingCandidates.mockResolvedValue([]);
+  fetchPairingVariantLinks.mockResolvedValue([{ code: "PR-1/S", sizeLabel: "S", url: null }]);
+  let resolveSave: (() => void) | undefined;
+  savePairingVariantLink.mockImplementation(
+    () =>
+      new Promise<void>((resolve) => {
+        resolveSave = resolve;
+      }),
+  );
+
+  render(<PairingReviewCard item={MATCHED_ITEM} role="manazer" onDecided={() => {}} onSessionExpired={() => {}} />);
+  fireEvent.click(screen.getByTestId("pairing-review-split-PR-1"));
+  await screen.findByTestId("pairing-review-split-row-PR-1/S");
+
+  const doneButton = screen.getByTestId<HTMLButtonElement>("pairing-review-split-done-PR-1");
+  expect(doneButton.disabled).toBe(false);
+
+  const input = screen.getByTestId<HTMLInputElement>("pairing-review-split-input-PR-1/S");
+  fireEvent.change(input, { target: { value: "https://dodavatel.example.com/velkost-s" } });
+  fireEvent.click(screen.getByTestId("pairing-review-split-save-PR-1/S"));
+
+  await waitFor(() => {
+    expect(doneButton.disabled).toBe(true);
+  });
+
+  resolveSave?.();
+  await waitFor(() => {
+    expect(doneButton.disabled).toBe(false);
   });
 });
 

--- a/apps/web/src/components/PairingReviewCard.test.tsx
+++ b/apps/web/src/components/PairingReviewCard.test.tsx
@@ -10,16 +10,21 @@ import { PairingReviewCard } from "./PairingReviewCard.js";
 // issue 398/401/409 — testy prerobené na novú UX (žiadne "✗ Zlé", priamy
 // riadok ✓ Dobré/„vyber url"/📦/🚫, adapterless hláška, obrázky v paneli).
 
-const { fetchPairingCandidates, sendPairingDecision } = vi.hoisted(() => ({
+const { fetchPairingCandidates, sendPairingDecision, fetchPairingVariantLinks, savePairingVariantLink } = vi.hoisted(() => ({
   fetchPairingCandidates: vi.fn(),
   sendPairingDecision: vi.fn(),
+  fetchPairingVariantLinks: vi.fn(),
+  savePairingVariantLink: vi.fn(),
 }));
 
 // `PairingReviewUnauthorizedError` ostáva SKUTOČNÁ trieda (rovnaký dôvod ako
 // `PairingReviewSection.test.tsx` — `instanceof` v komponente musí fungovať).
+// issue 399 — `fetchPairingVariantLinks`/`savePairingVariantLink` mockované
+// TU (nie len v `PairingReviewSplitPanel.test.tsx`), lebo `PairingReviewCard`
+// vykresľuje `PairingReviewSplitPanel` priamo (rovnaký modul, rovnaký mock).
 vi.mock("../pairingReviewApi.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../pairingReviewApi.js")>();
-  return { ...actual, fetchPairingCandidates, sendPairingDecision };
+  return { ...actual, fetchPairingCandidates, sendPairingDecision, fetchPairingVariantLinks, savePairingVariantLink };
 });
 
 const { PairingReviewUnauthorizedError } = await import("../pairingReviewApi.js");
@@ -338,4 +343,95 @@ it("401 pri odoslaní rozhodnutia zavolá onSessionExpired namiesto zobrazenia v
   await waitFor(() => {
     expect(onSessionExpired).toHaveBeenCalledTimes(1);
   });
+});
+
+// issue 399 — "✂ Rozdeliť na veľkosti": dostupné len keď produkt MÁ viac než
+// 1 veľkosť A ešte nemá rozhodnutie (MATCHED_ITEM má variantCount:2).
+it("'✂ Rozdeliť na veľkosti' tlačidlo je vidno pri viacveľkostnom nerozhodnutom produkte, chýba pri jednovariantnom", () => {
+  render(<PairingReviewCard item={MATCHED_ITEM} role="manazer" onDecided={() => {}} onSessionExpired={() => {}} />);
+  expect(screen.getByTestId("pairing-review-split-PR-1")).toBeDefined();
+  cleanup();
+
+  render(<PairingReviewCard item={{ ...MATCHED_ITEM, variantCount: 1 }} role="manazer" onDecided={() => {}} onSessionExpired={() => {}} />);
+  expect(screen.queryByTestId("pairing-review-split-PR-1")).toBeNull();
+});
+
+it("'citanie' rola nevidí '✂ Rozdeliť na veľkosti' tlačidlo (nemá žiadne akčné tlačidlo vôbec)", () => {
+  render(<PairingReviewCard item={MATCHED_ITEM} role="citanie" onDecided={() => {}} onSessionExpired={() => {}} />);
+  expect(screen.queryByTestId("pairing-review-split-PR-1")).toBeNull();
+});
+
+it("klik na '✂ Rozdeliť na veľkosti' NAHRADÍ celú pravú stranu split editorom (kandidát/akcie zmiznú), načíta veľkosti", async () => {
+  fetchPairingCandidates.mockResolvedValue([]);
+  fetchPairingVariantLinks.mockResolvedValue([
+    { code: "PR-1/S", sizeLabel: "S", url: null },
+    { code: "PR-1/M", sizeLabel: "M", url: null },
+  ]);
+
+  render(<PairingReviewCard item={MATCHED_ITEM} role="manazer" onDecided={() => {}} onSessionExpired={() => {}} />);
+  fireEvent.click(screen.getByTestId("pairing-review-split-PR-1"));
+
+  expect(await screen.findByTestId("pairing-review-split-panel-PR-1")).toBeDefined();
+  expect(screen.queryByTestId("pairing-review-candidate-PR-1")).toBeNull();
+  expect(screen.queryByTestId("pairing-review-good-PR-1")).toBeNull();
+  await waitFor(() => {
+    expect(fetchPairingVariantLinks).toHaveBeenCalledWith("PR-1");
+  });
+  expect(await screen.findByTestId("pairing-review-split-row-PR-1/S")).toBeDefined();
+  expect(screen.getByTestId("pairing-review-split-row-PR-1/M")).toBeDefined();
+});
+
+it("split riadok: uloženie manuálnej URL zavolá savePairingVariantLink a prepne stav na '✓ link nastavený'", async () => {
+  fetchPairingCandidates.mockResolvedValue([]);
+  fetchPairingVariantLinks.mockResolvedValue([{ code: "PR-1/S", sizeLabel: "S", url: null }]);
+  savePairingVariantLink.mockResolvedValue(undefined);
+
+  render(<PairingReviewCard item={MATCHED_ITEM} role="manazer" onDecided={() => {}} onSessionExpired={() => {}} />);
+  fireEvent.click(screen.getByTestId("pairing-review-split-PR-1"));
+  await screen.findByTestId("pairing-review-split-row-PR-1/S");
+
+  const input = screen.getByTestId<HTMLInputElement>("pairing-review-split-input-PR-1/S");
+  fireEvent.change(input, { target: { value: "https://dodavatel.example.com/velkost-s" } });
+  fireEvent.click(screen.getByTestId("pairing-review-split-save-PR-1/S"));
+
+  await waitFor(() => {
+    expect(savePairingVariantLink).toHaveBeenCalledWith("PR-1", "PR-1/S", "https://dodavatel.example.com/velkost-s");
+  });
+  await waitFor(() => {
+    expect(screen.getByTestId("pairing-review-split-state-PR-1/S").textContent).toBe("✓ link nastavený");
+  });
+});
+
+it("'✓ Hotovo – rozdelené' s chýbajúcimi linkami sa OPÝTA (confirm) pred odoslaním split rozhodnutia; potvrdenie odošle {status:'split'}", async () => {
+  fetchPairingCandidates.mockResolvedValue([]);
+  fetchPairingVariantLinks.mockResolvedValue([{ code: "PR-1/S", sizeLabel: "S", url: null }]);
+  sendPairingDecision.mockResolvedValue(undefined);
+  const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+  const onDecided = vi.fn();
+
+  render(<PairingReviewCard item={MATCHED_ITEM} role="manazer" onDecided={onDecided} onSessionExpired={() => {}} />);
+  fireEvent.click(screen.getByTestId("pairing-review-split-PR-1"));
+  await screen.findByTestId("pairing-review-split-row-PR-1/S");
+
+  fireEvent.click(screen.getByTestId("pairing-review-split-done-PR-1"));
+  expect(confirmSpy).toHaveBeenCalledTimes(1);
+  await waitFor(() => {
+    expect(sendPairingDecision).toHaveBeenCalledWith("PR-1", { status: "split" });
+  });
+  await waitFor(() => {
+    expect(onDecided).toHaveBeenCalledTimes(1);
+  });
+  confirmSpy.mockRestore();
+});
+
+it("produkt UŽ rozdelený (decision.status==='split') ukáže odznak + editor priamo, bez kliku, s '↩ Zrušiť rozdelenie'", async () => {
+  fetchPairingCandidates.mockResolvedValue([]);
+  fetchPairingVariantLinks.mockResolvedValue([{ code: "PR-5/S", sizeLabel: "S", url: "https://dodavatel.example.com/s" }]);
+  const SPLIT_ITEM = { ...MATCHED_ITEM, productKey: "PR-5", decision: { status: "split" as const, url: null, decidedAt: "2026-08-13T04:00:00.000Z" } };
+
+  render(<PairingReviewCard item={SPLIT_ITEM} role="manazer" onDecided={() => {}} onSessionExpired={() => {}} />);
+  expect(screen.getByTestId("pairing-review-decision-badge-PR-5").textContent).toBe("✂ Rozdelené na veľkosti");
+  expect(await screen.findByTestId("pairing-review-split-panel-PR-5")).toBeDefined();
+  expect(screen.getByTestId("pairing-review-split-cancel-PR-5")).toBeDefined();
+  expect(screen.queryByTestId("pairing-review-split-done-PR-5")).toBeNull();
 });

--- a/apps/web/src/components/PairingReviewCard.tsx
+++ b/apps/web/src/components/PairingReviewCard.tsx
@@ -9,7 +9,9 @@ import {
   type PairingReviewCandidate,
   type PairingReviewItem,
 } from "../pairingReviewApi.js";
-import { PanelCandidateRow, TerminalButtons } from "./PairingReviewPanelParts.js";
+import { PairingReviewDecisionPanel } from "./PairingReviewDecisionPanel.js";
+import { TerminalButtons } from "./PairingReviewPanelParts.js";
+import { PairingReviewSplitPanel } from "./PairingReviewSplitPanel.js";
 
 // issue 387 E5: karta jedného produktu, vyčlenená VOPRED z `PairingReviewSection.tsx`
 // (rovnaký princíp ako `OrderLineRow.tsx`/`UpozornenieCard.tsx` — dvojstĺpcová
@@ -61,6 +63,7 @@ const DECISION_BADGE_LABELS: Readonly<Record<NonNullable<PairingReviewItem["deci
   manual: "✓ Vybraný link",
   unavailable: "📦 Nie je skladom",
   discontinued: "🚫 Už sa nebude predávať",
+  split: "✂ Rozdelené na veľkosti",
 };
 
 const CAN_EDIT_ROLES: ReadonlySet<Me["role"]> = new Set(["admin", "manazer"]);
@@ -93,6 +96,13 @@ export function PairingReviewCard({
   const [manualUrl, setManualUrl] = useState("");
   const [busy, setBusy] = useState(false);
   const [actionError, setActionError] = useState("");
+  // issue 399 — "✂ Rozdeliť na veľkosti": prechodný (transient) stav, či
+  // manažér PRÁVE TERAZ otvoril split editor — rovnaký princíp ako stará
+  // appky's `splitOpen` Set, len tu PER-KARTE `useState` (karta je od E6
+  // stavová per-inštancia, `.claude/rules/pairing-search.md`). Editor sa
+  // ukazuje AJ keď `!splitOpen`, ale produkt UŽ MÁ `decision.status ===
+  // "split"` — `showSplitPanel` nižšie zjednocuje oba prípady.
+  const [splitOpen, setSplitOpen] = useState(false);
 
   // "Latest ref" vzor (`.claude/rules/frontend-design.md`) — panel sa môže
   // zavrieť/znovu otvoriť skôr, než dobehne pôvodný `fetchPairingCandidates`.
@@ -127,6 +137,7 @@ export function PairingReviewCard({
 
   const openPanel = useCallback(() => {
     setPanelOpen(true);
+    setSplitOpen(false); // vzájomne sa vylučujúce editory na jednej karte
     setActionError("");
     // Predvyplní vlastnú URL len keď ide o EXISTUJÚCE manuálne rozhodnutie,
     // čo NESEDÍ so žiadnym kandidátom (rovnaký vzor ako stará appka's
@@ -134,6 +145,16 @@ export function PairingReviewCard({
     setManualUrl(item.decision?.status === "manual" ? (item.decision.url ?? "") : "");
     loadCandidates();
   }, [item.decision, loadCandidates]);
+
+  // issue 399 — "✂ Rozdeliť na veľkosti" trigger: zdieľa TEN ISTÝ
+  // `loadCandidates()` ako "vyber url" (top-8 kandidátov slúžia ako
+  // quick-picky PER veľkosť v `PairingReviewSplitPanel.tsx`, žiadny druhý fetch).
+  const openSplit = useCallback(() => {
+    setSplitOpen(true);
+    setPanelOpen(false);
+    setActionError("");
+    loadCandidates();
+  }, [loadCandidates]);
 
   const autoShowsPanel = item.decision === null && item.chosenCandidate === null;
   // Beží pri MOUNTE (keď karta odrazu štartuje v "bez kandidáta" stave) AJ
@@ -161,6 +182,7 @@ export function PairingReviewCard({
       sendPairingDecision(item.productKey, action)
         .then(() => {
           setPanelOpen(false);
+          setSplitOpen(false); // úspešné "split"/"revert" zavrie prechodný split editor
           onDecided();
         })
         .catch((err: unknown) => {
@@ -186,6 +208,11 @@ export function PairingReviewCard({
     }
     submit({ status: "manual", url: trimmed });
   }, [manualUrl, submit]);
+
+  // issue 399 — zjednocuje "editor PRÁVE TERAZ otvorený" (`splitOpen`) s
+  // "produkt UŽ MÁ rozhodnutie split" (rovnaký princíp ako stará appky's
+  // `splitOpen.has(p.key) || s === 'split'`).
+  const showSplitPanel = splitOpen || item.decision?.status === "split";
 
   return (
     <div className="card pairing-review-card" data-testid={`pairing-review-card-${item.productKey}`}>
@@ -231,155 +258,176 @@ export function PairingReviewCard({
         </div>
 
         <div className="pairing-review-side">
-          <div className="pairing-review-label">Navrhnutý kandidát</div>
-          {item.chosenCandidate === null ? (
-            item.supplierHasAdapter ? (
-              <p className="pairing-review-nocandidate" data-testid={`pairing-review-no-candidate-${item.productKey}`}>
-                Nenašiel sa žiadny kandidát u dodávateľa.
-              </p>
-            ) : (
-              // issue 401 — dodávateľ NEMÁ automatický adaptér (nie
-              // WETLAND/BETALOV/ODIMON) — gather preň vôbec nebehal, na
-              // rozdiel od "gather behal, nič nenašiel" vyššie.
-              <p className="pairing-review-nocandidate" data-testid={`pairing-review-no-adapter-${item.productKey}`}>
-                Tento dodávateľ zatiaľ nemá automatické vyhľadávanie — link treba zadať ručne.
-              </p>
-            )
-          ) : (
-            <div data-testid={`pairing-review-candidate-${item.productKey}`}>
-              <a
-                className="pairing-review-name"
-                href={item.chosenCandidate.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                data-testid={`pairing-review-candidate-link-${item.productKey}`}
-              >
-                {item.chosenCandidate.name}
-              </a>
-              <div className="pairing-review-meta">
-                skóre {item.chosenCandidate.rawScore.toFixed(1)} · {CONFIDENCE_LABELS[item.confidence]}
-                {item.chosenCandidate.codeHit && " · kód sedí"}
-              </div>
-              {item.verdict !== null && (
-                <div className={"pairing-review-verdict pairing-review-verdict-" + item.verdict} data-testid={`pairing-review-verdict-${item.productKey}`}>
-                  {VERDICT_LABELS[item.verdict]}
-                </div>
+          {/* issue 399 — split editor (transientne otvorený, ALEBO produkt
+              UŽ MÁ decision.status === "split") NAHRADÍ CELÚ pravú stranu,
+              presne ako stará appky's `splitOpen.has(p.key) || s === 'split'`
+              early-return v `renderCard`. */}
+          {showSplitPanel ? (
+            <>
+              <div className="pairing-review-label">Rozdelenie na veľkosti</div>
+              {item.decision?.status === "split" && (
+                <span
+                  className="pairing-review-decision-badge pairing-review-decision-split"
+                  data-testid={`pairing-review-decision-badge-${item.productKey}`}
+                >
+                  {DECISION_BADGE_LABELS.split}
+                </span>
               )}
-              <div className="pairing-review-imgbox">
-                {item.chosenCandidate.imageUrl !== null ? (
-                  <img src={item.chosenCandidate.imageUrl} alt={item.chosenCandidate.name} loading="lazy" />
-                ) : (
-                  <span className="pairing-review-noimg">bez obrázka</span>
-                )}
-              </div>
-            </div>
-          )}
-
-          {!canEdit ? (
-            item.decision !== null && (
-              <span
-                className={"pairing-review-decision-badge pairing-review-decision-" + item.decision.status}
-                data-testid={`pairing-review-decision-badge-${item.productKey}`}
-              >
-                {DECISION_BADGE_LABELS[item.decision.status]}
-              </span>
-            )
+              {canEdit && (
+                <PairingReviewSplitPanel
+                  item={item}
+                  busy={busy}
+                  submit={submit}
+                  candidates={candidates}
+                  candidatesError={candidatesError}
+                  onSessionExpired={onSessionExpired}
+                />
+              )}
+            </>
           ) : (
             <>
-              {actionError !== "" && <p role="alert">{actionError}</p>}
+              <div className="pairing-review-label">Navrhnutý kandidát</div>
+              {item.chosenCandidate === null ? (
+                item.supplierHasAdapter ? (
+                  <p className="pairing-review-nocandidate" data-testid={`pairing-review-no-candidate-${item.productKey}`}>
+                    Nenašiel sa žiadny kandidát u dodávateľa.
+                  </p>
+                ) : (
+                  // issue 401 — dodávateľ NEMÁ automatický adaptér (nie
+                  // WETLAND/BETALOV/ODIMON) — gather preň vôbec nebehal, na
+                  // rozdiel od "gather behal, nič nenašiel" vyššie.
+                  <p className="pairing-review-nocandidate" data-testid={`pairing-review-no-adapter-${item.productKey}`}>
+                    Tento dodávateľ zatiaľ nemá automatické vyhľadávanie — link treba zadať ručne.
+                  </p>
+                )
+              ) : (
+                <div data-testid={`pairing-review-candidate-${item.productKey}`}>
+                  <a
+                    className="pairing-review-name"
+                    href={item.chosenCandidate.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    data-testid={`pairing-review-candidate-link-${item.productKey}`}
+                  >
+                    {item.chosenCandidate.name}
+                  </a>
+                  <div className="pairing-review-meta">
+                    skóre {item.chosenCandidate.rawScore.toFixed(1)} · {CONFIDENCE_LABELS[item.confidence]}
+                    {item.chosenCandidate.codeHit && " · kód sedí"}
+                  </div>
+                  {item.verdict !== null && (
+                    <div className={"pairing-review-verdict pairing-review-verdict-" + item.verdict} data-testid={`pairing-review-verdict-${item.productKey}`}>
+                      {VERDICT_LABELS[item.verdict]}
+                    </div>
+                  )}
+                  <div className="pairing-review-imgbox">
+                    {item.chosenCandidate.imageUrl !== null ? (
+                      <img src={item.chosenCandidate.imageUrl} alt={item.chosenCandidate.name} loading="lazy" />
+                    ) : (
+                      <span className="pairing-review-noimg">bez obrázka</span>
+                    )}
+                  </div>
+                </div>
+              )}
 
-              {item.decision !== null && !panelOpen && (
-                <div className="pairing-review-actions">
+              {!canEdit ? (
+                item.decision !== null && (
                   <span
                     className={"pairing-review-decision-badge pairing-review-decision-" + item.decision.status}
                     data-testid={`pairing-review-decision-badge-${item.productKey}`}
                   >
                     {DECISION_BADGE_LABELS[item.decision.status]}
                   </span>
-                  {(item.decision.status === "good" || item.decision.status === "manual") && (
-                    <button type="button" className="btn ghost sm" disabled={busy} onClick={openPanel} data-testid={`pairing-review-change-${item.productKey}`}>
-                      ✗ Zmeniť / iný link
-                    </button>
+                )
+              ) : (
+                <>
+                  {actionError !== "" && <p role="alert">{actionError}</p>}
+
+                  {item.decision !== null && !panelOpen && (
+                    <div className="pairing-review-actions">
+                      <span
+                        className={"pairing-review-decision-badge pairing-review-decision-" + item.decision.status}
+                        data-testid={`pairing-review-decision-badge-${item.productKey}`}
+                      >
+                        {DECISION_BADGE_LABELS[item.decision.status]}
+                      </span>
+                      {(item.decision.status === "good" || item.decision.status === "manual") && (
+                        <button type="button" className="btn ghost sm" disabled={busy} onClick={openPanel} data-testid={`pairing-review-change-${item.productKey}`}>
+                          ✗ Zmeniť / iný link
+                        </button>
+                      )}
+                      <button type="button" className="btn ghost sm" disabled={busy} onClick={() => { submit({ status: "revert" }); }} data-testid={`pairing-review-revert-${item.productKey}`}>
+                        ↩ Vrátiť
+                      </button>
+                    </div>
                   )}
-                  <button type="button" className="btn ghost sm" disabled={busy} onClick={() => { submit({ status: "revert" }); }} data-testid={`pairing-review-revert-${item.productKey}`}>
-                    ↩ Vrátiť
-                  </button>
-                </div>
-              )}
 
-              {/* issue 398 — vysvetlenie dôsledku pri už rozhodnutom
-                  terminálnom stave: appka SAMA nič na eshope nemení hneď,
-                  reálne prepnutie robí nočná automatika (E7 stavový writeback). */}
-              {item.decision !== null && !panelOpen && (item.decision.status === "unavailable" || item.decision.status === "discontinued") && (
-                <p className="pairing-review-terminal-note" data-testid={`pairing-review-terminal-note-${item.productKey}`}>
-                  Reálne prepnutie viditeľnosti na eshope urobí nočná automatika (stavový zápis) — toto rozhodnutie je len príprava naň.
-                </p>
-              )}
+                  {/* issue 398 — vysvetlenie dôsledku pri už rozhodnutom
+                      terminálnom stave: appka SAMA nič na eshope nemení hneď,
+                      reálne prepnutie robí nočná automatika (E7 stavový writeback). */}
+                  {item.decision !== null && !panelOpen && (item.decision.status === "unavailable" || item.decision.status === "discontinued") && (
+                    <p className="pairing-review-terminal-note" data-testid={`pairing-review-terminal-note-${item.productKey}`}>
+                      Reálne prepnutie viditeľnosti na eshope urobí nočná automatika (stavový zápis) — toto rozhodnutie je len príprava naň.
+                    </p>
+                  )}
 
-              {/* issue 398 — posledná podoba starej appky: KOLEKTÍVNY riadok
-                  všetkých možností priamo na karte, žiadny "✗ Zlé" medzikrok. */}
-              {item.decision === null && item.chosenCandidate !== null && !panelOpen && (
-                <div className="pairing-review-actions">
-                  <button
-                    type="button"
-                    className="btn good sm"
-                    disabled={busy}
-                    onClick={() => {
-                      submit({ status: "good" });
-                    }}
-                    data-testid={`pairing-review-good-${item.productKey}`}
-                  >
-                    ✓ Dobré
-                  </button>
-                  <button type="button" className="btn ghost sm" disabled={busy} onClick={openPanel} data-testid={`pairing-review-open-panel-${item.productKey}`}>
-                    vyber url
-                  </button>
-                  <TerminalButtons busy={busy} submit={submit} productKey={item.productKey} />
-                </div>
-              )}
+                  {/* issue 398 — posledná podoba starej appky: KOLEKTÍVNY riadok
+                      všetkých možností priamo na karte, žiadny "✗ Zlé" medzikrok. */}
+                  {item.decision === null && item.chosenCandidate !== null && !panelOpen && (
+                    <div className="pairing-review-actions">
+                      <button
+                        type="button"
+                        className="btn good sm"
+                        disabled={busy}
+                        onClick={() => {
+                          submit({ status: "good" });
+                        }}
+                        data-testid={`pairing-review-good-${item.productKey}`}
+                      >
+                        ✓ Dobré
+                      </button>
+                      <button type="button" className="btn ghost sm" disabled={busy} onClick={openPanel} data-testid={`pairing-review-open-panel-${item.productKey}`}>
+                        vyber url
+                      </button>
+                      <TerminalButtons busy={busy} submit={submit} productKey={item.productKey} />
+                    </div>
+                  )}
 
-              {/* Bez kandidáta niet čo "prijať" — panel (kandidáti/manuál/terminálne stavy) sa ukazuje priamo, presne ako stará appka. */}
-              {(panelOpen || (item.decision === null && item.chosenCandidate === null)) && (
-                <div className="pairing-review-panel" data-testid={`pairing-review-panel-${item.productKey}`}>
-                  {candidatesError !== "" && <p role="alert">{candidatesError}</p>}
-                  {candidates === null && candidatesError === "" && <p>Načítavam kandidátov…</p>}
-                  {candidates !== null &&
-                    candidates.map((c, i) => (
-                      <PanelCandidateRow key={c.url} candidate={c} index={i} busy={busy} submit={submit} productKey={item.productKey} />
-                    ))}
+                  {/* issue 399 — "✂ Rozdeliť na veľkosti": dostupné VŽDY, kým
+                      produkt nemá rozhodnutie a má viac než 1 veľkosť —
+                      nezávisle od toho, či má navrhnutého kandidáta (rovnaký
+                      zámer ako stará appky's `splitButton`). */}
+                  {item.decision === null && item.variantCount > 1 && !panelOpen && (
+                    <div className="pairing-review-actions">
+                      <button
+                        type="button"
+                        className="btn ghost sm"
+                        disabled={busy}
+                        onClick={openSplit}
+                        title="Nastaviť iný dodávateľský link pre každú veľkosť"
+                        data-testid={`pairing-review-split-${item.productKey}`}
+                      >
+                        ✂ Rozdeliť na veľkosti
+                      </button>
+                    </div>
+                  )}
 
-                  <div className="pairing-review-manual-row">
-                    <input
-                      type="url"
-                      placeholder="Vlož vlastnú URL dodávateľa…"
-                      value={manualUrl}
-                      disabled={busy}
-                      data-testid={`pairing-review-manual-input-${item.productKey}`}
-                      onChange={(e) => {
-                        setManualUrl(e.target.value);
-                      }}
+                  {/* Bez kandidáta niet čo "prijať" — panel (kandidáti/manuál/terminálne stavy) sa ukazuje priamo, presne ako stará appka. */}
+                  {(panelOpen || (item.decision === null && item.chosenCandidate === null)) && (
+                    <PairingReviewDecisionPanel
+                      productKey={item.productKey}
+                      busy={busy}
+                      candidatesError={candidatesError}
+                      candidates={candidates}
+                      manualUrl={manualUrl}
+                      onManualUrlChange={setManualUrl}
+                      onSaveManual={saveManual}
+                      submit={submit}
+                      panelOpen={panelOpen}
+                      onClose={closePanel}
                     />
-                    <button
-                      type="button"
-                      className="btn good sm"
-                      disabled={busy || manualUrl.trim() === ""}
-                      onClick={saveManual}
-                      data-testid={`pairing-review-manual-save-${item.productKey}`}
-                    >
-                      Uložiť URL
-                    </button>
-                  </div>
-
-                  <div className="pairing-review-terminal-row">
-                    <TerminalButtons busy={busy} submit={submit} productKey={item.productKey} />
-                  </div>
-
-                  {panelOpen && (
-                    <button type="button" className="btn ghost sm" disabled={busy} onClick={closePanel} data-testid={`pairing-review-panel-cancel-${item.productKey}`}>
-                      Zavrieť
-                    </button>
                   )}
-                </div>
+                </>
               )}
             </>
           )}

--- a/apps/web/src/components/PairingReviewDecisionPanel.tsx
+++ b/apps/web/src/components/PairingReviewDecisionPanel.tsx
@@ -1,0 +1,70 @@
+import type { JSX } from "react";
+import type { PairingDecisionAction, PairingReviewCandidate } from "../pairingReviewApi.js";
+import { PanelCandidateRow, TerminalButtons } from "./PairingReviewPanelParts.js";
+
+// issue 399 — vyčlenené z `PairingReviewCard.tsx` (eslint `max-lines: 400`,
+// `.claude/rules/frontend-design.md`'s zavedený vzor "component file that
+// grows past the cap gets its repeated/self-contained rendering unit
+// extracted") — pridanie "✂ Rozdeliť na veľkosti" (`PairingReviewSplitPanel.tsx`)
+// posunulo súbor cez limit. Čisto presentational: VŠETOK stav (`candidates`/
+// `manualUrl`/`busy`/`panelOpen`) ostáva vlastníctvom `PairingReviewCard.tsx`,
+// tento komponent len vykresľuje panel "vyber url"/kandidáti/manuál/terminálne
+// tlačidlá/Zavrieť — presne ten istý JSX blok, čo tu bol predtým priamo.
+
+export function PairingReviewDecisionPanel({
+  productKey,
+  busy,
+  candidatesError,
+  candidates,
+  manualUrl,
+  onManualUrlChange,
+  onSaveManual,
+  submit,
+  panelOpen,
+  onClose,
+}: {
+  readonly productKey: string;
+  readonly busy: boolean;
+  readonly candidatesError: string;
+  readonly candidates: readonly PairingReviewCandidate[] | null;
+  readonly manualUrl: string;
+  readonly onManualUrlChange: (value: string) => void;
+  readonly onSaveManual: () => void;
+  readonly submit: (action: PairingDecisionAction) => void;
+  readonly panelOpen: boolean;
+  readonly onClose: () => void;
+}): JSX.Element {
+  return (
+    <div className="pairing-review-panel" data-testid={`pairing-review-panel-${productKey}`}>
+      {candidatesError !== "" && <p role="alert">{candidatesError}</p>}
+      {candidates === null && candidatesError === "" && <p>Načítavam kandidátov…</p>}
+      {candidates !== null && candidates.map((c, i) => <PanelCandidateRow key={c.url} candidate={c} index={i} busy={busy} submit={submit} productKey={productKey} />)}
+
+      <div className="pairing-review-manual-row">
+        <input
+          type="url"
+          placeholder="Vlož vlastnú URL dodávateľa…"
+          value={manualUrl}
+          disabled={busy}
+          data-testid={`pairing-review-manual-input-${productKey}`}
+          onChange={(e) => {
+            onManualUrlChange(e.target.value);
+          }}
+        />
+        <button type="button" className="btn good sm" disabled={busy || manualUrl.trim() === ""} onClick={onSaveManual} data-testid={`pairing-review-manual-save-${productKey}`}>
+          Uložiť URL
+        </button>
+      </div>
+
+      <div className="pairing-review-terminal-row">
+        <TerminalButtons busy={busy} submit={submit} productKey={productKey} />
+      </div>
+
+      {panelOpen && (
+        <button type="button" className="btn ghost sm" disabled={busy} onClick={onClose} data-testid={`pairing-review-panel-cancel-${productKey}`}>
+          Zavrieť
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/PairingReviewSection.test.tsx
+++ b/apps/web/src/components/PairingReviewSection.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, expect, it, vi } from "vitest";
 import { PairingReviewSection } from "./PairingReviewSection.js";
 
@@ -163,4 +163,32 @@ it("hlavička karty 'Náš produkt' je odlíšená od 'Navrhnutý kandidát' —
   await screen.findByTestId("pairing-review-card-PR-1");
 
   expect(screen.queryByRole("heading")).toBeNull();
+});
+
+// issue 399 — "Hľadať / opraviť" pod-záložka: prepínač NIKDY nie je
+// blokovaný "Prehľad"'s vlastným načítavaním (`.claude/rules/frontend-
+// design.md`'s "druhá pod-obrazovka nesmie zdediť prvej gate" pravidlo).
+it("klik na 'Hľadať / opraviť' prepne na vyhľadávaciu záložku, aj keď 'Prehľad' ešte nedokončil svoje vlastné načítanie", async () => {
+  // Nikdy sa nevyrieši — simuluje "Prehľad" večne visiaci v načítavaní.
+  searchPairingReview.mockImplementation(() => new Promise(() => undefined));
+
+  render(<PairingReviewSection role="manazer" onSessionExpired={() => {}} />);
+  fireEvent.click(screen.getByTestId("pairing-review-tab-hladat"));
+
+  expect(await screen.findByTestId("pairing-search-fix")).toBeDefined();
+  expect(screen.queryByTestId("pairing-review-filters")).toBeNull();
+});
+
+it("prepnutie späť na 'Prehľad' ukáže pôvodný zoznam bez nového vyhľadávania", async () => {
+  searchPairingReview.mockResolvedValue({ total: 0, gatheredTotal: 0, linkedTotal: 0, items: [] });
+
+  render(<PairingReviewSection role="manazer" onSessionExpired={() => {}} />);
+  await screen.findByTestId("pairing-review-empty");
+
+  fireEvent.click(screen.getByTestId("pairing-review-tab-hladat"));
+  await screen.findByTestId("pairing-search-fix");
+
+  fireEvent.click(screen.getByTestId("pairing-review-tab-prehlad"));
+  expect(await screen.findByTestId("pairing-review-empty")).toBeDefined();
+  expect(searchPairingReview).toHaveBeenCalledTimes(1); // žiadne ĎALŠIE volanie pri prepnutí späť
 });

--- a/apps/web/src/components/PairingReviewSection.tsx
+++ b/apps/web/src/components/PairingReviewSection.tsx
@@ -11,6 +11,7 @@ import {
 import { PairingReviewBadgeRefreshContext } from "../pairingReviewBadgeContext.js";
 import { useLoadMore } from "../useLoadMore.js";
 import { PairingReviewCard } from "./PairingReviewCard.js";
+import { PairingSearchFixTab } from "./PairingSearchFixTab.js";
 
 // issue 387 E5: "Eshop → Párovanie" — čítacia obrazovka (karty + filtre) nad
 // tým, čo E3 (gather)/E4 (verify) zozbierali. Design komentár na tickete
@@ -70,6 +71,12 @@ export function PairingReviewSection({ role, onSessionExpired }: { readonly role
   const [linkedTotal, setLinkedTotal] = useState(0);
   const [loaded, setLoaded] = useState(false);
   const [error, setError] = useState("");
+  // issue 399 — "Hľadať / opraviť" pod-záložka, NEZÁVISLÁ od "Prehľad"'s
+  // vlastného načítavania/chybového stavu (`.claude/rules/frontend-design.md`'s
+  // "druhá pod-obrazovka nesmie zdediť prvej gate" pravidlo — táto obrazovka
+  // navyše ani žiadnu blokujúcu gate nemala, ale tabBar sa napriek tomu
+  // počíta a vetví AŽ v návratovom JSX, nikdy skorším `return`om).
+  const [activeTab, setActiveTab] = useState<"prehlad" | "hladat">("prehlad");
 
   const searchSeq = useRef(0);
   const mountedRef = useRef(true);
@@ -193,8 +200,46 @@ export function PairingReviewSection({ role, onSessionExpired }: { readonly role
   const progressPct = gatheredTotal > 0 ? Math.round((100 * linkedTotal) / gatheredTotal) : 0;
   const showingAll = total === 0 || items.length >= total;
 
+  // issue 399 — pod-záložky (rovnaký vzor ako Upozornenia Otvorené/Vybavené):
+  // vždy vykreslené OBIDVE, jedna aktívna cez `hidden`/podmienený obsah, nikdy
+  // skorší `return` blokujúci prepínač.
+  const tabBar = (
+    <div className="chip-row" data-testid="pairing-review-tabs">
+      <button
+        type="button"
+        className={"chip" + (activeTab === "prehlad" ? " active" : " chip-neutral")}
+        data-testid="pairing-review-tab-prehlad"
+        onClick={() => {
+          setActiveTab("prehlad");
+        }}
+      >
+        Prehľad
+      </button>
+      <button
+        type="button"
+        className={"chip" + (activeTab === "hladat" ? " active" : " chip-neutral")}
+        data-testid="pairing-review-tab-hladat"
+        onClick={() => {
+          setActiveTab("hladat");
+        }}
+      >
+        Hľadať / opraviť
+      </button>
+    </div>
+  );
+
+  if (activeTab === "hladat") {
+    return (
+      <section data-testid="pairing-review-section">
+        {tabBar}
+        <PairingSearchFixTab role={role} onSessionExpired={onSessionExpired} />
+      </section>
+    );
+  }
+
   return (
     <section data-testid="pairing-review-section">
+      {tabBar}
       <p>
         Produkty bez napárovaného odkazu na dodávateľa — vľavo náš produkt, vpravo najlepší nájdený kandidát (ak ho
         appka u dodávateľa s automatickým vyhľadávaním našla). Na karte priamo potvrdíš navrhnutý odkaz, vyberieš

--- a/apps/web/src/components/PairingReviewSplitPanel.tsx
+++ b/apps/web/src/components/PairingReviewSplitPanel.tsx
@@ -1,0 +1,226 @@
+import { useCallback, useEffect, useRef, useState, type JSX } from "react";
+import {
+  fetchPairingVariantLinks,
+  PairingReviewUnauthorizedError,
+  savePairingVariantLink,
+  type PairingDecisionAction,
+  type PairingReviewCandidate,
+  type PairingReviewItem,
+  type PairingVariantLink,
+} from "../pairingReviewApi.js";
+import { validateSupplierLinkUrl } from "../ordersApi.js";
+
+// issue 399 — "✂ Rozdeliť na veľkosti": port starej appky's `splitPanel`/
+// `splitRow` (`parovanie_produktov` @ f76cafa, `webreview/static/app.js:254-
+// 341`) — per-veľkosť editor, otvorený z `PairingReviewCard.tsx` (trigger +
+// `decision.status === "split"` obe volajú TENTO panel, presne ako stará
+// appka "while open OR committed"). Vlastný, NEZÁVISLÝ zápis
+// (`POST .../variant-link`, `variant-links.ts`) — každý riadok sa uloží
+// SAMOSTATNE, hneď pri kliku "Uložiť", nie hromadne s "✓ Hotovo – rozdelené".
+// `candidates`/`candidatesError` sú PREVZATÉ z rodiča (`PairingReviewCard.tsx`'s
+// už existujúci `loadCandidates()`) — žiadny druhý fetch tých istých top-8
+// kandidátov, len znovupoužité ako quick-pick tlačidlá per riadok (rovnaký
+// zdroj dát, aký stará appka's `p.candidates` použila).
+//
+// Design komentár (root cause/prístup/zamietnutá alternatíva/Architektúra)
+// pre #399: https://github.com/zbynekdrlik/forestshop-app/issues/399
+
+function VariantRow({
+  productKey,
+  variant,
+  candidates,
+  busy,
+  onSaved,
+}: {
+  readonly productKey: string;
+  readonly variant: PairingVariantLink;
+  readonly candidates: readonly PairingReviewCandidate[] | null;
+  readonly busy: boolean;
+  readonly onSaved: (code: string, url: string | null) => void;
+}): JSX.Element {
+  const [draft, setDraft] = useState(variant.url ?? "");
+  const [rowBusy, setRowBusy] = useState(false);
+  const [rowError, setRowError] = useState("");
+  const label = variant.sizeLabel ?? variant.code;
+
+  const save = useCallback(
+    (url: string) => {
+      const trimmed = url.trim();
+      if (trimmed !== "") {
+        const validationError = validateSupplierLinkUrl(trimmed);
+        if (validationError !== null) {
+          setRowError(validationError);
+          return;
+        }
+      }
+      setRowError("");
+      setRowBusy(true);
+      savePairingVariantLink(productKey, variant.code, trimmed === "" ? null : trimmed)
+        .then(() => {
+          onSaved(variant.code, trimmed === "" ? null : trimmed);
+        })
+        .catch((err: unknown) => {
+          setRowError(err instanceof Error ? err.message : "Uloženie sa nepodarilo.");
+        })
+        .finally(() => {
+          setRowBusy(false);
+        });
+    },
+    [productKey, variant.code, onSaved],
+  );
+
+  const disabled = busy || rowBusy;
+
+  return (
+    <div className="pairing-review-split-row" data-testid={`pairing-review-split-row-${variant.code}`}>
+      <div className="pairing-review-split-row-head">
+        <span className="pairing-review-split-size">{label}</span>
+        {variant.sizeLabel !== null && <span className="pairing-review-split-code">{variant.code}</span>}
+        <span
+          className={"pairing-review-split-state" + (variant.url !== null ? " has" : "")}
+          data-testid={`pairing-review-split-state-${variant.code}`}
+        >
+          {variant.url !== null ? "✓ link nastavený" : "bez linku"}
+        </span>
+      </div>
+
+      {candidates !== null && candidates.length > 0 && (
+        <div className="pairing-review-split-candidates">
+          {candidates.map((c) => (
+            <button
+              key={c.url}
+              type="button"
+              className="btn ghost sm"
+              disabled={disabled}
+              onClick={() => {
+                setDraft(c.url);
+                save(c.url);
+              }}
+            >
+              Vybrať: {c.name}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {rowError !== "" && <p role="alert">{rowError}</p>}
+      <div className="pairing-review-split-manual">
+        <input
+          type="url"
+          placeholder={`Link dodávateľa pre veľkosť ${label}…`}
+          value={draft}
+          disabled={disabled}
+          data-testid={`pairing-review-split-input-${variant.code}`}
+          onChange={(e) => {
+            setDraft(e.target.value);
+          }}
+        />
+        <button
+          type="button"
+          className="btn good sm"
+          disabled={disabled}
+          onClick={() => {
+            save(draft);
+          }}
+          data-testid={`pairing-review-split-save-${variant.code}`}
+        >
+          Uložiť
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function PairingReviewSplitPanel({
+  item,
+  busy,
+  submit,
+  candidates,
+  candidatesError,
+  onSessionExpired,
+}: {
+  readonly item: PairingReviewItem;
+  readonly busy: boolean;
+  readonly submit: (action: PairingDecisionAction) => void;
+  readonly candidates: readonly PairingReviewCandidate[] | null;
+  readonly candidatesError: string;
+  readonly onSessionExpired: () => void;
+}): JSX.Element {
+  const [variants, setVariants] = useState<readonly PairingVariantLink[] | null>(null);
+  const [variantsError, setVariantsError] = useState("");
+  const loadSeq = useRef(0);
+
+  useEffect(() => {
+    const seq = (loadSeq.current += 1);
+    fetchPairingVariantLinks(item.productKey)
+      .then((result) => {
+        if (seq !== loadSeq.current) return;
+        setVariants(result);
+      })
+      .catch((err: unknown) => {
+        if (seq !== loadSeq.current) return;
+        if (err instanceof PairingReviewUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setVariantsError("Zoznam veľkostí sa nepodarilo načítať.");
+      });
+    // `item.productKey` je stabilné pre celú životnosť karty (karty sú
+    // kľúčované `productKey`, `PairingReviewSection.tsx`) — netreba
+    // `onSessionExpired` do závislostí (stabilná funkcia z `App.tsx`,
+    // rovnaký vzor ako `PairingReviewCard.tsx`'s `loadCandidates`).
+  }, [item.productKey]);
+
+  const onVariantSaved = useCallback((code: string, url: string | null) => {
+    setVariants((prev) => (prev === null ? prev : prev.map((v) => (v.code === code ? { ...v, url } : v))));
+  }, []);
+
+  const isSplit = item.decision?.status === "split";
+  const missingCount = variants?.filter((v) => v.url === null).length ?? 0;
+
+  return (
+    <div className="pairing-review-split-panel" data-testid={`pairing-review-split-panel-${item.productKey}`}>
+      <p className="pairing-review-split-hint">Dodávateľ má inú stránku pre každú veľkosť? Nastav vlastný link pre KAŽDÚ veľkosť.</p>
+      {variantsError !== "" && <p role="alert">{variantsError}</p>}
+      {variants === null && variantsError === "" && <p>Načítavam veľkosti…</p>}
+      {variants !== null &&
+        variants.map((v) => <VariantRow key={v.code} productKey={item.productKey} variant={v} candidates={candidates} busy={busy} onSaved={onVariantSaved} />)}
+      {candidatesError !== "" && <p role="alert">{candidatesError}</p>}
+
+      <div className="pairing-review-split-foot">
+        {isSplit ? (
+          <button
+            type="button"
+            className="btn ghost sm"
+            disabled={busy}
+            onClick={() => {
+              submit({ status: "revert" });
+            }}
+            data-testid={`pairing-review-split-cancel-${item.productKey}`}
+          >
+            ↩ Zrušiť rozdelenie
+          </button>
+        ) : (
+          <button
+            type="button"
+            className="btn good sm"
+            disabled={busy || variants === null}
+            onClick={() => {
+              // issue 399 (port starej appky's #180 varovanie) — veľkosť bez
+              // vlastného linku ostane s pôvodným (produktovým) odkazom,
+              // manažér o tom musí vedieť PRED uzavretím.
+              if (missingCount > 0) {
+                const veta = missingCount === 1 ? "Jedna veľkosť nemá vlastný link — ostane jej pôvodný link produktu." : `${String(missingCount)} veľkostí nemá vlastný link — ostanú im pôvodný link produktu.`;
+                if (!window.confirm(`${veta} Pokračovať?`)) return;
+              }
+              submit({ status: "split" });
+            }}
+            data-testid={`pairing-review-split-done-${item.productKey}`}
+          >
+            ✓ Hotovo – rozdelené
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/PairingReviewSplitPanel.tsx
+++ b/apps/web/src/components/PairingReviewSplitPanel.tsx
@@ -31,12 +31,14 @@ function VariantRow({
   candidates,
   busy,
   onSaved,
+  onBusyChange,
 }: {
   readonly productKey: string;
   readonly variant: PairingVariantLink;
   readonly candidates: readonly PairingReviewCandidate[] | null;
   readonly busy: boolean;
   readonly onSaved: (code: string, url: string | null) => void;
+  readonly onBusyChange: (code: string, busy: boolean) => void;
 }): JSX.Element {
   const [draft, setDraft] = useState(variant.url ?? "");
   const [rowBusy, setRowBusy] = useState(false);
@@ -55,6 +57,7 @@ function VariantRow({
       }
       setRowError("");
       setRowBusy(true);
+      onBusyChange(variant.code, true);
       savePairingVariantLink(productKey, variant.code, trimmed === "" ? null : trimmed)
         .then(() => {
           onSaved(variant.code, trimmed === "" ? null : trimmed);
@@ -64,9 +67,10 @@ function VariantRow({
         })
         .finally(() => {
           setRowBusy(false);
+          onBusyChange(variant.code, false);
         });
     },
-    [productKey, variant.code, onSaved],
+    [productKey, variant.code, onSaved, onBusyChange],
   );
 
   const disabled = busy || rowBusy;
@@ -148,6 +152,7 @@ export function PairingReviewSplitPanel({
 }): JSX.Element {
   const [variants, setVariants] = useState<readonly PairingVariantLink[] | null>(null);
   const [variantsError, setVariantsError] = useState("");
+  const [busyRowCodes, setBusyRowCodes] = useState<ReadonlySet<string>>(new Set());
   const loadSeq = useRef(0);
 
   useEffect(() => {
@@ -175,8 +180,25 @@ export function PairingReviewSplitPanel({
     setVariants((prev) => (prev === null ? prev : prev.map((v) => (v.code === code ? { ...v, url } : v))));
   }, []);
 
+  // issue 399 (review finding, #423 self-review) — "✓ Hotovo" nesmie ísť
+  // odoslať, kým NIEKTORÝ riadok ešte čaká na svoj VLASTNÝ zápis (`save()`
+  // vyššie) — bez tohto by klik mohol vidieť `variants`'ov ešte-nezapísaný
+  // (starý) stav a zbytočne (konzervatívne) ukázať varovací dialóg o
+  // chýbajúcom linku, hoci zápis, čo je práve v letu, ho o pár ms doplní.
+  const onRowBusyChange = useCallback((code: string, rowBusy: boolean) => {
+    setBusyRowCodes((prev) => {
+      const has = prev.has(code);
+      if (rowBusy === has) return prev;
+      const next = new Set(prev);
+      if (rowBusy) next.add(code);
+      else next.delete(code);
+      return next;
+    });
+  }, []);
+
   const isSplit = item.decision?.status === "split";
   const missingCount = variants?.filter((v) => v.url === null).length ?? 0;
+  const anyRowBusy = busyRowCodes.size > 0;
 
   return (
     <div className="pairing-review-split-panel" data-testid={`pairing-review-split-panel-${item.productKey}`}>
@@ -184,7 +206,7 @@ export function PairingReviewSplitPanel({
       {variantsError !== "" && <p role="alert">{variantsError}</p>}
       {variants === null && variantsError === "" && <p>Načítavam veľkosti…</p>}
       {variants !== null &&
-        variants.map((v) => <VariantRow key={v.code} productKey={item.productKey} variant={v} candidates={candidates} busy={busy} onSaved={onVariantSaved} />)}
+        variants.map((v) => <VariantRow key={v.code} productKey={item.productKey} variant={v} candidates={candidates} busy={busy} onSaved={onVariantSaved} onBusyChange={onRowBusyChange} />)}
       {candidatesError !== "" && <p role="alert">{candidatesError}</p>}
 
       <div className="pairing-review-split-foot">
@@ -204,7 +226,7 @@ export function PairingReviewSplitPanel({
           <button
             type="button"
             className="btn good sm"
-            disabled={busy || variants === null}
+            disabled={busy || variants === null || anyRowBusy}
             onClick={() => {
               // issue 399 (port starej appky's #180 varovanie) — veľkosť bez
               // vlastného linku ostane s pôvodným (produktovým) odkazom,

--- a/apps/web/src/components/PairingSearchFixTab.test.tsx
+++ b/apps/web/src/components/PairingSearchFixTab.test.tsx
@@ -1,0 +1,169 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { PairingSearchFixTab } from "./PairingSearchFixTab.js";
+
+// issue 399 — "Hľadať / opraviť" pod-záložka: vyhľadávacie pole (zdieľané
+// `GET /api/search`) + jednoproduktová karta (zdieľaný `PairingReviewCard.tsx`,
+// nová `fetchPairingReviewItem`). Rovnaký mock vzor ako `PairingReviewCard
+// .test.tsx`/`SearchSection.tsx` — obe moduly namockované naraz, lebo
+// `PairingReviewCard` (vykreslený z tohto komponentu po otvorení produktu)
+// importuje z `pairingReviewApi.js` nezávisle.
+
+const { globalSearch, fetchPairingReviewItem, fetchPairingCandidates, sendPairingDecision } = vi.hoisted(() => ({
+  globalSearch: vi.fn(),
+  fetchPairingReviewItem: vi.fn(),
+  fetchPairingCandidates: vi.fn(),
+  sendPairingDecision: vi.fn(),
+}));
+
+vi.mock("../searchApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../searchApi.js")>();
+  return { ...actual, globalSearch };
+});
+vi.mock("../pairingReviewApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../pairingReviewApi.js")>();
+  return { ...actual, fetchPairingReviewItem, fetchPairingCandidates, sendPairingDecision };
+});
+
+const { SearchUnauthorizedError } = await import("../searchApi.js");
+const { PairingReviewUnauthorizedError } = await import("../pairingReviewApi.js");
+
+const HIT_A_SIZE_S = {
+  productKey: "PR-A",
+  variantCode: "PR-A/S",
+  productName: "Bunda Alfa",
+  sizeLabel: "S",
+  supplier: "DODAVATEL-A",
+  externalCode: null,
+  state: "sellable" as const,
+};
+const HIT_A_SIZE_M = { ...HIT_A_SIZE_S, variantCode: "PR-A/M", sizeLabel: "M" };
+const HIT_B = {
+  productKey: "PR-B",
+  variantCode: "PR-B",
+  productName: "Čiapka Beta",
+  sizeLabel: null,
+  supplier: null,
+  externalCode: "EXT-1",
+  state: "out_of_stock" as const,
+};
+
+const ITEM_A = {
+  productKey: "PR-A",
+  productName: "Bunda Alfa",
+  supplier: "DODAVATEL-A",
+  externalCodes: [],
+  variantCount: 2,
+  productState: "sellable" as const,
+  priceMin: null,
+  priceMax: null,
+  currency: null,
+  ourUrl: "https://www.forestshop.sk/bunda-alfa",
+  ourUrlIsSearchFallback: false,
+  ourImageUrl: null,
+  hasEffectiveLink: true,
+  supplierHasAdapter: false,
+  gatheredAt: null,
+  confidence: "none" as const,
+  chosenReason: null,
+  verdict: null,
+  chosenCandidate: null,
+  decision: null,
+};
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+function search(q: string): void {
+  fireEvent.change(screen.getByLabelText("Kód, názov alebo dodávateľ"), { target: { value: q } });
+  fireEvent.click(screen.getByRole("button", { name: "Hľadať" }));
+}
+
+it("výsledky sa DEDUPUJÚ podľa productKey — dva varianty toho istého produktu ukážu JEDEN riadok", async () => {
+  globalSearch.mockResolvedValue({ products: [HIT_A_SIZE_S, HIT_A_SIZE_M, HIT_B], orders: [] });
+  render(<PairingSearchFixTab role="manazer" onSessionExpired={() => {}} />);
+
+  search("bunda");
+
+  await waitFor(() => {
+    expect(screen.getByTestId("pairing-search-fix-row-PR-A")).toBeDefined();
+  });
+  expect(screen.getByTestId("pairing-search-fix-row-PR-B")).toBeDefined();
+  expect(screen.queryAllByTestId(/pairing-search-fix-row-PR-A/)).toHaveLength(1);
+});
+
+it("žiadne výsledky ukážu 'Nič sa nenašlo.'", async () => {
+  globalSearch.mockResolvedValue({ products: [], orders: [] });
+  render(<PairingSearchFixTab role="manazer" onSessionExpired={() => {}} />);
+
+  search("neexistuje");
+  expect(await screen.findByTestId("pairing-search-fix-empty")).toBeDefined();
+});
+
+it("klik na 'Otvoriť' nájde produkt cez fetchPairingReviewItem a vykreslí PairingReviewCard", async () => {
+  globalSearch.mockResolvedValue({ products: [HIT_A_SIZE_S], orders: [] });
+  fetchPairingReviewItem.mockResolvedValue(ITEM_A);
+  fetchPairingCandidates.mockResolvedValue([]);
+  render(<PairingSearchFixTab role="manazer" onSessionExpired={() => {}} />);
+
+  search("alfa");
+  fireEvent.click(await screen.findByTestId("pairing-search-fix-open-PR-A"));
+
+  await waitFor(() => {
+    expect(fetchPairingReviewItem).toHaveBeenCalledWith("PR-A");
+  });
+  expect(await screen.findByTestId("pairing-review-card-PR-A")).toBeDefined();
+});
+
+it("neznámy productKey (404 -> null) ukáže 'Produkt sa nenašiel.'", async () => {
+  globalSearch.mockResolvedValue({ products: [HIT_A_SIZE_S], orders: [] });
+  fetchPairingReviewItem.mockResolvedValue(null);
+  render(<PairingSearchFixTab role="manazer" onSessionExpired={() => {}} />);
+
+  search("alfa");
+  fireEvent.click(await screen.findByTestId("pairing-search-fix-open-PR-A"));
+
+  expect(await screen.findByTestId("pairing-search-fix-notfound")).toBeDefined();
+});
+
+it("'← Späť na výsledky' sa vráti na predošlé výsledky bez nového vyhľadávania", async () => {
+  globalSearch.mockResolvedValue({ products: [HIT_A_SIZE_S], orders: [] });
+  fetchPairingReviewItem.mockResolvedValue(ITEM_A);
+  fetchPairingCandidates.mockResolvedValue([]);
+  render(<PairingSearchFixTab role="manazer" onSessionExpired={() => {}} />);
+
+  search("alfa");
+  fireEvent.click(await screen.findByTestId("pairing-search-fix-open-PR-A"));
+  await screen.findByTestId("pairing-review-card-PR-A");
+
+  fireEvent.click(screen.getByTestId("pairing-search-fix-back"));
+  expect(screen.getByTestId("pairing-search-fix-row-PR-A")).toBeDefined();
+  expect(globalSearch).toHaveBeenCalledTimes(1); // žiadne ĎALŠIE vyhľadávanie
+});
+
+it("401 pri vyhľadávaní zavolá onSessionExpired", async () => {
+  globalSearch.mockRejectedValue(new SearchUnauthorizedError());
+  const onSessionExpired = vi.fn();
+  render(<PairingSearchFixTab role="manazer" onSessionExpired={onSessionExpired} />);
+
+  search("čokoľvek");
+  await waitFor(() => {
+    expect(onSessionExpired).toHaveBeenCalledTimes(1);
+  });
+});
+
+it("401 pri otváraní produktu zavolá onSessionExpired", async () => {
+  globalSearch.mockResolvedValue({ products: [HIT_A_SIZE_S], orders: [] });
+  fetchPairingReviewItem.mockRejectedValue(new PairingReviewUnauthorizedError());
+  const onSessionExpired = vi.fn();
+  render(<PairingSearchFixTab role="manazer" onSessionExpired={onSessionExpired} />);
+
+  search("alfa");
+  fireEvent.click(await screen.findByTestId("pairing-search-fix-open-PR-A"));
+
+  await waitFor(() => {
+    expect(onSessionExpired).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/PairingSearchFixTab.tsx
+++ b/apps/web/src/components/PairingSearchFixTab.tsx
@@ -1,0 +1,206 @@
+import { useCallback, useRef, useState, type SyntheticEvent, type JSX } from "react";
+import type { Me } from "../api.js";
+import { fetchPairingReviewItem, PairingReviewUnauthorizedError, type PairingReviewItem } from "../pairingReviewApi.js";
+import { globalSearch, SearchUnauthorizedError, type ProductSearchHit } from "../searchApi.js";
+import { PairingReviewCard } from "./PairingReviewCard.js";
+
+// issue 399 — "Hľadať / opraviť": pod-záložka obrazovky "Eshop → Párovanie",
+// NIE duplikát "Eshop → Vyhľadať" (#240) — vyhľadávacie pole ZNOVUPOUŽÍVA TEN
+// ISTÝ `GET /api/search` (kód/názov/dodávateľ, presne zadanie), ale
+// výsledok otvára `PairingReviewCard.tsx` NEZMENENÚ cez NOVÝ jednoproduktový
+// endpoint (`fetchPairingReviewItem`, `getPairingReviewItem` na serveri) —
+// funguje pre AKÝKOĽVEK produkt, nezávisle od `listPairingReview`'s
+// populácie (design komentár na tickete, sekcia "Prístup 1"). Zdieľanú kartu
+// dostáva ZADARMO: 📦/🚫 terminálne tlačidlá, "✗ Zmeniť / iný link" pre už
+// rozhodnuté produkty, aj nové "✂ Rozdeliť na veľkosti" — nulová duplicita UI.
+//
+// `GET /api/search` vracia PER-VARIANT riadky — dedup podľa `productKey`
+// (prvý výskyt vyhráva), keďže Párovanie je produktovo-úrovňová obrazovka.
+
+const STATE_LABELS: Readonly<Record<ProductSearchHit["state"], string>> = {
+  sellable: "🟢 Skladom",
+  out_of_stock: "📦 Nie je skladom",
+  discontinued: "🚫 Už sa nebude predávať",
+};
+
+function dedupeByProductKey(hits: readonly ProductSearchHit[]): ProductSearchHit[] {
+  const seen = new Set<string>();
+  const out: ProductSearchHit[] = [];
+  for (const hit of hits) {
+    if (seen.has(hit.productKey)) continue;
+    seen.add(hit.productKey);
+    out.push(hit);
+  }
+  return out;
+}
+
+export function PairingSearchFixTab({
+  role,
+  onSessionExpired,
+}: {
+  readonly role: Me["role"];
+  readonly onSessionExpired: () => void;
+}): JSX.Element {
+  const [query, setQuery] = useState("");
+  const [hits, setHits] = useState<readonly ProductSearchHit[]>([]);
+  const [searched, setSearched] = useState(false);
+  const [searchError, setSearchError] = useState("");
+  const searchSeq = useRef(0);
+
+  const [selectedProductKey, setSelectedProductKey] = useState<string | null>(null);
+  const [item, setItem] = useState<PairingReviewItem | null>(null);
+  const [itemLoaded, setItemLoaded] = useState(false);
+  const [itemError, setItemError] = useState("");
+  const itemSeq = useRef(0);
+
+  const search = useCallback(
+    (q: string) => {
+      const seq = (searchSeq.current += 1);
+      setSearchError("");
+      globalSearch(q)
+        .then((r) => {
+          if (seq !== searchSeq.current) return;
+          setHits(dedupeByProductKey(r.products));
+          setSearched(true);
+        })
+        .catch((err: unknown) => {
+          if (seq !== searchSeq.current) return;
+          setSearched(true);
+          if (err instanceof SearchUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setHits([]);
+          setSearchError("Vyhľadávanie zlyhalo — server neodpovedal.");
+        });
+    },
+    [onSessionExpired],
+  );
+
+  function submit(event: SyntheticEvent): void {
+    event.preventDefault();
+    search(query);
+  }
+
+  const openItem = useCallback(
+    (productKey: string) => {
+      setSelectedProductKey(productKey);
+      setItem(null);
+      setItemLoaded(false);
+      setItemError("");
+      const seq = (itemSeq.current += 1);
+      fetchPairingReviewItem(productKey)
+        .then((result) => {
+          if (seq !== itemSeq.current) return;
+          setItem(result);
+          setItemLoaded(true);
+        })
+        .catch((err: unknown) => {
+          if (seq !== itemSeq.current) return;
+          setItemLoaded(true);
+          if (err instanceof PairingReviewUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setItemError("Produkt sa nepodarilo načítať.");
+        });
+    },
+    [onSessionExpired],
+  );
+
+  const backToResults = useCallback(() => {
+    setSelectedProductKey(null);
+    setItem(null);
+  }, []);
+
+  // Po rozhodnutí/uložení na karte znova načítaj TEN ISTÝ produkt (rovnaký
+  // zdroj pravdy ako `PairingReviewSection.tsx`'s `onDecided`, žiadna
+  // duplicitná klientská logika) — karta ostane otvorená, len sa obnoví.
+  const onDecided = useCallback(() => {
+    if (selectedProductKey !== null) openItem(selectedProductKey);
+  }, [selectedProductKey, openItem]);
+
+  if (selectedProductKey !== null) {
+    return (
+      <div data-testid="pairing-search-fix-detail">
+        <button type="button" className="btn ghost sm" onClick={backToResults} data-testid="pairing-search-fix-back">
+          ← Späť na výsledky
+        </button>
+        {itemError !== "" && <p role="alert">{itemError}</p>}
+        {!itemLoaded && itemError === "" && <p>Načítavam produkt…</p>}
+        {itemLoaded && item === null && (
+          <p data-testid="pairing-search-fix-notfound">Produkt sa nenašiel.</p>
+        )}
+        {item !== null && <PairingReviewCard item={item} role={role} onDecided={onDecided} onSessionExpired={onSessionExpired} />}
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="pairing-search-fix">
+      <p>
+        Nájdi ktorýkoľvek produkt (kód, názov alebo dodávateľ) a nastav/oprav mu odkaz na dodávateľa — funguje aj
+        pre produkty, čo už nejaký odkaz majú.
+      </p>
+      <form onSubmit={submit}>
+        <div className="field">
+          <label htmlFor="pairing-search-fix-q">Kód, názov alebo dodávateľ</label>
+          <input
+            id="pairing-search-fix-q"
+            type="search"
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value);
+            }}
+          />
+        </div>
+        <div className="form-actions">
+          <button type="submit" className="btn good">
+            Hľadať
+          </button>
+        </div>
+      </form>
+
+      {searchError !== "" && <p role="alert">{searchError}</p>}
+      {searched && hits.length === 0 && <p data-testid="pairing-search-fix-empty">Nič sa nenašlo.</p>}
+
+      {hits.length > 0 && (
+        <div className="fs-table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Kód</th>
+                <th>Názov</th>
+                <th>Dodávateľ</th>
+                <th>Stav</th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              {hits.map((h) => (
+                <tr key={h.productKey} data-testid={`pairing-search-fix-row-${h.productKey}`}>
+                  <td>{h.variantCode}</td>
+                  <td>{h.productName}</td>
+                  <td>{h.supplier ?? "(bez dodávateľa)"}</td>
+                  <td>{STATE_LABELS[h.state]}</td>
+                  <td>
+                    <button
+                      type="button"
+                      className="btn sm ghost"
+                      data-testid={`pairing-search-fix-open-${h.productKey}`}
+                      onClick={() => {
+                        openItem(h.productKey);
+                      }}
+                    >
+                      Otvoriť
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/pairingReviewApi.ts
+++ b/apps/web/src/pairingReviewApi.ts
@@ -17,7 +17,9 @@ const chosenCandidateSchema = z.object({
   codeHit: z.boolean(),
 });
 
-export const PAIRING_DECISION_STATUSES = ["good", "manual", "unavailable", "discontinued"] as const;
+// issue 399 — `split`: produkt rozdelený na per-veľkosť linky (žiadna `url`
+// na TOMTO stĺpci, presne ako `unavailable`/`discontinued`).
+export const PAIRING_DECISION_STATUSES = ["good", "manual", "unavailable", "discontinued", "split"] as const;
 export type PairingDecisionStatus = (typeof PAIRING_DECISION_STATUSES)[number];
 
 const decisionSchema = z.object({
@@ -130,12 +132,13 @@ export async function fetchPairingCandidates(productKey: string): Promise<readon
 }
 
 // issue 387 E6 — diskriminovaná únia presne zrkadliaca server (`http/pairing-
-// review-routes.ts`'s `pairingDecisionBody`).
+// review-routes.ts`'s `pairingDecisionBody`). issue 399 — `split` pridané.
 export type PairingDecisionAction =
   | { readonly status: "good" }
   | { readonly status: "manual"; readonly url: string }
   | { readonly status: "unavailable" }
   | { readonly status: "discontinued" }
+  | { readonly status: "split" }
   | { readonly status: "revert" };
 
 export async function sendPairingDecision(productKey: string, action: PairingDecisionAction): Promise<void> {
@@ -145,4 +148,37 @@ export async function sendPairingDecision(productKey: string, action: PairingDec
     body: JSON.stringify(action),
   });
   await readJson(response, "Uloženie rozhodnutia sa nepodarilo");
+}
+
+// issue 399 — "Hľadať / opraviť": jedna karta pre AKÝKOĽVEK produkt, `null`
+// = neznámy `productKey` (404 sa NIKDY nehádže — volajúci to rieši ako
+// "nenájdené", nie ako sieťovú/serverovú chybu).
+export async function fetchPairingReviewItem(productKey: string): Promise<PairingReviewItem | null> {
+  const response = await fetch(`/api/pairing-review/${encodeURIComponent(productKey)}`);
+  if (response.status === 401) throw new PairingReviewUnauthorizedError();
+  if (response.status === 404) return null;
+  if (!response.ok) throw new Error(await serverErrorMessage(response, "Produkt sa nepodarilo načítať"));
+  const itemSchemaWrap = z.object({ item: itemSchema });
+  return itemSchemaWrap.parse(await response.json()).item;
+}
+
+// issue 399 — "✂ Rozdeliť na veľkosti": zoznam variantov produktu s ich
+// AKTUÁLNYM per-veľkosť linkom.
+const variantLinkSchema = z.object({ code: z.string(), sizeLabel: z.string().nullable(), url: z.string().nullable() });
+export type PairingVariantLink = z.infer<typeof variantLinkSchema>;
+const variantLinksSchema = z.object({ variants: z.array(variantLinkSchema) });
+
+export async function fetchPairingVariantLinks(productKey: string): Promise<readonly PairingVariantLink[]> {
+  const response = await fetch(`/api/pairing-review/${encodeURIComponent(productKey)}/variants`);
+  return variantLinksSchema.parse(await readJson(response, "Zoznam veľkostí sa nepodarilo načítať")).variants;
+}
+
+// `url: null`/`""` vymaže per-veľkosť link (server ich rieši rovnako).
+export async function savePairingVariantLink(productKey: string, code: string, url: string | null): Promise<void> {
+  const response = await fetch(`/api/pairing-review/${encodeURIComponent(productKey)}/variant-link`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ code, url }),
+  });
+  await readJson(response, "Uloženie linku sa nepodarilo");
 }

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -3201,6 +3201,78 @@ a.upozornenie-title:hover {
   flex: 1 1 0%;
   min-width: 12rem;
 }
+/* issue 399 — "✂ Rozdeliť na veľkosti": piaty stav dostáva VLASTNÚ farbu
+   (rovnaký princíp ako good/manual/unavailable/discontinued vyššie) —
+   fialová, aby sa vizuálne odlíšila od produktovo-úrovňových stavov (toto
+   je jediný stav BEZ produktovej efektívnej linky, čo je napriek tomu
+   zrevidovaný/vyriešený). */
+.pairing-review-decision-split {
+  background: var(--fs-brand-soft);
+  color: var(--fs-brand-strong);
+}
+.pairing-review-split-panel {
+  margin-top: var(--fs-space-3);
+  padding: var(--fs-space-3);
+  background: var(--fs-surface-alt);
+  border: 1px solid var(--fs-border);
+  border-radius: var(--fs-radius-sm);
+  display: flex;
+  flex-direction: column;
+  gap: var(--fs-space-3);
+}
+.pairing-review-split-hint {
+  font-size: var(--fs-text-sm);
+  color: var(--fs-ink-muted);
+  margin: 0;
+}
+.pairing-review-split-row {
+  display: flex;
+  flex-direction: column;
+  gap: var(--fs-space-1);
+  padding: var(--fs-space-2);
+  background: var(--fs-surface);
+  border: 1px solid var(--fs-border);
+  border-radius: var(--fs-radius-sm);
+}
+.pairing-review-split-row-head {
+  display: flex;
+  align-items: center;
+  gap: var(--fs-space-2);
+  flex-wrap: wrap;
+}
+.pairing-review-split-size {
+  font-weight: var(--fs-weight-semibold);
+}
+.pairing-review-split-code {
+  font-size: var(--fs-text-xs);
+  color: var(--fs-ink-faint);
+}
+.pairing-review-split-state {
+  font-size: var(--fs-text-xs);
+  color: var(--fs-ink-faint);
+}
+.pairing-review-split-state.has {
+  color: var(--fs-success);
+}
+.pairing-review-split-candidates {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--fs-space-2);
+}
+.pairing-review-split-manual {
+  display: flex;
+  align-items: center;
+  gap: var(--fs-space-2);
+  flex-wrap: wrap;
+}
+.pairing-review-split-manual input {
+  flex: 1 1 0%;
+  min-width: 12rem;
+}
+.pairing-review-split-foot {
+  display: flex;
+  gap: var(--fs-space-2);
+}
 
 /* ---------------- 20. ESHOP → OBJEDNÁVKY PREDAJŇA (issue 410) ----------------
    Nahrádza Štěpánovo Discord vlákno. `.floor-notes-panel` ohraničuje šírku

--- a/apps/web/tests/e2e/catalog.spec.ts
+++ b/apps/web/tests/e2e/catalog.spec.ts
@@ -46,16 +46,20 @@ test("manažér vidí stav katalógu, vyhľadá variant a konzola je čistá", a
   // — druhý/alternatívny kandidát s vlastným obrázkom v paneli) + 2
   // seedované produkty pre "Objednávky predajňa" ("E2E-PREDAJNA-1"/
   // "E2E-PREDAJNA-2", issue 410, `scripts/e2e-fixtures-floor-notes.ts`)
-  // = 107. (issue 311's 3 seedované produkty "E2E-RL-*" — issue 387 E8 ich
+  // + 2 ĎALŠIE seedované VARIANTY pre "Párovanie → ✂ Rozdeliť na veľkosti"
+  // (issue 399: "E2E-PR-SPLIT/S"+"E2E-PR-SPLIT/M", DVA varianty JEDNÉHO
+  // produktu — jediný viacveľkostný fixtúrový produkt v tomto súbore)
+  // = 109. (issue 311's 3 seedované produkty "E2E-RL-*" — issue 387 E8 ich
   // fixtúru odstránilo spolu s celou obrazovkou "Vypredané → Skladom:
   // návrhy odkazov" — z tohto súčtu preto vypadli, pôvodný súčet bol 106.)
   // Prví dvaja (PREP-1/PREP-2) sú `out_of_stock` (nemenia "sellable"/
   // "missing" nižšie), zvyšných 5, všetkých 60 "E2E-PAGE-*", všetkých 5
-  // "E2E-PR-*" a oba "E2E-PREDAJNA-*" sú `sellable` (posúvajú filter
-  // "sellable" 7→77 nižšie), "missing"(1) sa nemení ani jedným z nich.
+  // "E2E-PR-*", oba "E2E-PREDAJNA-*" a OBA "E2E-PR-SPLIT/*" varianty sú
+  // `sellable` (posúvajú filter "sellable" 7→79 nižšie), "missing"(1) sa
+  // nemení ani jedným z nich.
   await expect(page.getByTestId("snapshot")).toContainText("Posledný import: prijatý");
-  await expect(page.getByTestId("counts")).toContainText("Variantov v katalógu (vrátane chýbajúcich): 107");
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 107 (zobrazených prvých 50)");
+  await expect(page.getByTestId("counts")).toContainText("Variantov v katalógu (vrátane chýbajúcich): 109");
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 109 (zobrazených prvých 50)");
 
   await page.getByLabel("Kód alebo názov").fill("40237/3XL");
   await page.getByRole("button", { name: "Hľadať", exact: true }).click();
@@ -75,11 +79,11 @@ test("filter podľa stavu zúži zoznam na predajné varianty", async ({ page })
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 107 (zobrazených prvých 50)");
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 109 (zobrazených prvých 50)");
   await page.getByLabel("Stav", { exact: true }).selectOption("sellable");
   await page.getByRole("button", { name: "Hľadať", exact: true }).click();
 
-  // 77 = 7 od issue 219 (variant "40237/L" má oba texty dostupnosti prázdne,
+  // 79 = 7 od issue 219 (variant "40237/L" má oba texty dostupnosti prázdne,
   // čo znamená predvolenú dostupnosť Shoptetu — "Skladom", nie vypredané) +
   // 2 sellable produkty issue 239's fixtúry ("E2E-PL-CHYBA"/"E2E-PL-OPRAVA")
   // + 1 sellable produkt issue 240's fixtúry ("E2E-SEARCH-1") + 60 sellable
@@ -87,11 +91,13 @@ test("filter podľa stavu zúži zoznam na predajné varianty", async ({ page })
   // sellable produkty issue 387/398/401's fixtúry ("E2E-PR-CHYBA"/
   // "E2E-PR-NENAJDENY"/"E2E-PR-SLINKOU"/"E2E-PR-BEZADAPTERA"/"E2E-PR-PANEL")
   // + 2 sellable produkty issue 410's fixtúry ("E2E-PREDAJNA-1"/
-  // "E2E-PREDAJNA-2"). (issue 311's 2 sellable "E2E-RL-NAVRH"/"E2E-RL-CUDZI"
-  // vypadli skôr — issue 387 E8 fixtúru odstránilo, vtedajší súčet bol 75 —
-  // a 4 nové produkty (2 issue 398/401 + 2 issue 410) vyššie súčet zdvihli
-  // o 4, na 77.)
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 77 (zobrazených prvých 50)");
+  // "E2E-PREDAJNA-2") + 2 sellable VARIANTY issue 399's fixtúry
+  // ("E2E-PR-SPLIT/S"/"E2E-PR-SPLIT/M"). (issue 311's 2 sellable
+  // "E2E-RL-NAVRH"/"E2E-RL-CUDZI" vypadli skôr — issue 387 E8 fixtúru
+  // odstránilo, vtedajší súčet bol 75 — a 4 nové produkty (2 issue 398/401
+  // + 2 issue 410) vyššie súčet zdvihli o 4, na 77; issue 399's 2 varianty
+  // ho zdvihli o ďalšie 2, na 79.)
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 79 (zobrazených prvých 50)");
   await expect(page.getByTestId("variant-40237/M")).toBeVisible();
 });
 
@@ -103,7 +109,7 @@ test("filter 'Chýbajúce' nájde presne označený variant a riadok ukazuje, od
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 107 (zobrazených prvých 50)");
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 109 (zobrazených prvých 50)");
   await page.getByLabel("Stav", { exact: true }).selectOption("missing");
   await page.getByRole("button", { name: "Hľadať", exact: true }).click();
 
@@ -160,7 +166,7 @@ test("import (ešte prebiehajúci) nesmie prepísať MEDZITÝM zmenený filter z
   await page.getByLabel("E-mail").fill(E2E_RACE_EMAIL);
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
-  await expect(page.getByTestId("total")).toHaveText("Nájdených: 107 (zobrazených prvých 50)");
+  await expect(page.getByTestId("total")).toHaveText("Nájdených: 109 (zobrazených prvých 50)");
 
   await page.getByRole("button", { name: "Stiahnuť a naimportovať export" }).click();
 

--- a/apps/web/tests/e2e/pairing-review-split.spec.ts
+++ b/apps/web/tests/e2e/pairing-review-split.spec.ts
@@ -1,0 +1,180 @@
+import { expect, test } from "@playwright/test";
+
+const E2E_HESLO = "e2e-test-heslo"; // testovacie údaje, existujú len v testovacej databáze
+// Musí sa zhodovať s hodnotou v `scripts/e2e-fixtures-pairing-review.ts` —
+// zdieľaný izolovaný účet s `pairing-review.spec.ts` (rovnaká obrazovka,
+// vyčlenené do VLASTNÉHO súboru len kvôli `.claude/rules/testing.md`'s
+// `max-lines: 400` splitu, nie kvôli inému fixtúrovému balíku).
+const E2E_PAROVANIE_REVIEW_EMAIL = "e2e-parovanie-review@forestshop.sk";
+
+// issue 399 — "✂ Rozdeliť na veľkosti" (per-veľkosť linky, `pairing_variant_link`,
+// nová `pairing_decision.status = 'split'`) + "Hľadať / opraviť" pod-záložka
+// (jednoproduktová karta pre AKÝKOĽVEK produkt, `GET /api/pairing-review/:productKey`).
+// Fixtúra: "E2E-PR-SPLIT" (2 varianty S/M, jeden navrhnutý kandidát) —
+// jediný viacveľkostný produkt v `scripts/e2e-fixtures-pairing-review.ts`.
+
+async function login(page: import("@playwright/test").Page): Promise<void> {
+  await page.goto("/");
+  await page.getByLabel("E-mail").fill(E2E_PAROVANIE_REVIEW_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await page.getByTestId("nav-tab-pairing-review").click();
+}
+
+// issue 399 — POZOR na PORADIE v tomto súbore: OBA split testy zdieľajú
+// TEN ISTÝ fixtúrový produkt "E2E-PR-SPLIT" a `scripts/e2e-setup.ts` sa
+// seeduje LEN RAZ pri štarte `webServer`u (nie pred KAŽDÝM testom) —
+// zmeny jedného testu preto PRETRVÁVAJÚ do ďalšieho v tom istom súbore
+// (`.claude/rules/testing.md`'s "dva testy v jednom súbore bežia
+// sekvenčne, zdieľané dáta"). Tento test beží PRVÝ a KONČÍ s
+// `decision === null` (revert na konci) — nasledujúci test tak nájde
+// split TRIGGER tlačidlo (zobrazí sa len keď `decision === null`), nie
+// panel už otvorený od predošlého testu.
+test("✂ Rozdeliť na veľkosti: 'Hotovo' s CHÝBAJÚCIM linkom pre jednu veľkosť sa OPÝTA (confirm) — po potvrdení sa split aj tak odošle; '↩ Zrušiť rozdelenie' vráti do Nezrevidované, per-veľkosť linky PREŽIJÚ", async ({
+  page,
+}) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+  page.on("dialog", (d) => {
+    void d.accept();
+  });
+
+  await login(page);
+  // "Všetky" HNEĎ na začiatku — split/revert prechody menia, či
+  // "Nezrevidované" produkt zahŕňa; "Všetky" ho drží viditeľný počas celého testu.
+  await page.getByTestId("pairing-review-filter-all").click();
+
+  const karta = page.getByTestId("pairing-review-card-E2E-PR-SPLIT");
+  await karta.getByTestId("pairing-review-split-E2E-PR-SPLIT").click();
+  const panel = page.getByTestId("pairing-review-split-panel-E2E-PR-SPLIT");
+
+  // Len veľkosť S dostane link — M ostáva zámerne PRÁZDNA.
+  await panel.getByTestId("pairing-review-split-input-E2E-PR-SPLIT/S").fill("https://e2e-dodavatel.example.com/len-s");
+  await panel.getByTestId("pairing-review-split-save-E2E-PR-SPLIT/S").click();
+  await expect(panel.getByTestId("pairing-review-split-state-E2E-PR-SPLIT/S")).toHaveText("✓ link nastavený");
+
+  await panel.getByTestId("pairing-review-split-done-E2E-PR-SPLIT").click();
+  // Dialóg bol AUTOMATICKY prijatý (`page.on("dialog")` vyššie) — split sa
+  // napriek chýbajúcej veľkosti M odoslal.
+  await expect(page.getByTestId("pairing-review-decision-badge-E2E-PR-SPLIT")).toHaveText("✂ Rozdelené na veľkosti");
+
+  // "↩ Zrušiť rozdelenie" — decision zmizne, PER-VEĽKOSŤ linky prežijú.
+  await page.getByTestId("pairing-review-split-cancel-E2E-PR-SPLIT").click();
+  await expect(page.getByTestId("pairing-review-decision-badge-E2E-PR-SPLIT")).toHaveCount(0);
+  // Karta ostáva viditeľná ("Všetky"), aj keď decision zmizol — krížové
+  // overenie, že sa naozaj vrátil do "Nezrevidované".
+  await page.getByTestId("pairing-review-filter-unreviewed").click();
+  await expect(page.getByTestId("pairing-review-card-E2E-PR-SPLIT")).toBeVisible();
+
+  // Znovu otvor split — veľkosť S má SVOJ predtým uložený link, nikdy sa nestratil.
+  await page.getByTestId("pairing-review-card-E2E-PR-SPLIT").getByTestId("pairing-review-split-E2E-PR-SPLIT").click();
+  await expect(page.getByTestId("pairing-review-split-state-E2E-PR-SPLIT/S")).toHaveText("✓ link nastavený");
+  // Zavri panel bez rozhodnutia (žiadny explicitný "Zrušiť" tlačidlo pre
+  // TRANSIENTNE otvorený — bez uloženej "split" decision — panel; navigácia
+  // preč z obrazovky v `afterEach`-like zmysle nie je potrebná, ĎALŠÍ test
+  // si filter/kartu nájde nanovo). `decision` zostáva `null` (revert vyššie).
+
+  expect(chyby).toEqual([]);
+});
+
+// Tento test beží DRUHÝ (viď poznámka vyššie) — nájde "E2E-PR-SPLIT" so
+// `decision === null` (predošlý test skončil revertom), takže split
+// TRIGGER tlačidlo je dostupné. Explicitne PREPÍŠE OBE veľkosti vlastnými
+// hodnotami (nezávisle od toho, čo tam nechal predošlý test).
+test("✂ Rozdeliť na veľkosti: nastavenie linku pre KAŽDÚ veľkosť (kandidát + ručne) → '✓ Hotovo' bez varovania (obe majú link) → odznak + vypadne z Nezrevidované; konzola je čistá", async ({
+  page,
+}) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await login(page);
+  // "Všetky" HNEĎ na začiatku — po "✓ Hotovo" `onDecided()` znova načíta
+  // AKTUÁLNY filter (rovnaký vzor ako `pairing-review.spec.ts`'s ostatné
+  // rozhodovacie testy); predvolené "Nezrevidované" by kartu po split
+  // rozhodnutí VYRADILO (split je zrevidovaný), takže by zmizla zo stránky
+  // skôr, než sa dá overiť odznak. "Všetky" ju drží viditeľnú počas celého testu.
+  await page.getByTestId("pairing-review-filter-all").click();
+
+  const karta = page.getByTestId("pairing-review-card-E2E-PR-SPLIT");
+  await expect(karta).toBeVisible();
+  await expect(karta.getByTestId("pairing-review-split-E2E-PR-SPLIT")).toBeVisible();
+
+  await karta.getByTestId("pairing-review-split-E2E-PR-SPLIT").click();
+  const panel = page.getByTestId("pairing-review-split-panel-E2E-PR-SPLIT");
+  await expect(panel).toBeVisible();
+  // Kandidátov panel A hlavný "Navrhnutý kandidát" blok karty zmizli.
+  await expect(page.getByTestId("pairing-review-candidate-E2E-PR-SPLIT")).toHaveCount(0);
+
+  // Veľkosť S — quick-pick z navrhnutého kandidáta.
+  await expect(panel.getByTestId("pairing-review-split-row-E2E-PR-SPLIT/S")).toBeVisible();
+  await panel.getByTestId("pairing-review-split-row-E2E-PR-SPLIT/S").getByRole("button", { name: /Vybrať:/ }).click();
+  await expect(panel.getByTestId("pairing-review-split-state-E2E-PR-SPLIT/S")).toHaveText("✓ link nastavený");
+
+  // Veľkosť M — ručne vpísaná URL.
+  await panel.getByTestId("pairing-review-split-input-E2E-PR-SPLIT/M").fill("https://e2e-dodavatel.example.com/bunda-gama-m");
+  await panel.getByTestId("pairing-review-split-save-E2E-PR-SPLIT/M").click();
+  await expect(panel.getByTestId("pairing-review-split-state-E2E-PR-SPLIT/M")).toHaveText("✓ link nastavený");
+
+  // Obe veľkosti majú link → "✓ Hotovo" sa odošle BEZ potvrdzovacej otázky.
+  await panel.getByTestId("pairing-review-split-done-E2E-PR-SPLIT").click();
+
+  await expect(page.getByTestId("pairing-review-decision-badge-E2E-PR-SPLIT")).toHaveText("✂ Rozdelené na veľkosti");
+  // Krížové overenie "zrevidovaný": "Nezrevidované" ho VYRADÍ.
+  await page.getByTestId("pairing-review-filter-unreviewed").click();
+  await expect(page.getByTestId("pairing-review-card-E2E-PR-SPLIT")).toHaveCount(0);
+
+  expect(chyby).toEqual([]);
+});
+
+// issue 399 — "Hľadať / opraviť": nájde produkt MIMO dnešnej "Nezrevidované"
+// populácie (E2E-PR-SLINKOU už má efektívnu linku z internalNote) a otvorí
+// jeho kartu cez ZDIEĽANÝ jednoproduktový endpoint — presne akceptačný
+// prípad ("funguje aj pre produkty, čo už nejaký odkaz majú").
+test("Hľadať / opraviť: nájde produkt podľa mena, otvorí zdieľanú kartu, '↩ Vrátiť' funguje presne ako na Prehľade; konzola je čistá", async ({ page }) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await login(page);
+
+  await page.getByTestId("pairing-review-tab-hladat").click();
+  await expect(page.getByTestId("pairing-search-fix")).toBeVisible();
+
+  await page.getByLabel("Kód, názov alebo dodávateľ").fill("E2E Produkt Už S Linkou");
+  // `exact: true` — bare "Hľadať" by substring-om (case-insensitive) zasiahol
+  // AJ sidebarov "Vyhľadať" tab, AJ TÚTO obrazovkinu vlastnú "Hľadať /
+  // opraviť" pod-záložku (`.claude/rules/testing.md`'s zdokumentovaná
+  // trieda kolízie — rovnaký vzor ako `catalog.spec.ts`).
+  await page.getByRole("button", { name: "Hľadať", exact: true }).click();
+
+  await expect(page.getByTestId("pairing-search-fix-row-E2E-PR-SLINKOU")).toBeVisible();
+  await page.getByTestId("pairing-search-fix-open-E2E-PR-SLINKOU").click();
+
+  const karta = page.getByTestId("pairing-review-card-E2E-PR-SLINKOU");
+  await expect(karta).toBeVisible();
+  await expect(karta).toContainText("E2E Produkt Už S Linkou");
+
+  // Bez rozhodnutia + bez kandidáta (`pairing-review.spec.ts`'s fixtúra:
+  // E2E-PR-SLINKOU má `chosenUrl: null`) → panel (manuál/terminál) je vidno
+  // priamo — presne to isté správanie ako na "Prehľad".
+  await expect(karta.getByTestId("pairing-review-manual-input-E2E-PR-SLINKOU")).toBeVisible();
+
+  await page.getByTestId("pairing-search-fix-back").click();
+  await expect(page.getByTestId("pairing-search-fix-row-E2E-PR-SLINKOU")).toBeVisible();
+
+  expect(chyby).toEqual([]);
+});

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -3935,3 +3935,78 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   supervisor mergne priamo z tejto REF-y a spustí CI pri round-integrácii.
   Throwaway Postgres kontajner (`agent-a5e9dfcc17ee273e4-pg`, port 5440)
   odstránený na konci.
+
+## 2026-08-13 — #399 (Párovanie: ✂ Rozdeliť na veľkosti + Hľadať/opraviť)
+
+- Worktree-izolovaný autopilot dispatch (`isolation: "worktree"`, plná
+  autorita) — commity na vlastnej vetve `worktree-agent-a71f1f73fa045c975`,
+  supervisor mergne priamo z tejto REF-y a spustí CI pri round-integrácii.
+- Pôvodne otázkový ticket, vyriešený supervisorom + potvrdený majiteľom
+  (komentáre https://github.com/zbynekdrlik/forestshop-app/issues/399#issuecomment-5285260185
+  a …#issuecomment-5285283097: "1 ano uplne vsetko zo starej") — obe funkcie
+  zo starej appky (`parovanie_produktov` @ f76cafa) sa portujú v plnom rozsahu.
+- Version bump `47f6971` (0.3.0-dev.250→.251), first commit.
+- Design komentár (Triage: NON-TRIVIAL, 2-3 zvažované prístupy +
+  Architektúra sekcia) BEFORE prvý feature-kódový commit (`d5d4744`, 22:11
+  local — komentár 21:24 local, predchádza):
+  https://github.com/zbynekdrlik/forestshop-app/issues/399#issuecomment-5285366354
+  — root cause: stará appka mala DVE funkcie ("✂ Rozdeliť na veľkosti" +
+  "Hľadať/opraviť"), nová appka žiadnu z nich; zvolený prístup: NOVÁ
+  nezávislá `pairing_variant_link` tabuľka (per-veľkosť linky) + nový
+  `pairing_decision.status = 'split'` (žiadna URL na produktovej úrovni,
+  rovnaký tvar ako `unavailable`/`discontinued`) + zdieľaná
+  `PairingReviewCard` pre "Hľadať/opraviť" (žiadna paralelná UI); zamietnutá
+  alternatíva: reuse `product_supplier_link_override`
+  (korumpovalo by "1 riadok = 1 produkt" predpoklad iných automatizácií —
+  writeback E7, dodávateľský sklad #212/#213) a reuse F4's `pairing` tabuľky
+  (explicitne zamietnutá minulým merge rozhodnutím).
+- Doplnok k dizajnu (nález počas implementácie — appka už má JEDNU "✂
+  Rozdeliť" na inej obrazovke, žiadna kolízia):
+  https://github.com/zbynekdrlik/forestshop-app/issues/399#issuecomment-5285383307
+- STEP 0 validácia (ticket stále platný, obe funkcie reálne chýbajú):
+  https://github.com/zbynekdrlik/forestshop-app/issues/399#issuecomment-5285383649
+- Migrácia: `0053_pale_epoch.sql` (enum `ADD VALUE 'split'` samostatne) +
+  `0054_zippy_invisible_woman.sql` (`pairing_variant_link` tabuľka + CHECK
+  constraint) — Postgres NEDOVOLÍ použiť novú enum hodnotu v CHECK/INSERT
+  v TEJ ISTEJ transakcii, keď sa posiela ako samostatné príkazy (drizzle-
+  kit-ov migrátor aj `psql` skript-mód) — empiricky overené (RED aj GREEN)
+  na čerstvej Postgres 18 inštancii, plný 54-migračný reťazec.
+- API: `variant-links.ts` (`listPairingVariantLinks`/`setPairingVariantLink`,
+  vlastná NEZÁVISLÁ zápisová cesta), `queries.ts` refaktor
+  (`determineReviewPopulationKeys`/`buildPairingReviewItems` extrakcia,
+  nový `getPairingReviewItem` pre jednoproduktovú kartu — SCOPED dopyt,
+  nie plný katalóg), `decisions.ts`'s `split` vetva, 3 nové HTTP trasy
+  (`GET /:productKey`, `GET/POST /:productKey/variants|variant-link`).
+- Web: `PairingReviewSplitPanel.tsx` (nový, per-veľkosť editor),
+  `PairingReviewDecisionPanel.tsx` (extrahovaný z `PairingReviewCard.tsx`,
+  400-line cap), `PairingSearchFixTab.tsx` (nová "Hľadať/opraviť"
+  pod-záložka, zdieľa `PairingReviewCard` — žiadna paralelná UI),
+  `PairingReviewSection.tsx` (nový `activeTab` prepínač).
+- Self-review (fresh-context `general-purpose` dispatch, CYCLE step 6,
+  diff `6195b06..cca6a5d`): 0 🔴 0 🟡 3 🔵 — všetky opravené v TEJTO vetve,
+  commit `7999d05`: (1) zastaraný test komentár, (2) "✓ Hotovo" row-busy
+  guard (`busyRowCodes`), (3) server-side obranná kontrola proti split na
+  jednovariantnom produkte (`not_multi_variant` → 400).
+- Testy: integračné (`pairing-review-item-http`,
+  `pairing-review-variant-links-http` — 13 testov vrátane cross-product
+  404, CHECK constraint, revert-preserves-links, single-variant reject),
+  frontend unit (`PairingReviewCard.test.tsx` +6 vrátane row-busy guard,
+  nový `PairingSearchFixTab.test.tsx` +7), e2e
+  (`pairing-review-split.spec.ts`, 3 testy — confirm dialóg pri chýbajúcom
+  linku, obe veľkosti bez varovania, Hľadať/opraviť cross-tab flow).
+- Plný lokálny beh na izolovanej throwaway Postgres inštancii (port 15544):
+  typecheck + lint čisté, plný web unit balík 85 súborov/646 testov
+  zelený, plný API `test:integration` balík 107 súborov/804 testov zelený
+  (pred opravami self-review nálezov; scoped pairing-review sada — 5
+  súborov/52 testov — zelená AJ po opravách), plná lokálna e2e sada 60/60
+  zelená (3 nové bugy nájdené+opravené: filter-viditeľnosť po split
+  rozhodnutí, medzi-testové zdieľanie fixtúry `E2E-PR-SPLIT`, "Hľadať"
+  accessible-name kolízia so sidebarom).
+- Follow-up filed: #423 (downstream šírenie per-veľkosť linkov do
+  Shoptet writeback + dodávateľský sklad — `Scope-gate: cross-cutting`,
+  zámerne mimo tohto ticketu).
+- Playbook: `.claude/rules/pairing-search.md`'s nová sekcia "issue 399 —
+  ✂ Rozdeliť na veľkosti + Hľadať/opraviť (mimo E1-E9)" — 2-migration enum
+  past, split dátový model rozhodnutie, `isUnreviewed`/scoped-vs-full-
+  catalog split, 3-file card extraction, e2e fixtúra/poradie/dialóg/
+  "Hľadať" kolízia gotchas.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.250",
+  "version": "0.3.0-dev.251",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.249",
+  "version": "0.3.0-dev.250",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-fixtures-pairing-review.ts
+++ b/scripts/e2e-fixtures-pairing-review.ts
@@ -122,6 +122,78 @@ export async function seedPairingReviewFixtures(db: Database, teraz: Date, snaps
     fetchedAt: teraz,
   });
 
+  // issue 399 — "✂ Rozdeliť na veľkosti" + "Hľadať / opraviť": jediný
+  // fixtúrový produkt v tomto súbore s VIAC ako 1 variantom (`seedProdukt`
+  // vyššie vždy vytvorí presne jeden, `code === productKey`) — potrebný na
+  // to, aby `PairingReviewCard.tsx`'s `variantCount > 1` podmienka split
+  // tlačidlo vôbec zobrazila. Dva sellable/visible varianty (S/M) posúvajú
+  // `catalog.spec.ts`'s pevné počty o +2 (`.claude/rules/testing.md`'s
+  // dokumentovaná pasca) — zdokumentované priamo tam.
+  await db.insert(products).values({
+    key: "E2E-PR-SPLIT",
+    name: "E2E Bunda Gama Viacveľkostná",
+    supplier: ADAPTER_SUPPLIER_NAME,
+    internalNote: null,
+    firstSeenAt: teraz,
+    lastSeenAt: teraz,
+    lastSeenSnapshotId: snapshotId,
+  });
+  await db.insert(variants).values([
+    {
+      code: "E2E-PR-SPLIT/S",
+      productKey: "E2E-PR-SPLIT",
+      guid: "E2E-PR-SPLIT",
+      sizeLabel: "S",
+      externalCode: "E2E-PR-SPLIT-S-KOD",
+      name: "E2E Bunda Gama Viacveľkostná",
+      stock: 5,
+      availabilityInStockText: "Skladom",
+      availabilityOutOfStockText: "Vypredané",
+      availabilityText: "Skladom",
+      productVisibility: "visible",
+      state: "sellable",
+      firstSeenAt: teraz,
+      lastSeenAt: teraz,
+      lastSeenSnapshotId: snapshotId,
+    },
+    {
+      code: "E2E-PR-SPLIT/M",
+      productKey: "E2E-PR-SPLIT",
+      guid: "E2E-PR-SPLIT",
+      sizeLabel: "M",
+      externalCode: "E2E-PR-SPLIT-M-KOD",
+      name: "E2E Bunda Gama Viacveľkostná",
+      stock: 5,
+      availabilityInStockText: "Skladom",
+      availabilityOutOfStockText: "Vypredané",
+      availabilityText: "Skladom",
+      productVisibility: "visible",
+      state: "sellable",
+      firstSeenAt: teraz,
+      lastSeenAt: teraz,
+      lastSeenSnapshotId: snapshotId,
+    },
+  ]);
+  await db.insert(pairingCandidateSets).values({
+    productKey: "E2E-PR-SPLIT",
+    gatheredAt: teraz,
+    queries: ["e2e bunda gama"],
+    inputHash: "e2e-hash-split",
+    chosenUrl: "https://e2e-dodavatel.example.com/bunda-gama-navrh",
+    chosenReason: "najlepší nájdený",
+    confidence: "medium",
+    verdict: null,
+  });
+  await db.insert(pairingCandidates).values({
+    productKey: "E2E-PR-SPLIT",
+    position: 0,
+    name: "E2E Bunda Gama u dodávateľa",
+    url: "https://e2e-dodavatel.example.com/bunda-gama-navrh",
+    imageUrl: null,
+    rawScore: "80.0000",
+    codeHit: false,
+  });
+
   await seedProdukt("E2E-PR-NENAJDENY", "E2E Produkt Bez Kandidáta");
   await db.insert(pairingCandidateSets).values({
     productKey: "E2E-PR-NENAJDENY",

--- a/scripts/e2e-setup.ts
+++ b/scripts/e2e-setup.ts
@@ -268,7 +268,10 @@ await db.execute(
   // issue 387 E7: "pairing_state_writeback_settings" je rovnaká situácia ako
   // "pairing_search_settings"/"restock_settings" (žiadny FK, singleton id,
   // žiadny migračný seed riadok).
-  'TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, nedostupne_replacement_link, mail_template, mail_template_history, supplier_stock, restock_settings, restock_event, shop_product_url, theme_color, dpd_pickup_request, upozornenie, daily_task, mail_log, dpd_shipment, product_supplier_override, product_supplier_link_override, pairing_candidate, pairing_candidate_set, pairing_search_settings, pairing_decision, pairing_state_writeback_settings, floor_note, floor_note_product RESTART IDENTITY CASCADE',
+  // issue 399: "pairing_variant_link" má reálny FK do "variant" (cascade),
+  // takže by ju CASCADE strhol aj bez uvedenia — pridané ručne rovnako ako
+  // "pairing" vyššie.
+  'TRUNCATE TABLE ingest_issue, variant, product, catalog_snapshot, job_run, audit_events, sessions, users, order_line, "order", supplier_contact, pairing, supplier, order_open_status, posta_uncollected_settings, posta_uncollected_state, order_reminder_settings, order_reminder_state, nedostupne_state, nedostupne_replacement_link, mail_template, mail_template_history, supplier_stock, restock_settings, restock_event, shop_product_url, theme_color, dpd_pickup_request, upozornenie, daily_task, mail_log, dpd_shipment, product_supplier_override, product_supplier_link_override, pairing_candidate, pairing_candidate_set, pairing_search_settings, pairing_decision, pairing_state_writeback_settings, pairing_variant_link, floor_note, floor_note_product RESTART IDENTITY CASCADE',
 );
 // Rovnaký dôvod ako `tests/helpers/db.ts`: bez tohto by "Na objednanie" bolo
 // v CELOM e2e behu prázdne pre KAŽDÚ objednávku (žiadny nastavený otvorený


### PR DESCRIPTION
issue 399 — majiteľ: „1 ano uplne vsetko zo starej" (posledná podoba starej
appky @ f76cafa).

## Obsah

- **✂ Rozdeliť na veľkosti**: viacveľkostný produkt sa rozdelí — každá veľkosť
  dostane vlastný dodávateľský link (výber z kandidátov aj ručná URL), per-veľkosť
  indikátor „✓ link nastavený"/„bez linku", „✓ Hotovo – rozdelené" s potvrdením,
  „↩ Zrušiť rozdelenie" (linky prežívajú). Nová tabuľka `pairing_variant_link`
  (kód PK, FK na variants) + nový stav `pairing_decision.status='split'`;
  zámerne NEznečisťuje `product_supplier_link_override` (1 riadok = 1 produkt,
  závisí od toho writeback aj dodávateľský sklad).
- **Záložka „Hľadať / opraviť"**: vyhľadanie ĽUBOVOĽNÉHO produktu v celom
  katalógu (nie len fronty na revíziu) a nastavenie/oprava linku — tá istá
  PairingReviewCard, žiadne paralelné UI; funguje aj pre už napárované produkty.
- Follow-up #423 (cross-cutting): nočný spätný zápis split linkov + zapojenie
  do dodávateľského skladu.

## Testy

typecheck+lint čisté; unit 646 web; integračné 805 (po review opravách);
e2e 60/60 (izolovaný Postgres; 3 reálne bugy nájdené a opravené počas práce,
zdokumentované v playbooku). Review: 0 🔴 0 🟡 3 🔵 — všetko opravené (7999d05).
