### PR TITLE
Oprava migrácie 0054 po výpadku (55P04 — enum v jednej transakcii, issue 399)

### DIFF
--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -38,11 +38,23 @@ paths:
 - **Migrácie bežia pri štarte aplikácie** (`apps/api/src/index.ts`), nie ako
   samostatný deploy krok — `deploy.yml` preto nemá vlastný migračný step,
   spolieha sa na to, že appka si to spraví sama pri boote kontajnera.
-- **Drizzle-ov migrátor nedrží advisory lock.** Každá migrácia beží vo
-  vlastnej transakcii (takže appka nikdy neobslúži polovične zmigrovanú
-  schému), ale dve súčasne štartujúce inštancie by si mohli pretekať o rovnaké
-  DDL. Netýka sa dnešného deploy flow (beží vždy presne jedna inštancia) —
-  ak sa niekedy pridá druhá replika appky, toto sa musí doriešiť pred tým.
+- **Drizzle-ov migrátor nedrží advisory lock.** Dve súčasne štartujúce
+  inštancie by si mohli pretekať o rovnaké DDL. Netýka sa dnešného deploy
+  flow (beží vždy presne jedna inštancia) — ak sa niekedy pridá druhá
+  replika appky, toto sa musí doriešiť pred tým.
+  **OPRAVA (issue 399, 13. 8. 2026) — predošlá veta tu tvrdila "Každá
+  migrácia beží vo vlastnej transakcii", čo je NESPRÁVNE a bolo priamou
+  príčinou produkčného výpadku.** Skutočnosť (overené priamo v
+  `drizzle-orm@0.38.4`'s `pg-core/dialect.js`'s `PgDialect.migrate()`):
+  JEDNO `await session.transaction(async (tx) => { for await (const
+  migration of migrations) { ... } })` obaľuje VŠETKY čakajúce migrácie
+  naraz — nie je to per-súbor transakcia. Toto platí ROVNAKO pre runtime
+  `migrate()` volaný z `apps/api/src/index.ts` AJ pre `drizzle-kit migrate`
+  CLI (`db:migrate`) — obe idú cez ten istý `dialect.migrate()`, empiricky
+  overené priamym CLI behom s dvomi čakajúcimi migráciami naraz proti DB s
+  existujúcim riadkom (rovnaký pád, rovnaký rollback). Plný incident +
+  praktický dôsledok (kedy je "ADD VALUE do enumu + použitie hodnoty" v
+  DVOCH SÚBOROCH napriek tomu nebezpečné) nižšie pri "issue 399 — produkčný výpadok".
 - **`drizzle-kit` 0.30.x nevie `db:generate`/`db:migrate`, keď jeden
   `src/db/schema*.ts` súbor cez `export * from "./other.js"` odkazuje na iný
   (napr. `schema.ts` re-exportuje `schema-catalog.ts`).** Jeho zabudovaný
@@ -323,3 +335,74 @@ paths:
   nevytvorí žiadnu tabuľku) → `db:migrate` odznova → `select conname from
   pg_constraint where conrelid = '<tabuľka>'::regclass;` — potvrď, že meno
   je PRESNE také, aké si zadal, nie orezané.
+- **issue 399 (13. 8. 2026, produkčný výpadok pri deployi) — `ALTER TYPE ... ADD VALUE`
+  + POUŽITIE tej istej hodnoty v CHECK/porovnaní, DVE SÚBORY, DVE súvislé
+  MIGRÁCIE naraz čakajúce na nasadenie + tabuľka s existujúcim riadkom =
+  55P04 pád, aj keď hodnota a jej použitie sú v ODDELENÝCH `.sql`
+  súboroch.** Nasadenie `0.3.0-dev.251` (issue 399: `0053_pale_epoch.sql`
+  `ALTER TYPE pairing_decision_status ADD VALUE 'split'` +
+  `0054_zippy_invisible_woman.sql`'s `pairing_decision_url_ck` CHECK
+  referencujúci `'split'`) zhodilo appku hneď pri štarte s Postgresovou
+  `55P04 unsafe use of new value "split" ... New enum values must be
+  committed before they can be used`, celá transakcia sa rollbackla
+  (enum bez `'split'`, `pairing_variant_link` neexistuje), appka
+  crashloopovala → ručný rollback na `0.3.0-dev.249`.
+  **Prečo boli 0053/0054 v SAMOSTATNÝCH súboroch a AJ TAK to spadlo:**
+  rozdelenie do dvoch súborov je štandardná obrana proti tomu, že Postgres
+  odmieta použiť ešte-necommitnutú enum hodnotu VNÚTRI JEDNÉHO `.sql`
+  súboru (viď opravený bod vyššie + `docs/autopilot-log.md`'s issue 399
+  záznam) — ale táto obrana funguje LEN vtedy, keď migrátor commitne PO
+  KAŽDOM súbore zvlášť. Overené priamo v `drizzle-orm@0.38.4`'s
+  `pg-core/dialect.js`: `PgDialect.migrate()` obaľuje VŠETKY momentálne
+  ČAKAJÚCE migrácie do JEDNÉHO `session.transaction(...)` volania — takže
+  keď je pri jednom spustení `migrate()` čakajúcich viac než jedna
+  migrácia (tu: `0053`+`0054` naraz, appka nebola nasadená od skoršej
+  verzie), Postgres vidí `ADD VALUE` aj jeho použitie v TEJ ISTEJ
+  transakcii bez ohľadu na to, že sú v dvoch rôznych súboroch/príkazoch.
+  **DRUHÁ, rovnako nutná podmienka — CHECK sa musí SKUTOČNE VYHODNOTIŤ
+  proti existujúcemu riadku.** `ALTER TABLE ... ADD CONSTRAINT CHECK (...)`
+  validuje VŠETKY existujúce riadky cieľovej tabuľky; keď má tabuľka NULA
+  riadkov, Postgres výraz nikdy nevyhodnotí (0 riadkov na skenovanie), takže
+  "unsafe use" strážca sa vôbec nespustí — CHECK sa ticho vytvorí aj s
+  ešte-necommitnutou hodnotou. Priamo overené (throwaway Postgres 18,
+  `docker run postgres:18-alpine`): identický `migrate()` beh nad
+  PRÁZDNOU `pairing_decision` tabuľkou prešiel bez chyby; ten istý beh nad
+  tabuľkou s JEDNÝM existujúcim riadkom (ľubovoľného stavu, nie `'split'`)
+  spadol s presne `55P04`. `pairing_decision` na produkcii má reálne
+  objednávkové dáta — preto padlo LEN naživo, nikdy v CI/lokálne.
+  **Prečo CI aj lokálny vývoj tento pád nikdy neuvideli (obe podmienky
+  chýbali, nie len jedna):** CI (`ci.yml`) beží `db:migrate` proti ČERSTVÉMU
+  efemérnemu Postgresu PRED akýmkoľvek seedom testových dát — `pairing_
+  decision` má vtedy vždy 0 riadkov, takže druhá podmienka vyššie nikdy
+  nenastane, bez ohľadu na to, koľko migrácií čaká naraz. Lokálny vývoj
+  (issue 399's vlastný log: "empiricky overené (RED aj GREEN)") aplikoval
+  `0053` a `0054` KAŽDÚ ZVLÁŠŤ, hneď po jej vygenerovaní (bežný cyklus,
+  `.claude/rules/local-dev.md`) — pri KAŽDOM jednotlivom `db:migrate` behu
+  bola čakajúca len JEDNA migrácia, takže prvá podmienka (≥2 migrácie naraz
+  v jednej `migrate()` transakcii) nenastala. **`drizzle-kit migrate` CLI
+  TU NIE JE BEZPEČNEJŠIE než runtime `migrate()`** — omyl v predošlej verzii
+  tohto playbooku (opravený bod vyššie). Priamo overené: rovnaký CLI beh
+  (`drizzle-kit migrate`, `db:migrate` skript) proti DB s existujúcim
+  riadkom a OBOMA migráciami čakajúcimi naraz spadol identicky (exit 1,
+  rovnaký rollback) — CLI len ZVYČAJNE nenaráža na podmienku "≥2 migrácie
+  naraz", nie preto, že by commitovalo po súbore.
+  **Fix (nie nová migrácia — oprava OBOCH ešte-nenasadených súborov, keďže
+  na produkcii sa vôbec nezapísali, `#0053`/`#0054` boli po rollbacku ROVNAKO
+  "pending" ako predtým):** `0054`'s CHECK porovnáva `status::text IN (...)`
+  namiesto `status IN (...)` — textové porovnanie nepotrebuje "commitnutú"
+  enum hodnotu vôbec, takže obchádza celý mechanizmus (nie len jednu z
+  dvoch podmienok vyššie). **Test na KAŽDÚ ĎALŠIU `ADD VALUE` + CHECK/
+  index/generated-column POUŽITIE tej istej hodnoty, aj keď sú v
+  RÔZNYCH `.sql` súboroch:** buď (a) porovnávaj cez `::text`, nikdy priamo
+  enum literálom, v KAŽDOM výraze, čo môže bežať v TEJ ISTEJ `migrate()`
+  transakcii ako svoj vlastný `ADD VALUE` (t.j. v migrácii s VYŠŠÍM alebo
+  ROVNAKÝM číslom, kým appka nie je nasadená MEDZI nimi), alebo (b) nasaď
+  appku so SAMOTNÝM `ADD VALUE` PRED tým, než napíšeš/nasadíš migráciu, čo
+  hodnotu používa — nikdy sa nespoliehaj len na to, že sú v oddelených
+  súboroch/PR-och. Reprodukcia + fix boli overené throwaway Postgres 18
+  kontajnermi (nie proti produkcii) — `docker run --rm -d -p 127.0.0.1:
+  <voľný-port>:5432 postgres:18-alpine`, seed jedného `pairing_decision`
+  riadku cez priamy SQL insert (produkt/používateľ/snapshot závislosti),
+  potom `migrate()`/`drizzle-kit migrate` nad zvyšnými čakajúcimi
+  migráciami — presne rovnaký vzor ako issue 400/403 vyššie, len s
+  DÔRAZOM na existujúci riadok v cieľovej tabuľke, nie na súbežnosť.

--- a/apps/api/drizzle/0054_zippy_invisible_woman.sql
+++ b/apps/api/drizzle/0054_zippy_invisible_woman.sql
@@ -6,4 +6,4 @@ CREATE TABLE "pairing_variant_link" (
 --> statement-breakpoint
 ALTER TABLE "pairing_decision" DROP CONSTRAINT "pairing_decision_url_ck";--> statement-breakpoint
 ALTER TABLE "pairing_variant_link" ADD CONSTRAINT "pairing_variant_link_code_variant_code_fk" FOREIGN KEY ("code") REFERENCES "public"."variant"("code") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "pairing_decision" ADD CONSTRAINT "pairing_decision_url_ck" CHECK (("pairing_decision"."status" IN ('good','manual') AND "pairing_decision"."url" IS NOT NULL) OR ("pairing_decision"."status" IN ('unavailable','discontinued','split') AND "pairing_decision"."url" IS NULL));
+ALTER TABLE "pairing_decision" ADD CONSTRAINT "pairing_decision_url_ck" CHECK (("pairing_decision"."status"::text IN ('good','manual') AND "pairing_decision"."url" IS NOT NULL) OR ("pairing_decision"."status"::text IN ('unavailable','discontinued','split') AND "pairing_decision"."url" IS NULL));

--- a/apps/api/drizzle/meta/0054_snapshot.json
+++ b/apps/api/drizzle/meta/0054_snapshot.json
@@ -3256,7 +3256,7 @@
       "checkConstraints": {
         "pairing_decision_url_ck": {
           "name": "pairing_decision_url_ck",
-          "value": "(\"pairing_decision\".\"status\" IN ('good','manual') AND \"pairing_decision\".\"url\" IS NOT NULL) OR (\"pairing_decision\".\"status\" IN ('unavailable','discontinued','split') AND \"pairing_decision\".\"url\" IS NULL)"
+          "value": "(\"pairing_decision\".\"status\"::text IN ('good','manual') AND \"pairing_decision\".\"url\" IS NOT NULL) OR (\"pairing_decision\".\"status\"::text IN ('unavailable','discontinued','split') AND \"pairing_decision\".\"url\" IS NULL)"
         }
       },
       "isRLSEnabled": false

--- a/apps/api/src/db/schema-pairing-review.ts
+++ b/apps/api/src/db/schema-pairing-review.ts
@@ -199,7 +199,20 @@ export const pairingDecisions = pgTable(
       "pairing_decision_url_ck",
       // issue 399 — `split` pridané do NULOVEJ vetvy (žiadna URL na tomto
       // riadku, per-veľkosť linky žijú v `pairingVariantLinks`).
-      sql`(${t.status} IN ('good','manual') AND ${t.url} IS NOT NULL) OR (${t.status} IN ('unavailable','discontinued','split') AND ${t.url} IS NULL)`,
+      //
+      // issue 399 (prod výpadok, 13. 8. 2026) — `${t.status}` sa musí porovnávať cez
+      // `::text`, NIE priamo ako enum literál. Runtime drizzle-orm migrátor
+      // (`apps/api/src/index.ts`) beží VŠETKY čakajúce migrácie v JEDNEJ
+      // transakcii (na rozdiel od `drizzle-kit` CLI, ktoré commitne po
+      // súbore) — Postgres odmieta použiť novú enum hodnotu (`ADD VALUE
+      // 'split'` z 0053) v tej istej transakcii, čo ju pridala (55P04 "New
+      // enum values must be committed before they can be used"), aj keď je
+      // použitie v NASLEDUJÚCOM .sql SÚBORE (0054). `::text` porovnanie sa
+      // tomuto úplne vyhne — reťazcová rovnosť nepotrebuje enum hodnotu
+      // "commitnutú". Pozri `.claude/rules/database.md` pre plné vysvetlenie
+      // a test na KAŽDÝ ďalší `ADD VALUE` + použitie v tej istej/blízkej
+      // migrácii.
+      sql`(${t.status}::text IN ('good','manual') AND ${t.url} IS NOT NULL) OR (${t.status}::text IN ('unavailable','discontinued','split') AND ${t.url} IS NULL)`,
     ),
   ],
 );

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -4010,3 +4010,72 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   past, split dátový model rozhodnutie, `isUnreviewed`/scoped-vs-full-
   catalog split, 3-file card extraction, e2e fixtúra/poradie/dialóg/
   "Hľadať" kolízia gotchas.
+
+## 2026-08-13 — #399 fix-forward (produkčný výpadok pri nasadení dev.251)
+
+- **URGENT fix-forward, priama práca na `dev` bez worktree** — nasadenie
+  `0.3.0-dev.251` (issue 399 vyššie) zhodilo produkciu hneď pri štarte
+  appky: Postgres `55P04 unsafe use of new value "split" of enum type
+  pairing_decision_status ... New enum values must be committed before
+  they can be used`. Ručný rollback na `0.3.0-dev.249` (predošlý stabilný
+  image) stabilizoval produkciu; issue 399's funkcie (✂ Rozdeliť na
+  veľkosti + Hľadať/opraviť) zostali NENASADENÉ, kým sa migrácie neopravia.
+- **Príčina (overená priamo, nie prevzatá):** `0053_pale_epoch.sql`
+  (`ALTER TYPE pairing_decision_status ADD VALUE 'split'`) +
+  `0054_zippy_invisible_woman.sql` (nový `pairing_decision_url_ck` CHECK
+  referencujúci `'split'`) boli OBE ešte nenasadené na produkcii (overené
+  priamym dopytom: `select hash from drizzle.__drizzle_migrations order by
+  created_at desc limit 1` sedí presne s `sha256sum
+  0052_thankful_invisible_woman.sql`). Runtime drizzle-orm migrátor
+  (`apps/api/src/index.ts`) aj `drizzle-kit migrate` CLI obaľujú VŠETKY
+  momentálne čakajúce migrácie do JEDNÉHO `session.transaction(...)` —
+  keď je pri jednom behu čakajúcich viac než jedna migrácia (tu: obe
+  naraz), `ADD VALUE` aj jeho použitie skončia v TEJ ISTEJ transakcii, aj
+  keď sú v dvoch rôznych `.sql` súboroch. Postgres to dovolí LEN vtedy, keď
+  sa CHECK výraz nikdy reálne nevyhodnotí (tabuľka s 0 riadkami) — na
+  produkcii má `pairing_decision` reálne dáta, takže `ADD CONSTRAINT`
+  validácia narazila na existujúci riadok a spustila "unsafe use" strážcu.
+  Presne preto to nikdy nespadlo v CI (čerstvá prázdna DB pred seedom) ani
+  lokálne počas vývoja (migrácie aplikované jedna-po-druhej, nie naraz).
+  Plný mechanizmus + oprava PREDOŠLEJ nesprávnej playbook vety (tvrdila
+  "každá migrácia vo vlastnej transakcii"): `.claude/rules/database.md`'s
+  nová sekcia "issue 399 (13. 8. 2026, produkčný výpadok pri deployi)".
+- **REPRO-THEN-PROVE, throwaway Postgres 18 kontajnery (nikdy proti
+  produkcii):** (1) RED — čerstvý kontajner, migrácie 0000-0052 cez CLI,
+  seed JEDNÉHO reálneho `pairing_decision` riadku (product/user/snapshot
+  závislosti), runtime `migrate()` proti PÔVODNÝM (rozbitým) `0053`+`0054`
+  → `55P04`, presne rovnaká hláška ako na produkcii, transakcia sa celá
+  rollbackla (enum bez `'split'`, `pairing_variant_link` neexistuje —
+  zhoduje sa 1:1 s pozorovaným produkčným stavom). (2) GREEN — ten istý
+  seedovaný stav, runtime `migrate()` proti OPRAVENÝM súborom → úspech,
+  `pg_get_constraintdef` potvrdil `::text` porovnanie, insert `split`
+  riadku s `url IS NULL` prešiel, s `url` vyplneným zamietnutý CHECK
+  porušením. (3) Rovnaký RED/GREEN pár zopakovaný cez `drizzle-kit migrate`
+  CLI (`--config` na dočasný config so scratch `out` priečinkom) — potvrdil,
+  že CLI NIE JE bezpečnejšie (rovnaký pád na rozbitých súboroch, rovnaký
+  úspech na opravených).
+- **Fix:** `0054`'s CHECK (`apps/api/drizzle/0054_zippy_invisible_woman.sql`
+  aj zdroj `apps/api/src/db/schema-pairing-review.ts`'s `pairing_decision_url_ck`
+  aj `apps/api/drizzle/meta/0054_snapshot.json`) porovnáva
+  `status::text IN (...)` namiesto `status IN (...)` — textové porovnanie
+  neobchádza jednu z dvoch podmienok vyššie, obchádza CELÝ mechanizmus
+  (nepotrebuje "commitnutú" enum hodnotu vôbec). `db:generate` po oprave:
+  "No schema changes, nothing to migrate" (žiadny nový/zabudnutý súbor).
+- **Gates:** `pnpm gates:local` (lint + typecheck čisté; unit: api 73
+  súborov/962 testov, web 85 súborov/646 testov, oba zelené) +
+  scoped `pairing-review-*.integration.test.ts` (5 súborov/52 testov)
+  proti izolovanej throwaway Postgres inštancii (nie zdieľaná lokálna
+  5433 — súbežný worktree worker na issue 422 mohol bežať naraz, plus
+  tento box hostuje živú produkciu, `.claude/rules/local-dev.md`'s "Vývoj
+  a produkcia bežia na TOM ISTOM 2-jadrovom stroji" — plná `test:
+  integration`/e2e sada zámerne NEBEŽALA lokálne, necháva sa na CI).
+  Version bump `0.3.0-dev.251 → 0.3.0-dev.253` (súbežný worker na issue
+  422 — nesúvisiaci ticket, "Párovanie: doplniť AI zdôvodnenie..." — v tom
+  čase držal `.252`).
+- Playbook: `.claude/rules/database.md` — opravená nesprávna veta o
+  per-súbor transakciách + nová dedikovaná sekcia "issue 399 (13. 8. 2026,
+  produkčný výpadok pri deployi)" s plným mechanizmom, dôkazmi a testom
+  na budúce `ADD VALUE` + použitie kombinácie.
+- Súvisiace, NEMENENÉ týmto fix-forward: issue 425 (chýbajúci automatický
+  rollback v `deploy.yml` pri zlyhanom overení — samostatný, už filed
+  ticket o deploy workflow odolnosti, nie o tejto migračnej príčine).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.251",
+  "version": "0.3.0-dev.253",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
issue 399 — oprava migrácie po výpadku produkcie (13. 8. ~20:54 UTC, 55P04).

## Príčina (empiricky dokázaná, byte-identická repro)

`PgDialect.migrate()` (runtime AJ drizzle-kit CLI — obe) beží VŠETKY čakajúce
migrácie v JEDNEJ transakcii. Zlyhanie potrebuje dve podmienky naraz:
(1) ≥2 čakajúce migrácie v jednom behu (0053 `ADD VALUE 'split'` + 0054 CHECK),
(2) tabuľka s ≥1 riadkom — na 0 riadkoch Postgres CHECK vôbec nevyhodnocuje,
preto CI (prázdna DB) ani lokál (migrácie po jednej) chybu nevideli.

## Oprava

- CHECK `pairing_decision_url_ck` porovnáva `status::text` namiesto enum —
  textové porovnanie sa nikdy nedotkne nezacommitovanej enum hodnoty.
- Rovnaký výraz v schéme aj snapshot-e (`db:generate` → „No schema changes").
- RED→GREEN dôkaz na throwaway Postgrese: pôvodná 0054 + seednutý riadok →
  presne prod 55P04; opravená → prejde; `split`+url NULL vloží, `split`+url
  odmietne.
- Playbook database.md: opravené staršie nesprávne tvrdenie „každá migrácia
  vo vlastnej transakcii" + celý incident.

Deploy auto-rollback + retry overenia založený samostatne ako #425
(cross-cutting; prod bol down ~10 min do ručného rollbacku na .249).

## Testy

lint+typecheck čisté; unit 962 API + 646 web; scoped pairing integračné 52/52
(izolovaný Postgres); plná sada beží v CI.
