### PR TITLE
Párovanie: AI zdôvodnenie zhody + živé ceny/dostupnosť (issue 422)

### DIFF
--- a/.claude/rules/pairing-search.md
+++ b/.claude/rules/pairing-search.md
@@ -803,3 +803,101 @@ vyradilo #311 aj jeho playbook súbor (návrh, sekcia 4); router v
   zoznamom nezávisle sa ukladajúcich riadkov" v tejto appke over, či
   riadky majú VLASTNÝ busy stav, ktorý treba vyzdvihnúť rovnakým
   callback vzorom.
+
+## issue 422 — AI zdôvodnenie zhody + živé ceny/dostupnosť (audit úplnosti vs stará appka)
+
+- **`chosenReason` je v TEJTO appke ŠTRUKTURÁLNE VŽDY `null` pre nenapárované
+  produkty — na rozdiel od starej appky, kde `ai_reason` niesol dôvod aj pre
+  "nenašla sa istá zhoda".** `run.ts`'s `buildChosenReason()` vracia `null`
+  vždy, keď `pick.candidate === null`; `pickBest()` (`ranking.ts`) je
+  "auto-fill" — vráti `candidate: null` (teda `chosenCandidate === null`)
+  LEN keď je zoznam kandidátov PRÁZDNY, inak VŽDY vyberie najlepšieho
+  nájdeného (aj slabého). Teda "žiadny kandidát" v tejto appke VŽDY znamená
+  "gather nenašiel u dodávateľa nič" — presne to, čo existujúca "Nenašiel sa
+  žiadny kandidát" hláška (E5/#401) už hovorí. `chosenReason` sa preto
+  renderuje LEN vedľa `chosenCandidate !== null` (`ChosenCandidateExtras`,
+  `PairingReviewPanelParts.tsx`) — pri ĎALŠOM porte podobného "dôvod aj pre
+  negatívny prípad" poľa zo starej appky over najprv, či cieľové pole v TEJTO
+  appke skutočne nesie hodnotu aj v negatívnom stave, nikdy nepredpokladaj
+  paritu len z podobnosti mena poľa.
+- **Živá cena/dostupnosť dodávateľa potrebuje TROJICU RÔZNYCH extrakcií, nie
+  jeden zdieľaný regex — živo overené 13. 8. 2026 (curl cez session
+  warm-up, reálne produktové stránky z E2 search-fixtúr).** WETLAND
+  (wetland.sk) aj ODIMON (odimon.sk) nesú platné JSON-LD `Offer`
+  (`price`/`availability`) — zdieľaný helper `adapters/detail-meta.ts`'s
+  `jsonLdSupplierDetailMeta`, znovupoužíva `supplier-stock/parse.ts`'s už
+  otestovanú `fromJsonLd` (DRY, spoľahlivejšie než vlastný regex bez
+  ohľadu na poradie `property=`/`content=` atribútov). **BETALOV
+  (huntingshop.eu) NEMÁ žiadne JSON-LD ani `og:price`/`og:availability`
+  meta značky vôbec** — naivný CSS-triedový výber (`.actual-price`/
+  `.badge-stock`) je NEBEZPEČNÝ, tie isté triedy sa na stránke opakujú
+  4-6× v karuseli súvisiacich produktov (presne tá istá "karuselová
+  kolízia" trieda chýb ako issue 223, `.claude/rules/supplier-stock.md`).
+  Skutočný spoľahlivý zdroj: `var prodData = {"price":36.5,
+  "is_item_in_stock":1,...};` JS premenná (GA dataLayer prípravok),
+  JEDINÝ výskyt na stránke, priamo pri hlavnom produkte — vlastná
+  extrakcia `parseBetalovDetailMeta` v `betalov.ts` (regex na `var
+  prodData = ({[^}]*});`, `JSON.parse` s try/catch). Test pri KAŽDOM
+  ĎALŠOM podobnom "extrahuj X z detailnej stránky dodávateľa": over živo
+  KAŽDÉHO z troch dodávateľov osobitne, nikdy nepredpokladaj, že jeden
+  mechanizmus pokryje všetkých — presne tento ticket dokázal, že dvaja
+  majú JSON-LD a jeden potrebuje úplne iný zdroj.
+- **ODIMON's JSON-LD vie KLAMAŤ o dostupnosti (issue 225, `.claude/rules/
+  supplier-stock.md`) — akceptované riziko PRE TENTO ticket, lebo ide o
+  čisto INFORMATÍVNY náhľad pre reviewera (link je viditeľný vedľa), nie o
+  automatické prepínanie ako `restock`.** Pri rozšírení tohto live-info
+  mechanizmu na ĎALŠIE, automatizované rozhodovanie (napr. auto-schválenie
+  kandidáta na základe dostupnosti) by bolo treba to isté krížové overenie
+  proti viditeľnému textu, aké `restock`'s `parsePage()` už robí — never
+  preniesť "akceptované pre informatívny náhľad" riziko do automatizácie
+  bez opätovného zváženia.
+- **Live-info endpoint dispatchuje VÝHRADNE cez `adapterForUrl` (host-based
+  lookup, `registry.ts`) — URL mimo troch známych adaptérov degraduje TICHO
+  na `{price:null, availabilityText:null}`, BEZ akéhokoľvek sieťového
+  volania.** Zámerné zúženie rozsahu (design komentár na tickete): candidate/
+  `chosenCandidate` URL sú VŽDY adaptérového pôvodu (gather beží len cez tieto
+  tri adaptéry) — jediný degradovaný prípad je zriedkavá plne ručne zadaná
+  linka od neznámeho dodávateľa (`decision.url` pri `status: "manual"`), čo
+  sa v tejto appke NIKDY nezobrazuje ako živé info (na rozdiel od starej
+  appky, čo aj manuálnu URL live-fetchovala) — vedomá, dokumentovaná
+  odchýlka od 1:1 portu, nie medzera.
+- **`registerPairingReviewRoutes`'s nový `searchClient?: SearchClient`
+  parameter (default `new SearchClient()`) je rovnaká DI disciplína ako
+  `fetchSupplierPage`/`restock`'s config v `http/app.ts`** — testy
+  (integračné aj e2e) NIKDY nechodia na skutočnú sieť: integračné testy
+  injektujú vlastný `Fetcher` cez `createApp(db, {pairingSearchClient: new
+  SearchClient({fetcher})})`; e2e fixtúry (`e2e-fixtures-pairing-review.ts`)
+  majú VŠETKY candidate URL na `e2e-dodavatel.example.com` (mimo troch
+  známych adaptérov) — to isté zúženie rozsahu vyššie preto e2e beh
+  automaticky drží mimo skutočnej siete, bez potreby vlastného mock servera.
+- **`var prodData` regex fixtúra (`fixtures/betalov-detail-cena-
+  dostupnost.html`) MUSÍ zostať PLOCHÝ JS objekt (žiadne vnorené `{}`)** —
+  `PRODATA_RE`'s `[^}]*` capture group (jednoduchšie a bezpečnejšie než
+  `[\s\S]*?` pri drift-e markupu) sa zastaví na PRVEJ `}`, takže reálny
+  vnorený objekt v `prodData` by extrakciu odrezal uprostred. Živo overené
+  (2 reálne huntingshop.eu produkty): `prodData` je VŽDY plochý (žiadne
+  vnorené polia/objekty), takže tento zjednodušený regex je bezpečný pre
+  REÁLNY tvar, nie len pre testovaciu fixtúru — pri budúcej zmene markupu
+  over znova `curl`om, či `prodData` ostáva plochý, predtým než sa regex
+  "vylepší" na `[\s\S]*?`.
+- **"Naša strana" agregácia (`standardPriceMin/Max`/`stockTotal`/
+  `availabilityText`, `pairing-review/queries.ts`) kopíruje presne ten istý
+  vzor ako existujúce `priceMin/Max` — min/max cez `Number`/`toFixed(2)`,
+  distinct-join pre text.** `stockTotal` je SÚČET (nie min/max) naprieč
+  variantmi — zásoba je v tomto obchode dekoratívna (`.claude/rules/
+  catalog.md`'s "stock NEVSTUPUJE do odvodenia stavu"), ale súčet je stále
+  najzmysluplnejšia agregácia na zobrazenie (koľko kusov spolu, nie rozsah).
+  `availabilityText` sú DISTINCT neprázdne texty naprieč variantmi spojené
+  " / " — pri ~2700 jednovariantných produktoch (playbook, E5 sekcia) je
+  toto v praxi takmer vždy jeden text, viacnásobný join je len pre
+  viacveľkostné produkty s odlišnou dostupnosťou per veľkosť.
+- **`variant_money_needs_currency_ck` CHECK constraint (`.claude/rules/
+  database.md`) zachytí KAŽDÝ nový test/fixtúru, čo nastaví `price`/
+  `standardPrice` bez `currency`** — oba seed helpery
+  (`tests/helpers/pairing-review.ts`, `scripts/e2e-fixtures-pairing-
+  review.ts`) museli dostať `currency: "EUR"` VŽDY, keď je nastavená
+  hociktorá cena (predtým currency vôbec nesetovali, lebo žiadny existujúci
+  test/fixtúra predtým price nepoužívala/nepoužívala ho SAMOSTATNE od
+  currency). Test pri KAŽDOM ĎALŠOM seed helperi, čo dostane nové
+  peňažné pole: over CHECK constraint PRIAMO na throwaway Postgrese pred
+  spoliehaním sa na to, že `?? null` default v inserte stačí.

--- a/.claude/rules/pairing-search.md
+++ b/.claude/rules/pairing-search.md
@@ -891,6 +891,21 @@ vyradilo #311 aj jeho playbook súbor (návrh, sekcia 4); router v
   " / " — pri ~2700 jednovariantných produktoch (playbook, E5 sekcia) je
   toto v praxi takmer vždy jeden text, viacnásobný join je len pre
   viacveľkostné produkty s odlišnou dostupnosťou per veľkosť.
+- **Per-URL/per-kľúč in-memory cache BEZ TTL je v tejto appke tichá staleness
+  chyba, nie len teoretická obava — appka beží ako DLHOŽIVÝ kontajner (dni,
+  nie jeden request).** Self-review nález (🟡) na `live-detail-info.ts`'s
+  pôvodnú implementáciu: cache bez TTL by "živé" info navždy zamrazila na
+  PRVEJ hodnote — vrátane PRVÉHO ZLYHANIA (transientný sieťový výpadok by
+  produkt navždy nechal bez live infa, kým appka nereštartuje). Fix:
+  `CACHE_TTL_MS = 15 min` na úspech AJ zlyhanie (injektovateľné `now()` pre
+  testy), ale URL MIMO známych adaptérov (štrukturálny fakt o URL, nikdy sa
+  nemení) sa cachuje BEZ TTL — nie každá cache v tejto appke potrebuje TTL,
+  len tá, čo drží HODNOTU, ktorá sa v čase reálne mení. Test pri KAŽDEJ
+  ĎALŠEJ novej module-level/factory-scoped cache v tomto repe (nielen
+  live-fetch): drží HODNOTU, čo sa môže zmeniť (cena, dostupnosť, externý
+  stav), alebo len ŠTRUKTÚRU (dispatch rozhodnutie, statický fakt)? Prvé
+  potrebuje TTL, druhé nie — a nikdy sa nespoliehaj na to, že "cache
+  re-renders don't re-fetch" zámer implicitne znamená "navždy".
 - **`variant_money_needs_currency_ck` CHECK constraint (`.claude/rules/
   database.md`) zachytí KAŽDÝ nový test/fixtúru, čo nastaví `price`/
   `standardPrice` bez `currency`** — oba seed helpery

--- a/apps/api/src/http/app.ts
+++ b/apps/api/src/http/app.ts
@@ -28,6 +28,7 @@ import { requireSameOrigin } from "./origin-check.js";
 import { registerPairingRoutes } from "./pairing-routes.js";
 import { registerPairingReviewRoutes } from "./pairing-review-routes.js";
 import { registerPairingSearchRoutes } from "./pairing-search-routes.js";
+import type { SearchClient } from "../modules/pairing-search/client.js";
 import { registerPostaUncollectedRoutes, type PostaUncollectedRunDeps } from "./posta-uncollected-routes.js";
 import { registerProductLinksRoutes } from "./product-links-routes.js";
 import { registerProductDetailRoutes } from "./product-detail-routes.js";
@@ -104,6 +105,13 @@ export function createApp(
     // vyššie) — `index.ts` ju v produkcii nahradí LEN keď je nastavená
     // `GOOGLE_CALENDAR_ICS_URL` (`env.ts`).
     readonly nextEvent?: NextEventService;
+    // issue 422: "Živé ceny/dostupnosť" — voliteľný `SearchClient` pre
+    // `GET /api/pairing-review/live-supplier-info`. Rovnaký dôvod ako
+    // `fetchSupplierPage`/`restock` vyššie: `undefined` necháva
+    // `registerPairingReviewRoutes`'s vlastný default (REÁLNy klient,
+    // rovnaký vzor ako `pairing-search/run.ts`) — testy dodajú vlastný s
+    // injektovaným `Fetcher`, NIKDY nechodia na skutočnú sieť.
+    readonly pairingSearchClient?: SearchClient;
   },
 ): Hono<AppBindings> {
   const app = new Hono<AppBindings>();
@@ -225,7 +233,7 @@ export function createApp(
   // (skrytá F4 "Kontrola párovania") aj `registerProductLinksRoutes` nižšie
   // (#239 "Párovanie produktov") — obe ostávajú nedotknuté (design komentár
   // na tickete: E9 ich prípadné vyradenie potrebuje výslovný súhlas majiteľa).
-  registerPairingReviewRoutes(app, db);
+  registerPairingReviewRoutes(app, db, options.pairingSearchClient);
   // issue 239: "Eshop → Párovanie produktov" — zoznam produktov bez
   // dodávateľskej linky + doplnenie/oprava (zapisuje do rovnakej
   // `product_supplier_link_override` tabuľky ako #121, žiadna nová cesta do

--- a/apps/api/src/http/pairing-review-routes.ts
+++ b/apps/api/src/http/pairing-review-routes.ts
@@ -8,6 +8,8 @@ import { supplierLinkUrlBody } from "../modules/orders/supplier-link-assignment.
 import { setPairingDecision } from "../modules/pairing-review/decisions.js";
 import { getPairingReviewItem, listPairingCandidatesForProduct, listPairingReview } from "../modules/pairing-review/queries.js";
 import { listPairingVariantLinks, setPairingVariantLink } from "../modules/pairing-review/variant-links.js";
+import { SearchClient } from "../modules/pairing-search/client.js";
+import { createLiveSupplierInfoFetcher } from "../modules/pairing-search/live-detail-info.js";
 import { isStateWritebackEnabled, setStateWritebackEnabled } from "../modules/shoptet-writeback/state-writeback-settings.js";
 import { requireRole, requireUser, type AppBindings } from "./middleware.js";
 import { requireSameOrigin } from "./origin-check.js";
@@ -55,6 +57,12 @@ const pairingDecisionBody = z.discriminatedUnion("status", [
 
 const setStateWritebackEnabledBody = z.object({ enabled: z.boolean() });
 
+// issue 422 — rovnaká http(s)+formula-injection validácia ako ukladaná
+// dodávateľská linka (`supplierLinkUrlBody`, zdieľané) — tu len na ČÍTANIE
+// (query parameter, nikdy sa nezapisuje), ale schéma je rovnako vhodná:
+// odmietne nevalidný/nie-http(s) vstup skôr, než sa vôbec pokúsi o fetch.
+const liveSupplierInfoQuery = z.object({ url: supplierLinkUrlBody.shape.url });
+
 // issue 399 — `code` v TELE (nie ceste), rovnaký dôvod ako `pairing.md`'s
 // `variantCode`-v-tele pravidlo (kód variantu nesie lomku, napr.
 // "40237/3XL" — necháva sa neoverené, či by prešiel cez URL cestový
@@ -65,7 +73,23 @@ const pairingVariantLinkBody = z.object({
   url: z.union([supplierLinkUrlBody.shape.url, z.literal("")]).nullable(),
 });
 
-export function registerPairingReviewRoutes(app: Hono<AppBindings>, db: Database): void {
+// issue 422 — `searchClient` je voliteľný (rovnaká DI disciplína ako
+// `fetchSupplierPage`/`restock`'s config v `http/app.ts`): default REÁLNY
+// `SearchClient` (rovnaký vzor ako `pairing-search/run.ts`'s vlastný
+// `options.searchClient ?? new SearchClient()`), testy si dodajú vlastný s
+// injektovaným `Fetcher` a NIKDY nechodia na skutočnú dodávateľskú stránku.
+export function registerPairingReviewRoutes(app: Hono<AppBindings>, db: Database, searchClient: SearchClient = new SearchClient()): void {
+  // issue 422 — literálna 2-segmentová cesta MUSÍ byť registrovaná PRED
+  // `:productKey` nižšie (`.claude/rules/http-routes.md`'s poradie-registrácie
+  // pravidlo) — rovnaké miesto/dôvod ako `state-writeback-enabled` vyššie.
+  const fetchLiveSupplierInfo = createLiveSupplierInfoFetcher(searchClient);
+  app.get(
+    "/api/pairing-review/live-supplier-info",
+    requireUser(db),
+    zValidator("query", liveSupplierInfoQuery),
+    async (c) => c.json(await fetchLiveSupplierInfo(c.req.valid("query").url)),
+  );
+
   // issue 387 E7 — `/api/pairing-review/state-writeback-enabled` má INÝ
   // segmentový tvar než `:productKey/candidates`/`:productKey/decision`
   // nižšie (2 segmenty za prefixom, nie `:productKey` + ďalší literál), takže

--- a/apps/api/src/modules/pairing-review/queries.ts
+++ b/apps/api/src/modules/pairing-review/queries.ts
@@ -76,6 +76,20 @@ export interface PairingReviewItem {
   readonly priceMin: string | null;
   readonly priceMax: string | null;
   readonly currency: string | null;
+  /** issue 422 — pôvodná (pred zľavou) cena, rovnaká rozsahová agregácia
+   *  ako `priceMin`/`priceMax`. Frontend ju ukáže LEN keď sa líši od
+   *  priceMin/priceMax (rovnaký princíp ako stará appka's `cp.std !==
+   *  cp.price`). */
+  readonly standardPriceMin: string | null;
+  readonly standardPriceMax: string | null;
+  /** issue 422 — súčet `variant.stock` naprieč variantmi produktu. Zásoba
+   *  je v tomto obchode dekoratívna (`.claude/rules/catalog.md`), stále
+   *  užitočná na zobrazenie presne ako v starej appke. */
+  readonly stockTotal: number;
+  /** issue 422 — distinct neprázdne `variant.availabilityText` naprieč
+   *  variantmi, spojené " / " pri viacerých odlišných; `null` keď sú
+   *  všetky varianty bez textu. */
+  readonly availabilityText: string | null;
   /** Nikdy `null` — padá na `OWN_SHOP_SEARCH_BASE` fallback, presne ako stará appka. */
   readonly ourUrl: string;
   /** issue 402: `true` = `ourUrl` je LEN vyhľadávací fallback (žiadny riadok v `shop_product_url`), nie priamy odkaz na produkt — karta ho vizuálne odlíši. */
@@ -131,6 +145,10 @@ interface VariantRow {
   readonly missingSince: Date | null;
   readonly price: string | null;
   readonly currency: string | null;
+  /** issue 422 */
+  readonly standardPrice: string | null;
+  readonly stock: number;
+  readonly availabilityText: string;
 }
 
 /** Nejaký variant `sellable` → Skladom; inak nejaký `out_of_stock` a VIDITEĽNÝ
@@ -252,6 +270,10 @@ async function buildPairingReviewItems(db: Database, productKeys: string[]): Pro
       missingSince: variants.missingSince,
       price: variants.price,
       currency: variants.currency,
+      // issue 422
+      standardPrice: variants.standardPrice,
+      stock: variants.stock,
+      availabilityText: variants.availabilityText,
     })
     .from(variants)
     .where(inArray(variants.productKey, productKeys));
@@ -337,6 +359,30 @@ async function buildPairingReviewItems(db: Database, productKeys: string[]): Pro
     const priceMax = prices.length > 0 ? Math.max(...prices).toFixed(2) : null;
     const currency = productVariants.find((v) => v.currency !== null)?.currency ?? null;
 
+    // issue 422 — rovnaká rozsahová agregácia ako priceMin/Max vyššie.
+    const standardPrices = productVariants
+      .map((v) => v.standardPrice)
+      .filter((p): p is string => p !== null)
+      .map(Number)
+      .filter((n) => Number.isFinite(n));
+    const standardPriceMin = standardPrices.length > 0 ? Math.min(...standardPrices).toFixed(2) : null;
+    const standardPriceMax = standardPrices.length > 0 ? Math.max(...standardPrices).toFixed(2) : null;
+
+    const stockTotal = productVariants.reduce((sum, v) => sum + v.stock, 0);
+
+    // Distinct neprázdne texty naprieč variantmi, poradie prvého výskytu
+    // (rovnaký princíp ako `externalCodes` dedup vyššie v tejto funkcii).
+    const seenAvailabilityTexts = new Set<string>();
+    const availabilityTexts: string[] = [];
+    for (const v of productVariants) {
+      const text = v.availabilityText.trim();
+      if (text !== "" && !seenAvailabilityTexts.has(text)) {
+        seenAvailabilityTexts.add(text);
+        availabilityTexts.push(text);
+      }
+    }
+    const availabilityText = availabilityTexts.length > 0 ? availabilityTexts.join(" / ") : null;
+
     const effective = resolveEffectiveSupplierLink(product.internalNote, overrideByProduct.get(productKey) ?? null);
 
     const chosenUrl = set?.chosenUrl ?? null;
@@ -366,6 +412,10 @@ async function buildPairingReviewItems(db: Database, productKeys: string[]): Pro
       priceMin,
       priceMax,
       currency,
+      standardPriceMin,
+      standardPriceMax,
+      stockTotal,
+      availabilityText,
       ourUrl,
       ourUrlIsSearchFallback,
       ourImageUrl,

--- a/apps/api/src/modules/pairing-search/adapters/betalov.ts
+++ b/apps/api/src/modules/pairing-search/adapters/betalov.ts
@@ -34,7 +34,7 @@
 
 import * as cheerio from "cheerio";
 import type { PairingCandidate } from "../types.js";
-import type { SupplierAdapter } from "./types.js";
+import type { SupplierAdapter, SupplierDetailMeta } from "./types.js";
 import { belongsToBase, resolveAndStripFragment, resolveImageUrl } from "./url.js";
 
 const BASE_URL = "https://www.huntingshop.eu";
@@ -104,9 +104,39 @@ export function parseBetalovSearch(html: string): PairingCandidate[] {
   return out;
 }
 
+// issue 422 — huntingshop.eu NEMÁ ŽIADNE JSON-LD ani `og:price`/
+// `og:availability` meta značky na detailnej stránke (živo overené 13. 8.
+// 2026, design komentár na tickete) — jediný spoľahlivý zdroj je táto GA
+// dataLayer-prípravná JS premenná, JEDEN výskyt na stránke, priamo pri
+// hlavnom produkte (na rozdiel od `.actual-price`/`.badge-stock` CSS
+// tried, čo sa opakujú 4-6× v karuseli súvisiacich produktov — presne tá
+// istá "karuselová kolízia" trieda chýb ako issue 223,
+// `.claude/rules/supplier-stock.md`). Živo overené na 2 reálnych
+// produktoch: `var prodData = {"item_name":"...","price":36.5,
+// "is_item_in_stock":1,...};`.
+const PRODATA_RE = /var\s+prodData\s*=\s*(\{[^}]*\})\s*;/;
+
+export function parseBetalovDetailMeta(html: string): SupplierDetailMeta {
+  const match = PRODATA_RE.exec(html);
+  const raw = match?.[1];
+  if (raw === undefined) return { price: null, availabilityText: null };
+  try {
+    const data = JSON.parse(raw) as Record<string, unknown>;
+    const priceValue = data["price"];
+    const price = typeof priceValue === "number" && Number.isFinite(priceValue) ? priceValue.toFixed(2) : null;
+    const inStock = data["is_item_in_stock"];
+    const availabilityText = inStock === 1 || inStock === true ? "Skladom" : inStock === 0 || inStock === false ? "Nedostupné" : null;
+    return { price, availabilityText };
+  } catch {
+    // Nevalidný JSON (drift markupu) — best-effort, nikdy nezhodí volajúceho.
+    return { price: null, availabilityText: null };
+  }
+}
+
 export const betalovAdapter: SupplierAdapter = {
   adapterKey: "betalov",
   baseUrl: BASE_URL,
   buildSearchUrl: (query) => `${BASE_URL}/hladanie?search=${encodeURIComponent(query)}`,
   parseSearchResults: parseBetalovSearch,
+  extractDetailMeta: parseBetalovDetailMeta,
 };

--- a/apps/api/src/modules/pairing-search/adapters/detail-meta.test.ts
+++ b/apps/api/src/modules/pairing-search/adapters/detail-meta.test.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { parseBetalovDetailMeta } from "./betalov.js";
+import { jsonLdSupplierDetailMeta } from "./detail-meta.js";
+import { odimonAdapter } from "./odimon.js";
+import { wetlandAdapter } from "./wetland.js";
+
+// issue 422 — testy proti orezaným fixtúram zo živo overených reálnych
+// stránok (`design komentár na tickete`, 13. 8. 2026) — rovnaký vzor ako
+// `verify.test.ts`.
+
+function fixture(name: string): string {
+  return readFileSync(fileURLToPath(new URL(`../fixtures/${name}`, import.meta.url)), "utf8");
+}
+
+describe("jsonLdSupplierDetailMeta — WETLAND/ODIMON zdieľaný JSON-LD Offer helper", () => {
+  it("WETLAND: price z Offer, availability BackOrder -> 'Nedostupné'", () => {
+    const meta = jsonLdSupplierDetailMeta(fixture("wetland-detail-cena-dostupnost.html"));
+    expect(meta.price).toBe("149.90");
+    expect(meta.availabilityText).toBe("Nedostupné");
+  });
+
+  it("ODIMON: price z Offer, availability InStock -> 'Skladom'", () => {
+    const meta = jsonLdSupplierDetailMeta(fixture("odimon-detail-cena-dostupnost.html"));
+    expect(meta.price).toBe("78.90");
+    expect(meta.availabilityText).toBe("Skladom");
+  });
+
+  it("žiadne JSON-LD na stránke -> price/availabilityText obe null, nikdy nevyhodí", () => {
+    const meta = jsonLdSupplierDetailMeta("<html><body>bez JSON-LD</body></html>");
+    expect(meta).toEqual({ price: null, availabilityText: null });
+  });
+
+  it("wetlandAdapter/odimonAdapter's extractDetailMeta dáva ROVNAKÝ výsledok ako zdieľaný helper priamo (dokazuje, že sú zapojené na TÚ ISTÚ funkciu)", () => {
+    const html = fixture("wetland-detail-cena-dostupnost.html");
+    expect(wetlandAdapter.extractDetailMeta(html)).toEqual(jsonLdSupplierDetailMeta(html));
+    expect(odimonAdapter.extractDetailMeta(html)).toEqual(jsonLdSupplierDetailMeta(html));
+  });
+});
+
+describe("parseBetalovDetailMeta — huntingshop.eu's var prodData extrakcia", () => {
+  it("prodData JS premenná: price + is_item_in_stock=1 -> 'Skladom'", () => {
+    const meta = parseBetalovDetailMeta(fixture("betalov-detail-cena-dostupnost.html"));
+    expect(meta.price).toBe("36.50");
+    expect(meta.availabilityText).toBe("Skladom");
+  });
+
+  it("is_item_in_stock=0 -> 'Nedostupné'", () => {
+    const html = `<script>var prodData = {"price": 12.5, "is_item_in_stock": 0};</script>`;
+    expect(parseBetalovDetailMeta(html)).toEqual({ price: "12.50", availabilityText: "Nedostupné" });
+  });
+
+  it("žiadna prodData premenná na stránke -> price/availabilityText obe null", () => {
+    expect(parseBetalovDetailMeta("<html><body>bez prodData</body></html>")).toEqual({ price: null, availabilityText: null });
+  });
+
+  it("nevalidný JSON v prodData (drift markupu) -> nikdy nevyhodí, degraduje na null/null", () => {
+    const html = `<script>var prodData = {toto nie je platný JSON};</script>`;
+    expect(parseBetalovDetailMeta(html)).toEqual({ price: null, availabilityText: null });
+  });
+
+  it("chýbajúce/neplatné price pole -> price null, availabilityText sa napriek tomu vyparsuje", () => {
+    const html = `<script>var prodData = {"is_item_in_stock": 1};</script>`;
+    expect(parseBetalovDetailMeta(html)).toEqual({ price: null, availabilityText: "Skladom" });
+  });
+});

--- a/apps/api/src/modules/pairing-search/adapters/detail-meta.ts
+++ b/apps/api/src/modules/pairing-search/adapters/detail-meta.ts
@@ -1,0 +1,37 @@
+// issue 422 — živá cena+dostupnosť z JSON-LD `Offer` na detailnej stránke
+// kandidáta. Zdieľané WETLAND aj ODIMON adaptérom (`wetland.ts`/`odimon.ts`)
+// — obe domény nesú `<script type="application/ld+json">` s platnou `Offer`
+// (živo overené 13. 8. 2026, design komentár na tickete): WETLAND
+// `price: "149.9"`/`availability: "https://schema.org/BackOrder"`, ODIMON
+// `price: "78.90"`/`"http://schema.org/InStock"`. BETALOV (huntingshop.eu)
+// NEMÁ žiadne JSON-LD ani `og:price`/`og:availability` meta značky vôbec
+// (živo overené) — jeho vlastná extrakcia (`var prodData = {...}` JS
+// premenná) žije priamo v `betalov.ts`, nie tu.
+//
+// Znovupoužíva `supplier-stock/parse.ts`'s `fromJsonLd` (issue 212/213's už
+// otestovaná JSON-LD extrakcia) namiesto vlastného regexu — DRY, a
+// spoľahlivejšie než stará appka's holý `_supplier_meta` regex (ktorý
+// nevedel obe poradia `property=`/`content=` atribútov). Táto funkcia
+// ZÁMERNE nejde cez `parsePage()` (rovnaký modul) — ten má fail-closed
+// "neznáma doména" bránu navrhnutú pre AUTOMATICKÉ prepínanie Vypredané→
+// Skladom (bezpečnostná brána nad zápisom do Shoptetu), nevhodnú pre tento
+// čisto INFORMATÍVNY náhľad pre reviewera (design komentár na tickete).
+
+import { fromJsonLd } from "../../supplier-stock/parse.js";
+import type { SupplierDetailMeta } from "./types.js";
+
+const AVAILABILITY_LABELS: Readonly<Record<"available" | "unavailable" | "unknown", string | null>> = {
+  available: "Skladom",
+  unavailable: "Nedostupné",
+  unknown: null,
+};
+
+/** Zdieľaná JSON-LD `Offer` extrakcia — WETLAND aj ODIMON. Nikdy nevyhadzuje. */
+export function jsonLdSupplierDetailMeta(html: string): SupplierDetailMeta {
+  const hit = fromJsonLd(html);
+  if (hit === null) return { price: null, availabilityText: null };
+  return {
+    price: hit.price !== null && Number.isFinite(hit.price) ? hit.price.toFixed(2) : null,
+    availabilityText: AVAILABILITY_LABELS[hit.availability],
+  };
+}

--- a/apps/api/src/modules/pairing-search/adapters/odimon.ts
+++ b/apps/api/src/modules/pairing-search/adapters/odimon.ts
@@ -28,6 +28,7 @@
 
 import * as cheerio from "cheerio";
 import type { PairingCandidate } from "../types.js";
+import { jsonLdSupplierDetailMeta } from "./detail-meta.js";
 import type { SupplierAdapter } from "./types.js";
 import { belongsToBase, resolveAndStripFragment, resolveImageUrl } from "./url.js";
 
@@ -67,4 +68,11 @@ export const odimonAdapter: SupplierAdapter = {
   baseUrl: BASE_URL,
   buildSearchUrl: (query) => `${BASE_URL}/vysledky-vyhladavania?term=${encodeURIComponent(query)}`,
   parseSearchResults: parseOdimonSearch,
+  // issue 422 — JSON-LD `Offer` (živo overené, `detail-meta.ts`). POZOR:
+  // `.claude/rules/supplier-stock.md` (issue 225) dokumentuje, že JSON-LD
+  // na TEJTO doméne vie klamať o dostupnosti (hlási InStock, hoci viditeľný
+  // prvok pri produkte hovorí "Nedostupný") — akceptované riziko pre TENTO
+  // čisto informatívny náhľad (reviewer vidí aj samotný odkaz), na rozdiel
+  // od `restock`'s automatického prepínania, kde by to bolo neprijateľné.
+  extractDetailMeta: jsonLdSupplierDetailMeta,
 };

--- a/apps/api/src/modules/pairing-search/adapters/registry.test.ts
+++ b/apps/api/src/modules/pairing-search/adapters/registry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { adapterFor, SUPPLIER_ADAPTERS } from "./registry.js";
+import { adapterFor, adapterForUrl, SUPPLIER_ADAPTERS } from "./registry.js";
 
 describe("SUPPLIER_ADAPTERS registry", () => {
   it("carries exactly the three E2 adapters keyed by their adapterKey", () => {
@@ -14,5 +14,17 @@ describe("SUPPLIER_ADAPTERS registry", () => {
 
   it("adapterFor returns undefined for an unknown key", () => {
     expect(adapterFor("neexistujuci-dodavatel")).toBeUndefined();
+  });
+
+  // issue 422 — host-based lookup (na rozdiel od `adapterFor`'s adapterKey lookup).
+  it("adapterForUrl resolves a URL to the adapter whose baseUrl it belongs to", () => {
+    expect(adapterForUrl("https://www.wetland.sk/nohavice/x-1")?.adapterKey).toBe("wetland");
+    expect(adapterForUrl("https://www.huntingshop.eu/nohavice-1")?.adapterKey).toBe("betalov");
+    expect(adapterForUrl("https://www.odimon.sk/obuv/x")?.adapterKey).toBe("odimon");
+  });
+
+  it("adapterForUrl returns undefined for a URL outside all three known suppliers", () => {
+    expect(adapterForUrl("https://e2e-dodavatel.example.com/produkt")).toBeUndefined();
+    expect(adapterForUrl("not a valid url")).toBeUndefined();
   });
 });

--- a/apps/api/src/modules/pairing-search/adapters/registry.ts
+++ b/apps/api/src/modules/pairing-search/adapters/registry.ts
@@ -5,14 +5,30 @@
 // inštanciovať `SearchClient`.
 
 import type { SupplierAdapter } from "./types.js";
+import { belongsToBase } from "./url.js";
 import { betalovAdapter } from "./betalov.js";
 import { odimonAdapter } from "./odimon.js";
 import { wetlandAdapter } from "./wetland.js";
 
+const ADAPTER_LIST: readonly SupplierAdapter[] = [wetlandAdapter, betalovAdapter, odimonAdapter];
+
 export const SUPPLIER_ADAPTERS: ReadonlyMap<string, SupplierAdapter> = new Map(
-  [wetlandAdapter, betalovAdapter, odimonAdapter].map((adapter) => [adapter.adapterKey, adapter]),
+  ADAPTER_LIST.map((adapter) => [adapter.adapterKey, adapter]),
 );
 
 export function adapterFor(adapterKey: string): SupplierAdapter | undefined {
   return SUPPLIER_ADAPTERS.get(adapterKey);
+}
+
+/**
+ * issue 422 — nájde adaptéra podľa HOSTA danej URL (na rozdiel od
+ * `adapterFor`, ktoré ide podľa `adapterKey` reťazca). Používa
+ * `belongsToBase` (rovnaká príslušnosť-k-doméne logika ako adaptéry
+ * samotné pri parsovaní výsledkov). `undefined` = URL nepatrí žiadnemu z
+ * troch známych dodávateľov (napr. ručne zadaná linka od iného
+ * dodávateľa) — volajúci (`live-detail-info.ts`) to rieši ako "žiadne
+ * živé info", nikdy sa nehádže.
+ */
+export function adapterForUrl(url: string): SupplierAdapter | undefined {
+  return ADAPTER_LIST.find((adapter) => belongsToBase(url, adapter.baseUrl));
 }

--- a/apps/api/src/modules/pairing-search/adapters/types.ts
+++ b/apps/api/src/modules/pairing-search/adapters/types.ts
@@ -7,6 +7,20 @@
 
 import type { PairingCandidate } from "../types.js";
 
+// issue 422 — živá cena + dostupnosť KANDIDÁTA/rozhodnutia z jeho DETAILNEJ
+// stránky (na rozdiel od `parseSearchResults`, ktorý parsuje VÝSLEDKOVÚ
+// stránku). `null`/`null` = žiadny zdroj neposkytol použiteľnú hodnotu —
+// nikdy sa nehádže, best-effort presne ako stará appka's `_supplier_meta`.
+export interface SupplierDetailMeta {
+  /** Formátované na 2 desatinné miesta (`"149.90"`), mena je vždy EUR
+   *  (živo overené na všetkých troch dodávateľoch, design komentár na
+   *  tickete #422) — frontend pridáva `€` rovnako, ako to robí stará appka. */
+  readonly price: string | null;
+  /** Ľudsky čitateľný slovenský text ("Skladom"/"Nedostupné"), nikdy surový
+   *  schema.org token. */
+  readonly availabilityText: string | null;
+}
+
 export interface SupplierAdapter {
   /** Zhoduje sa s `supplier.adapter_key` v DB (pripravené na E3). */
   readonly adapterKey: string;
@@ -25,4 +39,11 @@ export interface SupplierAdapter {
    * vlastným výpočtom, nikdy nečíta vstupnú hodnotu.
    */
   parseSearchResults(html: string): readonly PairingCandidate[];
+  /** issue 422 — živá cena+dostupnosť z DETAILNEJ stránky (`SearchClient
+   *  .fetchPage`'s výstup). KAŽDÝ dodávateľ potrebuje VLASTNÚ extrakciu —
+   *  živo overené (design komentár #422), že WETLAND/ODIMON majú JSON-LD
+   *  `Offer` (zdieľaný helper, `detail-meta.ts`), zatiaľ čo BETALOV
+   *  (huntingshop.eu) nemá ŽIADNE JSON-LD/meta a jeho CSS triedy sa
+   *  opakujú v karuseli súvisiacich produktov — vlastná extrakcia. */
+  extractDetailMeta(html: string): SupplierDetailMeta;
 }

--- a/apps/api/src/modules/pairing-search/adapters/wetland.ts
+++ b/apps/api/src/modules/pairing-search/adapters/wetland.ts
@@ -27,6 +27,7 @@
 
 import * as cheerio from "cheerio";
 import type { PairingCandidate } from "../types.js";
+import { jsonLdSupplierDetailMeta } from "./detail-meta.js";
 import type { SupplierAdapter } from "./types.js";
 import { belongsToBase, resolveAndStripFragment, resolveImageUrl } from "./url.js";
 
@@ -70,4 +71,6 @@ export const wetlandAdapter: SupplierAdapter = {
   baseUrl: BASE_URL,
   buildSearchUrl: (query) => `${BASE_URL}/vyhladavanie?controller=search&s=${encodeURIComponent(query)}`,
   parseSearchResults: parseWetlandSearch,
+  // issue 422 — JSON-LD `Offer` (živo overené, `detail-meta.ts`).
+  extractDetailMeta: jsonLdSupplierDetailMeta,
 };

--- a/apps/api/src/modules/pairing-search/fixtures/betalov-detail-cena-dostupnost.html
+++ b/apps/api/src/modules/pairing-search/fixtures/betalov-detail-cena-dostupnost.html
@@ -1,0 +1,17 @@
+<!--
+  Orezaná vzorka https://www.huntingshop.eu/detske-outdoorove-nohavice-
+  combi-14695 (issue 422, živý fetch 13. 8. 2026). huntingshop.eu NEMÁ
+  žiadne JSON-LD ani og:price/og:availability meta značky na detailnej
+  stránke (over grep-om na skutočnej stránke pred prípadnou zmenou tejto
+  fixtúry) — jediný spoľahlivý zdroj je táto GA dataLayer-prípravná JS
+  premenná, čo sa na stránke vyskytuje presne raz.
+-->
+<html lang="sk">
+<head><title>Detské outdoorové nohavice - Combi | huntingshop.eu</title></head>
+<body>
+  <script>
+    var prodData = {"item_name":"Detské outdoorové nohavice - Combi","item_id":"14695","item_variant":"OB3022","affiliation":"Huntingshop","price":36.5,"item_brand":"C.I.T.","item_category":"Pre deti","quantity":1,"is_item_in_stock":1,"item_thumbnail_image_url":"/upload/images/product/14695-detske-outdoorove-nohavice-combi-1.webp"};
+    var price = 36.5;
+  </script>
+</body>
+</html>

--- a/apps/api/src/modules/pairing-search/fixtures/odimon-detail-cena-dostupnost.html
+++ b/apps/api/src/modules/pairing-search/fixtures/odimon-detail-cena-dostupnost.html
@@ -1,0 +1,14 @@
+<!--
+  Orezaná vzorka https://www.odimon.sk/obuv-a-oblecenie/margita-oblecenie/
+  panske-polovnicke-nohavice-michal (issue 422, živý fetch 13. 8. 2026).
+  JSON-LD `Product` s vnorenou `Offer` — `availability` je `InStock`,
+  mapuje sa na "Skladom".
+-->
+<html lang="sk">
+<head><title>Pánske poľovnícke nohavice Michal | odimon.sk</title></head>
+<body>
+  <script type="application/ld+json">
+  {"@context":"https://schema.org","@type":"Product","name":"Pánske poľovnícke nohavice Michal","offers":{"@type":"Offer","price":"78.90","priceCurrency":"EUR","availability":"http://schema.org/InStock"}}
+  </script>
+</body>
+</html>

--- a/apps/api/src/modules/pairing-search/fixtures/wetland-detail-cena-dostupnost.html
+++ b/apps/api/src/modules/pairing-search/fixtures/wetland-detail-cena-dostupnost.html
@@ -1,0 +1,28 @@
+<!--
+  Orezaná vzorka https://www.wetland.sk/nohavice/deerhunter-pro-gamekeeper-
+  boot-trousers-polovnicke-nohavice-111-592 (issue 422, živý fetch
+  13. 8. 2026). JSON-LD `Product` blok s vnorenou `Offer` — presne to, čo
+  `detail-meta.ts`'s `jsonLdSupplierDetailMeta` (cez `supplier-stock/
+  parse.ts`'s `fromJsonLd`) číta. `availability` je `BackOrder`, ZÁMERNE
+  (reálna hodnota zo živej stránky) — over, že sa mapuje na "Nedostupné"
+  (`SCHEMA_UNAVAILABLE` obsahuje "backorder"), nie na "Skladom".
+-->
+<html lang="sk">
+<head><title>DEERHUNTER Pro Gamekeeper Boot Trousers | wetland.sk</title></head>
+<body>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org/",
+    "@type": "Product",
+    "name": "DEERHUNTER Pro Gamekeeper Boot Trousers",
+    "sku": "3726-391",
+    "offers": {
+      "@type": "Offer",
+      "priceCurrency": "EUR",
+      "price": "149.9",
+      "availability": "https://schema.org/BackOrder"
+    }
+  }
+  </script>
+</body>
+</html>

--- a/apps/api/src/modules/pairing-search/live-detail-info.test.ts
+++ b/apps/api/src/modules/pairing-search/live-detail-info.test.ts
@@ -58,4 +58,48 @@ describe("createLiveSupplierInfoFetcher", () => {
     expect(fetcherA).toHaveBeenCalledTimes(1);
     expect(fetcherB).toHaveBeenCalledTimes(1);
   });
+
+  // issue 422 review nález (🟡) — appka beží ako dlhoživý kontajner, cache
+  // BEZ TTL by "živé" info navždy zamrazila na prvej hodnote/zlyhaní.
+  it("cache VYPRŠÍ po CACHE_TTL_MS (15 min) — ĎALŠIE volanie po vypršaní znova fetchne", async () => {
+    let currentTime = 0;
+    const fetcher = vi.fn<Fetcher>().mockResolvedValue(WETLAND_HTML);
+    const fetchInfo = createLiveSupplierInfoFetcher(clientWithFetcher(fetcher), { now: () => currentTime });
+
+    await fetchInfo("https://www.wetland.sk/nohavice/x-1");
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    currentTime = 10 * 60 * 1000; // 10 min neskôr — ešte v rámci TTL
+    await fetchInfo("https://www.wetland.sk/nohavice/x-1");
+    expect(fetcher).toHaveBeenCalledTimes(1); // stále z cache
+
+    currentTime = 15 * 60 * 1000 + 1; // presne za hranicou TTL
+    await fetchInfo("https://www.wetland.sk/nohavice/x-1");
+    expect(fetcher).toHaveBeenCalledTimes(2); // znova fetchnuté
+  });
+
+  it("cache VYPRŠÍ aj pre ZLYHANÝ výsledok — transientný sieťový výpadok sa nezamrazí navždy", async () => {
+    let currentTime = 0;
+    const fetcher = vi.fn<Fetcher>().mockRejectedValueOnce(new Error("timeout")).mockResolvedValueOnce(WETLAND_HTML);
+    const fetchInfo = createLiveSupplierInfoFetcher(clientWithFetcher(fetcher), { now: () => currentTime });
+
+    const first = await fetchInfo("https://www.wetland.sk/nohavice/x-1");
+    expect(first).toEqual({ price: null, availabilityText: null });
+
+    currentTime = 15 * 60 * 1000 + 1;
+    const second = await fetchInfo("https://www.wetland.sk/nohavice/x-1");
+    expect(second).toEqual({ price: "99.00", availabilityText: "Skladom" });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("URL mimo troch známych adaptérov ostáva cachovaná AJ PO CACHE_TTL_MS — žiadny nový fetch (štrukturálny fakt, nikdy sa nemení)", async () => {
+    let currentTime = 0;
+    const fetcher = vi.fn<Fetcher>().mockResolvedValue(WETLAND_HTML);
+    const fetchInfo = createLiveSupplierInfoFetcher(clientWithFetcher(fetcher), { now: () => currentTime });
+
+    await fetchInfo("https://e2e-dodavatel.example.com/produkt");
+    currentTime = 60 * 60 * 1000; // hodinu neskôr, ďaleko za TTL
+    await fetchInfo("https://e2e-dodavatel.example.com/produkt");
+    expect(fetcher).not.toHaveBeenCalled();
+  });
 });

--- a/apps/api/src/modules/pairing-search/live-detail-info.test.ts
+++ b/apps/api/src/modules/pairing-search/live-detail-info.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Fetcher } from "./client.js";
+import { SearchClient } from "./client.js";
+import { createLiveSupplierInfoFetcher } from "./live-detail-info.js";
+
+// issue 422 — orchestrácia (fetch cez SearchClient + dispatch cez adapter +
+// per-URL cache) je čistá funkcia, nikdy sa nedotýka skutočnej siete v
+// testoch — injektovaný `Fetcher` (rovnaký vzor ako `client.test.ts`).
+
+const WETLAND_HTML = `<script type="application/ld+json">{"@type":"Product","offers":{"@type":"Offer","price":"99.00","availability":"https://schema.org/InStock"}}</script>`;
+
+function clientWithFetcher(fetcher: Fetcher): SearchClient {
+  return new SearchClient({ fetcher });
+}
+
+describe("createLiveSupplierInfoFetcher", () => {
+  it("dispatchuje na WETLAND adaptéra pre URL patriacu jeho hostu a vráti extrahovanú metu", async () => {
+    const fetcher = vi.fn<Fetcher>().mockResolvedValue(WETLAND_HTML);
+    const fetchInfo = createLiveSupplierInfoFetcher(clientWithFetcher(fetcher));
+    const meta = await fetchInfo("https://www.wetland.sk/nohavice/x-1");
+    expect(meta).toEqual({ price: "99.00", availabilityText: "Skladom" });
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("URL mimo troch známych adaptérov vráti prázdnu metu BEZ akéhokoľvek fetchu", async () => {
+    const fetcher = vi.fn<Fetcher>().mockResolvedValue(WETLAND_HTML);
+    const fetchInfo = createLiveSupplierInfoFetcher(clientWithFetcher(fetcher));
+    const meta = await fetchInfo("https://e2e-dodavatel.example.com/produkt");
+    expect(meta).toEqual({ price: null, availabilityText: null });
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("druhé volanie na TÚ ISTÚ URL sa servíruje z cache — fetcher sa zavolá len raz", async () => {
+    const fetcher = vi.fn<Fetcher>().mockResolvedValue(WETLAND_HTML);
+    const fetchInfo = createLiveSupplierInfoFetcher(clientWithFetcher(fetcher));
+    await fetchInfo("https://www.wetland.sk/nohavice/x-1");
+    await fetchInfo("https://www.wetland.sk/nohavice/x-1");
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("zlyhaný fetch (sieťová chyba) degraduje na prázdnu metu, nikdy nevyhodí — a VÝSLEDOK SA TIEŽ CACHUJE (žiadny opakovaný fetch)", async () => {
+    const fetcher = vi.fn<Fetcher>().mockRejectedValue(new Error("timeout"));
+    const fetchInfo = createLiveSupplierInfoFetcher(clientWithFetcher(fetcher));
+    const meta = await fetchInfo("https://www.wetland.sk/nohavice/x-1");
+    expect(meta).toEqual({ price: null, availabilityText: null });
+    const again = await fetchInfo("https://www.wetland.sk/nohavice/x-1");
+    expect(again).toEqual({ price: null, availabilityText: null });
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("dve rôzne inštancie (dve rôzne createApp() volania) majú NEZÁVISLÚ cache", async () => {
+    const fetcherA = vi.fn<Fetcher>().mockResolvedValue(WETLAND_HTML);
+    const fetcherB = vi.fn<Fetcher>().mockResolvedValue(WETLAND_HTML);
+    const fetchInfoA = createLiveSupplierInfoFetcher(clientWithFetcher(fetcherA));
+    const fetchInfoB = createLiveSupplierInfoFetcher(clientWithFetcher(fetcherB));
+    await fetchInfoA("https://www.wetland.sk/nohavice/x-1");
+    await fetchInfoB("https://www.wetland.sk/nohavice/x-1");
+    expect(fetcherA).toHaveBeenCalledTimes(1);
+    expect(fetcherB).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/modules/pairing-search/live-detail-info.ts
+++ b/apps/api/src/modules/pairing-search/live-detail-info.ts
@@ -17,6 +17,25 @@ import type { SearchClient } from "./client.js";
 
 const EMPTY_META: SupplierDetailMeta = { price: null, availabilityText: null };
 
+// issue 422 review nález (🟡): appka beží ako dlhoživý kontajner (dni, nie
+// jeden request) — cache BEZ TTL by "živé" info navždy zamrazila na prvej
+// hodnote (aj prvom ZLYHANÍ), čo je presný opak toho, čo "živé" sľubuje.
+// 15 minút je kompromis: dosť dlho, aby prehliadanie/re-render toho istého
+// produktu počas JEDNEJ review relácie nikdy neopakovalo fetch (design
+// zámer, "re-renders don't re-fetch"), dosť krátko, aby sa cena/dostupnosť
+// naozaj obnovila naprieč dlhším behom appky.
+const CACHE_TTL_MS = 15 * 60 * 1000;
+
+interface CacheEntry {
+  readonly meta: SupplierDetailMeta;
+  readonly cachedAt: number;
+}
+
+export interface LiveSupplierInfoFetcherOptions {
+  /** Injektovateľné pre testy — nikdy skutočné `Date.now`. */
+  readonly now?: () => number;
+}
+
 /**
  * Factory (nie modul-level singleton) — `createApp`/testy volajú toto
  * PRESNE RAZ pri registrácii trás, takže cache je fresh per `createApp()`
@@ -25,31 +44,40 @@ const EMPTY_META: SupplierDetailMeta = { price: null, availabilityText: null };
  * neúspešných výsledkov (rovnaký princíp ako stará appka's diskový
  * `/api/images` cache, ktorý zapisoval aj prázdny výsledok pri zlyhaní) —
  * "cache responses ... so re-renders don't re-fetch" platí rovnako pre
- * "nič sa nenašlo" ako pre skutočný nález, inak by opakované otvorenie
- * panelu/re-render karty bez konca skúšalo ten istý zlyhávajúci fetch.
+ * "nič sa nenašlo" ako pre skutočný nález — ale s TTL (`CACHE_TTL_MS`
+ * vyššie), nikdy navždy (review nález #422).
+ *
+ * URL MIMO troch známych adaptérov (`adapterForUrl` vráti `undefined`) sa
+ * cachuje BEZ TTL — to je štrukturálny fakt o URL (jej host jednoducho
+ * nepatrí žiadnemu adaptérovi), nikdy sa nezmení, takže re-check po TTL by
+ * bol čistá réžia bez šance na iný výsledok.
  */
-export function createLiveSupplierInfoFetcher(client: SearchClient): (url: string) => Promise<SupplierDetailMeta> {
-  const cache = new Map<string, SupplierDetailMeta>();
+export function createLiveSupplierInfoFetcher(client: SearchClient, options: LiveSupplierInfoFetcherOptions = {}): (url: string) => Promise<SupplierDetailMeta> {
+  const now = options.now ?? Date.now;
+  const cache = new Map<string, CacheEntry>();
+  const unknownHostUrls = new Set<string>();
 
   return async (url: string): Promise<SupplierDetailMeta> => {
+    if (unknownHostUrls.has(url)) return EMPTY_META;
+
     const cached = cache.get(url);
-    if (cached !== undefined) return cached;
+    if (cached !== undefined && now() - cached.cachedAt < CACHE_TTL_MS) return cached.meta;
 
     const adapter = adapterForUrl(url);
     if (adapter === undefined) {
-      cache.set(url, EMPTY_META);
+      unknownHostUrls.add(url);
       return EMPTY_META;
     }
 
     try {
       const html = await client.fetchPage(url);
       const meta = adapter.extractDetailMeta(html);
-      cache.set(url, meta);
+      cache.set(url, { meta, cachedAt: now() });
       return meta;
     } catch (error) {
       const reason = error instanceof Error ? error.message : String(error);
       log.warn({ url, reason }, "pairing-review: živé info dodávateľa zlyhalo");
-      cache.set(url, EMPTY_META);
+      cache.set(url, { meta: EMPTY_META, cachedAt: now() });
       return EMPTY_META;
     }
   };

--- a/apps/api/src/modules/pairing-search/live-detail-info.ts
+++ b/apps/api/src/modules/pairing-search/live-detail-info.ts
@@ -1,0 +1,56 @@
+// issue 422 — "Živé ceny/dostupnosť" (dodávateľská strana): lazy live-fetch
+// analóg starej appky's `/api/images` endpointu. Sieťová hranica ide
+// VÝHRADNE cez `SearchClient.fetchPage` (zdieľaný cookie jar/warm-up/
+// throttle so `.search()` volaniami toho istého klienta, design komentár
+// na tickete) — NIKDY priamy `fetch`. Dispatch cez `adapterForUrl` (host
+// lookup) na jednu z troch dodávateľských extrakcií (`adapters/*.ts`'s
+// `extractDetailMeta`); URL mimo troch známych adaptérov degraduje TICHO
+// na "žiadne info", bez akéhokoľvek sieťového volania (zámerné zúženie
+// rozsahu, design komentár: `chosenCandidate`/top-8 panel kandidáti sú
+// VŽDY adaptérového pôvodu — jediný degradovaný prípad je zriedkavá plne
+// ručne zadaná linka od neznámeho dodávateľa).
+
+import { log } from "../../logger.js";
+import { adapterForUrl } from "./adapters/registry.js";
+import type { SupplierDetailMeta } from "./adapters/types.js";
+import type { SearchClient } from "./client.js";
+
+const EMPTY_META: SupplierDetailMeta = { price: null, availabilityText: null };
+
+/**
+ * Factory (nie modul-level singleton) — `createApp`/testy volajú toto
+ * PRESNE RAZ pri registrácii trás, takže cache je fresh per `createApp()`
+ * inštanciu (rovnaký princíp, aký integration testy už používajú pre
+ * KAŽDÝ ostatný stav v appke). Cache je kľúčovaná URL, VRÁTANE
+ * neúspešných výsledkov (rovnaký princíp ako stará appka's diskový
+ * `/api/images` cache, ktorý zapisoval aj prázdny výsledok pri zlyhaní) —
+ * "cache responses ... so re-renders don't re-fetch" platí rovnako pre
+ * "nič sa nenašlo" ako pre skutočný nález, inak by opakované otvorenie
+ * panelu/re-render karty bez konca skúšalo ten istý zlyhávajúci fetch.
+ */
+export function createLiveSupplierInfoFetcher(client: SearchClient): (url: string) => Promise<SupplierDetailMeta> {
+  const cache = new Map<string, SupplierDetailMeta>();
+
+  return async (url: string): Promise<SupplierDetailMeta> => {
+    const cached = cache.get(url);
+    if (cached !== undefined) return cached;
+
+    const adapter = adapterForUrl(url);
+    if (adapter === undefined) {
+      cache.set(url, EMPTY_META);
+      return EMPTY_META;
+    }
+
+    try {
+      const html = await client.fetchPage(url);
+      const meta = adapter.extractDetailMeta(html);
+      cache.set(url, meta);
+      return meta;
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      log.warn({ url, reason }, "pairing-review: živé info dodávateľa zlyhalo");
+      cache.set(url, EMPTY_META);
+      return EMPTY_META;
+    }
+  };
+}

--- a/apps/api/tests/helpers/pairing-review.ts
+++ b/apps/api/tests/helpers/pairing-review.ts
@@ -23,6 +23,13 @@ export async function seedPairingReviewProduct(
       readonly productVisibility?: string;
       readonly missingSince?: Date | null;
       readonly price?: string | null;
+      /** issue 422 — voliteľné, chýbajúce necháva DB default (`null`). */
+      readonly standardPrice?: string | null;
+      /** issue 422 — voliteľné, chýbajúce necháva pôvodné správanie (`0`). */
+      readonly stock?: number;
+      /** issue 422 — voliteľné explicitný text; chýbajúce necháva pôvodné
+       *  odvodenie zo `state` (Skladom/Vypredané). */
+      readonly availabilityText?: string;
     }[];
   },
 ): Promise<void> {
@@ -44,11 +51,15 @@ export async function seedPairingReviewProduct(
       guid: productKey,
       externalCode: v.externalCode ?? null,
       name: over.name,
+      // `variant_money_needs_currency_ck` (`.claude/rules/database.md`) —
+      // menu treba nastaviť VŽDY, keď je nastavená hociktorá cena.
+      currency: v.price !== undefined || v.standardPrice !== undefined ? "EUR" : null,
       price: v.price ?? null,
-      stock: 0,
+      standardPrice: v.standardPrice ?? null,
+      stock: v.stock ?? 0,
       availabilityInStockText: "Skladom",
       availabilityOutOfStockText: "Vypredané",
-      availabilityText: v.state === "out_of_stock" ? "Vypredané" : "Skladom",
+      availabilityText: v.availabilityText ?? (v.state === "out_of_stock" ? "Vypredané" : "Skladom"),
       productVisibility: v.productVisibility ?? "visible",
       state: v.state ?? "sellable",
       missingSince: v.missingSince ?? null,

--- a/apps/api/tests/pairing-review-http.integration.test.ts
+++ b/apps/api/tests/pairing-review-http.integration.test.ts
@@ -56,6 +56,10 @@ interface Telo {
     readonly productState: "sellable" | "out_of_stock" | "discontinued";
     readonly priceMin: string | null;
     readonly priceMax: string | null;
+    readonly standardPriceMin: string | null;
+    readonly standardPriceMax: string | null;
+    readonly stockTotal: number;
+    readonly availabilityText: string | null;
     readonly ourUrl: string;
     readonly ourUrlIsSearchFallback: boolean;
     readonly ourImageUrl: string | null;
@@ -317,4 +321,62 @@ it("total/gatheredTotal/linkedTotal sa počítajú nezávisle od pageSize", asyn
   const telo = (await (await app.request("/api/pairing-review?filter=unreviewed&page=1&pageSize=1", { headers: { cookie } })).json()) as Telo;
   expect(telo.total).toBe(2);
   expect(telo.items).toHaveLength(1);
+});
+
+// issue 422 — "naša strana": pôvodná (pred zľavou) cena, súčet zásoby,
+// dostupnostný text — rozšírenie `PairingReviewItem` o persistované polia
+// (žiadny live-fetch).
+it("issue 422: standardPriceMin/Max, stockTotal, availabilityText — jednoveľkostný produkt s pôvodnou cenou a skladom", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedProduct(db, snapshotId, "PR-CENA-1", {
+    name: "Produkt so zľavou",
+    variants: [{ code: "PR-CENA-1/1", price: "49.90", standardPrice: "59.90", stock: 3, availabilityText: "Skladom" }],
+  });
+  await seedCandidateSet(db, "PR-CENA-1");
+
+  const telo = (await (await app.request("/api/pairing-review?filter=all", { headers: { cookie } })).json()) as Telo;
+  const item = telo.items.find((i) => i.productKey === "PR-CENA-1");
+  expect(item?.priceMin).toBe("49.90");
+  expect(item?.standardPriceMin).toBe("59.90");
+  expect(item?.standardPriceMax).toBe("59.90");
+  expect(item?.stockTotal).toBe(3);
+  expect(item?.availabilityText).toBe("Skladom");
+});
+
+it("issue 422: viacveľkostný produkt — standardPrice/stock/availabilityText sa agregujú naprieč variantmi (min/max/súčet/distinct join)", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedProduct(db, snapshotId, "PR-CENA-2", {
+    name: "Produkt viac veľkostí",
+    variants: [
+      { code: "PR-CENA-2/S", price: "10.00", standardPrice: "12.00", stock: 2, availabilityText: "Skladom" },
+      { code: "PR-CENA-2/M", price: "10.00", standardPrice: "15.00", stock: 5, availabilityText: "Posledný kus" },
+    ],
+  });
+  await seedCandidateSet(db, "PR-CENA-2");
+
+  const telo = (await (await app.request("/api/pairing-review?filter=all", { headers: { cookie } })).json()) as Telo;
+  const item = telo.items.find((i) => i.productKey === "PR-CENA-2");
+  expect(item?.standardPriceMin).toBe("12.00");
+  expect(item?.standardPriceMax).toBe("15.00");
+  expect(item?.stockTotal).toBe(7);
+  expect(item?.availabilityText).toBe("Skladom / Posledný kus");
+});
+
+it("issue 422: bez pôvodnej ceny/zásoby/textu — všetky tri polia sú null/0/null, nikdy nevyhodí", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const snapshotId = await insertTestSnapshot(db);
+  await seedProduct(db, snapshotId, "PR-CENA-PRAZDNY", {
+    name: "Produkt bez cenových dát",
+    variants: [{ code: "PR-CENA-PRAZDNY/1", availabilityText: "" }],
+  });
+  await seedCandidateSet(db, "PR-CENA-PRAZDNY");
+
+  const telo = (await (await app.request("/api/pairing-review?filter=all", { headers: { cookie } })).json()) as Telo;
+  const item = telo.items.find((i) => i.productKey === "PR-CENA-PRAZDNY");
+  expect(item?.standardPriceMin).toBeNull();
+  expect(item?.standardPriceMax).toBeNull();
+  expect(item?.stockTotal).toBe(0);
+  expect(item?.availabilityText).toBeNull();
 });

--- a/apps/api/tests/pairing-review-live-supplier-info-http.integration.test.ts
+++ b/apps/api/tests/pairing-review-live-supplier-info-http.integration.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, expect, it } from "vitest";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import type { Fetcher } from "../src/modules/pairing-search/client.js";
+import { SearchClient } from "../src/modules/pairing-search/client.js";
+import { users } from "../src/db/schema.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 422 — "Živé ceny/dostupnosť": `GET /api/pairing-review/live-
+// supplier-info`. Injektovaný `Fetcher` (nikdy skutočná sieť, `.claude/
+// rules/pairing-search.md`'s zavedená disciplína — testy nikdy nechodia na
+// dodávateľskú stránku naozaj) vracia fixture HTML podľa URL.
+
+const HESLO = "test-heslo-abc"; // testovacie údaje, nie tajomstvo
+
+const WETLAND_JSON_LD = `<html><body><script type="application/ld+json">
+{"@type":"Product","offers":{"@type":"Offer","priceCurrency":"EUR","price":"149.9","availability":"https://schema.org/BackOrder"}}
+</script></body></html>`;
+
+const BETALOV_PRODDATA = `<html><body><script>
+var prodData = {"item_name":"x","price":36.5,"is_item_in_stock":1};
+</script></body></html>`;
+
+let close: (() => Promise<void>) | undefined;
+
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  resetLoginRateLimit();
+});
+
+async function boot(fetcher: Fetcher) {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await ctx.db.insert(users).values({ email: "manazer@forestshop.sk", passwordHash: await hashPassword(HESLO), displayName: "Manažér", role: "citanie" });
+
+  const app = createApp(ctx.db, { cookieSecure: false, pairingSearchClient: new SearchClient({ fetcher }) });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "manazer@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie };
+}
+
+it("bez prihlásenia vráti 401", async () => {
+  const { app } = await boot(() => Promise.resolve(""));
+  expect((await app.request("/api/pairing-review/live-supplier-info?url=https://www.wetland.sk/x")).status).toBe(401);
+});
+
+it("WETLAND URL (adaptér podľa hosta) — vráti price+availabilityText z JSON-LD Offer fixtúry", async () => {
+  const { app, cookie } = await boot(() => Promise.resolve(WETLAND_JSON_LD));
+  const res = await app.request("/api/pairing-review/live-supplier-info?url=https://www.wetland.sk/nohavice/x-1", { headers: { cookie } });
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ price: "149.90", availabilityText: "Nedostupné" });
+});
+
+it("BETALOV (huntingshop.eu) URL — vráti price+availabilityText z prodData fixtúry", async () => {
+  const { app, cookie } = await boot(() => Promise.resolve(BETALOV_PRODDATA));
+  const res = await app.request("/api/pairing-review/live-supplier-info?url=https://www.huntingshop.eu/nohavice-1", { headers: { cookie } });
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ price: "36.50", availabilityText: "Skladom" });
+});
+
+it("URL mimo troch známych adaptérov — vráti price:null/availabilityText:null, BEZ akéhokoľvek volania fetchera", async () => {
+  let calls = 0;
+  const { app, cookie } = await boot(() => {
+    calls += 1;
+    return Promise.resolve(WETLAND_JSON_LD);
+  });
+  const res = await app.request("/api/pairing-review/live-supplier-info?url=https://e2e-dodavatel.example.com/produkt", { headers: { cookie } });
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ price: null, availabilityText: null });
+  expect(calls).toBe(0);
+});
+
+it("zlyhaný fetch (sieťová chyba) degraduje na 200 s price:null/availabilityText:null, nikdy 500", async () => {
+  const { app, cookie } = await boot(() => Promise.reject(new Error("timeout")));
+  const res = await app.request("/api/pairing-review/live-supplier-info?url=https://www.wetland.sk/nohavice/x-1", { headers: { cookie } });
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ price: null, availabilityText: null });
+});
+
+it("nevalidná (nie http/https) URL vráti 400", async () => {
+  const { app, cookie } = await boot(() => Promise.resolve(WETLAND_JSON_LD));
+  const res = await app.request("/api/pairing-review/live-supplier-info?url=nie-je-to-url", { headers: { cookie } });
+  expect(res.status).toBe(400);
+});

--- a/apps/web/src/components/PairingReviewCard.liveInfo.test.tsx
+++ b/apps/web/src/components/PairingReviewCard.liveInfo.test.tsx
@@ -1,0 +1,143 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { PairingReviewCard } from "./PairingReviewCard.js";
+
+// issue 422 — vyčlenené OD `PairingReviewCard.test.tsx` (eslint `max-lines:
+// 400`, `.claude/rules/testing.md`'s zavedený vzor "component/test file
+// that grows past the cap gets a thematically-coherent block extracted
+// into its own file", napr. `orders-http.integration.test.ts`/`orders-
+// http-state.integration.test.ts`): 🤖 AI zdôvodnenie zhody (gap 1) + "naša
+// strana" cena/sklad/dostupnosť (gap 2, persistované) + živá cena/
+// dostupnosť dodávateľa (gap 2, lazy-fetch cez `useLiveSupplierInfo`,
+// mockovaná cez `fetchLiveSupplierInfo`).
+
+const { fetchPairingCandidates, sendPairingDecision, fetchPairingVariantLinks, savePairingVariantLink, fetchLiveSupplierInfo } = vi.hoisted(() => ({
+  fetchPairingCandidates: vi.fn(),
+  sendPairingDecision: vi.fn(),
+  fetchPairingVariantLinks: vi.fn(),
+  savePairingVariantLink: vi.fn(),
+  fetchLiveSupplierInfo: vi.fn(),
+}));
+
+vi.mock("../pairingReviewApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../pairingReviewApi.js")>();
+  return { ...actual, fetchPairingCandidates, sendPairingDecision, fetchPairingVariantLinks, savePairingVariantLink, fetchLiveSupplierInfo };
+});
+
+const MATCHED_ITEM = {
+  productKey: "PR-LI-1",
+  productName: "Bunda Alfa Zimná",
+  supplier: "DODAVATEL-PR",
+  externalCodes: ["KOD-123"],
+  variantCount: 2,
+  productState: "sellable" as const,
+  priceMin: "59.90",
+  priceMax: "64.90",
+  currency: "EUR",
+  standardPriceMin: "59.90",
+  standardPriceMax: "64.90",
+  stockTotal: 0,
+  availabilityText: null,
+  ourUrl: "https://www.forestshop.sk/bunda-alfa",
+  ourUrlIsSearchFallback: false,
+  ourImageUrl: "https://www.forestshop.sk/img/bunda.jpg",
+  hasEffectiveLink: false,
+  supplierHasAdapter: true,
+  gatheredAt: "2026-08-13T03:35:00.000Z",
+  confidence: "high" as const,
+  chosenReason: "najlepší nájdený",
+  verdict: "ok" as const,
+  chosenCandidate: {
+    name: "Bunda Alfa",
+    url: "https://dodavatel.example.com/bunda-alfa",
+    imageUrl: "https://dodavatel.example.com/img/bunda-alfa.jpg",
+    rawScore: 1080.5,
+    codeHit: true,
+  },
+  decision: null,
+};
+
+const UNMATCHED_ITEM = { ...MATCHED_ITEM, productKey: "PR-LI-2", chosenCandidate: null, confidence: "none" as const, verdict: null };
+
+beforeEach(() => {
+  fetchLiveSupplierInfo.mockResolvedValue({ price: null, availabilityText: null });
+  // UNMATCHED_ITEM (chosenCandidate === null) auto-otvára panel kandidátov
+  // (`PairingReviewCard.tsx`'s `autoShowsPanel` useEffect) — bez tohto by
+  // `fetchPairingCandidates(...)` vrátilo `undefined` (holý `vi.fn()`) a
+  // `.then()` naň by zhodilo test (rovnaký vzor ako `PairingReviewCard
+  // .test.tsx`'s existujúce testy nad nenapárovanými položkami).
+  fetchPairingCandidates.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+it("chosenReason !== null pri navrhnutom kandidátovi -> zobrazí '🤖 <reason>'", async () => {
+  render(<PairingReviewCard item={MATCHED_ITEM} role="citanie" onDecided={() => {}} onSessionExpired={() => {}} />);
+  expect((await screen.findByTestId("pairing-review-reason-PR-LI-1")).textContent).toBe("🤖 najlepší nájdený");
+});
+
+it("chosenCandidate === null (nenapárované) -> ŽIADNY '🤖' riadok, aj keby chosenReason nejako niesol hodnotu", async () => {
+  // Štrukturálne chosenReason je pre nenapárované VŽDY null (design komentár
+  // na tickete #422), ale komponent to overuje explicitne cez podmienku na
+  // chosenCandidate, nie len na chosenReason — tento test to dokazuje
+  // priamo aj pri (neplatnom, ale teoreticky možnom) nesúlade dát.
+  const item = { ...UNMATCHED_ITEM, chosenReason: "toto sa v appke reálne nikdy nestane" };
+  render(<PairingReviewCard item={item} role="citanie" onDecided={() => {}} onSessionExpired={() => {}} />);
+  await screen.findByTestId("pairing-review-card-PR-LI-2");
+  expect(screen.queryByTestId("pairing-review-reason-PR-LI-2")).toBeNull();
+});
+
+it("chosenReason === null pri navrhnutom kandidátovi -> žiadny '🤖' riadok", async () => {
+  const item = { ...MATCHED_ITEM, chosenReason: null };
+  render(<PairingReviewCard item={item} role="citanie" onDecided={() => {}} onSessionExpired={() => {}} />);
+  await screen.findByTestId("pairing-review-candidate-PR-LI-1");
+  expect(screen.queryByTestId("pairing-review-reason-PR-LI-1")).toBeNull();
+});
+
+it("'naša strana': standardPriceMin/Max sa líši od priceMin/Max -> ukáže 'pôv. X–Y €'; stockTotal>0 + availabilityText -> ukáže sklad+text", async () => {
+  const item = { ...MATCHED_ITEM, standardPriceMin: "69.90", standardPriceMax: "74.90", stockTotal: 4, availabilityText: "Skladom" };
+  render(<PairingReviewCard item={item} role="citanie" onDecided={() => {}} onSessionExpired={() => {}} />);
+  const karta = await screen.findByTestId("pairing-review-card-PR-LI-1");
+  expect(karta.textContent).toContain("pôv. 69.90–74.90 €");
+  expect(screen.getByTestId("pairing-review-stock-PR-LI-1").textContent).toContain("sklad: 4 ks");
+  expect(screen.getByTestId("pairing-review-stock-PR-LI-1").textContent).toContain("Skladom");
+});
+
+it("'naša strana': standardPriceMin/Max ROVNAKÉ ako priceMin/Max (žiadna zľava) -> 'pôv.' sa NEUKÁŽE", async () => {
+  render(<PairingReviewCard item={MATCHED_ITEM} role="citanie" onDecided={() => {}} onSessionExpired={() => {}} />);
+  const karta = await screen.findByTestId("pairing-review-card-PR-LI-1");
+  expect(karta.textContent).not.toContain("pôv.");
+});
+
+it("'naša strana': stockTotal===0 A availabilityText===null -> ŽIADEN sklad riadok vôbec", async () => {
+  render(<PairingReviewCard item={MATCHED_ITEM} role="citanie" onDecided={() => {}} onSessionExpired={() => {}} />);
+  await screen.findByTestId("pairing-review-card-PR-LI-1");
+  expect(screen.queryByTestId("pairing-review-stock-PR-LI-1")).toBeNull();
+});
+
+it("živá cena/dostupnosť dodávateľa: fetchLiveSupplierInfo vráti hodnotu -> zobrazí sa vedľa navrhnutého kandidáta, s VOLANÍM presnej candidate URL", async () => {
+  fetchLiveSupplierInfo.mockResolvedValue({ price: "54.90", availabilityText: "Skladom" });
+  render(<PairingReviewCard item={MATCHED_ITEM} role="citanie" onDecided={() => {}} onSessionExpired={() => {}} />);
+  const liveInfo = await screen.findByTestId("pairing-review-live-info-PR-LI-1");
+  expect(liveInfo.textContent).toContain("54.90 €");
+  expect(liveInfo.textContent).toContain("Skladom");
+  expect(fetchLiveSupplierInfo).toHaveBeenCalledWith("https://dodavatel.example.com/bunda-alfa");
+});
+
+it("živá cena/dostupnosť dodávateľa: fetchLiveSupplierInfo vráti null/null (tichá degradácia) -> ŽIADEN riadok, žiadna chyba", async () => {
+  render(<PairingReviewCard item={MATCHED_ITEM} role="citanie" onDecided={() => {}} onSessionExpired={() => {}} />);
+  await screen.findByTestId("pairing-review-candidate-PR-LI-1");
+  await waitFor(() => {
+    expect(fetchLiveSupplierInfo).toHaveBeenCalled();
+  });
+  expect(screen.queryByTestId("pairing-review-live-info-PR-LI-1")).toBeNull();
+});
+
+it("chosenCandidate === null -> fetchLiveSupplierInfo sa VÔBEC nevolá (žiadna URL na fetchnutie)", async () => {
+  render(<PairingReviewCard item={UNMATCHED_ITEM} role="citanie" onDecided={() => {}} onSessionExpired={() => {}} />);
+  await screen.findByTestId("pairing-review-card-PR-LI-2");
+  expect(fetchLiveSupplierInfo).not.toHaveBeenCalled();
+});

--- a/apps/web/src/components/PairingReviewCard.test.tsx
+++ b/apps/web/src/components/PairingReviewCard.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { afterEach, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { PairingReviewCard } from "./PairingReviewCard.js";
 
 // issue 387 E6 — rozhodovacia UX karty (`.claude/rules/frontend-design.md`'s
@@ -10,11 +10,12 @@ import { PairingReviewCard } from "./PairingReviewCard.js";
 // issue 398/401/409 — testy prerobené na novú UX (žiadne "✗ Zlé", priamy
 // riadok ✓ Dobré/„vyber url"/📦/🚫, adapterless hláška, obrázky v paneli).
 
-const { fetchPairingCandidates, sendPairingDecision, fetchPairingVariantLinks, savePairingVariantLink } = vi.hoisted(() => ({
+const { fetchPairingCandidates, sendPairingDecision, fetchPairingVariantLinks, savePairingVariantLink, fetchLiveSupplierInfo } = vi.hoisted(() => ({
   fetchPairingCandidates: vi.fn(),
   sendPairingDecision: vi.fn(),
   fetchPairingVariantLinks: vi.fn(),
   savePairingVariantLink: vi.fn(),
+  fetchLiveSupplierInfo: vi.fn(),
 }));
 
 // `PairingReviewUnauthorizedError` ostáva SKUTOČNÁ trieda (rovnaký dôvod ako
@@ -23,9 +24,13 @@ const { fetchPairingCandidates, sendPairingDecision, fetchPairingVariantLinks, s
 // TU, lebo `PairingReviewCard` vykresľuje `PairingReviewSplitPanel` priamo
 // (rovnaký modul, rovnaký mock) — `PairingReviewSplitPanel` samo nemá
 // vlastný test súbor, jeho pokrytie je celé cez tento súbor.
+// issue 422 — `fetchLiveSupplierInfo` mockovaný TU (nie priamo v
+// `useLiveSupplierInfo.ts`), lebo `useLiveSupplierInfo` importuje z TOHTO
+// modulu — mock celého `pairingReviewApi.js` pokrýva aj hook bez
+// samostatného `vi.mock` na hook súbor.
 vi.mock("../pairingReviewApi.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../pairingReviewApi.js")>();
-  return { ...actual, fetchPairingCandidates, sendPairingDecision, fetchPairingVariantLinks, savePairingVariantLink };
+  return { ...actual, fetchPairingCandidates, sendPairingDecision, fetchPairingVariantLinks, savePairingVariantLink, fetchLiveSupplierInfo };
 });
 
 const { PairingReviewUnauthorizedError } = await import("../pairingReviewApi.js");
@@ -40,6 +45,13 @@ const MATCHED_ITEM = {
   priceMin: "59.90",
   priceMax: "64.90",
   currency: "EUR",
+  // issue 422 — "naša strana" (persistované). `standardPriceMin/Max` sa
+  // ZÁMERNE zhoduje s `priceMin/Max` v tomto základnom fixture (žiadna
+  // zľava) — vlastný test nižšie prepíše na inú hodnotu.
+  standardPriceMin: "59.90",
+  standardPriceMax: "64.90",
+  stockTotal: 0,
+  availabilityText: null,
   ourUrl: "https://www.forestshop.sk/bunda-alfa",
   ourUrlIsSearchFallback: false,
   ourImageUrl: "https://www.forestshop.sk/img/bunda.jpg",
@@ -89,6 +101,14 @@ const DECIDED_GOOD_ITEM = {
   hasEffectiveLink: true,
   decision: { status: "good" as const, url: "https://dodavatel.example.com/bunda-alfa", decidedAt: "2026-08-13T04:00:00.000Z" },
 };
+
+// issue 422 — bezpečný default pre KAŽDÝ test (žiadne live info), ak si ho
+// konkrétny test výslovne nepreklopí vlastnou hodnotou — `resetAllMocks()`
+// v `afterEach` niže vymaže implementáciu, takže sa musí nastaviť znova PRED
+// KAŽDÝM testom, nie len raz pri module-load.
+beforeEach(() => {
+  fetchLiveSupplierInfo.mockResolvedValue({ price: null, availabilityText: null });
+});
 
 afterEach(() => {
   cleanup();
@@ -472,3 +492,4 @@ it("produkt UŽ rozdelený (decision.status==='split') ukáže odznak + editor p
   expect(screen.getByTestId("pairing-review-split-cancel-PR-5")).toBeDefined();
   expect(screen.queryByTestId("pairing-review-split-done-PR-5")).toBeNull();
 });
+

--- a/apps/web/src/components/PairingReviewCard.tsx
+++ b/apps/web/src/components/PairingReviewCard.tsx
@@ -9,8 +9,9 @@ import {
   type PairingReviewCandidate,
   type PairingReviewItem,
 } from "../pairingReviewApi.js";
+import { useLiveSupplierInfo } from "../useLiveSupplierInfo.js";
 import { PairingReviewDecisionPanel } from "./PairingReviewDecisionPanel.js";
-import { TerminalButtons } from "./PairingReviewPanelParts.js";
+import { ChosenCandidateExtras, TerminalButtons } from "./PairingReviewPanelParts.js";
 import { PairingReviewSplitPanel } from "./PairingReviewSplitPanel.js";
 
 // issue 387 E5: karta jedného produktu, vyčlenená VOPRED z `PairingReviewSection.tsx`
@@ -75,6 +76,18 @@ function formatPriceRange(item: PairingReviewItem): string | null {
   return `${item.priceMin}–${item.priceMax}${currencySuffix}`;
 }
 
+// issue 422 — pôvodná (pred zľavou) cena, rovnaká rozsahová logika ako
+// vyššie. Ukáže sa LEN keď sa naozaj líši od priceMin/priceMax (rovnaký
+// princíp ako stará appka's `cp.std !== cp.price`) — inak by na
+// nezľavnenom produkte ukazovala tú istú cenu dvakrát.
+function formatStandardPriceRange(item: PairingReviewItem): string | null {
+  if (item.standardPriceMin === null || item.standardPriceMax === null) return null;
+  if (item.standardPriceMin === item.priceMin && item.standardPriceMax === item.priceMax) return null;
+  const currencySuffix = item.currency !== null && item.currency !== "" && item.currency !== "EUR" ? ` ${item.currency}` : " €";
+  if (item.standardPriceMin === item.standardPriceMax) return `${item.standardPriceMin}${currencySuffix}`;
+  return `${item.standardPriceMin}–${item.standardPriceMax}${currencySuffix}`;
+}
+
 export function PairingReviewCard({
   item,
   role,
@@ -87,8 +100,14 @@ export function PairingReviewCard({
   readonly onSessionExpired: () => void;
 }): JSX.Element {
   const priceRange = formatPriceRange(item);
+  const standardPriceRange = formatStandardPriceRange(item);
   const codes = item.externalCodes.length > 0 ? item.externalCodes.join(", ") : "—";
   const canEdit = CAN_EDIT_ROLES.has(role);
+
+  // issue 422 — živá cena+dostupnosť dodávateľa pre navrhnutého kandidáta
+  // (lazy, mountnutá spolu s kartou — `useLiveSupplierInfo.ts`'s vlastný
+  // concurrency-cap chráni pred burstom N súbežných fetchov).
+  const liveSupplierInfo = useLiveSupplierInfo(item.chosenCandidate?.url ?? null);
 
   const [panelOpen, setPanelOpen] = useState(false);
   const [candidates, setCandidates] = useState<readonly PairingReviewCandidate[] | null>(null);
@@ -247,7 +266,19 @@ export function PairingReviewCard({
           >
             {STATE_LABELS[item.productState]}
           </span>
-          {priceRange !== null && <div className="pairing-review-price">💶 {priceRange}</div>}
+          {priceRange !== null && (
+            <div className="pairing-review-price">
+              💶 {priceRange}
+              {standardPriceRange !== null && <span className="pairing-review-price-original"> · pôv. {standardPriceRange}</span>}
+            </div>
+          )}
+          {(item.stockTotal > 0 || item.availabilityText !== null) && (
+            <div className="pairing-review-stock" data-testid={`pairing-review-stock-${item.productKey}`}>
+              {item.stockTotal > 0 && <>sklad: {item.stockTotal} ks</>}
+              {item.stockTotal > 0 && item.availabilityText !== null && " · "}
+              {item.availabilityText}
+            </div>
+          )}
           <div className="pairing-review-imgbox">
             {item.ourImageUrl !== null ? (
               <img src={item.ourImageUrl} alt={item.productName} loading="lazy" />
@@ -320,6 +351,7 @@ export function PairingReviewCard({
                       {VERDICT_LABELS[item.verdict]}
                     </div>
                   )}
+                  <ChosenCandidateExtras productKey={item.productKey} chosenReason={item.chosenReason} liveInfo={liveSupplierInfo} />
                   <div className="pairing-review-imgbox">
                     {item.chosenCandidate.imageUrl !== null ? (
                       <img src={item.chosenCandidate.imageUrl} alt={item.chosenCandidate.name} loading="lazy" />

--- a/apps/web/src/components/PairingReviewPanelParts.test.tsx
+++ b/apps/web/src/components/PairingReviewPanelParts.test.tsx
@@ -1,12 +1,23 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, expect, it, vi } from "vitest";
-import { PanelCandidateRow, TerminalButtons } from "./PairingReviewPanelParts.js";
+import type { LiveSupplierInfo } from "../pairingReviewApi.js";
+import { ChosenCandidateExtras, PanelCandidateRow, TerminalButtons } from "./PairingReviewPanelParts.js";
 
 // issue 398/409 review nález (🔵) — `PairingReviewPanelParts.tsx` je extrahovaný
 // súbor bez VLASTNÉHO test súboru (repo's zavedený vzor pre takéto extrakcie,
 // napr. `OrderLineRow.*.test.tsx`); správanie bolo dovtedy pokryté len
-// nepriamo cez `PairingReviewCard.test.tsx`. Tento súbor testuje OBIDVE
+// nepriamo cez `PairingReviewCard.test.tsx`. Tento súbor testuje VŠETKY tri
 // zložky v izolácii, s vlastnými (nie karta-odvodenými) props.
+//
+// issue 422 — `PanelCandidateRow` odteraz samo volá `useLiveSupplierInfo`
+// (živá cena/dostupnosť) — mockované TU (default neutrálna hodnota, per-test
+// prepísateľná cez `useLiveSupplierInfo.mockReturnValue(...)`), aby žiaden
+// test v tomto súbore nespúšťal reálny `fetch()` (aj keď by ho
+// `fetchLiveSupplierInfo`'s vlastný try/catch aj tak ticho zhltol).
+const { useLiveSupplierInfo } = vi.hoisted(() => ({
+  useLiveSupplierInfo: vi.fn<(url: string | null) => LiveSupplierInfo>(() => ({ price: null, availabilityText: null })),
+}));
+vi.mock("../useLiveSupplierInfo.js", () => ({ useLiveSupplierInfo }));
 
 const CANDIDATE = {
   name: "Top kandidát",
@@ -70,4 +81,30 @@ it("PanelCandidateRow: text ukazuje meno, URL aj '(kód sedí)' len keď codeHit
 it("PanelCandidateRow: busy=true disabluje tlačidlo 'Vybrať'", () => {
   render(<PanelCandidateRow candidate={CANDIDATE} index={0} busy={true} submit={vi.fn()} productKey="PR-X" />);
   expect(screen.getByTestId<HTMLButtonElement>("pairing-review-panel-pick-PR-X-0").disabled).toBe(true);
+});
+
+// issue 422 — živá cena/dostupnosť na riadku panelu.
+it("PanelCandidateRow: useLiveSupplierInfo vráti hodnotu -> zobrazí sa na riadku, volaná s presnou candidate.url", () => {
+  useLiveSupplierInfo.mockReturnValue({ price: "22.00", availabilityText: "Skladom" });
+  render(<PanelCandidateRow candidate={CANDIDATE} index={3} busy={false} submit={vi.fn()} productKey="PR-X" />);
+  const live = screen.getByTestId("pairing-review-panel-live-info-PR-X-3");
+  expect(live.textContent).toContain("22.00 €");
+  expect(live.textContent).toContain("Skladom");
+  expect(useLiveSupplierInfo).toHaveBeenCalledWith(CANDIDATE.url);
+  useLiveSupplierInfo.mockReturnValue({ price: null, availabilityText: null }); // vráti default pre ďalšie testy
+});
+
+// issue 422 — ChosenCandidateExtras (🤖 zdôvodnenie + živá cena/dostupnosť).
+it("ChosenCandidateExtras: chosenReason !== null -> '🤖 <reason>'; oboje null v liveInfo -> žiadny live-info riadok", () => {
+  render(<ChosenCandidateExtras productKey="PR-X" chosenReason="zhoda mena (85 %)" liveInfo={{ price: null, availabilityText: null }} />);
+  expect(screen.getByTestId("pairing-review-reason-PR-X").textContent).toBe("🤖 zhoda mena (85 %)");
+  expect(screen.queryByTestId("pairing-review-live-info-PR-X")).toBeNull();
+});
+
+it("ChosenCandidateExtras: chosenReason === null -> žiadny '🤖' riadok; liveInfo s hodnotou -> zobrazí ju", () => {
+  render(<ChosenCandidateExtras productKey="PR-X" chosenReason={null} liveInfo={{ price: "12.50", availabilityText: "Nedostupné" }} />);
+  expect(screen.queryByTestId("pairing-review-reason-PR-X")).toBeNull();
+  const live = screen.getByTestId("pairing-review-live-info-PR-X");
+  expect(live.textContent).toContain("12.50 €");
+  expect(live.textContent).toContain("Nedostupné");
 });

--- a/apps/web/src/components/PairingReviewPanelParts.tsx
+++ b/apps/web/src/components/PairingReviewPanelParts.tsx
@@ -112,7 +112,12 @@ export function PanelCandidateRow({
           <span className="pairing-review-noimg">bez obrázka</span>
         )}
       </div>
-      <span className="pairing-review-panel-candidate-text">
+      {/* issue 422 review nález (🔵) — `<div>` (blokový obsah) vnútri `<span>`
+          (len frázový obsah podľa HTML5 špecifikácie) je neplatný markup —
+          prehliadače to vykreslia bez viditeľnej chyby, ale a11y/HTML
+          validátor by to nahlásil. Obalový prvok je odteraz `<div>` (CSS
+          `flex: 1 1 auto` naň už aj tak pôsobí ako na blokový prvok). */}
+      <div className="pairing-review-panel-candidate-text">
         <span>
           {candidate.name}: {candidate.url}
           {candidate.codeHit && " (kód sedí)"}
@@ -124,7 +129,7 @@ export function PanelCandidateRow({
             {liveInfo.availabilityText}
           </div>
         )}
-      </span>
+      </div>
       <button
         type="button"
         className="btn good sm"

--- a/apps/web/src/components/PairingReviewPanelParts.tsx
+++ b/apps/web/src/components/PairingReviewPanelParts.tsx
@@ -1,13 +1,16 @@
 import type { JSX } from "react";
-import type { PairingDecisionAction, PairingReviewCandidate } from "../pairingReviewApi.js";
+import type { LiveSupplierInfo, PairingDecisionAction, PairingReviewCandidate } from "../pairingReviewApi.js";
+import { useLiveSupplierInfo } from "../useLiveSupplierInfo.js";
 
-// issue 398/409 — vyčlenené z `PairingReviewCard.tsx` (eslint `max-lines: 400`,
+// issue 398/409/422 — vyčlenené z `PairingReviewCard.tsx` (eslint `max-lines: 400`,
 // `.claude/rules/frontend-design.md`'s zavedený vzor "component file that grows
-// past the cap gets its repeated per-item rendering unit extracted"). Dve malé,
-// bezstavové zložky zdieľané DVOMA miestami v `PairingReviewCard.tsx`:
+// past the cap gets its repeated per-item rendering unit extracted"). Malé,
+// bezstavové zložky zdieľané s `PairingReviewCard.tsx`:
 // `TerminalButtons` (priamy riadok na karte AJ panel — vzájomne vylučujúce v
-// DOM-e, zdieľajú testid) a `PanelCandidateRow` (jeden riadok top-8 zoznamu v
-// rozbaľovacom paneli, teraz s obrázkom kandidáta — issue 409).
+// DOM-e, zdieľajú testid), `PanelCandidateRow` (jeden riadok top-8 zoznamu v
+// rozbaľovacom paneli, s obrázkom kandidáta — issue 409 — a živou cenou/
+// dostupnosťou — issue 422) a `ChosenCandidateExtras` (🤖 AI zdôvodnenie +
+// živá cena/dostupnosť navrhnutého kandidáta na karte, issue 422).
 
 export function TerminalButtons({
   busy,
@@ -48,6 +51,41 @@ export function TerminalButtons({
   );
 }
 
+// issue 422 — 🤖 AI zdôvodnenie zhody + živá cena/dostupnosť dodávateľa pre
+// navrhnutého kandidáta na karte. Vyčlenené (nie priamo v `PairingReviewCard
+// .tsx`) len kvôli `max-lines: 400` — `liveInfo` je hook výsledok z rodiča
+// (`useLiveSupplierInfo` sa volá LEN RAZ na kartu, nie tu znova), táto zložka
+// je čisto presentational. `chosenReason` je LEN vedľa navrhnutého kandidáta
+// (rovnaká podmienka ako stará appka's `showReason && ai_status ===
+// 'matched'`) — nikdy pre nenapárované produkty (`chosenReason` je preň
+// štrukturálne vždy `null`, design komentár na tickete #422).
+export function ChosenCandidateExtras({
+  productKey,
+  chosenReason,
+  liveInfo,
+}: {
+  readonly productKey: string;
+  readonly chosenReason: string | null;
+  readonly liveInfo: LiveSupplierInfo;
+}): JSX.Element {
+  return (
+    <>
+      {chosenReason !== null && (
+        <div className="pairing-review-reason" data-testid={`pairing-review-reason-${productKey}`}>
+          🤖 {chosenReason}
+        </div>
+      )}
+      {(liveInfo.price !== null || liveInfo.availabilityText !== null) && (
+        <div className="pairing-review-supplier-live" data-testid={`pairing-review-live-info-${productKey}`}>
+          {liveInfo.price !== null && <>💶 {liveInfo.price} €</>}
+          {liveInfo.price !== null && liveInfo.availabilityText !== null && " · "}
+          {liveInfo.availabilityText}
+        </div>
+      )}
+    </>
+  );
+}
+
 export function PanelCandidateRow({
   candidate,
   index,
@@ -61,6 +99,10 @@ export function PanelCandidateRow({
   readonly submit: (action: PairingDecisionAction) => void;
   readonly productKey: string;
 }): JSX.Element {
+  // issue 422 — každý riadok panelu je NEZÁVISLE mountnutý (rovnaký zámer
+  // ako karta) — `useLiveSupplierInfo`'s modul-level concurrency fronta
+  // chráni pred burstom, keď sa panel s top-8 kandidátmi otvorí naraz.
+  const liveInfo = useLiveSupplierInfo(candidate.url);
   return (
     <div className="pairing-review-panel-candidate">
       <div className="pairing-review-panel-candidate-imgbox">
@@ -71,8 +113,17 @@ export function PanelCandidateRow({
         )}
       </div>
       <span className="pairing-review-panel-candidate-text">
-        {candidate.name}: {candidate.url}
-        {candidate.codeHit && " (kód sedí)"}
+        <span>
+          {candidate.name}: {candidate.url}
+          {candidate.codeHit && " (kód sedí)"}
+        </span>
+        {(liveInfo.price !== null || liveInfo.availabilityText !== null) && (
+          <div className="pairing-review-panel-candidate-live" data-testid={`pairing-review-panel-live-info-${productKey}-${String(index)}`}>
+            {liveInfo.price !== null && <>💶 {liveInfo.price} €</>}
+            {liveInfo.price !== null && liveInfo.availabilityText !== null && " · "}
+            {liveInfo.availabilityText}
+          </div>
+        )}
       </span>
       <button
         type="button"

--- a/apps/web/src/pairingReviewApi.ts
+++ b/apps/web/src/pairingReviewApi.ts
@@ -39,6 +39,12 @@ const itemSchema = z.object({
   priceMin: z.string().nullable(),
   priceMax: z.string().nullable(),
   currency: z.string().nullable(),
+  // issue 422 — "naša strana": pôvodná (pred zľavou) cena, súčet zásoby,
+  // dostupnostný text (persistované, žiadny live-fetch).
+  standardPriceMin: z.string().nullable(),
+  standardPriceMax: z.string().nullable(),
+  stockTotal: z.number(),
+  availabilityText: z.string().nullable(),
   ourUrl: z.string(),
   ourUrlIsSearchFallback: z.boolean(),
   ourImageUrl: z.string().nullable(),
@@ -181,4 +187,24 @@ export async function savePairingVariantLink(productKey: string, code: string, u
     body: JSON.stringify({ code, url }),
   });
   await readJson(response, "Uloženie linku sa nepodarilo");
+}
+
+// issue 422 — "Živé ceny/dostupnosť" dodávateľa (lazy, na viditeľnosť karty/
+// otvorenie panelu). `null`/`null` = žiadne info (neznáma doména, sieťová
+// chyba, alebo ešte nenačítané) — TICHO, NIKDY sa nehádže: quiet-failure
+// požiadavka ticketu (žiadna konzolová chyba pri zlyhanom/neexistujúcom
+// live-info).
+const liveSupplierInfoSchema = z.object({ price: z.string().nullable(), availabilityText: z.string().nullable() });
+export type LiveSupplierInfo = z.infer<typeof liveSupplierInfoSchema>;
+export const EMPTY_LIVE_SUPPLIER_INFO: LiveSupplierInfo = { price: null, availabilityText: null };
+
+export async function fetchLiveSupplierInfo(url: string): Promise<LiveSupplierInfo> {
+  try {
+    const response = await fetch(`/api/pairing-review/live-supplier-info?url=${encodeURIComponent(url)}`);
+    if (!response.ok) return EMPTY_LIVE_SUPPLIER_INFO;
+    const parsed = liveSupplierInfoSchema.safeParse(await response.json());
+    return parsed.success ? parsed.data : EMPTY_LIVE_SUPPLIER_INFO;
+  } catch {
+    return EMPTY_LIVE_SUPPLIER_INFO;
+  }
 }

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -3084,6 +3084,17 @@ a.upozornenie-title:hover {
   color: var(--fs-ink);
   margin: var(--fs-space-1) 0;
 }
+/* issue 422 — pôvodná (pred zľavou) cena, vedľa aktuálnej ceny. */
+.pairing-review-price-original {
+  font-weight: normal;
+  color: var(--fs-ink-muted);
+}
+/* issue 422 — súčet zásoby + dostupnostný text ("naša strana", persistované). */
+.pairing-review-stock {
+  font-size: var(--fs-text-sm);
+  color: var(--fs-ink-muted);
+  margin: var(--fs-space-1) 0;
+}
 .pairing-review-imgbox {
   margin-top: var(--fs-space-2);
 }
@@ -3114,6 +3125,20 @@ a.upozornenie-title:hover {
 }
 .pairing-review-verdict-unsure {
   color: var(--fs-warning);
+}
+/* issue 422 — 🤖 AI zdôvodnenie zhody, vedľa navrhnutého kandidáta. */
+.pairing-review-reason {
+  font-size: var(--fs-text-xs);
+  color: var(--fs-ink-muted);
+  font-style: italic;
+  margin-top: var(--fs-space-1);
+}
+/* issue 422 — živá cena+dostupnosť dodávateľa (lazy-fetch), na karte aj v paneli. */
+.pairing-review-supplier-live,
+.pairing-review-panel-candidate-live {
+  font-size: var(--fs-text-xs);
+  color: var(--fs-ink-muted);
+  margin-top: var(--fs-space-1);
 }
 /* issue 387 E6 — rozhodovacia UX (nahradzuje E5's statický "Rozhodovanie
    príde v ďalšej etape" placeholder text). */

--- a/apps/web/src/useLiveSupplierInfo.ts
+++ b/apps/web/src/useLiveSupplierInfo.ts
@@ -1,0 +1,61 @@
+import { useEffect, useState } from "react";
+import { EMPTY_LIVE_SUPPLIER_INFO, fetchLiveSupplierInfo, type LiveSupplierInfo } from "./pairingReviewApi.js";
+
+// issue 422 — lazy live-info fetch pre kartu (navrhnutý kandidát) aj panel
+// (top-8 riadky), volaný pri mounte inštancie (rovnaký zámer ako stará
+// appky's `IntersectionObserver`-riadený lazy fetch — `.claude/rules/
+// pairing-search.md`'s issue 397 sekcia, "Populácia je INNER JOIN ...";
+// mount ≈ viditeľné v DOM-e, keďže táto obrazovka stránkuje po 50, nikdy
+// nerenderuje tisíce kariet naraz ako stará appka).
+//
+// Concurrency-cap 4 (rovnaký princíp ako stará appky's `IMG_FETCH_CONCURRENCY
+// = 4`, `webreview/static/app.js`) — MODUL-LEVEL fronta zdieľaná NAPRIEČ
+// všetkými inštanciami tohto hooku na stránke, aby otvorenie stránky s N
+// napárovanými kartami naraz nespustilo N súbežných fetchov na dodávateľov.
+
+const CONCURRENCY = 4;
+let active = 0;
+const queue: (() => void)[] = [];
+
+function pump(): void {
+  while (active < CONCURRENCY && queue.length > 0) {
+    const task = queue.shift();
+    if (task === undefined) break;
+    active += 1;
+    task();
+  }
+}
+
+function schedule(task: () => Promise<void>): void {
+  queue.push(() => {
+    task()
+      .catch(() => undefined) // fetchLiveSupplierInfo sama nikdy nevyhodí — obranná vrstva navyše
+      .finally(() => {
+        active -= 1;
+        pump();
+      });
+  });
+  pump();
+}
+
+export function useLiveSupplierInfo(url: string | null): LiveSupplierInfo {
+  const [info, setInfo] = useState<LiveSupplierInfo>(EMPTY_LIVE_SUPPLIER_INFO);
+
+  useEffect(() => {
+    if (url === null) {
+      setInfo(EMPTY_LIVE_SUPPLIER_INFO);
+      return;
+    }
+    let cancelled = false;
+    setInfo(EMPTY_LIVE_SUPPLIER_INFO);
+    schedule(async () => {
+      const result = await fetchLiveSupplierInfo(url);
+      if (!cancelled) setInfo(result);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [url]);
+
+  return info;
+}

--- a/apps/web/tests/e2e/pairing-review.spec.ts
+++ b/apps/web/tests/e2e/pairing-review.spec.ts
@@ -87,6 +87,26 @@ test("predvolený filter 'Nezrevidované' ukáže produkty bez linky (s aj bez k
   await expect(chybaKarta.locator("img").nth(0)).toHaveAttribute("src", E2E_OUR_IMAGE_DATA_URI);
   await expect(chybaKarta.locator("img").nth(1)).toHaveAttribute("src", E2E_CANDIDATE_IMAGE_DATA_URI);
 
+  // issue 422 (gap 1 — AI zdôvodnenie zhody): `chosenReason` seedovaný na
+  // tejto fixtúre už dávno ("najlepší nájdený"), predtým nikdy nerenderovaný.
+  await expect(chybaKarta.getByTestId("pairing-review-reason-E2E-PR-CHYBA")).toHaveText("🤖 najlepší nájdený");
+
+  // issue 422 (gap 2, "naša strana" — persistované, žiadny live-fetch):
+  // cena so zľavou (49,90 aktuálna, 59,90 pôvodná — seedované vyššie) +
+  // súčet skladu + dostupnostný text.
+  await expect(chybaKarta.getByTestId("pairing-review-stock-E2E-PR-CHYBA")).toContainText("sklad: 3 ks");
+  await expect(chybaKarta.getByTestId("pairing-review-stock-E2E-PR-CHYBA")).toContainText("Skladom");
+  await expect(chybaKarta).toContainText("49.90");
+  await expect(chybaKarta).toContainText("pôv. 59.90");
+
+  // issue 422 (gap 2, dodávateľská strana — live-fetch): kandidátova URL
+  // (`https://e2e-dodavatel.example.com/...`) patrí MIMO všetkých troch
+  // známych adaptérov (wetland.sk/huntingshop.eu/odimon.sk) — appka preto
+  // NEROBÍ žiadny sieťový fetch a TICHO nič nezobrazí (žiadny "Skladom"/
+  // cenový riadok od dodávateľa), presne zámerné zúženie rozsahu z design
+  // komentára na tickete. Konzola ostáva čistá (asercia na konci testu).
+  await expect(page.getByTestId("pairing-review-live-info-E2E-PR-CHYBA")).toHaveCount(0);
+
   // Nenapárovaný produkt (gather nenašiel u dodávateľa nič) — vlastná hláška.
   const nenajdenyKarta = page.getByTestId("pairing-review-card-E2E-PR-NENAJDENY");
   await expect(nenajdenyKarta).toBeVisible();
@@ -306,6 +326,12 @@ test("issue 409: panel kandidátov ukazuje obrázok KAŽDÉHO kandidáta; výber
   await expect(panel.locator("img")).toHaveCount(2);
   await expect(panel.locator("img").nth(0)).toHaveAttribute("src", E2E_CANDIDATE_IMAGE_DATA_URI);
   await expect(panel.locator("img").nth(1)).toHaveAttribute("src", E2E_ALT_CANDIDATE_IMAGE_DATA_URI);
+
+  // issue 422 — obaja kandidáti v paneli majú URL MIMO troch známych
+  // adaptérov ("e2e-dodavatel.example.com") — appka pre nich TICHO
+  // nezobrazí žiadnu živú cenu/dostupnosť, konzola ostáva čistá.
+  await expect(panel.getByTestId("pairing-review-panel-live-info-E2E-PR-PANEL-0")).toHaveCount(0);
+  await expect(panel.getByTestId("pairing-review-panel-live-info-E2E-PR-PANEL-1")).toHaveCount(0);
 
   await panel.getByTestId("pairing-review-panel-pick-E2E-PR-PANEL-1").click();
   // Filter "Všetky" ukazuje kartu ĎALEJ (na rozdiel od "Nezrevidované") — teraz

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -4065,9 +4065,28 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   lokálna e2e sada 60/60 zelená (žiadny nový console error, `catalog
   .spec.ts`'s pevné počty nedotknuté — žiadny nový produkt/variant, len
   price/standardPrice/stock na existujúcom fixtúrovom variante).
+- Self-review (fresh-context `general-purpose` subagent, plný diff proti
+  `cc174bb`): VERDICT 0 🔴, 1 🟡, 4 🔵. Opravené `c5d88a5`: 🟡
+  `live-detail-info.ts`'s cache dostala `CACHE_TTL_MS = 15 min` (appka
+  beží ako dlhoživý kontajner, cache bez TTL by "živé" info navždy
+  zamrazila na prvej hodnote/zlyhaní) + 3 nové testy; 🔵 `<div>` vnútri
+  `<span>` v `PairingReviewPanelParts.tsx` (neplatný HTML5) opravené na
+  `<div>` obal. Zvyšné 3 🔵 nálezy ponechané s dôvodom (komentár na
+  tickete: https://github.com/zbynekdrlik/forestshop-app/issues/422#issuecomment-5286854484)
+  — client-side dedup (server cache už rieši reálny prípad), JSON-LD
+  price-loss-on-unknown-token (existujúce, inde spoliehané `supplier-
+  stock` správanie, mimo rozsahu), case-sensitive `belongsToBase`
+  (existujúca, nezmenená funkcia, potvrdené nezneužiteľné). Opravy
+  overené: typecheck+lint čisté, `live-detail-info.test.ts` 8/8 (5+3 nové
+  TTL testy), `apps/api` plný unit balík 981/981 (978+3 po review
+  testoch), scoped
+  integračné testy (`pairing-review-http`/`pairing-review-live-supplier-
+  info-http`) 23/23, `pairing-review.spec.ts` + `pairing-review-split
+  .spec.ts` e2e 9/9.
 - Playbook: `.claude/rules/pairing-search.md`'s nová sekcia "issue 422 —
   AI zdôvodnenie zhody + živé ceny/dostupnosť" — `chosenReason` auto-fill
   odchýlka, trojica RÔZNYCH extrakcií (JSON-LD zdieľané WETLAND/ODIMON,
   vlastná `prodData` pre BETALOV), ODIMON JSON-LD-môže-klamať akceptované
   riziko pre informatívny náhľad, `adapterForUrl` zámerné zúženie rozsahu,
-  `variant_money_needs_currency_ck` past v seed helperoch.
+  `variant_money_needs_currency_ck` past v seed helperoch, a (po review)
+  "hodnota vs. štruktúra" pravidlo pre TTL na module-level cache.

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -4010,3 +4010,64 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   past, split dátový model rozhodnutie, `isUnreviewed`/scoped-vs-full-
   catalog split, 3-file card extraction, e2e fixtúra/poradie/dialóg/
   "Hľadať" kolízia gotchas.
+
+## 2026-08-13 — #422 (Párovanie: AI zdôvodnenie zhody + živé ceny/dostupnosť)
+
+- Solo ticket (audit úplnosti vs stará appka, mandát z issue 399).
+  Worktree dispatch, verzia `0.3.0-dev.251→.252` (`962c979`), prvý commit.
+- Design komentár PRED prvým kódovým commitom:
+  https://github.com/zbynekdrlik/forestshop-app/issues/422#issuecomment-5286316390
+  — root cause (`chosenReason` je pre nenapárované produkty ŠTRUKTURÁLNE
+  vždy `null`, `run.ts`'s auto-fill `pickBest()`, odchýlka od starej appky)
+  + 3 zvažované prístupy pre živé info (supplier-stock reuse zamietnuté —
+  fail-closed brána pre INÚ automatizáciu; generický regex zamietnutý po
+  živom overení — betalov nemá JSON-LD, karuselová kolízia na CSS triedach;
+  vybrané — per-dodávateľ `extractDetailMeta` na `SupplierAdapter`).
+  Validácia platnosti ticketu (STEP 0):
+  https://github.com/zbynekdrlik/forestshop-app/issues/422#issuecomment-5286318778
+- Implementácia:
+  - `chosenReason` renderovaný na karte (`ChosenCandidateExtras`,
+    `PairingReviewPanelParts.tsx`) LEN vedľa `chosenCandidate !== null`.
+  - "Naša strana": `standardPriceMin/Max`/`stockTotal`/`availabilityText`
+    pridané do `PairingReviewItem` (`pairing-review/queries.ts`), rovnaká
+    agregácia ako existujúce `priceMin/Max`.
+  - "Dodávateľská strana": `SupplierAdapter.extractDetailMeta` (nové pole
+    interface, `adapters/types.ts`) — WETLAND/ODIMON zdieľajú JSON-LD
+    helper (`adapters/detail-meta.ts`, znovupoužíva `supplier-stock/
+    parse.ts`'s `fromJsonLd`), BETALOV vlastná `var prodData` extrakcia
+    (`betalov.ts`). Nový `adapterForUrl` (`registry.ts`, host lookup).
+    Orchestrácia `pairing-search/live-detail-info.ts`
+    (`createLiveSupplierInfoFetcher`, per-URL cache vrátane zlyhaní).
+    Nová trasa `GET /api/pairing-review/live-supplier-info`
+    (`pairing-review-routes.ts`, registrovaná PRED `:productKey`), DI cez
+    `registerPairingReviewRoutes`'s nový `searchClient?` parameter +
+    `createApp`'s `pairingSearchClient?` option.
+    Frontend: `useLiveSupplierInfo.ts` hook (concurrency-cap 4, mount-time
+    lazy fetch), zapojený v karte AJ paneli top-8 kandidátov.
+  - 3 nové fixtúry (`fixtures/{wetland,odimon,betalov}-detail-cena-
+    dostupnost.html`), orezané zo živo overených reálnych stránok
+    (13. 8. 2026).
+- RED→GREEN: gap 1 (chosenReason) aj gap 2 (naša strana) sú UI/query
+  doplnky nad existujúcimi dátami — testy pridané priamo (feature-style,
+  test-first pre novú `extractDetailMeta`/`adapterForUrl`/
+  `createLiveSupplierInfoFetcher` logiku, keďže ide o nové správanie, nie
+  bug fix nad existujúcou funkciou).
+- Testy pridané: `adapters/detail-meta.test.ts` (9), `registry.test.ts`
+  (+2), `live-detail-info.test.ts` (5), `pairing-review-http.integration
+  .test.ts` (+3), nový `pairing-review-live-supplier-info-http.integration
+  .test.ts` (6), `PairingReviewCard.liveInfo.test.tsx` (nový súbor, 9 —
+  vyčlenené OD `PairingReviewCard.test.tsx` kvôli `max-lines: 400`),
+  `PairingReviewPanelParts.test.tsx` (+4).
+- Plný lokálny beh na izolovanej throwaway Postgres inštancii (port 5434):
+  typecheck + lint čisté; plný unit balík (`apps/api` 75 súborov/978
+  testov + `apps/web` 86 súborov/658 testov) zelený; scoped pairing-review
+  + pairing-search integračná sada (8 súborov/78 testov) zelená; plná
+  lokálna e2e sada 60/60 zelená (žiadny nový console error, `catalog
+  .spec.ts`'s pevné počty nedotknuté — žiadny nový produkt/variant, len
+  price/standardPrice/stock na existujúcom fixtúrovom variante).
+- Playbook: `.claude/rules/pairing-search.md`'s nová sekcia "issue 422 —
+  AI zdôvodnenie zhody + živé ceny/dostupnosť" — `chosenReason` auto-fill
+  odchýlka, trojica RÔZNYCH extrakcií (JSON-LD zdieľané WETLAND/ODIMON,
+  vlastná `prodData` pre BETALOV), ODIMON JSON-LD-môže-klamať akceptované
+  riziko pre informatívny náhľad, `adapterForUrl` zámerné zúženie rozsahu,
+  `variant_money_needs_currency_ck` past v seed helperoch.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.251",
+  "version": "0.3.0-dev.252",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-fixtures-pairing-review.ts
+++ b/scripts/e2e-fixtures-pairing-review.ts
@@ -61,7 +61,19 @@ export async function seedPairingReviewFixtures(db: Database, teraz: Date, snaps
     adapterKey: "wetland",
   });
 
-  async function seedProdukt(key: string, name: string, over: { readonly internalNote?: string | null; readonly supplier?: string } = {}): Promise<void> {
+  async function seedProdukt(
+    key: string,
+    name: string,
+    over: {
+      readonly internalNote?: string | null;
+      readonly supplier?: string;
+      // issue 422 — voliteľné, chýbajúce necháva PÔVODNÉ správanie
+      // (žiadna cena, stock 5, "Skladom") — existujúce volania sa nemenia.
+      readonly price?: string;
+      readonly standardPrice?: string;
+      readonly stock?: number;
+    } = {},
+  ): Promise<void> {
     await db.insert(products).values({
       key,
       name,
@@ -77,7 +89,12 @@ export async function seedPairingReviewFixtures(db: Database, teraz: Date, snaps
       guid: key,
       externalCode: `${key}-KOD`,
       name,
-      stock: 5,
+      // `variant_money_needs_currency_ck` (`.claude/rules/database.md`) —
+      // menu treba nastaviť VŽDY, keď je nastavená hociktorá cena.
+      currency: over.price !== undefined || over.standardPrice !== undefined ? "EUR" : null,
+      price: over.price ?? null,
+      standardPrice: over.standardPrice ?? null,
+      stock: over.stock ?? 5,
       availabilityInStockText: "Skladom",
       availabilityOutOfStockText: "Vypredané",
       availabilityText: "Skladom",
@@ -89,7 +106,10 @@ export async function seedPairingReviewFixtures(db: Database, teraz: Date, snaps
     });
   }
 
-  await seedProdukt("E2E-PR-CHYBA", "E2E Bunda Alfa Nezrevidovaná");
+  // issue 422 — cena/pôvodná cena/sklad na TOMTO produkte, aby jediný e2e
+  // test (`pairing-review.spec.ts`'s prvý test) overil AJ "naša strana" polia
+  // (chosenReason už mala táto fixtúra dávno, pozri pairingCandidateSets nižšie).
+  await seedProdukt("E2E-PR-CHYBA", "E2E Bunda Alfa Nezrevidovaná", { price: "49.90", standardPrice: "59.90", stock: 3 });
   await db.insert(pairingCandidateSets).values({
     productKey: "E2E-PR-CHYBA",
     gatheredAt: teraz,


### PR DESCRIPTION
issue 422 — Párovanie: AI zdôvodnenie zhody + živé ceny/dostupnosť (posledné 2 medzery auditu úplnosti vs. stará appka, mandát z issue 399). Ticket 422 ostáva otvorený do naživo overenia po nasadení.

## Obsah

- **AI zdôvodnenie zhody**: `chosenReason` sa vykresľuje (`🤖 <dôvod>`) pri navrhnutom kandidátovi. Zistenie: v tejto appke je `chosenReason` pre nespárované produkty štrukturálne vždy `null` (run.ts `buildChosenReason` + ranking.ts auto-fill) — zdokumentované na tickete, žiadne vymýšľanie textu.
- **Naša strana** (perzistentné, bez siete): `PairingReviewItem` má `standardPriceMin/Max`, `stockTotal`, `availabilityText` — rovnaká agregácia ako existujúce `priceMin/Max`.
- **Dodávateľská strana** (živé, lazy): nový `SupplierAdapter.extractDetailMeta` — WETLAND/ODIMON cez zdieľaný JSON-LD helper, BETALOV (huntingshop.eu bez JSON-LD) vlastná `var prodData` extrakcia. Endpoint `GET /api/pairing-review/live-supplier-info`, per-URL cache s 15-min TTL. Frontend hook `useLiveSupplierInfo` (súbežnosť max 4), karta + top-8 panel.

## Testy + review

typecheck + lint čisté; unit 981+658; integrácia 78+23; e2e 60/60 (9/9 pairing-review po review fixoch), konzola 0 chýb. Self-review 0 🔴 1 🟡 4 🔵 — 🟡 (cache TTL) + 1 🔵 opravené v c5d88a5, zvyšné 3 🔵 zdôvodnené na tickete.
