### PR TITLE
Deploy: automatický rollback + retry overenie (issue 425)

### DIFF
--- a/.claude/rules/deploy.md
+++ b/.claude/rules/deploy.md
@@ -173,10 +173,54 @@ paths:
   `main` mohli spôsobiť, že novší build stiahne starší `:latest`. Workflow má
   aj `concurrency: { group: deploy, cancel-in-progress: false }` — deploy sa
   nikdy nezruší uprostred behu, druhý push len počká vo fronte.
-- **Deploy overuje živú verziu proti `package.json`** — posledný krok
-  `deploy.yml` curluje `https://forestshop.newlevel.media/api/version` a
-  porovná s `require('./package.json').version`; zlyhá nahlas pri
-  nezhode, nikdy nehlási úspech naslepo.
+- **Nasadenie overuje živú verziu s retry a AUTOMATICKÝM rollbackom
+  (`scripts/deploy-verify.sh`, issue 425 — výpadok 13. 8. 2026).** Deploy job
+  už nemá inline `sleep 5` + jeden curl. Celý tok (zapamätaj predošlý image →
+  pull + up → over `/api/version` v retry slučke → pri zlyhaní vráť predošlý
+  image → over zotavenie) je v `scripts/deploy-verify.sh`:
+  - **PRED nasadením** si zapamätá tag práve bežiaceho image
+    (`docker compose ps -q app` → `docker inspect --format '{{.Config.Image}}'`,
+    z neho `${img##*:}`). Deploye vždy pinujú `IMAGE_TAG=<verzia>` (nie
+    `:latest`), takže tag je jednoznačný.
+  - **Overenie je retry slučka** (default `VERIFY_RETRIES=12` × `VERIFY_INTERVAL=5`
+    s = do ~60 s), nie jeden pokus po `sleep 5` — pomalý zdravý štart s
+    migráciami už nie je falošné zlyhanie. 502/nedostupnosť pri jednom pokuse
+    sa CHYTÍ (`if curl ...; then`) a skúša sa znova, `set -euo pipefail` skript
+    nezhodí.
+  - **Pri zlyhaní overenia (alebo pádu `pull`/`up`)** skript automaticky vráti
+    predošlý image (`IMAGE_TAG=<predošlá> docker compose up -d app`) a overí, že
+    sa produkcia zotavila (hlási predošlú verziu). Job **napriek tomu skončí
+    nenulovo** — je červený, aby bolo jasné, že nová verzia nešla — ale
+    produkcia beží ďalej na predošlej verzii namiesto ~10 min výpadku.
+  - **Poradie krokov v `deploy.yml`:** „Upratať staršie obrazy" beží AŽ ZA
+    skriptom (predtým pred overením). Keby bežalo pred ním, zmazalo by práve
+    ten predošlý image, na ktorý rollback potrebuje siahnuť; a keďže Actions po
+    zlyhanom kroku ďalšie preskočí, pri rollbacku sa upratovanie nespustí a
+    predošlý image ostane lokálne.
+  - **Testovanie:** `scripts/deploy-verify.test.sh` (root `pnpm test:deploy-script`,
+    beží v CI `check` jobe pri každom push/PR) mockuje `docker`/`curl` cez PATH
+    stuby a overí 5 vetiev (šťastná cesta, pomalý štart s retry, rollback sa
+    zotaví, žiaden predošlý image, rollback tiež zlyhá). CI skutočný produkčný
+    deploy odbehnúť nevie — táto logika sa testuje takto.
+  - **Ručné overenie / rollback (keď treba zasiahnuť rukou):**
+    ```bash
+    ssh admin@forestshop-dev.newlevel.media
+    cd /srv/forestshop
+    # 1. Aká verzia je práve nasadená (naživo)?
+    curl -fsS https://forestshop.newlevel.media/api/version
+    # 2. Aký image beží kontajner appky (tag na rollback)?
+    docker inspect --format '{{.Config.Image}}' \
+      "$(docker compose -f docker-compose.prod.yml ps -q app)"
+    # 3. Ručný rollback na konkrétnu predošlú verziu (ak by automatika zlyhala):
+    IMAGE_TAG=<predošlá-verzia> docker compose -f docker-compose.prod.yml up -d app
+    # 4. Over zotavenie:
+    curl -fsS https://forestshop.newlevel.media/api/version   # má hlásiť <predošlá-verzia>
+    docker compose -f docker-compose.prod.yml logs --tail 50 app
+    ```
+    Predošlé verzie, čo sú ešte lokálne k dispozícii:
+    `docker images 'ghcr.io/zbynekdrlik/forestshop-app'`. Ak sa image už
+    upratal, dá sa stiahnuť späť: `IMAGE_TAG=<verzia> docker compose -f
+    docker-compose.prod.yml pull app` pred `up -d app`.
 - **Docker build je súčasťou CI (`docker-build` job v `ci.yml`), beží pri
   KAŽDOM push/PR**, nielen pri deploy — deploy cesta sa tak overuje ešte pred
   mergom. `.dockerignore` musí mať `**/`-prefixované vzory

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,10 @@ jobs:
       - run: pnpm typecheck
       - run: pnpm lint
       - run: pnpm test
+      # issue 425: bash-unit test rollback/verify logiky z scripts/deploy-verify.sh
+      # (mockuje docker/curl cez PATH stuby — CI skutočný produkčný deploy
+      # odbehnúť nevie, túto logiku áno). Beží pri každom push/PR.
+      - run: pnpm test:deploy-script
 
   integration:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,24 +74,47 @@ jobs:
       IMAGE_TAG: ${{ needs.build.outputs.version }}
     steps:
       - uses: actions/checkout@v4
-      - name: Nasadiť (migrácie si aplikácia spustí sama pri štarte)
+      - name: Priprava súborov na serveri
         working-directory: /srv/forestshop
         run: |
           cp "$GITHUB_WORKSPACE/docker-compose.prod.yml" .
-          # scripts/ (zálohovanie, obnovovací drill) musí byť na serveri vždy presne to,
-          # čo je v repozitári — inak sa tichým opomenutím rozíde od gitu naveky.
+          # scripts/ (zálohovanie, obnovovací drill, deploy-verify.sh) musí byť na
+          # serveri vždy presne to, čo je v repozitári — inak sa tichým opomenutím
+          # rozíde od gitu naveky. Samotné nasadenie robí ďalší krok cez
+          # deploy-verify.sh (volaný z $GITHUB_WORKSPACE checkoutu).
           mkdir -p scripts
           rsync -a --delete "$GITHUB_WORKSPACE/scripts/" scripts/
-          docker compose -f docker-compose.prod.yml pull app
-          docker compose -f docker-compose.prod.yml up -d
+      - name: Nasadiť s overením a automatickým rollbackom
+        # issue 425 (výpadok 13. 8. 2026): skript si PRED nasadením zapamätá tag
+        # práve bežiaceho image, nasadí novú verziu (pull + up), overí
+        # /api/version v retry slučke (12× 5 s — pomalý štart s migráciami nie je
+        # zlyhanie), a pri zlyhaní AUTOMATICKY vráti predošlý image a overí
+        # zotavenie. Logika je vyčlenená do skriptu, aby sa dala jednotkovo
+        # testovať (scripts/deploy-verify.test.sh, beží v CI `check` jobe — CI
+        # skutočný produkčný deploy odbehnúť nevie, túto logiku áno s mocknutým
+        # docker/curl). Skript pri neúspechu novej verzie skončí NENULOVO — job
+        # ostane červený (no-continue-on-error, rollback chybu neskryje) —, ale
+        # produkcia beží ďalej na predošlej verzii.
+        working-directory: /srv/forestshop
+        # LIVE_HOSTNAME (workflow env) aj IMAGE_TAG (job env) sú v rozsahu; retry
+        # parametre (12× 5 s) sú defaulty v skripte. Skript parsuje /api/version
+        # portable sed-om, takže tento krok už nepotrebuje `node` na runneri.
+        run: bash "$GITHUB_WORKSPACE/scripts/deploy-verify.sh"
       - name: Upratať staršie obrazy TEJTO appky
-        # issue 206: dev2 (vtedajší cieľ nasadenia) bol zdieľaný stroj a bol na 100 % disku — jeden náš
-        # obraz má ~1,4 GB, takže každé nasadenie doteraz nechalo po sebe
-        # ďalší. Maže sa VÝHRADNE `ghcr.io/<repo>` (naše vlastné obrazy) a
-        # nikdy ten práve nasadený — cudzie projekty na tom istom stroji sa
-        # tým nikdy nedotkneme. `|| true` je tu zámerne: obraz môže držať
-        # ešte dobiehajúci starý kontajner a nasadenie je v tej chvíli už
-        # hotové a overené — neuprataný obraz nesmie zhodiť úspešný deploy.
+        # issue 206: forestshop-dev je zdieľaný stroj — jeden náš obraz má
+        # ~1,4 GB, takže každé nasadenie doteraz nechalo po sebe ďalší. Maže sa
+        # VÝHRADNE `ghcr.io/<repo>` (naše vlastné obrazy) a nikdy ten práve
+        # nasadený — cudzie projekty na tom istom stroji sa tým nikdy nedotkneme.
+        # `|| true` je tu zámerne: obraz môže držať ešte dobiehajúci starý
+        # kontajner a nasadenie je v tej chvíli už hotové a overené — neuprataný
+        # obraz nesmie zhodiť úspešný deploy.
+        #
+        # issue 425: tento krok beží AŽ ZA overením/rollbackom (predtým bol PRED
+        # ním). GitHub Actions po zlyhanom kroku ďalšie kroky preskočí, takže pri
+        # neúspešnom deployi (rollback) sa upratovanie NEspustí a predošlý image
+        # ostane lokálne k dispozícii pre rollback. Keby upratovanie bežalo pred
+        # overením ako predtým, zmazalo by práve ten image, na ktorý rollback
+        # potrebuje siahnuť.
         run: |
           keep="ghcr.io/${GITHUB_REPOSITORY,,}:${IMAGE_TAG}"
           docker images --format '{{.Repository}}:{{.Tag}}' \
@@ -99,10 +122,3 @@ jobs:
             | grep -v "^${keep}$" \
             | xargs -r -n1 docker rmi || true
           df -h / | tail -1
-      - name: Overiť verziu na živej stránke
-        run: |
-          sleep 5
-          live=$(curl -fsS "https://${LIVE_HOSTNAME}/api/version" | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).version")
-          want=$(node -p "require('./package.json').version")
-          echo "live=$live want=$want"
-          [ "$live" = "$want" ] || { echo "::error::nasadená verzia $live sa nezhoduje s $want"; exit 1; }

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -4159,3 +4159,22 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   riziko pre informatívny náhľad, `adapterForUrl` zámerné zúženie rozsahu,
   `variant_money_needs_currency_ck` past v seed helperoch, a (po review)
   "hodnota vs. štruktúra" pravidlo pre TTL na module-level cache.
+- **issue 425** — Deploy: automatický rollback + retry namiesto sleep 5
+  (výpadok 13. 8. 2026). Verzia 0.3.0-dev.255. Koreňová príčina: `deploy.yml`
+  overoval verziu jedným curl-om po `sleep 5` a pri zlyhaní NEROLLBACKOVAL —
+  13. 8. crashloopujúci image (v0.3.0-dev.251, Postgres 55P04) nechal produkciu
+  down ~10 min. Vyčlenené do `scripts/deploy-verify.sh` (nový): zapamätaj
+  predošlý image (`docker compose ps -q app` + `docker inspect`) → pull+up →
+  over `/api/version` v retry slučke (12× 5 s) → pri zlyhaní vráť predošlý
+  image + over zotavenie, job vždy nenulovo (červený), ale produkcia hore.
+  Krok „Upratať staršie obrazy" presunutý AŽ za overenie (inak by zmazal
+  rollback image). Test: `scripts/deploy-verify.test.sh` (root
+  `pnpm test:deploy-script`, wired do CI `check` jobu) mockuje docker/curl cez
+  PATH stuby, 5 scenárov (šťastná/pomalý-štart-retry/rollback-sa-zotaví/
+  žiaden-predošlý/rollback-tiež-zlyhá) — 17/17 asertov zelených lokálne.
+  Skript parsuje JSON portable sed-om, odpadá `node` na runneri pri overení.
+  Lokálne overené: typecheck+lint+test zelené, bash test 17/17.
+- Playbook: `.claude/rules/deploy.md`'s prepísaný bullet o overení nasadenia
+  — nový retry+auto-rollback tok, poradie krokov (upratovanie až za overením)
+  a POSTUP RUČNÉHO overenia/rollbacku (SSH, `docker inspect` tagu, `IMAGE_TAG=
+  <predošlá> docker compose up -d app`, over zotavenie).

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc -b && tsc -p scripts/tsconfig.json && tsc -p apps/api/tests/tsconfig.json && tsc -p apps/web/tests/e2e/tsconfig.json",
     "lint": "eslint . --concurrency=off",
     "test": "pnpm -r test",
+    "test:deploy-script": "bash scripts/deploy-verify.test.sh",
     "test:integration": "pnpm --filter @forestshop/api test:integration",
     "gates:local": "pnpm typecheck && pnpm lint && pnpm test",
     "catalog:ingest": "tsx scripts/catalog-ingest.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.254",
+  "version": "0.3.0-dev.255",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/deploy-verify.sh
+++ b/scripts/deploy-verify.sh
@@ -32,6 +32,14 @@ APP_SERVICE="${APP_SERVICE:-app}"
 VERIFY_RETRIES="${VERIFY_RETRIES:-12}"
 VERIFY_INTERVAL="${VERIFY_INTERVAL:-5}"
 VERSION_PATH="${VERSION_PATH:-/api/version}"
+# Každý pokus musí byť OHRANIČENÝ v čase — cieľom tiketu je RÝCHLE, ohraničené
+# zotavenie. Crashloopujúca appka odpovedá rýchlo (connection-refused / 502 z
+# tunela), ale appka, ktorá VISÍ na požiadavke (napr. zaseknuté DB spojenie pri
+# štarte), by bez tohto blokovala curl až do vzdialeného edge timeoutu pri
+# KAŽDOM pokuse a odsúvala tak automatický rollback, ktorý má tento skript
+# garantovať. `--max-time` drží každý pokus predvídateľne krátky.
+CURL_CONNECT_TIMEOUT="${CURL_CONNECT_TIMEOUT:-5}"
+CURL_MAX_TIME="${CURL_MAX_TIME:-10}"
 : "${IMAGE_TAG:?chýba IMAGE_TAG (nová verzia na nasadenie)}"
 : "${LIVE_HOSTNAME:?chýba LIVE_HOSTNAME}"
 
@@ -51,7 +59,7 @@ verify_version() {
   local want="$1" attempts="$2" interval="$3"
   local i body live
   for ((i = 1; i <= attempts; i++)); do
-    if body=$(curl -fsS "https://${LIVE_HOSTNAME}${VERSION_PATH}" 2>/dev/null); then
+    if body=$(curl -fsS --connect-timeout "$CURL_CONNECT_TIMEOUT" --max-time "$CURL_MAX_TIME" "https://${LIVE_HOSTNAME}${VERSION_PATH}" 2>/dev/null); then
       live=$(extract_version "$body")
       if [ "$live" = "$want" ]; then
         echo "overenie OK (pokus $i/$attempts): live=$live"
@@ -89,8 +97,13 @@ deploy() {
 # 1 = ani rollback sa nepodaril (treba ručný zásah).
 rollback() {
   local prev_tag="$1"
-  if [ -z "$prev_tag" ]; then
-    echo "::error::žiaden predošlý image na rollback — produkcia môže byť down, treba ručný zásah"
+  # Bezpečný rollback cieľ musí byť konkrétny PREDOŠLÝ verzný tag. Prázdny =
+  # prvé nasadenie. `latest` (kontajner spustený mimo pipeline s nepinnutým
+  # IMAGE_TAG) aj tag ZHODNÝ s novou verziou by rollback nasmerovali na ten
+  # istý práve pokazený image (build job pushuje aj `:latest`) — v oboch
+  # prípadoch nie je na čo bezpečne rollbacknúť.
+  if [ -z "$prev_tag" ] || [ "$prev_tag" = "latest" ] || [ "$prev_tag" = "$NEW_TAG" ]; then
+    echo "::error::žiaden bezpečný predošlý image na rollback (tag='${prev_tag:-<žiaden>}') — produkcia môže byť down, treba ručný zásah"
     return 1
   fi
   echo "vraciam predošlý image: $prev_tag"

--- a/scripts/deploy-verify.sh
+++ b/scripts/deploy-verify.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Nasadenie appky s overením a AUTOMATICKÝM rollbackom (issue 425 — výpadok
+# 13. 8. 2026). Vyčlenené z `.github/workflows/deploy.yml` do skriptu, aby sa
+# rollback logika dala jednotkovo testovať (scripts/deploy-verify.test.sh) —
+# CI nevie skutočný produkčný deploy odbehnúť, ale túto logiku áno, s
+# mocknutými `docker`/`curl` cez PATH stuby.
+#
+# Tok:
+#   1. Zapamätaj tag PRÁVE bežiaceho image (pred akoukoľvek zmenou).
+#   2. Nasaď: `docker compose pull app` + `up -d`.
+#   3. Over `/api/version` v ohraničenej retry slučke (nie jeden pokus po
+#      sleep 5 — pomalý štart s migráciami nie je zlyhanie).
+#   4. Pri zlyhaní overenia (alebo pádu nasadenia) vráť predošlý image
+#      (`IMAGE_TAG=<predošlá> docker compose up -d app`) a over zotavenie.
+#   5. Ak nová verzia neprešla, skonči NENULOVO — job ostane červený (signál,
+#      že nová verzia nešla), ale produkcia beží ďalej na predošlej. Rollback
+#      chybu NIKDY neskryje (no-continue-on-error).
+#
+# Konfigurácia cez env (rozumné defaulty):
+#   IMAGE_TAG       (povinné) — nová verzia/tag na nasadenie (očakávaná verzia)
+#   LIVE_HOSTNAME   (povinné) — hostname pre https://<host>/api/version
+#   COMPOSE_FILE    (default docker-compose.prod.yml) — relatívny k cwd
+#   APP_SERVICE     (default app) — názov compose služby appky
+#   VERIFY_RETRIES  (default 12) — počet pokusov overenia
+#   VERIFY_INTERVAL (default 5)  — sekundy medzi pokusmi
+#   VERSION_PATH    (default /api/version)
+
+COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.prod.yml}"
+APP_SERVICE="${APP_SERVICE:-app}"
+VERIFY_RETRIES="${VERIFY_RETRIES:-12}"
+VERIFY_INTERVAL="${VERIFY_INTERVAL:-5}"
+VERSION_PATH="${VERSION_PATH:-/api/version}"
+: "${IMAGE_TAG:?chýba IMAGE_TAG (nová verzia na nasadenie)}"
+: "${LIVE_HOSTNAME:?chýba LIVE_HOSTNAME}"
+
+NEW_TAG="$IMAGE_TAG"
+
+# Vytiahni "version" pole z JSON tela /api/version bez závislosti na node —
+# telo je plochý objekt {"version":"...","commit":"..."}. Portable sed
+# (rovnaký výsledok na runneri aj v teste s mocknutým curl).
+extract_version() {
+  printf '%s' "$1" | sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p'
+}
+
+# Over, že živá appka hlási očakávanú verziu — v retry slučke. Padnutý curl
+# (HTTP chyba / nedostupné) sa CHYTÍ cez `if`, takže `set -e` skript nezhodí
+# uprostred overovania (zámerné ošetrenie, nie bypass). Návrat 0 = OK, 1 = nie.
+verify_version() {
+  local want="$1" attempts="$2" interval="$3"
+  local i body live
+  for ((i = 1; i <= attempts; i++)); do
+    if body=$(curl -fsS "https://${LIVE_HOSTNAME}${VERSION_PATH}" 2>/dev/null); then
+      live=$(extract_version "$body")
+      if [ "$live" = "$want" ]; then
+        echo "overenie OK (pokus $i/$attempts): live=$live"
+        return 0
+      fi
+      echo "pokus $i/$attempts: live=${live:-<prázdne>}, čakám na $want"
+    else
+      echo "pokus $i/$attempts: ${VERSION_PATH} neodpovedá (HTTP chyba / nedostupné)"
+    fi
+    if [ "$i" -lt "$attempts" ]; then sleep "$interval"; fi
+  done
+  return 1
+}
+
+# Tag práve bežiaceho image (PRED nasadením). Prázdny, ak žiaden kontajner
+# nebeží (prvé nasadenie) — vtedy nie je na čo rollbacknúť.
+capture_prev_tag() {
+  local container image
+  container=$(docker compose -f "$COMPOSE_FILE" ps -q "$APP_SERVICE" 2>/dev/null || true)
+  [ -n "$container" ] || { echo ""; return 0; }
+  image=$(docker inspect --format '{{.Config.Image}}' "$container" 2>/dev/null || true)
+  # ghcr.io/...:<tag> — po poslednej dvojbodke je tag (registre tu nemajú port,
+  # tag verzie je tvaru X.Y.Z-dev.N bez dvojbodky), takže ##*: je jednoznačné.
+  echo "${image##*:}"
+}
+
+# Nasaď novú verziu. `&&` reťaz: keď pull padne, up sa nespustí. Volané v `if`
+# podmienke, takže návratový kód sa vyhodnotí bez zhodenia skriptu pod `set -e`.
+deploy() {
+  docker compose -f "$COMPOSE_FILE" pull "$APP_SERVICE" \
+    && docker compose -f "$COMPOSE_FILE" up -d
+}
+
+# Vráť predošlý image a over zotavenie. Návrat 0 = produkcia sa zotavila,
+# 1 = ani rollback sa nepodaril (treba ručný zásah).
+rollback() {
+  local prev_tag="$1"
+  if [ -z "$prev_tag" ]; then
+    echo "::error::žiaden predošlý image na rollback — produkcia môže byť down, treba ručný zásah"
+    return 1
+  fi
+  echo "vraciam predošlý image: $prev_tag"
+  if ! IMAGE_TAG="$prev_tag" docker compose -f "$COMPOSE_FILE" up -d "$APP_SERVICE"; then
+    echo "::error::rollback príkaz (up -d $APP_SERVICE) zlyhal — produkcia môže byť down, treba ručný zásah"
+    return 1
+  fi
+  if verify_version "$prev_tag" "$VERIFY_RETRIES" "$VERIFY_INTERVAL"; then
+    echo "rollback OK — produkcia beží na $prev_tag (nová verzia $NEW_TAG NEPREŠLA)"
+    return 0
+  fi
+  echo "::error::rollback zlyhal — predošlá verzia $prev_tag sa neohlásila, produkcia môže byť down, treba ručný zásah"
+  return 1
+}
+
+main() {
+  local prev_tag
+  prev_tag=$(capture_prev_tag)
+  echo "predošlý bežiaci tag: ${prev_tag:-<žiaden>}; nasadzujem: $NEW_TAG"
+
+  if deploy && verify_version "$NEW_TAG" "$VERIFY_RETRIES" "$VERIFY_INTERVAL"; then
+    echo "nasadenie OK — produkcia beží na $NEW_TAG"
+    return 0
+  fi
+
+  echo "::warning::nasadenie/overenie novej verzie $NEW_TAG zlyhalo — spúšťam automatický rollback"
+  # Rollback obnoví produkciu, ale job MUSÍ ostať červený (nová verzia nešla) —
+  # preto `main` vždy vráti 1 na tejto vetve, bez ohľadu na výsledok rollbacku.
+  rollback "$prev_tag" || true
+  return 1
+}
+
+main "$@"

--- a/scripts/deploy-verify.test.sh
+++ b/scripts/deploy-verify.test.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bash-unit test rollback/verify logiky z scripts/deploy-verify.sh (issue 425).
+# CI nevie skutočný produkčný deploy odbehnúť — tento test mockuje `docker` a
+# `curl` cez PATH stuby a overí vetvy: šťastná cesta, pomalý štart s retry,
+# rollback sa zotaví, žiaden predošlý image, rollback tiež zlyhá.
+# Spustenie: bash scripts/deploy-verify.test.sh  (alebo `pnpm test:deploy-script`)
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$HERE/deploy-verify.sh"
+[ -f "$SCRIPT" ] || { echo "nenašiel som $SCRIPT" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+BIN="$WORK/bin"
+mkdir -p "$BIN"
+LOG="$WORK/docker.log"
+SEQ="$WORK/curl.seq"
+
+# --- docker stub: zaloguje každé volanie (vrátane IMAGE_TAG env), vráti
+#     mocknuté ps/inspect výstupy, ostatné (pull/up) uspejú.
+cat > "$BIN/docker" <<'STUB'
+#!/usr/bin/env bash
+echo "IMAGE_TAG=${IMAGE_TAG:-} ARGS=$*" >> "$MOCK_DOCKER_LOG"
+mode=
+for a in "$@"; do
+  case "$a" in
+    inspect) mode=inspect ;;
+    ps) mode=ps ;;
+  esac
+done
+case "$mode" in
+  inspect) printf '%s\n' "${MOCK_PREV_IMAGE:-}" ;;
+  ps) printf '%s\n' "${MOCK_PREV_CONTAINER:-}" ;;
+  *) exit "${MOCK_DOCKER_EXIT:-0}" ;;
+esac
+STUB
+chmod +x "$BIN/docker"
+
+# --- curl stub: skriptovaná postupnosť odpovedí (MOCK_CURL_SEQ, token na
+#     riadok). Token "FAIL" = HTTP chyba (exit 22, ako curl -f na 5xx), inak
+#     vráti {"version":"<token>",...}. Po vyčerpaní opakuje posledný riadok.
+cat > "$BIN/curl" <<'STUB'
+#!/usr/bin/env bash
+seqfile="$MOCK_CURL_SEQ"
+cnt="${seqfile}.n"
+i=0; [ -f "$cnt" ] && i=$(cat "$cnt")
+i=$((i + 1)); printf '%s' "$i" > "$cnt"
+line=$(sed -n "${i}p" "$seqfile")
+[ -n "$line" ] || line=$(tail -n1 "$seqfile")
+if [ "$line" = "FAIL" ]; then exit 22; fi
+printf '{"version":"%s","commit":"test"}\n' "$line"
+STUB
+chmod +x "$BIN/curl"
+
+# --- výsledky
+FAILS=0
+CASE=""
+ok()   { echo "  ✓ [$CASE] $1"; }
+fail() { echo "  ✗ [$CASE] $1"; FAILS=$((FAILS + 1)); }
+
+# --- spustenie skriptu s mocknutým prostredím. Args = postupnosť curl odpovedí.
+OUT=""; RC=0
+run() {
+  rm -f "$SEQ" "$SEQ.n"; : > "$LOG"
+  printf '%s\n' "$@" > "$SEQ"
+  set +e
+  OUT=$(PATH="$BIN:$PATH" \
+    MOCK_DOCKER_LOG="$LOG" MOCK_CURL_SEQ="$SEQ" \
+    MOCK_PREV_CONTAINER="${PREV_CONTAINER-}" MOCK_PREV_IMAGE="${PREV_IMAGE-}" \
+    COMPOSE_FILE="docker-compose.prod.yml" APP_SERVICE="app" \
+    LIVE_HOSTNAME="example.test" IMAGE_TAG="${NEW-}" \
+    VERIFY_RETRIES="${RETRIES-3}" VERIFY_INTERVAL="0" \
+    bash "$SCRIPT" 2>&1)
+  RC=$?
+  set -e
+}
+
+assert_rc()        { if [ "$RC" = "$1" ]; then ok "exit $RC"; else fail "exit: čakal $1, dostal $RC"; fi; }
+assert_out_has()   { if printf '%s' "$OUT" | grep -qF -- "$1"; then ok "výstup obsahuje: $1"; else fail "výstup NEobsahuje: $1"; fi; }
+assert_out_hasnt() { if printf '%s' "$OUT" | grep -qF -- "$1"; then fail "výstup NEMÁ obsahovať: $1"; else ok "výstup neobsahuje: $1"; fi; }
+assert_log_has()   { if grep -qF -- "$1" "$LOG"; then ok "docker volanie: $1"; else fail "docker NEvolal: $1"; fi; }
+assert_log_hasnt() { if grep -qF -- "$1" "$LOG"; then fail "docker NEMAL volať: $1"; else ok "docker nevolal: $1"; fi; }
+
+ROLLBACK_CALL="IMAGE_TAG=0.3.0-dev.254 ARGS=compose -f docker-compose.prod.yml up -d app"
+
+# ---------------------------------------------------------------------------
+CASE="1. šťastná cesta (overí sa hneď, žiaden rollback)"
+PREV_CONTAINER="cid-prev"; PREV_IMAGE="ghcr.io/zbynekdrlik/forestshop-app:0.3.0-dev.254"
+NEW="0.3.0-dev.255"; RETRIES=3
+run "0.3.0-dev.255"
+assert_rc 0
+assert_out_has "nasadenie OK — produkcia beží na 0.3.0-dev.255"
+assert_log_hasnt "up -d app"
+
+# ---------------------------------------------------------------------------
+CASE="2. pomalý štart — retry (2× 502, potom OK; žiaden rollback)"
+run FAIL FAIL "0.3.0-dev.255"
+assert_rc 0
+assert_out_has "pokus 3/3"
+assert_out_has "nasadenie OK — produkcia beží na 0.3.0-dev.255"
+assert_log_hasnt "up -d app"
+
+# ---------------------------------------------------------------------------
+CASE="3. zlá verzia → rollback sa zotaví (job ostane červený)"
+run FAIL FAIL FAIL "0.3.0-dev.254"
+assert_rc 1
+assert_out_has "spúšťam automatický rollback"
+assert_out_has "rollback OK — produkcia beží na 0.3.0-dev.254 (nová verzia 0.3.0-dev.255 NEPREŠLA)"
+assert_log_has "$ROLLBACK_CALL"
+
+# ---------------------------------------------------------------------------
+CASE="4. žiaden predošlý image — nie je na čo rollbacknúť"
+PREV_CONTAINER=""; PREV_IMAGE=""
+run FAIL FAIL FAIL
+assert_rc 1
+assert_out_has "žiaden predošlý image na rollback"
+assert_log_hasnt "up -d app"
+
+# ---------------------------------------------------------------------------
+CASE="5. rollback tiež zlyhá — kritická chyba (job červený)"
+PREV_CONTAINER="cid-prev"; PREV_IMAGE="ghcr.io/zbynekdrlik/forestshop-app:0.3.0-dev.254"
+run FAIL FAIL FAIL FAIL FAIL FAIL
+assert_rc 1
+assert_out_has "rollback zlyhal — predošlá verzia 0.3.0-dev.254 sa neohlásila"
+assert_log_has "$ROLLBACK_CALL"
+
+# ---------------------------------------------------------------------------
+echo ""
+if [ "$FAILS" -eq 0 ]; then
+  echo "VŠETKY testy prešli."
+else
+  echo "ZLYHANÍ: $FAILS"
+  exit 1
+fi

--- a/scripts/deploy-verify.test.sh
+++ b/scripts/deploy-verify.test.sh
@@ -115,7 +115,15 @@ CASE="4. žiaden predošlý image — nie je na čo rollbacknúť"
 PREV_CONTAINER=""; PREV_IMAGE=""
 run FAIL FAIL FAIL
 assert_rc 1
-assert_out_has "žiaden predošlý image na rollback"
+assert_out_has "žiaden bezpečný predošlý image na rollback"
+assert_log_hasnt "up -d app"
+
+# ---------------------------------------------------------------------------
+CASE="6. predošlý tag je :latest — nie je bezpečný rollback cieľ (ukazuje na nový obraz)"
+PREV_CONTAINER="cid-prev"; PREV_IMAGE="ghcr.io/zbynekdrlik/forestshop-app:latest"
+run FAIL FAIL FAIL
+assert_rc 1
+assert_out_has "žiaden bezpečný predošlý image na rollback (tag='latest')"
 assert_log_hasnt "up -d app"
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Zhrnutie

Nasadenie na `forestshop-dev` sa doteraz overovalo jediným curl-om po `sleep 5` a pri zlyhaní nechalo bežať pokazenú verziu (výpadok 13. 8., ~10 min). Toto PR (issue 425):

- `scripts/deploy-verify.sh` — zapamätá si bežiaci IMAGE_TAG pred nasadením, overí novú verziu v retry slučke (12× 5 s), pri zlyhaní automaticky vráti predošlý image a overí zotavenie; job pri zlyhaní novej verzie skončí VŽDY červený, ale prod ostáva hore.
- `scripts/deploy-verify.test.sh` — hermetický bash-unit test (6 scenárov, 20 asertov, mock docker/curl cez PATH stuby), zapojený do CI (`check` job).
- `deploy.yml` — volá skript; upratovanie starých imageov presunuté AŽ ZA overenie (inak by zmazalo rollback cieľ).
- `.claude/rules/deploy.md` — retry + rollback tok a postup ručného overenia/rollbacku cez SSH.

Ticket 425 ostáva otvorený do naživo overenia po nasadení (zavrie sa ručne s dôkazmi).
