### PR TITLE
Split linky: nočný writeback + dodávateľský sklad (issue 423)

### DIFF
--- a/.claude/rules/shoptet-writeback.md
+++ b/.claude/rules/shoptet-writeback.md
@@ -328,3 +328,40 @@ paths:
   procesy/`docker ps`, spusti izolovaný re-beh na throwaway Postgres inštancii,
   presne ako `.claude/rules/local-dev.md`'s vlastný postup pre iné testy) —
   nehľadaj appkin bug, kým izolovaný beh sám neflaká.
+- **Split (per-veľkosť) linky sa zapisujú ZLÚČENÉ do EXISTUJÚCEHO linkového
+  importu, NIE tretím samostatným importom (issue 423).** Split produkt
+  (`pairing_decision.status='split'`) má linky per veľkosť vo
+  `pairing_variant_link` (kľúč `variant.code`), NIE v
+  `product_supplier_link_override`. Keďže linkový CSV je aj tak per-variant
+  `code;pairCode;internalNote`, split riadky majú IDENTICKÝ tvar a stačí ich
+  primiešať: `select-variant-links.ts`'s `selectChangedVariantLinks` (gate
+  `status='split'` + časový diff cez nový `pairing_variant_link.synced_at`)
+  dodá per-veľkosť riadky, `run-writeback.ts` ich ZLÚČI s produktovými do
+  JEDNÉHO `runShoptetImportIsolated` behu (žiadny druhý browser child-proces,
+  žiadny nový Štart/Stop prepínač — internalNote je privátna poznámka).
+  **Kľúčová invariant: kódy oboch ciest musia byť DISJUNKTNÉ**, inak Shoptet
+  zruší CELÝ import na duplicitnom kóde — preto `selectChangedSupplierLinks`
+  (produktová cesta) VYLÚČI split-riadené varianty (LEFT JOIN
+  `pairing_variant_link` + `pairing_decision`, `WHERE NOT (link existuje A
+  status='split')`); `dedupeWritebackRowsByCode` (per-veľkosť riadky prvé) je
+  len obranná vrstva. Po úspechu sa označia OBE strany synced
+  (`markSuppliersLinksSynced` + `markVariantLinksSynced`, oba `updated_at <=
+  now` race guard). Rovnaký "časový diff + gate + mark-after-confirm" vzor
+  ako stavový writeback (E7), len nad `pairing_variant_link`.
+- **`selectChangedSupplierLinks`'s marking set je od issue 423 GROUP BY count
+  (zmenené overridy s ≥1 variantom), nie productKeys emitovaných riadkov.**
+  Dôvod: fully-split produkt (override zmenený, VŠETKY varianty split-riadené)
+  vyprodukuje 0 riadkov, ale jeho override je dormantný (pokrytý per-veľkosť
+  linkami) — musí sa označiť synced, inak re-selectuje donekonečna. Skutočná
+  "override na productKey s 0 variantmi" anomália (PR 140) sa STÁLE NEoznačí a
+  zaloguje — jedna GROUP BY otázka rozlíši oboje podľa `count(variants.code) >
+  0`. Test pokrýva oba (`P10` fully-split → marked, `P7` no-variant → warned).
+- **Nová appka NEMÔŽE spoľahnúť sa na round-trip cez Shoptet pre per-veľkosť
+  dáta (issue 423) — na rozdiel od starej appky.** `products.internalNote` je
+  PRODUKTOVÁ úroveň (jedna hodnota na produkt, katalógový import ju kolapsuje),
+  `variants` nemá vlastný `internal_note` stĺpec — takže per-veľkosť link
+  zapísaný do Shoptetu sa round-tripom NEVRÁTI ako per-variant. Preto downstream
+  flow (supplier-stock, `.claude/rules/supplier-stock.md`) čítajú
+  `pairing_variant_link` PRIAMO, nie cez `products.internalNote`. Prieskum
+  starej appky (`parovanie_produktov` @ f76cafa): mala `internalNote` per
+  variant v exporte, takže round-trip tam fungoval — v tejto appke NIE.

--- a/.claude/rules/supplier-stock.md
+++ b/.claude/rules/supplier-stock.md
@@ -493,3 +493,33 @@ paths:
   jedno-riadkovej vitest fixtúry: `grep` existujúce `screen.getByRole`/
   `screen.getByText` volania v tom istom test súbore — nesporí sa nejaké o
   text, ktorý bude po zmene zdieľaný viacerými riadkami?
+- **Split (per-veľkosť) linky sa do kontroly dostupnosti zapájajú ČÍTANÍM
+  `pairing_variant_link` PRIAMO, nie cez `products.internalNote` (issue 423).**
+  Split produkt (`pairing_decision.status='split'`) nemá produktovú
+  `internalNote` linku — jeho linky žijú per veľkosť. `collectSupplierLinks`
+  (`run.ts`) preto navyše pozbiera split-riadené `pairing_variant_link.url`
+  (gate `status='split'`, rovnaká `extractSupplierLink` normalizácia +
+  vylúčenie vlastného e-shopu ako produktové linky). Každá split linka je
+  JEDNA URL na JEDNU veľkosť (jednoveľkostná stránka), takže sa scrapne ako
+  BLANKET (`size_label=''`) — `collectOurSizesByLink` (per-produkt
+  `internalNote` grouping) ju zámerne NEZAHRNIE, takže sa nikdy neskúša ako
+  viac-veľkostná stránka.
+- **`restock/queries.ts`'s efektívna linka je od issue 423 `coalesce(CASE WHEN
+  decision.status='split' THEN per-veľkosť link END, produktová linka)`.**
+  Split variant sa tak spáruje na svoj BLANKET `supplier_stock` riadok cez
+  existujúcu `size_label=''` vetvu OR-u. **Pasca poradia JOIN-ov:** dva nové
+  LEFT JOINy (`pairing_variant_link` na `variant.code`, `pairing_decision` na
+  `product.key`) MUSIA byť v reťazi PRED `supplierStock` innerJoinom — jeho ON
+  klauzula referencuje `link` (coalesce nad týmito dvoma tabuľkami), a Postgres
+  vyžaduje, aby referencovaná tabuľka bola v JOIN zozname skôr. Non-split
+  variant: `coalesce` padne na produktovú linku → NULOVÁ zmena existujúceho
+  správania (overené restock-run regresiou). Dormantná per-veľkosť linka
+  (produkt nerozdelený) sa ignoruje — `status != 'split'` → produktová linka.
+- **Split-governed predikát (`pairing_variant_link existuje A
+  pairing_decision.status='split'`) sa aplikuje KONZISTENTNE na 4 miestach
+  (issue 423):** `select-variant-links.ts` (writeback vyberie), `select-
+  changes.ts` (writeback vylúči z produktovej cesty), `collectSupplierLinks`
+  (scrape), `restock/queries.ts` (efektívna linka). Dormantná per-veľkosť
+  linka (link nastavený v paneli, ale "✓ Hotovo" nekliknuté, alebo produkt
+  vrátený z rozdelenia) sa VŠADE ignoruje — jej efektívna linka je produktová.
+  Pri KAŽDEJ ďalšej zmene split logiky over všetky štyri miesta naraz.

--- a/apps/api/drizzle/0055_daily_rafael_vega.sql
+++ b/apps/api/drizzle/0055_daily_rafael_vega.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "pairing_variant_link" ADD COLUMN "synced_at" timestamp with time zone;

--- a/apps/api/drizzle/meta/0055_snapshot.json
+++ b/apps/api/drizzle/meta/0055_snapshot.json
@@ -1,0 +1,3790 @@
+{
+  "id": "8f18dfad-c981-4e8f-a290-d6502becbe30",
+  "prevId": "e278a653-afad-4028-8d05-45fc03196490",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_code": {
+          "name": "external_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_open_status": {
+      "name": "order_open_status",
+      "schema": "",
+      "columns": {
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Vybavuje sa'"
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop_remark": {
+          "name": "shop_remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shoptet_order_id": {
+          "name": "shoptet_order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_updated_at": {
+          "name": "comment_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_synced_at": {
+          "name": "comment_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_carrier_name": {
+          "name": "shipping_carrier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_price_with_vat": {
+          "name": "total_price_with_vat",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_marked_at": {
+          "name": "claim_marked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_note": {
+          "name": "claim_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_full_name": {
+          "name": "delivery_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_company": {
+          "name": "delivery_company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_street": {
+          "name": "delivery_street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_house_number": {
+          "name": "delivery_house_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_city": {
+          "name": "delivery_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_zip": {
+          "name": "delivery_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_country_name": {
+          "name": "delivery_country_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_name": {
+          "name": "payment_method_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_to_pay": {
+          "name": "price_to_pay",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_link_override": {
+      "name": "product_supplier_link_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_link_override_product_key_product_key_fk": {
+          "name": "product_supplier_link_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_link_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_override": {
+      "name": "product_supplier_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_override_product_key_product_key_fk": {
+          "name": "product_supplier_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing": {
+      "name": "pairing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_url": {
+          "name": "supplier_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "pairing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'navrhnute'"
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pairing_state_idx": {
+          "name": "pairing_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_confirmed_by_idx": {
+          "name": "pairing_confirmed_by_idx",
+          "columns": [
+            {
+              "expression": "confirmed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_variant_code_variant_code_fk": {
+          "name": "pairing_variant_code_variant_code_fk",
+          "tableFrom": "pairing",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pairing_confirmed_by_users_id_fk": {
+          "name": "pairing_confirmed_by_users_id_fk",
+          "tableFrom": "pairing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pairing_variant_code_unique": {
+          "name": "pairing_variant_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pairing_confirmation_ck": {
+          "name": "pairing_confirmation_ck",
+          "value": "(\"pairing\".\"state\" = 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)\n        OR (\"pairing\".\"state\" != 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NULL AND \"pairing\".\"confirmed_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier": {
+      "name": "supplier",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wholesale_base_url": {
+          "name": "wholesale_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_key": {
+          "name": "adapter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_settings": {
+      "name": "posta_uncollected_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_state": {
+      "name": "posta_uncollected_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notify_count": {
+          "name": "notify_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_state": {
+          "name": "terminal_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_settings": {
+      "name": "order_reminder_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_state": {
+      "name": "order_reminder_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_replacement_link": {
+      "name": "nedostupne_replacement_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nedostupne_replacement_link_variant_idx": {
+          "name": "nedostupne_replacement_link_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_state": {
+      "name": "nedostupne_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "nedostupne_email_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nedostupne_state_order_variant_type_uq": {
+          "name": "nedostupne_state_order_variant_type_uq",
+          "columns": [
+            {
+              "expression": "order_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template_history": {
+      "name": "mail_template_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "mail_template_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_template_history_key_idx": {
+          "name": "mail_template_history_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_template_history_changed_by_user_id_users_id_fk": {
+          "name": "mail_template_history_changed_by_user_id_users_id_fk",
+          "tableFrom": "mail_template_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template": {
+      "name": "mail_template",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail_template_updated_by_user_id_users_id_fk": {
+          "name": "mail_template_updated_by_user_id_users_id_fk",
+          "tableFrom": "mail_template",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_log": {
+      "name": "mail_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "mail_log_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_log_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "mail_log_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_log_created_idx": {
+          "name": "mail_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_log_source_created_idx": {
+          "name": "mail_log_source_created_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_log_actor_user_id_users_id_fk": {
+          "name": "mail_log_actor_user_id_users_id_fk",
+          "tableFrom": "mail_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_stock": {
+      "name": "supplier_stock",
+      "schema": "",
+      "columns": {
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "supplier_availability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "supplier_stock_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "supplier_stock_host_idx": {
+          "name": "supplier_stock_host_idx",
+          "columns": [
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "supplier_stock_avail_idx": {
+          "name": "supplier_stock_avail_idx",
+          "columns": [
+            {
+              "expression": "availability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "supplier_stock_link_size_label_pk": {
+          "name": "supplier_stock_link_size_label_pk",
+          "columns": [
+            "link",
+            "size_label"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_event": {
+      "name": "restock_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_link": {
+          "name": "supplier_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_availability_text": {
+          "name": "supplier_availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "supplier_price": {
+          "name": "supplier_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "restock_event_at_idx": {
+          "name": "restock_event_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "restock_event_variant_idx": {
+          "name": "restock_event_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_settings": {
+      "name": "restock_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shop_product_url": {
+      "name": "shop_product_url",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "shop_product_url_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'feed'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.theme_color": {
+      "name": "theme_color",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "theme_color_updated_by_user_id_users_id_fk": {
+          "name": "theme_color_updated_by_user_id_users_id_fk",
+          "tableFrom": "theme_color",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upozornenie": {
+      "name": "upozornenie",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "upozornenie_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "upozornenie_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedup_key": {
+          "name": "dedup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postponed_until": {
+          "name": "postponed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seen_at": {
+          "name": "seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "upozornenie_dedup_key_uq": {
+          "name": "upozornenie_dedup_key_uq",
+          "columns": [
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "resolved_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upozornenie_resolved_at_idx": {
+          "name": "upozornenie_resolved_at_idx",
+          "columns": [
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upozornenie_dedup_key_idx": {
+          "name": "upozornenie_dedup_key_idx",
+          "columns": [
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upozornenie_resolved_by_user_id_users_id_fk": {
+          "name": "upozornenie_resolved_by_user_id_users_id_fk",
+          "tableFrom": "upozornenie",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "upozornenie_created_by_user_id_users_id_fk": {
+          "name": "upozornenie_created_by_user_id_users_id_fk",
+          "tableFrom": "upozornenie",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dpd_pickup_request": {
+      "name": "dpd_pickup_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "pickup_date": {
+          "name": "pickup_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "dpd_operation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dpd_shipment": {
+      "name": "dpd_shipment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "dpd_operation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parcel_number": {
+          "name": "parcel_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cod_amount": {
+          "name": "cod_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dpd_shipment_order_uq": {
+          "name": "dpd_shipment_order_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dpd_shipment_order_id_order_id_fk": {
+          "name": "dpd_shipment_order_id_order_id_fk",
+          "tableFrom": "dpd_shipment",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_task": {
+      "name": "daily_task",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "done_at": {
+          "name": "done_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "daily_task_user_id_created_at_idx": {
+          "name": "daily_task_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_task_user_id_users_id_fk": {
+          "name": "daily_task_user_id_users_id_fk",
+          "tableFrom": "daily_task",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing_candidate_set": {
+      "name": "pairing_candidate_set",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gathered_at": {
+          "name": "gathered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "queries": {
+          "name": "queries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chosen_url": {
+          "name": "chosen_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chosen_reason": {
+          "name": "chosen_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "pairing_confidence",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "pairing_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verdict_checked_at": {
+          "name": "verdict_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pairing_candidate_set_product_key_product_key_fk": {
+          "name": "pairing_candidate_set_product_key_product_key_fk",
+          "tableFrom": "pairing_candidate_set",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing_candidate": {
+      "name": "pairing_candidate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_score": {
+          "name": "raw_score",
+          "type": "numeric(8, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_hit": {
+          "name": "code_hit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pairing_candidate_product_url_uq": {
+          "name": "pairing_candidate_product_url_uq",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_candidate_product_idx": {
+          "name": "pairing_candidate_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_candidate_product_key_fk": {
+          "name": "pairing_candidate_product_key_fk",
+          "tableFrom": "pairing_candidate",
+          "tableTo": "pairing_candidate_set",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "product_key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing_decision": {
+      "name": "pairing_decision",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "pairing_decision_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_synced_at": {
+          "name": "state_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pairing_decision_product_key_product_key_fk": {
+          "name": "pairing_decision_product_key_product_key_fk",
+          "tableFrom": "pairing_decision",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pairing_decision_decided_by_users_id_fk": {
+          "name": "pairing_decision_decided_by_users_id_fk",
+          "tableFrom": "pairing_decision",
+          "tableTo": "users",
+          "columnsFrom": [
+            "decided_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pairing_decision_url_ck": {
+          "name": "pairing_decision_url_ck",
+          "value": "(\"pairing_decision\".\"status\"::text IN ('good','manual') AND \"pairing_decision\".\"url\" IS NOT NULL) OR (\"pairing_decision\".\"status\"::text IN ('unavailable','discontinued','split') AND \"pairing_decision\".\"url\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pairing_search_settings": {
+      "name": "pairing_search_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing_state_writeback_settings": {
+      "name": "pairing_state_writeback_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing_variant_link": {
+      "name": "pairing_variant_link",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pairing_variant_link_code_variant_code_fk": {
+          "name": "pairing_variant_link_code_variant_code_fk",
+          "tableFrom": "pairing_variant_link",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.floor_note_product": {
+      "name": "floor_note_product",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "floor_note_id": {
+          "name": "floor_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "floor_note_product_note_idx": {
+          "name": "floor_note_product_note_idx",
+          "columns": [
+            {
+              "expression": "floor_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "floor_note_product_note_variant_uq": {
+          "name": "floor_note_product_note_variant_uq",
+          "columns": [
+            {
+              "expression": "floor_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "floor_note_product_floor_note_id_floor_note_id_fk": {
+          "name": "floor_note_product_floor_note_id_floor_note_id_fk",
+          "tableFrom": "floor_note_product",
+          "tableTo": "floor_note",
+          "columnsFrom": [
+            "floor_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "floor_note_product_variant_code_variant_code_fk": {
+          "name": "floor_note_product_variant_code_variant_code_fk",
+          "tableFrom": "floor_note_product",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.floor_note": {
+      "name": "floor_note",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "resolved": {
+          "name": "resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "called": {
+          "name": "called",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "floor_note_created_at_idx": {
+          "name": "floor_note_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "floor_note_created_by_user_id_users_id_fk": {
+          "name": "floor_note_created_by_user_id_users_id_fk",
+          "tableFrom": "floor_note",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne"
+      ]
+    },
+    "public.pairing_state": {
+      "name": "pairing_state",
+      "schema": "public",
+      "values": [
+        "navrhnute",
+        "potvrdene"
+      ]
+    },
+    "public.nedostupne_email_type": {
+      "name": "nedostupne_email_type",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "alternativa"
+      ]
+    },
+    "public.mail_template_action": {
+      "name": "mail_template_action",
+      "schema": "public",
+      "values": [
+        "save",
+        "reset"
+      ]
+    },
+    "public.mail_log_source": {
+      "name": "mail_log_source",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "posta_uncollected",
+        "order_reminder",
+        "supplier_order",
+        "order_merge"
+      ]
+    },
+    "public.mail_log_status": {
+      "name": "mail_log_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.mail_log_trigger": {
+      "name": "mail_log_trigger",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "manual"
+      ]
+    },
+    "public.supplier_availability": {
+      "name": "supplier_availability",
+      "schema": "public",
+      "values": [
+        "available",
+        "unavailable",
+        "unknown"
+      ]
+    },
+    "public.supplier_stock_source": {
+      "name": "supplier_stock_source",
+      "schema": "public",
+      "values": [
+        "json_ld",
+        "meta",
+        "text",
+        "size_list",
+        "none"
+      ]
+    },
+    "public.shop_product_url_source": {
+      "name": "shop_product_url_source",
+      "schema": "public",
+      "values": [
+        "feed",
+        "sitemap",
+        "probe"
+      ]
+    },
+    "public.upozornenie_source": {
+      "name": "upozornenie_source",
+      "schema": "public",
+      "values": [
+        "vlastne",
+        "appka"
+      ]
+    },
+    "public.upozornenie_type": {
+      "name": "upozornenie_type",
+      "schema": "public",
+      "values": [
+        "vlastna_poznamka",
+        "nevyzdvihnuta_zasielka",
+        "vratenie",
+        "vratena_zasielka",
+        "objednavka_visi"
+      ]
+    },
+    "public.dpd_operation_status": {
+      "name": "dpd_operation_status",
+      "schema": "public",
+      "values": [
+        "submitted",
+        "failed"
+      ]
+    },
+    "public.pairing_confidence": {
+      "name": "pairing_confidence",
+      "schema": "public",
+      "values": [
+        "high",
+        "medium",
+        "low",
+        "none"
+      ]
+    },
+    "public.pairing_decision_status": {
+      "name": "pairing_decision_status",
+      "schema": "public",
+      "values": [
+        "good",
+        "manual",
+        "unavailable",
+        "discontinued",
+        "split"
+      ]
+    },
+    "public.pairing_verdict": {
+      "name": "pairing_verdict",
+      "schema": "public",
+      "values": [
+        "ok",
+        "unsure"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -386,6 +386,13 @@
       "when": 1786649301861,
       "tag": "0054_zippy_invisible_woman",
       "breakpoints": true
+    },
+    {
+      "idx": 55,
+      "version": "7",
+      "when": 1786665933403,
+      "tag": "0055_daily_rafael_vega",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema-pairing-review.ts
+++ b/apps/api/src/db/schema-pairing-review.ts
@@ -141,6 +141,14 @@ export const pairingVariantLinks = pgTable("pairing_variant_link", {
     .references(() => variants.code, { onDelete: "cascade" }),
   url: text("url").notNull(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  // issue 423 — nočný spätný zápis per-veľkosť linkov do Shoptetu. Presný
+  // mirror `product_supplier_link_override.synced_at`: `null` = ešte nikdy
+  // odoslané; `synced_at < updated_at` = odoslané, ale odvtedy znova zmenené.
+  // Táto appka VŠADE sleduje "zmenené od posledného syncu" časovým diffom
+  // (nie value-diffom ako Python stará appka) — konzistentná voľba. Nulluje
+  // sa TÝMTO stĺpcom pri každej zmene linky (`variant-links.ts`'s
+  // `setPairingVariantLink` už `updated_at` obnovuje, čo diff zachytí).
+  syncedAt: timestamp("synced_at", { withTimezone: true }),
 });
 
 // issue 387 E7 — Singleton Štart/Stop prepínač PRE STAVOVÝ WRITEBACK

--- a/apps/api/src/modules/restock/queries.ts
+++ b/apps/api/src/modules/restock/queries.ts
@@ -6,7 +6,7 @@
 
 import { and, asc, desc, eq, isNull, ne, or, sql } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
-import { products, restockEvents, shopProductUrl, supplierStock, variants } from "../../db/schema.js";
+import { pairingDecisions, pairingVariantLinks, products, restockEvents, shopProductUrl, supplierStock, variants } from "../../db/schema.js";
 import { FEED_IN_STOCK } from "../catalog/feed-cross-check.js";
 import {
   CONFIRMATION_MAX_AGE_HOURS,
@@ -86,7 +86,18 @@ async function allRestockCandidates(db: Database, now: Date): Promise<readonly R
   // (`supplier-link.ts` → prvý `http(s)://…` výskyt): `substring` s rovnakým
   // vzorom, aby sa kľúč na `supplier_stock` nemohol rozísť. Koncová
   // interpunkcia sa oreže rovnako ako tam.
-  const link = sql<string>`trim(both from regexp_replace(substring(${products.internalNote} from 'https?://[^[:space:]]+'), '[.,;:)\\]]+$', ''))`;
+  const productLink = sql<string>`trim(both from regexp_replace(substring(${products.internalNote} from 'https?://[^[:space:]]+'), '[.,;:)\\]]+$', ''))`;
+  // issue 423: split-riadený variant (má `pairing_variant_link` A jeho
+  // produkt má `pairing_decision.status='split'`) má VLASTNÚ per-veľkosť
+  // linku namiesto produktovej. Efektívna linka = per-veľkosť linka pri
+  // split produkte, inak produktová — rovnaká trailing-punct normalizácia
+  // oboch strán, aby sa kľúč na `supplier_stock` nemohol rozísť s
+  // `collectSupplierLinks` scraperom (ktorý split linku scrapuje ako
+  // blanket `size_label=''`, čo pod-JOIN nižšie cez `size_label=''` vetvu
+  // spáruje). Dormantná per-veľkosť linka (produkt nerozdelený) sa
+  // ignoruje — `coalesce` padne na produktovú.
+  const variantLink = sql<string>`trim(both from regexp_replace(substring(${pairingVariantLinks.url} from 'https?://[^[:space:]]+'), '[.,;:)\\]]+$', ''))`;
+  const link = sql<string>`coalesce(case when ${pairingDecisions.status} = 'split' then ${variantLink} end, ${productLink})`;
 
   const rows = await db
     .select({
@@ -102,6 +113,11 @@ async function allRestockCandidates(db: Database, now: Date): Promise<readonly R
     })
     .from(variants)
     .innerJoin(products, eq(variants.productKey, products.key))
+    // issue 423: LEFT JOINy PRED `supplierStock` innerJoinom — jeho ON
+    // klauzula (`eq(supplierStock.link, link)`) referencuje `link`, ktorý
+    // referencuje tieto dve tabuľky, takže musia byť v JOIN zozname skôr.
+    .leftJoin(pairingVariantLinks, eq(pairingVariantLinks.code, variants.code))
+    .leftJoin(pairingDecisions, eq(pairingDecisions.productKey, products.key))
     // issue 224: odkaz s pravidlom na veľkosti nesie VIAC riadkov naraz —
     // jeden na KAŽDÚ našu veľkosť. Variant sa spáruje buď na SVOJU vlastnú
     // veľkosť (`size_label = coalesce(variant.size_label,'')`), alebo na

--- a/apps/api/src/modules/shoptet-writeback/csv.test.ts
+++ b/apps/api/src/modules/shoptet-writeback/csv.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildRestockCsv, buildStatesCsv, buildWritebackCsv, dedupeStateRowsByCode } from "./csv.js";
+import { buildRestockCsv, buildStatesCsv, buildWritebackCsv, dedupeStateRowsByCode, dedupeWritebackRowsByCode } from "./csv.js";
 
 describe("buildWritebackCsv", () => {
   it("has the canonical Shoptet import header + BOM + CRLF + ';' delimiter", () => {
@@ -135,6 +135,30 @@ describe("buildStatesCsv", () => {
       "DUP;1;visible;0;Vypredané;Vypredané",
       "OK;3;detailOnly;0;Predaj výrobku skončil;Predaj výrobku skončil",
     ]);
+  });
+});
+
+describe("dedupeWritebackRowsByCode (issue 423)", () => {
+  it("necháva neduplicitné riadky bezo zmeny (rovnaké poradie)", () => {
+    const rows = [
+      { code: "A", pairCode: "", internalNote: "https://a.example/x" },
+      { code: "B", pairCode: "", internalNote: "https://b.example/x" },
+    ];
+    expect(dedupeWritebackRowsByCode(rows)).toEqual(rows);
+  });
+
+  it("zachová PRVÝ výskyt kódu — per-veľkosť link (dáva sa prvý) vyhrá nad produktovým override", () => {
+    const rows = [
+      { code: "X/L", pairCode: "1", internalNote: "https://dodavatel.example/velkost-L" }, // per-veľkosť (prvý)
+      { code: "X/L", pairCode: "1", internalNote: "https://dodavatel.example/produkt" }, // produktový override
+    ];
+    expect(dedupeWritebackRowsByCode(rows)).toEqual([
+      { code: "X/L", pairCode: "1", internalNote: "https://dodavatel.example/velkost-L" },
+    ]);
+  });
+
+  it("je no-op pre prázdny zoznam", () => {
+    expect(dedupeWritebackRowsByCode([])).toEqual([]);
   });
 });
 

--- a/apps/api/src/modules/shoptet-writeback/csv.ts
+++ b/apps/api/src/modules/shoptet-writeback/csv.ts
@@ -44,9 +44,31 @@ function dataRowToLine(values: readonly string[]): string {
 }
 
 /**
+ * Dedup podľa `code`, PRVÝ výskyt vyhráva — Shoptet zruší CELÝ import pri
+ * duplicitnom kóde. issue 423: zlúčený linkový import spája produktovú cestu
+ * (`select-changes.ts`, split-riadené varianty VYLÚČENÉ) a per-veľkosť cestu
+ * (`select-variant-links.ts`, LEN split-riadené varianty) — tie sú
+ * konštrukčne DISJUNKTNÉ po kóde, takže tu duplikát nikdy nevznikne;
+ * `variants.code` je navyše DB primárny kľúč. Táto funkcia je obranná vrstva
+ * navyše (rovnaký princíp ako `dedupeStateRowsByCode`), nikdy jediná ochrana.
+ * Volajúci (`run-writeback.ts`) dáva per-veľkosť riadky PRVÉ, aby pri
+ * (nemožnom) strete kódu vyhral konkrétnejší per-veľkosť link, nie produktový
+ * override.
+ */
+export function dedupeWritebackRowsByCode(rows: readonly WritebackRow[]): readonly WritebackRow[] {
+  const seen = new Set<string>();
+  return rows.filter((r) => {
+    if (seen.has(r.code)) return false;
+    seen.add(r.code);
+    return true;
+  });
+}
+
+/**
  * Builds the write-back CSV as a Buffer ready to upload — UTF-8 BOM prefix,
  * one row per given variant (caller decides which variants: one per changed
- * product's variant codes, `select-changes.ts`). Throws when given no rows —
+ * product's variant codes, `select-changes.ts`; plus split per-size links,
+ * `select-variant-links.ts`, issue 423). Throws when given no rows —
  * Shoptet's bulk import must never be invoked with a file that changes
  * nothing.
  */

--- a/apps/api/src/modules/shoptet-writeback/mark-variant-synced.ts
+++ b/apps/api/src/modules/shoptet-writeback/mark-variant-synced.ts
@@ -1,0 +1,27 @@
+import { and, inArray, lte } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { pairingVariantLinks } from "../../db/schema.js";
+
+/**
+ * Označí dané per-veľkosť linky (`pairing_variant_link.code`) ako úspešne
+ * zapísané do Shoptetu — mirror `markSuppliersLinksSynced` (mark-synced.ts),
+ * len na `pairing_variant_link.synced_at`. Volaj LEN po POTVRDENOM úspechu
+ * (zlúčený linkový import prešiel, Log ukázal presne toľko spracovaných
+ * riadkov, koľko sa poslalo, `run-writeback.ts`). Pri chybe/nejednoznačnom
+ * výsledku ostáva `synced_at` nezmenené, takže nasledujúci beh tie isté
+ * linky pošle znova. No-op pre prázdny zoznam.
+ *
+ * `now` je čas ZAČIATKU celého behu (rovnaký race guard ako linkový/stavový
+ * zápis, `.claude/rules/shoptet-writeback.md`): keby sa link zmenil ZNOVA
+ * MEDZI výberom a týmto zápisom (import cez prehliadač trvá desiatky sekúnd),
+ * jeho nový `updated_at` je NUTNE neskôr než `now`, takže ho `updated_at <=
+ * now` podmienka NEoznačí ako synchronizovaný a nasledujúci beh ho pošle
+ * znova (do Shoptetu odišla len STARŠIA hodnota).
+ */
+export async function markVariantLinksSynced(db: Database, codes: readonly string[], now: Date): Promise<void> {
+  if (codes.length === 0) return;
+  await db
+    .update(pairingVariantLinks)
+    .set({ syncedAt: now })
+    .where(and(inArray(pairingVariantLinks.code, [...codes]), lte(pairingVariantLinks.updatedAt, now)));
+}

--- a/apps/api/src/modules/shoptet-writeback/run-writeback.ts
+++ b/apps/api/src/modules/shoptet-writeback/run-writeback.ts
@@ -52,7 +52,18 @@ export async function runShoptetWriteback(
   const product = await selectChangedSupplierLinks(db);
   const variant = await selectChangedVariantLinks(db);
   const rows = dedupeWritebackRowsByCode([...variant.rows, ...product.rows]);
-  if (rows.length === 0) return { status: "nothing_changed" };
+  if (rows.length === 0) {
+    // Žiadny CSV na nahranie — ALE fully-split produkt (override zmenený,
+    // VŠETKY varianty split-riadené) je v `product.productKeys` s 0 riadkami:
+    // jeho override je dormantný (nič sa preň neposiela, per-veľkosť linky ho
+    // pokrývajú) → musí sa označiť synced TERAZ, inak by re-selectoval každý
+    // hodinový beh donekonečna (invariant dokumentovaný v `select-changes.ts`).
+    // `variant.codes` je pri 0 riadkoch prázdny (no-op). Žiadny Shoptet import
+    // sa nedeje ani nepreskakuje — pre dormantný override niet čo poslať;
+    // `updated_at <= now` guard (`mark-synced.ts`) drží race ochranu.
+    await markSuppliersLinksSynced(db, product.productKeys, now);
+    return { status: "nothing_changed" };
+  }
 
   const csv = buildWritebackCsv(rows);
   let outcome: ShoptetImportOutcome;

--- a/apps/api/src/modules/shoptet-writeback/run-writeback.ts
+++ b/apps/api/src/modules/shoptet-writeback/run-writeback.ts
@@ -1,16 +1,19 @@
 import type { Database } from "../../db/client.js";
-import { buildWritebackCsv } from "./csv.js";
+import { buildWritebackCsv, dedupeWritebackRowsByCode } from "./csv.js";
 import type { ShoptetImportConfig } from "./config.js";
 import { markSuppliersLinksSynced } from "./mark-synced.js";
+import { markVariantLinksSynced } from "./mark-variant-synced.js";
 import { runShoptetImportIsolated, type ShoptetImportOutcome } from "./playwright-import.js";
 import { selectChangedSupplierLinks } from "./select-changes.js";
+import { selectChangedVariantLinks } from "./select-variant-links.js";
 
 export type WritebackRunResult =
   | { readonly status: "nothing_changed" }
-  | { readonly status: "ok"; readonly productCount: number; readonly rowCount: number }
+  | { readonly status: "ok"; readonly productCount: number; readonly variantLinkCount: number; readonly rowCount: number }
   | {
       readonly status: "failed";
       readonly productCount: number;
+      readonly variantLinkCount: number;
       readonly rowCount: number;
       readonly processed: number | null;
       readonly failed: number | null;
@@ -18,30 +21,37 @@ export type WritebackRunResult =
     };
 
 /**
- * Celý beh issue 122: vyber zmenené odkazy → postav CSV → nahraj cez
- * Playwright → LEN po POTVRDENOM úspechu označ dané produkty ako
- * synchronizované. Pri chybe/nejednoznačnom výsledku sa `syncedAt` NIKDY
- * nezmení — nasledujúci beh (naplánovaná úloha, `scheduler/jobs.ts`) tie isté
- * produkty pošle znova. `now` sa berie ako parameter (nie `new Date()` tu
- * vnútri), rovnaká disciplína ako `catalogImportJob`/`ordersImportJob`.
+ * Celý beh issue 122 + issue 423: vyber zmenené PRODUKTOVÉ odkazy
+ * (`select-changes.ts`, split-riadené varianty vylúčené) A zmenené
+ * PER-VEĽKOSŤ split linky (`select-variant-links.ts`, LEN split-riadené) →
+ * ZLÚČ do JEDNÉHO CSV (identické stĺpce `code;pairCode;internalNote`,
+ * disjunktné po kóde) → nahraj cez JEDEN Playwright import → LEN po
+ * POTVRDENOM úspechu označ OBE strany ako synchronizované. Žiadny druhý
+ * browser child-proces navyše, žiadny nový Štart/Stop prepínač (linkový
+ * zápis mení len privátnu poznámku, nie viditeľnosť — rovnaké zdôvodnenie
+ * ako #122). Pri chybe/nejednoznačnom výsledku sa `syncedAt` ani na jednej
+ * strane NIKDY nezmení — nasledujúci beh (naplánovaná úloha,
+ * `scheduler/jobs.ts`) tie isté položky pošle znova. `now` sa berie ako
+ * parameter (nie `new Date()` tu vnútri), rovnaká disciplína ako
+ * `catalogImportJob`/`ordersImportJob`.
+ *
+ * Per-veľkosť riadky idú do zlúčenia PRVÉ, aby pri (konštrukčne nemožnom)
+ * strete kódu vyhral konkrétnejší per-veľkosť link, nie produktový override.
  *
  * issue 387 E7 (review nález): `runShoptetImportIsolated` VYHADZUJE (nie len
- * vracia `{ok:false}`) na TVRDOM zlyhaní (nenájde prihlasovací formulár,
- * nenájde bezpečný radio, dieťa proces skončí bez výsledku — `child-
- * runner.ts`) — TENTO `try`/`catch` PREMIEŇA aj tento prípad na normálny
- * `{status:"failed"}` výsledok (`processed`/`failed` `null`, keďže žiadny
- * štruktúrovaný Log výsledok nebol získaný). Bez neho by výnimka prešla AŽ
- * DO `run-writeback-sequence.ts`, kde by ZASTAVILA aj pokus o DRUHÝ
- * (stavový) import — presne opak toho, čo `runShoptetWritebackSequence`
- * sľubuje ("nezávislé"). Predtým sa toto nikdy neprejavilo, lebo `run-
- * writeback.ts` bolo JEDINÝM krokom behu (issue 122) — teraz je PRVÝM z DVOCH.
+ * vracia `{ok:false}`) na TVRDOM zlyhaní — TENTO `try`/`catch` PREMIEŇA aj
+ * tento prípad na normálny `{status:"failed"}` výsledok, aby výnimka nikdy
+ * neprešla do `run-writeback-sequence.ts` a nezastavila DRUHÝ (stavový)
+ * import.
  */
 export async function runShoptetWriteback(
   db: Database,
   config: ShoptetImportConfig,
   now: Date,
 ): Promise<WritebackRunResult> {
-  const { productKeys, rows } = await selectChangedSupplierLinks(db);
+  const product = await selectChangedSupplierLinks(db);
+  const variant = await selectChangedVariantLinks(db);
+  const rows = dedupeWritebackRowsByCode([...variant.rows, ...product.rows]);
   if (rows.length === 0) return { status: "nothing_changed" };
 
   const csv = buildWritebackCsv(rows);
@@ -51,7 +61,8 @@ export async function runShoptetWriteback(
   } catch (error) {
     return {
       status: "failed",
-      productCount: productKeys.length,
+      productCount: product.productKeys.length,
+      variantLinkCount: variant.codes.length,
       rowCount: rows.length,
       processed: null,
       failed: null,
@@ -62,7 +73,8 @@ export async function runShoptetWriteback(
   if (!outcome.ok) {
     return {
       status: "failed",
-      productCount: productKeys.length,
+      productCount: product.productKeys.length,
+      variantLinkCount: variant.codes.length,
       rowCount: rows.length,
       processed: outcome.processed,
       failed: outcome.failed,
@@ -70,6 +82,7 @@ export async function runShoptetWriteback(
     };
   }
 
-  await markSuppliersLinksSynced(db, productKeys, now);
-  return { status: "ok", productCount: productKeys.length, rowCount: rows.length };
+  await markSuppliersLinksSynced(db, product.productKeys, now);
+  await markVariantLinksSynced(db, variant.codes, now);
+  return { status: "ok", productCount: product.productKeys.length, variantLinkCount: variant.codes.length, rowCount: rows.length };
 }

--- a/apps/api/src/modules/shoptet-writeback/select-changes.ts
+++ b/apps/api/src/modules/shoptet-writeback/select-changes.ts
@@ -1,14 +1,20 @@
-import { eq, isNull, lt, or } from "drizzle-orm";
+import { and, count, eq, isNull, lt, ne, or } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
-import { productSupplierLinkOverrides, variants } from "../../db/schema.js";
+import { pairingDecisions, pairingVariantLinks, productSupplierLinkOverrides, variants } from "../../db/schema.js";
 import { log } from "../../logger.js";
 import type { WritebackRow } from "./csv.js";
 
 export interface SelectedWriteback {
-  /** productKey of every override actually included below — used to mark
-   * `syncedAt` after a CONFIRMED successful import (run-writeback.ts). */
+  /** productKey of every changed override that owns at least one variant —
+   * used to mark `syncedAt` after a CONFIRMED successful import
+   * (run-writeback.ts). Includes a fully-split product (0 emitted rows, its
+   * override dormant/covered by per-size links) so it never re-selects
+   * forever; excludes only the true "no variant at all" data anomaly. */
   readonly productKeys: readonly string[];
-  /** one row per variant of every changed product, ready for buildWritebackCsv. */
+  /** one row per NON-split-governed variant of every changed product, ready
+   * for buildWritebackCsv. Split-governed variants (a per-size link AND
+   * `pairing_decision.status='split'`) are excluded here — their internalNote
+   * is owned by `select-variant-links.ts` (issue 423). */
   readonly rows: readonly WritebackRow[];
 }
 
@@ -20,6 +26,15 @@ export interface SelectedWriteback {
  * danému produktu — `internalNote` (odkaz na dodávateľa) je produktové pole,
  * ale Shoptet páruje import podľa variantového `code`+`pairCode`
  * (`parovanie_produktov`'s `link_rows`, viď design komentár na #122).
+ *
+ * issue 423 — split-riadené varianty (majú `pairing_variant_link` A ich
+ * produkt má `pairing_decision.status = 'split'`) sú z produktovej cesty
+ * VYLÚČENÉ: ich internalNote vlastní `pairing_variant_link`, píše ho
+ * `select-variant-links.ts` cez zlúčený import. Bez tohto vylúčenia by
+ * produktový override prepísal internalNote split veľkosti — a keby bol
+ * override zmenený, vyprodukoval by DUPLICITNÝ kód popri per-veľkosť ceste
+ * (Shoptet zruší CELÝ import pri duplicitnom kóde). Vylúčenie robí kódy
+ * oboch ciest DISJUNKTNÉ konštrukčne.
  */
 export async function selectChangedSupplierLinks(db: Database): Promise<SelectedWriteback> {
   const changedCondition = or(
@@ -36,24 +51,50 @@ export async function selectChangedSupplierLinks(db: Database): Promise<Selected
     })
     .from(productSupplierLinkOverrides)
     .innerJoin(variants, eq(variants.productKey, productSupplierLinkOverrides.productKey))
-    .where(changedCondition);
+    // issue 423: `pairing_variant_link` per variantovom `code`,
+    // `pairing_decision` per produkte — spolu určujú, či je variant
+    // split-riadený (a teda vylúčený z produktovej cesty). LEFT JOINy
+    // (nie inner) — variant BEZ per-veľkosť linku / BEZ rozhodnutia ostáva.
+    .leftJoin(pairingVariantLinks, eq(pairingVariantLinks.code, variants.code))
+    .leftJoin(pairingDecisions, eq(pairingDecisions.productKey, productSupplierLinkOverrides.productKey))
+    .where(
+      and(
+        changedCondition,
+        // Vylúč variant IBA keď má per-veľkosť link A produkt je split.
+        or(
+          isNull(pairingVariantLinks.code),
+          isNull(pairingDecisions.status),
+          ne(pairingDecisions.status, "split"),
+        ),
+      ),
+    );
 
-  const productKeys = [...new Set(rows.map((r) => r.productKey))];
-
-  // review of PR 140: an override for a productKey with ZERO variant rows
-  // (a data anomaly — every real product has at least one variant) would
-  // otherwise silently drop out of the innerJoin above forever, never
-  // synced and never logged. Making the gap OBSERVABLE (rather than a
-  // permanently silent no-op) is cheap — one extra id-only query, only run
-  // when there is anything changed at all to compare against.
-  const changedOverrides = await db
-    .select({ productKey: productSupplierLinkOverrides.productKey })
+  // Marking set (issue 423): každý zmenený override, ktorý MÁ aspoň jeden
+  // variant, sa smie označiť ako synced — vrátane produktu, ktorého VŠETKY
+  // varianty sú split-riadené (0 emitovaných riadkov vyššie, ale jeho
+  // override je dormantný, pokrytý per-veľkosť linkami — nesmie donekonečna
+  // re-selectovať). Skutočná "anomália bez variantu" (override na productKey
+  // s NULA variantmi, dátová anomália z PR 140 review #122) sa NEoznačí a
+  // zaloguje ako predtým — jedna GROUP BY otázka pokrýva oboje.
+  const overrideVariantCounts = await db
+    .select({
+      productKey: productSupplierLinkOverrides.productKey,
+      variantCount: count(variants.code),
+    })
     .from(productSupplierLinkOverrides)
-    .where(changedCondition);
-  const skipped = changedOverrides.map((o) => o.productKey).filter((key) => !productKeys.includes(key));
-  if (skipped.length > 0) {
+    .leftJoin(variants, eq(variants.productKey, productSupplierLinkOverrides.productKey))
+    .where(changedCondition)
+    .groupBy(productSupplierLinkOverrides.productKey);
+
+  const productKeys: string[] = [];
+  const noVariantAnomaly: string[] = [];
+  for (const row of overrideVariantCounts) {
+    if (row.variantCount > 0) productKeys.push(row.productKey);
+    else noVariantAnomaly.push(row.productKey);
+  }
+  if (noVariantAnomaly.length > 0) {
     log.warn(
-      { skippedProductKeys: skipped },
+      { skippedProductKeys: noVariantAnomaly },
       "shoptet write-back: preskočené zmenené odkazy na dodávateľa bez žiadneho variantu (dátová anomália)",
     );
   }

--- a/apps/api/src/modules/shoptet-writeback/select-variant-links.ts
+++ b/apps/api/src/modules/shoptet-writeback/select-variant-links.ts
@@ -1,0 +1,58 @@
+import { and, eq, isNull, lt, or } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { pairingDecisions, pairingVariantLinks, variants } from "../../db/schema.js";
+import type { WritebackRow } from "./csv.js";
+
+export interface SelectedVariantLinkWriteback {
+  /** `code` of every per-size link actually included below — used to mark
+   * `syncedAt` after a CONFIRMED successful import (run-writeback.ts). */
+  readonly codes: readonly string[];
+  /** one row per SPLIT-governed variant with a per-size link, ready to merge
+   * into buildWritebackCsv (same `code;pairCode;internalNote` shape as the
+   * product-level path). */
+  readonly rows: readonly WritebackRow[];
+}
+
+/**
+ * "Zmenilo sa niečo od posledného úspešného zápisu per-veľkosť liniek?"
+ * (issue 423) — mirror `selectChangedSupplierLinks` (select-changes.ts), len
+ * nad `pairing_variant_link` namiesto `product_supplier_link_override`.
+ * `synced_at IS NULL` = ešte nikdy odoslané; `synced_at < updated_at` =
+ * odoslané, ale link odvtedy znova zmenený (`variant-links.ts`'s
+ * `setPairingVariantLink` obnovuje `updated_at` pri KAŽDEJ zmene).
+ *
+ * GATE `pairing_decision.status = 'split'` — presne starej appky's
+ * `split_codes` gate (`webreview/app.py`'s `_do_upload_variant_links`): link
+ * je "efektívny" LEN keď je produkt reálne ROZDELENÝ, nie len rozpísaný v
+ * paneli, ešte nepotvrdený "✓ Hotovo". Dormantná per-veľkosť linka (produkt
+ * nerozdelený / vrátený späť) sa do Shoptetu nikdy neposiela — jeho efektívna
+ * linka je produktová (`select-changes.ts`).
+ *
+ * `pairing_variant_link.code` je FK na `variant.code` (cascade), takže
+ * `innerJoin variants` NIKDY nič nestratí — na rozdiel od
+ * `selectChangedSupplierLinks`/`selectChangedStateDecisions` tu nie je
+ * "anomália bez variantu" (link bez variantu je štrukturálne nemožný).
+ */
+export async function selectChangedVariantLinks(db: Database): Promise<SelectedVariantLinkWriteback> {
+  const rows = await db
+    .select({
+      code: pairingVariantLinks.code,
+      pairCode: variants.pairCode,
+      url: pairingVariantLinks.url,
+    })
+    .from(pairingVariantLinks)
+    .innerJoin(variants, eq(variants.code, pairingVariantLinks.code))
+    .innerJoin(pairingDecisions, eq(pairingDecisions.productKey, variants.productKey))
+    .where(
+      and(
+        or(isNull(pairingVariantLinks.syncedAt), lt(pairingVariantLinks.syncedAt, pairingVariantLinks.updatedAt)),
+        eq(pairingDecisions.status, "split"),
+      ),
+    )
+    .orderBy(pairingVariantLinks.code);
+
+  return {
+    codes: rows.map((r) => r.code),
+    rows: rows.map((r) => ({ code: r.code, pairCode: r.pairCode ?? "", internalNote: r.url })),
+  };
+}

--- a/apps/api/src/modules/supplier-stock/run.ts
+++ b/apps/api/src/modules/supplier-stock/run.ts
@@ -6,7 +6,7 @@
 
 import { and, eq, isNotNull, like, notInArray, or } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
-import { products, supplierStock, variants } from "../../db/schema.js";
+import { pairingDecisions, pairingVariantLinks, products, supplierStock, variants } from "../../db/schema.js";
 import { extractSupplierLink } from "../catalog/supplier-link.js";
 import { MAX_AGE_HOURS, OWN_SHOP_HOST, PER_HOST_DELAY_MS, SUPPLIER_STOCK_RUN_LOCK_KEY } from "./constants.js";
 import type { PageFetcher } from "./page-fetcher.js";
@@ -60,7 +60,18 @@ function isOwnShopHost(host: string): boolean {
 
 /** Unikátne dodávateľské linky z katalógu, v stabilnom poradí. Odkazy na NÁŠ
  * VLASTNÝ e-shop (issue 227 — omylom vytiahnuté z `internalNote` tým istým
- * regexom ako skutočné odkazy) sa sem nikdy nedostanú. */
+ * regexom ako skutočné odkazy) sa sem nikdy nedostanú.
+ *
+ * issue 423: navyše split-riadené per-veľkosť linky (`pairing_variant_link`
+ * pre variant produktu s `pairing_decision.status='split'`). Split produkt
+ * NEMÁ produktovú `internalNote` linku (jeho linky žijú per veľkosť), takže
+ * bez tohto by sa jeho veľkosti nikdy nescrapovali. Každá split linka je
+ * jedna URL na jednu veľkosť (jednoveľkostná stránka), takže sa scrapne ako
+ * blanket (`size_label=''`, `collectOurSizesByLink` ju per-produkt grouping
+ * NEZAHRNIE) a `restock/queries.ts`'s JOIN ju cez `size_label=''` vetvu
+ * spáruje. Rovnaká `extractSupplierLink` normalizácia + vylúčenie vlastného
+ * e-shopu ako pri produktových linkách, aby sa kľúč na `supplier_stock`
+ * nemohol rozísť s `restock/queries.ts`. */
 export async function collectSupplierLinks(db: Database): Promise<readonly string[]> {
   const rows = await db
     .select({ internalNote: products.internalNote })
@@ -72,6 +83,19 @@ export async function collectSupplierLinks(db: Database): Promise<readonly strin
     const host = url === null ? "" : hostOf(url);
     if (url !== null && host !== "" && !isOwnShopHost(host)) links.add(url);
   }
+
+  const variantLinkRows = await db
+    .select({ url: pairingVariantLinks.url })
+    .from(pairingVariantLinks)
+    .innerJoin(variants, eq(variants.code, pairingVariantLinks.code))
+    .innerJoin(pairingDecisions, eq(pairingDecisions.productKey, variants.productKey))
+    .where(eq(pairingDecisions.status, "split"));
+  for (const row of variantLinkRows) {
+    const url = extractSupplierLink(row.url).url;
+    const host = url === null ? "" : hostOf(url);
+    if (url !== null && host !== "" && !isOwnShopHost(host)) links.add(url);
+  }
+
   return [...links].sort((a, b) => a.localeCompare(b));
 }
 

--- a/apps/api/tests/restock-split-links.integration.test.ts
+++ b/apps/api/tests/restock-split-links.integration.test.ts
@@ -109,6 +109,19 @@ describe("restock kandidáti — split per-veľkosť linky (issue 423)", () => {
     expect(picked).toEqual([]);
   });
 
+  it("for a DORMANT per-size link uses the PRODUCT link, not the per-size one (coalesce fallback)", async () => {
+    const PRODUCT_URL = "https://dodavatel.example/produkt-cely";
+    await seedSplitVariant({ split: false, internalNote: PRODUCT_URL });
+    // the per-size link's own supplier row is AVAILABLE but must be IGNORED
+    await seedBlanketSupplierStock(SPLIT_URL, "available");
+    // the PRODUCT link's supplier row is what must drive the candidate
+    await seedBlanketSupplierStock(PRODUCT_URL, "available");
+
+    const { picked } = await selectRestockCandidates(db, NOW);
+    expect(picked.map((c) => c.variantCode)).toEqual(["SPLIT/L"]);
+    expect(picked[0]?.supplierLink).toBe(PRODUCT_URL);
+  });
+
   it("does NOT switch a split variant whose per-size link the supplier reports unavailable", async () => {
     await seedSplitVariant({ split: true, internalNote: null });
     await seedBlanketSupplierStock(SPLIT_URL, "unavailable");

--- a/apps/api/tests/restock-split-links.integration.test.ts
+++ b/apps/api/tests/restock-split-links.integration.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Database } from "../src/db/client.js";
+import { pairingDecisions, pairingVariantLinks, products, supplierStock, users, variants } from "../src/db/schema.js";
+import { selectRestockCandidates } from "../src/modules/restock/queries.js";
+import { insertTestSnapshot } from "./helpers/catalog.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 423: split-riadený variant má VLASTNÚ per-veľkosť linku (nie
+// produktovú `internalNote`) — `allRestockCandidates` ju musí použiť ako
+// efektívnu linku a spárovať na jej blanket `supplier_stock` riadok, inak sa
+// split veľkosť nikdy neprepne späť na "Skladom".
+
+const NOW = new Date("2026-08-04T04:50:00.000Z");
+const SPLIT_URL = "https://dodavatel.example/velkost-L";
+
+describe("restock kandidáti — split per-veľkosť linky (issue 423)", () => {
+  let db: Database;
+  let close: () => Promise<void>;
+  let snapshotId: string;
+  let userId: string;
+
+  beforeEach(async () => {
+    ({ db, close } = await withCleanDb());
+    snapshotId = await insertTestSnapshot(db);
+    const [user] = await db
+      .insert(users)
+      .values({ email: "d@forestshop.sk", passwordHash: "x", displayName: "D", role: "manazer" })
+      .returning({ id: users.id });
+    if (user === undefined) throw new Error("user");
+    userId = user.id;
+  });
+  afterEach(async () => {
+    await close();
+  });
+
+  async function seedSplitVariant(opts: { split: boolean; internalNote: string | null }): Promise<void> {
+    await db.insert(products).values({
+      key: "SPLIT",
+      name: "Split produkt",
+      supplier: "Dodávateľ",
+      internalNote: opts.internalNote,
+      firstSeenAt: NOW,
+      lastSeenAt: NOW,
+      lastSeenSnapshotId: snapshotId,
+    });
+    await db.insert(variants).values({
+      code: "SPLIT/L",
+      productKey: "SPLIT",
+      guid: "SPLIT",
+      sizeLabel: "L",
+      name: "Split produkt",
+      stock: 0,
+      availabilityInStockText: "Skladom",
+      availabilityOutOfStockText: "Vypredané",
+      availabilityText: "Vypredané",
+      productVisibility: "visible",
+      state: "out_of_stock",
+      missingSince: null,
+      firstSeenAt: NOW,
+      lastSeenAt: NOW,
+      lastSeenSnapshotId: snapshotId,
+    });
+    if (opts.split) {
+      await db.insert(pairingDecisions).values({
+        productKey: "SPLIT",
+        status: "split",
+        url: null,
+        decidedBy: userId,
+        decidedAt: NOW,
+        updatedAt: NOW,
+      });
+    }
+    await db.insert(pairingVariantLinks).values({ code: "SPLIT/L", url: SPLIT_URL, updatedAt: NOW });
+  }
+
+  // The supplier page for a per-size split link is a single-size page → the
+  // scraper writes it as a BLANKET row (size_label='').
+  async function seedBlanketSupplierStock(link: string, availability: "available" | "unavailable"): Promise<void> {
+    await db.insert(supplierStock).values({
+      link,
+      sizeLabel: "",
+      host: "dodavatel.example",
+      availability,
+      availabilityText: availability === "available" ? "skladom" : "vypredané",
+      price: "12.50",
+      source: "json_ld",
+      ok: true,
+      error: null,
+      httpStatus: 200,
+      checkedAt: NOW,
+      confirmedAt: new Date(NOW.getTime() - 3_600_000),
+    });
+  }
+
+  it("makes a SPLIT variant a candidate when its own per-size link is confirmed available", async () => {
+    await seedSplitVariant({ split: true, internalNote: null });
+    await seedBlanketSupplierStock(SPLIT_URL, "available");
+
+    const { picked } = await selectRestockCandidates(db, NOW);
+    expect(picked.map((c) => c.variantCode)).toEqual(["SPLIT/L"]);
+    expect(picked[0]?.supplierLink).toBe(SPLIT_URL);
+  });
+
+  it("does NOT make a DORMANT per-size link (product not split) a candidate — falls back to the (null) product link", async () => {
+    await seedSplitVariant({ split: false, internalNote: null });
+    await seedBlanketSupplierStock(SPLIT_URL, "available");
+
+    const { picked } = await selectRestockCandidates(db, NOW);
+    expect(picked).toEqual([]);
+  });
+
+  it("does NOT switch a split variant whose per-size link the supplier reports unavailable", async () => {
+    await seedSplitVariant({ split: true, internalNote: null });
+    await seedBlanketSupplierStock(SPLIT_URL, "unavailable");
+
+    const { picked } = await selectRestockCandidates(db, NOW);
+    expect(picked).toEqual([]);
+  });
+});

--- a/apps/api/tests/shoptet-writeback-mark-variant-synced.integration.test.ts
+++ b/apps/api/tests/shoptet-writeback-mark-variant-synced.integration.test.ts
@@ -1,0 +1,84 @@
+import { eq } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Database } from "../src/db/client.js";
+import { pairingDecisions, pairingVariantLinks, users } from "../src/db/schema.js";
+import { markVariantLinksSynced } from "../src/modules/shoptet-writeback/mark-variant-synced.js";
+import { selectChangedVariantLinks } from "../src/modules/shoptet-writeback/select-variant-links.js";
+import { withCleanDb } from "./helpers/db.js";
+import { insertTestVariantForProduct } from "./helpers/orders.js";
+
+// issue 423: mirror `shoptet-writeback-mark-synced.integration.test.ts`, len
+// na `pairing_variant_link.synced_at` per `code`.
+
+describe("markVariantLinksSynced", () => {
+  let db: Database;
+  let close: () => Promise<void>;
+  let userId: string;
+
+  async function splitProductWithLink(productKey: string, code: string, updatedAt: Date): Promise<void> {
+    await insertTestVariantForProduct(db, productKey, code, { pairCode: "1", sizeLabel: "S" });
+    await db.insert(pairingDecisions).values({
+      productKey,
+      status: "split",
+      url: null,
+      decidedBy: userId,
+      decidedAt: new Date("2026-01-01T00:00:00Z"),
+      updatedAt: new Date("2026-01-01T00:00:00Z"),
+    });
+    await db.insert(pairingVariantLinks).values({ code, url: `https://dodavatel.example/${code}`, updatedAt });
+  }
+
+  beforeEach(async () => {
+    ({ db, close } = await withCleanDb());
+    const [row] = await db
+      .insert(users)
+      .values({ email: "rozhodca@forestshop.sk", passwordHash: "x", displayName: "Rozhodca", role: "manazer" })
+      .returning({ id: users.id });
+    if (row === undefined) throw new Error("testovací používateľ sa nepodarilo vložiť");
+    userId = row.id;
+  });
+
+  afterEach(async () => {
+    await close();
+  });
+
+  it("sets syncedAt on exactly the given codes, leaving an untouched sibling row alone", async () => {
+    await splitProductWithLink("P1", "P1/S", new Date("2026-01-01T00:00:00Z"));
+    await splitProductWithLink("P2", "P2/S", new Date("2026-01-01T00:00:00Z"));
+
+    await markVariantLinksSynced(db, ["P1/S"], new Date("2026-02-01T00:00:00Z"));
+
+    const [p1] = await db.select({ syncedAt: pairingVariantLinks.syncedAt }).from(pairingVariantLinks).where(eq(pairingVariantLinks.code, "P1/S"));
+    const [p2] = await db.select({ syncedAt: pairingVariantLinks.syncedAt }).from(pairingVariantLinks).where(eq(pairingVariantLinks.code, "P2/S"));
+    expect(p1?.syncedAt?.toISOString()).toBe("2026-02-01T00:00:00.000Z");
+    expect(p2?.syncedAt).toBeNull();
+  });
+
+  it("removes the marked codes from the next selectChangedVariantLinks() result", async () => {
+    await splitProductWithLink("P3", "P3/S", new Date("2026-01-01T00:00:00Z"));
+
+    expect((await selectChangedVariantLinks(db)).codes).toEqual(["P3/S"]);
+    await markVariantLinksSynced(db, ["P3/S"], new Date("2026-01-02T00:00:00Z"));
+    expect((await selectChangedVariantLinks(db)).codes).toEqual([]);
+  });
+
+  it("is a no-op for an empty codes list", async () => {
+    await splitProductWithLink("P4", "P4/S", new Date("2026-01-01T00:00:00Z"));
+
+    await markVariantLinksSynced(db, [], new Date("2026-01-02T00:00:00Z"));
+    expect((await selectChangedVariantLinks(db)).codes).toEqual(["P4/S"]);
+  });
+
+  it("does NOT mark a code synced if it was edited AGAIN after the run started (race window)", async () => {
+    // run started 10:00, selected the link (updatedAt 09:00); the owner
+    // re-edited the SAME per-size link at 10:05, after the run's start but
+    // before this mark call executes. Only the 09:00 value reached Shoptet.
+    await splitProductWithLink("P5", "P5/S", new Date("2026-01-01T10:05:00Z"));
+
+    await markVariantLinksSynced(db, ["P5/S"], new Date("2026-01-01T10:00:00Z"));
+
+    const [row] = await db.select({ syncedAt: pairingVariantLinks.syncedAt }).from(pairingVariantLinks).where(eq(pairingVariantLinks.code, "P5/S"));
+    expect(row?.syncedAt).toBeNull();
+    expect((await selectChangedVariantLinks(db)).codes).toEqual(["P5/S"]);
+  });
+});

--- a/apps/api/tests/shoptet-writeback-run.integration.test.ts
+++ b/apps/api/tests/shoptet-writeback-run.integration.test.ts
@@ -128,6 +128,55 @@ describe("runShoptetWriteback (end-to-end proti fixture)", () => {
   );
 
   it(
+    "issue 423: a fully-split product's CHANGED but dormant override is marked synced even with nothing to upload (never re-selects forever)",
+    async () => {
+      const [user] = await db
+        .insert(users)
+        .values({ email: "d2@forestshop.sk", passwordHash: "x", displayName: "D", role: "manazer" })
+        .returning({ id: users.id });
+      if (user === undefined) throw new Error("user");
+
+      // fully-split product: BOTH variants have per-size links, product split
+      await insertTestVariantForProduct(db, "FS", "FS/S", { pairCode: "1", sizeLabel: "S" });
+      await insertTestVariantForProduct(db, "FS", "FS/M", { pairCode: "2", sizeLabel: "M" });
+      await db.insert(pairingDecisions).values({
+        productKey: "FS",
+        status: "split",
+        url: null,
+        decidedBy: user.id,
+        decidedAt: new Date("2026-01-01T00:00:00Z"),
+        updatedAt: new Date("2026-01-01T00:00:00Z"),
+      });
+      // per-size links ALREADY synced (nothing to send for them)
+      await db.insert(pairingVariantLinks).values([
+        { code: "FS/S", url: "https://x.example/S", updatedAt: new Date("2026-01-01T00:00:00Z"), syncedAt: new Date("2026-01-02T00:00:00Z") },
+        { code: "FS/M", url: "https://x.example/M", updatedAt: new Date("2026-01-01T00:00:00Z"), syncedAt: new Date("2026-01-02T00:00:00Z") },
+      ]);
+      // a CHANGED (never-synced) product-level override that is now dormant —
+      // all its variants are split-governed, so nothing to upload for it
+      await db
+        .insert(productSupplierLinkOverrides)
+        .values({ productKey: "FS", url: "https://x.example/dormant", updatedAt: new Date("2026-01-03T00:00:00Z") });
+
+      const result = await runShoptetWriteback(db, fixtureConfig(), new Date("2026-02-01T00:00:00Z"));
+      // nothing to upload — but the dormant override MUST have been marked
+      expect(result).toEqual({ status: "nothing_changed" });
+      expect(fixture.logEntryCount()).toBe(1); // no import happened (only the seed)
+
+      const [row] = await db
+        .select({ syncedAt: productSupplierLinkOverrides.syncedAt })
+        .from(productSupplierLinkOverrides)
+        .where(eq(productSupplierLinkOverrides.productKey, "FS"));
+      expect(row?.syncedAt?.toISOString()).toBe("2026-02-01T00:00:00.000Z");
+
+      // second run: it does NOT re-select the now-marked dormant override
+      const second = await runShoptetWriteback(db, fixtureConfig(), new Date("2026-02-02T00:00:00Z"));
+      expect(second).toEqual({ status: "nothing_changed" });
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
     "on a hard Shoptet failure leaves syncedAt untouched, so the same product is retried next run",
     async () => {
       await insertTestVariantForProduct(db, "P2", "P2", {});

--- a/apps/api/tests/shoptet-writeback-run.integration.test.ts
+++ b/apps/api/tests/shoptet-writeback-run.integration.test.ts
@@ -1,7 +1,7 @@
 import { eq } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { Database } from "../src/db/client.js";
-import { productSupplierLinkOverrides } from "../src/db/schema.js";
+import { pairingDecisions, pairingVariantLinks, productSupplierLinkOverrides, users } from "../src/db/schema.js";
 import { runShoptetWriteback } from "../src/modules/shoptet-writeback/run-writeback.js";
 import { withCleanDb } from "./helpers/db.js";
 import { insertTestVariantForProduct } from "./helpers/orders.js";
@@ -61,13 +61,64 @@ describe("runShoptetWriteback (end-to-end proti fixture)", () => {
         .values({ productKey: "P1", url: "https://x.example/p1", updatedAt: new Date("2026-01-01T00:00:00Z") });
 
       const result = await runShoptetWriteback(db, fixtureConfig(), new Date("2026-02-01T00:00:00Z"));
-      expect(result).toEqual({ status: "ok", productCount: 1, rowCount: 2 });
+      expect(result).toEqual({ status: "ok", productCount: 1, variantLinkCount: 0, rowCount: 2 });
 
       const [row] = await db
         .select({ syncedAt: productSupplierLinkOverrides.syncedAt })
         .from(productSupplierLinkOverrides)
         .where(eq(productSupplierLinkOverrides.productKey, "P1"));
       expect(row?.syncedAt?.toISOString()).toBe("2026-02-01T00:00:00.000Z");
+
+      // second run: nothing changed since the sync above
+      const second = await runShoptetWriteback(db, fixtureConfig(), new Date("2026-02-02T00:00:00Z"));
+      expect(second).toEqual({ status: "nothing_changed" });
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "issue 423: merges a product override AND a split product's per-size links into ONE import, marking BOTH synced",
+    async () => {
+      const [user] = await db
+        .insert(users)
+        .values({ email: "d@forestshop.sk", passwordHash: "x", displayName: "D", role: "manazer" })
+        .returning({ id: users.id });
+      if (user === undefined) throw new Error("user");
+
+      // non-split product with a product-level override (1 variant)
+      await insertTestVariantForProduct(db, "PROD", "PROD/1", { pairCode: "9" });
+      await db
+        .insert(productSupplierLinkOverrides)
+        .values({ productKey: "PROD", url: "https://x.example/prod", updatedAt: new Date("2026-01-01T00:00:00Z") });
+
+      // split product with 2 per-size links (no product override)
+      await insertTestVariantForProduct(db, "SPLIT", "SPLIT/S", { pairCode: "1", sizeLabel: "S" });
+      await insertTestVariantForProduct(db, "SPLIT", "SPLIT/M", { pairCode: "2", sizeLabel: "M" });
+      await db.insert(pairingDecisions).values({
+        productKey: "SPLIT",
+        status: "split",
+        url: null,
+        decidedBy: user.id,
+        decidedAt: new Date("2026-01-01T00:00:00Z"),
+        updatedAt: new Date("2026-01-01T00:00:00Z"),
+      });
+      await db.insert(pairingVariantLinks).values([
+        { code: "SPLIT/S", url: "https://x.example/velkost-S", updatedAt: new Date("2026-01-01T00:00:00Z") },
+        { code: "SPLIT/M", url: "https://x.example/velkost-M", updatedAt: new Date("2026-01-01T00:00:00Z") },
+      ]);
+
+      const result = await runShoptetWriteback(db, fixtureConfig(), new Date("2026-02-01T00:00:00Z"));
+      // 1 product row + 2 per-size rows = 3 rows in the single merged import
+      expect(result).toEqual({ status: "ok", productCount: 1, variantLinkCount: 2, rowCount: 3 });
+
+      // both the product override AND both per-size links are marked synced
+      const [prod] = await db
+        .select({ syncedAt: productSupplierLinkOverrides.syncedAt })
+        .from(productSupplierLinkOverrides)
+        .where(eq(productSupplierLinkOverrides.productKey, "PROD"));
+      expect(prod?.syncedAt?.toISOString()).toBe("2026-02-01T00:00:00.000Z");
+      const linkRows = await db.select({ code: pairingVariantLinks.code, syncedAt: pairingVariantLinks.syncedAt }).from(pairingVariantLinks);
+      expect(linkRows.every((r) => r.syncedAt?.toISOString() === "2026-02-01T00:00:00.000Z")).toBe(true);
 
       // second run: nothing changed since the sync above
       const second = await runShoptetWriteback(db, fixtureConfig(), new Date("2026-02-02T00:00:00Z"));

--- a/apps/api/tests/shoptet-writeback-select-variant-links.integration.test.ts
+++ b/apps/api/tests/shoptet-writeback-select-variant-links.integration.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Database } from "../src/db/client.js";
+import { pairingDecisions, pairingVariantLinks, users } from "../src/db/schema.js";
+import { selectChangedVariantLinks } from "../src/modules/shoptet-writeback/select-variant-links.js";
+import { withCleanDb } from "./helpers/db.js";
+import { insertTestVariantForProduct } from "./helpers/orders.js";
+
+// issue 423: mirror `shoptet-writeback-select.integration.test.ts` /
+// `select-states`, teraz nad `pairing_variant_link` (per-veľkosť split
+// linky). Kľúčový rozdiel: GATE na `pairing_decision.status='split'` —
+// dormantná per-veľkosť linka (produkt nerozdelený) sa NIKDY neposiela.
+
+describe("selectChangedVariantLinks", () => {
+  let db: Database;
+  let close: () => Promise<void>;
+  let userId: string;
+
+  async function splitProduct(productKey: string, decidedAt = new Date("2026-01-01T00:00:00Z")): Promise<void> {
+    await db.insert(pairingDecisions).values({
+      productKey,
+      status: "split",
+      url: null,
+      decidedBy: userId,
+      decidedAt,
+      updatedAt: decidedAt,
+    });
+  }
+
+  beforeEach(async () => {
+    ({ db, close } = await withCleanDb());
+    const [row] = await db
+      .insert(users)
+      .values({ email: "rozhodca@forestshop.sk", passwordHash: "x", displayName: "Rozhodca", role: "manazer" })
+      .returning({ id: users.id });
+    if (row === undefined) throw new Error("testovací používateľ sa nepodarilo vložiť");
+    userId = row.id;
+  });
+
+  afterEach(async () => {
+    await close();
+  });
+
+  it("returns no rows when there are no variant links at all", async () => {
+    const result = await selectChangedVariantLinks(db);
+    expect(result.codes).toEqual([]);
+    expect(result.rows).toEqual([]);
+  });
+
+  it("emits ONE row per never-synced per-size link of a SPLIT product, carrying code+pairCode+its OWN url", async () => {
+    await insertTestVariantForProduct(db, "P1", "P1/S", { pairCode: "1001", sizeLabel: "S" });
+    await insertTestVariantForProduct(db, "P1", "P1/M", { pairCode: "1002", sizeLabel: "M" });
+    await splitProduct("P1");
+    await db.insert(pairingVariantLinks).values([
+      { code: "P1/S", url: "https://dodavatel.example/S", updatedAt: new Date("2026-01-02T00:00:00Z") },
+      { code: "P1/M", url: "https://dodavatel.example/M", updatedAt: new Date("2026-01-02T00:00:00Z") },
+    ]);
+
+    const result = await selectChangedVariantLinks(db);
+    expect(result.codes.slice().sort()).toEqual(["P1/M", "P1/S"]);
+    expect(result.rows).toEqual(
+      expect.arrayContaining([
+        { code: "P1/S", pairCode: "1001", internalNote: "https://dodavatel.example/S" },
+        { code: "P1/M", pairCode: "1002", internalNote: "https://dodavatel.example/M" },
+      ]),
+    );
+  });
+
+  it("NEVER emits a DORMANT per-size link whose product is NOT split (staged but not committed)", async () => {
+    await insertTestVariantForProduct(db, "P2", "P2/S", { pairCode: "1", sizeLabel: "S" });
+    // no split decision — the manager set the link in the panel but never clicked "✓ Hotovo"
+    await db
+      .insert(pairingVariantLinks)
+      .values({ code: "P2/S", url: "https://dodavatel.example/S", updatedAt: new Date("2026-01-02T00:00:00Z") });
+
+    const result = await selectChangedVariantLinks(db);
+    expect(result.codes).toEqual([]);
+    expect(result.rows).toEqual([]);
+  });
+
+  it("does NOT emit a per-size link whose product decision reverted away from split", async () => {
+    await insertTestVariantForProduct(db, "P3", "P3/S", { pairCode: "1", sizeLabel: "S" });
+    await db.insert(pairingDecisions).values({
+      productKey: "P3",
+      status: "good",
+      url: "https://dodavatel.example/product",
+      decidedBy: userId,
+      decidedAt: new Date("2026-01-01T00:00:00Z"),
+      updatedAt: new Date("2026-01-01T00:00:00Z"),
+    });
+    await db
+      .insert(pairingVariantLinks)
+      .values({ code: "P3/S", url: "https://dodavatel.example/S", updatedAt: new Date("2026-01-02T00:00:00Z") });
+
+    const result = await selectChangedVariantLinks(db);
+    expect(result.codes).toEqual([]);
+  });
+
+  it("excludes a per-size link already synced AFTER its last update (nothing changed since)", async () => {
+    await insertTestVariantForProduct(db, "P4", "P4/S", { pairCode: "1", sizeLabel: "S" });
+    await splitProduct("P4");
+    await db.insert(pairingVariantLinks).values({
+      code: "P4/S",
+      url: "https://dodavatel.example/S",
+      updatedAt: new Date("2026-01-01T00:00:00Z"),
+      syncedAt: new Date("2026-01-02T00:00:00Z"),
+    });
+
+    const result = await selectChangedVariantLinks(db);
+    expect(result.codes).toEqual([]);
+  });
+
+  it("includes a per-size link whose updatedAt moved PAST its last syncedAt (changed again after a sync)", async () => {
+    await insertTestVariantForProduct(db, "P5", "P5/S", { pairCode: "1", sizeLabel: "S" });
+    await splitProduct("P5");
+    await db.insert(pairingVariantLinks).values({
+      code: "P5/S",
+      url: "https://dodavatel.example/S-new",
+      updatedAt: new Date("2026-01-03T00:00:00Z"),
+      syncedAt: new Date("2026-01-01T00:00:00Z"),
+    });
+
+    const result = await selectChangedVariantLinks(db);
+    expect(result.codes).toEqual(["P5/S"]);
+    expect(result.rows).toEqual([{ code: "P5/S", pairCode: "1", internalNote: "https://dodavatel.example/S-new" }]);
+  });
+});

--- a/apps/api/tests/shoptet-writeback-select.integration.test.ts
+++ b/apps/api/tests/shoptet-writeback-select.integration.test.ts
@@ -1,7 +1,7 @@
 import { eq } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { Database } from "../src/db/client.js";
-import { products, productSupplierLinkOverrides } from "../src/db/schema.js";
+import { pairingDecisions, pairingVariantLinks, products, productSupplierLinkOverrides, users } from "../src/db/schema.js";
 import { selectChangedSupplierLinks } from "../src/modules/shoptet-writeback/select-changes.js";
 import { insertTestSnapshot } from "./helpers/catalog.js";
 import { withCleanDb } from "./helpers/db.js";
@@ -18,6 +18,24 @@ describe("selectChangedSupplierLinks", () => {
   afterEach(async () => {
     await close();
   });
+
+  // issue 423: seedne split rozhodnutie na produkte (potrebný používateľ pre
+  // `decidedBy`), aby sa variant s per-veľkosť linkom stal "split-riadeným".
+  async function seedSplitDecision(productKey: string): Promise<void> {
+    const [user] = await db
+      .insert(users)
+      .values({ email: `d-${productKey}@forestshop.sk`, passwordHash: "x", displayName: "D", role: "manazer" })
+      .returning({ id: users.id });
+    if (user === undefined) throw new Error("používateľ sa nepodarilo vložiť");
+    await db.insert(pairingDecisions).values({
+      productKey,
+      status: "split",
+      url: null,
+      decidedBy: user.id,
+      decidedAt: new Date("2026-01-01T00:00:00Z"),
+      updatedAt: new Date("2026-01-01T00:00:00Z"),
+    });
+  }
 
   it("returns no rows when there are no overrides at all", async () => {
     const result = await selectChangedSupplierLinks(db);
@@ -124,5 +142,57 @@ describe("selectChangedSupplierLinks", () => {
     const result = await selectChangedSupplierLinks(db);
     expect(result.productKeys).toEqual([]);
     expect(result.rows).toEqual([]);
+  });
+
+  // ── issue 423: split-governed variants excluded from the product path ──
+
+  it("EXCLUDES a split-governed variant (per-size link AND product split), still emits its non-split siblings", async () => {
+    await insertTestVariantForProduct(db, "P8", "P8/S", { pairCode: "1", sizeLabel: "S" });
+    await insertTestVariantForProduct(db, "P8", "P8/M", { pairCode: "2", sizeLabel: "M" });
+    await seedSplitDecision("P8");
+    // only P8/S has a per-size link → only P8/S is split-governed and excluded
+    await db.insert(pairingVariantLinks).values({ code: "P8/S", url: "https://dodavatel.example/S", updatedAt: new Date("2026-01-02T00:00:00Z") });
+    await db
+      .insert(productSupplierLinkOverrides)
+      .values({ productKey: "P8", url: "https://dodavatel.example/produkt", updatedAt: new Date("2026-01-02T00:00:00Z") });
+
+    const result = await selectChangedSupplierLinks(db);
+    // P8/M (no per-size link) still gets the product override; P8/S excluded
+    expect(result.rows).toEqual([{ code: "P8/M", pairCode: "2", internalNote: "https://dodavatel.example/produkt" }]);
+    // the override still owns a variant → marked (not looped)
+    expect(result.productKeys).toEqual(["P8"]);
+  });
+
+  it("still writes the product override to a variant with a DORMANT per-size link (product NOT split)", async () => {
+    await insertTestVariantForProduct(db, "P9", "P9/S", { pairCode: "1", sizeLabel: "S" });
+    // per-size link exists but no split decision → dormant, product path owns it
+    await db.insert(pairingVariantLinks).values({ code: "P9/S", url: "https://dodavatel.example/S", updatedAt: new Date("2026-01-02T00:00:00Z") });
+    await db
+      .insert(productSupplierLinkOverrides)
+      .values({ productKey: "P9", url: "https://dodavatel.example/produkt", updatedAt: new Date("2026-01-02T00:00:00Z") });
+
+    const result = await selectChangedSupplierLinks(db);
+    expect(result.rows).toEqual([{ code: "P9/S", pairCode: "1", internalNote: "https://dodavatel.example/produkt" }]);
+    expect(result.productKeys).toEqual(["P9"]);
+  });
+
+  it("a FULLY-split product with a changed override emits ZERO rows but is still marked (not a no-variant anomaly)", async () => {
+    await insertTestVariantForProduct(db, "P10", "P10/S", { pairCode: "1", sizeLabel: "S" });
+    await insertTestVariantForProduct(db, "P10", "P10/M", { pairCode: "2", sizeLabel: "M" });
+    await seedSplitDecision("P10");
+    await db.insert(pairingVariantLinks).values([
+      { code: "P10/S", url: "https://dodavatel.example/S", updatedAt: new Date("2026-01-02T00:00:00Z") },
+      { code: "P10/M", url: "https://dodavatel.example/M", updatedAt: new Date("2026-01-02T00:00:00Z") },
+    ]);
+    await db
+      .insert(productSupplierLinkOverrides)
+      .values({ productKey: "P10", url: "https://dodavatel.example/dormant", updatedAt: new Date("2026-01-02T00:00:00Z") });
+
+    const result = await selectChangedSupplierLinks(db);
+    // all variants split-governed → nothing to send from the product path
+    expect(result.rows).toEqual([]);
+    // BUT the override is dormant (covered by per-size links) → marked, so it
+    // never re-selects forever; NOT reported as the "no variant" anomaly
+    expect(result.productKeys).toEqual(["P10"]);
   });
 });

--- a/apps/api/tests/shoptet-writeback-sequence.integration.test.ts
+++ b/apps/api/tests/shoptet-writeback-sequence.integration.test.ts
@@ -84,7 +84,7 @@ describe("runShoptetWritebackSequence (end-to-end proti fixture)", () => {
 
       const result = await runShoptetWritebackSequence(db, fixtureConfig(), new Date("2026-02-01T00:00:00Z"));
       expect(result).toEqual({
-        link: { status: "ok", productCount: 1, rowCount: 1 },
+        link: { status: "ok", productCount: 1, variantLinkCount: 0, rowCount: 1 },
         state: { status: "ok", productCount: 1, rowCount: 1 },
       });
       // TWO separate uploads happened — one per import, never a combined file.

--- a/apps/api/tests/supplier-stock-split-links.integration.test.ts
+++ b/apps/api/tests/supplier-stock-split-links.integration.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Database } from "../src/db/client.js";
+import { pairingDecisions, pairingVariantLinks, users } from "../src/db/schema.js";
+import { collectSupplierLinks } from "../src/modules/supplier-stock/run.js";
+import { withCleanDb } from "./helpers/db.js";
+import { insertTestVariantForProduct } from "./helpers/orders.js";
+
+// issue 423: `collectSupplierLinks` musí navyše pozbierať split-riadené
+// per-veľkosť linky (`pairing_variant_link` pre variant produktu s
+// `pairing_decision.status='split'`) — inak sa veľkosti split produktu nikdy
+// nescrapujú.
+
+describe("collectSupplierLinks — split per-veľkosť linky (issue 423)", () => {
+  let db: Database;
+  let close: () => Promise<void>;
+  let userId: string;
+
+  async function splitDecision(productKey: string): Promise<void> {
+    await db.insert(pairingDecisions).values({
+      productKey,
+      status: "split",
+      url: null,
+      decidedBy: userId,
+      decidedAt: new Date("2026-01-01T00:00:00Z"),
+      updatedAt: new Date("2026-01-01T00:00:00Z"),
+    });
+  }
+
+  beforeEach(async () => {
+    ({ db, close } = await withCleanDb());
+    const [row] = await db
+      .insert(users)
+      .values({ email: "d@forestshop.sk", passwordHash: "x", displayName: "D", role: "manazer" })
+      .returning({ id: users.id });
+    if (row === undefined) throw new Error("user");
+    userId = row.id;
+  });
+  afterEach(async () => {
+    await close();
+  });
+
+  it("includes a SPLIT product's per-size links alongside product-level internalNote links", async () => {
+    // product-level linked product
+    await insertTestVariantForProduct(db, "PROD", "PROD/1", { internalNote: "https://dodavatel.example/prod" });
+    // split product: per-size links, product has NO internalNote of its own
+    await insertTestVariantForProduct(db, "SPLIT", "SPLIT/S", { sizeLabel: "S", internalNote: null });
+    await insertTestVariantForProduct(db, "SPLIT", "SPLIT/M", { sizeLabel: "M", internalNote: null });
+    await splitDecision("SPLIT");
+    await db.insert(pairingVariantLinks).values([
+      { code: "SPLIT/S", url: "https://dodavatel.example/velkost-S", updatedAt: new Date("2026-01-02T00:00:00Z") },
+      { code: "SPLIT/M", url: "https://dodavatel.example/velkost-M", updatedAt: new Date("2026-01-02T00:00:00Z") },
+    ]);
+
+    const links = await collectSupplierLinks(db);
+    expect(links).toEqual([
+      "https://dodavatel.example/prod",
+      "https://dodavatel.example/velkost-M",
+      "https://dodavatel.example/velkost-S",
+    ]);
+  });
+
+  it("does NOT include a DORMANT per-size link whose product is not split", async () => {
+    await insertTestVariantForProduct(db, "P2", "P2/S", { sizeLabel: "S", internalNote: null });
+    // per-size link set but no split decision
+    await db.insert(pairingVariantLinks).values({ code: "P2/S", url: "https://dodavatel.example/S", updatedAt: new Date("2026-01-02T00:00:00Z") });
+
+    const links = await collectSupplierLinks(db);
+    expect(links).toEqual([]);
+  });
+
+  it("excludes a split per-size link that points to OUR OWN e-shop (issue 227 discipline)", async () => {
+    await insertTestVariantForProduct(db, "P3", "P3/S", { sizeLabel: "S", internalNote: null });
+    await splitDecision("P3");
+    await db.insert(pairingVariantLinks).values({ code: "P3/S", url: "https://www.forestshop.sk/produkt-x", updatedAt: new Date("2026-01-02T00:00:00Z") });
+
+    const links = await collectSupplierLinks(db);
+    expect(links).toEqual([]);
+  });
+});

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -4159,3 +4159,38 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   riziko pre informatívny náhľad, `adapterForUrl` zámerné zúženie rozsahu,
   `variant_money_needs_currency_ck` past v seed helperoch, a (po review)
   "hodnota vs. štruktúra" pravidlo pre TTL na module-level cache.
+
+## 2026-08-14 — #423 (Split (✂) linky: nočný spätný zápis do Shoptetu + dodávateľský sklad)
+
+- Downstream follow-up issue 399 (Prístup 3, zámerne odložený). Worktree-izolovaný
+  dispatch na `forestshop-dev`, súbežný sibling worker na issue 425.
+- Verzia: 0.3.0-dev.255 (prvý commit; supervisor môže prečíslovať pri integrácii).
+- Migrácia 0055: `ADD COLUMN synced_at` do `pairing_variant_link` (nullable, žiadny
+  enum ADD VALUE → žiadne 55P04 riziko). Vygenerovaná pri poslednom čísle 0054;
+  paralelný worker môže kolidovať na čísle — supervisor rieši pri integrácii
+  (`.claude/rules/database.md`).
+- Flow 1 (writeback, commit 376ee75): `select-variant-links.ts`
+  (`selectChangedVariantLinks`, gate `status='split'` + časový diff),
+  `mark-variant-synced.ts`, `select-changes.ts` VYLÚČENIE split-riadených variantov
+  z produktovej cesty + GROUP BY marking (fully-split override označený, no-variant
+  anomália stále warned), `run-writeback.ts` ZLÚČENIE do JEDNÉHO importu,
+  `csv.ts` `dedupeWritebackRowsByCode`.
+- Flow 2 (supplier-stock, commit 228a4a9): `collectSupplierLinks` pozbiera
+  split-riadené per-veľkosť linky (blanket scrape), `restock/queries.ts` efektívna
+  linka `coalesce(split link, produktová linka)` (LEFT JOINy PRED supplierStock
+  innerJoinom).
+- Prieskum starej appky (`parovanie_produktov` @ f76cafa): per-code model,
+  mark-after-confirm, availability žiadne split-špecifické drôtovanie (round-trip).
+  Nová appka NEMÔŽE round-trip (products.internalNote produktová úroveň) → číta
+  pairing_variant_link priamo.
+- TDD: nové RED→GREEN testy — csv dedupe (unit), select-variant-links (6),
+  mark-variant-synced (4), select-changes split exclusion + fully-split (3 nové),
+  run merge (1 nový), supplier-stock-split-links (3), restock-split-links (3).
+- Overené lokálne (throwaway Postgres 5461, izolovaný od zdieľaného 5433):
+  typecheck+lint+unit (984 API + 658 web) zelené; CELÝ blast radius integrácie
+  (18 test súborov importujúcich zmenené moduly, ~129 testov) zelený. Žiadna UI
+  zmena → e2e nedotknuté (beží CI pri integrácii).
+- Playbook: `.claude/rules/shoptet-writeback.md` (split zlúčený import, GROUP BY
+  marking, round-trip nefunguje) + `.claude/rules/supplier-stock.md` (split čítanie
+  pairing_variant_link priamo, restock coalesce + JOIN poradie, 4-miestny
+  split-governed predikát).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.254",
+  "version": "0.3.0-dev.255",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Issue 423 — split linky sa premietajú do nočného zápisu a dodávateľského skladu

Rozdelené (per-veľkostné) linky z Párovania doteraz nič nečítalo — nočný writeback do Shoptetu aj dodávateľský sklad brali len produktový link. Teraz:

- **Nočný writeback** (`shoptet-writeback`): nový `select-variant-links.ts` vyberá zmenené variantné linky (gate `status='split'` + časový rozdiel), `select-changes.ts` vylučuje split-ovládané varianty z produktovej cesty, oba prúdy sa zlúčia do JEDNÉHO importu (`run-writeback.ts`), dedup riadkov podľa kódu (`csv.ts`). Po úspechu sa značí `synced_at` (`mark-variant-synced.ts`).
- **Dodávateľský sklad** (`supplier-stock/run.ts`): `collectSupplierLinks` číta split per-size linky.
- **Restock** (`restock/queries.ts`): efektívny link = `coalesce(split link, product link)`.
- **Migrácia** `0055_daily_rafael_vega.sql`: `ADD COLUMN synced_at` (nullable) do `pairing_variant_link` — žiadny enum ADD VALUE, žiadne 55P04 riziko.
- 7 nových/aktualizovaných integračných testov; playbook `.claude/rules/shoptet-writeback.md` + `supplier-stock.md`.

Verzia 0.3.0-dev.256 (pri integrácii prečíslovaná z .255 — sibling issue 425 medzitým obsadil .255).

Ticket 423 ostáva otvorený do naživo overenia po nasadení (nočný writeback je plánovaný job — overenie bude na úrovni DB/konfigurácie).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
