### PR TITLE
Skutočné pokrytie katalógu v Párovaní (issue 432) + display meno odosielateľa (issue 433)

### DIFF
--- a/.claude/rules/deploy.md
+++ b/.claude/rules/deploy.md
@@ -487,3 +487,26 @@ beží PRODUKCIA aj VÝVOJ. Ťažký lokálny beh (plná sada testov, build,
 (pozri `.claude/rules/testing.md`). Keď appka odpovedá `502`, najprv over
 `cat /proc/loadavg` a `docker logs forestshop-cloudflared-1 | grep -i
 "handshake"`, až potom hľadaj chybu v kóde.
+
+- **Cloudflare kešuje statické cesty na okraji — a cesta, ktorá PREDTÝM
+  padala na SPA fallback (napr. `/favicon.ico` → `index.html`, `text/html`),
+  drží STARÚ odpoveď aj po nasadení skutočného súboru** (issue 430, overené
+  naživo). Po nasadení favicony vracal `/favicon.ico` cez CF stále
+  `text/html` (`cf-cache-status: HIT`, `last-modified` z PRED nasadenia),
+  hoci origin už servíroval správny obrázok. **Diagnostika:** origin over
+  cache-busterom `curl -s -o /dev/null -w "%{content_type}"
+  "https://forestshop.newlevel.media/favicon.ico?cb=$(date +%s)"` (querystring
+  = iný CF cache kľúč → čerstvá odpoveď z originu) — ak vráti `image/x-icon`,
+  je to čisto stará CF keš, appka je v poriadku. NOVÉ cesty (`/favicon.svg`,
+  `/favicon-32.png`, `/apple-touch-icon.png`) nikdy neboli kešované, takže
+  idú hneď správne — problém je LEN pri ceste, čo existovala už predtým.
+  **Pracovný token `CF_API_TOKEN` (`/srv/forestshop/.env`) NEMÁ právo Cache
+  Purge** (má len Tunnel + DNS Write + Zone Read) — `POST
+  /zones/<zone>/purge_cache` vráti `Authentication error`. Keš sa aj tak sama
+  vyprázdni podľa `max-age` (favicon `14400` s = 4 h). Moderné prehliadače
+  aj tak berú favicon z `<link rel="icon" type="image/svg+xml">` (`/favicon.svg`,
+  servírovaný správne), takže karta ukazuje ikonu okamžite; stará keš
+  `/favicon.ico` je len kozmetika, ktorá do ~4 h zmizne. Ak by bolo treba
+  purge hneď, vytvor purge-schopný token zo správcovského tokenu
+  (`.claude` memory `cloudflare-access`) — na 3-hodinovú self-healing keš to
+  ale zvyčajne nestojí za nový prod token.

--- a/.claude/rules/mail-log.md
+++ b/.claude/rules/mail-log.md
@@ -63,3 +63,31 @@ paths:
   kniha teraz vie dokázať, ČO presne odišlo, nielen komu/kedy. `MailLogSection
   .tsx` zobrazuje telo cez per-riadkové "👁 zobraziť text" tlačidlo (`row.body
   !== null`), nie vždy — dlhý text by rozbil hustú tabuľku.
+- **issue 433: display meno odosielateľa má KÓDOVÝ default „Forestshop.sk"
+  v `transport.ts`'s `applyDefaultSenderName` — nielen v env `MAIL_FROM`.**
+  `resolveMailSender` obalí výsledok CELEJ fallback reťaze
+  (`config.from ?? config.user ?? config.host`): ak string NEOBSAHUJE `<`
+  (holá adresa/host), vráti `"Forestshop.sk" <adresa>` (RFC 5322
+  quoted-string — bodka v „Forestshop.sk" nedovolí holý atom); ak už `<`
+  obsahuje (`Meno <adresa>` tvar, vrátane produkčného
+  `MAIL_FROM=Forestshop.sk <eshop@forestshop.sk>`), prenesie sa BEZ zmeny —
+  explicitne nastavené meno sa nikdy neprepisuje. Bez holej adresy klienti
+  zobrazovali lokálnu časť („eshop"). `replyTo` (issue 358) sa ZÁMERNE
+  NEobaľuje — explicitný sa prenáša doslovne, nenastavený spadne na
+  už-obalený `from` (adresa vo vnútri `<>` nezmenená, odpovede idú správne).
+  Poistka je v jedinej odosielacej ceste, takže platí pre všetkých 5
+  odosielateľov cez `sendLoggedMail`. Env tvar odosielateľa je preto
+  `Meno <adresa>` (nie holá adresa) — a keďže default je aj v kóde, „eshop"
+  sa pri strate/zmene `MAIL_FROM` už ticho nevráti.
+- **`MAIL_BCC` NIE JE appkina premenná — je to MŔTVA env konfigurácia
+  (pozostatok BCC-vždy konvencie starej appky).** `env.ts` `MAIL_BCC` v zod
+  schéme NEMÁ (len v komentároch, ktoré vysvetľujú, prečo ho appka
+  nepoužíva) — zod neznáme kľúče zahodí, takže hodnota z `.env` sa nikdy
+  nenačíta. BCC, čo REÁLNE funguje, sa plní per-správa (`MailMessage.bcc` →
+  `sendLoggedMail` → `mail_log.bcc`) zo ŠTYROCH samostatných, per-automatizácia
+  premenných (`POSTA_UNCOLLECTED_BCC_EMAIL`/`ORDER_REMINDER_BCC_EMAIL`/
+  `NEDOSTUPNE_BCC_EMAIL`/`ORDER_MERGE_BCC_EMAIL`, drôtované v `index.ts`),
+  nikdy zo zdieľaného `MAIL_BCC`. Kto v budúcnosti uvidí `MAIL_BCC` v
+  `/srv/forestshop/.env` a bude ho chcieť „napojiť": je to zámerné
+  rozhodnutie (viď aj `.claude/rules/orders.md`), nie chýbajúce drôtovanie —
+  BCC už funguje cez vyhradené premenné.

--- a/.claude/rules/orders.md
+++ b/.claude/rules/orders.md
@@ -709,3 +709,25 @@ paths:
   upsert) — vyhradený deterministický regresný test tejto interakcie
   (rovnaká technika ako `orders-supplier-bulk-lock.integration.test.ts`)
   je samostatný ticket #416, mimo rozsahu #412.
+
+- **Identita zákazníka ("ten istý zákazník naprieč objednávkami") žije v
+  JEDNOM zdieľanom module `modules/orders/customer-identity.ts`
+  (`customerIdentityKey(email, customerName)`: `email:<trim/lower>`, inak
+  fallback `name:<trim/lower>` — zákaznícke id v schéme NEEXISTUJE) —
+  používa ho `merge-mail.ts` (záložka Zlúčenie objednávok, #257) aj
+  `queries.ts`'s odznak počtu otvorených objednávok v "Na objednanie" (#431,
+  `countOpenOrdersByCustomer` + `customerOpenOrderCount` na riadku).
+  KAŽDÁ ďalšia funkcia, čo počíta "ten istý zákazník", MUSÍ znovupoužiť
+  TENTO kľúč — inak sa odznak ("zváž zlúčenie") a samotné zlúčenie rozídu.
+  "Otvorená objednávka" = `order.status_name ∈ order_open_status`
+  (default "Vybavuje sa"; `open-statuses.ts`) — Stornovaná/Vybavená sa nikde
+  nepočítajú.
+- **Odznak (`.cust-order-badge`, `CustomerOrderCountBadge.tsx`) sa zobrazuje
+  LEN pri počte ≥ 2** a `title` == `aria-label`, skloňované podľa počtu
+  (2-4 → "otvorené objednávky", 5+ → "otvorených objednávok" — tá istá 2-4/5+
+  hranica ako `ordersSummary.ts`'s `formatOrderCount`). Pozor: keď sa pridá
+  NOVÉ povinné pole na `OrderLine`, doplň ho do VŠETKÝCH fixtúr (typovaných
+  aj NETYPOVANÝCH cez `vi.fn()` mocky — `grep -rl manualSupplierOverride
+  apps/web/src`), inak netypovaná fixtúra nesie `undefined` a napr.
+  `undefined < 2` je `false`, takže odznak sa VYKRESLÍ s textom "undefined"
+  (pravidlo "každé pole explicitne, nikdy undefined" vyššie v tomto súbore).

--- a/.claude/rules/pairing-search.md
+++ b/.claude/rules/pairing-search.md
@@ -916,3 +916,44 @@ vyradilo #311 aj jeho playbook súbor (návrh, sekcia 4); router v
   currency). Test pri KAŽDOM ĎALŠOM seed helperi, čo dostane nové
   peňažné pole: over CHECK constraint PRIAMO na throwaway Postgrese pred
   spoliehaním sa na to, že `?? null` default v inserte stačí.
+
+## issue 432 — DVE RÔZNE metriky na obrazovke Párovanie: veľkosť FRONTY vs. katalógové POKRYTIE
+
+- **`gatheredTotal`/`linkedTotal` (`listPairingReview`, `pairing-review/
+  queries.ts`) merajú VEĽKOSŤ RECENZNEJ FRONTY, NIE pokrytie katalógu
+  linkami — nikdy ich nezameň za "koľko produktov má odkaz".** Populácia
+  fronty je ÚNIA (`determineReviewPopulationKeys`): gatherované ∪ produkty
+  BEZ efektívnej linky ∪ rozhodnuté. Je teda Z DEFINÍCIE zložená hlavne z
+  produktov BEZ linky, takže `linkedTotal / gatheredTotal` vychádza extrémne
+  nízko (na prod ~2/2303) — vyzerá to ako "linky zmizli", hoci dáta sú v
+  poriadku. Presne toto majiteľ nahlásil ako #432; koreň bol commit 3779235
+  (#398/#401), ktorý populáciu rozšíril z "gatherované" na túto úniu, ale
+  frontend text „N / M s odkazom" ostal.
+- **Skutočné katalógové pokrytie = `computeCatalogCoverage(db)`
+  (`catalogActive`/`catalogLinked`).** `catalogActive` = produkty s aspoň
+  jedným PREDAJNÝM variantom (`variant.state === "sellable"`,
+  `db.selectDistinct` — tá istá definícia "sellable" ako `rollupProductState`
+  v tom istom súbore); `catalogLinked` = z NICH tie s efektívnou linkou
+  (`resolveEffectiveSupplierLink` = override ∪ `internalNote` extrakcia,
+  žiadny duplicitný regex). Počíta sa NEZÁVISLE od populácie fronty (aj keď
+  je fronta prázdna — napr. všetko olinkované — pokrytie ostáva správne;
+  aktívny olinkovaný produkt MIMO fronty sa v pokrytí objaví, hoci
+  `linkedTotal` ho minie). Menovateľ ZÁMERNE NIE JE celý katalóg (4547) —
+  ~2000 dávno ukončených produktov linku nikdy nemalo, stláčali by číslo na
+  ~49 % a vyzeralo by to zase ako strata; prod má vyjsť ~2081/2528.
+- **Frontend (`PairingReviewSection.tsx`): hlavný ukazovateľ + progress bar
+  = `catalogLinked`/`catalogActive`; `gatheredTotal` (veľkosť fronty) je len
+  samostatný menší riadok „vo fronte na revíziu: N"** (`data-testid=
+  "pairing-review-progress-queue"`). `linkedTotal` sa už nezobrazuje ako
+  hlavné číslo (state odstránený). Progres text sa smie ZALOMIŤ (žiadny
+  `white-space: nowrap` — dlhší popis by na `wide: true` obrazovke pretiekol,
+  issue 291/382); progress bar má `min-width` + `flex-wrap` na rodičovi, aby
+  sa na úzkej šírke zalomil pod text.
+- **Pri KAŽDOM ĎALŠOM "toto číslo mi nesedí" hlásení o počítadle na tejto
+  obrazovke:** najprv over, ČI daná metrika meria FRONTU (populácia úniou)
+  alebo KATALÓG (pokrytie) — sú to dve rôzne množiny a ľahko sa zamenia v
+  texte UI. Test na logiku (nie presné čísla) je
+  `pairing-review-catalog-coverage-http.integration.test.ts` (override link
+  počíta sa · internal_note URL počíta sa · bez linky len menovateľ · bez
+  sellable variantu ani v menovateli · aktívny olinkovaný MIMO fronty sa
+  ráta).

--- a/apps/api/src/modules/mail/transport.test.ts
+++ b/apps/api/src/modules/mail/transport.test.ts
@@ -7,50 +7,77 @@ import { resolveMailSender } from "./transport.js";
 // vytiahnutá z `createSmtpMailTransport`, aby sa dala otestovať bez
 // bežiaceho servera — presne rovnaké odvodenie, aké appka použije pri
 // KAŽDOM odoslaní zákazníkovi.
+//
+// issue 433: e-maily odchádzali s menom odosielateľa „eshop" (lokálna časť
+// holej adresy), lebo `resolveMailSender` skladala `from` ako holý string
+// bez display mena. Poistka: holá adresa (bez `<`) sa obalí defaultným
+// display menom „Forestshop.sk" → `"Forestshop.sk" <adresa>`; string, čo už
+// display meno má (obsahuje `<`), sa prenesie BEZ zmeny. Platí pre celú
+// fallback reťaz `config.from ?? config.user ?? config.host`.
 describe("resolveMailSender", () => {
-  it("from: použije explicitný config.from, keď je nastavený", () => {
+  it("from: holú explicitnú config.from adresu obalí defaultným display menom „Forestshop.sk\"", () => {
     const { from } = resolveMailSender({
       host: "mbox.myshoptet.com",
       user: "info@forestshop.sk",
       from: "eshop@forestshop.sk",
     });
-    expect(from).toBe("eshop@forestshop.sk");
+    expect(from).toBe('"Forestshop.sk" <eshop@forestshop.sk>');
   });
 
-  it("from: bez config.from spadne späť na SMTP účet (user)", () => {
+  it("from: bez config.from spadne späť na SMTP účet (user) a TIEŽ ho obalí", () => {
     const { from } = resolveMailSender({
       host: "mbox.myshoptet.com",
       user: "info@forestshop.sk",
     });
-    expect(from).toBe("info@forestshop.sk");
+    expect(from).toBe('"Forestshop.sk" <info@forestshop.sk>');
   });
 
-  it("from: bez config.from AJ bez user spadne späť na host", () => {
+  it("from: bez config.from AJ bez user spadne späť na host a TIEŽ ho obalí", () => {
     const { from } = resolveMailSender({
       host: "mbox.myshoptet.com",
     });
-    expect(from).toBe("mbox.myshoptet.com");
+    expect(from).toBe('"Forestshop.sk" <mbox.myshoptet.com>');
   });
 
-  it("replyTo: použije explicitný config.replyTo, NEZÁVISLE od from", () => {
+  it("from: keď MAIL_FROM UŽ má display meno (obsahuje `<`), prenesie sa BEZ zmeny", () => {
+    // Reálny produkčný `MAIL_FROM=Forestshop.sk <eshop@forestshop.sk>` (14. 8.)
+    // — appka nikdy neprepíše explicitne nastavené meno.
+    const { from } = resolveMailSender({
+      host: "mbox.myshoptet.com",
+      from: "Forestshop.sk <eshop@forestshop.sk>",
+    });
+    expect(from).toBe("Forestshop.sk <eshop@forestshop.sk>");
+  });
+
+  it("from: aj už zacitované display meno (`\"Meno\" <adresa>`) sa prenesie BEZ zmeny", () => {
+    const { from } = resolveMailSender({
+      host: "mbox.myshoptet.com",
+      from: '"Iné meno" <eshop@forestshop.sk>',
+    });
+    expect(from).toBe('"Iné meno" <eshop@forestshop.sk>');
+  });
+
+  it("replyTo: použije explicitný config.replyTo BEZ obalenia, NEZÁVISLE od from", () => {
     // issue 358, bod 2: Reply-To musí ostať eshop@forestshop.sk aj keby sa
     // odosielateľ (From) v budúcnosti zmenil na niečo iné — preto je
     // replyTo VLASTNÁ hodnota, nikdy odvodená z from, keď je nastavená.
+    // issue 433: explicitný Reply-To sa NEobaľuje display menom (obaľuje sa
+    // len fallback reťaz `from`), prenáša sa doslovne.
     const { from, replyTo } = resolveMailSender({
       host: "mbox.myshoptet.com",
       from: "novy-odosielatel@forestshop.sk",
       replyTo: "eshop@forestshop.sk",
     });
-    expect(from).toBe("novy-odosielatel@forestshop.sk");
+    expect(from).toBe('"Forestshop.sk" <novy-odosielatel@forestshop.sk>');
     expect(replyTo).toBe("eshop@forestshop.sk");
   });
 
-  it("replyTo: bez config.replyTo spadne späť na rovnakú hodnotu ako from (appka nikdy nepošle mail bez Reply-To)", () => {
+  it("replyTo: bez config.replyTo spadne späť na rovnakú (obalenú) hodnotu ako from (appka nikdy nepošle mail bez Reply-To)", () => {
     const { from, replyTo } = resolveMailSender({
       host: "mbox.myshoptet.com",
       from: "eshop@forestshop.sk",
     });
     expect(replyTo).toBe(from);
-    expect(replyTo).toBe("eshop@forestshop.sk");
+    expect(replyTo).toBe('"Forestshop.sk" <eshop@forestshop.sk>');
   });
 });

--- a/apps/api/src/modules/mail/transport.ts
+++ b/apps/api/src/modules/mail/transport.ts
@@ -37,14 +37,38 @@ export interface SmtpMailConfig {
   readonly replyTo?: string | undefined;
 }
 
+// issue 433: predvolené display meno odosielateľa. Klienti bez neho zobrazia
+// lokálnu časť holej adresy („eshop" z eshop@forestshop.sk) — majiteľ chce
+// „Forestshop.sk", ako to mala stará n8n cesta.
+const DEFAULT_SENDER_DISPLAY_NAME = "Forestshop.sk";
+
+// issue 433: kódová poistka proti regresii „meno odosielateľa = eshop".
+// Ak `from` NEOBSAHUJE `<` (holá adresa alebo host), obalíme ho defaultným
+// display menom → `"Forestshop.sk" <adresa>` (RFC 5322 quoted-string — bodka
+// v mene je tak bezpečná; nodemailer to pošle ako `From: "Forestshop.sk"
+// <adresa>`). Ak `from` už display meno má (obsahuje `<`, napr. produkčný
+// `MAIL_FROM=Forestshop.sk <eshop@forestshop.sk>`), prenesie sa BEZ zmeny —
+// explicitne nastavené meno nikdy neprepisujeme. Bez tejto poistky by sa pri
+// budúcej strate/zmene `MAIL_FROM` „eshop" ticho vrátil.
+function applyDefaultSenderName(from: string): string {
+  if (from.includes("<")) {
+    return from;
+  }
+  return `"${DEFAULT_SENDER_DISPLAY_NAME}" <${from}>`;
+}
+
 // Čistá funkcia (žiadny SMTP) — vytiahnutá z `createSmtpMailTransport`, aby
 // sa dala unit-testovať bez bežiaceho servera (issue 358).
 // Odosielateľ: explicitný `MAIL_FROM`, inak SMTP účet (`user`), inak
-// samotný host — appka nikdy nepošle mail bez hlavičky `From`.
+// samotný host — appka nikdy nepošle mail bez hlavičky `From`. Výsledok CELEJ
+// fallback reťaze prejde `applyDefaultSenderName` (issue 433). `replyTo`
+// (issue 358) sa ZÁMERNE neobaľuje — explicitný Reply-To sa prenáša doslovne,
+// nenastavený spadne na už-obalený `from` (adresa vo vnútri `<>` sa nemení,
+// odpovede stále idú na pôvodnú adresu).
 export function resolveMailSender(
   config: Pick<SmtpMailConfig, "host" | "user" | "from" | "replyTo">,
 ): { readonly from: string; readonly replyTo: string } {
-  const from = config.from ?? config.user ?? config.host;
+  const from = applyDefaultSenderName(config.from ?? config.user ?? config.host);
   const replyTo = config.replyTo ?? from;
   return { from, replyTo };
 }

--- a/apps/api/src/modules/pairing-review/queries.ts
+++ b/apps/api/src/modules/pairing-review/queries.ts
@@ -133,6 +133,14 @@ export interface PairingReviewSearchResult {
   /** Koľko z `gatheredTotal` už MÁ efektívnu linku — čitateľ pre progress
    * (doplnok `unreviewed` počtu, ktorý číta rovnaký endpoint s `filter=unreviewed`). */
   readonly linkedTotal: number;
+  /** issue 432 — SKUTOČNÉ katalógové pokrytie linkami (na rozdiel od
+   * `gatheredTotal`/`linkedTotal`, ktoré merajú veľkosť recenznej FRONTY):
+   * `catalogActive` = počet produktov s aspoň jedným PREDAJNÝM (`variant.state
+   * === "sellable"`) variantom (menovateľ); `catalogLinked` = koľko z NICH má
+   * efektívnu dodávateľskú linku (čitateľ). Počítané NEZÁVISLE od populácie
+   * fronty — `computeCatalogCoverage`. */
+  readonly catalogLinked: number;
+  readonly catalogActive: number;
   readonly items: readonly PairingReviewItem[];
 }
 
@@ -211,6 +219,40 @@ async function determineReviewPopulationKeys(db: Database): Promise<string[]> {
     if (setKeys.has(product.key) || effective.url === null || decisionKeys.has(product.key)) productKeys.push(product.key);
   }
   return productKeys;
+}
+
+// issue 432 — SKUTOČNÉ katalógové pokrytie linkami. NA ROZDIEL od
+// `gatheredTotal`/`linkedTotal` (veľkosť recenznej FRONTY = únia gatherované ∪
+// bez-linky ∪ rozhodnuté) toto meria KATALÓG: `catalogActive` = produkty s
+// aspoň jedným PREDAJNÝM (`variant.state === "sellable"`) variantom, `catalogLinked`
+// = koľko z NICH má EFEKTÍVNU dodávateľskú linku (`resolveEffectiveSupplierLink`
+// = override ∪ `internalNote` extrakcia — TÁ ISTÁ čítacia logika, žiadny
+// duplicitný regex). Rovnaký MVP "načítaj celý katalóg do JS" vzor ako
+// `determineReviewPopulationKeys` (efektívna linka je čistá JS funkcia, nedá sa
+// vyjadriť ako SQL predikát bez duplicity). Počíta sa NEZÁVISLE od populácie
+// fronty — aktívny olinkovaný produkt MIMO populácie (má linku, nebol
+// gatherovaný ani rozhodnutý) sa v pokrytí správne objaví, hoci `linkedTotal`
+// (odvodený z fronty) ho minie.
+async function computeCatalogCoverage(db: Database): Promise<{ readonly catalogActive: number; readonly catalogLinked: number }> {
+  const sellableRows = await db.selectDistinct({ productKey: variants.productKey }).from(variants).where(eq(variants.state, "sellable"));
+  const activeKeys = sellableRows.map((r) => r.productKey);
+  if (activeKeys.length === 0) return { catalogActive: 0, catalogLinked: 0 };
+
+  const productRows = await db.select({ key: products.key, internalNote: products.internalNote }).from(products).where(inArray(products.key, activeKeys));
+  const internalNoteByKey = new Map(productRows.map((r) => [r.key, r.internalNote]));
+
+  const overrideRows = await db
+    .select({ productKey: productSupplierLinkOverrides.productKey, url: productSupplierLinkOverrides.url })
+    .from(productSupplierLinkOverrides)
+    .where(inArray(productSupplierLinkOverrides.productKey, activeKeys));
+  const overrideByProduct = new Map(overrideRows.map((r) => [r.productKey, r.url]));
+
+  let catalogLinked = 0;
+  for (const key of activeKeys) {
+    const effective = resolveEffectiveSupplierLink(internalNoteByKey.get(key) ?? null, overrideByProduct.get(key) ?? null);
+    if (effective.url !== null) catalogLinked += 1;
+  }
+  return { catalogActive: activeKeys.length, catalogLinked };
 }
 
 // issue 399 — zdieľané budovanie karty(-diet) pre KONKRÉTNU množinu
@@ -445,8 +487,11 @@ export async function getPairingReviewItem(db: Database, productKey: string): Pr
 }
 
 export async function listPairingReview(db: Database, input: PairingReviewSearchInput): Promise<PairingReviewSearchResult> {
+  // issue 432 — katalógové pokrytie sa počíta NEZÁVISLE od populácie fronty
+  // (aj keď je fronta prázdna — napr. všetko olinkované — pokrytie ostáva správne).
+  const { catalogActive, catalogLinked } = await computeCatalogCoverage(db);
   const productKeys = await determineReviewPopulationKeys(db);
-  if (productKeys.length === 0) return { total: 0, gatheredTotal: 0, linkedTotal: 0, items: [] };
+  if (productKeys.length === 0) return { total: 0, gatheredTotal: 0, linkedTotal: 0, catalogLinked, catalogActive, items: [] };
 
   const allItems = await buildPairingReviewItems(db, productKeys);
 
@@ -514,7 +559,7 @@ export async function listPairingReview(db: Database, input: PairingReviewSearch
   const start = (input.page - 1) * input.pageSize;
   const items = filtered.slice(start, start + input.pageSize);
 
-  return { total, gatheredTotal, linkedTotal, items };
+  return { total, gatheredTotal, linkedTotal, catalogLinked, catalogActive, items };
 }
 
 export interface PairingReviewCandidate {

--- a/apps/api/tests/pairing-review-catalog-coverage-http.integration.test.ts
+++ b/apps/api/tests/pairing-review-catalog-coverage-http.integration.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, expect, it } from "vitest";
+import { productSupplierLinkOverrides, users } from "../src/db/schema.js";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import type { UserRole } from "../src/modules/auth/service.js";
+import { insertTestSnapshot } from "./helpers/catalog.js";
+import { withCleanDb } from "./helpers/db.js";
+import { seedPairingReviewProduct as seedProduct } from "./helpers/pairing-review.js";
+
+// issue 432 — `GET /api/pairing-review` popri veľkosti recenznej FRONTY
+// (`gatheredTotal`/`linkedTotal`) vracia aj SKUTOČNÉ katalógové pokrytie
+// linkami: `catalogActive` (produkty s aspoň jedným PREDAJNÝM — `state =
+// 'sellable'` — variantom, menovateľ) a `catalogLinked` (z aktívnych tie s
+// EFEKTÍVNOU linkou = override ∪ `internalNote` extrakcia, čitateľ). Vyčlenené
+// do vlastného súboru (`.claude/rules/testing.md`'s `max-lines: 400` vzor —
+// `pairing-review-http.integration.test.ts` je už na 382 riadkoch).
+
+const HESLO = "test-heslo-abc"; // testovacie údaje, nie tajomstvo
+
+let close: (() => Promise<void>) | undefined;
+
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  resetLoginRateLimit();
+});
+
+async function boot(role: UserRole) {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const [pouzivatel] = await ctx.db
+    .insert(users)
+    .values({ email: "manazer@forestshop.sk", passwordHash: await hashPassword(HESLO), displayName: "Manažér", role })
+    .returning({ id: users.id });
+  if (pouzivatel === undefined) throw new Error("testovací používateľ sa nepodarilo vložiť");
+
+  const app = createApp(ctx.db, { cookieSecure: false });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "manazer@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie, db: ctx.db };
+}
+
+interface Telo {
+  readonly total: number;
+  readonly gatheredTotal: number;
+  readonly linkedTotal: number;
+  readonly catalogLinked: number;
+  readonly catalogActive: number;
+}
+
+async function fetchCoverage(app: Awaited<ReturnType<typeof boot>>["app"], cookie: string): Promise<Telo> {
+  return (await (await app.request("/api/pairing-review?filter=all&pageSize=1", { headers: { cookie } })).json()) as Telo;
+}
+
+// Design bod 3 na tickete: override link počíta sa · internal_note URL počíta
+// sa · bez linky nepočíta sa (len do menovateľa) · bez sellable variantu nie
+// je ani v menovateli.
+it("issue 432: catalogLinked/catalogActive merajú katalógové pokrytie, nie veľkosť recenznej fronty", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const snapshotId = await insertTestSnapshot(db);
+
+  // (1) override link + sellable variant → čitateľ AJ menovateľ.
+  await seedProduct(db, snapshotId, "CC-OVERRIDE", { name: "Produkt s override linkou" });
+  await db.insert(productSupplierLinkOverrides).values({ productKey: "CC-OVERRIDE", url: "https://dodavatel.example.com/override", updatedAt: new Date() });
+
+  // (2) internal_note URL + sellable variant → čitateľ AJ menovateľ (efektívna
+  // linka cez extrakciu z voľného textu, žiadny override).
+  await seedProduct(db, snapshotId, "CC-NOTE", { name: "Produkt s linkou v poznámke", internalNote: "Dodávateľ: https://dodavatel.example.com/z-poznamky" });
+
+  // (3) bez linky + sellable variant → LEN menovateľ.
+  await seedProduct(db, snapshotId, "CC-NOLINK", { name: "Produkt bez linky" });
+
+  // (4) má override linku, ALE žiadny sellable variant (ukončený) → NIE JE v
+  // menovateli (a teda ani v čitateli) — presne to, čo tlačí prod číslo dole,
+  // keby sa rátal celý katalóg.
+  await seedProduct(db, snapshotId, "CC-DISCONTINUED", { name: "Ukončený produkt s linkou", variants: [{ code: "CC-DISCONTINUED/1", state: "discontinued" }] });
+  await db.insert(productSupplierLinkOverrides).values({ productKey: "CC-DISCONTINUED", url: "https://dodavatel.example.com/ukonceny", updatedAt: new Date() });
+
+  const telo = await fetchCoverage(app, cookie);
+
+  // Menovateľ = aktívne produkty (aspoň jeden sellable variant): CC-OVERRIDE,
+  // CC-NOTE, CC-NOLINK — nie CC-DISCONTINUED.
+  expect(telo.catalogActive).toBe(3);
+  // Čitateľ = aktívne produkty s efektívnou linkou: CC-OVERRIDE, CC-NOTE.
+  expect(telo.catalogLinked).toBe(2);
+});
+
+// Pokrytie katalógu sa počíta NEZÁVISLE od populácie recenznej fronty — aj
+// keď je fronta prázdna (produkt už MÁ efektívnu linku, nebol gatherovaný ani
+// rozhodnutý, takže NIE JE v populácii), aktívny olinkovaný produkt sa v
+// pokrytí objaví. Toto je práve prípad, ktorý front-based `linkedTotal` minul.
+it("issue 432: aktívny olinkovaný produkt MIMO recenznej fronty sa ráta do pokrytia", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const snapshotId = await insertTestSnapshot(db);
+
+  await seedProduct(db, snapshotId, "CC-LINKED-NOQUEUE", { name: "Olinkovaný, mimo fronty", internalNote: "https://dodavatel.example.com/mimo-fronty" });
+
+  const telo = await fetchCoverage(app, cookie);
+
+  // Fronta ho NEobsahuje (má linku, nebol gatherovaný/rozhodnutý).
+  expect(telo.gatheredTotal).toBe(0);
+  expect(telo.linkedTotal).toBe(0);
+  // Katalógové pokrytie ho VŠAK zaráta (aktívny + olinkovaný).
+  expect(telo.catalogActive).toBe(1);
+  expect(telo.catalogLinked).toBe(1);
+});

--- a/apps/web/src/components/PairingReviewSection.test.tsx
+++ b/apps/web/src/components/PairingReviewSection.test.tsx
@@ -67,7 +67,7 @@ afterEach(() => {
 });
 
 it("zobrazí karty pre napárovaný aj nenapárovaný produkt s progress počítadlom", async () => {
-  searchPairingReview.mockResolvedValue({ total: 2, gatheredTotal: 5, linkedTotal: 3, items: [MATCHED_ITEM, UNMATCHED_ITEM] });
+  searchPairingReview.mockResolvedValue({ total: 2, gatheredTotal: 5, linkedTotal: 3, catalogLinked: 2081, catalogActive: 2528, items: [MATCHED_ITEM, UNMATCHED_ITEM] });
 
   render(<PairingReviewSection role="citanie" onSessionExpired={() => {}} />);
 
@@ -80,11 +80,18 @@ it("zobrazí karty pre napárovaný aj nenapárovaný produkt s progress počít
   expect(unmatchedCard.textContent).toContain("Produkt bez kandidáta");
   expect(screen.getByTestId("pairing-review-no-candidate-PR-2")).toBeDefined();
 
-  expect(screen.getByTestId("pairing-review-progress").textContent).toContain("3 / 5 s odkazom");
+  // issue 432 — hlavný ukazovateľ je SKUTOČNÉ katalógové pokrytie
+  // (catalogLinked 2081 / catalogActive 2528), NIE veľkosť recenznej fronty
+  // (linkedTotal 3 / gatheredTotal 5). Front-based číslo sa už ako hlavné
+  // nezobrazuje; fronta je samostatný menší riadok.
+  const progress = screen.getByTestId("pairing-review-progress");
+  expect(progress.textContent).toContain("2081 / 2528 aktívnych produktov s odkazom na dodávateľa");
+  expect(progress.textContent).not.toContain("3 / 5");
+  expect(screen.getByTestId("pairing-review-progress-queue").textContent).toContain("vo fronte na revíziu: 5");
 });
 
 it("keď zoznam nezodpovedá žiadnemu produktu, zobrazí informačnú vetu", async () => {
-  searchPairingReview.mockResolvedValue({ total: 0, gatheredTotal: 0, linkedTotal: 0, items: [] });
+  searchPairingReview.mockResolvedValue({ total: 0, gatheredTotal: 0, linkedTotal: 0, catalogLinked: 0, catalogActive: 0, items: [] });
 
   render(<PairingReviewSection role="citanie" onSessionExpired={() => {}} />);
 
@@ -106,7 +113,7 @@ it("pri 401 zavolá onSessionExpired namiesto zobrazenia všeobecnej chyby", asy
 // prvé volanie po mounte MUSÍ toto poslať, aj bez akéhokoľvek predošlého
 // localStorage záznamu.
 it("predvolený filter pri prvom otvorení je 'unreviewed'", async () => {
-  searchPairingReview.mockResolvedValue({ total: 0, gatheredTotal: 0, linkedTotal: 0, items: [] });
+  searchPairingReview.mockResolvedValue({ total: 0, gatheredTotal: 0, linkedTotal: 0, catalogLinked: 0, catalogActive: 0, items: [] });
 
   render(<PairingReviewSection role="citanie" onSessionExpired={() => {}} />);
 
@@ -116,13 +123,13 @@ it("predvolený filter pri prvom otvorení je 'unreviewed'", async () => {
 });
 
 it("klik na iný filter znova načíta zoznam s novým filtrom a zapamätá si ho do localStorage", async () => {
-  searchPairingReview.mockResolvedValue({ total: 0, gatheredTotal: 0, linkedTotal: 0, items: [] });
+  searchPairingReview.mockResolvedValue({ total: 0, gatheredTotal: 0, linkedTotal: 0, catalogLinked: 0, catalogActive: 0, items: [] });
 
   render(<PairingReviewSection role="citanie" onSessionExpired={() => {}} />);
   await screen.findByTestId("pairing-review-empty");
 
   searchPairingReview.mockClear();
-  searchPairingReview.mockResolvedValue({ total: 1, gatheredTotal: 4, linkedTotal: 4, items: [MATCHED_ITEM] });
+  searchPairingReview.mockResolvedValue({ total: 1, gatheredTotal: 4, linkedTotal: 4, catalogLinked: 4, catalogActive: 4, items: [MATCHED_ITEM] });
 
   screen.getByTestId("pairing-review-filter-matched").click();
 
@@ -135,7 +142,7 @@ it("klik na iný filter znova načíta zoznam s novým filtrom a zapamätá si h
 // issue 398 — plný zoznam z majiteľovho komentára na tickete musí byť
 // naozaj VYKRESLENÝ, nielen definovaný v type/kóde.
 it("issue 398: filtre '✓ Dobré/Vybrané' a '⛔ Vyriešené-vypnuté' sú vykreslené a fungujú", async () => {
-  searchPairingReview.mockResolvedValue({ total: 0, gatheredTotal: 0, linkedTotal: 0, items: [] });
+  searchPairingReview.mockResolvedValue({ total: 0, gatheredTotal: 0, linkedTotal: 0, catalogLinked: 0, catalogActive: 0, items: [] });
 
   render(<PairingReviewSection role="citanie" onSessionExpired={() => {}} />);
   await screen.findByTestId("pairing-review-empty");
@@ -144,7 +151,7 @@ it("issue 398: filtre '✓ Dobré/Vybrané' a '⛔ Vyriešené-vypnuté' sú vyk
   expect(screen.getByTestId("pairing-review-filter-terminal").textContent).toBe("⛔ Vyriešené-vypnuté");
 
   searchPairingReview.mockClear();
-  searchPairingReview.mockResolvedValue({ total: 0, gatheredTotal: 0, linkedTotal: 0, items: [] });
+  searchPairingReview.mockResolvedValue({ total: 0, gatheredTotal: 0, linkedTotal: 0, catalogLinked: 0, catalogActive: 0, items: [] });
   screen.getByTestId("pairing-review-filter-terminal").click();
 
   await waitFor(() => {
@@ -157,7 +164,7 @@ it("issue 398: filtre '✓ Dobré/Vybrané' a '⛔ Vyriešené-vypnuté' sú vyk
 // záložky. Tento test dokazuje, že karta samotná (nie navigácia) NEPOUŽÍVA
 // zdieľaný nejednoznačný accessible name.
 it("hlavička karty 'Náš produkt' je odlíšená od 'Navrhnutý kandidát' — bez vlastného <h1>/<h2> obrazovky", async () => {
-  searchPairingReview.mockResolvedValue({ total: 1, gatheredTotal: 1, linkedTotal: 0, items: [MATCHED_ITEM] });
+  searchPairingReview.mockResolvedValue({ total: 1, gatheredTotal: 1, linkedTotal: 0, catalogLinked: 0, catalogActive: 1, items: [MATCHED_ITEM] });
 
   render(<PairingReviewSection role="citanie" onSessionExpired={() => {}} />);
   await screen.findByTestId("pairing-review-card-PR-1");
@@ -180,7 +187,7 @@ it("klik na 'Hľadať / opraviť' prepne na vyhľadávaciu záložku, aj keď 'P
 });
 
 it("prepnutie späť na 'Prehľad' ukáže pôvodný zoznam bez nového vyhľadávania", async () => {
-  searchPairingReview.mockResolvedValue({ total: 0, gatheredTotal: 0, linkedTotal: 0, items: [] });
+  searchPairingReview.mockResolvedValue({ total: 0, gatheredTotal: 0, linkedTotal: 0, catalogLinked: 0, catalogActive: 0, items: [] });
 
   render(<PairingReviewSection role="manazer" onSessionExpired={() => {}} />);
   await screen.findByTestId("pairing-review-empty");

--- a/apps/web/src/components/PairingReviewSection.tsx
+++ b/apps/web/src/components/PairingReviewSection.tsx
@@ -68,7 +68,12 @@ export function PairingReviewSection({ role, onSessionExpired }: { readonly role
   const [items, setItems] = useState<readonly PairingReviewItem[]>([]);
   const [total, setTotal] = useState(0);
   const [gatheredTotal, setGatheredTotal] = useState(0);
-  const [linkedTotal, setLinkedTotal] = useState(0);
+  // issue 432 — katalógové pokrytie (hlavný ukazovateľ): `catalogLinked` /
+  // `catalogActive` = aktívne produkty (s aspoň jedným predajným variantom) s
+  // efektívnou linkou / všetky aktívne produkty. NEZÁVISLÉ od `gatheredTotal`
+  // (veľkosť recenznej fronty, teraz už len samostatný menší riadok).
+  const [catalogLinked, setCatalogLinked] = useState(0);
+  const [catalogActive, setCatalogActive] = useState(0);
   const [loaded, setLoaded] = useState(false);
   const [error, setError] = useState("");
   // issue 399 — "Hľadať / opraviť" pod-záložka, NEZÁVISLÁ od "Prehľad"'s
@@ -115,7 +120,8 @@ export function PairingReviewSection({ role, onSessionExpired }: { readonly role
         setItems(result.items);
         setTotal(result.total);
         setGatheredTotal(result.gatheredTotal);
-        setLinkedTotal(result.linkedTotal);
+        setCatalogLinked(result.catalogLinked);
+        setCatalogActive(result.catalogActive);
         setLoaded(true);
       })
       .catch((err: unknown) => {
@@ -197,7 +203,8 @@ export function PairingReviewSection({ role, onSessionExpired }: { readonly role
     // Obnoviť scroll len RAZ, hneď po prvom úspešnom načítaní.
   }, [loaded]);
 
-  const progressPct = gatheredTotal > 0 ? Math.round((100 * linkedTotal) / gatheredTotal) : 0;
+  // issue 432 — progres z katalógového pokrytia (nie z veľkosti recenznej fronty).
+  const progressPct = catalogActive > 0 ? Math.round((100 * catalogLinked) / catalogActive) : 0;
   const showingAll = total === 0 || items.length >= total;
 
   // issue 399 — pod-záložky (rovnaký vzor ako Upozornenia Otvorené/Vybavené):
@@ -248,12 +255,17 @@ export function PairingReviewSection({ role, onSessionExpired }: { readonly role
       </p>
 
       <div className="pairing-review-progress" data-testid="pairing-review-progress">
-        <span className="pairing-review-progress-text">
-          {String(linkedTotal)} / {String(gatheredTotal)} s odkazom
-        </span>
-        <div className="pairing-review-progress-bar">
-          <div className="pairing-review-progress-bar-fill" style={{ width: `${String(progressPct)}%` }} />
+        <div className="pairing-review-progress-row">
+          <span className="pairing-review-progress-text">
+            {String(catalogLinked)} / {String(catalogActive)} aktívnych produktov s odkazom na dodávateľa
+          </span>
+          <div className="pairing-review-progress-bar">
+            <div className="pairing-review-progress-bar-fill" style={{ width: `${String(progressPct)}%` }} />
+          </div>
         </div>
+        <span className="pairing-review-progress-queue" data-testid="pairing-review-progress-queue">
+          vo fronte na revíziu: {String(gatheredTotal)}
+        </span>
       </div>
 
       <div className="chip-row" data-testid="pairing-review-filters">

--- a/apps/web/src/pairingReviewApi.ts
+++ b/apps/web/src/pairingReviewApi.ts
@@ -65,6 +65,11 @@ const searchSchema = z.object({
   total: z.number(),
   gatheredTotal: z.number(),
   linkedTotal: z.number(),
+  // issue 432 — skutočné katalógové pokrytie linkami (menovateľ = aktívne
+  // produkty s aspoň jedným predajným variantom, čitateľ = z nich s efektívnou
+  // linkou), na rozdiel od `gatheredTotal`/`linkedTotal` (veľkosť recenznej fronty).
+  catalogLinked: z.number(),
+  catalogActive: z.number(),
   items: z.array(itemSchema),
 });
 export type PairingReviewSearchResult = z.infer<typeof searchSchema>;

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2963,20 +2963,40 @@ a.upozornenie-title:hover {
    presne ako stará appka's `webreview` UX, ale VLASTNÝ dizajn nad appkinými
    tokenmi — `.claude/rules/frontend-design.md`'s "legacy app je referencia
    len na správanie, nikdy na vzhľad"). */
+/* issue 432 — stĺpec: hlavný riadok (pokrytie + progress bar) a pod ním
+   samostatný menší riadok s veľkosťou recenznej fronty. */
 .pairing-review-progress {
   display: flex;
-  align-items: center;
-  gap: var(--fs-space-3);
+  flex-direction: column;
+  gap: var(--fs-space-1);
   margin: var(--fs-space-3) 0;
   font-size: var(--fs-text-sm);
 }
+.pairing-review-progress-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--fs-space-3);
+}
+/* issue 432 — dlhší popis („N / M aktívnych produktov s odkazom na
+   dodávateľa") sa smie zalomiť; NIKDY `white-space: nowrap` (na `wide: true`
+   obrazovke by dlhý nezalomiteľný reťazec pretiekol/orezal `.main-wide` —
+   issue 291/382). Bar má vlastný min-width, takže na úzkej šírke sa zalomí
+   pod text namiesto zmrštenia na sliver. */
 .pairing-review-progress-text {
   color: var(--fs-ink-muted);
-  white-space: nowrap;
+}
+/* issue 432 — veľkosť recenznej fronty ako menší, decentnejší riadok pod
+   hlavným ukazovateľom katalógového pokrytia. */
+.pairing-review-progress-queue {
+  font-size: var(--fs-text-xs);
+  color: var(--fs-ink-muted);
 }
 .pairing-review-progress-bar {
-  flex: 1 1 auto;
-  min-width: 0;
+  /* issue 432 — `min-width` + wrap na rodičovi: na úzkej šírke sa bar zalomí
+     pod text na vlastný (plný) riadok namiesto zmrštenia na nečitateľný sliver. */
+  flex: 1 1 8rem;
+  min-width: 8rem;
   height: 8px;
   background: var(--fs-surface-alt);
   border-radius: 999px;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.257",
+  "version": "0.3.0-dev.258",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Issue 432 — Prehľad Párovania: skutočné pokrytie katalógu namiesto zavádzajúceho „2/2303 s odkazom"

Počítadlo na Prehľade meralo veľkosť recenznej fronty (únia gatherované ∪ bez-linky ∪ rozhodnuté), ale text tvrdil „s odkazom" — vyzeralo to ako strata napárovaných linkov (dáta boli celý čas v poriadku: 2246 produktov s URL v internal_note + 16 override liniek). Teraz:

- `GET /api/pairing-review` vracia navyše `catalogActive` (produkty s ≥1 predajným variantom) a `catalogLinked` (z nich s efektívnou linkou = override ∪ internal_note extrakcia cez existujúcu `resolveEffectiveSupplierLink`).
- Prehľad ukazuje hlavný ukazovateľ „N / M aktívnych produktov s odkazom na dodávateľa" (progress bar z tohto) + samostatný malý riadok „vo fronte na revíziu: N". Populácia obrazovky, filtre a karty bez zmeny.
- Nový integračný test (catalog-coverage): override sa počíta, internal_note URL sa počíta, bez linky len menovateľ, bez predajného variantu ani v menovateli, nezávislosť od fronty.

## Issue 433 — default display meno odosielateľa „Forestshop.sk"

Konfiguračná polovica je už na VPS hotová (`MAIL_FROM=Forestshop.sk <eshop@forestshop.sk>`, overená zložená hlavička). Tu kódová poistka proti regresii:

- `resolveMailSender` obalí holú adresu (bez `<`) defaultným menom „Forestshop.sk"; tvar `Meno <adresa>` prechádza bez zmeny; platí aj pre fallback user/host.
- Unit testy 7/7 (obalenie, passthrough, fallback), RED pred GREEN.
- Nález: `MAIL_BCC` bola mŕtva env premenná (appka ju nečíta; BCC ide cez 4 vyhradené premenné) — odstránená z `/srv/forestshop/.env`, bez kódovej zmeny.

Verzia 0.3.0-dev.258 (bump prišiel už s playbook commitom f82a03f po PR #434).

Lokálne gates: typecheck ✓, lint ✓, unit 1651 ✓, integračné 840 ✓ (čerstvá izolovaná DB, zdieľaná 5433 má schema-drift — viď poznámka na tickete 432).

Tickety 432 a 433 ostávajú otvorené do naživo overenia po nasadení.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
